### PR TITLE
Update armor penetration calculations and debuffs

### DIFF
--- a/sim/core/armor_test.go
+++ b/sim/core/armor_test.go
@@ -1,0 +1,264 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/wowsims/wotlk/sim/core/stats"
+)
+
+func TestSunderArmorStacks(t *testing.T) {
+	sim := Simulation{}
+	baseArmor := 10643.0
+	target := Unit{
+		Type:         EnemyUnit,
+		Index:        0,
+		Level:        83,
+		auraTracker:  newAuraTracker(),
+		initialStats: stats.Stats{stats.Armor: baseArmor},
+		PseudoStats:  stats.NewPseudoStats(),
+		Metrics:      NewUnitMetrics(),
+	}
+	target.stats = target.initialStats
+	expectedArmor := baseArmor
+	if target.Armor() != expectedArmor {
+		t.Fatalf("Armor value for target should be %f but found %f", 10643.0, target.Armor())
+	}
+	stacks := int32(1)
+	sunderAura := SunderArmorAura(&target, stacks)
+	sunderAura.Activate(&sim)
+	tolerance := 0.001
+	for stacks <= 5 {
+		expectedArmor = baseArmor * (1.0 - float64(stacks)*0.04)
+		if target.Armor() < expectedArmor-tolerance || target.Armor() > expectedArmor+tolerance {
+			t.Fatalf("Armor value for target should be %f but found %f", expectedArmor, target.Armor())
+		}
+		stacks++
+		sunderAura.AddStack(&sim)
+	}
+}
+
+func TestAcidSpitStacks(t *testing.T) {
+	sim := Simulation{}
+	baseArmor := 10643.0
+	target := Unit{
+		Type:         EnemyUnit,
+		Index:        0,
+		Level:        83,
+		auraTracker:  newAuraTracker(),
+		initialStats: stats.Stats{stats.Armor: baseArmor},
+		PseudoStats:  stats.NewPseudoStats(),
+		Metrics:      NewUnitMetrics(),
+	}
+	target.stats = target.initialStats
+	expectedArmor := baseArmor
+	if target.Armor() != expectedArmor {
+		t.Fatalf("Armor value for target should be %f but found %f", 10643.0, target.Armor())
+	}
+	stacks := int32(1)
+	acidSpitAura := AcidSpitAura(&target, stacks)
+	acidSpitAura.Activate(&sim)
+	tolerance := 0.001
+	for stacks <= 2 {
+		expectedArmor = baseArmor * (1.0 - float64(stacks)*0.1)
+		if target.Armor() < expectedArmor-tolerance || target.Armor() > expectedArmor+tolerance {
+			t.Fatalf("Armor value for target should be %f but found %f", expectedArmor, target.Armor())
+		}
+		stacks++
+		acidSpitAura.AddStack(&sim)
+	}
+}
+
+func TestExposeArmor(t *testing.T) {
+	sim := Simulation{}
+	baseArmor := 10643.0
+	target := Unit{
+		Type:         EnemyUnit,
+		Index:        0,
+		Level:        83,
+		auraTracker:  newAuraTracker(),
+		initialStats: stats.Stats{stats.Armor: baseArmor},
+		PseudoStats:  stats.NewPseudoStats(),
+		Metrics:      NewUnitMetrics(),
+	}
+	target.stats = target.initialStats
+	expectedArmor := baseArmor
+	if target.Armor() != expectedArmor {
+		t.Fatalf("Armor value for target should be %f but found %f", 10643.0, target.Armor())
+	}
+	exposeAura := ExposeArmorAura(&target, false)
+	exposeAura.Activate(&sim)
+	tolerance := 0.001
+	expectedArmor = baseArmor * (1.0 - 0.2)
+	if target.Armor() < expectedArmor-tolerance || target.Armor() > expectedArmor+tolerance {
+		t.Fatalf("Armor value for target should be %f but found %f", expectedArmor, target.Armor())
+	}
+}
+
+func TestMajorArmorReductionAurasDoNotStack(t *testing.T) {
+	sim := Simulation{}
+	baseArmor := 10643.0
+	target := Unit{
+		Type:         EnemyUnit,
+		Index:        0,
+		Level:        83,
+		auraTracker:  newAuraTracker(),
+		initialStats: stats.Stats{stats.Armor: baseArmor},
+		PseudoStats:  stats.NewPseudoStats(),
+		Metrics:      NewUnitMetrics(),
+	}
+	target.stats = target.initialStats
+	expectedArmor := baseArmor
+	if target.Armor() != expectedArmor {
+		t.Fatalf("Armor value for target should be %f but found %f", 10643.0, target.Armor())
+	}
+	stacks := int32(1)
+	acidSpitAura := AcidSpitAura(&target, stacks)
+	acidSpitAura.Activate(&sim)
+	tolerance := 0.001
+	expectedArmor = baseArmor * (1.0 - float64(stacks)*0.1)
+	if target.Armor() < expectedArmor-tolerance || target.Armor() > expectedArmor+tolerance {
+		t.Fatalf("Armor value for target should be %f but found %f", expectedArmor, target.Armor())
+	}
+	exposeArmorAura := ExposeArmorAura(&target, false)
+	exposeArmorAura.Activate(&sim)
+	expectedArmor = baseArmor * (1.0 - 0.2)
+	if target.Armor() < expectedArmor-tolerance || target.Armor() > expectedArmor+tolerance {
+		t.Fatalf("Armor value for target should be %f but found %f", expectedArmor, target.Armor())
+	}
+}
+
+func TestMajorAndMinorArmorReductionsApplyMultiplicatively(t *testing.T) {
+	sim := Simulation{}
+	baseArmor := 10643.0
+	target := Unit{
+		Type:         EnemyUnit,
+		Index:        0,
+		Level:        83,
+		auraTracker:  newAuraTracker(),
+		initialStats: stats.Stats{stats.Armor: baseArmor},
+		PseudoStats:  stats.NewPseudoStats(),
+		Metrics:      NewUnitMetrics(),
+	}
+	target.stats = target.initialStats
+	expectedArmor := baseArmor
+	if target.Armor() != expectedArmor {
+		t.Fatalf("Armor value for target should be %f but found %f", 10643.0, target.Armor())
+	}
+	stacks := int32(2)
+	acidSpitAura := AcidSpitAura(&target, stacks)
+	acidSpitAura.Activate(&sim)
+	tolerance := 0.001
+	expectedArmor = baseArmor * (1.0 - float64(stacks)*0.1)
+	if target.Armor() < expectedArmor-tolerance || target.Armor() > expectedArmor+tolerance {
+		t.Fatalf("Armor value for target should be %f but found %f", expectedArmor, target.Armor())
+	}
+	faerieFireAura := FaerieFireAura(&target, 5)
+	faerieFireAura.Activate(&sim)
+	expectedArmor = baseArmor * (1.0 - 0.2) * (1.0 - 0.05)
+	if target.Armor() < expectedArmor-tolerance || target.Armor() > expectedArmor+tolerance {
+		t.Fatalf("Armor value for target should be %f but found %f", expectedArmor, target.Armor())
+	}
+}
+
+func TestDamageReductionFromArmor(t *testing.T) {
+	sim := Simulation{}
+	baseArmor := 10643.0
+	target := Unit{
+		Type:         EnemyUnit,
+		Index:        0,
+		Level:        83,
+		auraTracker:  newAuraTracker(),
+		initialStats: stats.Stats{stats.Armor: baseArmor},
+		PseudoStats:  stats.NewPseudoStats(),
+		Metrics:      NewUnitMetrics(),
+	}
+	attacker := Unit{
+		Type:  PlayerUnit,
+		Level: 80,
+	}
+	target.stats = target.initialStats
+	expectedDamageReduction := 0.4113
+	attackTable := NewAttackTable(&attacker, &target)
+	tolerance := 0.0001
+	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+		t.Fatalf("Expected no armor modifiers to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	}
+
+	// Major
+	acidSpitAura := AcidSpitAura(&target, 2)
+	acidSpitAura.Activate(&sim)
+	expectedDamageReduction = 0.3585
+	attackTable.UpdateArmorDamageReduction()
+	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+		t.Fatalf("Expected major armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	}
+
+	// Major + Minor
+	faerieFireAura := FaerieFireAura(&target, 3)
+	faerieFireAura.Activate(&sim)
+	attackTable.UpdateArmorDamageReduction()
+	expectedDamageReduction = 0.3468
+	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	}
+
+	// Major + Minor + Spore
+	sporeCloudAura := SporeCloudAura(&target)
+	sporeCloudAura.Activate(&sim)
+	attackTable.UpdateArmorDamageReduction()
+	expectedDamageReduction = 0.34
+	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	}
+
+	// Major + Minor + Spore + Throw
+	shatteringThrowAura := ShatteringThrowAura(&target)
+	shatteringThrowAura.Activate(&sim)
+	attackTable.UpdateArmorDamageReduction()
+	expectedDamageReduction = 0.2918
+	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	}
+
+	// Just Major minor again; testing Deactivate
+	sporeCloudAura.Deactivate(&sim)
+	shatteringThrowAura.Deactivate(&sim)
+	attackTable.UpdateArmorDamageReduction()
+	expectedDamageReduction = 0.3468
+	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	}
+
+	// Cap armor pen
+	attacker.stats[stats.ArmorPenetration] = 1400
+	attackTable.UpdateArmorDamageReduction()
+	expectedDamageReduction = 0.0203
+	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	}
+
+	// Verify going past Cap doesn't help
+	attacker.stats[stats.ArmorPenetration] = 1600
+	attackTable.UpdateArmorDamageReduction()
+	expectedDamageReduction = 0.0203
+	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	}
+
+	// Add spore back
+	sporeCloudAura.Activate(&sim)
+	attackTable.UpdateArmorDamageReduction()
+	expectedDamageReduction = 0.0100
+	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	}
+
+	// Fully debuffs
+	shatteringThrowAura.Activate(&sim)
+	attackTable.UpdateArmorDamageReduction()
+	expectedDamageReduction = 0.0
+	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	}
+
+}

--- a/sim/core/armor_test.go
+++ b/sim/core/armor_test.go
@@ -29,7 +29,7 @@ func TestSunderArmorStacks(t *testing.T) {
 	tolerance := 0.001
 	for stacks <= 5 {
 		expectedArmor = baseArmor * (1.0 - float64(stacks)*0.04)
-		if target.Armor() < expectedArmor-tolerance || target.Armor() > expectedArmor+tolerance {
+		if !WithinToleranceFloat64(expectedArmor, target.Armor(), tolerance) {
 			t.Fatalf("Armor value for target should be %f but found %f", expectedArmor, target.Armor())
 		}
 		stacks++
@@ -60,7 +60,7 @@ func TestAcidSpitStacks(t *testing.T) {
 	tolerance := 0.001
 	for stacks <= 2 {
 		expectedArmor = baseArmor * (1.0 - float64(stacks)*0.1)
-		if target.Armor() < expectedArmor-tolerance || target.Armor() > expectedArmor+tolerance {
+		if !WithinToleranceFloat64(expectedArmor, target.Armor(), tolerance) {
 			t.Fatalf("Armor value for target should be %f but found %f", expectedArmor, target.Armor())
 		}
 		stacks++
@@ -89,7 +89,7 @@ func TestExposeArmor(t *testing.T) {
 	exposeAura.Activate(&sim)
 	tolerance := 0.001
 	expectedArmor = baseArmor * (1.0 - 0.2)
-	if target.Armor() < expectedArmor-tolerance || target.Armor() > expectedArmor+tolerance {
+	if !WithinToleranceFloat64(expectedArmor, target.Armor(), tolerance) {
 		t.Fatalf("Armor value for target should be %f but found %f", expectedArmor, target.Armor())
 	}
 }
@@ -116,13 +116,13 @@ func TestMajorArmorReductionAurasDoNotStack(t *testing.T) {
 	acidSpitAura.Activate(&sim)
 	tolerance := 0.001
 	expectedArmor = baseArmor * (1.0 - float64(stacks)*0.1)
-	if target.Armor() < expectedArmor-tolerance || target.Armor() > expectedArmor+tolerance {
+	if !WithinToleranceFloat64(expectedArmor, target.Armor(), tolerance) {
 		t.Fatalf("Armor value for target should be %f but found %f", expectedArmor, target.Armor())
 	}
 	exposeArmorAura := ExposeArmorAura(&target, false)
 	exposeArmorAura.Activate(&sim)
 	expectedArmor = baseArmor * (1.0 - 0.2)
-	if target.Armor() < expectedArmor-tolerance || target.Armor() > expectedArmor+tolerance {
+	if !WithinToleranceFloat64(expectedArmor, target.Armor(), tolerance) {
 		t.Fatalf("Armor value for target should be %f but found %f", expectedArmor, target.Armor())
 	}
 }
@@ -149,13 +149,13 @@ func TestMajorAndMinorArmorReductionsApplyMultiplicatively(t *testing.T) {
 	acidSpitAura.Activate(&sim)
 	tolerance := 0.001
 	expectedArmor = baseArmor * (1.0 - float64(stacks)*0.1)
-	if target.Armor() < expectedArmor-tolerance || target.Armor() > expectedArmor+tolerance {
+	if !WithinToleranceFloat64(expectedArmor, target.Armor(), tolerance) {
 		t.Fatalf("Armor value for target should be %f but found %f", expectedArmor, target.Armor())
 	}
 	faerieFireAura := FaerieFireAura(&target, 5)
 	faerieFireAura.Activate(&sim)
 	expectedArmor = baseArmor * (1.0 - 0.2) * (1.0 - 0.05)
-	if target.Armor() < expectedArmor-tolerance || target.Armor() > expectedArmor+tolerance {
+	if !WithinToleranceFloat64(expectedArmor, target.Armor(), tolerance) {
 		t.Fatalf("Armor value for target should be %f but found %f", expectedArmor, target.Armor())
 	}
 }
@@ -180,7 +180,7 @@ func TestDamageReductionFromArmor(t *testing.T) {
 	expectedDamageReduction := 0.4113
 	attackTable := NewAttackTable(&attacker, &target)
 	tolerance := 0.0001
-	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
 		t.Fatalf("Expected no armor modifiers to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
 	}
 
@@ -189,7 +189,7 @@ func TestDamageReductionFromArmor(t *testing.T) {
 	acidSpitAura.Activate(&sim)
 	expectedDamageReduction = 0.3585
 	attackTable.UpdateArmorDamageReduction()
-	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
 		t.Fatalf("Expected major armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
 	}
 
@@ -198,7 +198,7 @@ func TestDamageReductionFromArmor(t *testing.T) {
 	faerieFireAura.Activate(&sim)
 	attackTable.UpdateArmorDamageReduction()
 	expectedDamageReduction = 0.3468
-	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
 		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
 	}
 
@@ -207,7 +207,7 @@ func TestDamageReductionFromArmor(t *testing.T) {
 	sporeCloudAura.Activate(&sim)
 	attackTable.UpdateArmorDamageReduction()
 	expectedDamageReduction = 0.34
-	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
 		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
 	}
 
@@ -216,7 +216,7 @@ func TestDamageReductionFromArmor(t *testing.T) {
 	shatteringThrowAura.Activate(&sim)
 	attackTable.UpdateArmorDamageReduction()
 	expectedDamageReduction = 0.2918
-	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
 		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
 	}
 
@@ -225,7 +225,7 @@ func TestDamageReductionFromArmor(t *testing.T) {
 	shatteringThrowAura.Deactivate(&sim)
 	attackTable.UpdateArmorDamageReduction()
 	expectedDamageReduction = 0.3468
-	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
 		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
 	}
 
@@ -233,7 +233,7 @@ func TestDamageReductionFromArmor(t *testing.T) {
 	attacker.stats[stats.ArmorPenetration] = 1400
 	attackTable.UpdateArmorDamageReduction()
 	expectedDamageReduction = 0.0203
-	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
 		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
 	}
 
@@ -241,7 +241,7 @@ func TestDamageReductionFromArmor(t *testing.T) {
 	attacker.stats[stats.ArmorPenetration] = 1600
 	attackTable.UpdateArmorDamageReduction()
 	expectedDamageReduction = 0.0203
-	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
 		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
 	}
 
@@ -249,7 +249,7 @@ func TestDamageReductionFromArmor(t *testing.T) {
 	sporeCloudAura.Activate(&sim)
 	attackTable.UpdateArmorDamageReduction()
 	expectedDamageReduction = 0.0100
-	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
 		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
 	}
 
@@ -257,7 +257,7 @@ func TestDamageReductionFromArmor(t *testing.T) {
 	shatteringThrowAura.Activate(&sim)
 	attackTable.UpdateArmorDamageReduction()
 	expectedDamageReduction = 0.0
-	if attackTable.ArmorDamageReduction < expectedDamageReduction-tolerance || attackTable.ArmorDamageReduction > expectedDamageReduction+tolerance {
+	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
 		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
 	}
 

--- a/sim/core/constants.go
+++ b/sim/core/constants.go
@@ -12,6 +12,7 @@ const GCDDefault = time.Millisecond * 1500
 const MeleeAttackRatingPerDamage = 14.0
 const ExpertisePerQuarterPercentReduction = 32.79 / 4 // TODO: Does it still cutoff at 1/4 percents?
 const ArmorPenPerPercentArmor = 13.99
+const ReducibleArmorConstant = 15232.5
 
 const HasteRatingPerHastePercent = 32.79
 const CritRatingPerCritChance = 45.91

--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -63,7 +63,7 @@ func applyDebuffEffects(target *Unit, debuffs proto.Debuffs) {
 	}
 
 	if debuffs.ExposeArmor != proto.TristateEffect_TristateEffectMissing {
-		ScheduledExposeArmorAura(target, GetTristateValueInt32(debuffs.ExposeArmor, 0, 2))
+		ScheduledExposeArmorAura(target, false) // TODO: fix this
 	}
 
 	if debuffs.SunderArmor {
@@ -390,38 +390,38 @@ func WintersChillAura(target *Unit, startingStacks int32) *Aura {
 	})
 }
 
-var FaerieFireAuraTag = "Faerie Fire"
+var MinorArmorReductionAuraTag = "MinorArmorReductionAura"
 
 func FaerieFireAura(target *Unit, level int32) *Aura {
-	const armorReduction = 610
+	const armorReduction = 0.05
 
 	return target.GetOrRegisterAura(Aura{
 		Label:    "Faerie Fire-" + strconv.Itoa(int(level)),
-		Tag:      FaerieFireAuraTag,
+		Tag:      MinorArmorReductionAuraTag,
 		ActionID: ActionID{SpellID: 26993},
 		Duration: time.Second * 40,
 		Priority: float64(level),
 		OnGain: func(aura *Aura, sim *Simulation) {
-			aura.Unit.AddStatDynamic(sim, stats.Armor, -armorReduction)
+			aura.Unit.PseudoStats.ArmorMultiplier *= (1.0 - armorReduction)
 			aura.Unit.PseudoStats.BonusMeleeHitRating += float64(level) * MeleeHitRatingPerHitChance
 		},
 		OnExpire: func(aura *Aura, sim *Simulation) {
-			aura.Unit.AddStatDynamic(sim, stats.Armor, armorReduction)
+			aura.Unit.PseudoStats.ArmorMultiplier *= (1.0 / (1.0 - armorReduction))
 			aura.Unit.PseudoStats.BonusMeleeHitRating -= float64(level) * MeleeHitRatingPerHitChance
 		},
 	})
 }
 
 var SunderArmorAuraLabel = "Sunder Armor"
-var SunderExposeAuraTag = "SunderExpose"
+var MajorArmorReductionTag = "MajorArmorReductionAura"
 
 func SunderArmorAura(target *Unit, startingStacks int32) *Aura {
-	armorReductionPerStack := 520.0
+	armorReductionPerStack := 0.04
 
 	return target.GetOrRegisterAura(Aura{
 		Label:     SunderArmorAuraLabel,
-		Tag:       SunderExposeAuraTag,
-		ActionID:  ActionID{SpellID: 25225},
+		Tag:       MajorArmorReductionTag,
+		ActionID:  ActionID{SpellID: 25225}, // TODO: Fix spell id
 		Duration:  time.Second * 30,
 		MaxStacks: 5,
 		Priority:  armorReductionPerStack * 5,
@@ -429,7 +429,9 @@ func SunderArmorAura(target *Unit, startingStacks int32) *Aura {
 			aura.SetStacks(sim, startingStacks)
 		},
 		OnStacksChange: func(aura *Aura, sim *Simulation, oldStacks int32, newStacks int32) {
-			aura.Unit.AddStatDynamic(sim, stats.Armor, float64(oldStacks-newStacks)*armorReductionPerStack)
+			oldMultiplier := (1.0 - float64(oldStacks)*armorReductionPerStack)
+			newMultiplier := (1.0 - float64(newStacks)*armorReductionPerStack)
+			aura.Unit.PseudoStats.ArmorMultiplier *= (newMultiplier / oldMultiplier)
 		},
 	})
 }
@@ -453,26 +455,71 @@ func ScheduledSunderArmorAura(target *Unit) *Aura {
 	return aura
 }
 
-func ExposeArmorAura(target *Unit, talentPoints int32) *Aura {
-	armorReduction := 2050.0 * (1.0 + 0.25*float64(talentPoints))
+var AcidSpitAuraLabel = "Acid Spit"
+
+func AcidSpitAura(target *Unit, startingStacks int32) *Aura {
+	armorReductionPerStack := 0.1
 
 	return target.GetOrRegisterAura(Aura{
-		Label:    "ExposeArmor-" + strconv.Itoa(int(talentPoints)),
-		Tag:      SunderExposeAuraTag,
-		ActionID: ActionID{SpellID: 26866},
-		Duration: time.Second * 30,
-		Priority: armorReduction,
+		Label:     AcidSpitAuraLabel,
+		Tag:       MajorArmorReductionTag,
+		ActionID:  ActionID{SpellID: 55745}, // TODO: Spell id
+		Duration:  time.Second * 10,
+		MaxStacks: 2,
+		Priority:  armorReductionPerStack * 2,
 		OnGain: func(aura *Aura, sim *Simulation) {
-			aura.Unit.AddStatDynamic(sim, stats.Armor, -armorReduction)
+			aura.SetStacks(sim, startingStacks)
 		},
-		OnExpire: func(aura *Aura, sim *Simulation) {
-			aura.Unit.AddStatDynamic(sim, stats.Armor, armorReduction)
+		OnStacksChange: func(aura *Aura, sim *Simulation, oldStacks int32, newStacks int32) {
+			oldMultiplier := (1.0 - float64(oldStacks)*armorReductionPerStack)
+			newMultiplier := (1.0 - float64(newStacks)*armorReductionPerStack)
+			aura.Unit.PseudoStats.ArmorMultiplier *= (newMultiplier / oldMultiplier)
 		},
 	})
 }
 
-func ScheduledExposeArmorAura(target *Unit, talentPoints int32) *Aura {
-	aura := ExposeArmorAura(target, talentPoints)
+func ScheduledAcidSpitAura(target *Unit) *Aura {
+	aura := AcidSpitAura(target, 1)
+	aura.Duration = NeverExpires
+	aura.OnReset = func(aura *Aura, sim *Simulation) {
+		aura.Activate(sim)
+		StartPeriodicAction(sim, PeriodicActionOptions{
+			Period:   time.Duration(1.5 * float64(time.Second)),
+			NumTicks: 1,
+			Priority: ActionPriorityDOT,
+			OnAction: func(sim *Simulation) {
+				if aura.IsActive() {
+					aura.AddStack(sim)
+				}
+			},
+		})
+	}
+	return aura
+}
+
+func ExposeArmorAura(target *Unit, hasGlyph bool) *Aura {
+	armorReduction := 0.2
+	duration := time.Second * 30
+	if hasGlyph {
+		duration += 12
+	}
+	return target.GetOrRegisterAura(Aura{
+		Label:    "ExposeArmor",
+		Tag:      MajorArmorReductionTag,
+		ActionID: ActionID{SpellID: 26866}, // TODO: Spell id
+		Duration: duration,
+		Priority: armorReduction,
+		OnGain: func(aura *Aura, sim *Simulation) {
+			aura.Unit.PseudoStats.ArmorMultiplier *= (1.0 - armorReduction)
+		},
+		OnExpire: func(aura *Aura, sim *Simulation) {
+			aura.Unit.PseudoStats.ArmorMultiplier *= (1.0 / (1.0 - armorReduction))
+		},
+	})
+}
+
+func ScheduledExposeArmorAura(target *Unit, hasGlyph bool) *Aura {
+	aura := ExposeArmorAura(target, hasGlyph)
 	aura.Duration = NeverExpires
 	aura.OnReset = func(aura *Aura, sim *Simulation) {
 		StartPeriodicAction(sim, PeriodicActionOptions{
@@ -487,7 +534,7 @@ func ScheduledExposeArmorAura(target *Unit, talentPoints int32) *Aura {
 }
 
 func CurseOfRecklessnessAura(target *Unit) *Aura {
-	bonus := stats.Stats{stats.Armor: -800, stats.AttackPower: 135}
+	bonus := stats.Stats{stats.AttackPower: 135}
 
 	return target.GetOrRegisterAura(Aura{
 		Label:    "Curse of Recklessness",
@@ -498,6 +545,75 @@ func CurseOfRecklessnessAura(target *Unit) *Aura {
 		},
 		OnExpire: func(aura *Aura, sim *Simulation) {
 			aura.Unit.AddStatsDynamic(sim, bonus.Multiply(-1))
+		},
+	})
+}
+
+func CurseOfWeaknessAura(target *Unit) *Aura {
+	bonus := stats.Stats{stats.AttackPower: -478}
+	armorReduction := 0.05
+
+	return target.GetOrRegisterAura(Aura{
+		Label:    "Curse of Weakness",
+		Tag:      MinorArmorReductionAuraTag,
+		ActionID: ActionID{SpellID: 27226}, // TODO: Fix spell id
+		Duration: time.Minute * 2,
+		OnGain: func(aura *Aura, sim *Simulation) {
+			aura.Unit.AddStatsDynamic(sim, bonus)
+			aura.Unit.PseudoStats.ArmorMultiplier *= (1.0 - armorReduction)
+		},
+		OnExpire: func(aura *Aura, sim *Simulation) {
+			aura.Unit.AddStatsDynamic(sim, bonus.Multiply(-1))
+			aura.Unit.PseudoStats.ArmorMultiplier *= (1.0 / (1.0 - armorReduction))
+		},
+	})
+}
+
+func StingAura(target *Unit) *Aura {
+	armorReduction := 0.05
+
+	return target.GetOrRegisterAura(Aura{
+		Label:    "Sting",
+		Tag:      MinorArmorReductionAuraTag,
+		ActionID: ActionID{SpellID: 27226}, // TODO: Fix spell id
+		Duration: time.Second * 20,
+		OnGain: func(aura *Aura, sim *Simulation) {
+			aura.Unit.PseudoStats.ArmorMultiplier *= (1.0 - armorReduction)
+		},
+		OnExpire: func(aura *Aura, sim *Simulation) {
+			aura.Unit.PseudoStats.ArmorMultiplier *= (1.0 / (1.0 - armorReduction))
+		},
+	})
+}
+
+func SporeCloudAura(target *Unit) *Aura {
+	armorReduction := 0.03
+
+	return target.GetOrRegisterAura(Aura{
+		Label:    "Spore Cloud",
+		ActionID: ActionID{SpellID: 27226}, // TODO: Fix spell id
+		Duration: time.Second * 9,
+		OnGain: func(aura *Aura, sim *Simulation) {
+			aura.Unit.PseudoStats.ArmorMultiplier *= (1.0 - armorReduction)
+		},
+		OnExpire: func(aura *Aura, sim *Simulation) {
+			aura.Unit.PseudoStats.ArmorMultiplier *= (1.0 / (1.0 - armorReduction))
+		},
+	})
+}
+
+func ShatteringThrowAura(target *Unit) *Aura {
+	armorReduction := 0.2
+
+	return target.GetOrRegisterAura(Aura{
+		Label:    "Shattering Throw",
+		ActionID: ActionID{SpellID: 27226}, // TODO: Fix spell id
+		Duration: time.Second * 10,
+		OnGain: func(aura *Aura, sim *Simulation) {
+			aura.Unit.PseudoStats.ArmorMultiplier *= (1.0 - armorReduction)
+		},
+		OnExpire: func(aura *Aura, sim *Simulation) {
+			aura.Unit.PseudoStats.ArmorMultiplier *= (1.0 / (1.0 - armorReduction))
 		},
 	})
 }

--- a/sim/core/major_cooldown.go
+++ b/sim/core/major_cooldown.go
@@ -213,7 +213,7 @@ func (mcdm *majorCooldownManager) finalize(character *Character) {
 //
 // This function should be called from Agent.Init().
 func (mcdm *majorCooldownManager) DelayDPSCooldownsForArmorDebuffs() {
-	if !mcdm.character.CurrentTarget.HasAuraWithTag(SunderExposeAuraTag) {
+	if !mcdm.character.CurrentTarget.HasAuraWithTag(MajorArmorReductionTag) {
 		return
 	}
 

--- a/sim/core/spell_resistances.go
+++ b/sim/core/spell_resistances.go
@@ -43,10 +43,11 @@ func (spellEffect *SpellEffect) applyResistances(sim *Simulation, spell *Spell, 
 	}
 }
 
-// ArmorDamageReduction currently assumes a level 70 attacker
+// ArmorDamageReduction currently assumes a level 80 attacker
 func (at *AttackTable) UpdateArmorDamageReduction() {
-	effectiveArmor := MaxFloat(0, at.Defender.stats[stats.Armor]-at.Attacker.stats[stats.ArmorPenetration])
-	at.ArmorDamageReduction = MaxFloat(0.25, 1-(effectiveArmor/(effectiveArmor+(float64(at.Attacker.Level)*467.5-22167.5))))
+	reducibleArmor := MinFloat((at.Defender.Armor()+ReducibleArmorConstant)/3, at.Defender.Armor())
+	effectiveArmor := MaxFloat(at.Defender.Armor()-reducibleArmor*at.Attacker.ArmorPenetration(), 0)
+	at.ArmorDamageReduction = 1 / ((float64(at.Attacker.Level)*467.5-22167.5)/effectiveArmor + 1)
 }
 
 func (at *AttackTable) UpdatePartialResists() {

--- a/sim/core/stats/stats.go
+++ b/sim/core/stats/stats.go
@@ -480,6 +480,8 @@ type PseudoStats struct {
 
 	DamageTakenMultiplier float64 // All damage
 
+	ArmorMultiplier float64 // Major/minor/special multipicative armor modifiers
+
 	PhysicalDamageTakenMultiplier float64
 	ArcaneDamageTakenMultiplier   float64
 	FireDamageTakenMultiplier     float64
@@ -525,6 +527,8 @@ func NewPseudoStats() PseudoStats {
 
 		// Target effects.
 		DamageTakenMultiplier: 1,
+
+		ArmorMultiplier: 1,
 
 		PhysicalDamageTakenMultiplier: 1,
 		ArcaneDamageTakenMultiplier:   1,

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -285,6 +285,15 @@ func (unit *Unit) SwingSpeed() float64 {
 	return unit.PseudoStats.MeleeSpeedMultiplier * (1 + (unit.stats[stats.MeleeHaste] / (HasteRatingPerHastePercent * 100)))
 }
 
+func (unit *Unit) Armor() float64 {
+	return unit.PseudoStats.ArmorMultiplier * unit.stats[stats.Armor]
+}
+
+func (unit *Unit) ArmorPenetration() float64 {
+	// TODO: talents (e.g. mace spec) and battle stance are additive here
+	return MinFloat(unit.stats[stats.ArmorPenetration]/ArmorPenPerPercentArmor, 1.0)
+}
+
 func (unit *Unit) RangedSwingSpeed() float64 {
 	return unit.PseudoStats.RangedSpeedMultiplier * (1 + (unit.stats[stats.MeleeHaste] / (HasteRatingPerHastePercent * 100)))
 }

--- a/sim/core/utils.go
+++ b/sim/core/utils.go
@@ -170,3 +170,7 @@ func UnitLevelFloat64(unitLevel int32, maxLevelPlus0Val float64, maxLevelPlus1Va
 		return maxLevelPlus3Val
 	}
 }
+
+func WithinToleranceFloat64(expectedValue float64, actualValue float64, tolerance float64) bool {
+	return actualValue >= (expectedValue-tolerance) && actualValue <= (expectedValue+tolerance)
+}

--- a/sim/druid/faerie_fire.go
+++ b/sim/druid/faerie_fire.go
@@ -71,5 +71,5 @@ func (druid *Druid) ShouldFaerieFire(sim *core.Simulation) bool {
 		return false
 	}
 
-	return druid.CurrentTarget.ShouldRefreshAuraWithTagAtPriority(sim, core.FaerieFireAuraTag, druid.FaerieFireAura.Priority, time.Second*3)
+	return druid.CurrentTarget.ShouldRefreshAuraWithTagAtPriority(sim, core.MinorArmorReductionAuraTag, druid.FaerieFireAura.Priority, time.Second*3)
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -47,735 +47,735 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1981.5949603152442
-  tps: 1441.3764830239604
+  dps: 942.4579577150283
+  tps: 703.5892111778074
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Alchemist'sStone-13503"
  value: {
-  dps: 1984.3691834759125
-  tps: 1443.3487886212406
+  dps: 944.2924641088496
+  tps: 704.8943178706259
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 1960.9024327138281
-  tps: 1426.5572091246163
+  dps: 933.3273216280612
+  tps: 696.9788802537219
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Assassin'sAlchemistStone-35751"
  value: {
-  dps: 1991.78634781124
-  tps: 1448.484788843779
+  dps: 947.2246327657009
+  tps: 706.845971161446
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1988.0136096055105
-  tps: 1445.976645095806
+  dps: 945.7636756044952
+  tps: 705.979191955085
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1974.4461273865477
-  tps: 1436.1732323422466
+  dps: 695.2119170707534
+  tps: 527.9169430180337
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 2015.305035501723
-  tps: 1465.425989174406
+  dps: 957.796992240765
+  tps: 714.5952784591262
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 1964.7799713060585
-  tps: 1429.276446683841
+  dps: 935.0828304978527
+  tps: 698.1914767100144
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1982.7192701015986
-  tps: 1442.1024149647433
+  dps: 944.2651361461715
+  tps: 704.7999798563909
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 2010.3611809692627
-  tps: 1461.6729203859754
+  dps: 955.4927442544715
+  tps: 712.7163303184735
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 2015.3254054206357
-  tps: 1465.6540649391761
+  dps: 957.5229597374994
+  tps: 714.6143285041493
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 1998.7124906699398
-  tps: 1453.4023502734562
+  dps: 950.2642468467361
+  tps: 709.004097158981
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1972.340209921501
-  tps: 1434.8069926982237
+  dps: 938.5352514655516
+  tps: 700.8054721945
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 2006.0966822427858
-  tps: 1458.6451262901762
+  dps: 953.5943155173652
+  tps: 711.3684459151277
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1963.2075892296043
-  tps: 1428.1905521028677
+  dps: 936.8646849816805
+  tps: 699.4870900868423
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1980.6212796024174
-  tps: 1440.826568894607
+  dps: 941.2303955235159
+  tps: 702.8590411985864
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1969.1507880606337
-  tps: 1432.4999987828116
+  dps: 937.4241817873866
+  tps: 699.9741083288063
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1986.6660262770197
-  tps: 1444.8493605544834
+  dps: 944.8551571804703
+  tps: 705.1636434959327
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1991.0339578630978
-  tps: 1447.9505919805981
+  dps: 945.8179660310069
+  tps: 705.8472377798131
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1994.957531570107
-  tps: 1450.7363293125745
+  dps: 948.6105752437383
+  tps: 707.8299903208522
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1965.0516272060072
-  tps: 1429.5031372140634
+  dps: 940.3919700440773
+  tps: 701.9947806290932
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1957.3366628812291
-  tps: 1424.0553131025986
+  dps: 931.1824192601284
+  tps: 695.4858001316179
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1998.7124906699398
-  tps: 1453.4023502734562
+  dps: 950.2642468467361
+  tps: 709.004097158981
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1998.7124906699398
-  tps: 1453.4023502734562
+  dps: 950.2642468467361
+  tps: 709.004097158981
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1998.7124906699398
-  tps: 1453.4023502734562
+  dps: 950.2642468467361
+  tps: 709.004097158981
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1998.7124906699398
-  tps: 1453.4023502734562
+  dps: 950.2642468467361
+  tps: 709.004097158981
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 1998.7124906699398
-  tps: 1453.4023502734562
+  dps: 950.2642468467361
+  tps: 709.004097158981
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1968.130958355461
-  tps: 1431.877260632127
+  dps: 936.9084825074581
+  tps: 699.7093027800457
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1982.9004317157041
-  tps: 1442.175788415949
+  dps: 943.1622778391163
+  tps: 703.961699163571
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 2001.865393003907
-  tps: 1455.6409109305723
+  dps: 951.6239981820431
+  tps: 709.969520607049
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Guardian'sAlchemistStone-35748"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HandofJustice-11815"
  value: {
-  dps: 1974.822023393545
-  tps: 1436.8618503073824
+  dps: 938.8467805949821
+  tps: 701.3194279204035
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartrazor-29962"
  value: {
-  dps: 2021.1167027211354
-  tps: 1469.268773132376
+  dps: 960.7648059249852
+  tps: 716.4189264071085
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1977.8814018346911
-  tps: 1438.7116628649558
+  dps: 940.9253593976276
+  tps: 702.4728727346404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1972.5440204651397
-  tps: 1434.8174853307657
+  dps: 692.000510959039
+  tps: 525.6315935814343
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndestructibleAlchemist'sStone-44323"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1969.001913866359
-  tps: 1432.587868130536
+  dps: 937.1772261083814
+  tps: 699.9923398223723
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LivingRootoftheWildheart-30664"
  value: {
-  dps: 1979.1617336858346
-  tps: 1439.5213128147411
+  dps: 941.5139087512231
+  tps: 702.7913571111662
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 2003.1717906392628
-  tps: 1456.6587946802936
+  dps: 623.787567942137
+  tps: 477.2959965653349
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MalorneHarness"
  value: {
-  dps: 1692.655215332294
-  tps: 1236.0176933455316
+  dps: 819.4958153485395
+  tps: 616.074519357066
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MalorneRegalia"
  value: {
-  dps: 1391.0015266643923
-  tps: 1021.709733976925
+  dps: 685.567783670617
+  tps: 520.8517764513444
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1363.1612870874126
-  tps: 1001.7150007065693
+  dps: 676.800647421281
+  tps: 514.398946543616
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 2019.4501515715372
-  tps: 1470.7834939870497
+  dps: 958.6240967208306
+  tps: 717.5969950430485
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1997.1455732502855
-  tps: 1452.289838905501
+  dps: 949.6414970300341
+  tps: 708.5619447891223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MercurialAlchemistStone-44322"
  value: {
-  dps: 1958.5413526404561
-  tps: 1425.502845067544
+  dps: 933.2178967562368
+  tps: 697.5231913897479
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightyAlchemist'sStone-44324"
  value: {
-  dps: 1971.5558978740394
-  tps: 1433.9856119879087
+  dps: 937.690041940981
+  tps: 699.9408542754375
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NordrassilHarness"
  value: {
-  dps: 1685.578989441236
-  tps: 1230.5907401052284
+  dps: 816.2309765523376
+  tps: 613.3536509541107
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NordrassilRegalia"
  value: {
-  dps: 1403.3288675521696
-  tps: 1030.4100630335902
+  dps: 689.5257207209188
+  tps: 523.6098287834026
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PrimalIntent"
  value: {
-  dps: 1883.7164226832442
-  tps: 1372.254721655295
+  dps: 898.9641440205854
+  tps: 673.0806038048074
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Redeemer'sAlchemistStone-35750"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1844.1512526739566
-  tps: 1343.590929407956
+  dps: 881.6357789120937
+  tps: 660.2049430370332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 2016.1660343875753
-  tps: 1465.7943663129765
+  dps: 958.1353182500408
+  tps: 714.5925578553273
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1970.5932607895272
-  tps: 1433.4324459610807
+  dps: 943.6464835210187
+  tps: 704.30023410044
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1943.662513706529
-  tps: 1414.3168666294341
+  dps: 925.5641025347775
+  tps: 691.4669946974906
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1960.5487931959372
-  tps: 1426.3008739696318
+  dps: 933.602015927429
+  tps: 697.1686621089913
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1967.4907675195677
-  tps: 1431.2797912080289
+  dps: 936.5583634041328
+  tps: 699.3177842860699
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofContempt-34472"
  value: {
-  dps: 2001.389511452446
-  tps: 1455.3965361602518
+  dps: 952.077267776222
+  tps: 710.3848431501334
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 1959.6676998385585
-  tps: 1425.7507730403731
+  dps: 934.1604256697528
+  tps: 697.6406083805207
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 2008.6587008074828
-  tps: 1460.6562052939275
+  dps: 954.8801330559692
+  tps: 712.4734221903527
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1961.4366771780537
-  tps: 1427.0359083587432
+  dps: 933.5115082323904
+  tps: 697.2090384073222
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1967.6982780133317
-  tps: 1431.8388044799901
+  dps: 936.1054096137113
+  tps: 699.4078679162599
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1994.7965078757518
-  tps: 1450.6220024895824
+  dps: 948.5036771282705
+  tps: 707.7540926588706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1645.7174866940495
-  tps: 1202.586435760615
+  dps: 797.2193595955085
+  tps: 600.152765520651
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1661.4517021693446
-  tps: 1213.9023552387987
+  dps: 799.9160359223555
+  tps: 602.2120322034356
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 2015.49474424459
-  tps: 1465.3177503114566
+  dps: 957.8325847345299
+  tps: 714.377617059314
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1998.7124906699398
-  tps: 1453.4023502734562
+  dps: 950.2642468467361
+  tps: 709.004097158981
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1955.5366800899988
-  tps: 1422.747524761697
+  dps: 930.8770229280678
+  tps: 695.2391681767263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1960.5487931959372
-  tps: 1426.3008739696318
+  dps: 933.602015927429
+  tps: 697.1686621089913
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheTwinStars"
  value: {
-  dps: 1942.4229702476941
-  tps: 1413.666824527542
+  dps: 926.7074489420322
+  tps: 692.508804400522
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartHarness"
  value: {
-  dps: 1850.5241543534719
-  tps: 1348.3599199768576
+  dps: 329.72583246575886
+  tps: 268.5931114365822
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartRegalia"
  value: {
-  dps: 1318.3166896878347
-  tps: 970.6847434518033
+  dps: 650.8244130752687
+  tps: 496.7652270568815
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1963.368272209348
-  tps: 1428.307955166436
+  dps: 938.7086150474177
+  tps: 700.7995985814646
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1981.3466782991413
-  tps: 1441.1309507341828
+  dps: 942.269662874094
+  tps: 703.3862697823995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WastewalkerArmor"
  value: {
-  dps: 1514.5177088372373
-  tps: 1108.89673087639
+  dps: 743.1212887005204
+  tps: 561.2052725793205
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WindhawkArmor"
  value: {
-  dps: 1804.5830653798753
-  tps: 1315.1735812704183
+  dps: 863.8911817550768
+  tps: 647.2823438968114
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1978.9194104130468
-  tps: 1439.5858739421144
+  dps: 942.7341923405223
+  tps: 703.894369110622
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofSpellfire"
  value: {
-  dps: 1748.5820510656677
-  tps: 1275.5242171444959
+  dps: 838.3736200607113
+  tps: 629.2762311309768
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1961.7912890662578
-  tps: 1427.287682799368
+  dps: 933.6589420408217
+  tps: 697.3137164113084
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 1983.4977609892505
-  tps: 1442.7023350998015
+  dps: 943.6370300370455
+  tps: 704.4012161237291
  }
 }
 dps_results: {
  key: "TestFeral-SelfDrums-DPS"
  value: {
-  dps: 1995.6398575675983
-  tps: 1451.1714093863668
+  dps: 949.168036953953
+  tps: 708.1764167506776
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1998.7124906699398
-  tps: 2105.415506331624
+  dps: 950.2642468467361
+  tps: 1361.017253217149
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1998.7124906699398
-  tps: 1453.4023502734562
+  dps: 950.2642468467361
+  tps: 709.004097158981
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2203.0118225159295
-  tps: 1600.4707823751346
+  dps: 1030.4358017309087
+  tps: 767.9418076177698
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 716.9641043351003
-  tps: 511.55621007792115
+  dps: 430.1440732629453
+  tps: 307.9139880166913
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 716.9641043351003
-  tps: 511.55621007792115
+  dps: 430.1440732629453
+  tps: 307.9139880166913
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 874.8621975640467
-  tps: 624.2761602704732
+  dps: 502.62024420021874
+  tps: 359.98437338215524
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1830.3387345823132
-  tps: 1334.4363046382796
+  dps: 877.1218770761129
+  tps: 657.652335808877
  }
 }

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -47,1074 +47,1074 @@ character_stats_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 742.622573143502
-  tps: 1046.17630024956
+  dps: 346.93466524830313
+  tps: 473.2920502679826
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Alchemist'sStone-13503"
  value: {
-  dps: 733.2376760207615
-  tps: 1031.5058240268108
+  dps: 344.08929191918855
+  tps: 471.1904613312186
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 754.3251315849906
-  tps: 1060.536582333605
+  dps: 353.8721601047792
+  tps: 479.79671156730683
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Assassin'sAlchemistStone-35751"
  value: {
-  dps: 743.9528046882467
-  tps: 1045.9662572293294
+  dps: 350.47068429441185
+  tps: 476.34586715482516
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 738.1403025528462
-  tps: 1038.2041364590293
+  dps: 345.3486025544707
+  tps: 472.62877830182117
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 729.1316511003129
-  tps: 1027.7365845974457
+  dps: 257.35802764589704
+  tps: 347.11271847690296
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 750.0336453141508
-  tps: 1055.8314025022626
+  dps: 350.9836943903567
+  tps: 477.56788941198255
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 716.5672363480973
-  tps: 1008.9985449872834
+  dps: 338.8738220456565
+  tps: 463.8847183598069
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 729.2655365831629
-  tps: 1025.3950136044357
+  dps: 344.34376392604133
+  tps: 468.6812724278301
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 704.0660937983953
-  tps: 991.336056735018
+  dps: 336.31983129248823
+  tps: 458.32686054621183
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 759.333232136811
-  tps: 1068.5583787330581
+  dps: 355.0969137438522
+  tps: 483.18641353560105
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 753.3617653389175
-  tps: 1060.079174551812
+  dps: 355.1955086103589
+  tps: 484.58321218275813
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 730.9347355697214
-  tps: 1031.788064020938
+  dps: 345.8082285422164
+  tps: 474.93938818652794
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 724.7728294676085
-  tps: 1023.1258554042819
+  dps: 342.5406930951436
+  tps: 468.5212024109548
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 713.1253412479414
-  tps: 1006.6775210370621
+  dps: 337.45471747642483
+  tps: 463.50712532181666
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 751.4885840673684
-  tps: 1058.310942205706
+  dps: 350.09315731937454
+  tps: 478.21134553580663
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 970.5790992234112
+  dps: 333.11597375007244
+  tps: 445.67587657454396
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 716.4805166402294
-  tps: 1006.8155288057812
+  dps: 332.9038764473153
+  tps: 455.144832371771
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 706.6564265727774
-  tps: 994.4737044223759
+  dps: 335.1875008547627
+  tps: 457.1901042939198
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 719.4151274934998
-  tps: 1014.2517818877053
+  dps: 339.73990685013445
+  tps: 465.4068498464409
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 724.1872853201436
-  tps: 1024.2301943996986
+  dps: 340.83264695294037
+  tps: 464.43599905238165
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 737.8575257718394
-  tps: 1037.202755044395
+  dps: 346.78015126815086
+  tps: 471.9906175344238
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 739.3429243520831
-  tps: 1039.0816722588872
+  dps: 350.0374820092878
+  tps: 477.38240523695305
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 737.917988145045
-  tps: 1037.9441697708771
+  dps: 344.4710992865555
+  tps: 470.84018478050757
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 747.4980994742457
-  tps: 1052.848424581708
+  dps: 349.9962446643585
+  tps: 475.5266017030523
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 731.0542736765392
-  tps: 1028.7850422654499
+  dps: 347.7932110477848
+  tps: 471.8064992768224
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 727.5762565015932
-  tps: 1027.2256918711057
+  dps: 344.02714075843403
+  tps: 468.9963364649065
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 711.1108768967447
-  tps: 1000.4070525770175
+  dps: 337.0291977700474
+  tps: 458.5718913411058
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 712.6389139240557
-  tps: 1003.9270650659641
+  dps: 336.09263476879613
+  tps: 458.15117076022267
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Dragonmaw-28438"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Dragonstrike-28439"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 751.4885840673684
-  tps: 1058.310942205706
+  dps: 350.09315731937454
+  tps: 478.21134553580663
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 708.3400116348788
-  tps: 996.4253963414894
+  dps: 335.5571165439606
+  tps: 456.6139066861743
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 704.0660937983953
-  tps: 991.336056735018
+  dps: 336.31983129248823
+  tps: 458.32686054621183
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 708.6297693041623
-  tps: 996.388810378741
+  dps: 333.8625270523546
+  tps: 455.9342814867385
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 738.1304505400185
-  tps: 1037.2773275700044
+  dps: 349.27743449496774
+  tps: 475.5442553953069
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 751.5567264372244
-  tps: 1059.8579164446862
+  dps: 353.04465395840583
+  tps: 479.256705610134
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Guardian'sAlchemistStone-35748"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-HandofJustice-11815"
  value: {
-  dps: 739.4723441076264
-  tps: 1039.727667274172
+  dps: 346.3823740205805
+  tps: 473.8807706662715
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Heartrazor-29962"
  value: {
-  dps: 729.1852887067399
-  tps: 1026.1494422985402
+  dps: 339.80345768167206
+  tps: 465.32388661189134
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 736.9161173302662
-  tps: 1037.5813144864649
+  dps: 344.604379569581
+  tps: 470.01147030299927
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 739.3131130975808
-  tps: 1041.1364530301244
+  dps: 258.4186524210404
+  tps: 348.0350681190791
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 704.0660937983953
-  tps: 991.336056735018
+  dps: 336.31983129248823
+  tps: 458.32686054621183
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 708.6297693041623
-  tps: 996.388810378741
+  dps: 333.8625270523546
+  tps: 455.9342814867385
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IndestructibleAlchemist'sStone-44323"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 712.6073216108514
-  tps: 1000.9537172941547
+  dps: 337.92527395266995
+  tps: 461.2078004778293
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 735.800728788508
-  tps: 1037.1341792671922
+  dps: 343.77488789380135
+  tps: 470.7433513725135
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LivingRootoftheWildheart-30664"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 752.7359442516076
-  tps: 1057.5291702564425
+  dps: 268.0081723813558
+  tps: 358.7469335727209
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MalorneHarness"
  value: {
-  dps: 677.1478825956125
-  tps: 933.2264597214281
+  dps: 319.24654523595325
+  tps: 427.03625643300626
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MalorneRegalia"
  value: {
-  dps: 541.7676908075605
-  tps: 809.258581399508
+  dps: 275.635589464085
+  tps: 401.26089450417254
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 533.8565805422675
-  tps: 795.7774499787735
+  dps: 273.6021051581666
+  tps: 398.8098894212663
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 774.3549654230175
-  tps: 1096.5791974435933
+  dps: 366.41867951682894
+  tps: 500.0305635014453
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 754.9683310259592
-  tps: 1064.212955275938
+  dps: 353.25322238634215
+  tps: 479.83928661205806
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MercurialAlchemistStone-44322"
  value: {
-  dps: 731.2704943695857
-  tps: 1029.0667896056448
+  dps: 344.7002151826513
+  tps: 471.8637962360169
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MightyAlchemist'sStone-44324"
  value: {
-  dps: 733.4901595236335
-  tps: 1034.8414769303427
+  dps: 343.1550675092514
+  tps: 467.30061418234686
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NordrassilHarness"
  value: {
-  dps: 732.1307077637216
-  tps: 979.9672746266225
+  dps: 358.08372781943314
+  tps: 455.5797098506503
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NordrassilRegalia"
  value: {
-  dps: 542.2993925465585
-  tps: 811.3836723911903
+  dps: 279.33457061206997
+  tps: 407.69903923289786
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 713.3203984457067
-  tps: 1001.4608829077356
+  dps: 336.07622591328646
+  tps: 457.0842209611757
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 712.6073216108514
-  tps: 1000.9537172941547
+  dps: 337.92527395266995
+  tps: 461.2078004778293
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 714.5543825753928
-  tps: 1005.2689418577181
+  dps: 337.40638980436484
+  tps: 457.23462557660815
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PrimalIntent"
  value: {
-  dps: 742.7435108365801
-  tps: 1041.1551780230832
+  dps: 347.91036247609173
+  tps: 475.2210446848983
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Redeemer'sAlchemistStone-35750"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 725.8078871750381
-  tps: 1022.51825457813
+  dps: 339.9297706100239
+  tps: 463.7746218496532
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 666.312571588567
-  tps: 988.3528588550937
+  dps: 328.77155232608396
+  tps: 480.78460998647256
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 737.0034492830283
-  tps: 1038.7169246992137
+  dps: 345.31004492427127
+  tps: 471.5387966505647
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 744.5031274107195
-  tps: 1046.5430848418528
+  dps: 353.5832568063833
+  tps: 482.5008278858357
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 714.5066622390844
-  tps: 1008.0234540398367
+  dps: 338.71745207019734
+  tps: 465.3129114191462
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 733.7203605721961
-  tps: 1030.0122359775685
+  dps: 345.212026412163
+  tps: 470.0663861476945
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 728.564116137019
-  tps: 1027.125588893436
+  dps: 343.8840288003761
+  tps: 472.1373549617952
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ShardofContempt-34472"
  value: {
-  dps: 761.1386518125369
-  tps: 1070.285852940676
+  dps: 353.89098899869566
+  tps: 482.8293628283073
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 700.9066623613742
-  tps: 989.4810369544242
+  dps: 329.5651802803032
+  tps: 450.9907333863793
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 732.3951352937995
-  tps: 1029.6993476351984
+  dps: 344.85392134729204
+  tps: 467.38396629378394
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 728.946083067134
-  tps: 1025.1461573062818
+  dps: 341.7068948117265
+  tps: 468.1963090281708
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 731.4229037535777
-  tps: 1030.0616960609937
+  dps: 341.0027676428252
+  tps: 465.7850483535897
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 755.0777887605748
-  tps: 1063.5438333257841
+  dps: 352.2166255828544
+  tps: 481.3766930684537
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 619.4432459138078
-  tps: 948.3407374548707
+  dps: 314.16343801386324
+  tps: 479.6194745591736
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 608.4017143162505
-  tps: 927.9708285755067
+  dps: 308.8118204826192
+  tps: 466.98559830148116
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 714.5543825753928
-  tps: 1005.2689418577181
+  dps: 337.40638980436484
+  tps: 457.23462557660815
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 712.6073216108514
-  tps: 1000.9537172941547
+  dps: 337.92527395266995
+  tps: 461.2078004778293
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 713.3203984457067
-  tps: 1001.4608829077356
+  dps: 336.07622591328646
+  tps: 457.0842209611757
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 719.9855371994544
-  tps: 1010.6818583742144
+  dps: 334.1827599138549
+  tps: 452.7240084731321
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 733.210519207849
-  tps: 1029.9384582262417
+  dps: 344.4634030183775
+  tps: 468.03850679528676
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TheNightBlade-31331"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 722.687477179793
-  tps: 1014.7484528137729
+  dps: 341.38190910189473
+  tps: 465.54443282806375
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 738.6510030698657
-  tps: 1040.1531302299234
+  dps: 341.9275230691101
+  tps: 466.9628893989534
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TheTwinStars"
  value: {
-  dps: 698.4163802357243
-  tps: 982.6064805380589
+  dps: 330.2924664585927
+  tps: 450.5270782887017
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartHarness"
  value: {
-  dps: 779.9545888733726
-  tps: 1114.801493724985
+  dps: 123.25771397815802
+  tps: 160.7967296165931
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartRegalia"
  value: {
-  dps: 529.3873752127067
-  tps: 795.708808412862
+  dps: 270.5044654307731
+  tps: 396.98727076226515
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 706.0523831428841
-  tps: 994.8280140633891
+  dps: 337.4866388678079
+  tps: 458.08653710091386
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 709.6170753069325
-  tps: 999.0863346703688
+  dps: 336.25714518782144
+  tps: 459.51936473569816
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 730.5058451036344
-  tps: 1029.2508030768738
+  dps: 350.514364360076
+  tps: 478.52309642023704
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 705.3692488072417
-  tps: 990.170271316406
+  dps: 333.11597375007244
+  tps: 454.567255008038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 744.1034761219022
-  tps: 1046.9095891604804
+  dps: 348.5917423208706
+  tps: 477.20894836330905
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WastewalkerArmor"
  value: {
-  dps: 615.6464429110328
-  tps: 913.7171181459652
+  dps: 310.3242507428761
+  tps: 452.32385997715085
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WindhawkArmor"
  value: {
-  dps: 626.0387537170245
-  tps: 956.2137828938149
+  dps: 321.5943099603753
+  tps: 487.92348480435635
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WorldBreaker-30090"
  value: {
-  dps: 731.7402029156598
-  tps: 1029.905151250548
+  dps: 341.3084505161528
+  tps: 464.78532135916714
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WrathofSpellfire"
  value: {
-  dps: 619.0811382236371
-  tps: 929.3430341889779
+  dps: 317.53045201959134
+  tps: 472.24396625649126
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 725.3350107016267
-  tps: 1022.6051593122522
+  dps: 344.0888652139308
+  tps: 471.6322141520825
  }
 }
 dps_results: {
  key: "TestFeralTank-Average-Default"
  value: {
-  dps: 793.9773583174032
-  tps: 1191.4365987809201
-  dtps: 834.2323649268664
+  dps: 399.8294741392602
+  tps: 617.6762546866712
+  dtps: 756.5737900783956
  }
 }
 dps_results: {
  key: "TestFeralTank-SelfDrums-DPS"
  value: {
-  dps: 792.11295117472
-  tps: 1190.8919055523577
-  dtps: 832.4023171030592
+  dps: 398.1764394074324
+  tps: 617.4479908156452
+  dtps: 755.9436742282726
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1037.899040205923
-  tps: 1935.3409270301781
+  dps: 479.43029007429845
+  tps: 1085.6056340041064
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 837.425800264023
-  tps: 1175.855034748034
+  dps: 386.70708695247026
+  tps: 525.4414872104437
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 919.7689043063164
-  tps: 1333.5424029206906
+  dps: 421.9284892324547
+  tps: 596.9215304031725
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 293.340914997144
-  tps: 683.4513116141404
+  dps: 175.88908776513625
+  tps: 488.3078740772398
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 291.8667523470859
-  tps: 444.8334165114024
+  dps: 174.18620185140242
+  tps: 264.60740033788045
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 269.63275234709096
-  tps: 423.7734106484141
+  dps: 162.03045014050178
+  tps: 259.3656341717761
  }
 }
 dps_results: {
  key: "TestFeralTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 925.1246604580381
-  tps: 1380.3997819258427
-  dtps: 777.8535834469325
+  dps: 456.09371370322975
+  tps: 693.2968890074294
+  dtps: 705.4174201334977
  }
 }

--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -47,1484 +47,1484 @@ character_stats_results: {
 dps_results: {
  key: "TestHunter-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1655.4567954265074
-  tps: 1167.3468859510729
+  dps: 353.1983208554203
+  tps: 127.08182691948845
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Alchemist'sStone-13503"
  value: {
-  dps: 1643.6893419578819
-  tps: 1156.3972200556955
+  dps: 352.7672216347009
+  tps: 126.97357025807078
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 1655.5587991429973
-  tps: 1168.111203877135
+  dps: 353.0353012989687
+  tps: 127.28401956360763
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Assassin'sAlchemistStone-35751"
  value: {
-  dps: 1652.3732962846902
-  tps: 1165.5039264266725
+  dps: 352.6493466884451
+  tps: 127.18198527838253
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1146.9445480612885
+  dps: 353.07319040291253
+  tps: 126.92796229010372
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1655.4236312316907
-  tps: 1164.7585747774147
+  dps: 352.0567328175497
+  tps: 124.74151451740175
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1634.804226115692
-  tps: 1152.960790680814
+  dps: 345.4618730916846
+  tps: 122.46234674556923
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1670.582338682174
-  tps: 1176.8834728801073
+  dps: 356.6963141256784
+  tps: 127.86545089914848
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 1630.1124536427735
-  tps: 1147.629979716737
+  dps: 351.10749626312196
+  tps: 127.77069400009641
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1642.06051167207
-  tps: 1154.5669606193474
+  dps: 355.9108753918483
+  tps: 129.85417792751997
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1650.2927439278
-  tps: 1157.8211119242699
+  dps: 354.87359919524346
+  tps: 126.56738928251642
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1646.249307267424
-  tps: 1133.0432716963305
+  dps: 842.2758093157099
+  tps: 604.0081143842215
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BeastLordArmor"
  value: {
-  dps: 1526.0325357903237
-  tps: 1049.2031181562213
+  dps: 347.1492268020944
+  tps: 126.04164080522233
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1671.8147046275158
-  tps: 1180.7795098627028
+  dps: 355.4724813975787
+  tps: 127.95961602552119
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 1704.872749622955
-  tps: 1217.7118144198578
+  dps: 359.04979990998567
+  tps: 133.7577044990931
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1662.2714025194693
-  tps: 1173.105127000451
+  dps: 355.8067984880184
+  tps: 129.21732163995614
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 1661.2839814387316
-  tps: 1172.2261241133492
+  dps: 354.0283748592875
+  tps: 127.48642200925141
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1640.6781583318307
-  tps: 1152.6350422596122
+  dps: 350.8237691806093
+  tps: 124.75815830155781
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1667.3587711577761
-  tps: 1177.277112375828
+  dps: 354.8258093449574
+  tps: 127.78114935226533
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1637.9845832596527
-  tps: 1148.9731125448616
+  dps: 352.5410120169729
+  tps: 125.97950045350112
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1661.2839814387316
-  tps: 1172.2261241133492
+  dps: 354.0283748592875
+  tps: 127.48642200925141
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1124.5391218960258
+  dps: 353.07319040291253
+  tps: 124.9228678402646
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1146.9445480612885
+  dps: 353.07319040291253
+  tps: 126.92796229010372
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1650.0354489666922
-  tps: 1163.3020515874557
+  dps: 353.90326523831254
+  tps: 128.49252868023441
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1636.8877585569353
-  tps: 1148.67689639791
+  dps: 353.1298200316912
+  tps: 126.9845919188824
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1653.7819497813437
-  tps: 1165.9086946412333
+  dps: 353.17236955416064
+  tps: 127.17818309115287
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1663.6265199445395
-  tps: 1175.9401063412256
+  dps: 352.8205199276297
+  tps: 126.96053603767747
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1633.9836868962514
-  tps: 1147.4346245160752
+  dps: 351.619214793412
+  tps: 126.30769933358287
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1650.4722456484608
-  tps: 1163.4292043928192
+  dps: 352.5503918446947
+  tps: 126.997754279279
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1637.874798268351
-  tps: 1153.8420125564576
+  dps: 350.5841831087749
+  tps: 126.50964166576401
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1654.5579460954373
-  tps: 1167.3352982804963
+  dps: 352.8250027317119
+  tps: 127.18417472697935
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1636.3284609046316
-  tps: 1149.0475555190555
+  dps: 348.3646720142094
+  tps: 122.73949043666335
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DemonStalkerArmor"
  value: {
-  dps: 1553.7387310941067
-  tps: 1071.0916209520362
+  dps: 796.5176209428234
+  tps: 571.4308342973677
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DesolationBattlegear"
  value: {
-  dps: 1484.9593715313
-  tps: 1017.7787972087681
+  dps: 762.1524829773434
+  tps: 546.4377525401537
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Despair-28573"
  value: {
-  dps: 1600.164698683612
-  tps: 1121.0493037615865
+  dps: 347.7956549118313
+  tps: 126.1153203135519
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1635.7617820001053
-  tps: 1148.077768481511
+  dps: 353.3169904054066
+  tps: 127.38946121621687
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1647.3181105590515
-  tps: 1156.6523240437878
+  dps: 353.3916668745219
+  tps: 126.08486681466638
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Devastation-30316"
  value: {
-  dps: 1654.248761897412
-  tps: 1167.1695449081728
+  dps: 355.44496551959287
+  tps: 129.88725150769056
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1661.2839814387316
-  tps: 1172.2261241133492
+  dps: 354.0283748592875
+  tps: 127.48642200925141
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1661.2839814387316
-  tps: 1172.2261241133492
+  dps: 354.0283748592875
+  tps: 127.48642200925141
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1661.2839814387316
-  tps: 1172.2261241133492
+  dps: 354.0283748592875
+  tps: 127.48642200925141
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1146.9445480612885
+  dps: 353.07319040291253
+  tps: 126.92796229010372
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1638.2838048005697
-  tps: 1148.6395162769973
+  dps: 354.5567213696254
+  tps: 127.66983782561391
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1638.2838048005697
-  tps: 1148.6395162769973
+  dps: 354.5567213696254
+  tps: 127.66983782561391
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1661.2839814387316
-  tps: 1172.2261241133492
+  dps: 354.0283748592875
+  tps: 127.48642200925141
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 1661.2839814387316
-  tps: 1172.2261241133492
+  dps: 354.0283748592875
+  tps: 127.48642200925141
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1636.1375821979568
-  tps: 1148.2643270578462
+  dps: 352.61363993034064
+  tps: 126.61945346733293
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1645.5801495969824
-  tps: 1157.893735993669
+  dps: 352.2434504020143
+  tps: 126.38346651206211
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1639.5277288747602
-  tps: 1151.1035539405718
+  dps: 352.74848915514013
+  tps: 126.5347961351705
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1146.9445480612885
+  dps: 353.07319040291253
+  tps: 126.92796229010372
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1146.9445480612885
+  dps: 353.07319040291253
+  tps: 126.92796229010372
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FelstalkerArmor"
  value: {
-  dps: 1610.8961370055217
-  tps: 1126.6254284806457
+  dps: 824.9456989788362
+  tps: 600.6783111362475
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1626.1269996517287
-  tps: 1142.7872034154998
+  dps: 351.70301856502823
+  tps: 127.71623188248928
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1647.2671050748822
-  tps: 1161.240299512444
+  dps: 352.1089617568858
+  tps: 127.05531639188102
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1663.996580404539
-  tps: 1175.6346964581878
+  dps: 354.29477032316527
+  tps: 128.09455442465782
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1146.9445480612885
+  dps: 353.07319040291253
+  tps: 126.92796229010372
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1146.9445480612885
+  dps: 353.07319040291253
+  tps: 126.92796229010372
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GlaiveofthePit-28774"
  value: {
-  dps: 1600.164698683612
-  tps: 1121.0493037615865
+  dps: 347.7956549118313
+  tps: 126.1153203135519
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 1701.1233523772198
-  tps: 1204.182936962644
+  dps: 327.821059540548
+  tps: 95.46158640173176
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Guardian'sAlchemistStone-35748"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HandofJustice-11815"
  value: {
-  dps: 1628.0741374085137
-  tps: 1145.2999733767574
+  dps: 349.4596087457657
+  tps: 126.00307590632674
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Heartrazor-29962"
  value: {
-  dps: 1675.5240560734042
-  tps: 1183.0334546204137
+  dps: 354.50679230021325
+  tps: 126.27020331278005
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1643.1255717476076
-  tps: 1155.1022543168008
+  dps: 352.71655770573324
+  tps: 126.70717624550832
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1639.9167324350458
-  tps: 1159.891979466171
+  dps: 342.0438621924891
+  tps: 119.92591980317293
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1146.9445480612885
+  dps: 353.07319040291253
+  tps: 126.92796229010372
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1645.5801495969824
-  tps: 1157.893735993669
+  dps: 352.2434504020143
+  tps: 126.38346651206211
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1639.5277288747602
-  tps: 1151.1035539405718
+  dps: 352.74848915514013
+  tps: 126.5347961351705
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IndestructibleAlchemist'sStone-44323"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1684.578858738083
-  tps: 1194.8876613154573
+  dps: 358.4980102151028
+  tps: 133.63355741423723
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1663.2688420573004
-  tps: 1173.8863022896955
+  dps: 355.6080985801855
+  tps: 128.8350262077223
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1646.551913613645
-  tps: 1156.3884244393882
+  dps: 354.59211119147966
+  tps: 127.48810387279487
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 1614.1059050714
-  tps: 1131.4598611220208
+  dps: 350.2409499775959
+  tps: 126.74328157103523
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1650.9411918453156
-  tps: 1166.6049715062668
+  dps: 351.29898419710787
+  tps: 126.99649010885794
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-LionheartChampion-28429"
  value: {
-  dps: 1627.5914405238145
-  tps: 1143.9635533396752
+  dps: 350.22945062568937
+  tps: 126.37858510254405
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1627.5914405238145
-  tps: 1143.9635533396752
+  dps: 350.22945062568937
+  tps: 126.37858510254405
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1661.7447461527302
-  tps: 1174.5877027231145
+  dps: 343.22355205812084
+  tps: 117.58955798681787
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1383.443781470458
-  tps: 932.2653321362833
+  dps: 711.2408519388242
+  tps: 503.40324384361224
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 1755.5131590802494
-  tps: 1264.8980954168512
+  dps: 357.5263154657495
+  tps: 129.9976961607625
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1656.990157635375
-  tps: 1175.1467222004962
+  dps: 350.7441729157064
+  tps: 127.74464656959096
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MercurialAlchemistStone-44322"
  value: {
-  dps: 1628.5580100050588
-  tps: 1145.0873038222237
+  dps: 349.7971582442094
+  tps: 126.00404745660325
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MightyAlchemist'sStone-44324"
  value: {
-  dps: 1636.3830616706982
-  tps: 1154.2072179352856
+  dps: 348.5811777891322
+  tps: 125.4688688173217
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1146.9445480612885
+  dps: 353.07319040291253
+  tps: 126.92796229010372
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NetherscaleArmor"
  value: {
-  dps: 1617.185616667496
-  tps: 1128.5442237127377
+  dps: 827.9504224280088
+  tps: 600.4171962987305
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NetherstrikeArmor"
  value: {
-  dps: 1567.846824719577
-  tps: 1084.3571866545808
+  dps: 803.1130331555189
+  tps: 577.9027547893304
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1644.3811510625344
-  tps: 1154.5895908435596
+  dps: 354.30279294603827
+  tps: 127.38141023799658
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1646.551913613645
-  tps: 1156.3884244393882
+  dps: 354.59211119147966
+  tps: 127.48810387279487
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1641.6676978736455
-  tps: 1152.3410488487739
+  dps: 353.94114513923654
+  tps: 127.24804319449868
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1146.9445480612885
+  dps: 353.07319040291253
+  tps: 126.92796229010372
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1146.9445480612885
+  dps: 353.07319040291253
+  tps: 126.92796229010372
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1146.9445480612885
+  dps: 353.07319040291253
+  tps: 126.92796229010372
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PrimalIntent"
  value: {
-  dps: 1629.493571306366
-  tps: 1139.7303396412556
+  dps: 834.0378216520189
+  tps: 607.0888522890199
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Redeemer'sAlchemistStone-35750"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1667.481471550647
-  tps: 1176.298308844554
+  dps: 354.5998546729004
+  tps: 127.01822677643129
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1661.2839814387316
-  tps: 1172.2261241133492
+  dps: 354.0283748592875
+  tps: 127.48642200925141
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1647.4869345557447
-  tps: 1154.9092175536234
+  dps: 356.15290488201026
+  tps: 127.40522319823475
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RiftStalkerArmor"
  value: {
-  dps: 1640.5044231781833
-  tps: 1147.7351047846735
+  dps: 839.5969169661862
+  tps: 610.0609225783141
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1593.449395695651
-  tps: 1108.382441190594
+  dps: 816.2362096569973
+  tps: 591.7862587029333
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1675.642575320109
-  tps: 1184.1648236428446
+  dps: 355.91322000723454
+  tps: 128.18305027455708
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1653.962917879962
-  tps: 1167.7311166803174
+  dps: 364.6508641547549
+  tps: 139.4693260927258
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1609.7542634782262
-  tps: 1130.0567158038905
+  dps: 347.0632873391205
+  tps: 125.11743511863277
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1639.9092133440718
-  tps: 1156.6701406024679
+  dps: 349.49451557862557
+  tps: 125.79171756884035
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1631.3242383350675
-  tps: 1147.9833713935195
+  dps: 349.3616411016869
+  tps: 125.62521370639405
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1647.1798166679064
-  tps: 1161.003308682462
+  dps: 351.85596306834486
+  tps: 126.72881079744944
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 1633.1371903946247
-  tps: 1146.0016292800196
+  dps: 353.1982497860258
+  tps: 127.44550338664872
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 1658.8833364701557
-  tps: 1169.940376253289
+  dps: 355.2558107818828
+  tps: 128.7307679581093
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1630.91075884287
-  tps: 1144.4985565583995
+  dps: 349.269631490284
+  tps: 123.99826187152956
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1627.7325215501226
-  tps: 1144.6681716332935
+  dps: 351.33563727295484
+  tps: 127.74232883675114
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 1600.164698683612
-  tps: 1121.0493037615865
+  dps: 347.7956549118313
+  tps: 126.1153203135519
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1657.8543824534315
-  tps: 1169.4189905989997
+  dps: 353.5646196273553
+  tps: 127.32830986494785
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1510.270377181547
-  tps: 1036.5953093739386
+  dps: 774.5061933388563
+  tps: 555.5735043830686
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StormGauntlets-12632"
  value: {
-  dps: 1593.640975649909
-  tps: 1108.2042724632227
+  dps: 816.1842125293718
+  tps: 591.4220030947549
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1437.8956897156281
-  tps: 978.2746835390928
+  dps: 738.3113927530262
+  tps: 526.1020963603273
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1641.6676978736455
-  tps: 1152.3410488487739
+  dps: 353.94114513923654
+  tps: 127.24804319449868
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1646.551913613645
-  tps: 1156.3884244393882
+  dps: 354.59211119147966
+  tps: 127.48810387279487
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1146.9445480612885
+  dps: 353.07319040291253
+  tps: 126.92796229010372
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1644.3811510625344
-  tps: 1154.5895908435596
+  dps: 354.30279294603827
+  tps: 127.38141023799658
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1640.58231659809
-  tps: 1151.4416320508599
+  dps: 353.79648601651576
+  tps: 127.1946963770995
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1675.0903217092866
-  tps: 1183.7056428917106
+  dps: 355.8407259630827
+  tps: 128.15625687973764
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TalonofAl'ar-30448"
  value: {
-  dps: 1646.688330132777
-  tps: 1164.8448946978986
+  dps: 349.46304381759916
+  tps: 126.46351747148381
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1146.9445480612885
+  dps: 353.07319040291253
+  tps: 126.92796229010372
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheBladefist-29348"
  value: {
-  dps: 1600.164698683612
-  tps: 1121.0493037615865
+  dps: 347.7956549118313
+  tps: 126.1153203135519
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheDecapitator-28767"
  value: {
-  dps: 1673.145350200448
-  tps: 1180.1840565512089
+  dps: 360.1510880792098
+  tps: 131.71889071702606
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheFistsofFury"
  value: {
-  dps: 1643.7705040171597
-  tps: 1157.301709403366
+  dps: 353.66579790536866
+  tps: 128.34097891620493
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1625.2535188682427
-  tps: 1141.7911014834538
+  dps: 349.0009649832416
+  tps: 125.23596693102841
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1661.2839814387316
-  tps: 1172.2261241133492
+  dps: 354.0283748592875
+  tps: 127.48642200925141
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1622.5516013002916
-  tps: 1140.708165865413
+  dps: 348.73466830424763
+  tps: 125.73514195813212
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1634.470066439914
-  tps: 1149.1689097701815
+  dps: 351.80784196684647
+  tps: 127.07695396154458
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheTwinStars"
  value: {
-  dps: 1607.4693061981495
-  tps: 1124.5693703516988
+  dps: 351.47283653282943
+  tps: 127.52177064666324
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 1663.021423504394
-  tps: 1170.6859104769383
+  dps: 355.6740746094831
+  tps: 127.51264506402633
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1638.315380592211
-  tps: 1151.2335474142906
+  dps: 353.9796133261396
+  tps: 128.37698411743554
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1649.736690348369
-  tps: 1160.2219757745875
+  dps: 353.617724507688
+  tps: 126.84345623729715
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1630.5305909010085
-  tps: 1148.7120531897292
+  dps: 356.5641999303041
+  tps: 133.53297134961417
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1146.9445480612885
+  dps: 353.07319040291253
+  tps: 126.92796229010372
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1146.9445480612885
+  dps: 353.07319040291253
+  tps: 126.92796229010372
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1146.9445480612885
+  dps: 353.07319040291253
+  tps: 126.92796229010372
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1635.1554102203131
-  tps: 1146.9445480612885
+  dps: 353.07319040291253
+  tps: 126.92796229010372
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1648.029863106653
-  tps: 1161.7903654167794
+  dps: 351.83869073605587
+  tps: 126.67979756997362
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1688.5496310986696
-  tps: 1191.2841304149108
+  dps: 360.01617109420556
+  tps: 129.41618616594292
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WastewalkerArmor"
  value: {
-  dps: 1443.7326794282699
-  tps: 981.6331177140678
+  dps: 740.1744253071724
+  tps: 525.9657097226535
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WindhawkArmor"
  value: {
-  dps: 1569.7251191894945
-  tps: 1087.5065729065898
+  dps: 804.0269467581458
+  tps: 578.7865909286521
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1600.164698683612
-  tps: 1121.0493037615865
+  dps: 347.7956549118313
+  tps: 126.1153203135519
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WrathofSpellfire"
  value: {
-  dps: 1532.4775289186616
-  tps: 1058.0182397220792
+  dps: 785.5801076664361
+  tps: 566.3165787537446
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1632.630671497148
-  tps: 1146.5272154881607
+  dps: 351.3489293286345
+  tps: 126.28223850776014
  }
 }
 dps_results: {
  key: "TestHunter-Average-Default"
  value: {
-  dps: 1663.8837661953883
-  tps: 1174.2582650230322
+  dps: 354.669217850097
+  tps: 127.84549649748811
  }
 }
 dps_results: {
  key: "TestHunter-SelfDrums-DPS"
  value: {
-  dps: 1645.39173346412
-  tps: 1155.9986645978258
+  dps: 354.1390733785426
+  tps: 126.87435041054115
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1801.8525127465512
-  tps: 1843.5901763869742
+  dps: 347.474831407167
+  tps: 639.8158559378759
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1623.07588488738
-  tps: 1160.0340265763266
+  dps: 339.3651942311034
+  tps: 125.57373803758736
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1990.1646686067147
-  tps: 1416.6457446685883
+  dps: 402.6858506997502
+  tps: 133.30491443160562
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 760.3874360505464
-  tps: 750.3417656160117
+  dps: 196.63757696612274
+  tps: 284.44009679287115
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 693.3186313717276
-  tps: 508.3538916798085
+  dps: 191.91158133497564
+  tps: 103.2449167065796
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1073.5365263869123
-  tps: 832.0712254300155
+  dps: 236.4000144075384
+  tps: 115.69896402842193
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-French-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1719.2138105835984
-  tps: 1818.3677386882614
+  dps: 500.33186962043413
+  tps: 791.9534207335969
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-French-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1597.8113056264742
-  tps: 1147.4954836904685
+  dps: 510.5569022378939
+  tps: 269.50847354251994
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-French-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2008.3831388693739
-  tps: 1444.6496189607697
+  dps: 595.9926585198114
+  tps: 287.8978586187302
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-French-NoBuffs-LongMultiTarget"
  value: {
-  dps: 691.8629190170941
-  tps: 699.1350092568962
+  dps: 243.39072101729008
+  tps: 324.2293637712957
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-French-NoBuffs-LongSingleTarget"
  value: {
-  dps: 667.7559132538403
-  tps: 492.59830241178855
+  dps: 246.3285258473121
+  tps: 144.22596156966623
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-French-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1038.8621641228349
-  tps: 801.9718662552243
+  dps: 350.80310974446826
+  tps: 210.15069973222398
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-MeleeWeave-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2015.1454006012814
-  tps: 2181.8204974603645
+  dps: 468.23334495868113
+  tps: 836.8528056344534
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-MeleeWeave-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1885.658617771617
-  tps: 1423.8100677031023
+  dps: 468.3052088701229
+  tps: 223.73718108384253
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-MeleeWeave-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2317.4995156288883
-  tps: 1745.5087441109247
+  dps: 547.6319688901854
+  tps: 237.93051546750743
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-MeleeWeave-NoBuffs-LongMultiTarget"
  value: {
-  dps: 785.688907889153
-  tps: 786.9356063443116
+  dps: 200.40328494068916
+  tps: 278.1731952550863
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-MeleeWeave-NoBuffs-LongSingleTarget"
  value: {
-  dps: 767.7229421535699
-  tps: 587.0087426024152
+  dps: 206.61189116489342
+  tps: 102.48063124600755
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-MeleeWeave-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1164.072908486475
-  tps: 923.7225806503683
+  dps: 310.19246702124633
+  tps: 166.43892908953836
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1832.08354983322
-  tps: 2313.50828249569
+  dps: 360.2416747000199
+  tps: 950.2436055582864
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1648.7862326116056
-  tps: 1400.6986087834314
+  dps: 354.6167350163376
+  tps: 229.18663377991356
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2080.077747509356
-  tps: 1778.3910320860355
+  dps: 402.0201938253302
+  tps: 247.22700337539078
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 727.2174099046726
-  tps: 817.5089353659575
+  dps: 139.65727591127924
+  tps: 282.6109042130858
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 702.159049144203
-  tps: 589.1471724459657
+  dps: 136.30736550657983
+  tps: 74.21253462369877
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1065.8818308401944
-  tps: 922.072905795171
+  dps: 224.56984105214048
+  tps: 142.21384159731878
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1842.838032985396
-  tps: 1862.6779130428827
+  dps: 358.8713733300451
+  tps: 642.0294206355866
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1661.2839814387316
-  tps: 1172.2261241133492
+  dps: 354.0283748592875
+  tps: 127.48642200925141
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2062.2140079332285
-  tps: 1456.0852089069865
+  dps: 420.86255327950863
+  tps: 135.48206615789732
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 781.6752286145714
-  tps: 758.8707605718139
+  dps: 205.8613656508677
+  tps: 286.734718540529
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 710.0674951359248
-  tps: 512.4801178468216
+  dps: 200.5670685964718
+  tps: 105.50761676949159
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1115.0405424521382
-  tps: 851.5544129367289
+  dps: 261.6802679855728
+  tps: 129.96340213100288
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-French-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1761.1338425437339
-  tps: 1831.1319804652092
+  dps: 516.3122708466153
+  tps: 791.3083295487371
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-French-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1637.5859443866932
-  tps: 1155.8541650605862
+  dps: 524.7012118249485
+  tps: 269.12774849155784
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-French-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2078.609568502679
-  tps: 1475.8171337889812
+  dps: 623.4208977087609
+  tps: 290.4047547818562
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-French-NoBuffs-LongMultiTarget"
  value: {
-  dps: 709.1484877686402
-  tps: 703.7178690467922
+  dps: 251.17485386301524
+  tps: 323.90208662860374
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-French-NoBuffs-LongSingleTarget"
  value: {
-  dps: 687.3316548911904
-  tps: 500.1487975002073
+  dps: 255.63295112816417
+  tps: 147.56632412594882
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-French-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1065.3631616353662
-  tps: 819.286051287601
+  dps: 364.9668917178817
+  tps: 216.6106744192165
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-MeleeWeave-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2063.3660545302105
-  tps: 2201.8822424436557
+  dps: 483.9149712239828
+  tps: 838.0239103929737
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-MeleeWeave-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1928.175361726195
-  tps: 1439.6135530896822
+  dps: 485.00926809582495
+  tps: 224.21851832101726
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-MeleeWeave-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2400.131773725726
-  tps: 1789.3777838798296
+  dps: 562.4100730977347
+  tps: 233.92326250552455
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-MeleeWeave-NoBuffs-LongMultiTarget"
  value: {
-  dps: 805.2819147179497
-  tps: 794.2506900031817
+  dps: 209.95691518516608
+  tps: 279.1614373417845
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-MeleeWeave-NoBuffs-LongSingleTarget"
  value: {
-  dps: 788.8887754157305
-  tps: 596.8916758328073
+  dps: 213.20468714705987
+  tps: 101.20797912859742
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-MeleeWeave-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1194.6773759516338
-  tps: 934.4797424814138
+  dps: 313.4283795591857
+  tps: 158.6216747665166
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1860.709291300093
-  tps: 2317.3237579958286
+  dps: 369.4885245247338
+  tps: 947.001070819909
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1688.7679099794377
-  tps: 1424.4000852522763
+  dps: 366.35748029406574
+  tps: 231.7870732147375
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2136.775160220021
-  tps: 1817.7147054946922
+  dps: 417.304169496281
+  tps: 247.88795494762329
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 747.5729386642099
-  tps: 829.3575712041089
+  dps: 141.79626814900598
+  tps: 277.2756338009412
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 718.6489790655824
-  tps: 596.8733733534515
+  dps: 142.39189183545082
+  tps: 75.88351442128076
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1083.2112784385995
-  tps: 933.70765395303
+  dps: 234.60610672257536
+  tps: 146.22866873941385
  }
 }
 dps_results: {
  key: "TestHunter-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1584.16881244275
-  tps: 1170.7088362603824
+  dps: 313.54351163665626
+  tps: 126.1229456311889
  }
 }

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -47,1221 +47,1221 @@ character_stats_results: {
 dps_results: {
  key: "TestProtection-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 377.9153252895501
-  tps: 654.4283065710486
+  dps: 305.89488721478415
+  tps: 580.9674597347872
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 371.5641832313242
-  tps: 645.8291297623248
+  dps: 301.976245332787
+  tps: 574.849433105817
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Alchemist'sStone-13503"
  value: {
-  dps: 384.3522637031511
-  tps: 668.4074973992069
+  dps: 313.13859985267476
+  tps: 595.7695602717209
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 371.5641832313242
-  tps: 645.8291297623248
+  dps: 301.976245332787
+  tps: 574.849433105817
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AshtongueTalismanofZeal-32489"
  value: {
-  dps: 391.82776835583667
-  tps: 666.40322798963
+  dps: 322.2398304572996
+  tps: 595.4235313331222
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Assassin'sAlchemistStone-35751"
  value: {
-  dps: 377.2128496819899
-  tps: 651.7571772673062
+  dps: 304.38667899283865
+  tps: 577.474483164372
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 394.4827041472883
-  tps: 690.2452232974633
+  dps: 324.89476624875135
+  tps: 619.2655266409558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 373.91893917298313
-  tps: 648.2309808228168
+  dps: 302.9488811164755
+  tps: 575.8415216051792
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 372.1556132044058
-  tps: 646.432388334868
+  dps: 287.75596294968153
+  tps: 560.3447450750493
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 390.82735620089903
-  tps: 678.3771199631622
+  dps: 318.16177057586873
+  tps: 604.2582226256311
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 384.57956902714955
-  tps: 671.8906965706278
+  dps: 315.5392621284708
+  tps: 601.4695835339751
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 400.0889345108944
-  tps: 701.5864779479556
+  dps: 330.68338212622416
+  tps: 630.7928145155918
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 397.61898010367094
-  tps: 695.627530063318
+  dps: 327.53933094690734
+  tps: 624.1462879234186
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 379.9224561058782
-  tps: 654.6064860756404
+  dps: 305.57001166273074
+  tps: 578.7669927436301
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 374.65452966957776
-  tps: 646.9114192903284
+  dps: 301.94398789608124
+  tps: 572.7466666813617
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 394.4827041472883
-  tps: 690.2452232974633
+  dps: 324.89476624875135
+  tps: 619.2655266409558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 374.3805648720191
-  tps: 648.9734935123068
+  dps: 303.31451414393047
+  tps: 576.4861217696565
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 395.11647569304426
-  tps: 690.4911825866906
+  dps: 325.6404560087833
+  tps: 619.6256425087445
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Blinkstrike-31332"
  value: {
-  dps: 394.4827041472883
-  tps: 690.2452232974633
+  dps: 324.89476624875135
+  tps: 619.2655266409558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 378.1493834522917
-  tps: 652.7444226817041
+  dps: 304.80722862970794
+  tps: 577.9354247626688
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 399.75841199626007
-  tps: 686.9028386437742
+  dps: 330.1704740977229
+  tps: 617.3427359203965
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 397.4371005427122
-  tps: 695.9708435117947
+  dps: 327.8491626441752
+  tps: 624.991146855287
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 397.54544268382017
-  tps: 693.4058095231039
+  dps: 326.1676752303123
+  tps: 620.6004867205262
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 371.5641832313242
-  tps: 645.8291297623248
+  dps: 301.976245332787
+  tps: 574.849433105817
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 395.6639313365236
-  tps: 691.4500750304836
+  dps: 325.3763752424834
+  tps: 619.7567678145626
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 381.0448231996131
-  tps: 663.2127141371252
+  dps: 310.84625814259164
+  tps: 591.6101777789634
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 381.87036629260155
-  tps: 664.1828456252302
+  dps: 311.2652399535389
+  tps: 592.1656167593861
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BurningRage"
  value: {
-  dps: 372.7920550514786
-  tps: 630.49968334524
+  dps: 299.6308429879912
+  tps: 557.3384712817524
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 395.64291695956933
-  tps: 691.9283812713028
+  dps: 325.6904358935924
+  tps: 620.5768505840065
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 396.109123762313
-  tps: 692.5683124987828
+  dps: 325.9860126939245
+  tps: 621.0427392090266
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 398.9836579709131
-  tps: 695.1669644564641
+  dps: 326.9451811632373
+  tps: 621.6877181126348
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 371.5641832313242
-  tps: 645.8291297623248
+  dps: 301.976245332787
+  tps: 574.849433105817
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 371.5641832313242
-  tps: 645.8291297623248
+  dps: 301.976245332787
+  tps: 574.849433105817
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 376.3122730959035
-  tps: 650.8152174827775
+  dps: 304.0174198431271
+  tps: 577.0744671649455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgeArmor"
  value: {
-  dps: 356.74172210045646
-  tps: 606.8404395948141
+  dps: 288.07728021998355
+  tps: 538.1759977143412
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgeBattlegear"
  value: {
-  dps: 392.0488519640654
-  tps: 660.5689987775977
+  dps: 313.8868700172594
+  tps: 582.4070168307917
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 376.0676782216166
-  tps: 650.4749793343814
+  dps: 303.861033820988
+  tps: 576.8242020457399
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 371.5641832313242
-  tps: 645.8291297623248
+  dps: 301.976245332787
+  tps: 574.849433105817
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 389.25817865952894
-  tps: 680.1200929021843
+  dps: 319.6702407609919
+  tps: 609.1403962456766
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 377.53491442592315
-  tps: 652.0951903430035
+  dps: 304.5142023625063
+  tps: 577.6140640383185
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 379.4714813603607
-  tps: 655.0864311427991
+  dps: 305.9597916749556
+  tps: 580.1045076636859
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DesolationBattlegear"
  value: {
-  dps: 372.38669640891123
-  tps: 642.011508051045
+  dps: 306.7603970778489
+  tps: 576.3852087199824
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Despair-28573"
  value: {
-  dps: 363.21082036596147
-  tps: 578.3032032264052
+  dps: 268.1197940310674
+  tps: 481.31035636481306
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 395.29383295997354
-  tps: 691.2131465924658
+  dps: 325.31621367075286
+  tps: 619.835974917461
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 395.77576136340633
-  tps: 691.8169448158778
+  dps: 325.5843968365422
+  tps: 620.2217529984766
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DoomplateBattlegear"
  value: {
-  dps: 357.23784592727856
-  tps: 608.5485071874978
+  dps: 289.0783033843698
+  tps: 540.3889646445892
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dragonmaw-28438"
  value: {
-  dps: 394.4827041472883
-  tps: 690.2452232974633
+  dps: 324.89476624875135
+  tps: 619.2655266409558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 376.76480260845193
-  tps: 652.9394659446931
+  dps: 305.1203140714742
+  tps: 579.8620876369762
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dragonstrike-28439"
  value: {
-  dps: 394.4827041472883
-  tps: 690.2452232974633
+  dps: 324.89476624875135
+  tps: 619.2655266409558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 394.4827041472883
-  tps: 690.2452232974633
+  dps: 324.89476624875135
+  tps: 619.2655266409558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 394.4827041472883
-  tps: 690.2452232974633
+  dps: 324.89476624875135
+  tps: 619.2655266409558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 399.1034582224992
-  tps: 699.2222091828273
+  dps: 329.5155203239623
+  tps: 628.2425125263194
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 401.4397718947767
-  tps: 703.7499850797004
+  dps: 331.85183399623975
+  tps: 632.7702884231926
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 378.1493834522917
-  tps: 652.7444226817041
+  dps: 304.80722862970794
+  tps: 577.9354247626688
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 394.4827041472883
-  tps: 690.2452232974633
+  dps: 324.89476624875135
+  tps: 619.2655266409558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 395.1514237604166
-  tps: 691.0286058631593
+  dps: 325.2330045934516
+  tps: 619.7118183128554
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 395.5877763283952
-  tps: 691.6252000801665
+  dps: 325.5081271716313
+  tps: 620.1439579402675
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 395.4861273762057
-  tps: 691.4824130634665
+  dps: 325.44157082240594
+  tps: 620.0369653785909
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 386.35496462531626
-  tps: 674.493664103883
+  dps: 316.76702672677925
+  tps: 603.5139674473753
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 394.4827041472883
-  tps: 690.2452232974633
+  dps: 324.89476624875135
+  tps: 619.2655266409558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 394.4827041472883
-  tps: 690.2452232974633
+  dps: 324.89476624875135
+  tps: 619.2655266409558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 382.95971218510334
-  tps: 667.9136648747491
+  dps: 313.37177428656634
+  tps: 596.9339682182413
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FaithinFelsteel"
  value: {
-  dps: 355.83251081380536
-  tps: 613.5327255550446
+  dps: 292.70904504171665
+  tps: 550.4092597829558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FelstalkerArmor"
  value: {
-  dps: 388.530505731514
-  tps: 677.6165635116158
+  dps: 317.9597388917893
+  tps: 605.6343813350966
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 412.04584240320816
-  tps: 724.4556524865126
+  dps: 342.4579045046711
+  tps: 653.4759558300046
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 375.61888539418055
-  tps: 650.0878885777984
+  dps: 303.73345448160626
+  tps: 576.7647490469725
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 378.9075167742963
-  tps: 653.5385392042346
+  dps: 305.1326597098025
+  tps: 578.2881849984509
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FlameGuard"
  value: {
-  dps: 349.2013372751777
-  tps: 604.7424472767125
+  dps: 288.58450355211994
+  tps: 544.1256135536546
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 399.75841199626007
-  tps: 700.4695451087701
+  dps: 330.1704740977229
+  tps: 629.4898484522622
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 398.7032704264656
-  tps: 698.4246807465083
+  dps: 329.1153325279284
+  tps: 627.4449840900004
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GlaiveofthePit-28774"
  value: {
-  dps: 363.5154938883378
-  tps: 576.6203426086205
+  dps: 268.87701362647374
+  tps: 480.0890927415192
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 371.5641832313242
-  tps: 645.8291297623248
+  dps: 301.976245332787
+  tps: 574.849433105817
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Guardian'sAlchemistStone-35748"
  value: {
-  dps: 371.5641832313242
-  tps: 645.8291297623248
+  dps: 301.976245332787
+  tps: 574.849433105817
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HandofJustice-11815"
  value: {
-  dps: 375.5648724251562
-  tps: 651.5127075021406
+  dps: 304.5623352825025
+  tps: 579.0901196166337
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 373.16056263696504
-  tps: 647.6887682183008
+  dps: 302.776316423013
+  tps: 575.8968370800698
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 374.3496610057615
-  tps: 650.5393020515248
+  dps: 288.2249786897269
+  tps: 562.6921260891693
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 389.4692069734872
-  tps: 680.5290657746383
+  dps: 319.88126907495
+  tps: 609.5493691181304
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 397.4371005427122
-  tps: 695.9708435117947
+  dps: 327.8491626441752
+  tps: 624.991146855287
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 395.5877763283952
-  tps: 691.6252000801665
+  dps: 325.5081271716313
+  tps: 620.1439579402675
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 395.4861273762057
-  tps: 691.4824130634665
+  dps: 325.44157082240594
+  tps: 620.0369653785909
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IndestructibleAlchemist'sStone-44323"
  value: {
-  dps: 371.5641832313242
-  tps: 645.8291297623248
+  dps: 301.976245332787
+  tps: 574.849433105817
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 432.12579140534507
-  tps: 774.7425479522765
+  dps: 362.53785350680795
+  tps: 703.7628512957685
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 413.18344475338324
-  tps: 731.7341807465098
+  dps: 343.5955068548462
+  tps: 660.7544840900019
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 396.67940776699163
-  tps: 692.5505751049567
+  dps: 325.83215711654907
+  tps: 620.2863794415053
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JusticarArmor"
  value: {
-  dps: 364.746161583209
-  tps: 622.0488746120438
+  dps: 296.081719702736
+  tps: 553.3844327315708
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JusticarBattlegear"
  value: {
-  dps: 388.14804424437665
-  tps: 659.0069773650317
+  dps: 313.90528743781255
+  tps: 584.7642205584675
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 362.2333627679203
-  tps: 582.1855273677646
+  dps: 267.6986636494206
+  tps: 485.760134266895
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 376.1838492444912
-  tps: 653.0816682150903
+  dps: 305.43404495263553
+  tps: 580.9168678373971
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerArmor"
  value: {
-  dps: 367.72738023574783
-  tps: 623.403060785089
+  dps: 296.22648629979244
+  tps: 551.9021668491336
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerBattlegear"
  value: {
-  dps: 418.33673362855
-  tps: 697.4096907664887
+  dps: 328.9683136653695
+  tps: 608.0412708033082
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LionheartChampion-28429"
  value: {
-  dps: 367.9940713975973
-  tps: 583.8143338592103
+  dps: 267.64602446650304
+  tps: 481.45932598949423
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 374.211740805164
-  tps: 590.3269790671029
+  dps: 270.28979679965073
+  tps: 484.32659618147954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 377.6691540976572
-  tps: 653.5426144338369
+  dps: 292.23536975461286
+  tps: 566.4001544039318
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 394.67502544255564
-  tps: 696.5770062485185
+  dps: 337.1366291067991
+  tps: 639.038609912762
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 347.6074016210564
-  tps: 600.5390657321884
+  dps: 278.5084644356533
+  tps: 530.0581498030773
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 379.4095533016931
-  tps: 654.0625290747993
+  dps: 305.32406986063637
+  tps: 578.4953359649214
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 389.5015899178283
-  tps: 680.5918239207714
+  dps: 319.9136520192912
+  tps: 609.6121272642637
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MercurialAlchemistStone-44322"
  value: {
-  dps: 372.085971215039
-  tps: 644.9676169155729
+  dps: 301.3215819537838
+  tps: 572.7879398690928
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MightyAlchemist'sStone-44324"
  value: {
-  dps: 373.6908325186705
-  tps: 648.4483692437674
+  dps: 303.13665191822963
+  tps: 576.4831050313173
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 371.5641832313242
-  tps: 645.8291297623248
+  dps: 301.976245332787
+  tps: 574.849433105817
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 392.69845663112295
-  tps: 686.6640585444679
+  dps: 323.11051873258566
+  tps: 615.6843618879602
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherscaleArmor"
  value: {
-  dps: 389.13147161260605
-  tps: 680.2218068824819
+  dps: 319.22518852884843
+  tps: 608.9173981370491
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherstrikeArmor"
  value: {
-  dps: 404.10164847173195
-  tps: 717.5332185372796
+  dps: 339.4765458385809
+  tps: 651.615613851466
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 396.2609880299053
-  tps: 692.111460474958
+  dps: 325.65360647506384
+  tps: 620.0919312890195
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 396.67940776699163
-  tps: 692.5505751049567
+  dps: 325.83215711654907
+  tps: 620.2863794415053
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 395.73796335854735
-  tps: 691.5625671874593
+  dps: 325.4304181732071
+  tps: 619.8488710984125
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 394.4827041472883
-  tps: 690.2452232974633
+  dps: 324.89476624875135
+  tps: 619.2655266409558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 394.4827041472883
-  tps: 690.2452232974633
+  dps: 324.89476624875135
+  tps: 619.2655266409558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 394.4827041472883
-  tps: 690.2452232974633
+  dps: 324.89476624875135
+  tps: 619.2655266409558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrimalIntent"
  value: {
-  dps: 386.7330792764392
-  tps: 665.3554280040489
+  dps: 310.77667392896893
+  tps: 587.8798945496296
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 379.0772605808943
-  tps: 660.3064560657903
+  dps: 309.4893226823571
+  tps: 589.3267594092824
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Redeemer'sAlchemistStone-35750"
  value: {
-  dps: 384.85896701073364
-  tps: 671.5944207268196
+  dps: 315.27102911219646
+  tps: 600.6147240703117
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 396.42738836070976
-  tps: 692.6186393662706
+  dps: 325.9401164651199
+  tps: 620.7216220327689
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 395.9887240027389
-  tps: 692.1712017211404
+  dps: 325.75959060410617
+  tps: 620.5374856545351
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 404.50695257805836
-  tps: 709.9844108754196
+  dps: 334.9190146795213
+  tps: 639.0047142189119
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 396.5961325052948
-  tps: 698.2401563635982
+  dps: 329.2773291862101
+  tps: 629.5749769781316
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 394.4827041472883
-  tps: 690.2452232974633
+  dps: 324.89476624875135
+  tps: 619.2655266409558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 379.7637796609286
-  tps: 657.472903321684
+  dps: 310.1758417623915
+  tps: 586.493206665176
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 369.98281422534717
-  tps: 644.165180419281
+  dps: 301.27375203949066
+  tps: 574.0819369897073
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 411.56615510158935
-  tps: 723.3529512468978
+  dps: 341.97821720305234
+  tps: 652.3732545903902
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 373.23869620224366
-  tps: 647.8585360816944
+  dps: 302.8674594733309
+  tps: 576.0798746182031
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 371.5641832313242
-  tps: 645.8291297623248
+  dps: 301.976245332787
+  tps: 574.849433105817
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShardofContempt-34472"
  value: {
-  dps: 381.9844582148903
-  tps: 658.9306961312174
+  dps: 307.7470868411332
+  tps: 583.208577329985
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 405.0490154106361
-  tps: 711.6321606337697
+  dps: 335.94857115023115
+  tps: 641.1497074881567
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 398.1874700215342
-  tps: 692.7362190290884
+  dps: 325.5868890368726
+  tps: 618.6836264247335
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 372.86929522041976
-  tps: 647.3854631492516
+  dps: 302.6541212159103
+  tps: 575.7659856646518
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 383.4500063439212
-  tps: 666.9655353953468
+  dps: 312.6856170826663
+  tps: 594.7858583488668
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 377.5484111735888
-  tps: 652.1134422154142
+  dps: 304.549424407561
+  tps: 577.6544757140659
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 384.85896701073364
-  tps: 671.5944207268196
+  dps: 315.27102911219646
+  tps: 600.6147240703117
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 398.20566470086686
-  tps: 704.4085098639447
+  dps: 333.0035094767677
+  tps: 637.9023115353634
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StormGauntlets-12632"
  value: {
-  dps: 384.8794260964109
-  tps: 661.765323073845
+  dps: 318.12794025335626
+  tps: 595.0138372307905
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 359.00053720249895
-  tps: 632.0115321484075
+  dps: 296.20689143686155
+  tps: 567.9620134674573
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 395.73796335854735
-  tps: 691.5625671874593
+  dps: 325.4304181732071
+  tps: 619.8488710984125
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 396.67940776699163
-  tps: 692.5505751049567
+  dps: 325.83215711654907
+  tps: 620.2863794415053
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 397.0150439147946
-  tps: 695.1528977668912
+  dps: 327.42710601625737
+  tps: 624.1732011103833
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 396.2609880299053
-  tps: 692.111460474958
+  dps: 325.65360647506384
+  tps: 620.0919312890195
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 395.5287534900042
-  tps: 691.3430098724607
+  dps: 325.3411428524644
+  tps: 619.7516470221701
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 394.4827041472883
-  tps: 690.2452232974633
+  dps: 324.89476624875135
+  tps: 619.2655266409558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 394.4827041472883
-  tps: 690.2452232974633
+  dps: 324.89476624875135
+  tps: 619.2655266409558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 371.5641832313242
-  tps: 645.8291297623248
+  dps: 301.976245332787
+  tps: 574.849433105817
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 387.234806955076
-  tps: 676.1987985389546
+  dps: 317.6468690565388
+  tps: 605.219101882447
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 383.82906531367945
-  tps: 669.5507957712617
+  dps: 314.24112741514244
+  tps: 598.571099114754
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheTwinStars"
  value: {
-  dps: 408.59629260820503
-  tps: 719.7192256532203
+  dps: 340.13418221070265
+  tps: 649.887873047768
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 394.4827041472883
-  tps: 690.2452232974633
+  dps: 324.89476624875135
+  tps: 619.2655266409558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 396.00561761038193
-  tps: 692.7205439658845
+  dps: 326.0693315269074
+  tps: 621.3855321607402
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 397.0333207820466
-  tps: 694.1575301582175
+  dps: 326.7266638952784
+  tps: 622.4447401337138
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 400.7178505185336
-  tps: 685.847361940416
+  dps: 331.12991261999656
+  tps: 614.8676652839081
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 399.75841199626007
-  tps: 700.4695451087701
+  dps: 330.1704740977229
+  tps: 629.4898484522622
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 398.7032704264656
-  tps: 698.4246807465083
+  dps: 329.1153325279284
+  tps: 627.4449840900004
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TomeofFieryRedemption-30447"
  value: {
-  dps: 390.1076711057496
-  tps: 681.7664092629614
+  dps: 320.51973320721265
+  tps: 610.7867126064535
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 398.7032704264656
-  tps: 698.4246807465083
+  dps: 329.1153325279284
+  tps: 627.4449840900004
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 399.75841199626007
-  tps: 700.4695451087701
+  dps: 330.1704740977229
+  tps: 629.4898484522622
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 374.24618384133146
-  tps: 649.6640510365658
+  dps: 303.77990534121113
+  tps: 577.7884469664434
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WarpSlicer-30311"
  value: {
-  dps: 394.4827041472883
-  tps: 690.2452232974633
+  dps: 324.89476624875135
+  tps: 619.2655266409558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WastewalkerArmor"
  value: {
-  dps: 358.1047882465718
-  tps: 610.8012684511839
+  dps: 290.3409661226972
+  tps: 543.0374463273093
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WindhawkArmor"
  value: {
-  dps: 417.2103854534241
-  tps: 744.2962692261958
+  dps: 352.93709010949584
+  tps: 678.7375079753891
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WorldBreaker-30090"
  value: {
-  dps: 366.3735376136298
-  tps: 579.9508331017956
+  dps: 265.795597096785
+  tps: 477.3613337746138
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathofSpellfire"
  value: {
-  dps: 410.05135526328274
-  tps: 716.3467032785546
+  dps: 346.56125551696505
+  tps: 652.8566035322374
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 410.58668320696904
-  tps: 720.3929707220473
+  dps: 340.31402973789153
+  tps: 648.7148641835882
  }
 }
 dps_results: {
  key: "TestProtection-Average-Default"
  value: {
-  dps: 663.3827326621811
-  tps: 1258.957044889473
-  dtps: 913.615920992181
+  dps: 569.0985917304687
+  tps: 1164.1516944720756
+  dtps: 1072.084010375089
  }
 }
 dps_results: {
  key: "TestProtection-SelfDrums-DPS"
  value: {
-  dps: 661.673859682218
-  tps: 1254.1770840132872
-  dtps: 915.8819768890796
+  dps: 567.3394826706681
+  tps: 1159.2559909226825
+  dtps: 1075.2889134899808
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P4-Protection Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2440.289565906342
-  tps: 5247.187036295605
+  dps: 2359.1014188786644
+  tps: 5164.375126327378
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P4-Protection Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 429.2795043746943
-  tps: 738.2815145271036
+  dps: 348.0913573470178
+  tps: 655.4696045588734
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P4-Protection Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 550.5212918330634
-  tps: 1002.3181806859508
+  dps: 470.920045492608
+  tps: 921.1249094186869
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P4-Protection Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 984.9912948998036
-  tps: 2155.171612252282
+  dps: 949.4493372718101
+  tps: 2118.9188154717303
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P4-Protection Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 203.25228315381915
-  tps: 343.6671674885662
+  dps: 167.71032552582605
+  tps: 307.4143707080133
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P4-Protection Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 279.98786365521914
-  tps: 497.7619227726144
+  dps: 243.86227011438038
+  tps: 460.91381736095906
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P4-Protection Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2462.7299411035474
-  tps: 5290.544885829565
+  dps: 2380.518289845999
+  tps: 5206.689001546864
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P4-Protection Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 436.5130988385915
-  tps: 750.7807457314422
+  dps: 354.3014475810427
+  tps: 666.9248614487421
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P4-Protection Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 552.7873205636934
-  tps: 1005.1714836470966
+  dps: 472.2085301448452
+  tps: 922.9811174198719
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P4-Protection Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 987.5734225003149
-  tps: 2167.846985327085
+  dps: 951.5693865533788
+  tps: 2131.12286866121
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P4-Protection Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 206.2098749115856
-  tps: 348.9693501001286
+  dps: 170.20583896464984
+  tps: 312.2452334342541
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P4-Protection Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 274.69724847546354
-  tps: 486.5120774667279
+  dps: 238.0336551612394
+  tps: 449.1152122862191
  }
 }
 dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 698.477056962055
-  tps: 1300.1332904501014
-  dtps: 878.7548698671234
+  dps: 590.7919019401711
+  tps: 1192.1481750939106
+  dtps: 1030.1658586991007
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -47,1323 +47,1323 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1826.3589757453385
-  tps: 1325.9242420724365
+  dps: 1130.8214507118073
+  tps: 839.047974548965
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1805.1069927709632
-  tps: 1310.146157852157
+  dps: 1117.383919916073
+  tps: 828.7400068537337
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Alchemist'sStone-13503"
  value: {
-  dps: 1827.8845648948397
-  tps: 1326.126430463373
+  dps: 1130.9570456525717
+  tps: 838.2771669937856
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1805.1069927709632
-  tps: 1310.146157852157
+  dps: 1117.383919916073
+  tps: 828.7400068537337
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AshtongueTalismanofZeal-32489"
  value: {
-  dps: 1837.8003700662773
-  tps: 1333.0311784498094
+  dps: 1150.077297211387
+  tps: 851.6250274513858
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Assassin'sAlchemistStone-35751"
  value: {
-  dps: 1840.6510845530483
-  tps: 1335.0668803963626
+  dps: 1138.533395333658
+  tps: 843.5844979427893
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1816.6477074881966
-  tps: 1319.4566458325903
+  dps: 1127.0795304191533
+  tps: 836.7589218842601
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1823.475675035368
-  tps: 1323.0307838217368
+  dps: 1128.2819439273956
+  tps: 836.3951720461571
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1819.8265419922902
-  tps: 1320.4498423070856
+  dps: 945.9032105412712
+  tps: 708.7035102913725
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1862.2077809514553
-  tps: 1351.0861476280033
+  dps: 1157.1875731815533
+  tps: 857.5720021890718
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 1817.1856284485445
-  tps: 1319.576950180198
+  dps: 1129.709827795929
+  tps: 838.3438897233667
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1831.3949086747898
-  tps: 1329.5386658174393
+  dps: 1140.646095664093
+  tps: 846.0144967099518
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1824.0969407420966
-  tps: 1324.6312974763193
+  dps: 1131.4150511178887
+  tps: 839.7539747393737
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1847.0115876513798
-  tps: 1341.322746975014
+  dps: 1155.131866149296
+  tps: 857.0069419235551
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 1847.8754588221493
-  tps: 1341.3911638958414
+  dps: 1145.629599656862
+  tps: 849.8190624801408
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1823.9240396231116
-  tps: 1323.343064166285
+  dps: 1128.3802799590435
+  tps: 836.4624324014371
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1833.6047847887419
-  tps: 1331.3322084724643
+  dps: 1139.1949895913065
+  tps: 845.2453518342595
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1854.6951643087025
-  tps: 1346.1138336506283
+  dps: 1150.252367965981
+  tps: 853.0038762107226
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1846.6266353155215
-  tps: 1339.2563440050153
+  dps: 1142.0227471481005
+  tps: 846.0336222878203
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1819.9563933808383
-  tps: 1296.0020979568492
+  dps: 1130.3882163117955
+  tps: 822.9583284874852
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1818.500571588075
-  tps: 1320.7246499644243
+  dps: 1128.9323945190326
+  tps: 838.026926016094
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1832.7238358225277
-  tps: 1330.4942779225876
+  dps: 1136.7264354564381
+  tps: 843.2960976663242
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1805.1069927709632
-  tps: 1310.146157852157
+  dps: 1117.383919916073
+  tps: 828.7400068537337
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1818.8959433106484
-  tps: 1321.030410908306
+  dps: 1127.9958494531834
+  tps: 837.4003452080807
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 1803.5929851673811
-  tps: 1310.299130903476
+  dps: 1120.7800615017604
+  tps: 832.3300843375421
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 1821.3225317362119
-  tps: 1322.787072642629
+  dps: 1129.088728515733
+  tps: 838.223410388294
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BurningRage"
  value: {
-  dps: 1632.2072478040084
-  tps: 1189.8072416258549
+  dps: 1007.0650246224188
+  tps: 752.2076853987428
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1850.6537783140398
-  tps: 1343.2808449018887
+  dps: 1147.975042097797
+  tps: 851.405729550518
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1853.535457179445
-  tps: 1345.3003587194366
+  dps: 1149.5229436239251
+  tps: 852.4915992305727
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1840.657284255231
-  tps: 1335.6680892733648
+  dps: 1137.2937148112553
+  tps: 843.3135906625816
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 1805.1069927709632
-  tps: 1310.146157852157
+  dps: 1117.383919916073
+  tps: 828.7400068537337
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1805.1069927709632
-  tps: 1310.146157852157
+  dps: 1117.383919916073
+  tps: 828.7400068537337
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1835.0435351404763
-  tps: 1331.1352354102748
+  dps: 1135.1491423659522
+  tps: 841.2091604681085
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CrystalforgeArmor"
  value: {
-  dps: 1491.095635663615
-  tps: 1090.6994499190455
+  dps: 922.1219918692098
+  tps: 692.4178992629621
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CrystalforgeBattlegear"
  value: {
-  dps: 1637.329401843261
-  tps: 1192.7178574624193
+  dps: 1012.4239106783102
+  tps: 755.2840136469542
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1822.2777113684042
-  tps: 1322.17893341367
+  dps: 1126.4967443942335
+  tps: 835.1322565317507
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1805.1069927709632
-  tps: 1310.146157852157
+  dps: 1117.383919916073
+  tps: 828.7400068537337
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1814.977570257815
-  tps: 1317.1240335923724
+  dps: 1127.2544974029238
+  tps: 835.7178825939495
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1842.4927466607544
-  tps: 1336.3584175678739
+  dps: 1139.5663313694376
+  tps: 844.309926863952
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1810.1231722273742
-  tps: 1313.6516807373657
+  dps: 1122.400099372484
+  tps: 832.2455297389428
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1814.3933519720752
-  tps: 1316.6637207540498
+  dps: 1123.0310547526142
+  tps: 832.7101127004264
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DesolationBattlegear"
  value: {
-  dps: 1510.6201082596608
-  tps: 1104.8392502206882
+  dps: 941.8775637954434
+  tps: 706.7194690957353
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Despair-28573"
  value: {
-  dps: 1697.5544821089127
-  tps: 1238.510403352997
+  dps: 1063.5727287278912
+  tps: 794.7231759862822
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1821.9705584809055
-  tps: 1323.1408786595714
+  dps: 1130.2626770103277
+  tps: 838.9453616301668
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1825.460835641204
-  tps: 1325.5878899943168
+  dps: 1132.3025705795344
+  tps: 840.377104451148
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Devastation-30316"
  value: {
-  dps: 2263.381995810511
-  tps: 1638.3961427263089
+  dps: 1409.1706557470334
+  tps: 1040.4482046818746
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DoomplateBattlegear"
  value: {
-  dps: 1543.4317400796158
-  tps: 1127.6156590730452
+  dps: 956.6663987819766
+  tps: 716.8799201646971
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1851.2013890018827
-  tps: 1343.733081454664
+  dps: 1149.5908399560915
+  tps: 852.6056971226102
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1845.8546621984144
-  tps: 1340.1661337565179
+  dps: 1145.8361306389947
+  tps: 850.1531616649244
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1853.4800458144964
-  tps: 1345.3778976185984
+  dps: 1150.5527282917903
+  tps: 853.3287753527047
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1816.6477074881966
-  tps: 1319.4566458325903
+  dps: 1127.0795304191533
+  tps: 836.7589218842601
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1818.500571588075
-  tps: 1320.7246318229293
+  dps: 1128.9323945190326
+  tps: 838.026907874599
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1819.9563933808383
-  tps: 1321.7602989226862
+  dps: 1130.3882163117955
+  tps: 839.0625749743558
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1846.6266353155215
-  tps: 1339.2563440050153
+  dps: 1142.0227471481005
+  tps: 846.0336222878203
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 1847.234965488875
-  tps: 1341.1906679330516
+  dps: 1146.5563143904208
+  tps: 850.715612164134
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1821.3720080421556
-  tps: 1322.721633204603
+  dps: 1129.9510325062633
+  tps: 838.7269503294784
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1824.0969407420966
-  tps: 1324.6312974763193
+  dps: 1131.4150511178887
+  tps: 839.7539747393737
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1822.5700435552
-  tps: 1323.5612077436658
+  dps: 1130.5789873076837
+  tps: 839.1674683704044
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1814.3838785636094
-  tps: 1316.7016086393562
+  dps: 1126.6608057087194
+  tps: 835.2954576409334
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1816.6477074881966
-  tps: 1319.4566458325903
+  dps: 1127.0795304191533
+  tps: 836.7589218842601
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1816.6477074881966
-  tps: 1319.4566458325903
+  dps: 1127.0795304191533
+  tps: 836.7589218842601
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1812.4314102957592
-  tps: 1315.361978155197
+  dps: 1124.7083374408694
+  tps: 833.9558271567741
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FaithinFelsteel"
  value: {
-  dps: 1528.621797077575
-  tps: 1117.516884814244
+  dps: 948.8622571937234
+  tps: 711.6852068955479
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FelstalkerArmor"
  value: {
-  dps: 1700.2765276582413
-  tps: 1237.160991485311
+  dps: 1050.1270139435385
+  tps: 782.0563318850188
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1827.0073057786785
-  tps: 1325.636016332306
+  dps: 1139.2842329237878
+  tps: 844.2298653338826
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1831.3569211627641
-  tps: 1328.5502814890904
+  dps: 1132.9495302236382
+  tps: 839.6651078317028
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1847.2334495092978
-  tps: 1339.681324803792
+  dps: 1142.3430409011876
+  tps: 846.2580387781154
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FlameGuard"
  value: {
-  dps: 1471.4272674912831
-  tps: 1076.5991117312287
+  dps: 908.5680967168133
+  tps: 682.5976921891005
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1819.9563933808383
-  tps: 1321.7603170641812
+  dps: 1130.3882163117955
+  tps: 839.0625931158509
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1819.2946562023103
-  tps: 1321.2895592915643
+  dps: 1129.7264791332668
+  tps: 838.5918353432339
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GlaiveofthePit-28774"
  value: {
-  dps: 1686.6679397134014
-  tps: 1229.1032357602771
+  dps: 1061.5631579590172
+  tps: 791.5298885322078
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1805.1069927709632
-  tps: 1310.146157852157
+  dps: 1117.383919916073
+  tps: 828.7400068537337
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Guardian'sAlchemistStone-35748"
  value: {
-  dps: 1805.1069927709632
-  tps: 1310.146157852157
+  dps: 1117.383919916073
+  tps: 828.7400068537337
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HandofJustice-11815"
  value: {
-  dps: 1841.8105446327538
-  tps: 1336.1752302330028
+  dps: 1139.5568172972173
+  tps: 844.5976210981271
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1817.7928959548224
-  tps: 1319.1284435253408
+  dps: 1130.0698230999326
+  tps: 837.7222925269172
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1827.1208186960014
-  tps: 1325.588235502909
+  dps: 1130.8245882833853
+  tps: 838.1808742140778
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1820.6886971268416
-  tps: 1321.2554299716287
+  dps: 965.3187521939566
+  tps: 722.4964685186093
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1815.1132076193844
-  tps: 1317.2205766344766
+  dps: 1127.390134764494
+  tps: 835.8144256360533
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1818.500571588075
-  tps: 1320.7246499644243
+  dps: 1128.9323945190326
+  tps: 838.026926016094
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1824.0969407420966
-  tps: 1324.6312974763193
+  dps: 1131.4150511178887
+  tps: 839.7539747393737
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1822.5700435552
-  tps: 1323.5612077436658
+  dps: 1130.5789873076837
+  tps: 839.1674683704044
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IndestructibleAlchemist'sStone-44323"
  value: {
-  dps: 1805.1069927709632
-  tps: 1310.146157852157
+  dps: 1117.383919916073
+  tps: 828.7400068537337
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1816.7481282612644
-  tps: 1322.2351639321305
+  dps: 1127.1799511922213
+  tps: 839.5374399838003
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1816.7481282612644
-  tps: 1321.3427549439252
+  dps: 1127.1799511922213
+  tps: 838.6450309955949
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1830.499587899578
-  tps: 1329.1188025583115
+  dps: 1135.3639986549338
+  tps: 842.5238900870603
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JusticarArmor"
  value: {
-  dps: 1523.8506547669213
-  tps: 1113.6908607709606
+  dps: 955.3835907856651
+  tps: 715.7639159840804
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JusticarBattlegear"
  value: {
-  dps: 1590.357048314056
-  tps: 1160.5605906240114
+  dps: 985.0544617305874
+  tps: 736.8487800155833
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 1683.1194993048464
-  tps: 1230.9017837023414
+  dps: 1045.2790353914238
+  tps: 784.4134589629452
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1827.8720214969926
-  tps: 1326.9235712231018
+  dps: 1134.821615562287
+  tps: 841.7882870688081
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerArmor"
  value: {
-  dps: 1389.5771316390105
-  tps: 1018.7978286496607
+  dps: 853.5337595179399
+  tps: 643.5674681649111
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerBattlegear"
  value: {
-  dps: 1622.0740720561114
-  tps: 1185.3725781477594
+  dps: 1011.1379390135
+  tps: 757.7172850179314
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LionheartChampion-28429"
  value: {
-  dps: 1745.2544537534454
-  tps: 1271.1439645088692
+  dps: 1092.4193909933726
+  tps: 814.1594205768174
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1781.2981681193558
-  tps: 1296.4164519314552
+  dps: 1114.1214395982997
+  tps: 829.3927419667168
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1846.9750007861794
-  tps: 1339.6866981302737
+  dps: 933.4989072481955
+  tps: 700.2534326536846
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1400.9172418640903
-  tps: 1027.6968744469657
+  dps: 878.9076336660984
+  tps: 662.2901487083718
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 1224.5174202618082
-  tps: 916.8967488982714
+  dps: 749.7240980950273
+  tps: 584.5414233815249
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1849.9858965362218
-  tps: 1341.611735251708
+  dps: 1144.087803019084
+  tps: 847.4830697897119
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1816.6361685044385
-  tps: 1318.304792990275
+  dps: 1128.9130956495494
+  tps: 836.8986419918516
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MercurialAlchemistStone-44322"
  value: {
-  dps: 1812.1805087083103
-  tps: 1316.7908033454357
+  dps: 1135.794191837375
+  tps: 843.3203815357814
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MightyAlchemist'sStone-44324"
  value: {
-  dps: 1822.568489944127
-  tps: 1322.398221941036
+  dps: 1128.1665026802393
+  tps: 836.3168308563141
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1805.1069927709632
-  tps: 1310.146157852157
+  dps: 1117.383919916073
+  tps: 828.7400068537337
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1820.851961584287
-  tps: 1322.4253783931542
+  dps: 1129.6432295748234
+  tps: 838.5792659865298
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherscaleArmor"
  value: {
-  dps: 1691.872666117356
-  tps: 1230.3912877849682
+  dps: 1044.8222192228825
+  tps: 777.4559749588374
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherstrikeArmor"
  value: {
-  dps: 1647.2515926813162
-  tps: 1198.672756858835
+  dps: 1024.350885002467
+  tps: 762.6422614836401
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1827.8611344878868
-  tps: 1327.2688455378895
+  dps: 1133.786004705261
+  tps: 841.416254690052
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1830.499587899578
-  tps: 1329.1188025583115
+  dps: 1135.3639986549338
+  tps: 842.5238900870603
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1824.5630677232723
-  tps: 1325.0065168938556
+  dps: 1131.8135122681704
+  tps: 840.081828075285
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1816.6477074881966
-  tps: 1319.4566458325903
+  dps: 1127.0795304191533
+  tps: 836.7589218842601
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1816.6477074881966
-  tps: 1319.4566458325903
+  dps: 1127.0795304191533
+  tps: 836.7589218842601
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1816.6477074881966
-  tps: 1319.4566458325903
+  dps: 1127.0795304191533
+  tps: 836.7589218842601
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PrimalIntent"
  value: {
-  dps: 1767.3710692429854
-  tps: 1284.2301687279332
+  dps: 1089.5167712874456
+  tps: 809.7321601590555
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1816.240105098808
-  tps: 1318.6318989057881
+  dps: 1127.5701641763742
+  tps: 836.5629402600845
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Redeemer'sAlchemistStone-35750"
  value: {
-  dps: 1813.6521465498927
-  tps: 1316.230911624148
+  dps: 1125.9290736950024
+  tps: 834.8247606257247
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1860.6365546289612
-  tps: 1350.2813982035887
+  dps: 1153.7138470666503
+  tps: 855.435502909971
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1854.6951643087025
-  tps: 1346.1138336506283
+  dps: 1150.252367965981
+  tps: 853.0038762107226
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1816.6477074881966
-  tps: 1318.8691566265281
+  dps: 1127.0795304191533
+  tps: 836.1714326781976
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1759.8566104876413
-  tps: 1279.494217898265
+  dps: 1091.8053278484376
+  tps: 811.8583200508225
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1872.2025278836738
-  tps: 1358.3894317953104
+  dps: 1160.718171725723
+  tps: 860.3503824847455
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1827.1993190161154
-  tps: 1325.7696243780772
+  dps: 1136.056941223179
+  tps: 841.9699599230216
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1790.1095581673335
-  tps: 1299.6305203554095
+  dps: 1108.3084914273502
+  tps: 822.3697736374206
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1836.7917508906112
-  tps: 1332.7738019628655
+  dps: 1145.611117527196
+  tps: 848.9473586084745
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1818.6748244747253
-  tps: 1319.6666813999288
+  dps: 1125.6472106859956
+  tps: 834.5473517478174
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1805.1069927709632
-  tps: 1310.146157852157
+  dps: 1117.383919916073
+  tps: 828.7400068537337
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1877.2533027110555
-  tps: 1360.9820421667378
+  dps: 1163.8580743983387
+  tps: 861.605382347836
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 1824.9245454134248
-  tps: 1325.2512186871702
+  dps: 1134.5762491686378
+  tps: 842.0074113158194
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 1866.943470522257
-  tps: 1354.7067656635043
+  dps: 1157.95710235444
+  tps: 858.4163079460324
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1815.2519703154458
-  tps: 1317.2646131747015
+  dps: 1123.4254606566376
+  tps: 832.9860564135354
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1817.3683259152222
-  tps: 1320.6005326171894
+  dps: 1139.0921643545407
+  tps: 845.8072195247119
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 1642.9967855606599
-  tps: 1201.820052649025
+  dps: 1023.6409693877763
+  tps: 768.2709813280063
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1842.8396947919266
-  tps: 1336.6012358761864
+  dps: 1139.7737265869964
+  tps: 844.4550581327344
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1813.6521465498927
-  tps: 1316.230911624148
+  dps: 1125.9290736950024
+  tps: 834.8247606257247
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1651.9681895660242
-  tps: 1204.173226853324
+  dps: 1035.6451289477689
+  tps: 772.7470844205449
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StormGauntlets-12632"
  value: {
-  dps: 1783.792363795914
-  tps: 1296.1321184907101
+  dps: 1111.07160095064
+  tps: 825.2275844990186
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1574.5402647909268
-  tps: 1149.6183309652122
+  dps: 978.0276756847113
+  tps: 732.0595185908616
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1824.5630677232723
-  tps: 1325.0065168938556
+  dps: 1131.8135122681704
+  tps: 840.081828075285
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1830.499587899578
-  tps: 1329.1188025583115
+  dps: 1135.3639986549338
+  tps: 842.5238900870603
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1818.235876716665
-  tps: 1320.5363468553776
+  dps: 1128.6676996476217
+  tps: 837.8386229070476
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1827.8611344878868
-  tps: 1327.2688455378895
+  dps: 1133.786004705261
+  tps: 841.416254690052
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1823.2438410174257
-  tps: 1324.081538383645
+  dps: 1131.0245152933342
+  tps: 839.5280103767806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1871.5291677461748
-  tps: 1357.9172910890836
+  dps: 1160.315640811887
+  tps: 860.0678222350818
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1816.6477074881966
-  tps: 1319.4566458325903
+  dps: 1127.0795304191533
+  tps: 836.7589218842601
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheDecapitator-28767"
  value: {
-  dps: 1871.3458619440728
-  tps: 1357.73050961703
+  dps: 1160.5658835140985
+  tps: 860.1845247160487
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1838.4734075006231
-  tps: 1333.4441626345836
+  dps: 1150.7710023442478
+  tps: 852.0524790251204
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1813.9193402796632
-  tps: 1316.420954853287
+  dps: 1126.196267424773
+  tps: 835.0148038548641
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1822.8938604926734
-  tps: 1323.1855186780085
+  dps: 1134.2927703433195
+  tps: 841.1647555734603
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheTwinStars"
  value: {
-  dps: 1794.9736350462135
-  tps: 1304.0532028692398
+  dps: 1119.7379350940098
+  tps: 831.3882129026979
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 1857.6749853112142
-  tps: 1348.2038778973372
+  dps: 1152.0181012253377
+  tps: 854.2440590372235
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1819.956765731023
-  tps: 1322.1011502327362
+  dps: 1131.0732896519642
+  tps: 839.8827169773949
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1844.026491184467
-  tps: 1338.9618690677876
+  dps: 1142.986216844268
+  tps: 848.233677029649
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1811.0750366800573
-  tps: 1314.3927625827998
+  dps: 1123.3519638251664
+  tps: 832.986611584377
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1819.9563933808383
-  tps: 1321.7603170641812
+  dps: 1130.3882163117955
+  tps: 839.0625931158509
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1819.2946562023103
-  tps: 1321.2895592915643
+  dps: 1129.7264791332668
+  tps: 838.5918353432339
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeofFieryRedemption-30447"
  value: {
-  dps: 1816.7793815515831
-  tps: 1318.4528586397275
+  dps: 1129.056308696693
+  tps: 837.0467076413039
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1819.2946562023103
-  tps: 1321.2895592915643
+  dps: 1129.7264791332668
+  tps: 838.5918353432339
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1819.9563933808383
-  tps: 1321.7603170641812
+  dps: 1130.3882163117955
+  tps: 839.0625931158509
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1840.671723688747
-  tps: 1335.3311391671878
+  dps: 1140.1185731361454
+  tps: 844.9439337803674
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WarpSlicer-30311"
  value: {
-  dps: 2144.5181506139825
-  tps: 1555.8257090759923
+  dps: 1337.1534215134398
+  tps: 990.6703987056129
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WastewalkerArmor"
  value: {
-  dps: 1559.517224498013
-  tps: 1139.131721296146
+  dps: 971.6328281408972
+  tps: 727.6126438461645
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WindhawkArmor"
  value: {
-  dps: 1642.8754514909385
-  tps: 1195.1417457178684
+  dps: 1021.4380129338082
+  tps: 760.1355387278771
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1741.1777825330992
-  tps: 1267.254112592025
+  dps: 1086.9316577066293
+  tps: 809.2818252134957
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathofSpellfire"
  value: {
-  dps: 1626.4365531446374
-  tps: 1185.7791366411998
+  dps: 1017.5187666810109
+  tps: 759.5366861166605
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1839.373274369605
-  tps: 1334.331637877232
+  dps: 1147.2635352627785
+  tps: 849.8548205024537
  }
 }
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 1851.8570815907813
-  tps: 1344.091244704473
+  dps: 1148.8407607517286
+  tps: 851.9798201171373
  }
 }
 dps_results: {
  key: "TestRetribution-SelfDrums-DPS"
  value: {
-  dps: 1849.5994120788641
-  tps: 1342.3846061923998
+  dps: 1145.8930760023266
+  tps: 849.7901709388236
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1950.53630751569
-  tps: 2312.6725217274507
+  dps: 1245.918689843051
+  tps: 1819.4401893566028
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1854.6951643087025
-  tps: 1346.1138336506283
+  dps: 1150.252367965981
+  tps: 853.0038762107226
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2295.3048173635384
-  tps: 1665.3893566231384
+  dps: 1474.3370389970019
+  tps: 1090.7119117665627
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 570.9516788332794
-  tps: 738.2386217771827
+  dps: 391.9246401690696
+  tps: 559.2115831129727
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 570.9516788332794
-  tps: 579.3160259804747
+  dps: 391.9246401690696
+  tps: 400.28898731626475
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 859.4898756425932
-  tps: 882.1213181678265
+  dps: 598.9105563122931
+  tps: 621.5419988375266
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1956.9784491454789
-  tps: 2316.8181926175494
+  dps: 1249.9552643281852
+  tps: 1821.9019632454444
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1862.0001635931992
-  tps: 1351.0308414028411
+  dps: 1155.2439721485746
+  tps: 856.301507391604
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2349.9457405584217
-  tps: 1703.752540769949
+  dps: 1510.1871618619389
+  tps: 1115.9215356824113
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 575.4378652991396
-  tps: 742.4315080949676
+  dps: 396.1032437144607
+  tps: 563.0968865102886
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 575.4378652991396
-  tps: 583.787547438931
+  dps: 396.1032437144607
+  tps: 404.4529258542521
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 896.2296015241272
-  tps: 918.9358242145373
+  dps: 624.7472564209472
+  tps: 647.4534791113573
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1986.415496324212
-  tps: 2344.2380441422447
+  dps: 1272.7965822563283
+  tps: 1844.7048042947272
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1890.2015566969449
-  tps: 1370.9378342128302
+  dps: 1176.799286357152
+  tps: 871.5562449749757
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2375.787646711648
-  tps: 1720.875091591013
+  dps: 1533.894544963193
+  tps: 1131.5499203670945
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 579.1426685964433
-  tps: 744.4585584242966
+  dps: 398.80233547949314
+  tps: 564.1182253073464
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 579.1426685964433
-  tps: 587.408463087836
+  dps: 398.80233547949314
+  tps: 407.0681299708857
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 892.2323177013366
-  tps: 914.6556058842641
+  dps: 623.4647215664779
+  tps: 645.8880097494057
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1964.004296670136
-  tps: 2325.521101409229
+  dps: 1256.0241026656554
+  tps: 1829.9349656060915
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1868.893201237644
-  tps: 1355.7031642329277
+  dps: 1161.1731809910264
+  tps: 860.2991500602949
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2387.8424741345116
-  tps: 1730.1492704779039
+  dps: 1527.708370355489
+  tps: 1128.0553978325877
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 576.9764054354997
-  tps: 743.2916761262188
+  dps: 396.25547281846576
+  tps: 562.5707435091849
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 576.9764054354997
-  tps: 585.2921689700357
+  dps: 396.25547281846576
+  tps: 404.57123635300167
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 890.6416455742213
-  tps: 913.0602324129062
+  dps: 620.9774288702921
+  tps: 643.3960157089772
  }
 }
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1550.4942569741447
-  tps: 1131.586628941491
+  dps: 930.946803633252
+  tps: 697.9034116028665
  }
 }

--- a/sim/rogue/TestMutilate.results
+++ b/sim/rogue/TestMutilate.results
@@ -47,1029 +47,1029 @@ character_stats_results: {
 dps_results: {
  key: "TestMutilate-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1185.2668937395624
-  tps: 829.3893497634564
+  dps: 559.1949150923423
+  tps: 384.8782449239302
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Alchemist'sStone-13503"
  value: {
-  dps: 1175.616349922153
-  tps: 822.6298176882447
+  dps: 555.3416426444223
+  tps: 382.23477552105624
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 1184.6395984913067
-  tps: 829.0646876905421
+  dps: 558.9856876982573
+  tps: 384.85041102747743
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Assassin'sAlchemistStone-35751"
  value: {
-  dps: 1190.767865187851
-  tps: 833.38561370591
+  dps: 562.0804939480179
+  tps: 387.01758012562857
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AssassinationArmor"
  value: {
-  dps: 1025.8529994538942
-  tps: 716.3382791249003
+  dps: 488.4323242015377
+  tps: 334.76959969572715
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1182.571118814737
-  tps: 827.5283062162848
+  dps: 558.3487355116362
+  tps: 384.3304140710827
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1177.4379250005072
-  tps: 823.9213561728958
+  dps: 394.1485673695715
+  tps: 267.7859122549315
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1202.966242349216
-  tps: 842.0583439314727
+  dps: 566.2603317606545
+  tps: 389.99714741359435
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 1166.5606065754116
-  tps: 816.2730510750681
+  dps: 550.8290269196558
+  tps: 379.10362951948184
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1171.188054793099
-  tps: 819.5585393096267
+  dps: 552.8358544300646
+  tps: 380.528477051872
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1171.6899642400663
-  tps: 819.9111930493912
+  dps: 553.0771936580443
+  tps: 380.69612593615545
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1204.6227524595024
-  tps: 843.2225836687825
+  dps: 567.986131006291
+  tps: 391.2105824370023
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1210.9346626030201
-  tps: 847.6670686374961
+  dps: 569.7126374032852
+  tps: 392.3994307456843
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1176.561552798299
-  tps: 823.2710078455464
+  dps: 555.4836759887392
+  tps: 382.30571531075896
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1190.905510367152
-  tps: 833.4488560387307
+  dps: 560.3909007921077
+  tps: 385.7834832404494
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1178.6942247182171
-  tps: 824.9530965384859
+  dps: 558.0843978666953
+  tps: 384.3201194739052
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 799.0485980289537
+  dps: 550.8719029755532
+  tps: 371.496063627534
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1186.2713762345152
-  tps: 830.2015874394998
+  dps: 558.7097458861671
+  tps: 384.6328298921729
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1171.124207775097
-  tps: 819.4567523541393
+  dps: 553.3240684987514
+  tps: 380.81865346793404
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1187.0120231207857
-  tps: 830.6844800938111
+  dps: 558.7343476190559
+  tps: 384.60733048758283
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1191.7696446555415
-  tps: 834.1677661443781
+  dps: 561.6057853446581
+  tps: 386.75142603365157
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1175.9487617567231
-  tps: 822.8971564657134
+  dps: 554.1658924683038
+  tps: 381.4313192709357
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1187.3041922709276
-  tps: 830.9264059348945
+  dps: 560.59551161222
+  tps: 385.96324266721194
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1186.798970122578
-  tps: 830.5676982095667
+  dps: 560.353315849686
+  tps: 385.7912836758129
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1193.2706492540447
-  tps: 835.1625903929075
+  dps: 563.1324321187113
+  tps: 387.764456226821
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1171.9287350494226
-  tps: 820.001770155612
+  dps: 553.7907666929377
+  tps: 381.12381262250784
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Deathmantle"
  value: {
-  dps: 1132.7798559463033
-  tps: 792.1867389684064
+  dps: 533.2510229466446
+  tps: 366.5212675386491
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1167.4962956210104
-  tps: 816.8283135689703
+  dps: 550.4490663575655
+  tps: 378.72478079192445
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1171.6475860991302
-  tps: 819.871134480518
+  dps: 553.2938511207063
+  tps: 380.83998264583687
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1196.1048648836324
-  tps: 837.1748834899147
+  dps: 564.3512579238645
+  tps: 388.6298225484797
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1167.0593879606445
-  tps: 816.5181091301107
+  dps: 550.2638907832012
+  tps: 378.59330613412584
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1171.6899642400663
-  tps: 819.9111930493912
+  dps: 553.0771936580443
+  tps: 380.69612593615545
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1168.3866160409643
-  tps: 817.5025465729834
+  dps: 551.1251339045796
+  tps: 379.24689425615
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1184.3454168023331
-  tps: 828.8256753521923
+  dps: 559.3355181929063
+  tps: 385.0686473394994
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1196.2999686154144
-  tps: 837.3134071394802
+  dps: 564.4309837712976
+  tps: 388.68642790015735
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Guardian'sAlchemistStone-35748"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-HandofJustice-11815"
  value: {
-  dps: 1180.1504371874178
-  tps: 825.8867328745223
+  dps: 556.5555718140736
+  tps: 383.13437845944844
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Heartrazor-29962"
  value: {
-  dps: 1190.905510367152
-  tps: 833.4488560387307
+  dps: 560.3909007921077
+  tps: 385.7834832404494
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1183.0170338447483
-  tps: 827.8871945142791
+  dps: 558.4471337290507
+  tps: 384.4425654321339
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1175.6249422398548
-  tps: 822.6136487231737
+  dps: 395.260959514622
+  tps: 268.55522098825827
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1171.6899642400663
-  tps: 819.9111930493912
+  dps: 553.0771936580443
+  tps: 380.69612593615545
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1168.3866160409643
-  tps: 817.5025465729834
+  dps: 551.1251339045796
+  tps: 379.24689425615
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-IndestructibleAlchemist'sStone-44323"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1175.4945448961296
-  tps: 822.5596917100723
+  dps: 555.2011947009797
+  tps: 382.151413071516
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1176.1335951897838
-  tps: 822.9527897668256
+  dps: 554.5366306081036
+  tps: 381.61894491383276
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1196.0786128034424
-  tps: 837.1964896346626
+  dps: 320.14934461798185
+  tps: 215.2867092229857
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 905.0105184755064
-  tps: 630.4965559983723
+  dps: 435.9570860072452
+  tps: 297.4686189459069
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1200.9581905251541
-  tps: 840.6207446953957
+  dps: 566.4319603856242
+  tps: 390.107121296329
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MercurialAlchemistStone-44322"
  value: {
-  dps: 1175.5798718755086
-  tps: 822.6037030298919
+  dps: 554.3813342100516
+  tps: 381.55274128741695
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MightyAlchemist'sStone-44324"
  value: {
-  dps: 1174.9986249598755
-  tps: 822.1873866909668
+  dps: 554.5163065505284
+  tps: 381.6449406203304
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Netherblade"
  value: {
-  dps: 1086.7595109780964
-  tps: 759.4917008645075
+  dps: 515.6181825312865
+  tps: 353.98135766727165
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1173.5618877705413
-  tps: 821.1875051509052
+  dps: 554.3765677056602
+  tps: 381.5659279048393
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1175.4945448961296
-  tps: 822.5596917100723
+  dps: 555.2011947009797
+  tps: 382.151413071516
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1171.1460663635562
-  tps: 819.4722719519456
+  dps: 553.3457839615111
+  tps: 380.8340714464932
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PrimalIntent"
  value: {
-  dps: 1160.7212512140632
-  tps: 812.0858457116838
+  dps: 546.1140531672108
+  tps: 375.71473509841877
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Redeemer'sAlchemistStone-35750"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1197.873932847723
-  tps: 838.4918406720186
+  dps: 564.407909185058
+  tps: 388.73096387152674
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1190.905510367152
-  tps: 833.4488560387307
+  dps: 560.3909007921077
+  tps: 385.7834832404494
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1115.115604211996
-  tps: 779.661514060718
+  dps: 526.6928762166831
+  tps: 361.8813771840456
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1190.0645854207294
-  tps: 832.9574986135102
+  dps: 569.9149147488538
+  tps: 392.6512324364787
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1155.436534613167
-  tps: 808.3003689978846
+  dps: 547.0157000231761
+  tps: 376.32157643899103
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1171.4940205665089
-  tps: 819.723861876563
+  dps: 553.6860508480124
+  tps: 381.08020337643046
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1169.9385481384945
-  tps: 818.6803848466936
+  dps: 552.7452386315166
+  tps: 380.47313509673893
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1197.6220464999417
-  tps: 838.2807761590734
+  dps: 564.1202789454343
+  tps: 388.49452119537347
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 1166.0711333515092
-  tps: 815.9255250860978
+  dps: 550.6202934926005
+  tps: 378.95542878627253
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 1201.4288847932344
-  tps: 841.0295286097227
+  dps: 565.7079587201654
+  tps: 389.66767109784354
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1170.439994815213
-  tps: 818.9574968033085
+  dps: 553.05745266675
+  tps: 380.61589187790037
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1173.591929625954
-  tps: 821.1537282237808
+  dps: 553.7962270960176
+  tps: 381.09877942752604
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Slayer'sArmor"
  value: {
-  dps: 1205.1835252300236
-  tps: 843.6170021967208
+  dps: 96.02650194391671
+  tps: 56.11551566358473
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1193.2527420557165
-  tps: 835.1498762820946
+  dps: 563.1338796115534
+  tps: 387.76548394673887
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1040.0603748493306
-  tps: 726.3698158747371
+  dps: 494.7292304659654
+  tps: 339.18470336254796
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1010.4577480665866
-  tps: 705.3279761227845
+  dps: 481.7652488685582
+  tps: 329.9563016921845
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1171.1460663635562
-  tps: 819.4722719519456
+  dps: 553.3457839615111
+  tps: 380.8340714464932
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1175.4945448961296
-  tps: 822.5596917100723
+  dps: 555.2011947009797
+  tps: 382.151413071516
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1173.5618877705413
-  tps: 821.1875051509052
+  dps: 554.3765677056602
+  tps: 381.5659279048393
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1170.179737800762
-  tps: 818.7861786723615
+  dps: 552.9334704638514
+  tps: 380.54132886315494
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1190.905510367152
-  tps: 833.4488560387307
+  dps: 560.3909007921077
+  tps: 385.7834832404494
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1164.5641714633555
-  tps: 814.780991161518
+  dps: 550.8910088227449
+  tps: 379.0730456866846
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1167.4993886804816
-  tps: 816.8006475299918
+  dps: 551.1833181696281
+  tps: 379.21623746728625
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheTwinStars"
  value: {
-  dps: 1138.468771408028
-  tps: 796.2401731513816
+  dps: 538.0913701330046
+  tps: 369.97221824611523
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1173.747504930312
-  tps: 821.2889546758628
+  dps: 553.4248214366755
+  tps: 380.85984939538054
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1176.6864424667046
-  tps: 823.384193542211
+  dps: 554.9866080591654
+  tps: 381.97731111285776
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1171.5183469172166
-  tps: 819.79140085223
+  dps: 557.0577892606362
+  tps: 383.52440491605824
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1165.3480949867917
-  tps: 815.3557122744422
+  dps: 550.8719029755532
+  tps: 379.077615946463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1187.057175699
-  tps: 830.8064923487339
+  dps: 559.873703981905
+  tps: 385.5062274295968
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 1193.764709898633
-  tps: 835.550077962163
+  dps: 320.8030113542719
+  tps: 215.74727199566667
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WastewalkerArmor"
  value: {
-  dps: 1030.9110054718542
-  tps: 719.8443879808784
+  dps: 490.43433514456444
+  tps: 336.10595204850296
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WindhawkArmor"
  value: {
-  dps: 1053.9528003513713
-  tps: 736.2075433021924
+  dps: 500.4201745909985
+  tps: 343.19937901232805
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WrathofSpellfire"
  value: {
-  dps: 1045.0327300559925
-  tps: 729.9338078178339
+  dps: 496.512303917813
+  tps: 340.4843052597269
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1170.9532352540332
-  tps: 819.3218975148717
+  dps: 553.2762256446291
+  tps: 380.7712206921944
  }
 }
 dps_results: {
  key: "TestMutilate-Average-Default"
  value: {
-  dps: 1180.7986530920612
-  tps: 826.4223485824333
+  dps: 556.5256906733496
+  tps: 383.18854526514633
  }
 }
 dps_results: {
  key: "TestMutilate-SelfDrums-DPS"
  value: {
-  dps: 1191.9571653921673
-  tps: 834.210011589638
+  dps: 562.2309810153848
+  tps: 387.1044206821223
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1265.1831793067852
-  tps: 886.2345852183853
+  dps: 633.4991648839526
+  tps: 437.7389349781737
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1191.6027440280034
-  tps: 833.9859974437808
+  dps: 560.9862763008956
+  tps: 386.2483053575345
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1407.5332932748042
-  tps: 999.3486382251109
+  dps: 655.1705332941012
+  tps: 465.17107863881176
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 538.5136064087701
-  tps: 382.34466055022676
+  dps: 238.0628425535154
+  tps: 169.02461821299593
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 538.5136064087701
-  tps: 382.34466055022676
+  dps: 238.0628425535154
+  tps: 169.02461821299593
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 563.1014367368887
-  tps: 399.80202008319094
+  dps: 253.83474367159232
+  tps: 180.22266800683056
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1264.8250541057744
-  tps: 885.9803163256673
+  dps: 633.348272484916
+  tps: 437.6318013748579
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1190.905510367152
-  tps: 833.4488560387307
+  dps: 560.3909007921077
+  tps: 385.7834832404494
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1406.7720195305315
-  tps: 998.8081338666766
+  dps: 654.8502174532887
+  tps: 464.943654391835
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 538.3650696773853
-  tps: 382.23919947094356
+  dps: 237.99746304194304
+  tps: 168.9781987597796
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 538.3650696773853
-  tps: 382.23919947094356
+  dps: 237.99746304194304
+  tps: 168.9781987597796
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 563.1600681398852
-  tps: 399.8436483793185
+  dps: 253.86256702303788
+  tps: 180.2424225863568
  }
 }
 dps_results: {
  key: "TestMutilate-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1053.2981782214658
-  tps: 735.8017712769208
+  dps: 500.99013270548073
+  tps: 343.6630589605712
  }
 }

--- a/sim/rogue/TestRogue.results
+++ b/sim/rogue/TestRogue.results
@@ -47,1281 +47,1281 @@ character_stats_results: {
 dps_results: {
  key: "TestRogue-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1332.6597887931555
-  tps: 934.1299801124359
+  dps: 622.3736607398004
+  tps: 429.8268291945541
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1298.47633053121
-  tps: 909.8612028981098
+  dps: 606.8206376598439
+  tps: 418.7856609594398
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Alchemist'sStone-13503"
  value: {
-  dps: 1312.2113272391975
-  tps: 919.6130505607823
+  dps: 612.6567170262782
+  tps: 422.9292773096099
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1298.47633053121
-  tps: 909.8612028981098
+  dps: 606.8206376598439
+  tps: 418.7856609594398
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 1325.2304091559954
-  tps: 928.8565987217074
+  dps: 618.1550957533028
+  tps: 426.8331262057958
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Assassin'sAlchemistStone-35751"
  value: {
-  dps: 1329.1743693949572
-  tps: 931.6568104913719
+  dps: 619.8744555510253
+  tps: 428.05387166218026
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AssassinationArmor"
  value: {
-  dps: 1149.9120393986598
-  tps: 804.3991446261996
+  dps: 542.4539409029786
+  tps: 373.1038946942661
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1318.406335649125
-  tps: 924.0115065318313
+  dps: 615.2452446191222
+  tps: 424.7671319005291
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1314.7985309782734
-  tps: 921.4499652155265
+  dps: 420.93029193048125
+  tps: 286.80351549159406
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1353.2118522546298
-  tps: 948.7592038181677
+  dps: 630.7836713027508
+  tps: 435.83519534233375
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 1310.2553207723752
-  tps: 918.2600664657667
+  dps: 612.5096258160228
+  tps: 422.86062304675664
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1316.1428490171684
-  tps: 922.44021151957
+  dps: 615.0122147985335
+  tps: 424.6374612243392
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1315.0915855900248
-  tps: 921.6712651350417
+  dps: 614.4727075000458
+  tps: 424.2318616911559
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1345.348887842262
-  tps: 943.1407185889583
+  dps: 626.7356465246312
+  tps: 432.9253172534404
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1367.82039163284
-  tps: 959.1354561556619
+  dps: 636.6261039901342
+  tps: 439.9875119293405
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 1338.5887441305829
-  tps: 938.3542476988373
+  dps: 624.4494417816486
+  tps: 431.3153430310942
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1312.004786018284
-  tps: 919.4664062939337
+  dps: 612.539302366427
+  tps: 422.84591290111575
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1338.5887441305829
-  tps: 938.3542476988373
+  dps: 624.4494417816486
+  tps: 431.3153430310942
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1319.5723042357577
-  tps: 924.8778792218201
+  dps: 618.6207972669621
+  tps: 427.20230927397483
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1338.5887441305829
-  tps: 938.3542476988373
+  dps: 624.4494417816486
+  tps: 431.3153430310942
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 900.2277302171325
+  dps: 612.6395896506375
+  tps: 414.4717410577146
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1337.278912157082
-  tps: 937.4119028924985
+  dps: 623.748636178941
+  tps: 430.80540694801806
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1298.4763305310407
-  tps: 909.8612028979913
+  dps: 606.8206376597647
+  tps: 418.78566095938515
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1318.5851261728947
-  tps: 924.151678948879
+  dps: 615.9580935175493
+  tps: 425.28648576358336
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BulwarkofAzzinoth-32375"
  value: {
-  dps: 859.6838480919732
-  tps: 598.3598915190995
+  dps: 379.1606712128809
+  tps: 257.1884359349439
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1333.8929371040017
-  tps: 935.0202247099651
+  dps: 622.4538654050716
+  tps: 429.8984838037244
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1335.7360538590465
-  tps: 936.3288376060468
+  dps: 623.2354584741183
+  tps: 430.4534148827476
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1321.3107242605129
-  tps: 926.1542454552851
+  dps: 617.4380315324617
+  tps: 426.40463361836885
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 1298.5867132367116
-  tps: 909.9395746190173
+  dps: 606.8684885748191
+  tps: 418.8196351090737
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1298.47633053121
-  tps: 909.8612028981098
+  dps: 606.8206376598439
+  tps: 418.7856609594398
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1323.553380543347
-  tps: 927.6659084067288
+  dps: 617.4529990219264
+  tps: 426.33463752652045
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1326.287522334216
-  tps: 929.6071490782457
+  dps: 618.6179011254669
+  tps: 427.1617180200341
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1298.4763305310407
-  tps: 909.8612028979913
+  dps: 606.8206376597647
+  tps: 418.78566095938515
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1295.0345107464439
-  tps: 907.4175108509276
+  dps: 605.3077743528709
+  tps: 417.71152801149105
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1332.0296301938479
-  tps: 933.6840456585845
+  dps: 621.067931780323
+  tps: 428.90123978498195
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1298.5867132367116
-  tps: 909.9395746190173
+  dps: 606.8684885748191
+  tps: 418.8196351090737
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1307.1025279166524
-  tps: 915.9858030417756
+  dps: 610.4818863786799
+  tps: 421.38514754981503
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Deathmantle"
  value: {
-  dps: 1270.677121924945
-  tps: 890.1231566856416
+  dps: 594.3430772673378
+  tps: 409.92598497874104
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Despair-28573"
  value: {
-  dps: 993.9415013234099
-  tps: 693.68522275344
+  dps: 447.8653817505933
+  tps: 305.9711778567401
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1313.6638610689927
-  tps: 920.6575807251085
+  dps: 613.8671958604616
+  tps: 423.80194842705134
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1316.3521124772246
-  tps: 922.5662392249532
+  dps: 615.0078529230658
+  tps: 424.61181494150026
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Devastation-30316"
  value: {
-  dps: 1225.7858209349922
-  tps: 858.2943049888022
+  dps: 535.0803801996773
+  tps: 367.8934420667285
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1338.5887441305829
-  tps: 938.3542476988373
+  dps: 624.4494417816486
+  tps: 431.3153430310942
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1338.5887441305829
-  tps: 938.3542476988373
+  dps: 624.4494417816486
+  tps: 431.3153430310942
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1338.5887441305829
-  tps: 938.3542476988373
+  dps: 624.4494417816486
+  tps: 431.3153430310942
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1334.5964384333588
-  tps: 935.5064795086373
+  dps: 622.1559174692164
+  tps: 429.67370962409603
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 1338.5887441305829
-  tps: 938.3542476988373
+  dps: 624.4494417816486
+  tps: 431.3153430310942
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1313.352796198474
-  tps: 920.4367246670398
+  dps: 613.7353555481145
+  tps: 423.70834180528493
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1315.0915855900248
-  tps: 921.6712651350417
+  dps: 614.4727075000458
+  tps: 424.2318616911559
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1314.357558670168
-  tps: 921.1501060219431
+  dps: 614.1611677390727
+  tps: 424.01066846086525
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1298.4763305310407
-  tps: 909.8612028979913
+  dps: 606.8206376597647
+  tps: 418.78566095938515
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1298.5867132367116
-  tps: 909.9395746190173
+  dps: 606.8684885748191
+  tps: 418.8196351090737
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1295.0563213693436
-  tps: 907.4329963931864
+  dps: 605.3170074862298
+  tps: 417.71808353617575
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1321.1847458021716
-  tps: 925.984177740494
+  dps: 616.4724978885226
+  tps: 425.63848172180354
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1337.9770078267259
-  tps: 937.9066837779277
+  dps: 623.6003103936733
+  tps: 430.6992286004604
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-GlaiveofthePit-28774"
  value: {
-  dps: 951.5877860493085
-  tps: 663.6033554368133
+  dps: 426.41883220545634
+  tps: 290.73339820767836
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1298.47633053121
-  tps: 909.8612028981098
+  dps: 606.8206376598439
+  tps: 418.7856609594398
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Guardian'sAlchemistStone-35748"
  value: {
-  dps: 1298.5867132367116
-  tps: 909.9395746190173
+  dps: 606.8684885748191
+  tps: 418.8196351090737
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HandofJustice-11815"
  value: {
-  dps: 1332.8675243448108
-  tps: 934.3750972332366
+  dps: 622.0215510611006
+  tps: 429.6744562018029
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Heartrazor-29962"
  value: {
-  dps: 1338.5887441305829
-  tps: 938.3542476988373
+  dps: 624.4494417816486
+  tps: 431.3153430310942
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1295.0345107464439
-  tps: 907.4175108509276
+  dps: 605.3077743528709
+  tps: 417.71152801149105
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1319.5501512101516
-  tps: 924.8236155801595
+  dps: 615.7904997801515
+  tps: 425.15426306485926
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1320.7827710318368
-  tps: 925.6515527455144
+  dps: 422.28321585060473
+  tps: 287.71686856684
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1295.0345107464439
-  tps: 907.4175108509276
+  dps: 605.3077743528709
+  tps: 417.71152801149105
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1315.0915855900248
-  tps: 921.6712651350417
+  dps: 614.4727075000458
+  tps: 424.2318616911559
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1314.357558670168
-  tps: 921.1501060219431
+  dps: 614.1611677390727
+  tps: 424.01066846086525
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IndestructibleAlchemist'sStone-44323"
  value: {
-  dps: 1298.5867132367116
-  tps: 909.9395746190173
+  dps: 606.8684885748191
+  tps: 418.8196351090737
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1322.7005477192904
-  tps: 927.0736282468196
+  dps: 617.7153276699793
+  tps: 426.5341220118087
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 969.4270206970192
-  tps: 676.2801653830371
+  dps: 425.5743245679312
+  tps: 290.14475113138445
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1314.091947073738
-  tps: 920.9900070631916
+  dps: 614.19627876373
+  tps: 424.06408256308566
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-LionheartChampion-28429"
  value: {
-  dps: 1025.8736022026685
-  tps: 716.3547671649522
+  dps: 450.01879421048443
+  tps: 307.4978534905016
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1052.0620935819322
-  tps: 734.9485960442295
+  dps: 461.1718158407477
+  tps: 315.4164988479885
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1344.8153827975536
-  tps: 942.8314103674234
+  dps: 331.3150395324039
+  tps: 223.24616664916684
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1011.3076536847998
-  tps: 705.9893983126583
+  dps: 483.66352907106454
+  tps: 331.3620698369063
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 729.0755608224522
-  tps: 505.63035291824565
+  dps: 323.7721998324382
+  tps: 217.86496661533567
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1341.0695690120529
-  tps: 940.1024022195098
+  dps: 624.9323315973274
+  tps: 431.64496365505494
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1298.5867132367116
-  tps: 909.9395746190173
+  dps: 606.8684885748191
+  tps: 418.8196351090737
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MercurialAlchemistStone-44322"
  value: {
-  dps: 1314.7514974690148
-  tps: 921.4241220577916
+  dps: 614.5879005907382
+  tps: 424.3079682742152
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MightyAlchemist'sStone-44324"
  value: {
-  dps: 1309.8037925939
-  tps: 917.9037009626211
+  dps: 611.624697135392
+  tps: 422.19654318708103
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1298.4763305312176
-  tps: 909.861202898115
+  dps: 606.8206376598475
+  tps: 418.7856609594422
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Netherblade"
  value: {
-  dps: 1216.2321842885588
-  tps: 851.5080870897178
+  dps: 572.2749592480454
+  tps: 394.29845731095344
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1320.4272000236606
-  tps: 925.4595513829227
+  dps: 616.7485204281999
+  tps: 425.84768887014513
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1322.7005477192904
-  tps: 927.0736282468196
+  dps: 617.7153276699793
+  tps: 426.5341220118087
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1317.5855154041233
-  tps: 923.4419553030514
+  dps: 615.5400113759755
+  tps: 424.9896474430663
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PrimalIntent"
  value: {
-  dps: 1315.9582713874368
-  tps: 922.312748291631
+  dps: 613.2108763812221
+  tps: 423.3620978372184
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1298.5867132367116
-  tps: 909.9395746190173
+  dps: 606.8684885748191
+  tps: 418.8196351090737
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Redeemer'sAlchemistStone-35750"
  value: {
-  dps: 1298.5867132367116
-  tps: 909.9395746190173
+  dps: 606.8684885748191
+  tps: 418.8196351090737
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1344.5038343564415
-  tps: 942.5539617591971
+  dps: 626.9621037124475
+  tps: 433.0993330019612
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1338.5887441305829
-  tps: 938.3542476988373
+  dps: 624.4494417816486
+  tps: 431.3153430310942
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1262.5122845907383
-  tps: 884.3421010635727
+  dps: 591.1405033780558
+  tps: 407.6681364025683
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1338.5887441305829
-  tps: 938.3542476988373
+  dps: 624.4494417816486
+  tps: 431.3153430310942
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1335.6746378334838
-  tps: 936.2307347715323
+  dps: 634.0014140394668
+  tps: 438.0427458777802
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1285.8446773149437
-  tps: 900.8927291145628
+  dps: 601.4003839825468
+  tps: 414.93728084856093
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1312.2120531091825
-  tps: 919.5761859297336
+  dps: 613.958166816687
+  tps: 423.8159266620619
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1307.325349162659
-  tps: 916.1440061264403
+  dps: 610.5736468360508
+  tps: 421.45029747454856
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1298.4763305310407
-  tps: 909.8612028979913
+  dps: 606.8206376597647
+  tps: 418.78566095938515
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1349.1633400541766
-  tps: 945.9176047553282
+  dps: 628.74612278382
+  tps: 434.4213804933751
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 1309.6802175114608
-  tps: 917.851743150518
+  dps: 612.264947429663
+  tps: 422.6869013924414
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 1351.8855564081186
-  tps: 947.8175337671448
+  dps: 630.2265153540895
+  tps: 435.43961461878416
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1305.2133192230917
-  tps: 914.6444648693473
+  dps: 609.6776158712028
+  tps: 420.8141154895062
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1319.844735870482
-  tps: 925.0727405643889
+  dps: 616.1529007951032
+  tps: 425.45153766087003
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 911.9442988111634
-  tps: 635.4672817501421
+  dps: 401.7512029628688
+  tps: 273.2301836978531
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Slayer'sArmor"
  value: {
-  dps: 1385.177632616952
-  tps: 971.4223053659811
+  dps: 99.89897614075872
+  tps: 58.87445926788403
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1331.0894529438096
-  tps: 933.0165198110575
+  dps: 620.6630341901032
+  tps: 428.6137624959255
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1298.5867132367116
-  tps: 909.9395746190173
+  dps: 606.8684885748191
+  tps: 418.8196351090737
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1179.7548691521865
-  tps: 825.668099387484
+  dps: 555.6298533538404
+  tps: 382.53933817065825
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1143.4721167946689
-  tps: 799.8369614799146
+  dps: 540.2974325719607
+  tps: 371.58293568179187
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1317.5855154041233
-  tps: 923.4419553030514
+  dps: 615.5400113759755
+  tps: 424.9896474430663
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1322.7005477192904
-  tps: 927.0736282468196
+  dps: 617.7153276699793
+  tps: 426.5341220118087
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1320.4272000236606
-  tps: 925.4595513829227
+  dps: 616.7485204281999
+  tps: 425.84768887014513
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1316.4488415563087
-  tps: 922.6349168711026
+  dps: 615.0566077550859
+  tps: 424.6464308722344
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1338.5887441305829
-  tps: 938.3542476988373
+  dps: 624.4494417816486
+  tps: 431.3153430310942
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheBladefist-29348"
  value: {
-  dps: 1236.1286109286368
-  tps: 865.5715813122473
+  dps: 581.1029494597573
+  tps: 400.50336166934306
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheDecapitator-28767"
  value: {
-  dps: 1338.5887441305829
-  tps: 938.3542476988373
+  dps: 624.4494417816486
+  tps: 431.3153430310942
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheFistsofFury"
  value: {
-  dps: 1266.007825148086
-  tps: 886.8335349006479
+  dps: 601.7130794282745
+  tps: 415.1842654395815
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1298.5867132367116
-  tps: 909.9395746190173
+  dps: 606.8684885748191
+  tps: 418.8196351090737
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1338.5887441305829
-  tps: 938.3542476988373
+  dps: 624.4494417816486
+  tps: 431.3153430310942
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1295.0345107464439
-  tps: 907.4175108509276
+  dps: 605.3077743528709
+  tps: 417.71152801149105
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1313.6929165577326
-  tps: 920.6960394503999
+  dps: 614.8513290972952
+  tps: 424.5185123534894
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1482.3050853450823
-  tps: 1040.4008976359544
+  dps: 685.8973342631097
+  tps: 474.9513943677542
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinStars"
  value: {
-  dps: 1275.5960154293005
-  tps: 893.6637217138267
+  dps: 597.9642678159888
+  tps: 412.545180908376
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 1338.5887441305829
-  tps: 938.3542476988373
+  dps: 624.4494417816486
+  tps: 431.3153430310942
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1324.3114660372353
-  tps: 928.2699612904727
+  dps: 619.6507218281678
+  tps: 427.96083290203484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1332.522295865826
-  tps: 934.1005677925042
+  dps: 621.70281222375
+  tps: 429.41873440663005
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1307.7526369088423
-  tps: 916.4990811992549
+  dps: 616.2068454419998
+  tps: 425.5015692577968
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1310.7654723172343
-  tps: 918.5997247113598
+  dps: 612.6395896506375
+  tps: 422.93034801807613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1332.7107650084424
-  tps: 934.2136915662667
+  dps: 622.2606639477491
+  tps: 429.79411981317423
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 1332.6151661323709
-  tps: 934.139129909549
+  dps: 362.1210435608305
+  tps: 245.08830288375577
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1338.5887441305829
-  tps: 938.3542476988373
+  dps: 624.4494417816486
+  tps: 431.3153430310942
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WastewalkerArmor"
  value: {
-  dps: 1163.2743158259389
-  tps: 813.8897017404659
+  dps: 547.8980164315907
+  tps: 376.9725291704788
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WindhawkArmor"
  value: {
-  dps: 1194.4998687494783
-  tps: 836.0722573658837
+  dps: 561.6468686795255
+  tps: 386.746627316217
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WorldBreaker-30090"
  value: {
-  dps: 977.2125873233655
-  tps: 681.80382222344
+  dps: 429.49069866565935
+  tps: 292.92128127646885
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WrathofSpellfire"
  value: {
-  dps: 1178.3575272384855
-  tps: 824.6060854953499
+  dps: 554.4163037786544
+  tps: 381.6078168388693
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1302.3603591809529
-  tps: 912.6188632394291
+  dps: 608.413051193923
+  tps: 419.91627456863773
  }
 }
 dps_results: {
  key: "TestRogue-Average-Default"
  value: {
-  dps: 1336.0534249302693
-  tps: 936.6827708448377
+  dps: 623.3457629388139
+  tps: 430.6603308309046
  }
 }
 dps_results: {
  key: "TestRogue-SelfDrums-DPS"
  value: {
-  dps: 1329.9560233394614
-  tps: 932.1807918185614
+  dps: 620.3512067104983
+  tps: 428.3613720119981
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1626.7250211659914
-  tps: 1142.9229030488686
+  dps: 803.9515754048584
+  tps: 558.7537565584639
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1337.311388811207
-  tps: 937.4165739455791
+  dps: 624.0534880766447
+  tps: 431.0034644240401
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1671.83391930319
-  tps: 1187.0020827052647
+  dps: 776.1478041272672
+  tps: 551.0649409303595
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 778.7373602223354
-  tps: 552.9035257578579
+  dps: 349.4794103152417
+  tps: 248.13038132382155
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 669.1991889632877
-  tps: 475.1314241639342
+  dps: 294.9094598811052
+  tps: 209.38571651558476
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 741.005038645137
-  tps: 526.1135774380474
+  dps: 337.0107753751888
+  tps: 239.27765051638403
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1668.311141222961
-  tps: 1172.5217047336293
+  dps: 358.47990798619117
+  tps: 242.54152913552275
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1391.0127856063723
-  tps: 975.5972920448975
+  dps: 276.1978777994727
+  tps: 184.07870750199837
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1696.92426304246
-  tps: 1204.8162267601467
+  dps: 260.27122554930276
+  tps: 184.79257014000498
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-LongMultiTarget"
  value: {
-  dps: 752.970767391484
-  tps: 534.6092448479536
+  dps: 92.13944084920013
+  tps: 65.41900300293209
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 645.8803637647253
-  tps: 458.575058272955
+  dps: 80.3072053671323
+  tps: 57.01811581066395
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 720.0389623135176
-  tps: 511.22766324259743
+  dps: 91.25810864361803
+  tps: 64.79325713696879
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1622.1988530229535
-  tps: 1139.7969393908863
+  dps: 801.9861485071775
+  tps: 557.4459191846856
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1338.5887441305829
-  tps: 938.3542476988373
+  dps: 624.4494417816486
+  tps: 431.3153430310942
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1680.0281848728707
-  tps: 1192.820011259738
+  dps: 779.4234289065873
+  tps: 553.390634523677
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 783.9138071787853
-  tps: 556.5788030969375
+  dps: 351.98568212914654
+  tps: 249.90983431169388
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 671.7643676102882
-  tps: 476.95270100330475
+  dps: 296.2362587970771
+  tps: 210.32774374592455
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 744.7823117352609
-  tps: 528.7954413320352
+  dps: 339.0625436293994
+  tps: 240.73440597687352
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1683.7122856444144
-  tps: 1183.391284668137
+  dps: 361.9714919618876
+  tps: 244.9553211535432
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1400.6878031506913
-  tps: 982.4127737142186
+  dps: 277.2623820032652
+  tps: 184.78072469954637
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1716.155936761178
-  tps: 1218.470715100436
+  dps: 263.0607179394007
+  tps: 186.7731097369745
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-LongMultiTarget"
  value: {
-  dps: 758.5847797685861
-  tps: 538.5951936356962
+  dps: 92.90406458027896
+  tps: 65.96188585199806
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 645.9855101041386
-  tps: 458.6497121739384
+  dps: 79.66627251065371
+  tps: 56.56305348256416
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 720.3757124234943
-  tps: 511.46675582068116
+  dps: 92.11404086884326
+  tps: 65.40096901687872
  }
 }
 dps_results: {
  key: "TestRogue-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1189.2520002599913
-  tps: 832.3466161296861
+  dps: 558.4794104983702
+  tps: 384.498077398935
  }
 }

--- a/sim/rogue/expose_armor.go
+++ b/sim/rogue/expose_armor.go
@@ -11,7 +11,7 @@ func (rogue *Rogue) registerExposeArmorSpell() {
 	baseCost := 25.0
 	refundAmount := 0.4 * float64(rogue.Talents.QuickRecovery)
 
-	rogue.ExposeArmorAura = core.ExposeArmorAura(rogue.CurrentTarget, rogue.Talents.ImprovedExposeArmor)
+	rogue.ExposeArmorAura = core.ExposeArmorAura(rogue.CurrentTarget, false) // TODO: check glyph
 
 	rogue.ExposeArmor = rogue.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 26866, Tag: 5},

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -47,1183 +47,1183 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1796.1381988543853
-  tps: 1330.3441004515794
+  dps: 973.959666714057
+  tps: 754.8191279533489
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1755.246742062559
-  tps: 1299.51563055753
+  dps: 953.5242923677629
+  tps: 738.309915771173
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Alchemist'sStone-13503"
  value: {
-  dps: 1783.7220115575128
-  tps: 1319.508256898742
+  dps: 968.3031267242771
+  tps: 748.7150375154774
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1755.246742062559
-  tps: 1299.51563055753
+  dps: 953.5242923677629
+  tps: 738.309915771173
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AshtongueTalismanofVision-32491"
  value: {
-  dps: 1814.0669485533417
-  tps: 1342.0527931432566
+  dps: 982.6629552659813
+  tps: 760.0699978421044
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Assassin'sAlchemistStone-35751"
  value: {
-  dps: 1805.698062237578
-  tps: 1336.9275705584141
+  dps: 978.5246724418964
+  tps: 757.9061977014373
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1776.9145003001486
-  tps: 1314.349006235272
+  dps: 964.4346687079678
+  tps: 745.6131241207457
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1781.5856475449334
-  tps: 1317.5665396781214
+  dps: 964.7204074954337
+  tps: 745.7608716434714
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1771.397349133466
-  tps: 1310.821055507165
+  dps: 750.1482960863574
+  tps: 595.9467183741891
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1814.9547388139354
-  tps: 1343.416983880011
+  dps: 983.4658250464989
+  tps: 761.374744242805
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 1772.5808039318542
-  tps: 1313.070787032857
+  dps: 962.2742800641987
+  tps: 745.856220325498
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1777.4439377859433
-  tps: 1314.8000409564672
+  dps: 968.6098658391385
+  tps: 748.6161905937039
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1786.4875556196669
-  tps: 1320.0839774031126
+  dps: 972.4767941753079
+  tps: 750.2764443920614
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1825.5393682724948
-  tps: 1352.55627724921
+  dps: 989.0320733211206
+  tps: 767.0011707832477
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1827.0291291815772
-  tps: 1350.7028941390276
+  dps: 987.5881509158866
+  tps: 763.0942093530433
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 1805.4141102127498
-  tps: 1336.3908266495137
+  dps: 978.7885433644053
+  tps: 757.7529298556722
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1781.2921091394342
-  tps: 1317.2379767251887
+  dps: 966.2834864543611
+  tps: 746.7319408456376
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 1805.4141102127498
-  tps: 1336.3908266495137
+  dps: 978.7885433644053
+  tps: 757.7529298556722
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 1775.8360921333222
-  tps: 1317.4602570106279
+  dps: 964.1017122035504
+  tps: 749.2461910597885
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1780.5041210722238
-  tps: 1291.932917823029
+  dps: 968.0242894800434
+  tps: 734.5717533507936
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1778.9246879325096
-  tps: 1315.8767468728204
+  dps: 966.4448563403303
+  tps: 747.1408647582946
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1792.3562448724724
-  tps: 1327.8890935091267
+  dps: 969.7588267831575
+  tps: 752.0709008466054
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1755.246742062559
-  tps: 1299.51563055753
+  dps: 953.5242923677629
+  tps: 738.309915771173
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1783.2948589452917
-  tps: 1318.815257286873
+  dps: 967.1476477594078
+  tps: 747.5122094567539
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BulwarkofAzzinoth-32375"
  value: {
-  dps: 1260.2245849959531
-  tps: 954.5382833605614
+  dps: 719.0615872819533
+  tps: 575.7241849607615
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CataclysmHarness"
  value: {
-  dps: 1607.8255809865389
-  tps: 1195.1135618693181
+  dps: 883.5717355044154
+  tps: 688.135870031832
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CataclysmRegalia"
  value: {
-  dps: 1575.3205011884077
-  tps: 1167.7464126274447
+  dps: 892.8374450466124
+  tps: 690.0082733281877
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1812.4248946239388
-  tps: 1341.044878859415
+  dps: 983.0981263819855
+  tps: 760.5161410900473
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1812.7757274699165
-  tps: 1340.8221315986032
+  dps: 983.0090929149508
+  tps: 759.9854874101276
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 1802.957924674422
-  tps: 1334.250137807074
+  dps: 977.8630760408247
+  tps: 756.6837437635563
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 1755.246742062559
-  tps: 1299.51563055753
+  dps: 953.5242923677629
+  tps: 738.309915771173
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1755.246742062559
-  tps: 1299.51563055753
+  dps: 953.5242923677629
+  tps: 738.309915771173
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1804.9249211338974
-  tps: 1337.0558048005043
+  dps: 978.8602913817052
+  tps: 758.8105639739703
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1789.8090558907654
-  tps: 1325.9555241108817
+  dps: 968.305779724154
+  tps: 750.903230794254
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CycloneHarness"
  value: {
-  dps: 1561.017878340902
-  tps: 1160.5671073276749
+  dps: 859.5866195002143
+  tps: 669.5652261391937
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CycloneRegalia"
  value: {
-  dps: 1528.7759574844465
-  tps: 1133.5835243960305
+  dps: 864.8201655738486
+  tps: 668.8144700586117
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1755.246742062559
-  tps: 1299.51563055753
+  dps: 953.5242923677629
+  tps: 738.309915771173
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1765.6171671897275
-  tps: 1307.6155584156688
+  dps: 963.8947174949312
+  tps: 746.4098436293114
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1819.601828979748
-  tps: 1346.745518057596
+  dps: 987.3093015591285
+  tps: 764.1407488631627
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1763.3804025579627
-  tps: 1307.9064328709426
+  dps: 961.6579528631671
+  tps: 746.7007180845853
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1770.5219824466956
-  tps: 1312.3415991499453
+  dps: 961.8729902615182
+  tps: 746.2873046203215
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DesolationBattlegear"
  value: {
-  dps: 1596.992986898252
-  tps: 1191.4387799561594
+  dps: 878.1667803406996
+  tps: 688.2604353658731
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1788.3865567628998
-  tps: 1324.401455789981
+  dps: 970.200965610907
+  tps: 751.6715419835854
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1795.3005834866813
-  tps: 1329.6811148492454
+  dps: 972.9333829199514
+  tps: 754.0240744525336
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Devastation-30316"
  value: {
-  dps: 1743.8234695298822
-  tps: 1297.302218227781
+  dps: 927.1660940390997
+  tps: 725.6420553842336
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1805.4141102127498
-  tps: 1336.3908266495137
+  dps: 978.7885433644053
+  tps: 757.7529298556722
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1805.4141102127498
-  tps: 1336.3908266495137
+  dps: 978.7885433644053
+  tps: 757.7529298556722
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1805.4141102127498
-  tps: 1336.3908266495137
+  dps: 978.7885433644053
+  tps: 757.7529298556722
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1776.9145003001486
-  tps: 1314.349006235272
+  dps: 964.4346687079678
+  tps: 745.6131241207457
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1770.7694031019375
-  tps: 1310.8263961168889
+  dps: 963.1419378793626
+  tps: 745.4871704610857
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1772.3530510378848
-  tps: 1312.0330516561216
+  dps: 964.7255858153101
+  tps: 746.6938260003193
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1805.4141102127498
-  tps: 1336.3908266495137
+  dps: 978.7885433644053
+  tps: 757.7529298556722
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 1805.4141102127498
-  tps: 1336.3908266495137
+  dps: 978.7885433644053
+  tps: 757.7529298556722
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1785.152558837719
-  tps: 1321.9208483062375
+  dps: 970.5247787918701
+  tps: 751.6814022741432
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1785.4450098628693
-  tps: 1321.7157045846054
+  dps: 970.465404901206
+  tps: 751.2299811114412
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1786.9703547373783
-  tps: 1325.204060681414
+  dps: 969.6820953013457
+  tps: 753.1022790761915
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1764.2605004549325
-  tps: 1306.510889359881
+  dps: 962.5380507601373
+  tps: 745.3051745735243
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1776.9145003001486
-  tps: 1314.349006235272
+  dps: 964.4346687079678
+  tps: 745.6131241207457
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1776.9145003001486
-  tps: 1314.349006235272
+  dps: 964.4346687079678
+  tps: 745.6131241207457
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1766.0762207913544
-  tps: 1307.4278487959368
+  dps: 964.353771096559
+  tps: 746.2221340095801
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Fathom-BroochoftheTidewalker-30663"
  value: {
-  dps: 1772.2043277418766
-  tps: 1312.1121276434271
+  dps: 961.1430390630156
+  tps: 744.3692255682245
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FelstalkerArmor"
  value: {
-  dps: 1704.8767425124577
-  tps: 1265.9387891906795
+  dps: 928.8271623857016
+  tps: 722.7040831019498
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 1783.7939013802686
-  tps: 1319.994904722587
+  dps: 979.3158671614034
+  tps: 756.8602807693824
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1797.4098908691847
-  tps: 1330.1153603459368
+  dps: 972.0155753842853
+  tps: 752.3393395065079
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 1814.1389735195708
-  tps: 1342.3886879432778
+  dps: 981.3020625688554
+  tps: 759.4028502777768
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1780.5041210722238
-  tps: 1317.0771145166095
+  dps: 968.0242894800434
+  tps: 748.3412324020827
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1779.786196917809
-  tps: 1316.5314928603414
+  dps: 967.3063653256281
+  tps: 747.7956107458155
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1755.246742062559
-  tps: 1299.51563055753
+  dps: 953.5242923677629
+  tps: 738.309915771173
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Guardian'sAlchemistStone-35748"
  value: {
-  dps: 1755.246742062559
-  tps: 1299.51563055753
+  dps: 953.5242923677629
+  tps: 738.309915771173
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HandofJustice-11815"
  value: {
-  dps: 1790.3751381832726
-  tps: 1327.8589737078119
+  dps: 971.9002709118137
+  tps: 754.92656661779
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartrazor-29962"
  value: {
-  dps: 1805.4141102127498
-  tps: 1336.3908266495137
+  dps: 978.7885433644053
+  tps: 757.7529298556722
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1768.563792994171
-  tps: 1309.932125567631
+  dps: 966.8413432993756
+  tps: 748.7264107812734
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1789.0883146030578
-  tps: 1322.316082669297
+  dps: 970.4334835016334
+  tps: 749.2577008982995
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1786.783390972076
-  tps: 1321.7683159715868
+  dps: 761.7981375035471
+  tps: 604.2786385436158
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1765.7617089233318
-  tps: 1307.725730969866
+  dps: 964.0392592285361
+  tps: 746.5200161835091
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1778.9246879325096
-  tps: 1315.8767468728204
+  dps: 966.4448563403303
+  tps: 747.1408647582946
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1785.4450098628693
-  tps: 1321.7157045846054
+  dps: 970.465404901206
+  tps: 751.2299811114412
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1786.9703547373783
-  tps: 1325.204060681414
+  dps: 969.6820953013457
+  tps: 753.1022790761915
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IndestructibleAlchemist'sStone-44323"
  value: {
-  dps: 1755.246742062559
-  tps: 1299.51563055753
+  dps: 953.5242923677629
+  tps: 738.309915771173
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1791.3413102544876
-  tps: 1324.9649812816413
+  dps: 979.6571837557635
+  tps: 756.786092732534
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1786.690961210668
-  tps: 1320.2721815388002
+  dps: 973.1031470661264
+  tps: 750.7607116376214
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1796.5798453672232
-  tps: 1332.7071675652323
+  dps: 975.2043381304164
+  tps: 757.7443124994684
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1784.1217995361596
-  tps: 1319.2635833316097
+  dps: 967.0995686494681
+  tps: 747.3480217109257
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1812.9080459437582
-  tps: 1341.3527384163453
+  dps: 681.0856851094784
+  tps: 549.0770858323498
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1511.1960303652327
-  tps: 1130.5021233594216
+  dps: 848.5986139176086
+  tps: 666.6839318460849
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 1051.112360700617
-  tps: 806.9467774721337
+  dps: 637.9702110786146
+  tps: 517.7472727367316
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1803.331878225271
-  tps: 1333.175225871429
+  dps: 973.9827917574211
+  tps: 752.6308653439338
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1767.5327894189406
-  tps: 1308.880297664336
+  dps: 965.8103397241449
+  tps: 747.6745828779791
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MercurialAlchemistStone-44322"
  value: {
-  dps: 1768.4392560849083
-  tps: 1309.6123168121903
+  dps: 958.1112009233593
+  tps: 742.3826781991061
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MightyAlchemist'sStone-44324"
  value: {
-  dps: 1780.8723125196914
-  tps: 1318.0162042464542
+  dps: 967.0863110125127
+  tps: 748.3660031914296
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1755.246742062559
-  tps: 1299.51563055753
+  dps: 953.5242923677629
+  tps: 738.309915771173
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1776.9145003001486
-  tps: 1314.349006235272
+  dps: 964.4346687079678
+  tps: 745.6131241207457
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 1794.5039489586134
-  tps: 1335.3236073002388
+  dps: 992.0828056125928
+  tps: 773.6288069580246
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NetherscaleArmor"
  value: {
-  dps: 1700.2223703773475
-  tps: 1257.3781235051802
+  dps: 930.9775694395447
+  tps: 718.9067628487182
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NetherstrikeArmor"
  value: {
-  dps: 1652.6508649910634
-  tps: 1225.3481007486487
+  dps: 915.8269942494612
+  tps: 709.5713912295272
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1797.0280621683787
-  tps: 1329.8710467918477
+  dps: 975.3186226813386
+  tps: 754.6744391509197
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1796.5798453672232
-  tps: 1332.7071675652323
+  dps: 975.2043381304164
+  tps: 757.7443124994684
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1779.2615490719004
-  tps: 1318.1136175072847
+  dps: 966.5216880525718
+  tps: 749.1957147937552
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1776.9145003001486
-  tps: 1314.349006235272
+  dps: 964.4346687079678
+  tps: 745.6131241207457
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1776.9145003001486
-  tps: 1314.349006235272
+  dps: 964.4346687079678
+  tps: 745.6131241207457
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1776.9145003001486
-  tps: 1314.349006235272
+  dps: 964.4346687079678
+  tps: 745.6131241207457
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PrimalIntent"
  value: {
-  dps: 1765.7749695902537
-  tps: 1314.5601444614877
+  dps: 958.7217535005534
+  tps: 749.6228931986972
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1760.5947862059247
-  tps: 1303.5920150628453
+  dps: 958.8723365111294
+  tps: 742.3863002764884
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Redeemer'sAlchemistStone-35750"
  value: {
-  dps: 1764.3528712796424
-  tps: 1306.456501471986
+  dps: 962.6304215848459
+  tps: 745.2507866856292
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1813.6719349611387
-  tps: 1340.4895538605713
+  dps: 980.7983677258998
+  tps: 757.4780567959041
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1805.4141102127498
-  tps: 1336.3908266495137
+  dps: 978.7885433644053
+  tps: 757.7529298556722
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1782.9818989954056
-  tps: 1317.817556102938
+  dps: 968.5191626708158
+  tps: 747.6936406757245
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1728.0350276061563
-  tps: 1282.8251764945544
+  dps: 946.7436208980633
+  tps: 735.9211917988888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1794.5950708202408
-  tps: 1333.1880946461818
+  dps: 982.2953113751237
+  tps: 764.5782630345991
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1747.1739669792837
-  tps: 1295.7930001414256
+  dps: 948.9005029629028
+  tps: 737.0015753299593
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1800.9409254878565
-  tps: 1334.7281745271384
+  dps: 990.9318856682377
+  tps: 767.7218466534055
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1778.832262997664
-  tps: 1316.1369553523607
+  dps: 965.6292437559484
+  tps: 746.8948418831599
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1755.246742062559
-  tps: 1299.51563055753
+  dps: 953.5242923677629
+  tps: 738.309915771173
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1820.4598178883139
-  tps: 1348.7702580544908
+  dps: 985.516214481004
+  tps: 764.3097356693726
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 1768.3932069782497
-  tps: 1309.4873174898023
+  dps: 964.6695349599227
+  tps: 746.8807470769732
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 1814.610424503409
-  tps: 1344.1526693525693
+  dps: 983.1022351631608
+  tps: 762.0969368143955
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1770.4108539003425
-  tps: 1308.5164951881509
+  dps: 960.8820828410785
+  tps: 741.8463554466666
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1790.4295611278274
-  tps: 1325.2932182480527
+  dps: 973.9309547417631
+  tps: 753.7441937778077
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 1303.1632498550798
-  tps: 981.6440804100904
+  dps: 724.3003525440747
+  tps: 576.440052292387
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterHarness"
  value: {
-  dps: 1505.8069436597423
-  tps: 1112.1923591841019
+  dps: 843.5093251638077
+  tps: 648.5840262369481
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterRegalia"
  value: {
-  dps: 1507.546541572272
-  tps: 1116.2631564042028
+  dps: 877.1589673750591
+  tps: 674.9918544661542
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1808.6990940464707
-  tps: 1337.9794235576721
+  dps: 980.3488606495885
+  tps: 758.1342601798544
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 1764.3528712796424
-  tps: 1306.456501471986
+  dps: 962.6304215848459
+  tps: 745.2507866856292
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1678.495441256532
-  tps: 1252.0618114236918
+  dps: 930.0950430671271
+  tps: 728.1815326911078
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StormGauntlets-12632"
  value: {
-  dps: 1709.9722585410457
-  tps: 1265.158552179614
+  dps: 916.8439940379649
+  tps: 709.9687670274576
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1614.3913698587826
-  tps: 1209.4022490827
+  dps: 880.173374250232
+  tps: 695.4496521567147
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1779.2615490719004
-  tps: 1318.1136175072847
+  dps: 966.5216880525718
+  tps: 749.1957147937552
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1796.5798453672232
-  tps: 1332.7071675652323
+  dps: 975.2043381304164
+  tps: 757.7443124994684
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1778.6375182707443
-  tps: 1315.6584982103138
+  dps: 966.1576866785645
+  tps: 746.9226160957878
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1797.0280621683787
-  tps: 1329.8710467918477
+  dps: 975.3186226813386
+  tps: 754.6744391509197
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1783.9140245355377
-  tps: 1321.9331696083727
+  dps: 968.7033347772146
+  tps: 751.2856867775467
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1805.4141102127498
-  tps: 1336.3908266495137
+  dps: 978.7885433644053
+  tps: 757.7529298556722
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1776.9145003001486
-  tps: 1314.349006235272
+  dps: 964.4346687079678
+  tps: 745.6131241207457
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheBladefist-29348"
  value: {
-  dps: 1665.2291367827795
-  tps: 1239.037365292315
+  dps: 914.7976216775701
+  tps: 713.7353047186682
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheDecapitator-28767"
  value: {
-  dps: 1805.4141102127498
-  tps: 1336.3908266495137
+  dps: 978.7885433644053
+  tps: 757.7529298556722
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheFistsofFury"
  value: {
-  dps: 1567.8027034731813
-  tps: 1172.9803930706826
+  dps: 877.6744668894333
+  tps: 689.8906274620597
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1811.7907900692817
-  tps: 1355.0327359653706
+  dps: 1005.6597090868547
+  tps: 790.740979277671
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1805.4141102127498
-  tps: 1336.3908266495137
+  dps: 978.7885433644053
+  tps: 757.7529298556722
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1764.5133596369494
-  tps: 1306.7427007486174
+  dps: 962.7909099421539
+  tps: 745.5369859622607
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1775.5345084281146
-  tps: 1316.1196283679196
+  dps: 966.908415834099
+  tps: 750.0813635521095
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheTwinStars"
  value: {
-  dps: 1734.6298279497337
-  tps: 1282.6060126172133
+  dps: 950.5406819887985
+  tps: 733.7436104445588
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1792.455823640285
-  tps: 1327.9954959428142
+  dps: 973.2990692473546
+  tps: 754.5857678677628
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1786.8367187186307
-  tps: 1325.3912085508837
+  dps: 970.5078871688959
+  tps: 753.9610264660691
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TidefuryRaiment"
  value: {
-  dps: 1497.3901955374988
-  tps: 1115.4096132815764
+  dps: 841.1865048826697
+  tps: 656.0670298231961
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 1769.2783053708822
-  tps: 1313.9409296409765
+  dps: 966.9395883308816
+  tps: 752.303827712976
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1780.5041210722238
-  tps: 1317.0771145166095
+  dps: 968.0242894800434
+  tps: 748.3412324020827
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1779.786196917809
-  tps: 1316.5314928603414
+  dps: 967.3063653256281
+  tps: 747.7956107458155
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1779.786196917809
-  tps: 1316.5314928603414
+  dps: 967.3063653256281
+  tps: 747.7956107458155
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1780.5041210722238
-  tps: 1317.0771145166095
+  dps: 968.0242894800434
+  tps: 748.3412324020827
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1803.347124952437
-  tps: 1332.7743624790155
+  dps: 977.9453088163829
+  tps: 754.9930911837776
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WastewalkerArmor"
  value: {
-  dps: 1638.401227494316
-  tps: 1224.3577636681084
+  dps: 889.9857824389462
+  tps: 700.4669521293498
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WindhawkArmor"
  value: {
-  dps: 1641.8573594702832
-  tps: 1215.245279791919
+  dps: 910.98451748402
+  tps: 703.6342904015354
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1396.05821966414
-  tps: 1048.642906282998
+  dps: 767.3538873701707
+  tps: 608.5498736772189
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WrathofSpellfire"
  value: {
-  dps: 1643.1528803827998
-  tps: 1223.2601984544738
+  dps: 911.4171804108706
+  tps: 711.0452084741229
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1795.9219478427563
-  tps: 1328.891676826273
+  dps: 986.9257873313603
+  tps: 762.5943644682956
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 1801.6050181808625
-  tps: 1333.6004580473511
+  dps: 975.2951106243819
+  tps: 755.1835227578192
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2633.3269737613073
-  tps: 2517.3373147146576
+  dps: 1806.5737086458605
+  tps: 1938.6100291338453
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1815.600517679398
-  tps: 1344.6591083328415
+  dps: 987.5963017761358
+  tps: 765.0561572005587
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2025.4899244161588
-  tps: 1498.3694293905126
+  dps: 1108.0896616645048
+  tps: 856.1892454643546
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1081.3570501547824
-  tps: 1072.8466958437439
+  dps: 862.8663534418141
+  tps: 919.903208144666
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 633.1412078923444
-  tps: 490.4745935498528
+  dps: 414.185624156492
+  tps: 337.20568493475605
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 824.6401293960598
-  tps: 632.2496321227529
+  dps: 560.3614470460723
+  tps: 447.25455447776153
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2650.7799173678427
-  tps: 2474.6964824363963
+  dps: 1819.42828191523
+  tps: 1892.7503376195673
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1805.4141102127498
-  tps: 1336.3908266495137
+  dps: 978.7885433644053
+  tps: 757.7529298556722
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2020.8036292327677
-  tps: 1491.666453162651
+  dps: 1098.6536218764459
+  tps: 846.1614480132255
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1074.0116081732456
-  tps: 1053.4569705007946
+  dps: 856.0616602680478
+  tps: 900.8920069671558
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 628.1831776042204
-  tps: 486.8202475337852
+  dps: 409.99090500888684
+  tps: 334.0856567170516
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 827.960032789199
-  tps: 630.8092636224383
+  dps: 560.3190602451174
+  tps: 443.46058284158164
  }
 }
 dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1573.6987206659046
-  tps: 1173.4757890260732
+  dps: 873.8529583065381
+  tps: 683.5837553745162
  }
 }

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -47,1260 +47,1260 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 686.4521049968478
-  tps: 581.9696668276505
+  dps: 320.0206720901918
+  tps: 277.29979982520183
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Alchemist'sStone-13503"
  value: {
-  dps: 688.3021004883211
-  tps: 583.329572808783
+  dps: 321.15644994256394
+  tps: 277.92745368314195
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 686.6684222591284
-  tps: 581.9420654364426
+  dps: 316.3234254338482
+  tps: 274.1350776603753
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Assassin'sAlchemistStone-35751"
  value: {
-  dps: 701.1316028870851
-  tps: 594.8560125408995
+  dps: 323.93524361013425
+  tps: 280.56435382764175
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 690.4896998557717
-  tps: 585.623520088615
+  dps: 316.4198317427077
+  tps: 274.34508660324514
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 683.9601240100251
-  tps: 580.6240912377609
+  dps: 239.73399697058295
+  tps: 210.2411397448053
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 716.4662299117053
-  tps: 607.0545800801021
+  dps: 329.5547624958625
+  tps: 284.6344953547239
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 688.6223514915342
-  tps: 583.4839488292439
+  dps: 318.5021423384124
+  tps: 275.6849807617837
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 691.8301990576192
-  tps: 586.5174407813984
+  dps: 319.6488013523823
+  tps: 276.7843262146231
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 683.7236808970492
-  tps: 579.6223941993233
+  dps: 317.32001838543016
+  tps: 274.99180718528135
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 710.9006514507591
-  tps: 601.9696993174645
+  dps: 326.83603730305185
+  tps: 282.82774931301566
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 712.8987666430279
-  tps: 604.2001983257937
+  dps: 327.23684055824157
+  tps: 282.9560858299975
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 695.5523391160121
-  tps: 590.3073514952742
+  dps: 322.67420441680713
+  tps: 279.3546895508728
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 693.0272026373729
-  tps: 587.4496829425607
+  dps: 319.6712759747731
+  tps: 277.0351846132884
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 695.5523391160121
-  tps: 590.3073514952742
+  dps: 322.67420441680713
+  tps: 279.3546895508728
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 682.8028841522157
-  tps: 579.5611718492004
+  dps: 319.6290866650516
+  tps: 276.2279435607643
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Blinkstrike-31332"
  value: {
-  dps: 695.5523391160121
-  tps: 590.3073514952742
+  dps: 322.67420441680713
+  tps: 279.3546895508728
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BoldArmor"
  value: {
-  dps: 570.363775398551
-  tps: 484.1712062252298
+  dps: 265.4193736913835
+  tps: 229.5375728026078
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 566.2677332281264
+  dps: 313.93245567553754
+  tps: 266.68343920635243
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 697.4908647109254
-  tps: 591.3400034627078
+  dps: 321.25458754941275
+  tps: 277.8799754583522
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 678.72505606783
-  tps: 575.7582686328092
+  dps: 315.99824660666576
+  tps: 273.64833364672677
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 698.1186162451454
-  tps: 592.346349507208
+  dps: 324.73403576773745
+  tps: 281.0566562751259
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 699.7876352872015
-  tps: 593.4300150324974
+  dps: 324.9887027900199
+  tps: 281.1892156979348
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BurningRage"
  value: {
-  dps: 631.344325273979
-  tps: 534.5043044393337
+  dps: 292.00420688497
+  tps: 251.81186033291021
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 697.4008949825799
-  tps: 591.8736762434851
+  dps: 321.4226212168669
+  tps: 278.3111627260021
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 699.8808783441496
-  tps: 593.6403580848404
+  dps: 323.52276797059784
+  tps: 280.09473592735253
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 697.5844673614996
-  tps: 591.5916318171606
+  dps: 321.74570970427413
+  tps: 278.5771718068849
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 696.0594623425209
-  tps: 589.8540606211759
+  dps: 323.2382351851439
+  tps: 279.93275021511346
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 695.1531107153475
-  tps: 589.8005788723461
+  dps: 320.9230639296312
+  tps: 278.1770296824599
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 698.6689498866252
-  tps: 592.2067831090469
+  dps: 324.9005681304841
+  tps: 281.14638745048035
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 684.86545901677
-  tps: 580.7569365253539
+  dps: 320.364811060324
+  tps: 277.2119641932734
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 688.8183149865436
-  tps: 584.6218902863994
+  dps: 317.0748438971422
+  tps: 274.96890270493344
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DesolationBattlegear"
  value: {
-  dps: 575.2572552089067
-  tps: 487.6960003283275
+  dps: 271.2491539401724
+  tps: 234.44929668895122
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Despair-28573"
  value: {
-  dps: 796.47108673623
-  tps: 668.8941878666353
+  dps: 381.7240600880688
+  tps: 323.7376545000406
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestroyerArmor"
  value: {
-  dps: 569.3471232457865
-  tps: 482.0161118825386
+  dps: 270.5718988897878
+  tps: 233.77462653238416
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestroyerBattlegear"
  value: {
-  dps: 646.5885952532556
-  tps: 545.2738506747747
+  dps: 297.1377771177021
+  tps: 252.98169505734285
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 683.0672591965625
-  tps: 579.7247233178839
+  dps: 317.6865797224462
+  tps: 275.285986520739
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 684.880408068886
-  tps: 581.391406029781
+  dps: 316.15604386658686
+  tps: 273.8163288343735
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Devastation-30316"
  value: {
-  dps: 1078.9652878596244
-  tps: 902.0778588284865
+  dps: 510.94536991487905
+  tps: 431.1338951809094
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DoomplateBattlegear"
  value: {
-  dps: 585.6889178217853
-  tps: 495.84024196743565
+  dps: 275.50670783405604
+  tps: 237.91357755483065
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Dragonstrike-28439"
  value: {
-  dps: 695.5523391160121
-  tps: 590.3073514952742
+  dps: 322.67420441680713
+  tps: 279.3546895508728
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 695.5523391160121
-  tps: 590.3073514952742
+  dps: 322.67420441680713
+  tps: 279.3546895508728
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 705.1933523246728
-  tps: 597.8572751402011
+  dps: 324.1530571734109
+  tps: 280.81048682241993
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 695.5523391160121
-  tps: 590.3073514952742
+  dps: 322.67420441680713
+  tps: 279.3546895508728
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 680.0266635564846
-  tps: 577.19805557025
+  dps: 317.057422531479
+  tps: 274.4898324552763
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 683.7236808970492
-  tps: 579.6223941993233
+  dps: 317.32001838543016
+  tps: 274.99180718528135
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 682.6794569256741
-  tps: 579.200350637365
+  dps: 315.6949659664875
+  tps: 273.4285806600937
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FaithinFelsteel"
  value: {
-  dps: 581.5643709984511
-  tps: 495.232739682025
+  dps: 274.31984543261876
+  tps: 238.83795968400085
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FelstalkerArmor"
  value: {
-  dps: 669.4465192373418
-  tps: 568.2345773887369
+  dps: 312.6074333891986
+  tps: 271.268770634284
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 694.8036602292632
-  tps: 588.8904124323979
+  dps: 320.4702267483341
+  tps: 277.6427979968114
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 702.7331538669936
-  tps: 595.4427788179659
+  dps: 326.43149073840226
+  tps: 282.16931605635824
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FlameGuard"
  value: {
-  dps: 551.457124129692
-  tps: 467.77071457129875
+  dps: 260.08884392828725
+  tps: 225.16928585420246
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Guardian'sAlchemistStone-35748"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HandofJustice-11815"
  value: {
-  dps: 696.4080559193906
-  tps: 590.1910361960817
+  dps: 320.8043265958463
+  tps: 277.7483550134398
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Heartrazor-29962"
  value: {
-  dps: 695.5523391160121
-  tps: 590.3073514952742
+  dps: 322.67420441680713
+  tps: 279.3546895508728
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 691.4786768960694
-  tps: 586.9131211145623
+  dps: 320.40045901466124
+  tps: 277.5269662489491
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 698.3092513632478
-  tps: 592.247184781008
+  dps: 255.4680987858724
+  tps: 223.1085102622544
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 683.7236808970492
-  tps: 579.6223941993233
+  dps: 317.32001838543016
+  tps: 274.99180718528135
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 682.6794569256741
-  tps: 579.200350637365
+  dps: 315.6949659664875
+  tps: 273.4285806600937
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IndestructibleAlchemist'sStone-44323"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 690.062240031095
-  tps: 586.0985952726071
+  dps: 318.31946423298194
+  tps: 275.86751689830584
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 787.4241397402315
-  tps: 662.3047152780263
+  dps: 358.25858920762397
+  tps: 305.7877535474577
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 688.3567442950958
-  tps: 584.1686569624545
+  dps: 319.6069489144936
+  tps: 277.0933562860532
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LionheartChampion-28429"
  value: {
-  dps: 828.8958772949377
-  tps: 695.4438580961745
+  dps: 394.1547715091284
+  tps: 334.50511301377844
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 857.8096467485334
-  tps: 719.4476930172484
+  dps: 409.7970154749722
+  tps: 347.29011444671676
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 704.4233906233052
-  tps: 597.1642063009225
+  dps: 225.90816225912215
+  tps: 198.5510075468097
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 508.7518681024052
-  tps: 433.01612917170297
+  dps: 243.04369767532978
+  tps: 210.81247115196723
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 462.2386445935729
-  tps: 396.78345489410765
+  dps: 207.42276906112676
+  tps: 184.3307118571237
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 704.861958619951
-  tps: 597.7690931268048
+  dps: 327.94283782807304
+  tps: 283.687383266425
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MercurialAlchemistStone-44322"
  value: {
-  dps: 684.9436691763091
-  tps: 581.0037124954403
+  dps: 318.97008674864213
+  tps: 276.066258943494
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MightyAlchemist'sStone-44324"
  value: {
-  dps: 692.3939062799666
-  tps: 587.06299009204
+  dps: 317.413745126059
+  tps: 275.3819423101037
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 674.8015901656416
-  tps: 572.6305339860658
+  dps: 315.73842218542893
+  tps: 273.33714326152943
  }
 }
 dps_results: {
  key: "TestArms-AllItems-NetherscaleArmor"
  value: {
-  dps: 675.8303308280041
-  tps: 573.4983492816626
+  dps: 315.24142792780697
+  tps: 273.3119255381378
  }
 }
 dps_results: {
  key: "TestArms-AllItems-NetherstrikeArmor"
  value: {
-  dps: 634.7183819951163
-  tps: 539.6991048943391
+  dps: 297.21023185418585
+  tps: 258.35084358554997
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtArmor"
  value: {
-  dps: 538.4456578565355
-  tps: 457.82981408841965
+  dps: 256.6829331978663
+  tps: 222.3947681336986
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 683.7439316889066
-  tps: 579.269548357474
+  dps: 28.58459419219728
+  tps: 31.13976441429263
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 690.4431170491198
-  tps: 585.2880117797087
+  dps: 320.89696219632197
+  tps: 277.93913829191
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 690.062240031095
-  tps: 586.0985952726071
+  dps: 318.31946423298194
+  tps: 275.86751689830584
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 682.1094412331871
-  tps: 578.9804272594056
+  dps: 318.14218743081
+  tps: 275.58586146607706
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PrimalIntent"
  value: {
-  dps: 698.1376630076473
-  tps: 592.098528209161
+  dps: 325.186949650631
+  tps: 281.0399150416623
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 682.8302759457486
-  tps: 579.4580504606462
+  dps: 316.528037353283
+  tps: 274.1109969810605
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Redeemer'sAlchemistStone-35750"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 696.7240801047004
-  tps: 590.2957317721124
+  dps: 324.59041772734514
+  tps: 280.9060797958567
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 695.5523391160121
-  tps: 590.3073514952742
+  dps: 322.67420441680713
+  tps: 279.3546895508728
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 674.9913136999734
-  tps: 572.726167053689
+  dps: 311.715071842539
+  tps: 270.414291530002
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 695.5523391160121
-  tps: 590.3073514952742
+  dps: 322.67420441680713
+  tps: 279.3546895508728
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 707.0778350340959
-  tps: 599.5741251344377
+  dps: 332.738673382097
+  tps: 287.612757328621
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 666.4954644221127
-  tps: 565.7961704999093
+  dps: 310.72565963481406
+  tps: 269.58699844279334
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 687.887967917236
-  tps: 583.5436359881668
+  dps: 318.3408662972517
+  tps: 276.14882456636946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 683.9545072201486
-  tps: 579.6365064260855
+  dps: 319.3047860803324
+  tps: 276.5997314556048
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShardofContempt-34472"
  value: {
-  dps: 706.1063949606884
-  tps: 599.6308529678992
+  dps: 325.84067357835954
+  tps: 282.7110000193571
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 675.5123194430847
-  tps: 572.7101545213766
+  dps: 315.0639167223968
+  tps: 272.73248180188597
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 703.0621869604032
-  tps: 596.1009092549856
+  dps: 321.2924098172458
+  tps: 277.9352777171996
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 690.858281198797
-  tps: 585.6993931096097
+  dps: 317.03151413091507
+  tps: 274.5643237005617
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 691.8339797069547
-  tps: 586.8101911233233
+  dps: 319.2256482462682
+  tps: 276.7827677760252
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 713.7898764245246
-  tps: 601.0222972775748
+  dps: 332.22567748028337
+  tps: 283.99794309788854
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 699.1762314396099
-  tps: 592.7925181157096
+  dps: 325.6308535777203
+  tps: 281.87373453159375
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 616.4903214508671
-  tps: 523.7803003597078
+  dps: 289.07276149746116
+  tps: 251.24289984307944
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StormGauntlets-12632"
  value: {
-  dps: 671.6028280443148
-  tps: 570.2112366821408
+  dps: 315.68706417913063
+  tps: 273.53991976482587
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 605.765514783399
-  tps: 515.3486596399372
+  dps: 285.1538798487752
+  tps: 247.61433691330367
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 682.1094412331871
-  tps: 578.9804272594056
+  dps: 318.14218743081
+  tps: 275.58586146607706
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 690.062240031095
-  tps: 586.0985952726071
+  dps: 318.31946423298194
+  tps: 275.86751689830584
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 690.4431170491198
-  tps: 585.2880117797087
+  dps: 320.89696219632197
+  tps: 277.93913829191
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 684.6618339365309
-  tps: 580.4362492267195
+  dps: 317.7766118538901
+  tps: 275.25147246353595
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 695.5523391160121
-  tps: 590.3073514952742
+  dps: 322.67420441680713
+  tps: 279.3546895508728
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheBladefist-29348"
  value: {
-  dps: 641.3253396900415
-  tps: 545.4088534852327
+  dps: 297.953790678355
+  tps: 258.6935756333702
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheDecapitator-28767"
  value: {
-  dps: 695.5523391160121
-  tps: 590.3073514952742
+  dps: 322.67420441680713
+  tps: 279.3546895508728
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheFistsofFury"
  value: {
-  dps: 650.5165842903749
-  tps: 551.9638040549444
+  dps: 310.76699440230186
+  tps: 268.0212173806249
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 679.4546176122354
-  tps: 576.5308465079828
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheNightBlade-31331"
  value: {
-  dps: 695.5523391160121
-  tps: 590.3073514952742
+  dps: 322.67420441680713
+  tps: 279.3546895508728
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 679.1247829987019
-  tps: 576.1643957108993
+  dps: 314.9396224757683
+  tps: 272.8718133256289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 689.8838215916303
-  tps: 585.7151482811162
+  dps: 319.2405932239294
+  tps: 276.7592799164834
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 795.9961757181425
-  tps: 672.1165857437658
+  dps: 373.20707743900994
+  tps: 320.027732994994
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinStars"
  value: {
-  dps: 670.4051165009217
-  tps: 568.411714526843
+  dps: 310.676340606991
+  tps: 268.8577779980613
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 695.5523391160121
-  tps: 590.3073514952742
+  dps: 322.67420441680713
+  tps: 279.3546895508728
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 687.6378964279181
-  tps: 583.7571479751156
+  dps: 317.9281451628259
+  tps: 275.6606178350848
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 688.0053344198626
-  tps: 582.8764003295238
+  dps: 320.0331438390198
+  tps: 277.2746868283112
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 685.8988130663572
-  tps: 581.1572236994218
+  dps: 318.96959781303246
+  tps: 275.97642925143714
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 681.3543134362781
-  tps: 577.7562138818219
+  dps: 313.93245567553754
+  tps: 272.0578631357336
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 701.2816099512977
-  tps: 595.3004805912732
+  dps: 321.2248749092931
+  tps: 278.3765576501298
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WarbringerArmor"
  value: {
-  dps: 553.0690599390846
-  tps: 469.36022189092205
+  dps: 258.7436795186892
+  tps: 223.8361897814834
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WarbringerBattlegear"
  value: {
-  dps: 630.8998589716722
-  tps: 536.5363107965737
+  dps: 293.6450395163758
+  tps: 255.8542544778532
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WarpSlicer-30311"
  value: {
-  dps: 695.5523391160121
-  tps: 590.3073514952742
+  dps: 322.67420441680713
+  tps: 279.3546895508728
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WastewalkerArmor"
  value: {
-  dps: 601.2740683635288
-  tps: 509.9871145445411
+  dps: 279.01709035845465
+  tps: 241.3774485840093
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WindhawkArmor"
  value: {
-  dps: 629.7546386634722
-  tps: 535.2308426711861
+  dps: 296.95553657592444
+  tps: 257.8832793896496
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WorldBreaker-30090"
  value: {
-  dps: 795.3265952434326
-  tps: 667.1605677379973
+  dps: 381.7657871839689
+  tps: 324.0059911811424
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WrathofSpellfire"
  value: {
-  dps: 626.0471805334062
-  tps: 532.3686810259303
+  dps: 295.3464940809229
+  tps: 256.7661316041722
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 681.1864965288686
-  tps: 578.2766509617693
+  dps: 317.99538597449794
+  tps: 275.58564927849
  }
 }
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 699.8919630538205
-  tps: 593.7074517496192
+  dps: 324.6722164870476
+  tps: 281.1993580997241
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1140.982205126681
-  tps: 1079.695609038327
+  dps: 554.405013066023
+  tps: 575.6311819191782
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 689.9181422678716
-  tps: 585.2051908614347
+  dps: 320.6088016464307
+  tps: 278.0579467048612
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 845.2431240235333
-  tps: 716.6001115042375
+  dps: 387.0538978171116
+  tps: 334.22783957657055
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 857.2270206968498
-  tps: 841.0357359477389
+  dps: 427.1841578292101
+  tps: 468.44090741766763
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 508.71979810923096
-  tps: 434.6740663862049
+  dps: 247.8839033315585
+  tps: 216.4184744303077
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 631.2446453634017
-  tps: 538.0494464657567
+  dps: 306.8146373104295
+  tps: 267.34214935169626
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1157.1588917052268
-  tps: 1094.9677740474292
+  dps: 562.3474675338534
+  tps: 583.4156908389506
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 695.5523391160121
-  tps: 590.3073514952742
+  dps: 322.67420441680713
+  tps: 279.3546895508728
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 864.6288359819913
-  tps: 731.4871267864252
+  dps: 391.21985883106265
+  tps: 337.91324817638093
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 872.368300753304
-  tps: 853.1442145569079
+  dps: 434.19178812836844
+  tps: 473.99369729736515
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 509.9018988049493
-  tps: 435.42275580440383
+  dps: 251.9598297284866
+  tps: 219.65090462931053
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 657.1723961267127
-  tps: 559.5709479683057
+  dps: 311.0127399387894
+  tps: 271.02921834896193
  }
 }
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 592.446556539193
-  tps: 503.70305786722327
+  dps: 274.99325116996744
+  tps: 238.6948026201525
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -47,1260 +47,1260 @@ character_stats_results: {
 dps_results: {
  key: "TestFury-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 918.1584042875506
-  tps: 696.6977262426996
+  dps: 425.07130958150367
+  tps: 320.50988257891
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Alchemist'sStone-13503"
  value: {
-  dps: 914.9625271204616
-  tps: 694.388732241551
+  dps: 420.30096076143695
+  tps: 316.85905637448064
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 913.7082418074847
-  tps: 692.9813606440996
+  dps: 419.1032501190946
+  tps: 315.6803194531144
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Assassin'sAlchemistStone-35751"
  value: {
-  dps: 933.5317074806239
-  tps: 708.2467819323276
+  dps: 427.6124785190218
+  tps: 322.6116500977274
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 908.2622873263664
-  tps: 689.3978224865676
+  dps: 417.7899793524253
+  tps: 315.2098335781519
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 911.684794384116
-  tps: 692.0736266506187
+  dps: 318.8237703593443
+  tps: 240.87028059600044
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 955.0954888234318
-  tps: 724.7886852477578
+  dps: 434.65163065444256
+  tps: 328.19311391046887
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 914.3304923524659
-  tps: 694.2156664095739
+  dps: 420.9401204368315
+  tps: 317.55902008585764
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 916.449153592403
-  tps: 695.6355592402351
+  dps: 426.46985715324473
+  tps: 322.3420535230823
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 914.6211598109683
-  tps: 694.3332324143117
+  dps: 421.11039019693317
+  tps: 317.8651837787492
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 947.2737156601489
-  tps: 718.4415654117439
+  dps: 430.4300263797011
+  tps: 324.36990702810465
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 948.16273470698
-  tps: 718.9884307763541
+  dps: 431.7814781982494
+  tps: 325.68627262299776
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 923.3089051797666
-  tps: 701.0934378475658
+  dps: 425.312896498157
+  tps: 320.77302345758113
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 921.737486600389
-  tps: 699.9478366863736
+  dps: 418.53686689196627
+  tps: 316.00928818244586
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 923.3089051797666
-  tps: 701.0934378475658
+  dps: 425.312896498157
+  tps: 320.77302345758113
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 914.6396174550493
-  tps: 694.7468942196389
+  dps: 421.4964394550268
+  tps: 317.9807326156653
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Blinkstrike-31332"
  value: {
-  dps: 923.3089051797666
-  tps: 701.0934378475658
+  dps: 425.312896498157
+  tps: 320.77302345758113
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BoldArmor"
  value: {
-  dps: 769.6581987798736
-  tps: 581.8359230332305
+  dps: 346.19785014361844
+  tps: 259.87473253174693
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 671.5670035961717
+  dps: 416.5069619453105
+  tps: 307.98412372558806
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 924.223026692865
-  tps: 701.599015642
+  dps: 428.5301618317246
+  tps: 323.7498050059683
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 908.2785453113368
-  tps: 688.854800251808
+  dps: 420.7246145566428
+  tps: 317.50669331381874
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 921.6028082052825
-  tps: 699.6851633995116
+  dps: 428.2952123684538
+  tps: 323.47320077354453
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 930.6945441974382
-  tps: 707.1420579440573
+  dps: 427.2486538307838
+  tps: 322.746123087459
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BurningRage"
  value: {
-  dps: 849.6256106397851
-  tps: 643.2901748509239
+  dps: 387.02665770743556
+  tps: 290.1758816879917
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 927.9729289855177
-  tps: 704.9245489956973
+  dps: 426.44358770870434
+  tps: 321.591605619593
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 928.4877327814248
-  tps: 704.8539952151613
+  dps: 427.29078707898935
+  tps: 322.33669261578126
  }
 }
 dps_results: {
  key: "TestFury-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 924.0021583842067
-  tps: 700.9886235331527
+  dps: 425.3855796269428
+  tps: 321.295806298057
  }
 }
 dps_results: {
  key: "TestFury-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 926.6017295400954
-  tps: 702.70032500759
+  dps: 423.44510981279643
+  tps: 319.330059414503
  }
 }
 dps_results: {
  key: "TestFury-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 926.9012190734516
-  tps: 703.2138150068267
+  dps: 423.8165869019895
+  tps: 319.52904113482543
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 931.1410539088596
-  tps: 706.093082590988
+  dps: 428.63316245480144
+  tps: 323.39384295386606
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 911.6753693340308
-  tps: 692.0814185723514
+  dps: 418.46789983265626
+  tps: 314.9985834331658
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 906.7181625744961
-  tps: 688.0286703327045
+  dps: 417.4508471118747
+  tps: 314.6089930087667
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DesolationBattlegear"
  value: {
-  dps: 766.1087470342853
-  tps: 579.3699415858565
+  dps: 350.6584307031803
+  tps: 263.4841590444476
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Despair-28573"
  value: {
-  dps: 753.9838251625775
-  tps: 560.0167400190371
+  dps: 356.0263030170964
+  tps: 263.6251933006066
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestroyerArmor"
  value: {
-  dps: 766.2828493732048
-  tps: 577.9505414092008
+  dps: 348.4813909416087
+  tps: 261.2794326785205
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestroyerBattlegear"
  value: {
-  dps: 867.438730583398
-  tps: 658.0375798679266
+  dps: 400.5327250607198
+  tps: 301.6653996051896
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 909.7351362997838
-  tps: 690.1625555854018
+  dps: 417.4908712405279
+  tps: 314.5010171993831
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 912.2596853898497
-  tps: 692.7826864756657
+  dps: 419.5429071857832
+  tps: 316.9851152270199
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Devastation-30316"
  value: {
-  dps: 989.499275024127
-  tps: 739.2932357471245
+  dps: 489.7546870540742
+  tps: 362.62169728142044
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DoomplateBattlegear"
  value: {
-  dps: 795.9605401890408
-  tps: 600.8719193036777
+  dps: 358.6079807134488
+  tps: 268.6965739843811
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Dragonstrike-28439"
  value: {
-  dps: 923.3089051797666
-  tps: 701.0934378475658
+  dps: 425.312896498157
+  tps: 320.77302345758113
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 923.3089051797666
-  tps: 701.0934378475658
+  dps: 425.312896498157
+  tps: 320.77302345758113
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 936.6867837140202
-  tps: 711.1901946355019
+  dps: 429.76805196499004
+  tps: 323.8279196872033
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 923.3089051797666
-  tps: 701.0934378475658
+  dps: 425.312896498157
+  tps: 320.77302345758113
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 912.1353629759012
-  tps: 692.2230429988181
+  dps: 416.7636204830641
+  tps: 314.50598770418134
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 914.6211598109683
-  tps: 694.3332324143117
+  dps: 421.11039019693317
+  tps: 317.8651837787492
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 909.5845675511813
-  tps: 690.6886534575747
+  dps: 420.5643151714774
+  tps: 317.473084305539
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FaithinFelsteel"
  value: {
-  dps: 780.0815758696367
-  tps: 591.941022437846
+  dps: 356.09990134532666
+  tps: 268.2039090275122
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FelstalkerArmor"
  value: {
-  dps: 882.2858266188756
-  tps: 670.3082679950796
+  dps: 409.8758354164368
+  tps: 309.4189961543062
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 919.9987876935645
-  tps: 698.2128978534689
+  dps: 424.6579007802372
+  tps: 319.91570011691493
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 937.1396569875875
-  tps: 710.8206551788774
+  dps: 430.8625161311725
+  tps: 324.4502858411702
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FlameGuard"
  value: {
-  dps: 746.9149603337308
-  tps: 564.9598584099914
+  dps: 337.9973397746637
+  tps: 253.94930489886744
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Guardian'sAlchemistStone-35748"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-HandofJustice-11815"
  value: {
-  dps: 918.7160489229566
-  tps: 697.294072191129
+  dps: 422.61029629854767
+  tps: 318.79857405369467
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Heartrazor-29962"
  value: {
-  dps: 923.3089051797666
-  tps: 701.0934378475658
+  dps: 425.312896498157
+  tps: 320.77302345758113
  }
 }
 dps_results: {
  key: "TestFury-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 921.908750712617
-  tps: 699.6088088879974
+  dps: 424.51166533666293
+  tps: 320.16355979445956
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 916.7502599528649
-  tps: 696.0684217635308
+  dps: 325.59776631864486
+  tps: 244.92615124533805
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 914.6211598109683
-  tps: 694.3332324143117
+  dps: 421.11039019693317
+  tps: 317.8651837787492
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 909.5845675511813
-  tps: 690.6886534575747
+  dps: 420.5643151714774
+  tps: 317.473084305539
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IndestructibleAlchemist'sStone-44323"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 910.8025693034905
-  tps: 691.156062189607
+  dps: 421.9736880851223
+  tps: 318.2394483456565
  }
 }
 dps_results: {
  key: "TestFury-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 742.0789204559892
-  tps: 551.8463629074598
+  dps: 336.50732365321164
+  tps: 250.15549387533406
  }
 }
 dps_results: {
  key: "TestFury-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 915.9136955194112
-  tps: 695.4202665549819
+  dps: 421.007600040815
+  tps: 317.6478893117741
  }
 }
 dps_results: {
  key: "TestFury-AllItems-LionheartChampion-28429"
  value: {
-  dps: 782.1639652759873
-  tps: 582.0284020591964
+  dps: 356.0777197196608
+  tps: 264.1260514240833
  }
 }
 dps_results: {
  key: "TestFury-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 797.9615358450144
-  tps: 593.7632283236612
+  dps: 373.5072734119052
+  tps: 276.8558541230337
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 933.5781135149488
-  tps: 707.8210120673809
+  dps: 269.07311617675344
+  tps: 202.561445269788
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 680.5060059009251
-  tps: 513.2872695787585
+  dps: 313.15814100568707
+  tps: 235.4671262673022
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 595.6654460176366
-  tps: 446.27041904744675
+  dps: 257.2635846460877
+  tps: 193.68712945710934
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 940.8741632516122
-  tps: 713.813650752055
+  dps: 428.52027457207805
+  tps: 323.17725413863565
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MercurialAlchemistStone-44322"
  value: {
-  dps: 903.958078895593
-  tps: 686.1773466564862
+  dps: 416.30898993970595
+  tps: 313.9055584805446
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MightyAlchemist'sStone-44324"
  value: {
-  dps: 913.8767022338841
-  tps: 693.9595835873641
+  dps: 421.26509922285413
+  tps: 317.63455800608176
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 910.8020021822266
-  tps: 691.6632215627501
+  dps: 418.8944786666186
+  tps: 316.03102255764827
  }
 }
 dps_results: {
  key: "TestFury-AllItems-NetherscaleArmor"
  value: {
-  dps: 891.7174949485004
-  tps: 677.1839180941319
+  dps: 412.14645159202473
+  tps: 311.3869296473912
  }
 }
 dps_results: {
  key: "TestFury-AllItems-NetherstrikeArmor"
  value: {
-  dps: 836.8563586252359
-  tps: 635.5822310761909
+  dps: 386.94439429806573
+  tps: 291.7537570678279
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtArmor"
  value: {
-  dps: 726.5069909025458
-  tps: 547.0869781148624
+  dps: 329.3630278149095
+  tps: 247.33203647859943
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 933.7317546679135
-  tps: 707.5882787790586
+  dps: 28.598822482046423
+  tps: 26.025054553901327
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 917.8984443236633
-  tps: 696.5122577306096
+  dps: 419.3281758838163
+  tps: 316.29844684065046
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 910.8025693034905
-  tps: 691.156062189607
+  dps: 421.9736880851223
+  tps: 318.2394483456565
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 919.9552155044933
-  tps: 698.195838737403
+  dps: 418.3360255319774
+  tps: 316.10100663101616
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PrimalIntent"
  value: {
-  dps: 932.6892913117865
-  tps: 707.8418168256926
+  dps: 428.35323037090825
+  tps: 323.4468890248679
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 903.4403228787837
-  tps: 685.6873867883796
+  dps: 414.53235761795344
+  tps: 312.3594707130677
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Redeemer'sAlchemistStone-35750"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 934.5332022461029
-  tps: 710.1319950871522
+  dps: 427.3578067612852
+  tps: 322.6016591823411
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 923.3089051797666
-  tps: 701.0934378475658
+  dps: 425.312896498157
+  tps: 320.77302345758113
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 893.7563321974033
-  tps: 678.7458345279817
+  dps: 408.6803435365896
+  tps: 308.5351234092891
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 923.3089051797666
-  tps: 701.0934378475658
+  dps: 425.312896498157
+  tps: 320.77302345758113
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 927.8764572414938
-  tps: 703.4577673958593
+  dps: 428.63148009115605
+  tps: 322.1562484774083
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 889.3899256796175
-  tps: 674.3228863938343
+  dps: 409.873182234102
+  tps: 309.01330624811067
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 918.1363880109391
-  tps: 697.226030933994
+  dps: 417.99477876453835
+  tps: 314.9801181886086
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 912.6733289794776
-  tps: 692.7205254406923
+  dps: 420.0262078890226
+  tps: 316.79192973936324
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShardofContempt-34472"
  value: {
-  dps: 938.6343069563997
-  tps: 711.7930114727773
+  dps: 426.6797008797421
+  tps: 321.4370087393601
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 904.7433144525841
-  tps: 687.147304453396
+  dps: 420.1967180793058
+  tps: 316.8547837310028
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 943.9137249769826
-  tps: 716.5890730766945
+  dps: 432.68360419709376
+  tps: 326.9688049466859
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 911.0274801872362
-  tps: 691.5675562202496
+  dps: 416.0960629676619
+  tps: 313.6121266955013
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 914.6120440267441
-  tps: 694.5456577582422
+  dps: 418.9637251675129
+  tps: 316.14051835555716
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 728.7749616367744
-  tps: 542.5579922515367
+  dps: 327.987776056312
+  tps: 243.8410131954754
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 942.3876733288704
-  tps: 714.8342945052576
+  dps: 427.8070961751124
+  tps: 322.16384156298534
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 827.8956200264249
-  tps: 628.0060860473418
+  dps: 377.98965471193156
+  tps: 285.0419809383582
  }
 }
 dps_results: {
  key: "TestFury-AllItems-StormGauntlets-12632"
  value: {
-  dps: 897.0031107528889
-  tps: 681.2261189745967
+  dps: 410.86996308467775
+  tps: 309.6769951928427
  }
 }
 dps_results: {
  key: "TestFury-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 804.8534113145937
-  tps: 610.2573912691507
+  dps: 371.82191121196627
+  tps: 279.8946010611752
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 919.9552155044933
-  tps: 698.195838737403
+  dps: 418.3360255319774
+  tps: 316.10100663101616
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 910.8025693034905
-  tps: 691.156062189607
+  dps: 421.9736880851223
+  tps: 318.2394483456565
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 917.8984443236633
-  tps: 696.5122577306096
+  dps: 419.3281758838163
+  tps: 316.29844684065046
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 911.5359877806525
-  tps: 692.2734403156613
+  dps: 420.2110193060468
+  tps: 317.1649127510485
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 923.3089051797666
-  tps: 701.0934378475658
+  dps: 425.312896498157
+  tps: 320.77302345758113
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheBladefist-29348"
  value: {
-  dps: 887.4517271117676
-  tps: 673.7222967151448
+  dps: 409.17742339150385
+  tps: 308.7052069243989
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheDecapitator-28767"
  value: {
-  dps: 923.3089051797666
-  tps: 701.0934378475658
+  dps: 425.312896498157
+  tps: 320.77302345758113
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 924.2138564395057
-  tps: 699.742217675617
+  dps: 431.5047098832772
+  tps: 324.31462952896806
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheNightBlade-31331"
  value: {
-  dps: 923.3089051797666
-  tps: 701.0934378475658
+  dps: 425.312896498157
+  tps: 320.77302345758113
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 910.1471586403499
-  tps: 691.1460269567542
+  dps: 412.9687330720852
+  tps: 311.4215313574079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 909.6699163863041
-  tps: 690.1263122927089
+  dps: 415.25981137071454
+  tps: 312.7639138676406
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1016.0956706719112
-  tps: 769.6471114687379
+  dps: 468.5829586758523
+  tps: 353.3902320105902
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinStars"
  value: {
-  dps: 900.2426067054209
-  tps: 683.4122602821714
+  dps: 412.55347877122335
+  tps: 311.29822540237245
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 923.3089051797666
-  tps: 701.0934378475658
+  dps: 425.312896498157
+  tps: 320.77302345758113
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 916.1222020035943
-  tps: 695.6164672940365
+  dps: 420.8512812869231
+  tps: 317.67483976149305
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 923.3015528638119
-  tps: 701.4779870427816
+  dps: 423.4069482225054
+  tps: 319.83522325008283
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 909.5450171890614
-  tps: 690.5272026185244
+  dps: 417.3519404078764
+  tps: 314.50409050006317
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 902.5225854768983
-  tps: 685.1515722664049
+  dps: 416.5069619453105
+  tps: 314.1503847540014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 918.469147813477
-  tps: 696.3245231553185
+  dps: 425.8734803631534
+  tps: 321.1134432676404
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WarbringerArmor"
  value: {
-  dps: 741.8488171814932
-  tps: 559.4359164798324
+  dps: 335.7151029869084
+  tps: 251.9147983466837
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WarbringerBattlegear"
  value: {
-  dps: 845.9825529648045
-  tps: 642.8100192832728
+  dps: 386.036512284158
+  tps: 291.61438256131447
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WarpSlicer-30311"
  value: {
-  dps: 923.3089051797666
-  tps: 701.0934378475658
+  dps: 425.312896498157
+  tps: 320.77302345758113
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WastewalkerArmor"
  value: {
-  dps: 798.8381380904499
-  tps: 605.7565691294204
+  dps: 363.5682263760807
+  tps: 273.0706516202622
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WindhawkArmor"
  value: {
-  dps: 839.7755471568098
-  tps: 637.7024338116689
+  dps: 384.6401807177317
+  tps: 290.1053825861499
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WorldBreaker-30090"
  value: {
-  dps: 777.7289151177378
-  tps: 578.4951953912549
+  dps: 363.8802637037427
+  tps: 269.74913678973166
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WrathofSpellfire"
  value: {
-  dps: 832.1822769108053
-  tps: 632.2083623290908
+  dps: 385.6412982785936
+  tps: 291.35169967650137
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 907.1839598352608
-  tps: 688.7688375937774
+  dps: 416.35452909855985
+  tps: 313.97397640107357
  }
 }
 dps_results: {
  key: "TestFury-Average-Default"
  value: {
-  dps: 929.7162611199662
-  tps: 705.7296750830843
+  dps: 427.46711170376
+  tps: 322.69512700670845
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1559.2301057981201
-  tps: 1314.3390975496168
+  dps: 734.7311469059105
+  tps: 674.4029433405294
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 919.8076826149445
-  tps: 698.447298659721
+  dps: 420.0134776171966
+  tps: 317.31832040427673
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1004.0087607371366
-  tps: 759.4233994096465
+  dps: 448.0370830094673
+  tps: 337.2709653612276
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1118.9429787527833
-  tps: 971.4577675817033
+  dps: 527.1553570043608
+  tps: 512.500869629891
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 631.5750726851122
-  tps: 477.2298566207265
+  dps: 300.4062284468799
+  tps: 226.33896746937444
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 696.3346028025185
-  tps: 524.6940351491152
+  dps: 327.88183379421224
+  tps: 247.2696669876273
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1578.8378906837104
-  tps: 1327.7070839491334
+  dps: 746.3047805465367
+  tps: 682.3279655188812
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 923.3089051797666
-  tps: 701.0934378475658
+  dps: 425.312896498157
+  tps: 320.77302345758113
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1026.8536058273799
-  tps: 775.7218726022516
+  dps: 464.8489682351587
+  tps: 350.71626555615177
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1144.250388024604
-  tps: 989.9627504705967
+  dps: 533.8215227245449
+  tps: 517.6975006153949
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 643.8260678724753
-  tps: 486.09561959497967
+  dps: 303.2378449099831
+  tps: 228.2130163520525
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 710.5659878732519
-  tps: 534.5259110328409
+  dps: 336.3098571697756
+  tps: 253.64870211550726
  }
 }
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 795.7061458625634
-  tps: 605.5500628722549
+  dps: 364.28441364476515
+  tps: 276.484943109562
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -47,7 +47,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 0.256329916899989
+  weights: 0.07352737461738315
   weights: 0
   weights: 0
   weights: 0
@@ -65,7 +65,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.09772406948020944
+  weights: 0.03356282450097581
   weights: 0
   weights: 0
   weights: 0
@@ -74,12 +74,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.00368085839305536
+  weights: 0.0030094528857244995
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.13523152570664707
-  weights: -0.0312490251635802
+  weights: 0.04040117109212503
+  weights: -0.006078024481979866
   weights: 0
   weights: 0
   weights: 0
@@ -93,1284 +93,1284 @@ stat_weights_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 522.0806532030907
-  tps: 908.9569184385607
+  dps: 136.65558742301698
+  tps: 267.85509474938533
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Alchemist'sStone-13503"
  value: {
-  dps: 520.5897731998139
-  tps: 906.3496630851021
+  dps: 136.44372478832534
+  tps: 268.355344049669
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 515.5430152920248
-  tps: 898.1562768142682
+  dps: 135.52805139105448
+  tps: 266.39385747528166
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Assassin'sAlchemistStone-35751"
  value: {
-  dps: 525.5615122878037
-  tps: 914.2276501392728
+  dps: 138.7535045499113
+  tps: 272.1210914746409
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 520.6483945691091
-  tps: 906.588818951074
+  dps: 136.35966855617045
+  tps: 267.9128105031961
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 518.4819149714739
-  tps: 902.8039967351802
+  dps: 114.72681001890864
+  tps: 231.28107480376752
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 544.6669895913873
-  tps: 943.9807896354936
+  dps: 139.74990511160297
+  tps: 273.4002814452748
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BandoftheEternalDefender-29297"
  value: {
-  dps: 537.0417437004307
-  tps: 929.7827888919961
+  dps: 135.81749147222487
+  tps: 266.55932104607905
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 534.0223897023959
-  tps: 926.3572594458933
+  dps: 135.66306805271486
+  tps: 267.1712357641547
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 530.2158503092352
-  tps: 920.1043952870533
+  dps: 136.41462012854046
+  tps: 267.340083047084
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 533.7438603572525
-  tps: 927.8584122947316
+  dps: 141.4637035882905
+  tps: 276.2124986997949
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 539.5701128197669
-  tps: 938.7694962155634
+  dps: 139.33424039978104
+  tps: 273.4942671611764
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackoutTruncheon-27901"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 519.4187644345063
-  tps: 904.2359729171934
+  dps: 136.92126326354054
+  tps: 269.2599284451673
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BladeofUnquenchedThirst-31193"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlazefuryMedallion-17111"
  value: {
-  dps: 526.1059668856916
-  tps: 912.7930601206884
+  dps: 135.829673885098
+  tps: 266.7744158449083
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Blinkstrike-31332"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 529.2590200944555
-  tps: 921.0634588313947
+  dps: 140.12534357373528
+  tps: 273.8324927435554
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BoldArmor"
  value: {
-  dps: 492.9509590910943
-  tps: 843.8676951786973
+  dps: 129.99093058810368
+  tps: 251.38898965697376
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 898.2465615156696
+  dps: 135.36476488193676
+  tps: 260.61837910317786
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 536.1962232621969
-  tps: 930.3829413122963
+  dps: 137.28433298092384
+  tps: 270.14695445457045
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 533.9419624525847
-  tps: 926.1300651070061
+  dps: 135.96821752118788
+  tps: 266.61958942859246
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BulwarkofAzzinoth-32375"
  value: {
-  dps: 533.6069361171488
-  tps: 925.066471986246
+  dps: 135.9986843233195
+  tps: 266.6440785514985
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 533.7994255049157
-  tps: 927.743357702016
+  dps: 138.10039568915653
+  tps: 270.95223728028384
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 535.8327436569663
-  tps: 931.1253345651156
+  dps: 138.55226848472094
+  tps: 272.38977782636647
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BurningRage"
  value: {
-  dps: 521.9152542181305
-  tps: 890.3612032073976
+  dps: 136.69780067025027
+  tps: 263.1552525763513
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 537.8984150503503
-  tps: 932.3927688789179
+  dps: 137.3184330577517
+  tps: 269.0730332366305
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 540.9553416789621
-  tps: 937.7666391977888
+  dps: 137.37277717703185
+  tps: 269.61986107409507
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CloakofDarkness-33122"
  value: {
-  dps: 529.8952475195241
-  tps: 919.487696066302
+  dps: 133.72075384845192
+  tps: 262.40836337551747
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 521.7115743539612
-  tps: 907.6222466271824
+  dps: 139.07472587639506
+  tps: 272.8011191783593
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 522.4671428452268
-  tps: 909.5409543934443
+  dps: 137.4110313788477
+  tps: 269.71772929995706
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 527.4406254611033
-  tps: 917.2343176423891
+  dps: 138.90052026674766
+  tps: 272.30949853395543
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 520.6747321424818
-  tps: 906.2895496357944
+  dps: 136.65321202455902
+  tps: 268.6092394513175
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DesolationBattlegear"
  value: {
-  dps: 496.49680532886146
-  tps: 849.3350410124159
+  dps: 131.56117284523012
+  tps: 255.2635588014553
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Despair-28573"
  value: {
-  dps: 617.5160543259381
-  tps: 1042.7101635491053
+  dps: 198.06182866784238
+  tps: 365.1630912596604
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestroyerArmor"
  value: {
-  dps: 525.9917086757002
-  tps: 893.600060177137
+  dps: 132.67925775080477
+  tps: 256.36450249568816
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestroyerBattlegear"
  value: {
-  dps: 556.4029380467717
-  tps: 948.5010096111087
+  dps: 143.27438756825856
+  tps: 275.48530449483684
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 531.8459948028554
-  tps: 923.2533116671297
+  dps: 135.41483746847715
+  tps: 266.25272438241177
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 531.6764454435864
-  tps: 922.627105937927
+  dps: 136.63081271308127
+  tps: 267.86256261500483
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Devastation-30316"
  value: {
-  dps: 818.7851050470936
-  tps: 1367.0274777382187
+  dps: 271.04812180322585
+  tps: 491.10617330703593
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DoomplateBattlegear"
  value: {
-  dps: 513.9712605372438
-  tps: 878.0740051385758
+  dps: 133.95758219809045
+  tps: 258.82045684330757
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dragonmaw-28438"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 523.5378189299527
-  tps: 912.347264940787
+  dps: 135.1980724879715
+  tps: 265.4854808352176
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dragonstrike-28439"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 529.2590200944555
-  tps: 921.0634588313947
+  dps: 140.12534357373528
+  tps: 273.8324927435554
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmpyreanDemolisher-17112"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 532.340358935329
-  tps: 924.068458217033
+  dps: 134.8849147583927
+  tps: 265.65026391339813
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 530.2158503092352
-  tps: 920.1043952870533
+  dps: 136.41462012854046
+  tps: 267.340083047084
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 531.802820646983
-  tps: 923.4555047008428
+  dps: 135.67449434593257
+  tps: 266.8987421584443
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 530.817269731193
-  tps: 920.2910885363052
+  dps: 135.48202549201227
+  tps: 266.0477689728528
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 533.2967711749654
-  tps: 924.0720802879139
+  dps: 135.59928610208772
+  tps: 266.2265796771568
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FaithinFelsteel"
  value: {
-  dps: 478.9525287609771
-  tps: 818.2216672311166
+  dps: 125.53795411064135
+  tps: 243.7837433321977
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FelstalkerArmor"
  value: {
-  dps: 524.8955752599461
-  tps: 912.8840265658581
+  dps: 135.78949349322463
+  tps: 267.30325795935414
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-LivingRubySerpent-24126"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 522.9146004071492
-  tps: 910.1949847269356
+  dps: 138.17586272684318
+  tps: 270.4211216783461
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-ShadowsongPanther-35702"
  value: {
-  dps: 531.2336093195363
-  tps: 924.0242260318128
+  dps: 140.21947482734623
+  tps: 274.25170296453024
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FlameGuard"
  value: {
-  dps: 455.3217466166939
-  tps: 780.824967250305
+  dps: 120.91804662609984
+  tps: 236.03388471356132
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Guardian'sAlchemistStone-35748"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HandofJustice-11815"
  value: {
-  dps: 525.3331205033678
-  tps: 915.128131168526
+  dps: 136.96313461085515
+  tps: 269.08850352868177
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Heartrazor-29962"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 521.3280707075286
-  tps: 907.6123552032805
+  dps: 137.8341389116512
+  tps: 270.758759128895
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 530.2158503092352
-  tps: 920.1043952870533
+  dps: 136.41462012854046
+  tps: 267.340083047084
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 531.802820646983
-  tps: 923.4555047008428
+  dps: 135.67449434593257
+  tps: 266.8987421584443
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IndestructibleAlchemist'sStone-44323"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 534.1355136083727
-  tps: 925.984275076553
+  dps: 135.68818494245997
+  tps: 266.6675556523285
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KhoriumChampion-23541"
  value: {
-  dps: 615.3418268423312
-  tps: 1043.2949837589204
+  dps: 182.44054844188915
+  tps: 342.81911452374356
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 519.0501576599609
-  tps: 904.9242030778421
+  dps: 136.62507726986732
+  tps: 268.79561008400265
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LionheartChampion-28429"
  value: {
-  dps: 635.1882191916106
-  tps: 1071.4785972042537
+  dps: 194.2593268272633
+  tps: 360.3861120990066
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 655.3469071490374
-  tps: 1102.8902308427566
+  dps: 204.80866924866427
+  tps: 377.68528079604147
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 532.9927441793392
-  tps: 926.6863754171795
+  dps: 104.93976036552665
+  tps: 217.12661372792002
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 444.2376621267674
-  tps: 763.3353344461394
+  dps: 119.12462793897039
+  tps: 233.2091497217838
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ManualCrowdPummeler-9449"
  value: {
-  dps: 435.35443105537996
-  tps: 770.7709715809526
+  dps: 110.30590318969072
+  tps: 234.6401508122486
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 531.3990450898796
-  tps: 924.5099959080317
+  dps: 139.6750893954711
+  tps: 273.41267484956023
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MercurialAlchemistStone-44322"
  value: {
-  dps: 520.2728187703085
-  tps: 906.6323720351418
+  dps: 136.33910219164366
+  tps: 268.30540994569293
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MightyAlchemist'sStone-44324"
  value: {
-  dps: 518.0185581087435
-  tps: 902.2053698738773
+  dps: 136.12805126602615
+  tps: 267.7882556791135
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NetherscaleArmor"
  value: {
-  dps: 523.4003289647909
-  tps: 910.532765215087
+  dps: 136.5119262782756
+  tps: 268.5448096505031
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NetherstrikeArmor"
  value: {
-  dps: 494.310664171362
-  tps: 861.3564558576871
+  dps: 129.5106953733897
+  tps: 256.1868489647693
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 542.7270978339502
-  tps: 918.3235373756086
+  dps: 134.8340972245809
+  tps: 258.66501490559676
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 622.9693682476772
-  tps: 1058.3553115231207
+  dps: 19.4882688
+  tps: 89.46582635599896
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 535.0503724815297
-  tps: 928.1521134044164
+  dps: 135.98796201582013
+  tps: 267.1994379733526
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 534.1355136083727
-  tps: 925.984275076553
+  dps: 135.68818494245997
+  tps: 266.6675556523285
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 527.7416721690823
-  tps: 915.4752740642855
+  dps: 136.11182426658792
+  tps: 266.9397848651673
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PrimalIntent"
  value: {
-  dps: 547.5796391328081
-  tps: 950.5522693995534
+  dps: 141.57490552364808
+  tps: 277.2896957475377
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Redeemer'sAlchemistStone-35750"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 541.3388373142502
-  tps: 937.9599228708882
+  dps: 137.8667672886118
+  tps: 270.35054153367224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 542.1090557514988
-  tps: 939.7679500538927
+  dps: 137.93005707640404
+  tps: 270.871865899255
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 508.8731274668442
-  tps: 885.4874630646902
+  dps: 132.67323555057598
+  tps: 262.08201528753557
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 531.457581268641
-  tps: 924.5113992426012
+  dps: 144.65428991202472
+  tps: 281.9693626305302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 505.7044759579192
-  tps: 881.2412641657618
+  dps: 133.63228604142805
+  tps: 263.6788427409157
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 518.749056191915
-  tps: 903.5289254813019
+  dps: 137.84486421795975
+  tps: 271.36739915876393
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 516.9359631363021
-  tps: 900.0414050069251
+  dps: 135.7999033304161
+  tps: 266.7593952185452
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShardofContempt-34472"
  value: {
-  dps: 539.1406314389214
-  tps: 936.730580976649
+  dps: 140.2489813895807
+  tps: 275.4606916158398
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShatteredSunPendantofAcumen-34678"
  value: {
-  dps: 519.3188553902298
-  tps: 901.9627087768971
+  dps: 134.00691049951732
+  tps: 264.00298727093855
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShatteredSunPendantofMight-34679"
  value: {
-  dps: 539.8986087941842
-  tps: 935.8493932266994
+  dps: 138.29161943312835
+  tps: 270.97246005727334
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 515.0370613708194
-  tps: 897.0307484371009
+  dps: 134.9918663383941
+  tps: 265.12724459774057
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 521.8146802995794
-  tps: 909.2535700196668
+  dps: 136.62378522469697
+  tps: 269.011059633876
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SingingCrystalAxe-31318"
  value: {
-  dps: 599.1613680011844
-  tps: 1018.3380544053056
+  dps: 181.4403673821922
+  tps: 342.27691849508085
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 526.1930800812289
-  tps: 915.5678304846806
+  dps: 138.50907300134742
+  tps: 271.5706473125851
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sorcerer'sAlchemistStone-35749"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 506.8490034560403
-  tps: 882.4512617866599
+  dps: 132.81493737876264
+  tps: 262.4836984849861
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormGauntlets-12632"
  value: {
-  dps: 512.6571011521427
-  tps: 872.8074212022468
+  dps: 133.66129249107436
+  tps: 257.6933913060833
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 494.889083799577
-  tps: 862.0945703767982
+  dps: 129.51702251006597
+  tps: 255.5790781726491
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 527.7416721690823
-  tps: 915.4752740642855
+  dps: 136.11182426658792
+  tps: 266.9397848651673
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 534.1355136083727
-  tps: 925.984275076553
+  dps: 135.68818494245997
+  tps: 266.6675556523285
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 535.0503724815297
-  tps: 928.1521134044164
+  dps: 135.98796201582013
+  tps: 267.1994379733526
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 533.0646185373615
-  tps: 924.5130636099233
+  dps: 135.48005382899458
+  tps: 266.16088882911765
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheBladefist-29348"
  value: {
-  dps: 523.522480584193
-  tps: 907.4569609036447
+  dps: 139.80773591661523
+  tps: 271.86116809789587
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheDecapitator-28767"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 656.5788703292556
-  tps: 1129.5087170354461
+  dps: 186.25145983290398
+  tps: 358.3146855671386
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheNightBlade-31331"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 512.1306865830863
-  tps: 891.7959178937576
+  dps: 134.75592567430795
+  tps: 264.9405393608355
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 518.4017919255718
-  tps: 903.0291345300566
+  dps: 136.63627963267595
+  tps: 269.0128300689815
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 715.2164341247076
-  tps: 1224.9366473755094
+  dps: 193.39560493416542
+  tps: 374.2313069276751
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinStars"
  value: {
-  dps: 519.3188553902298
-  tps: 901.9627087768971
+  dps: 134.00691049951732
+  tps: 264.00298727093855
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 530.3218076839173
-  tps: 920.092349829091
+  dps: 135.31726179814484
+  tps: 265.7070093896612
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 533.3127298971199
-  tps: 925.9357074807713
+  dps: 134.8220033715252
+  tps: 264.7914904666593
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Timbal'sFocusingCrystal-34470"
  value: {
-  dps: 518.32715568724
-  tps: 901.8136102531159
+  dps: 139.8316950104931
+  tps: 272.8494261030254
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 524.6523150689278
-  tps: 913.1417096647342
+  dps: 138.32727423746832
+  tps: 271.3657161863145
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarbringerArmor"
  value: {
-  dps: 495.3862429190586
-  tps: 844.3755739872848
+  dps: 128.0106554518815
+  tps: 247.1734633711459
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarbringerBattlegear"
  value: {
-  dps: 547.6565950860453
-  tps: 941.2346018791452
+  dps: 143.67380773723804
+  tps: 281.0647459053623
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarpSlicer-30311"
  value: {
-  dps: 528.3377682874204
-  tps: 916.5100967846967
+  dps: 135.36476488193676
+  tps: 265.8689582685487
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WastewalkerArmor"
  value: {
-  dps: 515.91818090477
-  tps: 882.6842406012729
+  dps: 134.27046164470542
+  tps: 261.2563576815747
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WindhawkArmor"
  value: {
-  dps: 489.6169657847051
-  tps: 853.2369381933083
+  dps: 128.17232598718795
+  tps: 253.61712774581645
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WorldBreaker-30090"
  value: {
-  dps: 639.7039823936684
-  tps: 1077.8416139248334
+  dps: 195.52675856190376
+  tps: 361.77877560407245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WrathofSpellfire"
  value: {
-  dps: 481.269874988752
-  tps: 823.1333190358683
+  dps: 127.40624398117467
+  tps: 247.4639265231238
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 516.5372602641215
-  tps: 899.5558366663473
+  dps: 136.00884669101015
+  tps: 267.1503494623068
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 666.0369015488662
-  tps: 1284.638731204966
-  dtps: 642.9928441758773
+  dps: 209.62429717265354
+  tps: 552.9857735591935
+  dtps: 618.4880144859891
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-SelfDrums-DPS"
  value: {
-  dps: 666.7585962182588
-  tps: 1286.6357452843715
-  dtps: 650.1818534193812
+  dps: 210.43009987465382
+  tps: 554.9829493504202
+  dtps: 620.7663580079956
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 610.5557308352298
-  tps: 1190.1166422992715
+  dps: 161.72729597168373
+  tps: 441.0139552341883
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 596.0954085485057
-  tps: 1028.4969820330598
+  dps: 154.674122468659
+  tps: 302.13132389903336
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 657.0347623309658
-  tps: 1136.913220434408
+  dps: 142.5077824836272
+  tps: 283.7008194071662
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 252.17949979682663
-  tps: 588.7358510144047
+  dps: 78.37346405812151
+  tps: 290.710225097408
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 239.0797538565125
-  tps: 431.4676178124029
+  dps: 74.75499252316699
+  tps: 160.45992879060057
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 226.28303701387938
-  tps: 411.10362961953035
+  dps: 67.30260246454144
+  tps: 149.6833385476126
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 620.7387434521181
-  tps: 1207.51733371793
+  dps: 158.9420766656809
+  tps: 435.0856365644325
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 599.4497266412259
-  tps: 1033.6451359370644
+  dps: 153.6975780451277
+  tps: 300.0507303032492
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 659.5817277363038
-  tps: 1140.3790784415148
+  dps: 144.19214142868515
+  tps: 287.8491956650473
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 256.34203159943013
-  tps: 594.7267353995276
+  dps: 77.92724424578807
+  tps: 288.471252457534
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 243.2360626046058
-  tps: 438.1869178374124
+  dps: 74.94325131128723
+  tps: 160.50465423241624
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 227.65949730792195
-  tps: 414.2514350393467
+  dps: 66.79728628063265
+  tps: 148.2276554640723
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 757.394925048288
-  tps: 1436.5123354675286
-  dtps: 581.9771082531478
+  dps: 232.2524189766605
+  tps: 591.0106739773327
+  dtps: 559.7732094539566
  }
 }

--- a/sim/warrior/sunder_armor.go
+++ b/sim/warrior/sunder_armor.go
@@ -11,7 +11,8 @@ func (warrior *Warrior) newSunderArmorSpell(isDevastateEffect bool) *core.Spell 
 	cost := 15.0 - float64(warrior.Talents.ImprovedSunderArmor) - float64(warrior.Talents.FocusedRage)
 	refundAmount := cost * 0.8
 	warrior.SunderArmorAura = core.SunderArmorAura(warrior.CurrentTarget, 0)
-	warrior.ExposeArmorAura = core.ExposeArmorAura(warrior.CurrentTarget, 2)
+	warrior.ExposeArmorAura = core.ExposeArmorAura(warrior.CurrentTarget, false)
+	warrior.AcidSpitAura = core.AcidSpitAura(warrior.CurrentTarget, 0)
 
 	config := core.SpellConfig{
 		ActionID:    SunderArmorActionID,
@@ -70,5 +71,7 @@ func (warrior *Warrior) newSunderArmorSpell(isDevastateEffect bool) *core.Spell 
 }
 
 func (warrior *Warrior) CanSunderArmor(sim *core.Simulation) bool {
-	return warrior.CurrentRage() >= warrior.SunderArmor.DefaultCast.Cost && !warrior.ExposeArmorAura.IsActive()
+	return warrior.CurrentRage() >= warrior.SunderArmor.DefaultCast.Cost &&
+		!warrior.ExposeArmorAura.IsActive() &&
+		!warrior.AcidSpitAura.IsActive()
 }

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -68,6 +68,7 @@ type Warrior struct {
 	DemoralizingShoutAura *core.Aura
 	BloodFrenzyAuras      []*core.Aura
 	ExposeArmorAura       *core.Aura // Warriors don't cast this but they need to check it.
+	AcidSpitAura          *core.Aura // Warriors don't cast this but they need to check it.
 	RampageAura           *core.Aura
 	SunderArmorAura       *core.Aura
 	ThunderClapAura       *core.Aura


### PR DESCRIPTION
1. Introduces a PseudoStat for ArmorMultiplier
2. Add Armor() and ArmorPenetration() functions to unit that can be used to get the modified armor / armor pen percentages respectively
3. Updates debuffs to modify this multiplier and be tagged as Major/Minor (20%/5%)
4. Updates the damage reduction formula based on the model that has been discussed in the simonize vid
5. Adds tests to verify damage reduction and aura stacking

Still missing:
1. Correct spell ids for debuffs (only updated their respective armor modifiers)
2. Talent and stance based armor pen