### PR TITLE
3 Small Fixes to Combat Rogue Sim

### DIFF
--- a/sim/core/energy.go
+++ b/sim/core/energy.go
@@ -35,12 +35,12 @@ type energyBar struct {
 
 func (unit *Unit) EnableEnergyBar(maxEnergy float64, onEnergyGain OnEnergyGain) {
 	unit.energyBar = energyBar{
-		unit:         unit,
-		maxEnergy:    MaxFloat(100, maxEnergy),
-		onEnergyGain: onEnergyGain,
-
-		regenMetrics:        unit.NewEnergyMetrics(ActionID{OtherID: proto.OtherAction_OtherActionEnergyRegen}),
-		EnergyRefundMetrics: unit.NewEnergyMetrics(ActionID{OtherID: proto.OtherAction_OtherActionRefund}),
+		unit:                 unit,
+		maxEnergy:            MaxFloat(100, maxEnergy),
+		onEnergyGain:         onEnergyGain,
+		EnergyTickMultiplier: 1,
+		regenMetrics:         unit.NewEnergyMetrics(ActionID{OtherID: proto.OtherAction_OtherActionEnergyRegen}),
+		EnergyRefundMetrics:  unit.NewEnergyMetrics(ActionID{OtherID: proto.OtherAction_OtherActionRefund}),
 	}
 }
 
@@ -156,6 +156,5 @@ func (eb *energyBar) reset(sim *Simulation) {
 
 	eb.currentEnergy = eb.maxEnergy
 	eb.comboPoints = 0
-	eb.EnergyTickMultiplier = 1
 	eb.newTickAction(sim, true)
 }

--- a/sim/rogue/TestMutilate.results
+++ b/sim/rogue/TestMutilate.results
@@ -52,680 +52,680 @@ character_stats_results: {
 dps_results: {
  key: "TestMutilate-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 1626.3351032765993
-  tps: 1154.697923326385
+  dps: 1630.5394476248603
+  tps: 1157.68300781365
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AssassinationArmor"
  value: {
-  dps: 1483.1094009567157
-  tps: 1053.0076746792677
+  dps: 1479.6338314582867
+  tps: 1050.5400203353827
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1706.3475726966308
-  tps: 1211.5067766146083
+  dps: 1708.3841272244692
+  tps: 1212.952730329374
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1640.2562614177573
-  tps: 1164.5819456066074
+  dps: 1636.2124080158576
+  tps: 1161.7108096912593
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1140.9768360353953
+  dps: 1634.8165039045984
+  tps: 1137.50532341682
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 1639.7041357030375
-  tps: 1164.1899363491561
+  dps: 1642.5411149176207
+  tps: 1166.2041915915104
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1644.549040041017
-  tps: 1167.629818429122
+  dps: 1639.5546054878075
+  tps: 1164.0837698963428
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1650.865691945798
-  tps: 1172.1146412815167
+  dps: 1650.10868758361
+  tps: 1171.5771681843626
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1650.9358655582432
-  tps: 1172.1644645463527
+  dps: 1646.7717124359312
+  tps: 1169.2079158295112
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1639.911025596096
-  tps: 1164.3368281732273
+  dps: 1639.3035367677678
+  tps: 1163.9055111051148
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1674.3759868224129
-  tps: 1188.8069506439126
+  dps: 1672.8817212394226
+  tps: 1187.7460220799894
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 1685.955069826498
-  tps: 1197.0280995768126
+  dps: 1690.365439280238
+  tps: 1200.1594618889687
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 1701.3691824514774
-  tps: 1207.9721195405489
+  dps: 1704.3321951160938
+  tps: 1210.0758585324256
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 1654.3795973995555
-  tps: 1174.609514153684
+  dps: 1658.7063657171268
+  tps: 1177.6815196591597
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1637.343982386002
-  tps: 1162.5142274940604
+  dps: 1627.3655772417062
+  tps: 1155.429559841611
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Deathmantle"
  value: {
-  dps: 1602.1646854483095
-  tps: 1137.5369266682987
+  dps: 1597.8573535664677
+  tps: 1134.478721032191
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1607.6669655881085
-  tps: 1141.443545567557
+  dps: 1608.4114665477478
+  tps: 1141.9721412489002
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1640.97760096098
-  tps: 1165.0940966822957
+  dps: 1640.1668522321759
+  tps: 1164.5184650848444
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1641.6119867149544
-  tps: 1165.5445105676174
+  dps: 1638.3359386287048
+  tps: 1163.2185164263806
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1640.3832624081253
-  tps: 1164.672116309769
+  dps: 1639.6438393031037
+  tps: 1164.1471259052034
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1640.2562614177573
-  tps: 1164.5819456066074
+  dps: 1636.2124080158576
+  tps: 1161.7108096912593
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1641.7673696478532
-  tps: 1165.654832449976
+  dps: 1641.2279158941146
+  tps: 1165.2718202848205
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1661.7117961925023
-  tps: 1179.8153752966757
+  dps: 1656.3674229714952
+  tps: 1176.0208703097605
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1633.736523247019
-  tps: 1159.9529315053826
+  dps: 1632.3746378097376
+  tps: 1158.9859928449127
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1628.8352062124059
-  tps: 1156.4729964108076
+  dps: 1629.5229164742714
+  tps: 1156.9612706967314
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1707.5108724114384
-  tps: 1212.3327194121207
+  dps: 1708.2980349964457
+  tps: 1212.8916048474757
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1607.666965588004
-  tps: 1141.4435455674825
+  dps: 1608.4114665479697
+  tps: 1141.9721412490578
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1607.666965588004
-  tps: 1141.4435455674825
+  dps: 1608.4114665479697
+  tps: 1141.9721412490578
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1640.2562614177573
-  tps: 1164.5819456066074
+  dps: 1636.2124080158576
+  tps: 1161.7108096912593
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1641.7673696478532
-  tps: 1165.654832449976
+  dps: 1641.2279158941146
+  tps: 1165.2718202848205
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1667.6228858114503
-  tps: 1184.0122489261296
+  dps: 1668.6119698683026
+  tps: 1184.714498606495
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 1620.233276522161
-  tps: 1150.3656263307337
+  dps: 1617.8970988313013
+  tps: 1148.7069401702227
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1653.2743306323277
-  tps: 1173.8247747489522
+  dps: 1648.2612518958185
+  tps: 1170.2654888460306
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1607.666965588004
-  tps: 1141.4435455674825
+  dps: 1608.4114665479697
+  tps: 1141.9721412490578
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1607.666965588004
-  tps: 1141.4435455674825
+  dps: 1608.4114665479697
+  tps: 1141.9721412490578
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1341.739447483691
-  tps: 952.635007713421
+  dps: 1342.2432500946757
+  tps: 952.9927075672199
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1657.8643566989588
-  tps: 1177.08369325626
+  dps: 1659.1008947642038
+  tps: 1177.961635282584
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Netherblade"
  value: {
-  dps: 1553.2857595455655
-  tps: 1102.83288927735
+  dps: 1553.0443979588008
+  tps: 1102.6615225507471
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1607.6669655881085
-  tps: 1141.443545567557
+  dps: 1608.4114665477478
+  tps: 1141.9721412489002
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1650.7088853843557
-  tps: 1172.0033086228927
+  dps: 1645.7003475165375
+  tps: 1168.4472467367423
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1653.2743306323277
-  tps: 1173.8247747489522
+  dps: 1648.2612518958185
+  tps: 1170.2654888460306
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1647.5020788243914
-  tps: 1169.7264759653194
+  dps: 1642.4992170424368
+  tps: 1166.1744441001329
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PrimalIntent"
  value: {
-  dps: 1627.3847987596864
-  tps: 1155.4432071193767
+  dps: 1625.3308570622485
+  tps: 1153.9849085141968
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1607.666965588004
-  tps: 1141.4435455674825
+  dps: 1608.4114665479697
+  tps: 1141.9721412490578
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1741.765409633874
-  tps: 1236.6534408400496
+  dps: 1741.668247305979
+  tps: 1236.5844555872443
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1758.4756076204403
-  tps: 1248.517681410512
+  dps: 1758.3542627833478
+  tps: 1248.4315265761763
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1657.6216330594411
-  tps: 1176.911359472203
+  dps: 1656.9963383206368
+  tps: 1176.4674002076515
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1655.1015859582167
-  tps: 1175.1221260303334
+  dps: 1651.063968081159
+  tps: 1172.2554173376227
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1607.6669655881085
-  tps: 1141.443545567557
+  dps: 1608.4114665477478
+  tps: 1141.9721412489002
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1607.6669655881085
-  tps: 1141.443545567557
+  dps: 1608.4114665477478
+  tps: 1141.9721412489002
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 1622.183773853846
-  tps: 1151.7504794362299
+  dps: 1617.3692734112044
+  tps: 1148.3321841219547
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1607.666965588004
-  tps: 1141.4435455674825
+  dps: 1608.4114665479697
+  tps: 1141.9721412490578
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1607.6669655881085
-  tps: 1141.443545567557
+  dps: 1608.4114665477478
+  tps: 1141.9721412489002
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Slayer'sArmor"
  value: {
-  dps: 1716.8997035424281
-  tps: 1218.998789515124
+  dps: 1716.689645299292
+  tps: 1218.8496481624973
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SparkofLife-37657"
  value: {
-  dps: 1633.7813780818524
-  tps: 1159.9847784381136
+  dps: 1629.648807130546
+  tps: 1157.050653062687
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1501.3576602054816
-  tps: 1065.9639387458915
+  dps: 1503.1680910603152
+  tps: 1067.2493446528238
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1448.4838857060477
-  tps: 1028.4235588512934
+  dps: 1449.7120979390008
+  tps: 1029.2955895366897
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1647.5020788243914
-  tps: 1169.7264759653194
+  dps: 1642.4992170424368
+  tps: 1166.1744441001329
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1653.2743306323277
-  tps: 1173.8247747489522
+  dps: 1648.2612518958185
+  tps: 1170.2654888460306
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1650.7088853843557
-  tps: 1172.0033086228927
+  dps: 1645.7003475165375
+  tps: 1168.4472467367423
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1646.219356200405
-  tps: 1168.8157429022874
+  dps: 1641.2187648527981
+  tps: 1165.2653230454866
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheTwinStars"
  value: {
-  dps: 1584.5747667604874
-  tps: 1125.0480843999453
+  dps: 1582.9220103151904
+  tps: 1123.8746273237841
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1644.8639231139957
-  tps: 1167.8533854109367
+  dps: 1645.6706233360394
+  tps: 1168.426142568588
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1660.0241300006328
-  tps: 1178.617132300449
+  dps: 1657.1725911682454
+  tps: 1176.5925397294536
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1704.3008678779165
-  tps: 1210.053616193319
+  dps: 1699.0787279596707
+  tps: 1206.345896851365
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1708.2511329623883
-  tps: 1212.8583044032948
+  dps: 1709.5864004400914
+  tps: 1213.806344312464
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1639.8057430804747
-  tps: 1164.2620775871374
+  dps: 1634.8165039045984
+  tps: 1160.7197177722649
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 1726.8227766748457
-  tps: 1226.04417143914
+  dps: 1726.2900007826206
+  tps: 1225.6659005556603
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WastewalkerArmor"
  value: {
-  dps: 1494.1236437159664
-  tps: 1060.8277870383372
+  dps: 1492.5614965240968
+  tps: 1059.71866253211
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WindhawkArmor"
  value: {
-  dps: 1508.4057652132487
-  tps: 1070.9680933014056
+  dps: 1502.3447231290263
+  tps: 1066.6647534216077
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WrathofSpellfire"
  value: {
-  dps: 1506.3230860201697
-  tps: 1069.4893910743217
+  dps: 1500.7461183508399
+  tps: 1065.529744029097
  }
 }
 dps_results: {
  key: "TestMutilate-Average-Default"
  value: {
-  dps: 1648.526455137005
-  tps: 1170.4537831472776
+  dps: 1645.781884848754
+  tps: 1168.5051382426125
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2119.292565933865
-  tps: 1504.6977218130442
+  dps: 2119.7754761059196
+  tps: 1505.0405880352023
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1653.311421917971
-  tps: 1173.8511095617591
+  dps: 1652.5135993053125
+  tps: 1173.2846555067713
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1902.5627505008429
-  tps: 1350.819552855598
+  dps: 1878.191499148017
+  tps: 1333.515964395092
  }
 }
 dps_results: {
@@ -752,22 +752,22 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2120.637685925317
-  tps: 1505.652757006975
+  dps: 2116.747929159758
+  tps: 1502.891029703428
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1655.1015859582167
-  tps: 1175.1221260303334
+  dps: 1651.063968081159
+  tps: 1172.2554173376227
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1898.9145754285087
-  tps: 1348.2293485542407
+  dps: 1878.5875058519057
+  tps: 1333.7971291548529
  }
 }
 dps_results: {
@@ -794,7 +794,7 @@ dps_results: {
 dps_results: {
  key: "TestMutilate-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1477.8628327133777
-  tps: 1049.2826112264981
+  dps: 1470.3420966678543
+  tps: 1043.9428886341764
  }
 }

--- a/sim/rogue/TestRogue.results
+++ b/sim/rogue/TestRogue.results
@@ -52,847 +52,847 @@ character_stats_results: {
 dps_results: {
  key: "TestRogue-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 1759.487949573645
-  tps: 1249.236444197287
+  dps: 1835.776380031723
+  tps: 1303.4012298225232
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AssassinationArmor"
  value: {
-  dps: 1601.0452565237638
-  tps: 1136.7421321318727
+  dps: 1655.1049142274805
+  tps: 1175.1244891015112
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1837.8490631740635
-  tps: 1304.8728348535856
+  dps: 1913.241470817377
+  tps: 1358.4014442803375
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1773.0576264022625
-  tps: 1258.8709147456057
+  dps: 1853.6992099522786
+  tps: 1316.1264390661172
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1229.2159808262297
+  dps: 1847.4676645422046
+  tps: 1285.4680009884644
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BracingEarthstormDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 1768.982814867363
-  tps: 1255.9777985558262
+  dps: 1842.7050393067555
+  tps: 1308.3205779077957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BrutalEarthstormDiamond"
  value: {
-  dps: 1773.092623972237
-  tps: 1258.8957630202876
+  dps: 1854.1009467882814
+  tps: 1316.4116722196786
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ChaoticSkyfireDiamond"
  value: {
-  dps: 1780.0906450733892
-  tps: 1263.8643580021055
+  dps: 1861.8252719551433
+  tps: 1321.8959430881505
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1783.605063572366
-  tps: 1266.3595951363789
+  dps: 1865.0025819677012
+  tps: 1324.1518331970667
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1765.069766904477
-  tps: 1253.1995345021778
+  dps: 1838.5665234430783
+  tps: 1305.3822316445846
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1802.7457439183388
-  tps: 1279.94947818202
+  dps: 1875.3023735797428
+  tps: 1331.4646852416163
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 1821.8176085846744
-  tps: 1293.4905020951182
+  dps: 1896.9299537217064
+  tps: 1346.8202671424112
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 1836.764158198518
-  tps: 1304.1025523209473
+  dps: 1912.5876668040414
+  tps: 1357.9372434308689
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 1787.1779268431465
-  tps: 1268.8963280586338
+  dps: 1861.1259304160099
+  tps: 1321.3994105953661
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1757.7287289665546
-  tps: 1247.9873975662533
+  dps: 1832.1905414610328
+  tps: 1300.8552844373319
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Deathmantle"
  value: {
-  dps: 1723.1641254142423
-  tps: 1223.4465290441124
+  dps: 1785.8600718834402
+  tps: 1267.9606510372425
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1731.4141276985326
-  tps: 1229.3040306659575
+  dps: 1805.2514953403497
+  tps: 1281.7285616916477
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DestructiveSkyfireDiamond"
  value: {
-  dps: 1770.6338139471677
-  tps: 1257.1500079024886
+  dps: 1851.3502857576875
+  tps: 1314.4587028879569
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1773.7921773321377
-  tps: 1259.3924459058162
+  dps: 1854.9655689641793
+  tps: 1317.025553964567
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmberSkyfireDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnigmaticSkyfireDiamond"
  value: {
-  dps: 1769.7344603961308
-  tps: 1256.5114668812523
+  dps: 1850.6957682191244
+  tps: 1313.9939954355768
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1773.0576264022625
-  tps: 1258.8709147456057
+  dps: 1853.6992099522786
+  tps: 1316.1264390661172
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1771.5939591126175
-  tps: 1257.8317109699574
+  dps: 1852.4442060207748
+  tps: 1315.2353862747489
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EternalEarthstormDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1789.0683134129742
-  tps: 1270.2385025232104
+  dps: 1861.7232261590368
+  tps: 1321.8234905729148
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1759.9846440384874
-  tps: 1249.5890972673258
+  dps: 1832.9989182702857
+  tps: 1301.4292319719011
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1755.1232855536325
-  tps: 1246.1375327430783
+  dps: 1828.9225072838467
+  tps: 1298.5349801715308
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1840.7786601640846
-  tps: 1306.9528487164994
+  dps: 1918.4190477476368
+  tps: 1362.0775239008217
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1731.4141276981834
-  tps: 1229.3040306657094
+  dps: 1805.2514953402285
+  tps: 1281.7285616915615
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1731.4141276981834
-  tps: 1229.3040306657094
+  dps: 1805.2514953402285
+  tps: 1281.7285616915615
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImbuedUnstableDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1773.0576264022625
-  tps: 1258.8709147456057
+  dps: 1853.6992099522786
+  tps: 1316.1264390661172
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1771.5939591126175
-  tps: 1257.8317109699574
+  dps: 1852.4442060207748
+  tps: 1315.2353862747489
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1797.6598287189613
-  tps: 1276.3384783904623
+  dps: 1873.841041183647
+  tps: 1330.4271392403896
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 1741.4901102412448
-  tps: 1236.4579782712829
+  dps: 1815.743396081244
+  tps: 1289.1778112176828
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InsightfulEarthstormDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1781.3924739408114
-  tps: 1264.7886564979758
+  dps: 1862.776619357169
+  tps: 1322.57139974359
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1731.4141276981834
-  tps: 1229.3040306657094
+  dps: 1805.2514953402285
+  tps: 1281.7285616915615
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1731.4141276981834
-  tps: 1229.3040306657094
+  dps: 1805.2514953402285
+  tps: 1281.7285616915615
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1451.5057165187436
-  tps: 1030.569058728309
+  dps: 1499.491212039803
+  tps: 1064.6387605482605
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1796.969759298342
-  tps: 1275.848529101822
+  dps: 1871.0911023962794
+  tps: 1328.4746827013576
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MysticalSkyfireDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Netherblade"
  value: {
-  dps: 1682.8276591340123
-  tps: 1194.8076379851484
+  dps: 1762.2012762088025
+  tps: 1251.1629061082501
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1731.4141276985326
-  tps: 1229.3040306659575
+  dps: 1805.2514953403497
+  tps: 1281.7285616916477
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1778.5791579792497
-  tps: 1262.7912021652671
+  dps: 1859.8606279638436
+  tps: 1320.5010458543284
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1781.3924739408114
-  tps: 1264.7886564979758
+  dps: 1862.776619357169
+  tps: 1322.57139974359
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PotentUnstableDiamond"
  value: {
-  dps: 1775.0625130272965
-  tps: 1260.2943842493808
+  dps: 1856.215638722183
+  tps: 1317.9131034927505
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PowerfulEarthstormDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PrimalIntent"
  value: {
-  dps: 1768.8640576945227
-  tps: 1255.893480963111
+  dps: 1823.3659686291226
+  tps: 1294.5898377266772
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1731.4141276981834
-  tps: 1229.3040306657094
+  dps: 1805.2514953402285
+  tps: 1281.7285616915615
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1859.1453224943436
-  tps: 1319.9931789709826
+  dps: 1937.5950054856448
+  tps: 1375.6924538948076
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1874.9299067622683
-  tps: 1331.2002338012096
+  dps: 1953.9901809555936
+  tps: 1387.333028478471
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1787.8857744633742
-  tps: 1269.398899868996
+  dps: 1869.7731931915916
+  tps: 1327.5389671660305
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RelentlessEarthstormDiamond"
  value: {
-  dps: 1783.1292616156843
-  tps: 1266.0217757471357
+  dps: 1864.9974999995786
+  tps: 1324.1482249997018
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1731.4141276985326
-  tps: 1229.3040306659575
+  dps: 1805.2514953403497
+  tps: 1281.7285616916477
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1731.4141276985326
-  tps: 1229.3040306659575
+  dps: 1805.2514953403497
+  tps: 1281.7285616916477
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 1743.9836512076845
-  tps: 1238.228392357455
+  dps: 1818.161402877632
+  tps: 1290.8945960431188
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1731.4141276981834
-  tps: 1229.3040306657094
+  dps: 1805.2514953402285
+  tps: 1281.7285616915615
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1731.4141276985326
-  tps: 1229.3040306659575
+  dps: 1805.2514953403497
+  tps: 1281.7285616916477
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Slayer'sArmor"
  value: {
-  dps: 1864.6544339620064
-  tps: 1323.9046481130242
+  dps: 1934.1893810085548
+  tps: 1373.2744605160735
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SparkofLife-37657"
  value: {
-  dps: 1760.8111901196355
-  tps: 1250.1759449849408
+  dps: 1835.7110009076287
+  tps: 1303.3548106444157
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1622.9081998334032
-  tps: 1152.2648218817167
+  dps: 1674.5567117143762
+  tps: 1188.9352653172077
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1560.8764291614905
-  tps: 1108.2222647046585
+  dps: 1615.2369673877918
+  tps: 1146.818246845332
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftSkyfireDiamond"
  value: {
-  dps: 1775.0625130272965
-  tps: 1260.2943842493808
+  dps: 1856.215638722183
+  tps: 1317.9131034927505
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1781.3924739408114
-  tps: 1264.7886564979758
+  dps: 1862.776619357169
+  tps: 1322.57139974359
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftStarfireDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1778.5791579792497
-  tps: 1262.7912021652671
+  dps: 1859.8606279638436
+  tps: 1320.5010458543284
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1773.6558550465174
-  tps: 1259.295657083027
+  dps: 1854.75764302552
+  tps: 1316.877926548119
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TenaciousEarthstormDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheFistsofFury"
  value: {
-  dps: 1673.4098342207071
-  tps: 1188.1209822967028
+  dps: 1742.4559901934085
+  tps: 1237.1437530373205
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1944.1964391382865
-  tps: 1380.3794717881829
+  dps: 2019.5451590233204
+  tps: 1433.877062906557
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinStars"
  value: {
-  dps: 1705.661289669005
-  tps: 1211.0195156649932
+  dps: 1787.075849271561
+  tps: 1268.8238529828084
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ThunderingSkyfireDiamond"
  value: {
-  dps: 1784.6040150829785
-  tps: 1267.0688507089144
+  dps: 1853.0235959809436
+  tps: 1315.6467531464687
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1806.2016417487403
-  tps: 1282.4031656416046
+  dps: 1873.8624049971017
+  tps: 1330.4423075479413
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1852.7434169678756
-  tps: 1315.4478260471908
+  dps: 1928.4859982886553
+  tps: 1369.225058784944
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1860.6844626178852
-  tps: 1321.0859684586976
+  dps: 1938.3206061921023
+  tps: 1376.2076303963913
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1766.6225651426132
-  tps: 1254.3020212512545
+  dps: 1847.4676645422046
+  tps: 1311.7020418249635
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 1871.3707291568614
-  tps: 1328.673217701371
+  dps: 1950.8636468231136
+  tps: 1385.113189244409
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WastewalkerArmor"
  value: {
-  dps: 1615.1511348514175
-  tps: 1146.757305744506
+  dps: 1669.5953223574384
+  tps: 1185.4126788737815
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WindhawkArmor"
  value: {
-  dps: 1628.8288675781316
-  tps: 1156.4684959804736
+  dps: 1685.177347590875
+  tps: 1196.4759167895215
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WrathofSpellfire"
  value: {
-  dps: 1626.0712989387268
-  tps: 1154.5106222464954
+  dps: 1679.795800081874
+  tps: 1192.6550180581291
  }
 }
 dps_results: {
  key: "TestRogue-Average-Default"
  value: {
-  dps: 1781.2875855243688
-  tps: 1264.7141857222996
+  dps: 1854.599796806138
+  tps: 1316.7658557323623
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2420.69855977455
-  tps: 1718.6959774399313
+  dps: 2504.2681277837114
+  tps: 1778.0303707264359
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1775.0024530241592
-  tps: 1260.251741647154
+  dps: 1848.071364108807
+  tps: 1312.1306685172538
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2187.9900620403855
-  tps: 1553.472944048674
+  dps: 2263.360927277641
+  tps: 1606.9862583671263
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 671.3753010953276
-  tps: 476.67646377768267
+  dps: 720.0793833329578
+  tps: 511.2563621664
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 573.3647303819035
-  tps: 407.08895857115147
+  dps: 617.6400397267614
+  tps: 438.52442820600066
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 673.5512477367508
-  tps: 478.22138589309304
+  dps: 724.8001425419908
+  tps: 514.6081012048134
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2451.558295570663
-  tps: 1740.606389855171
+  dps: 2529.2122801030955
+  tps: 1795.7407188731981
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1804.3591401666847
-  tps: 1281.0949895183464
+  dps: 1871.7691171512454
+  tps: 1328.9560731773845
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2151.4311666619974
-  tps: 1527.5161283300183
+  dps: 2220.7825580684967
+  tps: 1576.7556162286326
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-LongMultiTarget"
  value: {
-  dps: 658.3983150087469
-  tps: 467.46280365621016
+  dps: 694.2648108182736
+  tps: 492.9280156809744
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 562.011098017317
-  tps: 399.02787959229516
+  dps: 593.1249919906151
+  tps: 421.1187443133368
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 648.6759997358084
-  tps: 460.55995981242415
+  dps: 702.4564900258719
+  tps: 498.74410791836897
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2430.5772794711675
-  tps: 1725.7098684245293
+  dps: 2510.467333733728
+  tps: 1782.4318069509466
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1783.1292616156843
-  tps: 1266.0217757471357
+  dps: 1864.9974999995786
+  tps: 1324.1482249997018
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2216.6149266617454
-  tps: 1573.7965979298388
+  dps: 2280.8021845165595
+  tps: 1619.3695510067566
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 678.4321751137225
-  tps: 481.686844330743
+  dps: 726.7065610471793
+  tps: 515.9616583434972
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 578.5435047407082
-  tps: 410.7658883659028
+  dps: 621.8345535317401
+  tps: 441.50253300753536
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 682.8667423706381
-  tps: 484.8353870831533
+  dps: 737.4471861020012
+  tps: 523.5875021324208
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2461.174015867086
-  tps: 1747.4335512656312
+  dps: 2541.49712088931
+  tps: 1804.4629558314098
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1817.9413141546745
-  tps: 1290.7383330498194
+  dps: 1886.518523459247
+  tps: 1339.4281516560648
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2153.7942653060522
-  tps: 1529.1939283672973
+  dps: 2243.0667047497996
+  tps: 1592.5773603723576
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-LongMultiTarget"
  value: {
-  dps: 662.5724807009146
-  tps: 470.4264612976495
+  dps: 700.819365922567
+  tps: 497.5817498050229
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 567.2206526858588
-  tps: 402.72666340696
+  dps: 598.1031043055582
+  tps: 424.65320405694627
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 653.7829960957222
-  tps: 464.1859272279629
+  dps: 705.9269568802301
+  tps: 501.2081393849635
  }
 }
 dps_results: {
  key: "TestRogue-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1605.7174237918898
-  tps: 1140.0593708922418
+  dps: 1673.6855924805245
+  tps: 1188.3167706611725
  }
 }

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -258,6 +258,7 @@ func NewRogue(character core.Character, options proto.Player) *Rogue {
 			rogue.doRotation(sim)
 		}
 	})
+	rogue.EnergyTickMultiplier *= (1 + []float64{0, 0.08, 0.16, 0.25}[rogue.Talents.Vitality])
 
 	rogue.EnableAutoAttacks(rogue, core.AutoAttackOptions{
 		MainHand:       rogue.WeaponFromMainHand(0), // Set crit multiplier later when we have targets.

--- a/sim/rogue/rotation.go
+++ b/sim/rogue/rotation.go
@@ -23,6 +23,10 @@ func (rogue *Rogue) OnGCDReady(sim *core.Simulation) {
 }
 
 func (rogue *Rogue) doRotation(sim *core.Simulation) {
+	if rogue.KillingSpreeAura.IsActive() {
+		rogue.DoNothing()
+		return
+	}
 	switch rogue.plan {
 	case PlanNone:
 		rogue.doPlanNone(sim)

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -27,8 +27,6 @@ func (rogue *Rogue) ApplyTalents() {
 		rogue.AutoAttacks.OHEffect.BaseDamage.Calculator = core.BaseDamageFuncMeleeWeapon(core.OffHand, false, 0, 1+0.1*float64(rogue.Talents.DualWieldSpecialization), true)
 	}
 
-	rogue.EnergyTickMultiplier *= (1 + []float64{0, 0.08, 0.16, 0.25}[rogue.Talents.Vitality])
-
 	if rogue.Talents.Deadliness > 0 {
 		rogue.AddStatDependency(stats.AttackPower, stats.AttackPower, 1.0+0.02*float64(rogue.Talents.Deadliness))
 	}
@@ -366,11 +364,11 @@ func (rogue *Rogue) registerAdrenalineRushCD() {
 		Duration: time.Second * 15,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			rogue.ResetEnergyTick(sim)
-			rogue.EnergyTickMultiplier = 2
+			rogue.EnergyTickMultiplier *= 2.0
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			rogue.ResetEnergyTick(sim)
-			rogue.EnergyTickMultiplier = 1
+			rogue.EnergyTickMultiplier *= 1 / 2.0
 		},
 	})
 

--- a/sim/rogue/thistle_tea.go
+++ b/sim/rogue/thistle_tea.go
@@ -15,7 +15,7 @@ func (rogue *Rogue) registerThistleTeaCD() {
 	actionID := core.ActionID{ItemID: 7676}
 	energyMetrics := rogue.NewEnergyMetrics(actionID)
 
-	const energyRegen = 40.0
+	const energyRegen = 20.0
 
 	thistleTeaSpell := rogue.RegisterSpell(core.SpellConfig{
 		ActionID: actionID,
@@ -41,7 +41,7 @@ func (rogue *Rogue) registerThistleTeaCD() {
 		Type:  core.CooldownTypeDPS,
 		ShouldActivate: func(sim *core.Simulation, character *core.Character) bool {
 			// Make sure we have plenty of room so we dont energy cap right after using.
-			return rogue.CurrentEnergy() <= 40
+			return rogue.CurrentEnergy() <= 60
 		},
 	})
 }


### PR DESCRIPTION
Updated Thistle tea - should be 20 energy not 40
Updated Rotation - do not use abilities while killing spree is active
Updated energy multiplier - resetting the bar does not reset the multiplier. This could potentially cause problems where the multiplier is not cleaned up across iterations but I verified that is not happening in practice. We can do a more thorough fix here (e.g. having a base energy multiplier ivar and resetting to that) when we make the broader changes to energy.