### PR TITLE
Add webhook actions

### DIFF
--- a/.github/workflows/on_issue.yml
+++ b/.github/workflows/on_issue.yml
@@ -8,5 +8,8 @@ jobs:
     steps:
       - name: Send webhook
         uses: Ilshidur/action-discord@master
+        continue-on-error: true
         env:
           DISCORD_WEBHOOK: ${{ secrets.WEBHOOK_URL }}
+      - name: Exit 0
+        run: exit 0

--- a/.github/workflows/on_issue.yml
+++ b/.github/workflows/on_issue.yml
@@ -1,0 +1,12 @@
+name: New issue webhook
+on:
+  issues:
+    types: [opened]
+jobs:
+  send_webhook:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send webhook
+        uses: Ilshidur/action-discord@master
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.WEBHOOK_URL }}

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -1,0 +1,13 @@
+name: New master pull request webhook
+on:
+  pull_request:
+    branches: [master]
+    types: [opened]
+jobs:
+  send_webhook:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send webhook
+        uses: Ilshidur/action-discord@master
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.WEBHOOK_URL }}

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -9,5 +9,8 @@ jobs:
     steps:
       - name: Send webhook
         uses: Ilshidur/action-discord@master
+        continue-on-error: true
         env:
           DISCORD_WEBHOOK: ${{ secrets.WEBHOOK_URL }}
+      - name: Exit 0
+        run: exit 0


### PR DESCRIPTION
Adds two new GitHub actions:

**on_issue**

Triggers a webhook in the Discord server, whenever a new issue is created.

**on_pull_request**

Triggers a webhook in the Discord server, whenever a new pull request is opened on master.

Requires a new secret, `WEBHOOK_URL` (do not append "/github" to the end of the URL, that's done by the action by default).