### PR TITLE
Sim page fix

### DIFF
--- a/makefile
+++ b/makefile
@@ -23,7 +23,8 @@ HTML_INDECIES := ui/balance_druid/index.html \
 				 ui/protection_warrior/index.html \
 				 ui/deathknight/index.html \
 				 ui/tank_deathknight/index.html \
-				 ui/raid/index.html
+				 ui/raid/index.html \
+				 ui/detailed_results/index.html
 
 $(OUT_DIR)/.dirstamp: \
   $(OUT_DIR)/lib.wasm \

--- a/makefile
+++ b/makefile
@@ -79,7 +79,8 @@ ui/core/proto/api.ts: proto/*.proto node_modules
 	npx protoc --ts_out ui/core/proto --proto_path proto proto/ui.proto
 
 ui/%/index.html: ui/index_template.html
-	cat ui/index_template.html | sed 's/@@TITLE@@/WOTLK $* Simulator/g' > $@
+	$(eval title := $(shell echo $(shell basename $(@D)) | sed -r 's/(^|_)([a-z])/\U \2/g' | cut -c 2-))
+	cat ui/index_template.html | sed 's/@@TITLE@@/WOTLK $(title) Simulator/g' > $@
 
 package-lock.json:
 	npm install

--- a/makefile
+++ b/makefile
@@ -70,7 +70,8 @@ clean:
 	  binary_dist \
 	  ui/core/index.ts \
 	  ui/core/proto/*.ts \
-	  node_modules 
+	  node_modules \
+	  $(HTML_INDECIES)
 	find . -name "*.results.tmp" -type f -delete
 
 


### PR DESCRIPTION
Reverts page title generation (`Balance Druid` instead of `balance_druid`).

Adds `detailed_results` as a UI dependency.

![image](https://user-images.githubusercontent.com/3380818/182655885-80cf023b-58bf-47de-9413-ab0fbe8adaf5.png)

![image](https://user-images.githubusercontent.com/3380818/182656319-7de1180d-8e4b-4203-ad20-54e7706cb536.png)
