### PR TITLE
Allow CI "Run Tests" action to catch TS errors.

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,8 +21,18 @@ jobs:
       - name: Install Protoc Go plugin
         run: go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
+
+      - name: Build 🔧
+        run: |
+          npm install
+          make
 
       - name: Test
         run: |


### PR DESCRIPTION
Some IDEs are not capable of tracking project wide TypeScript errors.

Current "Run Tests" action does not check for TypeScript errors on PRs.

This allows them to sneak past the PR testing CI and move into the deploy phase unnoticed.

This commit fixes that specific case.