### PR TITLE
Updated Mind Blast and Shadow Word Death Spells

### DIFF
--- a/sim/priest/mind_blast.go
+++ b/sim/priest/mind_blast.go
@@ -8,10 +8,24 @@ import (
 )
 
 func (priest *Priest) registerMindBlastSpell() {
-	baseCost := 450.0
+	baseCost := priest.BaseMana() * 0.17
+
+	Mult_mod := (1 + float64(priest.Talents.Darkness)*0.02) *
+		core.TernaryFloat64(priest.Talents.Shadowform, 1.15, 1) *
+		core.TernaryFloat64(ItemSetAbsolution.CharacterHasSetBonus(&priest.Character, 4), 1.1, 1)
+	if priest.ShadowWordPainDot.IsActive() {
+		Mult_mod = (1 + float64(priest.Talents.Darkness)*0.02 + float64(priest.Talents.TwistedFaith)*0.02) *
+			core.TernaryFloat64(priest.Talents.Shadowform, 1.15, 1) *
+			core.TernaryFloat64(ItemSetAbsolution.CharacterHasSetBonus(&priest.Character, 4), 1.1, 1)
+	}
+
+	base := core.BaseDamageConfigMagic(992, 1048, 0.429)
+	if priest.MiseryAura.IsActive() {
+		base = core.BaseDamageConfigMagic(992, 1048, 0.429*float64(priest.Talents.Misery)*0.05)
+	}
 
 	priest.MindBlast = priest.RegisterSpell(core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: 25375},
+		ActionID:    core.ActionID{SpellID: 48127},
 		SpellSchool: core.SpellSchoolShadow,
 
 		ResourceType: stats.Mana,
@@ -30,22 +44,18 @@ func (priest *Priest) registerMindBlastSpell() {
 		},
 
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
-			ProcMask: core.ProcMaskSpellDamage,
-			BonusSpellHitRating: 0 +
-				float64(priest.Talents.ShadowFocus)*2*core.SpellHitRatingPerHitChance +
-				float64(priest.Talents.FocusedPower)*2*core.SpellHitRatingPerHitChance,
+			ProcMask:            core.ProcMaskSpellDamage,
+			BonusSpellHitRating: 0 + float64(priest.Talents.ShadowFocus)*1*core.SpellHitRatingPerHitChance,
 
-			BonusSpellCritRating: float64(priest.Talents.ShadowPower) * 3 * core.CritRatingPerCritChance,
+			BonusSpellCritRating: float64(priest.Talents.MindMelt) * 2 * core.CritRatingPerCritChance,
 
-			DamageMultiplier: 1 *
-				(1 + float64(priest.Talents.Darkness)*0.02) *
-				core.TernaryFloat64(priest.Talents.Shadowform, 1.15, 1) *
-				core.TernaryFloat64(ItemSetAbsolution.CharacterHasSetBonus(&priest.Character, 4), 1.1, 1),
+			DamageMultiplier: Mult_mod,
 
 			ThreatMultiplier: 1 - 0.08*float64(priest.Talents.ShadowAffinity),
-
-			BaseDamage:     core.BaseDamageConfigMagic(711, 752, 0.429),
-			OutcomeApplier: priest.OutcomeFuncMagicHitAndCrit(priest.DefaultSpellCritMultiplier()),
+			BaseDamage:       base,
+			OutcomeApplier:   priest.OutcomeFuncMagicHitAndCrit(priest.SpellCritMultiplier(1, float64(priest.Talents.ShadowPower)/5)),
 		}),
 	})
 }
+
+// Need to add a check to see if VT is active, and if so, then apply replenishment

--- a/sim/priest/shadow_word_death.go
+++ b/sim/priest/shadow_word_death.go
@@ -8,10 +8,18 @@ import (
 )
 
 func (priest *Priest) registerShadowWordDeathSpell() {
-	baseCost := 309.0
+	baseCost := priest.BaseMana() * 0.12
+
+	playerMod := (1 + float64(priest.Talents.Darkness)*0.02 + float64(priest.Talents.TwinDisciplines)*0.01) *
+		core.TernaryFloat64(priest.Talents.Shadowform, 1.15, 1)
+	// target := priest.CurrentTarget // Add this section when we get target health simmed to investigate SWD glyph
+	// if priest.GlyphOfShadowWordDeath && target.CurrentHealth < 0.35*target.MaxHealth{
+	//	playerMod = 1 * (1 + float64(priest.Talents.Darkness)*0.02 + float64(priest.Talents.TwinDisciplines)*0.01) *
+	//	core.TernaryFloat64(priest.Talents.Shadowform, 1.15, 1)*1.1,
+	//}
 
 	priest.ShadowWordDeath = priest.RegisterSpell(core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: 32996},
+		ActionID:    core.ActionID{SpellID: 48158},
 		SpellSchool: core.SpellSchoolShadow,
 
 		ResourceType: stats.Mana,
@@ -30,14 +38,12 @@ func (priest *Priest) registerShadowWordDeathSpell() {
 
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			ProcMask:             core.ProcMaskSpellDamage,
-			BonusSpellHitRating:  float64(priest.Talents.ShadowFocus) * 2 * core.SpellHitRatingPerHitChance,
-			BonusSpellCritRating: float64(priest.Talents.ShadowPower) * 3 * core.CritRatingPerCritChance,
-			DamageMultiplier: 1 *
-				(1 + float64(priest.Talents.Darkness)*0.02) *
-				core.TernaryFloat64(priest.Talents.Shadowform, 1.15, 1),
-			ThreatMultiplier: 1 - 0.08*float64(priest.Talents.ShadowAffinity),
-			BaseDamage:       core.BaseDamageConfigMagic(572, 664, 0.429),
-			OutcomeApplier:   priest.OutcomeFuncMagicHitAndCrit(priest.DefaultSpellCritMultiplier()),
+			BonusSpellHitRating:  0 + float64(priest.Talents.ShadowFocus)*1*core.SpellHitRatingPerHitChance,
+			BonusSpellCritRating: float64(priest.Talents.MindMelt) * 2 * core.CritRatingPerCritChance,
+			DamageMultiplier:     playerMod,
+			ThreatMultiplier:     1 - 0.08*float64(priest.Talents.ShadowAffinity),
+			BaseDamage:           core.BaseDamageConfigMagic(750, 870, 0.429),
+			OutcomeApplier:       priest.OutcomeFuncMagicHitAndCrit(priest.SpellCritMultiplier(1, float64(priest.Talents.ShadowPower)/5)),
 		}),
 	})
 }


### PR DESCRIPTION
Updated mind blast and shadow word death priest spells. Still need to update including replenishment on MB hits and glyph of shadow word death if target is 35% health, but these are minor updates that can be made later.