### PR TITLE
Fix threat bugs, add individual modifier skipping flags, prevent Paladin RV from double dipping

### DIFF
--- a/sim/core/flags.go
+++ b/sim/core/flags.go
@@ -171,23 +171,26 @@ func (se SpellFlag) Matches(other SpellFlag) bool {
 }
 
 const (
-	SpellFlagNone             SpellFlag = 0
-	SpellFlagIgnoreResists    SpellFlag = 1 << iota // skip spell resist/armor
-	SpellFlagCannotBeDodged                         // Ignores dodge in physical hit rolls
-	SpellFlagBinary                                 // Does not do partial resists and could need a different hit roll.
-	SpellFlagChanneled                              // Spell is channeled
-	SpellFlagDisease                                // Spell is categorized as disease
-	SpellFlagIgnoreModifiers                        // Only used by Ignite
-	SpellFlagMeleeMetrics                           // Marks a spell as a melee ability for metrics.
-	SpellFlagNoOnCastComplete                       // Disables OnCastComplete callbacks.
-	SpellFlagNoMetrics                              // Disables metrics for a spell.
-	SpellFlagNoLogs                                 // Disables logs for a spell.
+	SpellFlagNone                    SpellFlag = 0
+	SpellFlagIgnoreResists           SpellFlag = 1 << iota // skip spell resist/armor
+	SpellFlagIgnoreTargetModifiers                         // skip target damage modifiers
+	SpellFlagIgnoreAttackerModifiers                       // skip attacker damage modifiers
+	SpellFlagCannotBeDodged                                // Ignores dodge in physical hit rolls
+	SpellFlagBinary                                        // Does not do partial resists and could need a different hit roll.
+	SpellFlagChanneled                                     // Spell is channeled
+	SpellFlagDisease                                       // Spell is categorized as disease
+	SpellFlagMeleeMetrics                                  // Marks a spell as a melee ability for metrics.
+	SpellFlagNoOnCastComplete                              // Disables OnCastComplete callbacks.
+	SpellFlagNoMetrics                                     // Disables metrics for a spell.
+	SpellFlagNoLogs                                        // Disables logs for a spell.
 
 	// Used to let agents categorize their spells.
 	SpellFlagAgentReserved1
 	SpellFlagAgentReserved2
 	SpellFlagAgentReserved3
 	SpellFlagAgentReserved4
+
+	SpellFlagIgnoreModifiers = SpellFlagIgnoreAttackerModifiers | SpellFlagIgnoreResists | SpellFlagIgnoreTargetModifiers
 )
 
 type SpellSchool byte

--- a/sim/core/spell_effect.go
+++ b/sim/core/spell_effect.go
@@ -197,31 +197,33 @@ func (spellEffect *SpellEffect) calculateBaseDamage(sim *Simulation, spell *Spel
 }
 
 func (spellEffect *SpellEffect) calcDamageSingle(sim *Simulation, spell *Spell, attackTable *AttackTable) {
-	if !spell.Flags.Matches(SpellFlagIgnoreModifiers) {
-		if sim.Log != nil {
-			baseDmg := spellEffect.Damage
-			if !spellEffect.IsPeriodic { // dots snapshot personal attack dmg bonuses
-				spellEffect.applyAttackerModifiers(sim, spell)
-			}
-			afterAttackMods := spellEffect.Damage
-			spellEffect.applyResistances(sim, spell, attackTable)
-			afterResistances := spellEffect.Damage
-			spellEffect.applyTargetModifiers(sim, spell, attackTable)
-			afterTargetMods := spellEffect.Damage
-			spellEffect.PreoutcomeDamage = spellEffect.Damage
+	if sim.Log != nil {
+		baseDmg := spellEffect.Damage
+		if !spellEffect.IsPeriodic { // dots snapshot personal attack dmg bonuses
+			spellEffect.applyAttackerModifiers(sim, spell)
+		}
+		afterAttackMods := spellEffect.Damage
+		spellEffect.applyResistances(sim, spell, attackTable)
+		afterResistances := spellEffect.Damage
+		spellEffect.applyTargetModifiers(sim, spell, attackTable)
+		afterTargetMods := spellEffect.Damage
+		spellEffect.PreoutcomeDamage = spellEffect.Damage
+		if spellEffect.OutcomeApplier != nil {
 			spellEffect.OutcomeApplier(sim, spell, spellEffect, attackTable)
-			afterOutcome := spellEffect.Damage
-			spell.Unit.Log(
-				sim,
-				"%s %s [DEBUG] BaseDamage:%0.01f, AfterAttackerMods:%0.01f, AfterResistances:%0.01f, AfterTargetMods:%0.01f, AfterOutcome:%0.01f",
-				spellEffect.Target.LogLabel(), spell.ActionID, baseDmg, afterAttackMods, afterResistances, afterTargetMods, afterOutcome)
-		} else {
-			if !spellEffect.IsPeriodic { // dots snapshot personal attack dmg bonuses
-				spellEffect.applyAttackerModifiers(sim, spell)
-			}
-			spellEffect.applyResistances(sim, spell, attackTable)
-			spellEffect.applyTargetModifiers(sim, spell, attackTable)
-			spellEffect.PreoutcomeDamage = spellEffect.Damage
+		}
+		afterOutcome := spellEffect.Damage
+		spell.Unit.Log(
+			sim,
+			"%s %s [DEBUG] BaseDamage:%0.01f, AfterAttackerMods:%0.01f, AfterResistances:%0.01f, AfterTargetMods:%0.01f, AfterOutcome:%0.01f",
+			spellEffect.Target.LogLabel(), spell.ActionID, baseDmg, afterAttackMods, afterResistances, afterTargetMods, afterOutcome)
+	} else {
+		if !spellEffect.IsPeriodic { // dots snapshot personal attack dmg bonuses
+			spellEffect.applyAttackerModifiers(sim, spell)
+		}
+		spellEffect.applyResistances(sim, spell, attackTable)
+		spellEffect.applyTargetModifiers(sim, spell, attackTable)
+		spellEffect.PreoutcomeDamage = spellEffect.Damage
+		if spellEffect.OutcomeApplier != nil {
 			spellEffect.OutcomeApplier(sim, spell, spellEffect, attackTable)
 		}
 	}
@@ -274,6 +276,10 @@ func (spellEffect *SpellEffect) String() string {
 }
 
 func (spellEffect *SpellEffect) applyAttackerModifiers(sim *Simulation, spell *Spell) {
+	if spell.Flags.Matches(SpellFlagIgnoreAttackerModifiers) {
+		return
+	}
+
 	attacker := spell.Unit
 
 	if spell.SpellSchool.Matches(SpellSchoolPhysical) {
@@ -323,6 +329,10 @@ func (spellEffect *SpellEffect) snapshotAttackModifiers(spell *Spell) float64 {
 }
 
 func (spellEffect *SpellEffect) applyTargetModifiers(sim *Simulation, spell *Spell, attackTable *AttackTable) {
+	if spell.Flags.Matches(SpellFlagIgnoreTargetModifiers) {
+		return
+	}
+
 	target := spellEffect.Target
 
 	spellEffect.Damage *= attackTable.DamageDealtMultiplier

--- a/sim/core/spell_effect.go
+++ b/sim/core/spell_effect.go
@@ -208,9 +208,7 @@ func (spellEffect *SpellEffect) calcDamageSingle(sim *Simulation, spell *Spell, 
 		spellEffect.applyTargetModifiers(sim, spell, attackTable)
 		afterTargetMods := spellEffect.Damage
 		spellEffect.PreoutcomeDamage = spellEffect.Damage
-		if spellEffect.OutcomeApplier != nil {
-			spellEffect.OutcomeApplier(sim, spell, spellEffect, attackTable)
-		}
+		spellEffect.OutcomeApplier(sim, spell, spellEffect, attackTable)
 		afterOutcome := spellEffect.Damage
 		spell.Unit.Log(
 			sim,
@@ -223,9 +221,7 @@ func (spellEffect *SpellEffect) calcDamageSingle(sim *Simulation, spell *Spell, 
 		spellEffect.applyResistances(sim, spell, attackTable)
 		spellEffect.applyTargetModifiers(sim, spell, attackTable)
 		spellEffect.PreoutcomeDamage = spellEffect.Damage
-		if spellEffect.OutcomeApplier != nil {
-			spellEffect.OutcomeApplier(sim, spell, spellEffect, attackTable)
-		}
+		spellEffect.OutcomeApplier(sim, spell, spellEffect, attackTable)
 	}
 }
 func (spellEffect *SpellEffect) calcDamageTargetOnly(sim *Simulation, spell *Spell, attackTable *AttackTable) {

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -53,601 +53,601 @@ dps_results: {
  key: "TestFire-AllItems-AldorRegalia"
  value: {
   dps: 1029.9321888272907
-  tps: 884.6122883264756
+  tps: 1038.2243737749516
  }
 }
 dps_results: {
  key: "TestFire-AllItems-AshtongueTalismanofInsight-32488"
  value: {
   dps: 1164.2331306687151
-  tps: 987.9132074841873
+  tps: 1169.4376117795473
  }
 }
 dps_results: {
  key: "TestFire-AllItems-AustereEarthsiegeDiamond"
  value: {
   dps: 1154.7764662364755
-  tps: 981.560534407773
+  tps: 1159.9903506359526
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bandit'sInsignia-40371"
  value: {
   dps: 1148.8529182248444
-  tps: 972.4245359161748
+  tps: 1154.1337485845543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
   dps: 1157.3399836567346
-  tps: 984.4484485136161
+  tps: 1162.8057127078066
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BracingEarthsiegeDiamond"
  value: {
   dps: 1167.412974261118
-  tps: 972.7229055731002
+  tps: 1149.4928342045846
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
   dps: 1158.621829743405
-  tps: 980.6882684660395
+  tps: 1163.8165418727435
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticSkyflareDiamond"
  value: {
   dps: 1178.0656673626013
-  tps: 996.3610296707332
+  tps: 1182.8992677395559
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
   dps: 1169.446583046648
-  tps: 982.2986427991834
+  tps: 1174.6965101099217
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Death-42990"
  value: {
   dps: 1215.8641842254106
-  tps: 1029.5897673751547
+  tps: 1220.1759942651092
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-42987"
  value: {
   dps: 958.251610232531
-  tps: 803.5450949390377
+  tps: 956.2769414371236
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44253"
  value: {
   dps: 958.251610232531
-  tps: 803.5450949390377
+  tps: 956.2769414371236
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44254"
  value: {
   dps: 1040.9287221333602
-  tps: 867.6183618832831
+  tps: 1037.290305040579
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
   dps: 1156.9032638374686
-  tps: 976.1465986376722
+  tps: 1162.1663222849259
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Defender'sCode-40257"
  value: {
   dps: 1148.8529182248444
-  tps: 972.4245359161748
+  tps: 1154.1337485845543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DestructiveSkyflareDiamond"
  value: {
   dps: 1160.5050113279187
-  tps: 984.0368482128181
+  tps: 1165.703324825567
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EffulgentSkyflareDiamond"
  value: {
   dps: 1154.7764662364755
-  tps: 981.560534407773
+  tps: 1159.9903506359526
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmberSkyflareDiamond"
  value: {
   dps: 1167.6547069278754
-  tps: 993.9785288395311
+  tps: 1172.8209215135244
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
   dps: 1159.5911856180137
-  tps: 983.6891901261484
+  tps: 1164.79427562986
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticStarflareDiamond"
  value: {
   dps: 1158.6648595384531
-  tps: 983.2721206404318
+  tps: 1163.8684760718907
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EternalEarthsiegeDiamond"
  value: {
   dps: 1154.7764662364755
-  tps: 981.560534407773
+  tps: 1159.9903506359526
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
   dps: 1193.6112801505712
-  tps: 1006.2483662488415
+  tps: 1198.4311482717665
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeoftheBroodmother-45308"
  value: {
   dps: 1296.7461779878327
-  tps: 1086.419028352989
+  tps: 1299.4366131522825
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForgeEmber-37660"
  value: {
   dps: 1214.030642010956
-  tps: 1019.6569178595398
+  tps: 1218.3258878949437
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornSkyflareDiamond"
  value: {
   dps: 1167.412974261118
-  tps: 991.9966503047106
+  tps: 1172.3741285001022
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornStarflareDiamond"
  value: {
   dps: 1164.8856726561894
-  tps: 989.9094271253228
+  tps: 1169.8973729272725
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
   dps: 1148.8529182248444
-  tps: 972.4245359161748
+  tps: 1154.1337485845543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuturesightRune-38763"
  value: {
   dps: 1178.2962827482418
-  tps: 999.0452002674037
+  tps: 1182.9679508174834
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
   dps: 1249.1532856995418
-  tps: 1055.0486787283476
+  tps: 1252.4281087097577
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
   dps: 1159.5911856180137
-  tps: 983.6891901261484
+  tps: 1164.79427562986
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveStarflareDiamond"
  value: {
   dps: 1158.6648595384531
-  tps: 983.2721206404318
+  tps: 1163.8684760718907
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IncisorFragment-37723"
  value: {
   dps: 1148.8529182248444
-  tps: 972.4245359161748
+  tps: 1154.1337485845543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InfusedColdstoneRune-35935"
  value: {
   dps: 1176.0089084277038
-  tps: 991.9492268520528
+  tps: 1180.889853983356
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
   dps: 1154.9949487439255
-  tps: 990.7792357616541
+  tps: 1168.0220330034651
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
   dps: 1154.7764662364755
-  tps: 981.560534407773
+  tps: 1159.9903506359526
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
   dps: 1148.8529182248444
-  tps: 972.4245359161748
+  tps: 1154.1337485845543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MajesticDragonFigurine-40430"
  value: {
   dps: 1150.120213186076
-  tps: 973.3700567540967
+  tps: 1155.381637646561
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Mana-EtchedRegalia"
  value: {
   dps: 995.9975617402655
-  tps: 854.4081090318783
+  tps: 1004.0583892296672
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MeteoriteWhetstone-37390"
  value: {
   dps: 1166.5096283334822
-  tps: 980.9059693703106
+  tps: 1171.7597944910192
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MindQuickeningGem-19339"
  value: {
   dps: 1160.8903127544054
-  tps: 980.2432689673433
+  tps: 1166.0486552235236
  }
 }
 dps_results: {
  key: "TestFire-AllItems-OfferingofSacrifice-37638"
  value: {
   dps: 1148.8529182248444
-  tps: 972.4245359161748
+  tps: 1154.1337485845543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthshatterDiamond"
  value: {
   dps: 1154.7764662364755
-  tps: 981.560534407773
+  tps: 1159.9903506359526
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
   dps: 1154.7764662364755
-  tps: 981.560534407773
+  tps: 1159.9903506359526
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
   dps: 1154.7764662364755
-  tps: 981.560534407773
+  tps: 1159.9903506359526
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
   dps: 1154.7764662364755
-  tps: 981.560534407773
+  tps: 1159.9903506359526
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PurifiedShardoftheGods"
  value: {
   dps: 1148.8529182248444
-  tps: 972.4245359161748
+  tps: 1154.1337485845543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47316"
  value: {
   dps: 1353.9866814597815
-  tps: 1150.7382058469186
+  tps: 1355.0942765547927
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47477"
  value: {
   dps: 1379.9616665601575
-  tps: 1172.9997334786674
+  tps: 1380.5497619531611
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
   dps: 1173.009990838014
-  tps: 994.0764940304355
+  tps: 1177.8592047454604
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
   dps: 1156.389467552465
-  tps: 983.6334635520059
+  tps: 1161.6310319256227
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RuneofRepulsion-40372"
  value: {
   dps: 1148.8529182248444
-  tps: 972.4245359161748
+  tps: 1154.1337485845543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SealofthePantheon-36993"
  value: {
   dps: 1148.8529182248444
-  tps: 972.4245359161748
+  tps: 1154.1337485845543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Serpent-CoilBraid-30720"
  value: {
   dps: 1164.056619992867
-  tps: 980.3122618374197
+  tps: 1169.1945213172164
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Serrah'sStar-37559"
  value: {
   dps: 1166.0056666944788
-  tps: 980.0434417666675
+  tps: 1171.2441770847959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShinyShardoftheGods"
  value: {
   dps: 1148.8529182248444
-  tps: 972.4245359161748
+  tps: 1154.1337485845543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
   dps: 1148.8529182248444
-  tps: 972.4245359161748
+  tps: 1154.1337485845543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SparkofLife-37657"
  value: {
   dps: 1170.0895645155795
-  tps: 991.2722800837073
+  tps: 1175.2344719494743
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SpellstrikeInfusion"
  value: {
   dps: 1100.7020898104054
-  tps: 937.6838121092118
+  tps: 1106.2893267384038
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftSkyflareDiamond"
  value: {
   dps: 1154.7764662364755
-  tps: 981.560534407773
+  tps: 1159.9903506359526
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftStarflareDiamond"
  value: {
   dps: 1154.7764662364755
-  tps: 981.560534407773
+  tps: 1159.9903506359526
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftWindfireDiamond"
  value: {
   dps: 1154.7764662364755
-  tps: 981.560534407773
+  tps: 1159.9903506359526
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TempestRegalia"
  value: {
   dps: 1124.118505420404
-  tps: 957.7959368094695
+  tps: 1134.5928146048145
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheTwinStars"
  value: {
   dps: 1161.0633598502047
-  tps: 987.4918628576976
+  tps: 1166.343776377407
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ThunderingSkyflareDiamond"
  value: {
   dps: 1154.7764662364755
-  tps: 981.560534407773
+  tps: 1159.9903506359526
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50351"
  value: {
   dps: 1185.0167751761644
-  tps: 1004.3793807449658
+  tps: 1190.0240133968477
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
   dps: 1185.0167751761644
-  tps: 1004.3793807449658
+  tps: 1190.0240133968477
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessSkyflareDiamond"
  value: {
   dps: 1167.412974261118
-  tps: 991.9966503047106
+  tps: 1172.3741285001022
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessStarflareDiamond"
  value: {
   dps: 1164.8856726561894
-  tps: 989.9094271253228
+  tps: 1169.8973729272725
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirisfalRegalia"
  value: {
   dps: 1079.757096863324
-  tps: 921.10276836991
+  tps: 1087.196963650264
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
   dps: 1164.8856726561894
-  tps: 989.9094271253228
+  tps: 1169.8973729272725
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
   dps: 1167.412974261118
-  tps: 991.9966503047106
+  tps: 1172.3741285001022
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WrathofSpellfire"
  value: {
   dps: 1133.0745414341984
-  tps: 960.9713414463055
+  tps: 1138.498499329721
  }
 }
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
   dps: 1168.3490201211132
-  tps: 992.0488422328759
+  tps: 1173.026973515513
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongMultiTarget"
  value: {
   dps: 4987.2979835489205
-  tps: 8689.888146437323
+  tps: 9140.259769463342
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongSingleTarget"
  value: {
   dps: 225.09164364929075
-  tps: 217.23538988653127
+  tps: 242.49769950051117
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-ShortSingleTarget"
  value: {
   dps: 537.3546948494399
-  tps: 549.0758233213228
+  tps: 620.1992195734825
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongMultiTarget"
  value: {
   dps: 4375.09941678216
-  tps: 7782.549411484446
+  tps: 8096.501799208544
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongSingleTarget"
  value: {
   dps: 94.10319485530111
-  tps: 95.20846633050805
+  tps: 103.73775595819504
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-ShortSingleTarget"
  value: {
   dps: 291.59614762835577
-  tps: 307.0519785104028
+  tps: 340.40984967578845
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongMultiTarget"
  value: {
   dps: 1175.5014563370135
-  tps: 1534.1552483555047
+  tps: 1719.169701694406
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongSingleTarget"
  value: {
   dps: 1175.5014563370135
-  tps: 995.3358875955779
+  tps: 1180.3503409344796
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-ShortSingleTarget"
  value: {
   dps: 1431.5651730138197
-  tps: 1208.8845939629025
+  tps: 1440.3497131745748
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongMultiTarget"
  value: {
   dps: 400.51738195999735
-  tps: 566.6587031306186
+  tps: 622.1070343207973
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongSingleTarget"
  value: {
   dps: 400.51738195999735
-  tps: 348.53870313061867
+  tps: 403.9870343207975
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-ShortSingleTarget"
  value: {
   dps: 788.3309424039386
-  tps: 669.8693860335283
+  tps: 777.8743235558595
  }
 }
 dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
   dps: 1175.5014563370135
-  tps: 995.3358875955779
+  tps: 1180.3503409344796
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -52,868 +52,868 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AegisBattlegear"
  value: {
-  dps: 3364.204234110598
+  dps: 3317.0195275883643
   tps: 3028.8033313751716
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AshtongueTalismanofZeal-32489"
  value: {
-  dps: 2861.7944594524884
+  dps: 2828.279447288417
   tps: 2611.3090882273764
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 2812.967712567108
+  dps: 2781.950295490456
   tps: 2567.270405905708
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2976.489413179971
+  dps: 2942.105611931654
   tps: 2709.2496441233143
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 2827.500483813215
+  dps: 2795.098916534337
   tps: 2577.841376812524
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2817.6495691055334
+  dps: 2786.5120034631786
   tps: 2521.246505133374
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 2868.8899791335825
+  dps: 2834.928558653965
   tps: 2609.985095101657
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BurningRage"
  value: {
-  dps: 2629.549999954967
+  dps: 2601.961958614153
   tps: 2405.343363342531
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2871.6230833795157
+  dps: 2839.0009163029868
   tps: 2618.766121196243
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2886.661297613514
+  dps: 2849.7318877278203
   tps: 2622.9181915479253
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2945.8810785681662
+  dps: 2910.409247228667
   tps: 2685.0989525257837
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 3105.1789350866275
+  dps: 3066.544621868521
   tps: 2804.5966680081983
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 2924.037671205009
+  dps: 2886.3139342578397
   tps: 2656.359043500909
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 2920.2551485869662
+  dps: 2885.8723514773656
   tps: 2655.1202312967093
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DeadlyGladiator'sLibramofFortitude-42852"
  value: {
-  dps: 2928.995510745155
+  dps: 2894.5320301893917
   tps: 2664.1102893355865
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 2849.641777188882
+  dps: 2815.6089650921394
   tps: 2596.3308011120453
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Defender'sCode-40257"
  value: {
-  dps: 2841.860575486572
+  dps: 2806.8805315618306
   tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DesolationBattlegear"
  value: {
-  dps: 2428.271334677921
+  dps: 2402.243030481216
   tps: 2238.44869132467
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2828.649167032682
+  dps: 2796.8582036407647
   tps: 2580.357894185279
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DoomplateBattlegear"
  value: {
-  dps: 2503.6854936232858
+  dps: 2477.8071700871515
   tps: 2302.1109321223307
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 2812.967712567108
+  dps: 2781.950295490456
   tps: 2567.270405905708
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2824.7340307048194
+  dps: 2790.7520784437547
   tps: 2569.9381113469476
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 2829.1985916791614
+  dps: 2797.5265848087456
   tps: 2579.981985421398
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2818.465737641479
+  dps: 2787.6041367959724
   tps: 2572.727589978817
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 2812.967712567108
+  dps: 2781.950295490456
   tps: 2567.270405905708
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2935.557070713627
+  dps: 2901.023014461117
   tps: 2677.089634453191
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2931.2357690990693
+  dps: 2894.2412870506196
   tps: 2660.070970442278
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FaithinFelsteel"
  value: {
-  dps: 2480.986723036219
+  dps: 2455.379347643854
   tps: 2281.684656672699
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FelstalkerArmor"
  value: {
-  dps: 2716.9179247262114
+  dps: 2685.6142862299876
   tps: 2485.681995271868
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FlameGuard"
  value: {
-  dps: 2406.0794130015756
+  dps: 2380.5533838766573
   tps: 2214.182048377362
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2860.914527145596
+  dps: 2825.495606680867
   tps: 2602.8458678738075
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2817.6495691055334
+  dps: 2786.5120034631786
   tps: 2570.780702620223
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2816.713197797849
+  dps: 2785.599661868635
   tps: 2570.0786432773207
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuriousGladiator'sLibramofFortitude-42853"
  value: {
-  dps: 2941.9087736168
+  dps: 2907.2734222912395
   tps: 2674.9172961911763
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 3008.4348407888024
+  dps: 2971.139514449562
   tps: 2722.509807668651
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2853.8795743515157
+  dps: 2818.5687481092564
   tps: 2592.7631590874707
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HatefulGladiator'sLibramofFortitude-42851"
  value: {
-  dps: 2920.876700875181
+  dps: 2886.526112949262
   tps: 2657.3205433023545
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 2880.3089919226454
+  dps: 2844.2763689428903
   tps: 2612.505404765773
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 2829.1985916791614
+  dps: 2797.5265848087456
   tps: 2579.981985421398
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2818.465737641479
+  dps: 2787.6041367959724
   tps: 2572.727589978817
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2939.69592055133
+  dps: 2903.2878049425917
   tps: 2667.073778830798
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 2848.1937056007223
+  dps: 2814.3830490627865
   tps: 2595.0186940523786
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 2829.4751924892053
+  dps: 2797.9210365988456
   tps: 2585.0068898329873
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2835.2555309425734
+  dps: 2803.9557733388056
   tps: 2585.9392584888283
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2841.860575486572
+  dps: 2806.8805315618306
   tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Liadrin'sBattlegear"
  value: {
-  dps: 3262.492821729803
+  dps: 3211.684225233192
   tps: 2919.2833804905176
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofDivineJudgement-33503"
  value: {
-  dps: 2864.429196386927
+  dps: 2830.825069680147
   tps: 2610.075255057628
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofFuriousBlows-37574"
  value: {
-  dps: 2860.38013117302
+  dps: 2827.928488546414
   tps: 2609.8034662086484
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofReciprocation-40706"
  value: {
-  dps: 2864.429196386927
+  dps: 2830.825069680147
   tps: 2610.075255057628
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofThreeTruths-50455"
  value: {
-  dps: 2924.325214006577
+  dps: 2889.923893379223
   tps: 2660.201755189481
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofValiance-47661"
  value: {
-  dps: 3130.4683591237535
+  dps: 3093.318645787108
   tps: 2833.373152705246
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerBattlegear"
  value: {
-  dps: 2721.7020789329044
+  dps: 2693.5643333303497
   tps: 2492.500464333846
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornBattlegear"
  value: {
-  dps: 3694.3009810176213
+  dps: 3644.12102334948
   tps: 3318.3854013885866
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 2841.860575486572
+  dps: 2806.8805315618306
   tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 2313.1561641698454
+  dps: 2288.9259217051595
   tps: 2137.420126075738
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2918.60716289303
+  dps: 2881.8464354749053
   tps: 2655.951610097109
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherscaleArmor"
  value: {
-  dps: 2694.060304501917
+  dps: 2663.7176636627664
   tps: 2463.8929904466795
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherstrikeArmor"
  value: {
-  dps: 2632.6085946770836
+  dps: 2602.130110386467
   tps: 2408.9439091708414
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2841.860575486572
+  dps: 2806.8805315618306
   tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 2831.0102322043895
+  dps: 2799.7642537486427
   tps: 2582.3832865682334
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2835.2555309425734
+  dps: 2803.9557733388056
   tps: 2585.9392584888283
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 2812.967712567108
+  dps: 2781.950295490456
   tps: 2567.270405905708
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 2812.967712567108
+  dps: 2781.950295490456
   tps: 2567.270405905708
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PrimalIntent"
  value: {
-  dps: 2766.9779486328707
+  dps: 2736.944780317449
   tps: 2529.1448941959256
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2841.860575486572
+  dps: 2806.8805315618306
   tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionBattlegear"
  value: {
-  dps: 2960.7194309285787
+  dps: 2926.461178543311
   tps: 2699.9432763700993
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 3021.8897232045138
+  dps: 2987.6093581155883
   tps: 2762.8455530309666
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 3045.592009273907
+  dps: 3011.221453152583
   tps: 2785.689403182092
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2871.331440887718
+  dps: 2838.709273811189
   tps: 2618.474478704446
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessGladiator'sLibramofFortitude-42854"
  value: {
-  dps: 2956.974246967055
+  dps: 2922.138379743398
   tps: 2687.525470856034
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2816.841038409116
+  dps: 2784.976224138223
   tps: 2568.289902415195
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2841.860575486572
+  dps: 2806.8805315618306
   tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SavageGladiator'sLibramofFortitude-42611"
  value: {
-  dps: 2914.4864173482097
+  dps: 2880.2203344659656
   tps: 2651.9720201048376
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2841.860575486572
+  dps: 2806.8805315618306
   tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 2854.204082423849
+  dps: 2819.7794875849795
   tps: 2598.314810865423
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2841.860575486572
+  dps: 2806.8805315618306
   tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2841.860575486572
+  dps: 2806.8805315618306
   tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SparkofLife-37657"
  value: {
-  dps: 2857.538534365379
+  dps: 2823.2081108161656
   tps: 2599.3771501888464
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 2607.4336264159024
+  dps: 2578.1169825091374
   tps: 2387.4755055149567
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 2511.0940067052998
+  dps: 2483.850956222218
   tps: 2309.195411894567
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2835.2555309425734
+  dps: 2803.9557733388056
   tps: 2585.9392584888283
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 2831.0102322043895
+  dps: 2799.7642537486427
   tps: 2582.3832865682334
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2823.580959412567
+  dps: 2792.42909446586
   tps: 2576.160335707194
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheTwinStars"
  value: {
-  dps: 2815.635796408397
+  dps: 2783.3933805763854
   tps: 2567.686768864641
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 2855.2002404389355
+  dps: 2822.3612057739533
   tps: 2604.122245973258
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2965.8622720994827
+  dps: 2932.4800639746563
   tps: 2715.937114519964
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 3008.9705202216264
+  dps: 2973.534486453169
   tps: 2750.077207126722
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2817.6495691055334
+  dps: 2786.5120034631786
   tps: 2570.780702620223
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2816.713197797849
+  dps: 2785.599661868635
   tps: 2570.0786432773207
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeofFieryRedemption-30447"
  value: {
-  dps: 2859.6090232363335
+  dps: 2824.099215164558
   tps: 2597.088314227488
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeoftheLightbringer-32368"
  value: {
-  dps: 2864.429196386927
+  dps: 2830.825069680147
   tps: 2610.075255057628
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2816.713197797849
+  dps: 2785.599661868635
   tps: 2570.0786432773207
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2817.6495691055334
+  dps: 2786.5120034631786
   tps: 2570.780702620223
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sBattlegear"
  value: {
-  dps: 3262.492821729803
+  dps: 3211.684225233192
   tps: 2919.2833804905176
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WastewalkerArmor"
  value: {
-  dps: 2446.9049791634197
+  dps: 2421.3935951901212
   tps: 2256.7898650296147
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WindhawkArmor"
  value: {
-  dps: 2597.117605765397
+  dps: 2567.737829655275
   tps: 2377.0201176155015
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathfulGladiator'sLibramofFortitude-51478"
  value: {
-  dps: 2974.1919307959147
+  dps: 2939.126902545862
   tps: 2701.934813330156
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathofSpellfire"
  value: {
-  dps: 2614.0685483315397
+  dps: 2583.01078260786
   tps: 2389.991302700595
  }
 }
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 2875.1282712843167
+  dps: 2841.335548757538
   tps: 2620.557747671168
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8141.013635913085
+  dps: 8098.996989742511
   tps: 9675.8160029312
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2855.722361653349
+  dps: 2823.838193474155
   tps: 2604.9767429494664
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3274.182186134308
+  dps: 3235.4507120517546
   tps: 3026.491061377251
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3423.4862199239265
+  dps: 3415.7726780756884
   tps: 4428.895239313473
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1161.4085120713469
+  dps: 1155.07347180965
   tps: 1082.217050094709
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1439.8605201877406
+  dps: 1430.8485326328496
   tps: 1371.7423420518464
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8256.320366884716
+  dps: 8212.127234133415
   tps: 9816.23330197263
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2913.1870433403756
+  dps: 2878.490524687821
   tps: 2656.6503487674086
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3293.4672290939898
+  dps: 3252.106494479524
   tps: 3037.1249649129113
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3573.285875051063
+  dps: 3565.4858727938968
   tps: 4613.982026626245
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1213.1992348603653
+  dps: 1206.2773907346066
   tps: 1132.3765314968002
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1437.2684153668572
+  dps: 1427.865764715088
   tps: 1366.5854058238424
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8295.02501548603
+  dps: 8250.845963417143
   tps: 9814.016780544505
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2939.6899468857537
+  dps: 2905.2360569234465
   tps: 2678.1874282560448
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3310.8719176443874
+  dps: 3272.900377954361
   tps: 3063.23106374365
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3477.17433254572
+  dps: 3470.159556356689
   tps: 4470.948286861637
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1200.401882124372
+  dps: 1193.899453942661
   tps: 1118.1338007124702
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1465.4131435481895
+  dps: 1455.4764835683884
   tps: 1388.9872796685079
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8267.809401187664
+  dps: 8225.670904464734
   tps: 9790.183871947407
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2919.309364326085
+  dps: 2883.549721923932
   tps: 2653.496511900742
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3279.856345491264
+  dps: 3241.7882877649404
   tps: 3028.668691000453
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3495.199861771785
+  dps: 3487.438902992527
   tps: 4492.605579760002
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1206.1731710056301
+  dps: 1199.1969657397553
   tps: 1121.3789605448615
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1450.6432832864143
+  dps: 1441.9329682447424
   tps: 1379.9762164827234
  }
 }
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2630.2438988032386
+  dps: 2598.347530455771
   tps: 2381.4934652207503
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -52,868 +52,868 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AegisBattlegear"
  value: {
-  dps: 3317.0195275883643
+  dps: 3339.0075412934975
   tps: 3028.8033313751716
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AshtongueTalismanofZeal-32489"
  value: {
-  dps: 2828.279447288417
+  dps: 2843.9691789370067
   tps: 2611.3090882273764
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 2781.950295490456
+  dps: 2796.2257054416086
   tps: 2567.270405905708
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2942.105611931654
+  dps: 2958.116939360327
   tps: 2709.2496441233143
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 2795.098916534337
+  dps: 2810.158600673094
   tps: 2577.841376812524
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2786.5120034631786
+  dps: 2800.84295634407
   tps: 2521.246505133374
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 2834.928558653965
+  dps: 2850.6246917205217
   tps: 2609.985095101657
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BurningRage"
  value: {
-  dps: 2601.961958614153
+  dps: 2614.827812694022
   tps: 2405.343363342531
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2839.0009163029868
+  dps: 2854.022660483029
   tps: 2618.766121196243
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2849.7318877278203
+  dps: 2867.0473055456214
   tps: 2622.9181915479253
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2910.409247228667
+  dps: 2926.782627550864
   tps: 2685.0989525257837
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 3066.544621868521
+  dps: 3084.397903128186
   tps: 2804.5966680081983
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 2886.3139342578397
+  dps: 2903.807291133461
   tps: 2656.359043500909
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 2885.8723514773656
+  dps: 2901.9122471758346
   tps: 2655.1202312967093
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DeadlyGladiator'sLibramofFortitude-42852"
  value: {
-  dps: 2894.5320301893917
+  dps: 2910.654274302212
   tps: 2664.1102893355865
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 2815.6089650921394
+  dps: 2831.5187573588505
   tps: 2596.3308011120453
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Defender'sCode-40257"
  value: {
-  dps: 2806.8805315618306
+  dps: 2823.0708351435546
   tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DesolationBattlegear"
  value: {
-  dps: 2402.243030481216
+  dps: 2414.563129372299
   tps: 2238.44869132467
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2796.8582036407647
+  dps: 2811.519572308972
   tps: 2580.357894185279
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DoomplateBattlegear"
  value: {
-  dps: 2477.8071700871515
+  dps: 2490.030072565533
   tps: 2302.1109321223307
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 2781.950295490456
+  dps: 2796.2257054416086
   tps: 2567.270405905708
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2790.7520784437547
+  dps: 2806.8269361091016
   tps: 2569.9381113469476
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 2797.5265848087456
+  dps: 2812.1108024592722
   tps: 2579.981985421398
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2787.6041367959724
+  dps: 2801.8151630478296
   tps: 2572.727589978817
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 2781.950295490456
+  dps: 2796.2257054416086
   tps: 2567.270405905708
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2901.023014461117
+  dps: 2916.8989138249335
   tps: 2677.089634453191
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2894.2412870506196
+  dps: 2911.5500426596964
   tps: 2660.070970442278
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FaithinFelsteel"
  value: {
-  dps: 2455.379347643854
+  dps: 2467.2972458209088
   tps: 2281.684656672699
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FelstalkerArmor"
  value: {
-  dps: 2685.6142862299876
+  dps: 2700.2225770615382
   tps: 2485.681995271868
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FlameGuard"
  value: {
-  dps: 2380.5533838766573
+  dps: 2392.517712407956
   tps: 2214.182048377362
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2825.495606680867
+  dps: 2842.082045582521
   tps: 2602.8458678738075
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2786.5120034631786
+  dps: 2800.84295634407
   tps: 2570.780702620223
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2785.599661868635
+  dps: 2799.9195061635774
   tps: 2570.0786432773207
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuriousGladiator'sLibramofFortitude-42853"
  value: {
-  dps: 2907.2734222912395
+  dps: 2923.475813282278
   tps: 2674.9172961911763
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2971.139514449562
+  dps: 2988.387515702841
   tps: 2722.509807668651
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2818.5687481092564
+  dps: 2834.9121736777697
   tps: 2592.7631590874707
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HatefulGladiator'sLibramofFortitude-42851"
  value: {
-  dps: 2886.526112949262
+  dps: 2902.5955877062706
   tps: 2657.3205433023545
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 2844.2763689428903
+  dps: 2860.9548329868885
   tps: 2612.505404765773
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 2797.5265848087456
+  dps: 2812.1108024592722
   tps: 2579.981985421398
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2787.6041367959724
+  dps: 2801.8151630478296
   tps: 2572.727589978817
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2903.2878049425917
+  dps: 2920.117971671227
   tps: 2667.073778830798
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 2814.3830490627865
+  dps: 2830.1686075411744
   tps: 2595.0186940523786
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 2797.9210365988456
+  dps: 2812.5924553129776
   tps: 2585.0068898329873
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2803.9557733388056
+  dps: 2818.360612555043
   tps: 2585.9392584888283
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2806.8805315618306
+  dps: 2823.0708351435546
   tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Liadrin'sBattlegear"
  value: {
-  dps: 3211.684225233192
+  dps: 3235.3291551510324
   tps: 2919.2833804905176
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofDivineJudgement-33503"
  value: {
-  dps: 2830.825069680147
+  dps: 2846.5465794018783
   tps: 2610.075255057628
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofFuriousBlows-37574"
  value: {
-  dps: 2827.928488546414
+  dps: 2842.9923946291824
   tps: 2609.8034662086484
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofReciprocation-40706"
  value: {
-  dps: 2830.825069680147
+  dps: 2846.5465794018783
   tps: 2610.075255057628
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofThreeTruths-50455"
  value: {
-  dps: 2889.923893379223
+  dps: 2906.0171510377545
   tps: 2660.201755189481
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofValiance-47661"
  value: {
-  dps: 3093.318645787108
+  dps: 3110.693578709838
   tps: 2833.373152705246
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerBattlegear"
  value: {
-  dps: 2693.5643333303497
+  dps: 2706.603607153074
   tps: 2492.500464333846
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornBattlegear"
  value: {
-  dps: 3644.12102334948
+  dps: 3667.4634092973783
   tps: 3318.3854013885866
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 2806.8805315618306
+  dps: 2823.0708351435546
   tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 2288.9259217051595
+  dps: 2300.195091619776
   tps: 2137.420126075738
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2881.8464354749053
+  dps: 2899.1270292946947
   tps: 2655.951610097109
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherscaleArmor"
  value: {
-  dps: 2663.7176636627664
+  dps: 2677.949924317615
   tps: 2463.8929904466795
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherstrikeArmor"
  value: {
-  dps: 2602.130110386467
+  dps: 2616.349341438056
   tps: 2408.9439091708414
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2806.8805315618306
+  dps: 2823.0708351435546
   tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 2799.7642537486427
+  dps: 2814.1444397715304
   tps: 2582.3832865682334
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2803.9557733388056
+  dps: 2818.360612555043
   tps: 2585.9392584888283
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 2781.950295490456
+  dps: 2796.2257054416086
   tps: 2567.270405905708
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 2781.950295490456
+  dps: 2796.2257054416086
   tps: 2567.270405905708
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PrimalIntent"
  value: {
-  dps: 2736.944780317449
+  dps: 2750.8169290531173
   tps: 2529.1448941959256
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2806.8805315618306
+  dps: 2823.0708351435546
   tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionBattlegear"
  value: {
-  dps: 2926.461178543311
+  dps: 2942.5309520310384
   tps: 2699.9432763700993
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 2987.6093581155883
+  dps: 3003.5569847940706
   tps: 2762.8455530309666
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 3011.221453152583
+  dps: 3027.210674263754
   tps: 2785.689403182092
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2838.709273811189
+  dps: 2853.731017991232
   tps: 2618.474478704446
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessGladiator'sLibramofFortitude-42854"
  value: {
-  dps: 2922.138379743398
+  dps: 2938.4342754256913
   tps: 2687.525470856034
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2784.976224138223
+  dps: 2799.83579770063
   tps: 2568.289902415195
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2806.8805315618306
+  dps: 2823.0708351435546
   tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SavageGladiator'sLibramofFortitude-42611"
  value: {
-  dps: 2880.2203344659656
+  dps: 2896.25041695483
   tps: 2651.9720201048376
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2806.8805315618306
+  dps: 2823.0708351435546
   tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 2819.7794875849795
+  dps: 2835.7345952737483
   tps: 2598.314810865423
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2806.8805315618306
+  dps: 2823.0708351435546
   tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2806.8805315618306
+  dps: 2823.0708351435546
   tps: 2583.776322109269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SparkofLife-37657"
  value: {
-  dps: 2823.2081108161656
+  dps: 2839.3144517508545
   tps: 2599.3771501888464
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 2578.1169825091374
+  dps: 2591.6932915964435
   tps: 2387.4755055149567
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 2483.850956222218
+  dps: 2496.681116662152
   tps: 2309.195411894567
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2803.9557733388056
+  dps: 2818.360612555043
   tps: 2585.9392584888283
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 2799.7642537486427
+  dps: 2814.1444397715304
   tps: 2582.3832865682334
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2792.42909446586
+  dps: 2806.766137400387
   tps: 2576.160335707194
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheTwinStars"
  value: {
-  dps: 2783.3933805763854
+  dps: 2798.313029030248
   tps: 2567.686768864641
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 2822.3612057739533
+  dps: 2837.6991399720873
   tps: 2604.122245973258
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2932.4800639746563
+  dps: 2948.100297665825
   tps: 2715.937114519964
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2973.534486453169
+  dps: 2990.0585682161372
   tps: 2750.077207126722
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2786.5120034631786
+  dps: 2800.84295634407
   tps: 2570.780702620223
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2785.599661868635
+  dps: 2799.9195061635774
   tps: 2570.0786432773207
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeofFieryRedemption-30447"
  value: {
-  dps: 2824.099215164558
+  dps: 2840.538263836122
   tps: 2597.088314227488
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeoftheLightbringer-32368"
  value: {
-  dps: 2830.825069680147
+  dps: 2846.5465794018783
   tps: 2610.075255057628
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2785.599661868635
+  dps: 2799.9195061635774
   tps: 2570.0786432773207
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2786.5120034631786
+  dps: 2800.84295634407
   tps: 2570.780702620223
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sBattlegear"
  value: {
-  dps: 3211.684225233192
+  dps: 3235.3291551510324
   tps: 2919.2833804905176
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WastewalkerArmor"
  value: {
-  dps: 2421.3935951901212
+  dps: 2433.259179562108
   tps: 2256.7898650296147
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WindhawkArmor"
  value: {
-  dps: 2567.737829655275
+  dps: 2581.4174597662213
   tps: 2377.0201176155015
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathfulGladiator'sLibramofFortitude-51478"
  value: {
-  dps: 2939.126902545862
+  dps: 2955.5296607324462
   tps: 2701.934813330156
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathofSpellfire"
  value: {
-  dps: 2583.01078260786
+  dps: 2597.6281249590947
   tps: 2389.991302700595
  }
 }
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 2841.335548757538
+  dps: 2857.0926385053363
   tps: 2620.557747671168
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8098.996989742511
+  dps: 8121.653697793004
   tps: 9675.8160029312
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2823.838193474155
+  dps: 2838.5350220261544
   tps: 2604.9767429494664
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3235.4507120517546
+  dps: 3255.1364825826377
   tps: 3026.491061377251
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3415.7726780756884
+  dps: 3422.135645642572
   tps: 4428.895239313473
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1155.07347180965
+  dps: 1160.3222621777575
   tps: 1082.217050094709
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1430.8485326328496
+  dps: 1438.3935449348141
   tps: 1371.7423420518464
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8212.127234133415
+  dps: 8235.826297754908
   tps: 9816.23330197263
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2878.490524687821
+  dps: 2894.757991399202
   tps: 2656.6503487674086
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3252.106494479524
+  dps: 3272.986625574663
   tps: 3037.1249649129113
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3565.4858727938968
+  dps: 3571.944229833781
   tps: 4613.982026626245
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1206.2773907346066
+  dps: 1211.9990381512823
   tps: 1132.3765314968002
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1427.865764715088
+  dps: 1435.75732053395
   tps: 1366.5854058238424
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8250.845963417143
+  dps: 8274.991359344023
   tps: 9814.016780544505
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2905.2360569234465
+  dps: 2921.3535700119255
   tps: 2678.1874282560448
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3272.900377954361
+  dps: 3292.049998164367
   tps: 3063.23106374365
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3470.159556356689
+  dps: 3475.9480992938034
   tps: 4470.948286861637
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1193.899453942661
+  dps: 1199.3064346992965
   tps: 1118.1338007124702
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1455.4764835683884
+  dps: 1463.8341811265318
   tps: 1388.9872796685079
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8225.670904464734
+  dps: 8248.654881859711
   tps: 9790.183871947407
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2883.549721923932
+  dps: 2900.2072379329475
   tps: 2653.496511900742
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3241.7882877649404
+  dps: 3261.166757353551
   tps: 3028.668691000453
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3487.438902992527
+  dps: 3493.8664772710044
   tps: 4492.605579760002
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1199.1969657397553
+  dps: 1204.964990558492
   tps: 1121.3789605448615
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P4-Retribution Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1441.9329682447424
+  dps: 1449.2075154828913
   tps: 1379.9762164827234
  }
 }
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2598.347530455771
+  dps: 2613.2098201296444
   tps: 2381.4934652207503
  }
 }

--- a/sim/paladin/talents.go
+++ b/sim/paladin/talents.go
@@ -455,16 +455,9 @@ func (paladin *Paladin) makeRighteousVengeanceDot(target *core.Unit) *core.Dot {
 					OutcomeApplier:   applier,
 					BaseDamage: core.BaseDamageConfig{
 						Calculator: func(_ *core.Simulation, _ *core.SpellEffect, _ *core.Spell) float64 {
-							multiplierRemover := 1 *
-								(1 / paladin.PseudoStats.HolyDamageDealtMultiplier) *
-								(1 / target.PseudoStats.HolyDamageTakenMultiplier) *
-								(1 / paladin.PseudoStats.DamageDealtMultiplier) *
-								(1 / target.PseudoStats.DamageTakenMultiplier) *
-								(1 / paladin.AttackTables[target.TableIndex].DamageDealtMultiplier)
-
 							tick := paladin.RighteousVengeanceDamage[target.Index]
 							paladin.RighteousVengeancePools[target.Index] -= tick
-							return tick * multiplierRemover
+							return tick
 						},
 						TargetSpellCoefficient: 1,
 					},
@@ -480,7 +473,7 @@ func (paladin *Paladin) registerRighteousVengeanceSpell() {
 	paladin.RighteousVengeanceSpell = paladin.RegisterSpell(core.SpellConfig{
 		ActionID:    dotActionID,
 		SpellSchool: core.SpellSchoolHoly,
-		Flags:       core.SpellFlagMeleeMetrics,
+		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIgnoreTargetModifiers | core.SpellFlagIgnoreAttackerModifiers,
 	})
 }
 

--- a/sim/paladin/talents.go
+++ b/sim/paladin/talents.go
@@ -455,9 +455,16 @@ func (paladin *Paladin) makeRighteousVengeanceDot(target *core.Unit) *core.Dot {
 					OutcomeApplier:   applier,
 					BaseDamage: core.BaseDamageConfig{
 						Calculator: func(_ *core.Simulation, _ *core.SpellEffect, _ *core.Spell) float64 {
+							multiplierRemover := 1 *
+								(1 / paladin.PseudoStats.HolyDamageDealtMultiplier) *
+								(1 / target.PseudoStats.HolyDamageTakenMultiplier) *
+								(1 / paladin.PseudoStats.DamageDealtMultiplier) *
+								(1 / target.PseudoStats.DamageTakenMultiplier) *
+								(1 / paladin.AttackTables[target.TableIndex].DamageDealtMultiplier)
+
 							tick := paladin.RighteousVengeanceDamage[target.Index]
 							paladin.RighteousVengeancePools[target.Index] -= tick
-							return tick
+							return tick * multiplierRemover
 						},
 						TargetSpellCoefficient: 1,
 					},

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -461,7 +461,7 @@ dps_results: {
  key: "TestElemental-AllItems-Nobundo'sRegalia"
  value: {
   dps: 2681.7477236817804
-  tps: 2049.8089375836767
+  tps: 2097.186514302557
  }
 }
 dps_results: {
@@ -664,7 +664,7 @@ dps_results: {
  key: "TestElemental-AllItems-Thrall'sRegalia"
  value: {
   dps: 2681.7477236817804
-  tps: 2049.8089375836767
+  tps: 2097.186514302557
  }
 }
 dps_results: {
@@ -755,7 +755,7 @@ dps_results: {
  key: "TestElemental-AllItems-WorldbreakerGarb"
  value: {
   dps: 2838.235961766876
-  tps: 2189.7946347421016
+  tps: 2231.309700244776
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -711,7 +711,7 @@ dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerGarb"
  value: {
   dps: 2502.477202622223
-  tps: 1767.190140398731
+  tps: 1777.692501470865
  }
 }
 dps_results: {

--- a/sim/shaman/lavaburst.go
+++ b/sim/shaman/lavaburst.go
@@ -106,8 +106,9 @@ func (shaman *Shaman) newLavaBurstSpell() *core.Spell {
 						return lvbdotDmg / 3 //spread dot over 3 ticks
 					},
 				},
-				IsPeriodic: true,
-				ProcMask:   core.ProcMaskEmpty,
+				IsPeriodic:     true,
+				ProcMask:       core.ProcMaskEmpty,
+				OutcomeApplier: shaman.OutcomeFuncTick(),
 			}),
 		})
 

--- a/sim/shaman/lightning_bolt.go
+++ b/sim/shaman/lightning_bolt.go
@@ -71,8 +71,9 @@ func (shaman *Shaman) newLightningBoltSpell(isLightningOverload bool) *core.Spel
 						return lbdotDmg / 2 //spread dot over 2 ticks
 					},
 				},
-				IsPeriodic: true,
-				ProcMask:   core.ProcMaskEmpty,
+				IsPeriodic:     true,
+				ProcMask:       core.ProcMaskEmpty,
+				OutcomeApplier: shaman.OutcomeFuncTick(),
 			}),
 		})
 		applyDot = func(sim *core.Simulation, dmg float64) {


### PR DESCRIPTION
https://wowwiki-archive.fandom.com/wiki/Patch_3.1.0

Righteous Vengeance reduced to 3 ranks for 10/20/30%. *The damage done by this talent no longer receives modifications from effects that increase or decrease damage done by a percentage.* Now triggered by Crusader Strike as well.