### PR TITLE
Paladin rename a set, change RV damage from physical to holy

### DIFF
--- a/sim/paladin/paladin.go
+++ b/sim/paladin/paladin.go
@@ -89,6 +89,8 @@ type Paladin struct {
 	ArtOfWarInstantCast *core.Aura
 
 	SpiritualAttunementMetrics *core.ResourceMetrics
+
+	HasTuralyonsOrLiadrinsBattlegear2Pc bool
 }
 
 // Implemented by each Paladin spec.
@@ -189,6 +191,8 @@ func NewPaladin(character core.Character, talents proto.PaladinTalents) *Paladin
 		Character: character,
 		Talents:   talents,
 	}
+
+	paladin.HasTuralyonsOrLiadrinsBattlegear2Pc = paladin.HasSetBonus(ItemSetTuralyonsBattlegear, 2) || paladin.HasSetBonus(ItemSetLiadrinsBattlegear, 2)
 
 	paladin.PseudoStats.CanParry = true
 

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -52,868 +52,868 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AegisBattlegear"
  value: {
-  dps: 3354.9886949078746
-  tps: 3022.478268145751
+  dps: 3364.204234110598
+  tps: 3028.8033313751716
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AshtongueTalismanofZeal-32489"
  value: {
-  dps: 2861.3458599149144
-  tps: 2613.244825013314
+  dps: 2861.7944594524884
+  tps: 2611.3090882273764
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 2806.716492943473
-  tps: 2564.0904028017167
+  dps: 2812.967712567108
+  tps: 2567.270405905708
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2970.6795192401178
-  tps: 2706.2786028834107
+  dps: 2976.489413179971
+  tps: 2709.2496441233143
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 2823.696169415504
-  tps: 2576.320936468757
+  dps: 2827.500483813215
+  tps: 2577.841376812524
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2811.352778303612
-  tps: 2518.102735607432
+  dps: 2817.6495691055334
+  tps: 2521.246505133374
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 2870.260850581274
-  tps: 2614.122843796513
+  dps: 2868.8899791335825
+  tps: 2609.985095101657
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BurningRage"
  value: {
-  dps: 2632.1791078795704
-  tps: 2411.0196229998237
+  dps: 2629.549999954967
+  tps: 2405.343363342531
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2866.1364173450156
-  tps: 2616.7139411124444
+  dps: 2871.6230833795157
+  tps: 2618.766121196243
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2882.332440035854
-  tps: 2621.799253347842
+  dps: 2886.661297613514
+  tps: 2622.9181915479253
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2937.0972310555294
-  tps: 2679.1941632627577
+  dps: 2945.8810785681662
+  tps: 2685.0989525257837
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 3105.02518408205
-  tps: 2806.33836416917
+  dps: 3105.1789350866275
+  tps: 2804.5966680081983
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 2921.325494006842
-  tps: 2656.250614533878
+  dps: 2924.037671205009
+  tps: 2656.359043500909
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 2919.1869237439887
-  tps: 2657.451173907185
+  dps: 2920.2551485869662
+  tps: 2655.1202312967093
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DeadlyGladiator'sLibramofFortitude-42852"
  value: {
-  dps: 2925.030064361842
-  tps: 2664.384738157116
+  dps: 2928.995510745155
+  tps: 2664.1102893355865
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 2851.5033564059513
-  tps: 2599.8583886240353
+  dps: 2849.641777188882
+  tps: 2596.3308011120453
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Defender'sCode-40257"
  value: {
-  dps: 2841.2929110396276
-  tps: 2585.0088157228424
+  dps: 2841.860575486572
+  tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DesolationBattlegear"
  value: {
-  dps: 2424.833621486929
-  tps: 2236.6979199367465
+  dps: 2428.271334677921
+  tps: 2238.44869132467
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2826.809868899091
-  tps: 2580.149579752459
+  dps: 2828.649167032682
+  tps: 2580.357894185279
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DoomplateBattlegear"
  value: {
-  dps: 2499.938085281557
-  tps: 2300.329699110732
+  dps: 2503.6854936232858
+  tps: 2302.1109321223307
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 2806.716492943473
-  tps: 2564.0904028017167
+  dps: 2812.967712567108
+  tps: 2567.270405905708
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2816.035763673883
-  tps: 2565.7595574365896
+  dps: 2824.7340307048194
+  tps: 2569.9381113469476
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 2823.8752562270574
-  tps: 2577.995585358388
+  dps: 2829.1985916791614
+  tps: 2579.981985421398
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2812.6604231472656
-  tps: 2569.1390534466173
+  dps: 2818.465737641479
+  tps: 2572.727589978817
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 2806.716492943473
-  tps: 2564.0904028017167
+  dps: 2812.967712567108
+  tps: 2567.270405905708
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2935.5228468234004
-  tps: 2679.3044087000926
+  dps: 2935.557070713627
+  tps: 2677.089634453191
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2930.0750044313518
-  tps: 2661.92420289587
+  dps: 2931.2357690990693
+  tps: 2660.070970442278
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FaithinFelsteel"
  value: {
-  dps: 2477.925889316356
-  tps: 2280.595397007824
+  dps: 2480.986723036219
+  tps: 2281.684656672699
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FelstalkerArmor"
  value: {
-  dps: 2709.6881497605873
-  tps: 2481.698854260349
+  dps: 2716.9179247262114
+  tps: 2485.681995271868
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FlameGuard"
  value: {
-  dps: 2410.4606842604658
-  tps: 2221.547200555676
+  dps: 2406.0794130015756
+  tps: 2214.182048377362
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2863.1683782263776
-  tps: 2607.8911395506634
+  dps: 2860.914527145596
+  tps: 2602.8458678738075
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2811.352778303612
-  tps: 2567.5727745325275
+  dps: 2817.6495691055334
+  tps: 2570.780702620223
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2810.4255212315857
-  tps: 2566.8763001863654
+  dps: 2816.713197797849
+  tps: 2570.0786432773207
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuriousGladiator'sLibramofFortitude-42853"
  value: {
-  dps: 2937.9130493160774
-  tps: 2675.184270449631
+  dps: 2941.9087736168
+  tps: 2674.9172961911763
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 3007.994670223298
-  tps: 2723.964761788754
+  dps: 3008.4348407888024
+  tps: 2722.509807668651
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2853.3470059417086
-  tps: 2594.0392331044936
+  dps: 2853.8795743515157
+  tps: 2592.7631590874707
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HatefulGladiator'sLibramofFortitude-42851"
  value: {
-  dps: 2916.9326918614847
-  tps: 2657.59949785668
+  dps: 2920.876700875181
+  tps: 2657.3205433023545
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 2879.8383689149205
-  tps: 2613.867377902697
+  dps: 2880.3089919226454
+  tps: 2612.505404765773
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 2823.8752562270574
-  tps: 2577.995585358388
+  dps: 2829.1985916791614
+  tps: 2579.981985421398
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2812.6604231472656
-  tps: 2569.1390534466173
+  dps: 2818.465737641479
+  tps: 2572.727589978817
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2939.121835804935
-  tps: 2668.3754167708166
+  dps: 2939.69592055133
+  tps: 2667.073778830798
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 2847.450207130498
-  tps: 2595.719160200661
+  dps: 2848.1937056007223
+  tps: 2595.0186940523786
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 2828.033256630236
-  tps: 2588.0593545721267
+  dps: 2829.4751924892053
+  tps: 2585.0068898329873
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2828.944289005894
-  tps: 2582.7272519331677
+  dps: 2835.2555309425734
+  tps: 2585.9392584888283
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2841.2929110396276
-  tps: 2585.0088157228424
+  dps: 2841.860575486572
+  tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Liadrin'sBattlegear"
  value: {
-  dps: 3259.3085696593275
-  tps: 2920.7059275186416
+  dps: 3262.492821729803
+  tps: 2919.2833804905176
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofDivineJudgement-33503"
  value: {
-  dps: 2860.615139590661
-  tps: 2610.3870766945392
+  dps: 2864.429196386927
+  tps: 2610.075255057628
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofFuriousBlows-37574"
  value: {
-  dps: 2850.672912671472
-  tps: 2601.9927486402084
+  dps: 2860.38013117302
+  tps: 2609.8034662086484
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofReciprocation-40706"
  value: {
-  dps: 2860.615139590661
-  tps: 2610.3870766945392
+  dps: 2864.429196386927
+  tps: 2610.075255057628
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofThreeTruths-50455"
  value: {
-  dps: 2920.370718136727
-  tps: 2660.4789073113234
+  dps: 2924.325214006577
+  tps: 2660.201755189481
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofValiance-47661"
  value: {
-  dps: 3126.065384384153
-  tps: 2833.581769743817
+  dps: 3130.4683591237535
+  tps: 2833.373152705246
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerBattlegear"
  value: {
-  dps: 2724.8822932494722
-  tps: 2499.613915749941
+  dps: 2721.7020789329044
+  tps: 2492.500464333846
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornBattlegear"
  value: {
-  dps: 3686.1942440384714
-  tps: 3316.024266429236
+  dps: 3694.3009810176213
+  tps: 3318.3854013885866
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 2841.2929110396276
-  tps: 2585.0088157228424
+  dps: 2841.860575486572
+  tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 2312.5206643174693
-  tps: 2137.8893461910075
+  dps: 2313.1561641698454
+  tps: 2137.420126075738
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2922.0148030074324
-  tps: 2660.877997344756
+  dps: 2918.60716289303
+  tps: 2655.951610097109
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherscaleArmor"
  value: {
-  dps: 2693.6998965212797
-  tps: 2466.9763173979013
+  dps: 2694.060304501917
+  tps: 2463.8929904466795
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherstrikeArmor"
  value: {
-  dps: 2629.4852238752155
-  tps: 2407.167124807306
+  dps: 2632.6085946770836
+  tps: 2408.9439091708414
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2841.2929110396276
-  tps: 2585.0088157228424
+  dps: 2841.860575486572
+  tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 2824.7104230892414
-  tps: 2579.1773759081298
+  dps: 2831.0102322043895
+  tps: 2582.3832865682334
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2828.944289005894
-  tps: 2582.7272519331677
+  dps: 2835.2555309425734
+  tps: 2585.9392584888283
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 2806.716492943473
-  tps: 2564.0904028017167
+  dps: 2812.967712567108
+  tps: 2567.270405905708
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 2806.716492943473
-  tps: 2564.0904028017167
+  dps: 2812.967712567108
+  tps: 2567.270405905708
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PrimalIntent"
  value: {
-  dps: 2774.0954317664696
-  tps: 2538.0476740223066
+  dps: 2766.9779486328707
+  tps: 2529.1448941959256
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2841.2929110396276
-  tps: 2585.0088157228424
+  dps: 2841.860575486572
+  tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionBattlegear"
  value: {
-  dps: 2956.0141038868232
-  tps: 2699.121355785923
+  dps: 2960.7194309285787
+  tps: 2699.9432763700993
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 3018.47429443131
-  tps: 2763.7520493381344
+  dps: 3021.8897232045138
+  tps: 2762.8455530309666
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 3041.8949797462365
-  tps: 2786.3251145122404
+  dps: 3045.592009273907
+  tps: 2785.689403182092
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2865.7967473166786
-  tps: 2616.3742710841075
+  dps: 2871.331440887718
+  tps: 2618.474478704446
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessGladiator'sLibramofFortitude-42854"
  value: {
-  dps: 2952.9431984293547
-  tps: 2687.783724790899
+  dps: 2956.974246967055
+  tps: 2687.525470856034
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2822.7994314624275
-  tps: 2576.2162924978247
+  dps: 2816.841038409116
+  tps: 2568.289902415195
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2841.2929110396276
-  tps: 2585.0088157228424
+  dps: 2841.860575486572
+  tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SavageGladiator'sLibramofFortitude-42611"
  value: {
-  dps: 2910.557119906297
-  tps: 2652.2546954609647
+  dps: 2914.4864173482097
+  tps: 2651.9720201048376
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2841.2929110396276
-  tps: 2585.0088157228424
+  dps: 2841.860575486572
+  tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 2859.8109341586346
-  tps: 2605.9912379852985
+  dps: 2854.204082423849
+  tps: 2598.314810865423
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2841.2929110396276
-  tps: 2585.0088157228424
+  dps: 2841.860575486572
+  tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2841.2929110396276
-  tps: 2585.0088157228424
+  dps: 2841.860575486572
+  tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SparkofLife-37657"
  value: {
-  dps: 2858.8916310285194
-  tps: 2601.4482488597455
+  dps: 2857.538534365379
+  tps: 2599.3771501888464
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 2607.5375199510718
-  tps: 2390.788105842588
+  dps: 2607.4336264159024
+  tps: 2387.4755055149567
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 2506.649690940764
-  tps: 2307.8024416480666
+  dps: 2511.0940067052998
+  tps: 2309.195411894567
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2828.944289005894
-  tps: 2582.7272519331677
+  dps: 2835.2555309425734
+  tps: 2585.9392584888283
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 2824.7104230892414
-  tps: 2579.1773759081298
+  dps: 2831.0102322043895
+  tps: 2582.3832865682334
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2817.301157735101
-  tps: 2572.9650928643123
+  dps: 2823.580959412567
+  tps: 2576.160335707194
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheTwinStars"
  value: {
-  dps: 2814.9159681268807
-  tps: 2568.2800580341577
+  dps: 2815.635796408397
+  tps: 2567.686768864641
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 2851.6474187735103
-  tps: 2605.5614385006725
+  dps: 2855.2002404389355
+  tps: 2604.122245973258
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2965.4548392955317
-  tps: 2718.660786603277
+  dps: 2965.8622720994827
+  tps: 2715.937114519964
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 3006.193890871901
-  tps: 2752.1931300921865
+  dps: 3008.9705202216264
+  tps: 2750.077207126722
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2811.352778303612
-  tps: 2567.5727745325275
+  dps: 2817.6495691055334
+  tps: 2570.780702620223
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2810.4255212315857
-  tps: 2566.8763001863654
+  dps: 2816.713197797849
+  tps: 2570.0786432773207
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeofFieryRedemption-30447"
  value: {
-  dps: 2858.5872385597286
-  tps: 2598.0130053241955
+  dps: 2859.6090232363335
+  tps: 2597.088314227488
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeoftheLightbringer-32368"
  value: {
-  dps: 2860.615139590661
-  tps: 2610.3870766945392
+  dps: 2864.429196386927
+  tps: 2610.075255057628
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2810.4255212315857
-  tps: 2566.8763001863654
+  dps: 2816.713197797849
+  tps: 2570.0786432773207
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2811.352778303612
-  tps: 2567.5727745325275
+  dps: 2817.6495691055334
+  tps: 2570.780702620223
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sBattlegear"
  value: {
-  dps: 3259.3085696593275
-  tps: 2920.7059275186416
+  dps: 3262.492821729803
+  tps: 2919.2833804905176
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WastewalkerArmor"
  value: {
-  dps: 2439.422277532997
-  tps: 2250.993840607999
+  dps: 2446.9049791634197
+  tps: 2256.7898650296147
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WindhawkArmor"
  value: {
-  dps: 2595.7333746720465
-  tps: 2377.168700796555
+  dps: 2597.117605765397
+  tps: 2377.0201176155015
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathfulGladiator'sLibramofFortitude-51478"
  value: {
-  dps: 2970.1205117016693
-  tps: 2702.183101180919
+  dps: 2974.1919307959147
+  tps: 2701.934813330156
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathofSpellfire"
  value: {
-  dps: 2612.735406794451
-  tps: 2391.8375443319137
+  dps: 2614.0685483315397
+  tps: 2389.991302700595
  }
 }
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 2872.1532235198943
-  tps: 2620.4586767314513
+  dps: 2875.1282712843167
+  tps: 2620.557747671168
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8151.280493579489
-  tps: 9684.924823417026
+  dps: 8141.013635913085
+  tps: 9675.8160029312
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2852.1630287001744
-  tps: 2605.4100934488724
+  dps: 2855.722361653349
+  tps: 2604.9767429494664
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3265.2455007308126
-  tps: 3019.8057485306276
+  dps: 3274.182186134308
+  tps: 3026.491061377251
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3425.636103481179
-  tps: 4428.506229179673
+  dps: 3423.4862199239265
+  tps: 4428.895239313473
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1162.14585848113
-  tps: 1081.3481692335831
+  dps: 1161.4085120713469
+  tps: 1082.217050094709
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1448.19821789808
-  tps: 1376.020160156602
+  dps: 1439.8605201877406
+  tps: 1371.7423420518464
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8257.111217367852
-  tps: 9814.770242283092
+  dps: 8256.320366884716
+  tps: 9816.23330197263
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2905.9392219566407
-  tps: 2653.579553422899
+  dps: 2913.1870433403756
+  tps: 2656.6503487674086
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3297.845764495201
-  tps: 3042.6404386700465
+  dps: 3293.4672290939898
+  tps: 3037.1249649129113
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3576.3906350577004
-  tps: 4615.134895126047
+  dps: 3573.285875051063
+  tps: 4613.982026626245
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1214.5518548451507
-  tps: 1131.2395585729196
+  dps: 1213.1992348603653
+  tps: 1132.3765314968002
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1446.8861018635623
-  tps: 1372.7402777066143
+  dps: 1437.2684153668572
+  tps: 1366.5854058238424
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8300.605173574364
-  tps: 9818.27748876256
+  dps: 8295.02501548603
+  tps: 9814.016780544505
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2934.975183749758
-  tps: 2677.5009831735724
+  dps: 2939.6899468857537
+  tps: 2678.1874282560448
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3307.914932245534
-  tps: 3061.4201511948563
+  dps: 3310.8719176443874
+  tps: 3063.23106374365
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3482.4291784556344
-  tps: 4474.029147400985
+  dps: 3477.17433254572
+  tps: 4470.948286861637
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1199.826799740093
-  tps: 1115.5922245537747
+  dps: 1200.401882124372
+  tps: 1118.1338007124702
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1476.562064095811
-  tps: 1395.308975043509
+  dps: 1465.4131435481895
+  tps: 1388.9872796685079
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8263.051385834395
-  tps: 9788.170353921005
+  dps: 8267.809401187664
+  tps: 9790.183871947407
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2918.0632688674373
-  tps: 2652.4126509271036
+  dps: 2919.309364326085
+  tps: 2653.496511900742
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3286.5238557363054
-  tps: 3039.712338361359
+  dps: 3279.856345491264
+  tps: 3028.668691000453
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3499.94194987253
-  tps: 4495.4571849616395
+  dps: 3495.199861771785
+  tps: 4492.605579760002
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1209.910090878572
-  tps: 1122.8652323228685
+  dps: 1206.1731710056301
+  tps: 1121.3789605448615
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1452.7823608677058
-  tps: 1378.4721382113564
+  dps: 1450.6432832864143
+  tps: 1379.9762164827234
  }
 }
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2628.5289065282805
-  tps: 2383.505736182803
+  dps: 2630.2438988032386
+  tps: 2381.4934652207503
  }
 }

--- a/sim/paladin/talents.go
+++ b/sim/paladin/talents.go
@@ -427,7 +427,8 @@ func (paladin *Paladin) applyJudgmentsOfTheWise() {
 func (paladin *Paladin) makeRighteousVengeanceDot(target *core.Unit) *core.Dot {
 	var applier core.OutcomeApplier
 
-	if paladin.HasSetBonus(ItemSetTuralyonsBattlegear, 2) || paladin.HasSetBonus(ItemSetLiadrinsBattlegear, 2) {
+	if paladin.HasTuralyonsOrLiadrinsBattlegear2Pc {
+		// Crits using melee crit.
 		applier = paladin.OutcomeFuncMeleeSpecialCritOnly(paladin.MeleeCritMultiplier())
 	} else {
 		applier = paladin.OutcomeFuncAlwaysHit()
@@ -471,7 +472,7 @@ func (paladin *Paladin) registerRighteousVengeanceSpell() {
 
 	paladin.RighteousVengeanceSpell = paladin.RegisterSpell(core.SpellConfig{
 		ActionID:    dotActionID,
-		SpellSchool: core.SpellSchoolPhysical,
+		SpellSchool: core.SpellSchoolHoly,
 		Flags:       core.SpellFlagMeleeMetrics,
 	})
 }

--- a/ui/retribution_paladin/presets.ts
+++ b/ui/retribution_paladin/presets.ts
@@ -85,7 +85,7 @@ export const DefaultConsumes = Consumes.create({
 const RET_BIS_DISCLAIMER = "<p>Please reference <a target=\"_blank\" href=\"https://docs.google.com/spreadsheets/d/1SxO6abYm4k7XRaP1MsxhaqYoukgyZ-cbWDE3ujadjx4/\">Baranor's TBC BiS Lists</a> for more detailed gearing options and information.</p>"
 
 export const PRE_RAID_PRESET = {
-	name: 'Pre-Patch Preset',
+	name: 'Pre-Raid Preset',
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
 	enableWhen: (player: Player<Spec.SpecRetributionPaladin>) => true,
 	gear: EquipmentSpec.fromJsonString(`{"items": [


### PR DESCRIPTION
Turns out RV's dot deals holy damage, not physical. But with 2pc t9 it uses physical crit rating and a physical crit multiplier.