### PR TITLE
Make ArmorDamageReduction name/calculation consistent

### DIFF
--- a/sim/core/armor_test.go
+++ b/sim/core/armor_test.go
@@ -177,88 +177,88 @@ func TestDamageReductionFromArmor(t *testing.T) {
 		Level: 80,
 	}
 	target.stats = target.initialStats
-	expectedDamageReduction := 0.5886
+	expectedDamageReduction := 0.41132
 	attackTable := NewAttackTable(&attacker, &target)
 	tolerance := 0.0001
-	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
-		t.Fatalf("Expected no armor modifiers to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	if !WithinToleranceFloat64(1-expectedDamageReduction, attackTable.ArmorDamageModifier, tolerance) {
+		t.Fatalf("Expected no armor modifiers to result in %f damage reduction got %f", expectedDamageReduction, 1-attackTable.ArmorDamageModifier)
 	}
 
 	// Major
 	acidSpitAura := AcidSpitAura(&target, 2)
 	acidSpitAura.Activate(&sim)
-	expectedDamageReduction = 0.6415
+	expectedDamageReduction = 0.3585
 	attackTable.UpdateArmorDamageReduction()
-	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
-		t.Fatalf("Expected major armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	if !WithinToleranceFloat64(1-expectedDamageReduction, attackTable.ArmorDamageModifier, tolerance) {
+		t.Fatalf("Expected major armor modifier to result in %f damage reduction got %f", expectedDamageReduction, 1-attackTable.ArmorDamageModifier)
 	}
 
 	// Major + Minor
 	faerieFireAura := FaerieFireAura(&target, 3)
 	faerieFireAura.Activate(&sim)
 	attackTable.UpdateArmorDamageReduction()
-	expectedDamageReduction = 0.6531
-	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
-		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	expectedDamageReduction = 0.3468
+	if !WithinToleranceFloat64(1-expectedDamageReduction, attackTable.ArmorDamageModifier, tolerance) {
+		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, 1-attackTable.ArmorDamageModifier)
 	}
 
 	// Major + Minor + Spore
 	sporeCloudAura := SporeCloudAura(&target)
 	sporeCloudAura.Activate(&sim)
 	attackTable.UpdateArmorDamageReduction()
-	expectedDamageReduction = 0.6600
-	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
-		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	expectedDamageReduction = 0.34
+	if !WithinToleranceFloat64(1-expectedDamageReduction, attackTable.ArmorDamageModifier, tolerance) {
+		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, 1-attackTable.ArmorDamageModifier)
 	}
 
 	// Major + Minor + Spore + Throw
 	shatteringThrowAura := ShatteringThrowAura(&target)
 	shatteringThrowAura.Activate(&sim)
 	attackTable.UpdateArmorDamageReduction()
-	expectedDamageReduction = 0.7082
-	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
-		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	expectedDamageReduction = 0.2918
+	if !WithinToleranceFloat64(1-expectedDamageReduction, attackTable.ArmorDamageModifier, tolerance) {
+		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, 1-attackTable.ArmorDamageModifier)
 	}
 
 	// Just Major minor again; testing Deactivate
 	sporeCloudAura.Deactivate(&sim)
 	shatteringThrowAura.Deactivate(&sim)
 	attackTable.UpdateArmorDamageReduction()
-	expectedDamageReduction = 0.6532
-	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
-		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	expectedDamageReduction = 0.3468
+	if !WithinToleranceFloat64(1-expectedDamageReduction, attackTable.ArmorDamageModifier, tolerance) {
+		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, 1-attackTable.ArmorDamageModifier)
 	}
 
 	// Cap armor pen
 	attacker.stats[stats.ArmorPenetration] = 1400
 	attackTable.UpdateArmorDamageReduction()
-	expectedDamageReduction = 0.9797
-	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
-		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	expectedDamageReduction = 0.0203
+	if !WithinToleranceFloat64(1-expectedDamageReduction, attackTable.ArmorDamageModifier, tolerance) {
+		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, 1-attackTable.ArmorDamageModifier)
 	}
 
 	// Verify going past Cap doesn't help
 	attacker.stats[stats.ArmorPenetration] = 1600
 	attackTable.UpdateArmorDamageReduction()
-	expectedDamageReduction = 0.9797
-	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
-		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	expectedDamageReduction = 0.0203
+	if !WithinToleranceFloat64(1-expectedDamageReduction, attackTable.ArmorDamageModifier, tolerance) {
+		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, 1-attackTable.ArmorDamageModifier)
 	}
 
 	// Add spore back
 	sporeCloudAura.Activate(&sim)
 	attackTable.UpdateArmorDamageReduction()
-	expectedDamageReduction = 0.9900
-	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
-		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	expectedDamageReduction = 0.0100
+	if !WithinToleranceFloat64(1-expectedDamageReduction, attackTable.ArmorDamageModifier, tolerance) {
+		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, 1-attackTable.ArmorDamageModifier)
 	}
 
 	// Fully debuffs
 	shatteringThrowAura.Activate(&sim)
 	attackTable.UpdateArmorDamageReduction()
-	expectedDamageReduction = 1.0
-	if !WithinToleranceFloat64(expectedDamageReduction, attackTable.ArmorDamageReduction, tolerance) {
-		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, attackTable.ArmorDamageReduction)
+	expectedDamageReduction = 0.0
+	if !WithinToleranceFloat64(1-expectedDamageReduction, attackTable.ArmorDamageModifier, tolerance) {
+		t.Fatalf("Expected major & minor armor modifier to result in %f damage reduction got %f", expectedDamageReduction, 1-attackTable.ArmorDamageModifier)
 	}
 
 }

--- a/sim/core/spell_resistances.go
+++ b/sim/core/spell_resistances.go
@@ -17,7 +17,7 @@ func (spellEffect *SpellEffect) applyResistances(sim *Simulation, spell *Spell, 
 		}
 
 		// Physical resistance (armor).
-		spellEffect.Damage *= attackTable.ArmorDamageReduction
+		spellEffect.Damage *= attackTable.ArmorDamageModifier
 	} else if !spell.Flags.Matches(SpellFlagBinary) {
 		// Magical resistance.
 
@@ -49,7 +49,7 @@ func (at *AttackTable) UpdateArmorDamageReduction() {
 	reducibleArmor := MinFloat((defenderArmor+ReducibleArmorConstant)/3, defenderArmor)
 	effectiveArmor := defenderArmor - reducibleArmor*at.Attacker.ArmorPenetration()
 	armorConstant := float64(at.Attacker.Level)*467.5 - 22167.5
-	at.ArmorDamageReduction = 1 - effectiveArmor/(effectiveArmor+armorConstant)
+	at.ArmorDamageModifier = 1 - effectiveArmor/(effectiveArmor+armorConstant)
 }
 
 func (at *AttackTable) UpdatePartialResists() {

--- a/sim/core/target.go
+++ b/sim/core/target.go
@@ -213,7 +213,7 @@ type AttackTable struct {
 	BinaryNatureHitChance float64
 	BinaryShadowHitChance float64
 
-	ArmorDamageReduction float64
+	ArmorDamageModifier float64
 
 	DamageDealtMultiplier float64
 }

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -362,7 +362,7 @@ func (rogue *Rogue) registerBladeFlurryCD() {
 			}
 
 			// Undo armor reduction to get the raw damage value.
-			curDmg = spellEffect.Damage / rogue.AttackTables[spellEffect.Target.Index].ArmorDamageReduction
+			curDmg = spellEffect.Damage / rogue.AttackTables[spellEffect.Target.Index].ArmorDamageModifier
 
 			bfHit.Cast(sim, rogue.Env.NextTargetUnit(spellEffect.Target))
 			bfHit.SpellMetrics[spellEffect.Target.TableIndex].Casts--

--- a/sim/warrior/sweeping_strikes.go
+++ b/sim/warrior/sweeping_strikes.go
@@ -52,7 +52,7 @@ func (warrior *Warrior) registerSweepingStrikesCD() {
 			// TODO: If the triggering spell is Execute and 2nd target health > 20%, do a normalized MH hit instead.
 
 			// Undo armor reduction to get the raw damage value.
-			curDmg = spellEffect.Damage / warrior.AttackTables[spellEffect.Target.Index].ArmorDamageReduction
+			curDmg = spellEffect.Damage / warrior.AttackTables[spellEffect.Target.Index].ArmorDamageModifier
 
 			ssHit.Cast(sim, warrior.Env.NextTargetUnit(spellEffect.Target))
 			ssHit.SpellMetrics[spellEffect.Target.TableIndex].Casts--


### PR DESCRIPTION
This is a slight adjustment to the initial fix to uses the complement of the armor damage reduction when calculating spell damage.