### PR TITLE
Paladin glyphs and bugfixes.

### DIFF
--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -1083,7 +1083,7 @@ func makeConjuredActivation(conjuredType proto.Conjured, character *Character) (
 	if conjuredType == proto.Conjured_ConjuredDarkRune {
 		actionID := ActionID{ItemID: 20520}
 		manaMetrics := character.NewManaMetrics(actionID)
-		damageTakenManaMetrics := character.NewManaMetrics(ActionID{SpellID: 33776})
+		// damageTakenManaMetrics := character.NewManaMetrics(ActionID{SpellID: 33776})
 		return MajorCooldown{
 				Type: CooldownTypeMana,
 				CanActivate: func(sim *Simulation, character *Character) bool {
@@ -1112,13 +1112,13 @@ func makeConjuredActivation(conjuredType proto.Conjured, character *Character) (
 					manaGain := 900 + (sim.RandomFloat("dark rune") * 600)
 					character.AddMana(sim, manaGain, manaMetrics, true)
 
-					if character.Class == proto.Class_ClassPaladin {
-						// Paladins gain extra mana from self-inflicted damage
-						// TO-DO: It is possible for damage to be resisted or to crit
-						// This would affect mana returns for Paladins
-						manaFromDamage := manaGain * 2.0 / 3.0 * 0.1
-						character.AddMana(sim, manaFromDamage, damageTakenManaMetrics, false)
-					}
+					// if character.Class == proto.Class_ClassPaladin {
+					// 	// Paladins gain extra mana from self-inflicted damage
+					// 	// TO-DO: It is possible for damage to be resisted or to crit
+					// 	// This would affect mana returns for Paladins
+					// 	manaFromDamage := manaGain * 2.0 / 3.0 * 0.1
+					// 	character.AddMana(sim, manaFromDamage, damageTakenManaMetrics, false)
+					// }
 				},
 			})
 	} else if conjuredType == proto.Conjured_ConjuredFlameCap {
@@ -1292,7 +1292,7 @@ func (character *Character) newBasicExplosiveSpellConfig(actionID ActionID, minD
 		}
 	}
 
-	damageTakenManaMetrics := character.NewManaMetrics(ActionID{SpellID: 33776})
+	// damageTakenManaMetrics := character.NewManaMetrics(ActionID{SpellID: 33776})
 	return SpellConfig{
 		ActionID:    actionID,
 		SpellSchool: school,
@@ -1312,13 +1312,13 @@ func (character *Character) newBasicExplosiveSpellConfig(actionID ActionID, minD
 			BaseDamage:     BaseDamageConfigRoll(minDamage, maxDamage),
 			OutcomeApplier: character.OutcomeFuncMagicHitAndCrit(2),
 			OnSpellHitDealt: func(sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
-				// Paladins gain extra mana from self-inflicted damage
-				// TO-DO: Check if self-inflicted damage can be resisted or crit
-				// This affects mana returns for Paladins
-				if character.Class == proto.Class_ClassPaladin && maxSelfDamage > 0 {
-					manaGain := (minSelfDamage + (sim.RandomFloat("sapper paladin") * (maxSelfDamage - minSelfDamage))) * 0.1
-					character.AddMana(sim, manaGain, damageTakenManaMetrics, false)
-				}
+				// // Paladins gain extra mana from self-inflicted damage
+				// // TO-DO: Check if self-inflicted damage can be resisted or crit
+				// // This affects mana returns for Paladins
+				// if character.Class == proto.Class_ClassPaladin && maxSelfDamage > 0 {
+				// 	manaGain := (minSelfDamage + (sim.RandomFloat("sapper paladin") * (maxSelfDamage - minSelfDamage))) * 0.1
+				// 	character.AddMana(sim, manaGain, damageTakenManaMetrics, false)
+				// }
 			},
 		}),
 	}

--- a/sim/paladin/consecration.go
+++ b/sim/paladin/consecration.go
@@ -13,42 +13,40 @@ import (
 func (paladin *Paladin) registerConsecrationSpell() {
 	// TODO: Properly implement max rank consecration.
 
-	var manaCost float64
-	var actionID core.ActionID
-	var baseDamage float64
-
-	manaCost = 0.22 * paladin.BaseMana
-	manaCost = manaCost * (1 - 0.02*float64(paladin.Talents.Benediction))
-	actionID.SpellID = 48819
-	baseDamage = 113
-
-	switch paladin.Equip[proto.ItemSlot_ItemSlotRanged].ID {
-	case 27917:
-		baseDamage += (47 * 0.952) // applies 47 "spell power" to the spell
-	}
-
-	// Check for bad input
-	if manaCost == 0.0 {
-		panic("Undefined Consecration rank specified.")
-	}
+	baseCost := 0.22 * paladin.BaseMana
+	actionID := core.ActionID{SpellID: 48819}
 
 	consecrationDot := core.NewDot(core.Dot{
 		Aura: paladin.RegisterAura(core.Aura{
 			Label:    "Consecration",
 			ActionID: actionID,
 		}),
-		NumberOfTicks: 8,
+		NumberOfTicks: 8 + core.TernaryInt(paladin.HasMajorGlyph(proto.PaladinMajorGlyph_GlyphOfConsecration), 2, 0),
 		TickLength:    time.Second * 1,
 		TickEffects: core.TickFuncAOESnapshot(paladin.Env, core.SpellEffect{
 			ProcMask: core.ProcMaskEmpty,
-			BonusSpellPower: core.TernaryFloat64(paladin.Equip[proto.ItemSlot_ItemSlotRanged].ID == 27917, 47*0.8, 0) +
-				core.TernaryFloat64(paladin.Equip[proto.ItemSlot_ItemSlotRanged].ID == 40337, 141, 0), // Libram of Resurgence
 
 			DamageMultiplier: 1,
 			ThreatMultiplier: 1,
-			BaseDamage:       core.BaseDamageConfigMagicNoRoll(baseDamage, 0.119),
-			OutcomeApplier:   paladin.OutcomeFuncMagicHit(),
-			IsPeriodic:       true,
+			BaseDamage: core.BaseDamageConfig{
+				Calculator: func(sim *core.Simulation, hitEffect *core.SpellEffect, spell *core.Spell) float64 {
+					// i = 113 + 0.04*HolP + 0.04*AP
+					scaling := hybridScaling{
+						AP: 0.04,
+						SP: 0.04,
+					}
+
+					sp := hitEffect.SpellPower(spell.Unit, spell) +
+						core.TernaryFloat64(paladin.Equip[proto.ItemSlot_ItemSlotRanged].ID == 27917, 47*0.8, 0) +
+						core.TernaryFloat64(paladin.Equip[proto.ItemSlot_ItemSlotRanged].ID == 40337, 141, 0) // Libram of Resurgence
+
+					damage := 113 + (scaling.AP * hitEffect.MeleeAttackPower(spell.Unit)) + (scaling.SP * sp)
+
+					return damage
+				},
+			},
+			OutcomeApplier: paladin.OutcomeFuncMagicHit(),
+			IsPeriodic:     true,
 		}),
 	})
 
@@ -57,16 +55,16 @@ func (paladin *Paladin) registerConsecrationSpell() {
 		SpellSchool: core.SpellSchoolHoly,
 
 		ResourceType: stats.Mana,
-		BaseCost:     manaCost,
+		BaseCost:     baseCost,
 
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
-				Cost: manaCost,
+				Cost: baseCost * (1 - 0.02*float64(paladin.Talents.Benediction)),
 				GCD:  core.GCDDefault,
 			},
 			CD: core.Cooldown{
 				Timer:    paladin.NewTimer(),
-				Duration: time.Second * 8,
+				Duration: (time.Second * 8) + core.TernaryDuration(paladin.HasMajorGlyph(proto.PaladinMajorGlyph_GlyphOfConsecration), time.Second*2, 0),
 			},
 		},
 

--- a/sim/paladin/exorcism.go
+++ b/sim/paladin/exorcism.go
@@ -34,8 +34,9 @@ func (paladin *Paladin) registerExorcismSpell() {
 
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
-				Cost: baseCost,
-				GCD:  core.GCDDefault,
+				Cost:     baseCost,
+				GCD:      core.GCDDefault,
+				CastTime: time.Millisecond * 1500,
 			},
 			CD: core.Cooldown{
 				Timer:    paladin.NewTimer(),

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -53,819 +53,819 @@ dps_results: {
  key: "TestRetribution-AllItems-AegisBattlegear"
  value: {
   dps: 3690.2949004160114
-  tps: 3158.749680930475
+  tps: 3158.7463592149934
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AshtongueTalismanofZeal-32489"
  value: {
   dps: 3330.4942928303444
-  tps: 2874.633712103293
+  tps: 2874.6304517941157
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AustereEarthsiegeDiamond"
  value: {
   dps: 3243.575721509667
-  tps: 2793.801976942892
+  tps: 2793.7994850405826
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bandit'sInsignia-40371"
  value: {
   dps: 3347.4297919790138
-  tps: 2888.0828504652427
+  tps: 2888.079304017396
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BeamingEarthsiegeDiamond"
  value: {
   dps: 3267.4890606944646
-  tps: 2815.5886790994405
+  tps: 2815.586888176191
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingEarthsiegeDiamond"
  value: {
   dps: 3248.894820937913
-  tps: 2743.3709337472874
+  tps: 2743.368441844978
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingEarthstormDiamond"
  value: {
   dps: 3246.5544171894867
-  tps: 2795.603460325324
+  tps: 2795.6009684230144
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
   dps: 3338.99316561852
-  tps: 2879.4248741930137
+  tps: 2879.4237014487658
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BrutalEarthstormDiamond"
  value: {
   dps: 3246.227212476332
-  tps: 2796.1609586226896
+  tps: 2796.1584667203797
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BurningRage"
  value: {
-  dps: 3018.975597103842
-  tps: 2610.9136956813386
+  dps: 3002.7783937835934
+  tps: 2601.8052930012695
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticSkyfireDiamond"
  value: {
   dps: 3310.878039015177
-  tps: 2853.0639088043304
+  tps: 2853.061416902021
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 3323.1138444265407
-  tps: 2859.7968867968775
+  dps: 3320.2462158622993
+  tps: 2858.8326762732877
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 3341.856744002688
-  tps: 2872.5746540878636
+  dps: 3342.5124499677636
+  tps: 2871.9063668652216
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 3382.3776775263923
-  tps: 2913.5298657344742
+  dps: 3398.1037559721753
+  tps: 2933.0979080085035
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 3578.0600332517492
-  tps: 3066.3001660443097
+  dps: 3590.3117241962464
+  tps: 3071.0953197914364
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 3474.902385890562
-  tps: 2974.3169041410238
+  dps: 3469.0764205491555
+  tps: 2964.9246377921427
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 3427.935325297577
-  tps: 2939.897613857813
+  dps: 3424.329149819451
+  tps: 2940.870723374443
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DeadlyGladiator'sLibramofFortitude-42852"
  value: {
   dps: 3366.9130808923137
-  tps: 2891.09734259017
+  tps: 2891.0945725517176
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 3323.567381893979
-  tps: 2858.8560770643567
+  dps: 3323.316684332828
+  tps: 2863.3533903966563
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Defender'sCode-40257"
  value: {
-  dps: 3290.127655406458
-  tps: 2839.4153553985434
+  dps: 3301.8450214987224
+  tps: 2844.0413349864994
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DesolationBattlegear"
  value: {
-  dps: 2750.617565623414
-  tps: 2413.026545696487
+  dps: 2755.107227541228
+  tps: 2413.703580246263
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 3254.7034717380884
-  tps: 2800.9117027831117
+  dps: 3251.1314052821936
+  tps: 2799.6708892184747
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 3259.7657776569354
-  tps: 2804.6223970037267
+  dps: 3257.33142866284
+  tps: 2804.057038970766
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DoomplateBattlegear"
  value: {
-  dps: 2838.9361863238005
-  tps: 2472.393452145168
+  dps: 2836.3441335640937
+  tps: 2471.606827217579
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EffulgentSkyflareDiamond"
  value: {
   dps: 3243.575721509667
-  tps: 2793.801976942892
+  tps: 2793.7994850405826
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberSkyfireDiamond"
  value: {
   dps: 3255.0420492336852
-  tps: 2804.9081468076292
+  tps: 2804.9057201409623
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberSkyflareDiamond"
  value: {
   dps: 3257.4242086834174
-  tps: 2806.3426607323945
+  tps: 2806.3402340657276
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticSkyfireDiamond"
  value: {
   dps: 3246.9476851033764
-  tps: 2797.358324910465
+  tps: 2797.355833008156
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 3258.6437860619103
-  tps: 2803.7426225987997
+  dps: 3255.8817683278785
+  tps: 2802.8495958259027
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 3256.345081859958
-  tps: 2802.1597148040614
+  dps: 3252.6466378749283
+  tps: 2800.8849983634027
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalEarthsiegeDiamond"
  value: {
   dps: 3243.575721509667
-  tps: 2793.801976942892
+  tps: 2793.7994850405826
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalEarthstormDiamond"
  value: {
   dps: 3243.575721509667
-  tps: 2793.801976942892
+  tps: 2793.7994850405826
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ExtractofNecromanticPower-40373"
  value: {
   dps: 3400.941263563272
-  tps: 2940.2632236921113
+  tps: 2940.2582166411858
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FaithinFelsteel"
  value: {
-  dps: 2833.557432223534
-  tps: 2472.336673634596
+  dps: 2842.9026756594
+  tps: 2478.601986463755
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FelstalkerArmor"
  value: {
-  dps: 3125.161193091102
-  tps: 2697.3235658454187
+  dps: 3125.2330317097826
+  tps: 2700.4867546684545
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FlameGuard"
  value: {
-  dps: 2737.9829386547735
-  tps: 2392.4955655000613
+  dps: 2749.238989953236
+  tps: 2398.155621136387
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForgeEmber-37660"
  value: {
-  dps: 3331.72021234881
-  tps: 2864.8844792514988
+  dps: 3332.1480901461236
+  tps: 2866.3477753167163
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornSkyflareDiamond"
  value: {
   dps: 3248.894820937913
-  tps: 2797.0189115543767
+  tps: 2797.0164196520673
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornStarflareDiamond"
  value: {
   dps: 3247.8310010522637
-  tps: 2796.3755246320793
+  tps: 2796.3730327297694
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuriousGladiator'sLibramofFortitude-42853"
  value: {
   dps: 3380.962689209839
-  tps: 2902.077009965223
+  tps: 2902.074239926771
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 3471.8622488819105
-  tps: 2981.5330258574554
+  dps: 3484.267143925422
+  tps: 2986.536579917456
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HatefulGladiator'sLibramofFortitude-42851"
  value: {
   dps: 3356.4894208539254
-  tps: 2883.074649916257
+  tps: 2883.071879877805
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 3333.3870894502156
-  tps: 2865.449812414078
+  dps: 3345.461469471274
+  tps: 2870.4210775919682
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImbuedUnstableDiamond"
  value: {
   dps: 3246.5544171894867
-  tps: 2795.603460325324
+  tps: 2795.6009684230144
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 3258.6437860619103
-  tps: 2803.7426225987997
+  dps: 3255.8817683278785
+  tps: 2802.8495958259027
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 3256.345081859958
-  tps: 2802.1597148040614
+  dps: 3252.6466378749283
+  tps: 2800.8849983634027
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IncisorFragment-37723"
  value: {
-  dps: 3311.3336625944266
-  tps: 2858.4534898250367
+  dps: 3323.3132498854434
+  tps: 2863.218732496753
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 3322.209925513232
-  tps: 2854.3047452307464
+  dps: 3316.6810657372757
+  tps: 2856.283520323801
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsightfulEarthsiegeDiamond"
  value: {
   dps: 3247.2144360547913
-  tps: 2804.476905640183
+  tps: 2804.470838241327
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 3261.947572805785
-  tps: 2813.965095529856
+  dps: 3254.457504846809
+  tps: 2809.807511035427
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
   dps: 3267.946759764084
-  tps: 2812.825532045427
+  tps: 2812.8230401431174
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 3290.127655406458
-  tps: 2839.4153553985434
+  dps: 3301.8450214987224
+  tps: 2844.0413349864994
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Liadrin'sBattlegear"
  value: {
   dps: 3731.630467474274
-  tps: 3070.2005910868625
+  tps: 3070.1969986453664
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofDivineJudgement-33503"
  value: {
   dps: 3296.665039304684
-  tps: 2836.1990057149046
+  tps: 2836.1962356764525
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofReciprocation-40706"
  value: {
   dps: 3296.665039304684
-  tps: 2836.1990057149046
+  tps: 2836.1962356764525
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofThreeTruths-50455"
  value: {
   dps: 3361.8353146642767
-  tps: 2887.1295654720843
+  tps: 2887.1267954336317
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofValiance-47661"
  value: {
   dps: 3586.2193489833876
-  tps: 3063.083745864163
+  tps: 3063.0809758257114
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerBattlegear"
  value: {
-  dps: 3015.9600580386777
-  tps: 2625.30628484332
+  dps: 3018.529020605654
+  tps: 2623.6310735700495
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornBattlegear"
  value: {
-  dps: 4601.592911118398
-  tps: 3888.773499067427
+  dps: 4646.585238219344
+  tps: 3928.6479686273187
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 3290.127655406458
-  tps: 2839.394706730095
+  dps: 3301.8450214987224
+  tps: 2844.0321578005223
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 2637.5606911137847
-  tps: 2306.472494312788
+  dps: 2616.4671561309133
+  tps: 2298.113698574088
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 3340.133993027551
-  tps: 2881.5884233101215
+  dps: 3337.149123814519
+  tps: 2871.589743629323
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 3244.6155600726847
-  tps: 2798.394339302898
+  dps: 3252.127291146996
+  tps: 2802.274578785023
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherscaleArmor"
  value: {
-  dps: 3120.347774852574
-  tps: 2688.2053027000884
+  dps: 3109.3603039091354
+  tps: 2688.3483748002664
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherstrikeArmor"
  value: {
-  dps: 3030.2546496504765
-  tps: 2622.632202180263
+  dps: 3031.4458263176166
+  tps: 2615.9674011953853
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 3290.127655406458
-  tps: 2839.4153553985434
+  dps: 3301.8450214987224
+  tps: 2844.0413349864994
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthshatterDiamond"
  value: {
   dps: 3263.304657239432
-  tps: 2809.2019977401824
+  tps: 2809.199505837873
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthsiegeDiamond"
  value: {
   dps: 3267.946759764084
-  tps: 2812.825532045427
+  tps: 2812.8230401431174
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PotentUnstableDiamond"
  value: {
   dps: 3257.5020290836173
-  tps: 2804.6725798586262
+  tps: 2804.6700879563164
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthshatterDiamond"
  value: {
   dps: 3243.575721509667
-  tps: 2793.801976942892
+  tps: 2793.7994850405826
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthsiegeDiamond"
  value: {
   dps: 3243.575721509667
-  tps: 2793.801976942892
+  tps: 2793.7994850405826
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthstormDiamond"
  value: {
   dps: 3243.575721509667
-  tps: 2793.801976942892
+  tps: 2793.7994850405826
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PrimalIntent"
  value: {
-  dps: 3239.34169430724
-  tps: 2780.3261817669454
+  dps: 3225.745187772111
+  tps: 2779.8294274651294
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 3290.127655406458
-  tps: 2839.4153553985434
+  dps: 3301.8450214987224
+  tps: 2844.0413349864994
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionBattlegear"
  value: {
-  dps: 3309.4260246152644
-  tps: 2860.8873127694737
+  dps: 3303.2059185445437
+  tps: 2858.921984055913
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 3520.1193417690483
-  tps: 3054.0126800083544
+  dps: 3541.2417664994773
+  tps: 3070.950453665652
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 3550.5809708264464
-  tps: 3082.9237428366932
+  dps: 3571.893341517985
+  tps: 3100.0447061035297
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 3326.0138358629133
-  tps: 2867.087894485295
+  dps: 3329.8951297274193
+  tps: 2863.857898618535
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 3324.2379378015694
-  tps: 2860.6710467871094
+  dps: 3321.6449664055413
+  tps: 2859.9814934317333
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessGladiator'sLibramofFortitude-42854"
  value: {
   dps: 3397.3538989136187
-  tps: 2914.8866219027864
+  tps: 2914.883851864334
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 3253.745388933887
-  tps: 2802.044652673366
+  dps: 3248.412426988496
+  tps: 2796.4659305151827
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 3290.127655406458
-  tps: 2839.4153553985434
+  dps: 3301.8450214987224
+  tps: 2844.0413349864994
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SavageGladiator'sLibramofFortitude-42611"
  value: {
   dps: 3349.716849357785
-  tps: 2877.7679732142187
+  tps: 2877.765203175766
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 3290.127655406458
-  tps: 2839.4153553985434
+  dps: 3301.8450214987224
+  tps: 2844.0413349864994
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 3323.0912869432336
-  tps: 2859.2407554046104
+  dps: 3320.736994159863
+  tps: 2860.839444468946
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 3290.127655406458
-  tps: 2839.4153553985434
+  dps: 3301.8450214987224
+  tps: 2844.0413349864994
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 3290.127655406458
-  tps: 2839.4153553985434
+  dps: 3301.8450214987224
+  tps: 2844.0413349864994
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SparkofLife-37657"
  value: {
-  dps: 3324.8154896907495
-  tps: 2868.6791768640915
+  dps: 3323.1520784767904
+  tps: 2863.562660268597
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 2973.70238245147
-  tps: 2576.399438513551
+  dps: 2985.141035248108
+  tps: 2590.4018081641057
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Spirit-WorldGlass-39388"
  value: {
-  dps: 3290.127655406458
-  tps: 2839.405719353267
+  dps: 3301.8450214987224
+  tps: 2844.0370522997096
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 2898.3274153378948
-  tps: 2531.9734111856383
+  dps: 2884.1256103687324
+  tps: 2521.3256870791156
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyfireDiamond"
  value: {
   dps: 3257.5020290836173
-  tps: 2804.6725798586262
+  tps: 2804.6700879563164
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyflareDiamond"
  value: {
   dps: 3267.946759764084
-  tps: 2812.825532045427
+  tps: 2812.8230401431174
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftStarfireDiamond"
  value: {
   dps: 3246.1288892352254
-  tps: 2795.3461055564044
+  tps: 2795.343613654096
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftStarflareDiamond"
  value: {
   dps: 3263.304657239432
-  tps: 2809.2019977401824
+  tps: 2809.199505837873
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftWindfireDiamond"
  value: {
   dps: 3255.1809778212933
-  tps: 2802.860812706004
+  tps: 2802.858320803695
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TenaciousEarthstormDiamond"
  value: {
   dps: 3243.575721509667
-  tps: 2793.801976942892
+  tps: 2793.7994850405826
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheTwinStars"
  value: {
-  dps: 3245.4517949011542
-  tps: 2794.2459727291616
+  dps: 3244.9643669542183
+  tps: 2790.8621944946394
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 3251.4027422460645
-  tps: 2800.6299488201953
+  dps: 3263.8648616765554
+  tps: 2810.5573771594622
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 3263.714341159659
-  tps: 2817.176038322026
+  dps: 3262.141450035801
+  tps: 2817.7504102343
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50351"
  value: {
   dps: 3466.413494370011
-  tps: 3004.5783285019743
+  tps: 3004.5762948479664
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50706"
  value: {
   dps: 3480.313772925255
-  tps: 3018.23169994579
+  tps: 3018.230486612456
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessSkyflareDiamond"
  value: {
   dps: 3248.894820937913
-  tps: 2797.0189115543767
+  tps: 2797.0164196520673
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessStarflareDiamond"
  value: {
   dps: 3247.8310010522637
-  tps: 2796.3755246320793
+  tps: 2796.3730327297694
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeofFieryRedemption-30447"
  value: {
-  dps: 3309.285509584793
-  tps: 2851.0205675591988
+  dps: 3321.1335856342125
+  tps: 2855.809848085326
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeoftheLightbringer-32368"
  value: {
   dps: 3296.665039304684
-  tps: 2836.1990057149046
+  tps: 2836.1962356764525
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthshatterDiamond"
  value: {
   dps: 3247.8310010522637
-  tps: 2796.3755246320793
+  tps: 2796.3730327297694
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthsiegeDiamond"
  value: {
   dps: 3248.894820937913
-  tps: 2797.0189115543767
+  tps: 2797.0164196520673
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sBattlegear"
  value: {
   dps: 3731.630467474274
-  tps: 3070.2005910868625
+  tps: 3070.1969986453664
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WastewalkerArmor"
  value: {
   dps: 2837.695341311453
-  tps: 2475.986869402314
+  tps: 2475.983173275215
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WindhawkArmor"
  value: {
   dps: 3026.443304102905
-  tps: 2607.1215724269214
+  tps: 2607.1214466606443
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathfulGladiator'sLibramofFortitude-51478"
  value: {
   dps: 3416.086710003656
-  tps: 2929.526178402857
+  tps: 2929.523408364405
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathofSpellfire"
  value: {
-  dps: 3018.9555347212836
-  tps: 2612.7958588310917
+  dps: 3017.8177679531946
+  tps: 2612.2504446912326
  }
 }
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 3319.147677227253
-  tps: 2860.286194860086
+  dps: 3319.413609600855
+  tps: 2860.796011978842
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7562.46094542213
-  tps: 9022.671985111117
+  dps: 7574.188230615937
+  tps: 9034.089816496566
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3324.2379378015694
-  tps: 2860.6710467871094
+  dps: 3321.6449664055413
+  tps: 2859.9814934317333
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
   dps: 3610.065398328517
-  tps: 3188.182082282023
+  tps: 3188.178861365533
  }
 }
 dps_results: {
@@ -892,22 +892,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7665.94229646592
-  tps: 9216.307757383622
+  dps: 7656.287371310635
+  tps: 9222.408758790487
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3362.125188382972
-  tps: 2899.701063076184
+  dps: 3354.7659049476006
+  tps: 2896.0772471562454
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3664.16918540506
-  tps: 3212.3237051990636
+  dps: 3666.4218284691033
+  tps: 3232.174940547773
  }
 }
 dps_results: {
@@ -934,22 +934,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7755.111214245363
-  tps: 9169.515737254913
+  dps: 7747.420132476424
+  tps: 9168.11777263843
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3423.1896405948764
-  tps: 2939.5042829226813
+  dps: 3429.767143097373
+  tps: 2950.8698391481407
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3743.400298178639
-  tps: 3267.5339946803156
+  dps: 3737.303618691253
+  tps: 3267.382559667073
  }
 }
 dps_results: {
@@ -976,22 +976,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7696.089975924119
-  tps: 9114.104654906378
+  dps: 7758.135515974536
+  tps: 9164.711595671846
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3412.046614755383
-  tps: 2935.0769897105124
+  dps: 3405.7145106563507
+  tps: 2929.9907637682572
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3762.9169853211606
-  tps: 3279.9672249623404
+  dps: 3742.9234757098075
+  tps: 3281.4317288929246
  }
 }
 dps_results: {
@@ -1018,7 +1018,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3024.2643328456998
-  tps: 2595.6152704623655
+  dps: 3022.032326823156
+  tps: 2587.0375696803258
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -52,973 +52,973 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AegisBattlegear"
  value: {
-  dps: 3529.546550134935
-  tps: 2996.459901009429
+  dps: 3508.2609261690723
+  tps: 2976.71951748581
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AshtongueTalismanofZeal-32489"
  value: {
-  dps: 3168.478356201356
-  tps: 2708.027846195943
+  dps: 3172.725425627321
+  tps: 2716.8708504757433
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 3101.1490263068113
-  tps: 2649.656513862302
+  dps: 3088.882273487262
+  tps: 2639.1085289204852
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 3184.2994609195075
-  tps: 2726.379275780604
+  dps: 3189.4958380026433
+  tps: 2730.1537525653875
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 3121.1431495754223
-  tps: 2664.7403102513904
+  dps: 3112.3136526787716
+  tps: 2660.414501244869
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 3107.408254502088
-  tps: 2603.2453730907255
+  dps: 3095.337479438416
+  tps: 2592.88473907778
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 3104.654194096166
-  tps: 2652.1047781674333
+  dps: 3092.497188819909
+  tps: 2641.5462319557455
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 3170.355098301676
-  tps: 2712.2445245377166
+  dps: 3178.5295067336624
+  tps: 2718.9612153081557
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 3103.8558642188586
-  tps: 2652.0228505970563
+  dps: 3091.5337707510516
+  tps: 2641.467516897411
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BurningRage"
  value: {
-  dps: 2851.4586282331124
-  tps: 2453.944887825895
+  dps: 2871.071936794376
+  tps: 2463.0141023353203
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 3165.7169883169763
-  tps: 2705.215624654767
+  dps: 3152.6014769116673
+  tps: 2694.7873467008203
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 3158.209168813339
-  tps: 2702.123438222151
+  dps: 3164.5379579993796
+  tps: 2701.230736213189
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 3183.7341264912407
-  tps: 2713.603934150983
+  dps: 3186.609123327944
+  tps: 2717.3308066373593
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 3239.181032291908
-  tps: 2773.533956467766
+  dps: 3226.6849042221043
+  tps: 2757.8411925587516
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 3409.02820642762
-  tps: 2885.6276940159332
+  dps: 3406.1724918293917
+  tps: 2894.4171723248164
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 3314.6370933822723
-  tps: 2811.119017003169
+  dps: 3317.346671217055
+  tps: 2816.7611894675174
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 3256.321102407011
-  tps: 2773.0634555755714
+  dps: 3264.9663005922957
+  tps: 2776.9631226320253
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DeadlyGladiator'sLibramofFortitude-42852"
  value: {
-  dps: 3213.2643355554646
-  tps: 2740.5626593545403
+  dps: 3203.292989260525
+  tps: 2727.478591563325
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 3166.088249896764
-  tps: 2698.009012190072
+  dps: 3167.852939552384
+  tps: 2703.1494358567
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Defender'sCode-40257"
  value: {
-  dps: 3137.378823401976
-  tps: 2676.4600225633308
+  dps: 3133.9001554232436
+  tps: 2683.1917639567855
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DesolationBattlegear"
  value: {
-  dps: 2644.057336977658
-  tps: 2295.3039774129084
+  dps: 2614.096124662826
+  tps: 2276.5123607300834
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 3106.228356474984
-  tps: 2653.637524704505
+  dps: 3099.7830959268053
+  tps: 2646.0007792470424
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 3099.829988520225
-  tps: 2651.5324363062186
+  dps: 3105.1908432347495
+  tps: 2650.0569148567565
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DoomplateBattlegear"
  value: {
-  dps: 2693.3780828450585
-  tps: 2329.5441294834263
+  dps: 2697.9570698880952
+  tps: 2331.4143357094626
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 3101.1490263068113
-  tps: 2649.656513862302
+  dps: 3088.882273487262
+  tps: 2639.1085289204852
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 3110.5675049164342
-  tps: 2654.1227170584134
+  dps: 3100.386896991942
+  tps: 2650.2529945658875
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 3113.434350189773
-  tps: 2656.055288679037
+  dps: 3103.2710466319027
+  tps: 2652.18949868088
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 3105.5663890934707
-  tps: 2653.292318491785
+  dps: 3092.60463854798
+  tps: 2643.0152783550684
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 3098.1449150817048
-  tps: 2650.2546604954446
+  dps: 3103.9135025750793
+  tps: 2649.0217913871834
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 3096.266593438178
-  tps: 2648.970206672553
+  dps: 3101.5367102527425
+  tps: 2647.36079547206
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 3101.1490263068113
-  tps: 2649.656513862302
+  dps: 3088.882273487262
+  tps: 2639.1085289204852
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 3101.1490263068113
-  tps: 2649.656513862302
+  dps: 3088.882273487262
+  tps: 2639.1085289204852
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 3256.6665352880846
-  tps: 2788.3385516443523
+  dps: 3246.4669818466077
+  tps: 2785.8117513207403
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FaithinFelsteel"
  value: {
-  dps: 2717.744790809717
-  tps: 2345.09652074325
+  dps: 2692.767461085361
+  tps: 2331.550497801532
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FelstalkerArmor"
  value: {
-  dps: 2979.9331590850475
-  tps: 2552.0009559607265
+  dps: 2974.6578054273123
+  tps: 2546.8266783326935
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FlameGuard"
  value: {
-  dps: 2603.878403515671
-  tps: 2259.486501829345
+  dps: 2600.933646848435
+  tps: 2255.450705068033
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForgeEmber-37660"
  value: {
-  dps: 3177.5052045467655
-  tps: 2706.647154771026
+  dps: 3177.3656762337946
+  tps: 2710.5337163607223
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 3107.408254502088
-  tps: 2654.0284144071793
+  dps: 3095.337479438416
+  tps: 2643.461570054879
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 3106.1564088630334
-  tps: 2653.154034298205
+  dps: 3094.046438248185
+  tps: 2642.590961828001
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuriousGladiator'sLibramofFortitude-42853"
  value: {
-  dps: 3226.530864216878
-  tps: 2750.8080315277252
+  dps: 3216.5698557027454
+  tps: 2737.685519534694
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 3309.100642670751
-  tps: 2808.2820228109804
+  dps: 3305.902665628166
+  tps: 2815.577413331745
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HatefulGladiator'sLibramofFortitude-42851"
  value: {
-  dps: 3203.2076248951444
-  tps: 2732.9069420996902
+  dps: 3193.320095316064
+  tps: 2719.9066635415616
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 3189.3810516876283
-  tps: 2711.5693920230365
+  dps: 3186.318973915494
+  tps: 2718.385605420815
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 3104.654194096166
-  tps: 2652.1047781674333
+  dps: 3092.497188819909
+  tps: 2641.5462319557455
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 3098.1449150817048
-  tps: 2650.2546604954446
+  dps: 3103.9135025750793
+  tps: 2649.0217913871834
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 3096.266593438178
-  tps: 2648.970206672553
+  dps: 3101.5367102527425
+  tps: 2647.36079547206
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IncisorFragment-37723"
  value: {
-  dps: 3158.2702779939195
-  tps: 2695.021798954434
+  dps: 3155.1061626112123
+  tps: 2702.22989838328
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 3161.771100505658
-  tps: 2695.516134448486
+  dps: 3167.6690251017535
+  tps: 2699.7715143910104
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 3086.827838368487
-  tps: 2645.7273449622853
+  dps: 3090.4663948113885
+  tps: 2647.7237652480985
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 3110.3602081964527
-  tps: 2661.9557966011316
+  dps: 3105.577717977831
+  tps: 2657.5952407019026
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 3124.185855873723
-  tps: 2667.413663562283
+  dps: 3111.929493936853
+  tps: 2656.8082662181964
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 3137.378823401976
-  tps: 2676.4600225633308
+  dps: 3133.9001554232436
+  tps: 2683.1917639567855
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Liadrin'sBattlegear"
  value: {
-  dps: 3590.922270795388
-  tps: 2913.563432884401
+  dps: 3558.650157971283
+  tps: 2897.2313565531895
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofDivineJudgement-33503"
  value: {
-  dps: 3146.9316922483936
-  tps: 2689.335798488615
+  dps: 3136.908657049417
+  tps: 2676.443951706473
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofReciprocation-40706"
  value: {
-  dps: 3146.9316922483936
-  tps: 2689.335798488615
+  dps: 3136.908657049417
+  tps: 2676.443951706473
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofThreeTruths-50455"
  value: {
-  dps: 3208.4693836597075
-  tps: 2736.8603590553603
+  dps: 3198.4946980107234
+  tps: 2723.790288529571
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofValiance-47661"
  value: {
-  dps: 3420.2415481472876
-  tps: 2900.9911708433006
+  dps: 3410.4669910469825
+  tps: 2887.332768284615
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerBattlegear"
  value: {
-  dps: 2855.2935777986027
-  tps: 2468.4984257322562
+  dps: 2865.1257531743963
+  tps: 2474.471979979039
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornBattlegear"
  value: {
-  dps: 4504.371334749691
-  tps: 3793.288917536887
+  dps: 4513.036421868613
+  tps: 3806.299614529131
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 3136.280818156748
-  tps: 2680.46918973464
+  dps: 3133.9001554232436
+  tps: 2683.1711152883377
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 2508.0168351458733
-  tps: 2187.9620362169044
+  dps: 2517.1168924173307
+  tps: 2186.041064630334
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 3191.0562114565855
-  tps: 2732.5567314714526
+  dps: 3180.3266703914032
+  tps: 2721.781844871009
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 3089.6437581456303
-  tps: 2647.2861208264158
+  dps: 3088.78863455292
+  tps: 2642.5748404440155
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherscaleArmor"
  value: {
-  dps: 2978.420359724613
-  tps: 2547.5733821010717
+  dps: 2971.6717439331587
+  tps: 2539.53455697846
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherstrikeArmor"
  value: {
-  dps: 2893.913914109179
-  tps: 2475.2499993376177
+  dps: 2889.7278690386715
+  tps: 2482.1087084791156
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 3137.378823401976
-  tps: 2676.4600225633308
+  dps: 3133.9001554232436
+  tps: 2683.1917639567855
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 3119.7978883371675
-  tps: 2664.0313493337167
+  dps: 3107.539547184549
+  tps: 2653.436887685299
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 3124.185855873723
-  tps: 2667.413663562283
+  dps: 3111.929493936853
+  tps: 2656.8082662181964
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 3114.312928916473
-  tps: 2659.803456548005
+  dps: 3102.0521137441697
+  tps: 2649.2226645191777
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 3101.1490263068113
-  tps: 2649.656513862302
+  dps: 3088.882273487262
+  tps: 2639.1085289204852
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 3101.1490263068113
-  tps: 2649.656513862302
+  dps: 3088.882273487262
+  tps: 2639.1085289204852
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 3101.1490263068113
-  tps: 2649.656513862302
+  dps: 3088.882273487262
+  tps: 2639.1085289204852
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PrimalIntent"
  value: {
-  dps: 3071.4863297529027
-  tps: 2624.6620788770774
+  dps: 3082.810504884748
+  tps: 2623.7988206593236
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 3137.378823401976
-  tps: 2676.4600225633308
+  dps: 3133.9001554232436
+  tps: 2683.1917639567855
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionBattlegear"
  value: {
-  dps: 3153.315631749821
-  tps: 2695.7526571474878
+  dps: 3149.37700597022
+  tps: 2700.841628626002
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 3383.7386803740474
-  tps: 2905.1629808794432
+  dps: 3383.502246046372
+  tps: 2914.6077114421355
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 3413.2876422498875
-  tps: 2933.1083357331627
+  dps: 3413.64090948654
+  tps: 2943.2079170751404
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 3170.116701872865
-  tps: 2710.0192606426626
+  dps: 3166.942939595621
+  tps: 2708.023378021489
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 3159.396506591922
-  tps: 2702.8853643237435
+  dps: 3165.3284527762175
+  tps: 2701.77129760523
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessGladiator'sLibramofFortitude-42854"
  value: {
-  dps: 3242.0084809885266
-  tps: 2762.760965729775
+  dps: 3232.059533218671
+  tps: 2749.59360216796
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 3118.434441898189
-  tps: 2664.825520749697
+  dps: 3098.551062295636
+  tps: 2646.853147353852
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 3137.378823401976
-  tps: 2676.4600225633308
+  dps: 3133.9001554232436
+  tps: 2683.1917639567855
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SavageGladiator'sLibramofFortitude-42611"
  value: {
-  dps: 3196.836764595513
-  tps: 2727.9743598040955
+  dps: 3186.933894757576
+  tps: 2714.9863565413625
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 3137.378823401976
-  tps: 2676.4600225633308
+  dps: 3133.9001554232436
+  tps: 2683.1917639567855
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 3161.1030892247863
-  tps: 2696.0406635599334
+  dps: 3165.673201271862
+  tps: 2700.199385675721
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 3137.378823401976
-  tps: 2676.4600225633308
+  dps: 3133.9001554232436
+  tps: 2683.1917639567855
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 3137.378823401976
-  tps: 2676.4600225633308
+  dps: 3133.9001554232436
+  tps: 2683.1917639567855
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SparkofLife-37657"
  value: {
-  dps: 3163.8243102164797
-  tps: 2710.50147564255
+  dps: 3159.9932711264064
+  tps: 2703.860798650351
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 2843.2201728433943
-  tps: 2447.361977194936
+  dps: 2837.1326117621384
+  tps: 2439.837696543339
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Spirit-WorldGlass-39388"
  value: {
-  dps: 3133.5819182102173
-  tps: 2677.9829352968254
+  dps: 3133.9001554232436
+  tps: 2683.1821279115097
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 2755.3795564181873
-  tps: 2381.5086599582078
+  dps: 2755.887020108652
+  tps: 2389.5357675443433
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 3114.312928916473
-  tps: 2659.803456548005
+  dps: 3102.0521137441697
+  tps: 2649.2226645191777
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 3124.185855873723
-  tps: 2667.413663562283
+  dps: 3111.929493936853
+  tps: 2656.8082662181964
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 3104.1534558405424
-  tps: 2651.7550261238434
+  dps: 3091.9807723438153
+  tps: 2641.1979886649947
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 3119.7978883371675
-  tps: 2664.0313493337167
+  dps: 3107.539547184549
+  tps: 2653.436887685299
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 3112.118945148198
-  tps: 2658.1122994337206
+  dps: 3099.8571403680185
+  tps: 2647.5369752527286
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 3101.1490263068113
-  tps: 2649.656513862302
+  dps: 3088.882273487262
+  tps: 2639.1085289204852
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheTwinStars"
  value: {
-  dps: 3088.353043127004
-  tps: 2646.848142451033
+  dps: 3092.091999744595
+  tps: 2640.8934158155184
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 3109.6293494254833
-  tps: 2662.722569316858
+  dps: 3095.433133060506
+  tps: 2644.6610149027756
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 3106.2300219207514
-  tps: 2656.7686824766793
+  dps: 3106.936804436904
+  tps: 2660.399911659327
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 3296.173140781019
-  tps: 2831.4631914899746
+  dps: 3302.2423989872327
+  tps: 2840.407784986233
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 3312.317081738731
-  tps: 2857.0443642773125
+  dps: 3315.9580485694078
+  tps: 2853.8771518979706
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 3107.408254502088
-  tps: 2654.0284144071793
+  dps: 3095.337479438416
+  tps: 2643.461570054879
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 3106.1564088630334
-  tps: 2653.154034298205
+  dps: 3094.046438248185
+  tps: 2642.590961828001
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeofFieryRedemption-30447"
  value: {
-  dps: 3160.869248889728
-  tps: 2691.9902133631613
+  dps: 3157.2903106231784
+  tps: 2699.0292771390423
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeoftheLightbringer-32368"
  value: {
-  dps: 3146.9316922483936
-  tps: 2689.335798488615
+  dps: 3136.908657049417
+  tps: 2676.443951706473
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 3106.1564088630334
-  tps: 2653.154034298205
+  dps: 3094.046438248185
+  tps: 2642.590961828001
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 3107.408254502088
-  tps: 2654.0284144071793
+  dps: 3095.337479438416
+  tps: 2643.461570054879
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sBattlegear"
  value: {
-  dps: 3590.922270795388
-  tps: 2913.563432884401
+  dps: 3558.650157971283
+  tps: 2897.2313565531895
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WastewalkerArmor"
  value: {
-  dps: 2693.4338296317333
-  tps: 2335.303327342619
+  dps: 2698.38226722281
+  tps: 2336.67379531367
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WindhawkArmor"
  value: {
-  dps: 2883.63272522182
-  tps: 2466.59770403865
+  dps: 2884.963606133603
+  tps: 2465.6422688538896
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathfulGladiator'sLibramofFortitude-51478"
  value: {
-  dps: 3259.6971858704137
-  tps: 2776.421461960687
+  dps: 3249.7620218083002
+  tps: 2763.202839463121
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathofSpellfire"
  value: {
-  dps: 2868.625635615313
-  tps: 2464.8404786922756
+  dps: 2882.3699552925273
+  tps: 2476.210947029841
  }
 }
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 3162.8450693358513
-  tps: 2703.6769486511866
+  dps: 3160.0625623432497
+  tps: 2701.204648322739
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5326.13640877358
-  tps: 6803.831282960032
+  dps: 5364.15528998869
+  tps: 6824.366329677676
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3159.396506591922
-  tps: 2702.8853643237435
+  dps: 3165.3284527762175
+  tps: 2701.77129760523
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3456.7355666052
-  tps: 3021.882410369304
+  dps: 3445.165040264416
+  tps: 3023.325553052523
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2235.296159310507
-  tps: 3262.81337321828
+  dps: 2260.671519452066
+  tps: 3272.154044317587
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1259.3148561064418
-  tps: 1096.2243551367703
+  dps: 1241.0849821775564
+  tps: 1083.0990114561914
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1627.9583936416902
-  tps: 1460.113754040566
+  dps: 1593.75849398558
+  tps: 1428.4104469978909
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5406.603373013853
-  tps: 6960.950285645469
+  dps: 5417.88574206179
+  tps: 6968.251202979488
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3212.7242700944485
-  tps: 2741.8705692368057
+  dps: 3200.649895926066
+  tps: 2738.226504278474
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3567.366204029411
-  tps: 3108.6696611846114
+  dps: 3494.7707304200467
+  tps: 3042.937905269746
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2267.4751272390035
-  tps: 3331.7726274372444
+  dps: 2328.448715766562
+  tps: 3426.076381832438
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1273.9786328632867
-  tps: 1115.1514540111602
+  dps: 1279.9595303337437
+  tps: 1119.0738518656703
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1648.3269416306491
-  tps: 1484.7466658536507
+  dps: 1631.7509230700632
+  tps: 1468.4023330083091
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5478.694088562345
-  tps: 6882.378189649475
+  dps: 5480.2387235858005
+  tps: 6894.643246595345
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3261.8146223214053
-  tps: 2783.421799518093
+  dps: 3259.732678925197
+  tps: 2776.056943700199
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3594.685131429644
-  tps: 3119.9175372297173
+  dps: 3577.2672834648693
+  tps: 3101.415646336786
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2273.8529313996055
-  tps: 3256.654619986487
+  dps: 2284.6996032552743
+  tps: 3260.8127745961824
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1301.3006246642935
-  tps: 1130.382226136283
+  dps: 1291.863000985636
+  tps: 1120.909799801133
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1686.385322262581
-  tps: 1506.8023689515808
+  dps: 1666.1126903441532
+  tps: 1487.2305969393221
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5471.262667823378
-  tps: 6904.409633126634
+  dps: 5449.26757186427
+  tps: 6867.282250846529
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3240.3057084359502
-  tps: 2768.515926743402
+  dps: 3249.097631742099
+  tps: 2772.128006697229
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3609.5189897944933
-  tps: 3134.991607394264
+  dps: 3594.6498646931914
+  tps: 3111.712954503887
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2277.775336699129
-  tps: 3269.816245274829
+  dps: 2338.0156634587624
+  tps: 3352.965316346009
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1299.0355130971427
-  tps: 1128.5492712227208
+  dps: 1278.4664009793125
+  tps: 1110.4939909646475
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1681.3398541316578
-  tps: 1500.2326715632212
+  dps: 1676.8473332318351
+  tps: 1493.8190509149654
  }
 }
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2890.1634530070205
-  tps: 2457.613599197582
+  dps: 2865.5546001503103
+  tps: 2436.9055377669765
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -458,8 +458,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-LightswornBattlegear"
  value: {
-  dps: 4513.036421868613
-  tps: 3806.299614529131
+  dps: 4440.00969000948
+  tps: 3727.1902779585107
  }
 }
 dps_results: {

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -52,973 +52,973 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AegisBattlegear"
  value: {
-  dps: 3508.2609261690723
-  tps: 2976.71951748581
+  dps: 3690.2949004160114
+  tps: 3158.749680930475
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AshtongueTalismanofZeal-32489"
  value: {
-  dps: 3172.725425627321
-  tps: 2716.8708504757433
+  dps: 3330.4942928303444
+  tps: 2874.633712103293
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 3088.882273487262
-  tps: 2639.1085289204852
+  dps: 3243.575721509667
+  tps: 2793.801976942892
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 3189.4958380026433
-  tps: 2730.1537525653875
+  dps: 3347.4297919790138
+  tps: 2888.0828504652427
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 3112.3136526787716
-  tps: 2660.414501244869
+  dps: 3267.4890606944646
+  tps: 2815.5886790994405
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 3095.337479438416
-  tps: 2592.88473907778
+  dps: 3248.894820937913
+  tps: 2743.3709337472874
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 3092.497188819909
-  tps: 2641.5462319557455
+  dps: 3246.5544171894867
+  tps: 2795.603460325324
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 3178.5295067336624
-  tps: 2718.9612153081557
+  dps: 3338.99316561852
+  tps: 2879.4248741930137
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 3091.5337707510516
-  tps: 2641.467516897411
+  dps: 3246.227212476332
+  tps: 2796.1609586226896
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BurningRage"
  value: {
-  dps: 2871.071936794376
-  tps: 2463.0141023353203
+  dps: 3018.975597103842
+  tps: 2610.9136956813386
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 3152.6014769116673
-  tps: 2694.7873467008203
+  dps: 3310.878039015177
+  tps: 2853.0639088043304
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 3164.5379579993796
-  tps: 2701.230736213189
+  dps: 3323.1138444265407
+  tps: 2859.7968867968775
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 3186.609123327944
-  tps: 2717.3308066373593
+  dps: 3341.856744002688
+  tps: 2872.5746540878636
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 3226.6849042221043
-  tps: 2757.8411925587516
+  dps: 3382.3776775263923
+  tps: 2913.5298657344742
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 3406.1724918293917
-  tps: 2894.4171723248164
+  dps: 3578.0600332517492
+  tps: 3066.3001660443097
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 3317.346671217055
-  tps: 2816.7611894675174
+  dps: 3474.902385890562
+  tps: 2974.3169041410238
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 3264.9663005922957
-  tps: 2776.9631226320253
+  dps: 3427.935325297577
+  tps: 2939.897613857813
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DeadlyGladiator'sLibramofFortitude-42852"
  value: {
-  dps: 3203.292989260525
-  tps: 2727.478591563325
+  dps: 3366.9130808923137
+  tps: 2891.09734259017
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 3167.852939552384
-  tps: 2703.1494358567
+  dps: 3323.567381893979
+  tps: 2858.8560770643567
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Defender'sCode-40257"
  value: {
-  dps: 3133.9001554232436
-  tps: 2683.1917639567855
+  dps: 3290.127655406458
+  tps: 2839.4153553985434
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DesolationBattlegear"
  value: {
-  dps: 2614.096124662826
-  tps: 2276.5123607300834
+  dps: 2750.617565623414
+  tps: 2413.026545696487
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 3099.7830959268053
-  tps: 2646.0007792470424
+  dps: 3254.7034717380884
+  tps: 2800.9117027831117
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 3105.1908432347495
-  tps: 2650.0569148567565
+  dps: 3259.7657776569354
+  tps: 2804.6223970037267
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DoomplateBattlegear"
  value: {
-  dps: 2697.9570698880952
-  tps: 2331.4143357094626
+  dps: 2838.9361863238005
+  tps: 2472.393452145168
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 3088.882273487262
-  tps: 2639.1085289204852
+  dps: 3243.575721509667
+  tps: 2793.801976942892
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 3100.386896991942
-  tps: 2650.2529945658875
+  dps: 3255.0420492336852
+  tps: 2804.9081468076292
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 3103.2710466319027
-  tps: 2652.18949868088
+  dps: 3257.4242086834174
+  tps: 2806.3426607323945
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 3092.60463854798
-  tps: 2643.0152783550684
+  dps: 3246.9476851033764
+  tps: 2797.358324910465
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 3103.9135025750793
-  tps: 2649.0217913871834
+  dps: 3258.6437860619103
+  tps: 2803.7426225987997
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 3101.5367102527425
-  tps: 2647.36079547206
+  dps: 3256.345081859958
+  tps: 2802.1597148040614
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 3088.882273487262
-  tps: 2639.1085289204852
+  dps: 3243.575721509667
+  tps: 2793.801976942892
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 3088.882273487262
-  tps: 2639.1085289204852
+  dps: 3243.575721509667
+  tps: 2793.801976942892
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 3246.4669818466077
-  tps: 2785.8117513207403
+  dps: 3400.941263563272
+  tps: 2940.2632236921113
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FaithinFelsteel"
  value: {
-  dps: 2692.767461085361
-  tps: 2331.550497801532
+  dps: 2833.557432223534
+  tps: 2472.336673634596
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FelstalkerArmor"
  value: {
-  dps: 2974.6578054273123
-  tps: 2546.8266783326935
+  dps: 3125.161193091102
+  tps: 2697.3235658454187
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FlameGuard"
  value: {
-  dps: 2600.933646848435
-  tps: 2255.450705068033
+  dps: 2737.9829386547735
+  tps: 2392.4955655000613
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForgeEmber-37660"
  value: {
-  dps: 3177.3656762337946
-  tps: 2710.5337163607223
+  dps: 3331.72021234881
+  tps: 2864.8844792514988
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 3095.337479438416
-  tps: 2643.461570054879
+  dps: 3248.894820937913
+  tps: 2797.0189115543767
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 3094.046438248185
-  tps: 2642.590961828001
+  dps: 3247.8310010522637
+  tps: 2796.3755246320793
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuriousGladiator'sLibramofFortitude-42853"
  value: {
-  dps: 3216.5698557027454
-  tps: 2737.685519534694
+  dps: 3380.962689209839
+  tps: 2902.077009965223
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 3305.902665628166
-  tps: 2815.577413331745
+  dps: 3471.8622488819105
+  tps: 2981.5330258574554
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HatefulGladiator'sLibramofFortitude-42851"
  value: {
-  dps: 3193.320095316064
-  tps: 2719.9066635415616
+  dps: 3356.4894208539254
+  tps: 2883.074649916257
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 3186.318973915494
-  tps: 2718.385605420815
+  dps: 3333.3870894502156
+  tps: 2865.449812414078
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 3092.497188819909
-  tps: 2641.5462319557455
+  dps: 3246.5544171894867
+  tps: 2795.603460325324
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 3103.9135025750793
-  tps: 2649.0217913871834
+  dps: 3258.6437860619103
+  tps: 2803.7426225987997
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 3101.5367102527425
-  tps: 2647.36079547206
+  dps: 3256.345081859958
+  tps: 2802.1597148040614
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IncisorFragment-37723"
  value: {
-  dps: 3155.1061626112123
-  tps: 2702.22989838328
+  dps: 3311.3336625944266
+  tps: 2858.4534898250367
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 3167.6690251017535
-  tps: 2699.7715143910104
+  dps: 3322.209925513232
+  tps: 2854.3047452307464
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 3090.4663948113885
-  tps: 2647.7237652480985
+  dps: 3247.2144360547913
+  tps: 2804.476905640183
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 3105.577717977831
-  tps: 2657.5952407019026
+  dps: 3261.947572805785
+  tps: 2813.965095529856
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 3111.929493936853
-  tps: 2656.8082662181964
+  dps: 3267.946759764084
+  tps: 2812.825532045427
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 3133.9001554232436
-  tps: 2683.1917639567855
+  dps: 3290.127655406458
+  tps: 2839.4153553985434
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Liadrin'sBattlegear"
  value: {
-  dps: 3558.650157971283
-  tps: 2897.2313565531895
+  dps: 3731.630467474274
+  tps: 3070.2005910868625
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofDivineJudgement-33503"
  value: {
-  dps: 3136.908657049417
-  tps: 2676.443951706473
+  dps: 3296.665039304684
+  tps: 2836.1990057149046
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofReciprocation-40706"
  value: {
-  dps: 3136.908657049417
-  tps: 2676.443951706473
+  dps: 3296.665039304684
+  tps: 2836.1990057149046
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofThreeTruths-50455"
  value: {
-  dps: 3198.4946980107234
-  tps: 2723.790288529571
+  dps: 3361.8353146642767
+  tps: 2887.1295654720843
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofValiance-47661"
  value: {
-  dps: 3410.4669910469825
-  tps: 2887.332768284615
+  dps: 3586.2193489833876
+  tps: 3063.083745864163
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerBattlegear"
  value: {
-  dps: 2865.1257531743963
-  tps: 2474.471979979039
+  dps: 3015.9600580386777
+  tps: 2625.30628484332
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornBattlegear"
  value: {
-  dps: 4440.00969000948
-  tps: 3727.1902779585107
+  dps: 4601.592911118398
+  tps: 3888.773499067427
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 3133.9001554232436
-  tps: 2683.1711152883377
+  dps: 3290.127655406458
+  tps: 2839.394706730095
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 2517.1168924173307
-  tps: 2186.041064630334
+  dps: 2637.5606911137847
+  tps: 2306.472494312788
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 3180.3266703914032
-  tps: 2721.781844871009
+  dps: 3340.133993027551
+  tps: 2881.5884233101215
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 3088.78863455292
-  tps: 2642.5748404440155
+  dps: 3244.6155600726847
+  tps: 2798.394339302898
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherscaleArmor"
  value: {
-  dps: 2971.6717439331587
-  tps: 2539.53455697846
+  dps: 3120.347774852574
+  tps: 2688.2053027000884
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherstrikeArmor"
  value: {
-  dps: 2889.7278690386715
-  tps: 2482.1087084791156
+  dps: 3030.2546496504765
+  tps: 2622.632202180263
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 3133.9001554232436
-  tps: 2683.1917639567855
+  dps: 3290.127655406458
+  tps: 2839.4153553985434
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 3107.539547184549
-  tps: 2653.436887685299
+  dps: 3263.304657239432
+  tps: 2809.2019977401824
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 3111.929493936853
-  tps: 2656.8082662181964
+  dps: 3267.946759764084
+  tps: 2812.825532045427
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 3102.0521137441697
-  tps: 2649.2226645191777
+  dps: 3257.5020290836173
+  tps: 2804.6725798586262
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 3088.882273487262
-  tps: 2639.1085289204852
+  dps: 3243.575721509667
+  tps: 2793.801976942892
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 3088.882273487262
-  tps: 2639.1085289204852
+  dps: 3243.575721509667
+  tps: 2793.801976942892
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 3088.882273487262
-  tps: 2639.1085289204852
+  dps: 3243.575721509667
+  tps: 2793.801976942892
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PrimalIntent"
  value: {
-  dps: 3082.810504884748
-  tps: 2623.7988206593236
+  dps: 3239.34169430724
+  tps: 2780.3261817669454
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 3133.9001554232436
-  tps: 2683.1917639567855
+  dps: 3290.127655406458
+  tps: 2839.4153553985434
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionBattlegear"
  value: {
-  dps: 3149.37700597022
-  tps: 2700.841628626002
+  dps: 3309.4260246152644
+  tps: 2860.8873127694737
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 3383.502246046372
-  tps: 2914.6077114421355
+  dps: 3520.1193417690483
+  tps: 3054.0126800083544
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 3413.64090948654
-  tps: 2943.2079170751404
+  dps: 3550.5809708264464
+  tps: 3082.9237428366932
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 3166.942939595621
-  tps: 2708.023378021489
+  dps: 3326.0138358629133
+  tps: 2867.087894485295
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 3165.3284527762175
-  tps: 2701.77129760523
+  dps: 3324.2379378015694
+  tps: 2860.6710467871094
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessGladiator'sLibramofFortitude-42854"
  value: {
-  dps: 3232.059533218671
-  tps: 2749.59360216796
+  dps: 3397.3538989136187
+  tps: 2914.8866219027864
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 3098.551062295636
-  tps: 2646.853147353852
+  dps: 3253.745388933887
+  tps: 2802.044652673366
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 3133.9001554232436
-  tps: 2683.1917639567855
+  dps: 3290.127655406458
+  tps: 2839.4153553985434
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SavageGladiator'sLibramofFortitude-42611"
  value: {
-  dps: 3186.933894757576
-  tps: 2714.9863565413625
+  dps: 3349.716849357785
+  tps: 2877.7679732142187
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 3133.9001554232436
-  tps: 2683.1917639567855
+  dps: 3290.127655406458
+  tps: 2839.4153553985434
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 3165.673201271862
-  tps: 2700.199385675721
+  dps: 3323.0912869432336
+  tps: 2859.2407554046104
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 3133.9001554232436
-  tps: 2683.1917639567855
+  dps: 3290.127655406458
+  tps: 2839.4153553985434
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 3133.9001554232436
-  tps: 2683.1917639567855
+  dps: 3290.127655406458
+  tps: 2839.4153553985434
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SparkofLife-37657"
  value: {
-  dps: 3159.9932711264064
-  tps: 2703.860798650351
+  dps: 3324.8154896907495
+  tps: 2868.6791768640915
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 2837.1326117621384
-  tps: 2439.837696543339
+  dps: 2973.70238245147
+  tps: 2576.399438513551
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Spirit-WorldGlass-39388"
  value: {
-  dps: 3133.9001554232436
-  tps: 2683.1821279115097
+  dps: 3290.127655406458
+  tps: 2839.405719353267
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 2755.887020108652
-  tps: 2389.5357675443433
+  dps: 2898.3274153378948
+  tps: 2531.9734111856383
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 3102.0521137441697
-  tps: 2649.2226645191777
+  dps: 3257.5020290836173
+  tps: 2804.6725798586262
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 3111.929493936853
-  tps: 2656.8082662181964
+  dps: 3267.946759764084
+  tps: 2812.825532045427
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 3091.9807723438153
-  tps: 2641.1979886649947
+  dps: 3246.1288892352254
+  tps: 2795.3461055564044
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 3107.539547184549
-  tps: 2653.436887685299
+  dps: 3263.304657239432
+  tps: 2809.2019977401824
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 3099.8571403680185
-  tps: 2647.5369752527286
+  dps: 3255.1809778212933
+  tps: 2802.860812706004
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 3088.882273487262
-  tps: 2639.1085289204852
+  dps: 3243.575721509667
+  tps: 2793.801976942892
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheTwinStars"
  value: {
-  dps: 3092.091999744595
-  tps: 2640.8934158155184
+  dps: 3245.4517949011542
+  tps: 2794.2459727291616
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 3095.433133060506
-  tps: 2644.6610149027756
+  dps: 3251.4027422460645
+  tps: 2800.6299488201953
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 3106.936804436904
-  tps: 2660.399911659327
+  dps: 3263.714341159659
+  tps: 2817.176038322026
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 3302.2423989872327
-  tps: 2840.407784986233
+  dps: 3466.413494370011
+  tps: 3004.5783285019743
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 3315.9580485694078
-  tps: 2853.8771518979706
+  dps: 3480.313772925255
+  tps: 3018.23169994579
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 3095.337479438416
-  tps: 2643.461570054879
+  dps: 3248.894820937913
+  tps: 2797.0189115543767
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 3094.046438248185
-  tps: 2642.590961828001
+  dps: 3247.8310010522637
+  tps: 2796.3755246320793
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeofFieryRedemption-30447"
  value: {
-  dps: 3157.2903106231784
-  tps: 2699.0292771390423
+  dps: 3309.285509584793
+  tps: 2851.0205675591988
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeoftheLightbringer-32368"
  value: {
-  dps: 3136.908657049417
-  tps: 2676.443951706473
+  dps: 3296.665039304684
+  tps: 2836.1990057149046
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 3094.046438248185
-  tps: 2642.590961828001
+  dps: 3247.8310010522637
+  tps: 2796.3755246320793
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 3095.337479438416
-  tps: 2643.461570054879
+  dps: 3248.894820937913
+  tps: 2797.0189115543767
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sBattlegear"
  value: {
-  dps: 3558.650157971283
-  tps: 2897.2313565531895
+  dps: 3731.630467474274
+  tps: 3070.2005910868625
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WastewalkerArmor"
  value: {
-  dps: 2698.38226722281
-  tps: 2336.67379531367
+  dps: 2837.695341311453
+  tps: 2475.986869402314
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WindhawkArmor"
  value: {
-  dps: 2884.963606133603
-  tps: 2465.6422688538896
+  dps: 3026.443304102905
+  tps: 2607.1215724269214
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathfulGladiator'sLibramofFortitude-51478"
  value: {
-  dps: 3249.7620218083002
-  tps: 2763.202839463121
+  dps: 3416.086710003656
+  tps: 2929.526178402857
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathofSpellfire"
  value: {
-  dps: 2882.3699552925273
-  tps: 2476.210947029841
+  dps: 3018.9555347212836
+  tps: 2612.7958588310917
  }
 }
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 3160.0625623432497
-  tps: 2701.204648322739
+  dps: 3319.147677227253
+  tps: 2860.286194860086
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5364.15528998869
-  tps: 6824.366329677676
+  dps: 7562.46094542213
+  tps: 9022.671985111117
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3165.3284527762175
-  tps: 2701.77129760523
+  dps: 3324.2379378015694
+  tps: 2860.6710467871094
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3445.165040264416
-  tps: 3023.325553052523
+  dps: 3610.065398328517
+  tps: 3188.182082282023
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2260.671519452066
-  tps: 3272.154044317587
+  dps: 2900.8896710681743
+  tps: 3912.3689523409785
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1241.0849821775564
-  tps: 1083.0990114561914
+  dps: 1298.2004999951603
+  tps: 1140.204665668048
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1593.75849398558
-  tps: 1428.4104469978909
+  dps: 1685.26835260881
+  tps: 1519.8828119773468
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5417.88574206179
-  tps: 6968.251202979488
+  dps: 7665.94229646592
+  tps: 9216.307757383622
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3200.649895926066
-  tps: 2738.226504278474
+  dps: 3362.125188382972
+  tps: 2899.701063076184
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3494.7707304200467
-  tps: 3042.937905269746
+  dps: 3664.16918540506
+  tps: 3212.3237051990636
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2328.448715766562
-  tps: 3426.076381832438
+  dps: 3008.705581814326
+  tps: 4106.325712885933
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1279.9595303337437
-  tps: 1119.0738518656703
+  dps: 1339.7523821900106
+  tps: 1178.8480437631335
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1631.7509230700632
-  tps: 1468.4023330083091
+  dps: 1727.9440954127215
+  tps: 1564.5725363643535
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5480.2387235858005
-  tps: 6894.643246595345
+  dps: 7755.111214245363
+  tps: 9169.515737254913
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3259.732678925197
-  tps: 2776.056943700199
+  dps: 3423.1896405948764
+  tps: 2939.5042829226813
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3577.2672834648693
-  tps: 3101.415646336786
+  dps: 3743.400298178639
+  tps: 3267.5339946803156
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2284.6996032552743
-  tps: 3260.8127745961824
+  dps: 2930.879061381938
+  tps: 3906.9858439013897
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1291.863000985636
-  tps: 1120.909799801133
+  dps: 1350.1834622956628
+  tps: 1179.2229543984918
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1666.1126903441532
-  tps: 1487.2305969393221
+  dps: 1763.4538080066702
+  tps: 1584.555782968897
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5449.26757186427
-  tps: 6867.282250846529
+  dps: 7696.089975924119
+  tps: 9114.104654906378
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3249.097631742099
-  tps: 2772.128006697229
+  dps: 3412.046614755383
+  tps: 2935.0769897105124
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3594.6498646931914
-  tps: 3111.712954503887
+  dps: 3762.9169853211606
+  tps: 3279.9672249623404
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2338.0156634587624
-  tps: 3352.965316346009
+  dps: 3029.8632544501497
+  tps: 4044.8002181982793
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1278.4664009793125
-  tps: 1110.4939909646475
+  dps: 1336.291491200442
+  tps: 1168.3040102559191
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1676.8473332318351
-  tps: 1493.8190509149654
+  dps: 1773.9223852876323
+  tps: 1590.881699385237
  }
 }
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2865.5546001503103
-  tps: 2436.9055377669765
+  dps: 3024.2643328456998
+  tps: 2595.6152704623655
  }
 }

--- a/sim/paladin/retribution/rotation.go
+++ b/sim/paladin/retribution/rotation.go
@@ -58,7 +58,7 @@ func (ret *RetributionPaladin) mainRotation(sim *core.Simulation) {
 					ret.DivineStorm.Cast(sim, target)
 				case ret.Consecration.IsReady(sim):
 					ret.Consecration.Cast(sim, target)
-				case ret.Exorcism.IsReady(sim):
+				case ret.Exorcism.IsReady(sim) && ret.ArtOfWarInstantCast.IsActive():
 					ret.Exorcism.Cast(sim, target)
 				}
 			} else {
@@ -75,7 +75,7 @@ func (ret *RetributionPaladin) mainRotation(sim *core.Simulation) {
 					ret.CrusaderStrike.Cast(sim, target)
 				case ret.Consecration.IsReady(sim):
 					ret.Consecration.Cast(sim, target)
-				case ret.Exorcism.IsReady(sim):
+				case ret.Exorcism.IsReady(sim) && ret.ArtOfWarInstantCast.IsActive():
 					ret.Exorcism.Cast(sim, target)
 				}
 			}
@@ -91,7 +91,7 @@ func (ret *RetributionPaladin) mainRotation(sim *core.Simulation) {
 				ret.CrusaderStrike.Cast(sim, target)
 			case ret.DivineStorm.IsReady(sim):
 				ret.DivineStorm.Cast(sim, target)
-			case ret.Exorcism.IsReady(sim):
+			case ret.Exorcism.IsReady(sim) && ret.ArtOfWarInstantCast.IsActive():
 				ret.Exorcism.Cast(sim, target)
 			case ret.Consecration.IsReady(sim):
 				ret.Consecration.Cast(sim, target)

--- a/sim/paladin/retribution/rotation.go
+++ b/sim/paladin/retribution/rotation.go
@@ -36,15 +36,15 @@ func (ret *RetributionPaladin) mainRotation(sim *core.Simulation) {
 	// Setup
 	target := ret.CurrentTarget
 
-	// gcdCD := ret.GCD.TimeToReady(sim)
 	nextSwingAt := ret.AutoAttacks.NextAttackAt()
 	isExecutePhase := sim.IsExecutePhase20()
 
 	if ret.GCD.IsReady(sim) {
 		if ret.HasSetBonus(paladin.ItemSetLightswornBattlegear, 2) {
 			// Needs 2pc t10 to be effective.
+			swingDelta := nextSwingAt - sim.CurrentTime
 
-			if nextSwingAt.Milliseconds() > 1500 {
+			if swingDelta.Milliseconds() >= 1500 {
 				switch {
 				case isExecutePhase && ret.HammerOfWrath.IsReady(sim):
 					ret.HammerOfWrath.Cast(sim, target)

--- a/sim/paladin/spiritual_attunement.go
+++ b/sim/paladin/spiritual_attunement.go
@@ -5,6 +5,10 @@ import (
 )
 
 func (paladin *Paladin) registerSpiritualAttunement() {
+	if paladin.Talents.SpiritualAttunement == 0 {
+		return
+	}
+
 	paladin.SpiritualAttunementMetrics = paladin.NewManaMetrics(core.ActionID{SpellID: 33776})
 
 	paladin.RegisterAura(core.Aura{

--- a/ui/retribution_paladin/presets.ts
+++ b/ui/retribution_paladin/presets.ts
@@ -31,13 +31,13 @@ import * as Tooltips from '/wotlk/core/constants/tooltips.js';
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/wotlk/talent-calc and copy the numbers in the url.
 export const AuraMasteryTalents = {
-	name: 'Basic w/Aura Mastery',
+	name: 'Basic w/Aura Mastery+LoH buff',
 	data: SavedTalents.create({
 		talentsString: '050501-05-05232051203331302133231331',
 		glyphs: Glyphs.create({
 			major1: PaladinMajorGlyph.GlyphOfSealOfVengeance,
 			major2: PaladinMajorGlyph.GlyphOfJudgement,
-			major3: PaladinMajorGlyph.GlyphOfExorcism,
+			major3: PaladinMajorGlyph.GlyphOfConsecration,
 			minor1: PaladinMinorGlyph.GlyphOfSenseUndead,
 			minor2: PaladinMinorGlyph.GlyphOfLayOnHands,
 			minor3: PaladinMinorGlyph.GlyphOfBlessingOfKings
@@ -47,13 +47,13 @@ export const AuraMasteryTalents = {
 
 
 export const DivineSacTalents = {
-	name: 'Suboptimal w/Dsac',
+	name: 'Basic w/Dsac',
 	data: SavedTalents.create({
-		talentsString: '-552201002-05232050203331302133231331',
+		talentsString: '03-453201002-05222051203331302133201331',
 		glyphs: Glyphs.create({
 			major1: PaladinMajorGlyph.GlyphOfSealOfVengeance,
 			major2: PaladinMajorGlyph.GlyphOfJudgement,
-			major3: PaladinMajorGlyph.GlyphOfExorcism,
+			major3: PaladinMajorGlyph.GlyphOfConsecration,
 			minor1: PaladinMinorGlyph.GlyphOfSenseUndead,
 			minor2: PaladinMinorGlyph.GlyphOfLayOnHands,
 			minor3: PaladinMinorGlyph.GlyphOfBlessingOfKings


### PR DESCRIPTION
Implement Glyph of Consecration.

Bugfixes: 
- Make sure exorcism has a base cast time.
- Check swing delta not next swing time.
- Exorcism should 100% crit on undead/demons.
- Properly implement consecration damage calculation.
- Spiritual Attunement should only work if talented. (Change in WOTLK)
- On-use items should not be using Spiritual Attunement SpellID