### PR TITLE
Naive energy tick update, Rogue rotation and crit damage fixes

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -271,25 +271,6 @@ enum Conjured {
 	ConjuredRogueThistleTea = 4;
 }
 
-enum WeaponImbue {
-	WeaponImbueUnknown = 0;
-	WeaponImbueAdamantiteSharpeningStone = 1;
-	WeaponImbueAdamantiteWeightstone = 5;
-	WeaponImbueElementalSharpeningStone = 2;
-	WeaponImbueBrilliantWizardOil = 3;
-	WeaponImbueSuperiorWizardOil = 4;
-
-	WeaponImbueShamanFlametongue = 6;
-	WeaponImbueShamanFrostbrand = 7;
-	WeaponImbueShamanRockbiter = 8;
-	WeaponImbueShamanWindfury = 9;
-
-	WeaponImbueRogueDeadlyPoison = 10;
-	WeaponImbueRogueInstantPoison = 11;
-
-	WeaponImbueRighteousWeaponCoating = 12;
-}
-
 enum Flask {
 	FlaskUnknown = 0;
 	FlaskOfTheFrostWyrm = 1;
@@ -518,9 +499,6 @@ message Consumes {
 	Flask flask = 1;
 	BattleElixir battle_elixir = 2;
 	GuardianElixir guardian_elixir = 3;
-
-	WeaponImbue main_hand_imbue = 4;
-	WeaponImbue off_hand_imbue = 5;
 
 	Food food = 6;
 	PetFood pet_food = 7;

--- a/proto/rogue.proto
+++ b/proto/rogue.proto
@@ -137,6 +137,7 @@ enum RogueMinorGlyph {
 	GlyphOfVanish = 43380;
 }
 
+
 message Rogue {
 	message Rotation {
 		enum Builder {
@@ -166,6 +167,13 @@ message Rogue {
 	
 	message Options {
 		RaidTarget tricks_of_the_trade_target = 1;
+		enum PoisonImbue {
+			NoPoison = 0;
+			InstantPoison = 1;
+			DeadlyPoison = 2;
+		}
+		PoisonImbue mh_imbue = 2;
+		PoisonImbue oh_imbue = 3;
 	}
 	Options options = 3;
 }

--- a/proto/rogue.proto
+++ b/proto/rogue.proto
@@ -155,6 +155,9 @@ message Rogue {
 		// Allows use of rupture when sensible.
 		bool use_rupture = 2;
 
+		// Allows use of envenom when sensible
+		bool use_envenom = 6;
+
 		// Shiv instead of regular builder if deadly poison is about to fall.
 		bool use_shiv = 5;
 

--- a/sim/core/energy.go
+++ b/sim/core/energy.go
@@ -7,10 +7,10 @@ import (
 )
 
 // Time between energy ticks.
-const EnergyTickDuration = time.Millisecond * 2020
+const EnergyTickDuration = time.Millisecond * 100
 
 // Extra 0.2 because Blizzard
-const EnergyPerTick = 20.2
+const EnergyPerTick = 1.0
 
 // OnEnergyGain is called any time energy is increased.
 type OnEnergyGain func(sim *Simulation)

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -19,7 +19,7 @@ character_stats_results: {
   final_stats: 810
   final_stats: 339
   final_stats: 0
-  final_stats: 6140.412299999999
+  final_stats: 6140.412299999998
   final_stats: 361.16
   final_stats: 1606.0794
   final_stats: 339
@@ -53,13 +53,13 @@ dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
   dps: 6362.22898966155
-  tps: 4384.6628147493775
+  tps: 4384.662814749376
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6177.958475541491
+  dps: 6177.958475541492
   tps: 4270.337354497193
  }
 }
@@ -73,8 +73,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6357.31657430152
-  tps: 4293.503009349426
+  dps: 6357.316574301518
+  tps: 4293.503009349425
  }
 }
 dps_results: {
@@ -115,22 +115,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6325.672880023479
+  dps: 6325.672880023478
   tps: 4339.032188957591
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6269.544449686394
-  tps: 4305.773159598113
+  dps: 6269.544449686395
+  tps: 4305.773159598112
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
   dps: 5876.136543555504
-  tps: 4092.0663611378973
+  tps: 4092.0663611378986
  }
 }
 dps_results: {
@@ -179,20 +179,20 @@ dps_results: {
  key: "TestFrost-AllItems-DoomplateBattlegear"
  value: {
   dps: 4886.50473362856
-  tps: 3407.7166071092333
+  tps: 3407.7166071092324
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6357.31657430152
+  dps: 6357.316574301518
   tps: 4381.1255197443115
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6357.31657430152
+  dps: 6357.316574301518
   tps: 4381.1255197443115
  }
 }
@@ -206,14 +206,14 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6370.690110243073
+  dps: 6370.690110243072
   tps: 4390.47485067371
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6357.31657430152
+  dps: 6357.316574301518
   tps: 4381.1255197443115
  }
 }
@@ -235,20 +235,20 @@ dps_results: {
  key: "TestFrost-AllItems-FaithinFelsteel"
  value: {
   dps: 5128.2004271326905
-  tps: 3563.6934079513167
+  tps: 3563.693407951317
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FelstalkerArmor"
  value: {
   dps: 5496.029434039918
-  tps: 3791.361727458455
+  tps: 3791.3617274584553
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FlameGuard"
  value: {
-  dps: 5027.671952074877
+  dps: 5027.671952074876
   tps: 3490.6720599784917
  }
 }
@@ -262,21 +262,21 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6357.31657430152
+  dps: 6357.316574301518
   tps: 4381.1255197443115
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6357.31657430152
+  dps: 6357.316574301518
   tps: 4381.1255197443115
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 6477.305126258348
+  dps: 6477.305126258345
   tps: 4446.598624569267
  }
 }
@@ -284,14 +284,14 @@ dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
   dps: 6272.457001656576
-  tps: 4319.678764034671
+  tps: 4319.67876403467
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
   dps: 6076.968960037166
-  tps: 4179.723320177911
+  tps: 4179.723320177912
  }
 }
 dps_results: {
@@ -305,7 +305,7 @@ dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
   dps: 6076.968960037166
-  tps: 4179.723320177911
+  tps: 4179.723320177912
  }
 }
 dps_results: {
@@ -318,35 +318,35 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6370.690110243073
+  dps: 6370.690110243072
   tps: 4390.47485067371
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6420.576679736327
+  dps: 6420.576679736328
   tps: 4415.56669074994
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 6000.371717160301
-  tps: 4153.292250067039
+  dps: 6000.3717171603
+  tps: 4153.29225006704
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6357.31657430152
+  dps: 6357.316574301518
   tps: 4381.1255197443115
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6383.097391193751
+  dps: 6383.09739119375
   tps: 4399.699542381191
  }
 }
@@ -354,21 +354,21 @@ dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
   dps: 6076.968960037166
-  tps: 4179.723320177911
+  tps: 4179.723320177912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
   dps: 6076.968960037166
-  tps: 4179.723320177911
+  tps: 4179.723320177912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Mana-EtchedRegalia"
  value: {
   dps: 4559.669683736446
-  tps: 3155.0679626188676
+  tps: 3155.0679626188667
  }
 }
 dps_results: {
@@ -395,35 +395,35 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6087.143058621126
-  tps: 4187.0282404790405
+  dps: 6087.143058621127
+  tps: 4187.028240479041
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6378.186759404754
-  tps: 4396.161633307499
+  dps: 6378.186759404755
+  tps: 4396.161633307498
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6383.097391193751
+  dps: 6383.09739119375
   tps: 4399.699542381191
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6357.31657430152
+  dps: 6357.316574301518
   tps: 4381.1255197443115
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6357.31657430152
+  dps: 6357.316574301518
   tps: 4381.1255197443115
  }
 }
@@ -438,7 +438,7 @@ dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
   dps: 6076.968960037166
-  tps: 4179.723320177911
+  tps: 4179.723320177912
  }
 }
 dps_results: {
@@ -459,7 +459,7 @@ dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
   dps: 6520.841995194874
-  tps: 4495.392135332442
+  tps: 4495.392135332441
  }
 }
 dps_results: {
@@ -472,7 +472,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6357.31657430152
+  dps: 6357.316574301518
   tps: 4381.1255197443115
  }
 }
@@ -480,14 +480,14 @@ dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
   dps: 6076.968960037166
-  tps: 4179.723320177911
+  tps: 4179.723320177912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
   dps: 5640.136713628772
-  tps: 3908.402847182715
+  tps: 3908.402847182716
  }
 }
 dps_results: {
@@ -500,14 +500,14 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 6233.687140577438
+  dps: 6233.687140577439
   tps: 4301.20206158439
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 5416.437408591657
+  dps: 5416.437408591659
   tps: 3787.95650685873
  }
 }
@@ -529,13 +529,13 @@ dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
   dps: 6076.968960037166
-  tps: 4179.723320177911
+  tps: 4179.723320177912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 6434.803463583671
+  dps: 6434.803463583672
   tps: 4420.113746788657
  }
 }
@@ -543,7 +543,7 @@ dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
   dps: 6748.518674830246
-  tps: 4642.203464196978
+  tps: 4642.203464196976
  }
 }
 dps_results: {
@@ -584,28 +584,28 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6383.097391193751
+  dps: 6383.09739119375
   tps: 4399.699542381191
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6378.186759404754
-  tps: 4396.161633307499
+  dps: 6378.186759404755
+  tps: 4396.161633307498
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6369.593153774011
-  tps: 4389.970292428541
+  dps: 6369.59315377401
+  tps: 4389.970292428539
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 5767.164120079676
+  dps: 5767.164120079675
   tps: 3971.38369060945
  }
 }
@@ -619,14 +619,14 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-TheTwinStars"
  value: {
-  dps: 6010.5306440700715
+  dps: 6010.530644070072
   tps: 4156.165291869653
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6424.227909550085
+  dps: 6424.227909550084
   tps: 4413.991914593806
  }
 }
@@ -647,28 +647,28 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6357.31657430152
+  dps: 6357.316574301518
   tps: 4381.1255197443115
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6357.31657430152
+  dps: 6357.316574301518
   tps: 4381.1255197443115
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6357.31657430152
+  dps: 6357.316574301518
   tps: 4381.1255197443115
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6357.31657430152
+  dps: 6357.316574301518
   tps: 4381.1255197443115
  }
 }
@@ -683,20 +683,20 @@ dps_results: {
  key: "TestFrost-AllItems-WindhawkArmor"
  value: {
   dps: 5376.321864780491
-  tps: 3696.945209160315
+  tps: 3696.945209160314
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 6499.420633220123
-  tps: 4460.184753725707
+  dps: 6499.420633220121
+  tps: 4460.184753725706
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathofSpellfire"
  value: {
-  dps: 5319.943069703348
+  dps: 5319.943069703347
   tps: 3689.751018921432
  }
 }
@@ -717,7 +717,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6429.408326024242
+  dps: 6429.408326024241
   tps: 4410.782724796669
  }
 }
@@ -731,7 +731,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8929.977755908656
+  dps: 8929.977755908654
   tps: 5724.239896589511
  }
 }
@@ -753,13 +753,13 @@ dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
   dps: 13221.883252555
-  tps: 8501.884861227989
+  tps: 8501.884861227987
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6424.227909550085
+  dps: 6424.227909550084
   tps: 4413.991914593806
  }
 }
@@ -794,7 +794,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5965.454749632465
+  dps: 5965.454749632464
   tps: 4147.385972173821
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -19,7 +19,7 @@ character_stats_results: {
   final_stats: 947.73
   final_stats: 339
   final_stats: 0
-  final_stats: 5715.748544000002
+  final_stats: 5715.748544000001
   final_stats: 361.16
   final_stats: 1743.8093999999999
   final_stats: 339
@@ -52,8 +52,8 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
@@ -66,14 +66,14 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7804.3378624850175
-  tps: 5555.98335081436
+  dps: 7804.337862485016
+  tps: 5555.983350814359
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7802.885078581344
+  dps: 7802.885078581343
   tps: 5411.037327985644
  }
 }
@@ -87,15 +87,15 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BurningRage"
  value: {
-  dps: 6543.135161595624
-  tps: 4590.393647249711
+  dps: 6543.135161595623
+  tps: 4590.39364724971
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7871.677147252516
-  tps: 5626.124246770797
+  dps: 7871.677147252512
+  tps: 5626.124246770795
  }
 }
 dps_results: {
@@ -143,8 +143,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7897.264895363242
-  tps: 5605.748383807864
+  dps: 7897.264895363241
+  tps: 5605.748383807862
  }
 }
 dps_results: {
@@ -165,14 +165,14 @@ dps_results: {
  key: "TestUnholy-AllItems-DesolationBattlegear"
  value: {
   dps: 5813.337035360382
-  tps: 4094.230039080913
+  tps: 4094.230039080912
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7809.1967871748
-  tps: 5551.425531628587
+  dps: 7809.196787174797
+  tps: 5551.425531628585
  }
 }
 dps_results: {
@@ -185,36 +185,36 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7804.3378624850175
-  tps: 5555.98335081436
+  dps: 7804.337862485016
+  tps: 5555.983350814359
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7797.414143367435
+  dps: 7797.414143367432
   tps: 5527.182467052329
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
@@ -235,21 +235,21 @@ dps_results: {
  key: "TestUnholy-AllItems-FaithinFelsteel"
  value: {
   dps: 6476.596891787629
-  tps: 4502.465375953943
+  tps: 4502.465375953945
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FelstalkerArmor"
  value: {
-  dps: 6738.956461616597
-  tps: 4730.235047676157
+  dps: 6738.956461616595
+  tps: 4730.235047676155
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FlameGuard"
  value: {
   dps: 6123.319461567808
-  tps: 4259.177869512493
+  tps: 4259.177869512494
  }
 }
 dps_results: {
@@ -262,15 +262,15 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
@@ -297,7 +297,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7783.725154078258
+  dps: 7783.725154078257
   tps: 5571.0677801197035
  }
 }
@@ -311,14 +311,14 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7804.3378624850175
-  tps: 5555.98335081436
+  dps: 7804.337862485016
+  tps: 5555.983350814359
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7797.414143367435
+  dps: 7797.414143367432
   tps: 5527.182467052329
  }
 }
@@ -326,7 +326,7 @@ dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
   dps: 7669.716070328643
-  tps: 5513.395112864991
+  tps: 5513.3951128649915
  }
 }
 dps_results: {
@@ -339,15 +339,15 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
   dps: 7837.243082794557
-  tps: 5549.909373127393
+  tps: 5549.909373127394
  }
 }
 dps_results: {
@@ -367,7 +367,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 5573.606391533362
+  dps: 5573.606391533361
   tps: 3932.7467530740773
  }
 }
@@ -382,7 +382,7 @@ dps_results: {
  key: "TestUnholy-AllItems-NetherscaleArmor"
  value: {
   dps: 6801.160426903179
-  tps: 4797.453787508371
+  tps: 4797.45378750837
  }
 }
 dps_results: {
@@ -403,34 +403,34 @@ dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
   dps: 7830.698701039658
-  tps: 5544.491713714528
+  tps: 5544.491713714526
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
   dps: 7837.243082794557
-  tps: 5549.909373127393
+  tps: 5549.909373127394
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PrimalIntent"
  value: {
-  dps: 6855.427914842197
+  dps: 6855.4279148421965
   tps: 4816.036453151809
  }
 }
@@ -458,8 +458,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7862.286920853039
-  tps: 5590.403719406483
+  dps: 7862.286920853037
+  tps: 5590.403719406482
  }
 }
 dps_results: {
@@ -472,8 +472,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
@@ -486,21 +486,21 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6915.214221309494
-  tps: 4861.382235941387
+  dps: 6915.214221309495
+  tps: 4861.382235941385
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6390.736948320038
+  dps: 6390.736948320037
   tps: 4444.8813275373
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7877.253239390748
+  dps: 7877.253239390749
   tps: 5673.456450204843
  }
 }
@@ -535,22 +535,22 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7861.921962682422
-  tps: 5553.799728031313
+  dps: 7861.92196268242
+  tps: 5553.799728031312
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8052.878675774002
+  dps: 8052.878675774
   tps: 5705.257440572538
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7921.1018459690295
-  tps: 5606.289241410178
+  dps: 7921.101845969026
+  tps: 5606.289241410175
  }
 }
 dps_results: {
@@ -585,20 +585,20 @@ dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
   dps: 7837.243082794557
-  tps: 5549.909373127393
+  tps: 5549.909373127394
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
   dps: 7830.698701039658
-  tps: 5544.491713714528
+  tps: 5544.491713714526
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7819.246032968588
+  dps: 7819.2460329685855
   tps: 5535.010809742007
  }
 }
@@ -619,22 +619,22 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinStars"
  value: {
-  dps: 7442.103452467995
+  dps: 7442.103452467994
   tps: 5267.265193590394
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7904.285051364536
-  tps: 5559.249622864902
+  dps: 7904.2850513645335
+  tps: 5559.2496228649015
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
   dps: 7554.148801709125
-  tps: 5382.370193755188
+  tps: 5382.370193755187
  }
 }
 dps_results: {
@@ -647,35 +647,35 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WastewalkerArmor"
  value: {
-  dps: 5844.155135073192
+  dps: 5844.15513507319
   tps: 4118.6710266167765
  }
 }
@@ -683,14 +683,14 @@ dps_results: {
  key: "TestUnholy-AllItems-WindhawkArmor"
  value: {
   dps: 6618.649099768123
-  tps: 4644.301586105541
+  tps: 4644.30158610554
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
   dps: 7958.826887493671
-  tps: 5652.771299361434
+  tps: 5652.771299361432
  }
 }
 dps_results: {
@@ -703,14 +703,14 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 7881.415756346828
-  tps: 5537.584441726819
+  dps: 7881.415756346826
+  tps: 5537.584441726818
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 32453.703816390916
+  dps: 32453.703816390924
   tps: 25490.39870633385
  }
 }
@@ -718,7 +718,7 @@ dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
   dps: 7753.441636068655
-  tps: 5525.704112720006
+  tps: 5525.704112720007
  }
 }
 dps_results: {
@@ -732,7 +732,7 @@ dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
   dps: 20344.405601144277
-  tps: 16562.08321035403
+  tps: 16562.083210354027
  }
 }
 dps_results: {
@@ -752,15 +752,15 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 32716.640049215144
-  tps: 25623.13443276902
+  dps: 32716.640049215126
+  tps: 25623.13443276901
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7904.285051364536
-  tps: 5559.249622864902
+  dps: 7904.2850513645335
+  tps: 5559.2496228649015
  }
 }
 dps_results: {
@@ -780,7 +780,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4021.968827110262
+  dps: 4021.9688271102627
   tps: 3274.884131396898
  }
 }
@@ -794,7 +794,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7510.298214773958
-  tps: 5251.276374151244
+  dps: 7510.298214773955
+  tps: 5251.2763741512435
  }
 }

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -67,7 +67,7 @@ dps_results: {
  key: "TestBalance-AllItems-Bandit'sInsignia-40371"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
@@ -87,7 +87,7 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 790.0394811819181
+  dps: 790.0394811819182
   tps: 785.8321186435279
  }
 }
@@ -144,7 +144,7 @@ dps_results: {
  key: "TestBalance-AllItems-Defender'sCode-40257"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
@@ -192,7 +192,7 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 837.7560022220556
+  dps: 837.7560022220557
   tps: 832.5941192628625
  }
 }
@@ -228,13 +228,13 @@ dps_results: {
  key: "TestBalance-AllItems-FuryoftheFiveFlights-40431"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuturesightRune-38763"
  value: {
-  dps: 817.2892983570878
+  dps: 817.2892983570877
   tps: 812.5742994751945
  }
 }
@@ -262,8 +262,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 861.4587894217129
-  tps: 855.8211740518603
+  dps: 861.4587894217127
+  tps: 855.8211740518606
  }
 }
 dps_results: {
@@ -284,7 +284,7 @@ dps_results: {
  key: "TestBalance-AllItems-IncisorFragment-37723"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
@@ -298,7 +298,7 @@ dps_results: {
  key: "TestBalance-AllItems-InsightfulEarthsiegeDiamond"
  value: {
   dps: 879.4973910940975
-  tps: 878.1787836907973
+  tps: 878.1787836907972
  }
 }
 dps_results: {
@@ -312,7 +312,7 @@ dps_results: {
  key: "TestBalance-AllItems-Lavanthor'sTalisman-37872"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
@@ -326,7 +326,7 @@ dps_results: {
  key: "TestBalance-AllItems-MajesticDragonFigurine-40430"
  value: {
   dps: 866.3971888920347
-  tps: 861.1056855327754
+  tps: 861.1056855327755
  }
 }
 dps_results: {
@@ -375,7 +375,7 @@ dps_results: {
  key: "TestBalance-AllItems-OfferingofSacrifice-37638"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
@@ -409,7 +409,7 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-PrimalIntent"
  value: {
-  dps: 673.0975417467082
+  dps: 673.0975417467081
   tps: 670.9586146636886
  }
 }
@@ -417,13 +417,13 @@ dps_results: {
  key: "TestBalance-AllItems-PurifiedShardoftheGods"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 873.8562231855442
+  dps: 873.8562231855443
   tps: 867.8968258070815
  }
 }
@@ -431,7 +431,7 @@ dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47477"
  value: {
   dps: 884.04733883803
-  tps: 877.8841191465175
+  tps: 877.8841191465174
  }
 }
 dps_results: {
@@ -452,14 +452,14 @@ dps_results: {
  key: "TestBalance-AllItems-RuneofRepulsion-40372"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SealofthePantheon-36993"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
@@ -473,20 +473,20 @@ dps_results: {
  key: "TestBalance-AllItems-ShinyShardoftheGods"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SparkofLife-37657"
  value: {
-  dps: 847.641984397768
+  dps: 847.6419843977683
   tps: 842.5248184617274
  }
 }
@@ -500,7 +500,7 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 646.8492086485306
+  dps: 646.8492086485307
   tps: 645.1654748941419
  }
 }
@@ -528,7 +528,7 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-TheTwinStars"
  value: {
-  dps: 808.4152583538465
+  dps: 808.4152583538468
   tps: 803.7052036053512
  }
 }
@@ -536,7 +536,7 @@ dps_results: {
  key: "TestBalance-AllItems-ThunderheartHarness"
  value: {
   dps: 521.1151212538555
-  tps: 520.9903459140266
+  tps: 520.9903459140268
  }
 }
 dps_results: {
@@ -620,7 +620,7 @@ dps_results: {
  key: "TestBalance-Average-Default"
  value: {
   dps: 796.1994695726255
-  tps: 791.5230203862071
+  tps: 791.523020386207
  }
 }
 dps_results: {

--- a/sim/druid/balance/presets.go
+++ b/sim/druid/balance/presets.go
@@ -42,7 +42,6 @@ var FullConsumes = &proto.Consumes{
 	Food:            proto.Food_FoodBlackenedBasilisk,
 	DefaultPotion:   proto.Potions_SuperManaPotion,
 	PrepopPotion:    proto.Potions_DestructionPotion,
-	MainHandImbue:   proto.WeaponImbue_WeaponImbueBrilliantWizardOil,
 	DefaultConjured: proto.Conjured_ConjuredDarkRune,
 }
 

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -19,9 +19,9 @@ character_stats_results: {
   final_stats: 136.07698329321138
   final_stats: 0
   final_stats: 0
-  final_stats: 5223.381240000001
+  final_stats: 5223.3812400000015
   final_stats: 135
-  final_stats: 2426.5963143999998
+  final_stats: 2412.5963143999998
   final_stats: 0
   final_stats: 0
   final_stats: 20
@@ -52,413 +52,413 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 1821.9592377768627
-  tps: 1317.1672621826133
+  dps: 1813.9183061867147
+  tps: 1311.5625641174042
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1904.1732126414704
-  tps: 1375.5391843364837
+  dps: 1902.042038366992
+  tps: 1374.130413965401
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 1839.7077111837916
-  tps: 1329.911347914404
+  dps: 1842.8220876572
+  tps: 1332.1257043625353
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1846.1250258186003
-  tps: 1334.336821692246
+  dps: 1848.482191761202
+  tps: 1336.0186367127512
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1884.1040986502073
-  tps: 1361.3138134026874
+  dps: 1881.411210473317
+  tps: 1359.4645188757422
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 1964.18332386765
-  tps: 1418.1937633070715
+  dps: 1975.7726028072914
+  tps: 1426.488777501405
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 1992.449268900556
-  tps: 1438.211234280435
+  dps: 1993.7691528477135
+  tps: 1439.0438092949885
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 1921.0662602143464
-  tps: 1387.7023279366936
+  dps: 1936.4394246603345
+  tps: 1398.4959778530106
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1821.488446030225
-  tps: 1316.8059241013932
+  dps: 1837.3396906212772
+  tps: 1328.0478837021474
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1816.6666636740138
-  tps: 1313.40953456959
+  dps: 1813.8151205417357
+  tps: 1311.489302309469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1874.784450689389
-  tps: 1354.692913350506
+  dps: 1862.8944819361345
+  tps: 1346.1532831046957
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1844.6535486253536
-  tps: 1333.3039228850412
+  dps: 1841.5390764747692
+  tps: 1331.1553037367732
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1832.41189171974
-  tps: 1324.5501139135145
+  dps: 1837.8270725572297
+  tps: 1328.484774876673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1901.0092504150791
-  tps: 1373.2927711557463
+  dps: 1899.4350212911365
+  tps: 1372.279431841544
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1822.5856861365482
-  tps: 1317.7660905179896
+  dps: 1821.8926123055135
+  tps: 1317.108641410165
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdolofTerror-33509"
  value: {
-  dps: 1811.3794717419337
-  tps: 1309.627978297813
+  dps: 1796.7140986787683
+  tps: 1299.3475767867626
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 1802.6087196187564
-  tps: 1303.4283942903571
+  dps: 1796.5699433878374
+  tps: 1299.2452265302013
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 1808.7566004472694
-  tps: 1307.7933896786017
+  dps: 1796.9321296020328
+  tps: 1299.5023787422801
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1816.6666636740138
-  tps: 1313.40953456959
+  dps: 1813.8151205417357
+  tps: 1311.489302309469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2005.087165014997
-  tps: 1447.1880905216879
+  dps: 2001.6446975465958
+  tps: 1444.8483019829189
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 1826.0089035493409
-  tps: 1320.0899248810724
+  dps: 1826.193295740642
+  tps: 1320.1598049889078
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1816.6666636740138
-  tps: 1313.40953456959
+  dps: 1813.8151205417357
+  tps: 1311.489302309469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LivingRootoftheWildheart-30664"
  value: {
-  dps: 1836.6975795382145
-  tps: 1327.6314848331726
+  dps: 1834.6243346945216
+  tps: 1326.2638443579474
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1830.9123468688754
-  tps: 1323.5595196379413
+  dps: 1836.3821660027934
+  tps: 1327.5497833493216
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MalorneHarness"
  value: {
-  dps: 1624.1885589689318
-  tps: 1175.849672254839
+  dps: 1634.8388826471223
+  tps: 1183.308601502641
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MalorneRegalia"
  value: {
-  dps: 1357.067467230164
-  tps: 986.003905094457
+  dps: 1349.4654311107147
+  tps: 980.3591378190067
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1338.5215444534895
-  tps: 972.6901499230183
+  dps: 1343.6042175705527
+  tps: 976.2296447063036
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1861.4713411439975
-  tps: 1345.833252088208
+  dps: 1866.4439576366653
+  tps: 1349.2054584943444
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NordrassilHarness"
  value: {
-  dps: 1613.9976249671768
-  tps: 1168.3650670877357
+  dps: 1621.6113845005289
+  tps: 1173.5541736914215
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NordrassilRegalia"
  value: {
-  dps: 1371.6128009718975
-  tps: 996.3429420510877
+  dps: 1360.3336480993826
+  tps: 988.0127903495311
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1816.6666636740138
-  tps: 1313.40953456959
+  dps: 1813.8151205417357
+  tps: 1311.489302309469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PrimalIntent"
  value: {
-  dps: 1745.321602106315
-  tps: 1262.3150663962329
+  dps: 1738.6022526925742
+  tps: 1257.367602772768
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1816.6666636740138
-  tps: 1313.40953456959
+  dps: 1813.8151205417357
+  tps: 1311.489302309469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1993.3362521599497
-  tps: 1438.8449423946038
+  dps: 1992.1867394193225
+  tps: 1438.1331517125557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 2015.3948101097903
-  tps: 1454.506518538991
+  dps: 2014.4579245558639
+  tps: 1453.9456931594998
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1816.6666636740138
-  tps: 1313.40953456959
+  dps: 1813.8151205417357
+  tps: 1311.489302309469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1816.6666636740138
-  tps: 1313.40953456959
+  dps: 1813.8151205417357
+  tps: 1311.489302309469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 1826.5972625344602
-  tps: 1320.4839597605064
+  dps: 1825.9548267068064
+  tps: 1319.9855403720271
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1816.6666636740138
-  tps: 1313.40953456959
+  dps: 1813.8151205417357
+  tps: 1311.489302309469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1816.6666636740138
-  tps: 1313.40953456959
+  dps: 1813.8151205417357
+  tps: 1311.489302309469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 1887.033251064516
-  tps: 1364.0499131464303
+  dps: 1894.8103100355377
+  tps: 1369.5401103741328
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1572.3584497326326
-  tps: 1138.8842026712096
+  dps: 1595.3032770991128
+  tps: 1155.213308407594
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1559.3193202127645
-  tps: 1130.2189207121028
+  dps: 1552.8347370097795
+  tps: 1125.6385666379833
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheTwinStars"
  value: {
-  dps: 1799.623495904095
-  tps: 1301.4536993609695
+  dps: 1810.4850328158439
+  tps: 1309.1269181121893
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartHarness"
  value: {
-  dps: 1746.332640419951
-  tps: 1262.7495280592057
+  dps: 1655.1366345277086
+  tps: 1197.5929139452708
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartRegalia"
  value: {
-  dps: 1303.071998246301
-  tps: 948.1766721159141
+  dps: 1283.353153772516
+  tps: 933.7148261088327
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1883.1417383545472
-  tps: 1361.8302196125226
+  dps: 1884.7374654335704
+  tps: 1362.901346642653
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1894.2313788525105
-  tps: 1369.9128410620522
+  dps: 1891.6017646122014
+  tps: 1367.8694678243648
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WastewalkerArmor"
  value: {
-  dps: 1471.848420139227
-  tps: 1067.1428816598914
+  dps: 1492.406845774563
+  tps: 1081.6895905120662
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WindhawkArmor"
  value: {
-  dps: 1687.8115001822848
-  tps: 1221.9065684904617
+  dps: 1664.0329500960877
+  tps: 1204.9036644115495
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofSpellfire"
  value: {
-  dps: 1626.6940666049222
-  tps: 1178.1734906505342
+  dps: 1620.0054293710323
+  tps: 1173.3318327438742
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 1849.2632357101695
-  tps: 1336.3825590374686
+  dps: 1849.2448972085074
+  tps: 1336.3185024447555
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1851.768545816612
-  tps: 1786.2797347505966
+  dps: 1848.8945136369337
+  tps: 1786.3264391789576
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1851.768545816612
-  tps: 1338.3318708908353
+  dps: 1848.8945136369337
+  tps: 1336.39567140706
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2085.7275823293426
-  tps: 1513.7698736904922
+  dps: 2064.7503917885306
+  tps: 1495.5625642533137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 767.4780911003065
-  tps: 545.4561446812178
+  dps: 767.450573526539
+  tps: 545.4366072038426
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 767.4780911003065
-  tps: 545.4561446812178
+  dps: 767.450573526539
+  tps: 545.4366072038426
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 951.4019591319604
-  tps: 677.0573909836919
+  dps: 959.9015664339979
+  tps: 683.0921121681386
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1691.8551660725225
-  tps: 1225.311244782637
+  dps: 1710.3105014394182
+  tps: 1238.446494335247
  }
 }

--- a/sim/druid/feral/presets.go
+++ b/sim/druid/feral/presets.go
@@ -69,7 +69,6 @@ var FullConsumes = &proto.Consumes{
 	GuardianElixir:  proto.GuardianElixir_ElixirOfMajorMageblood,
 	Food:            proto.Food_FoodGrilledMudfish,
 	DefaultPotion:   proto.Potions_HastePotion,
-	MainHandImbue:   proto.WeaponImbue_WeaponImbueAdamantiteWeightstone,
 	DefaultConjured: proto.Conjured_ConjuredDarkRune,
 }
 

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -21,7 +21,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 3726.6856000000007
   final_stats: 57
-  final_stats: 2124.3711576
+  final_stats: 2110.3711576
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -52,597 +52,597 @@ character_stats_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 651.2333921296133
-  tps: 894.1912243404183
+  dps: 630.6484252443564
+  tps: 869.4254575610039
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 601.2664450494447
-  tps: 825.4383746006054
+  dps: 604.6469675483042
+  tps: 829.049832309978
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 691.8327903729844
-  tps: 950.2229947826621
+  dps: 671.1250439161001
+  tps: 921.369171489507
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 618.4885000274082
-  tps: 849.0018430560607
+  dps: 597.4828058065937
+  tps: 823.6360599339403
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 601.2664450494447
-  tps: 809.1190237752595
+  dps: 604.6469675483042
+  tps: 812.6602523304449
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 645.2623574957533
-  tps: 887.149672750587
+  dps: 636.9862113890229
+  tps: 878.8921290932115
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 633.0310562920852
-  tps: 868.9378555602731
+  dps: 613.2019362717232
+  tps: 848.6302349026384
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 651.8776450946633
-  tps: 897.2071732586967
+  dps: 631.0974651518338
+  tps: 866.2814499757126
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 673.4115156395571
-  tps: 925.3043012269867
+  dps: 664.7973885555676
+  tps: 916.40253604798
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 677.1725184434521
-  tps: 934.5496973030783
+  dps: 668.9897427081281
+  tps: 920.754970316267
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 668.6052394086631
-  tps: 923.048797421931
+  dps: 656.3287549308209
+  tps: 906.5059616074535
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 636.2038268245391
-  tps: 878.5033677373369
+  dps: 621.7282806659534
+  tps: 856.5252568795291
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 634.4098360196803
-  tps: 876.0384850487453
+  dps: 629.4532360929519
+  tps: 869.5902564312925
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 636.1196821780234
-  tps: 874.0488236830719
+  dps: 617.2807518153421
+  tps: 845.9114699911634
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 616.2889750008501
-  tps: 849.7471797621698
+  dps: 608.5159236718155
+  tps: 840.3308105214574
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 601.2664450494447
-  tps: 825.4383746006054
+  dps: 604.6469675483042
+  tps: 829.049832309978
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 601.2664450494447
-  tps: 825.4383746006054
+  dps: 604.6469675483042
+  tps: 829.049832309978
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 618.4885000274082
-  tps: 849.0018430560607
+  dps: 597.4828058065937
+  tps: 823.6360599339403
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 620.3088323241465
-  tps: 850.4287023354067
+  dps: 600.6018888854044
+  tps: 823.9566729747487
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 601.2664450494447
-  tps: 825.4383746006054
+  dps: 604.6469675483042
+  tps: 829.049832309978
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 661.1282577865373
-  tps: 907.5701393759948
+  dps: 653.8448140294811
+  tps: 902.3379708684326
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 649.6307681193945
-  tps: 898.5239946088952
+  dps: 627.5021791218063
+  tps: 868.4196272124902
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 645.1428744253301
-  tps: 889.9919099610636
+  dps: 629.1416493267318
+  tps: 862.982648926034
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 601.2664450494447
-  tps: 825.4383746006054
+  dps: 604.6469675483042
+  tps: 829.049832309978
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 601.2664450494447
-  tps: 825.4383746006054
+  dps: 604.6469675483042
+  tps: 829.049832309978
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 670.1684380472229
-  tps: 921.0068376473388
+  dps: 655.1137869847147
+  tps: 898.4578777493649
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 636.1196821780234
-  tps: 874.0488236830719
+  dps: 617.2807518153421
+  tps: 845.9114699911634
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdolofTerror-33509"
  value: {
-  dps: 627.7656092956762
-  tps: 855.936631974907
+  dps: 629.5159560241759
+  tps: 864.7960368638769
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 634.1218084807404
-  tps: 871.3996431604746
+  dps: 615.5555749284694
+  tps: 843.6238854391701
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 647.5532066772413
-  tps: 889.109466990715
+  dps: 624.9101108012608
+  tps: 861.6841932878866
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 636.1196821780234
-  tps: 874.0488236830719
+  dps: 617.2807518153421
+  tps: 845.9114699911634
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 618.4885000274082
-  tps: 849.0018430560607
+  dps: 597.4828058065937
+  tps: 823.6360599339403
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 620.3088323241465
-  tps: 850.4287023354067
+  dps: 600.6018888854044
+  tps: 823.9566729747487
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 711.0404725743442
-  tps: 985.7230308033079
+  dps: 707.4788879561463
+  tps: 977.3834931772539
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 626.0685819714885
-  tps: 864.5326045564804
+  dps: 621.2647941964753
+  tps: 856.5374985562288
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 601.2664450494447
-  tps: 825.4383746006054
+  dps: 604.6469675483042
+  tps: 829.049832309978
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 610.5873050239283
-  tps: 841.905402028822
+  dps: 613.0874460581691
+  tps: 842.0057072239039
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 636.1196821780234
-  tps: 874.0488236830719
+  dps: 617.2807518153421
+  tps: 845.9114699911634
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LivingRootoftheWildheart-30664"
  value: {
-  dps: 636.1196821780234
-  tps: 874.0488236830719
+  dps: 617.2807518153421
+  tps: 845.9114699911634
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 636.1196821780234
-  tps: 874.0488236830719
+  dps: 617.2807518153421
+  tps: 845.9114699911634
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MalorneHarness"
  value: {
-  dps: 590.7896305688721
-  tps: 799.251937833318
+  dps: 576.6233810009462
+  tps: 778.0068671604752
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MalorneRegalia"
  value: {
-  dps: 478.0864545460289
-  tps: 648.6126684618339
+  dps: 467.40350177759757
+  tps: 633.8455226538097
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 480.49911621389657
-  tps: 649.2729445572081
+  dps: 459.90601741119826
+  tps: 630.3730886811185
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 653.4040231906031
-  tps: 905.2557434527755
+  dps: 654.5692617890243
+  tps: 904.9580550129218
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NordrassilHarness"
  value: {
-  dps: 635.3426176180892
-  tps: 835.9877937956801
+  dps: 610.8079138781329
+  tps: 804.399830042931
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NordrassilRegalia"
  value: {
-  dps: 481.77803742504966
-  tps: 655.8616491386489
+  dps: 471.68218903173135
+  tps: 642.3256010460038
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 636.1196821780234
-  tps: 874.0488236830719
+  dps: 617.2807518153421
+  tps: 845.9114699911634
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 623.68123490762
-  tps: 855.5866845932247
+  dps: 608.4303221260973
+  tps: 840.6932373335527
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 610.5873050239283
-  tps: 841.905402028822
+  dps: 613.0874460581691
+  tps: 842.0057072239039
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 601.2664450494447
-  tps: 825.4383746006054
+  dps: 604.6469675483042
+  tps: 829.049832309978
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 601.2664450494447
-  tps: 825.4383746006054
+  dps: 604.6469675483042
+  tps: 829.049832309978
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PrimalIntent"
  value: {
-  dps: 637.7615568238134
-  tps: 875.3906251849843
+  dps: 630.5141992235101
+  tps: 866.7468134111111
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 636.1196821780234
-  tps: 874.0488236830719
+  dps: 617.2807518153421
+  tps: 845.9114699911634
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 740.0646360537604
-  tps: 1017.9056472024986
+  dps: 733.2093664615645
+  tps: 1004.5434930679033
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 754.8202608208128
-  tps: 1037.47160564361
+  dps: 747.8575319097679
+  tps: 1023.9669604522214
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 620.2133172737697
-  tps: 854.579419645473
+  dps: 621.3612905944027
+  tps: 858.2785749012119
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 601.2664450494447
-  tps: 825.4383746006054
+  dps: 604.6469675483042
+  tps: 829.049832309978
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 636.1196821780234
-  tps: 874.0488236830719
+  dps: 617.2807518153421
+  tps: 845.9114699911634
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 636.1196821780234
-  tps: 874.0488236830719
+  dps: 617.2807518153421
+  tps: 845.9114699911634
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 622.354098356253
-  tps: 855.9136183504112
+  dps: 613.8359261268428
+  tps: 846.35412868807
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 636.1196821780234
-  tps: 874.0488236830719
+  dps: 617.2807518153421
+  tps: 845.9114699911634
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 636.1196821780234
-  tps: 874.0488236830719
+  dps: 617.2807518153421
+  tps: 845.9114699911634
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 641.081933401408
-  tps: 886.0893372743809
+  dps: 624.7954577731714
+  tps: 862.8632180260505
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 561.1596161153776
-  tps: 772.7535681438333
+  dps: 534.5442074932973
+  tps: 742.7362624465189
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 546.5347818949872
-  tps: 761.8295121587342
+  dps: 524.5101560617201
+  tps: 724.5606984202115
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 610.5873050239283
-  tps: 841.905402028822
+  dps: 613.0874460581691
+  tps: 842.0057072239039
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 623.68123490762
-  tps: 855.5866845932247
+  dps: 608.4303221260973
+  tps: 840.6932373335527
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 614.8264212087158
-  tps: 848.6568649881394
+  dps: 596.2506930853738
+  tps: 824.2036221555782
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TheTwinStars"
  value: {
-  dps: 600.0201753560448
-  tps: 828.7370642164042
+  dps: 587.2085991927227
+  tps: 809.2842344360741
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartHarness"
  value: {
-  dps: 659.2541884680547
-  tps: 931.2843478051321
+  dps: 651.2215060782862
+  tps: 907.001744929497
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartRegalia"
  value: {
-  dps: 470.0515959122482
-  tps: 636.5919506763909
+  dps: 463.06553160317225
+  tps: 628.392296630897
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 606.8737829709515
-  tps: 838.5588977345776
+  dps: 604.0701355153051
+  tps: 835.2678605887879
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 674.7949430385796
-  tps: 927.6736774608295
+  dps: 662.9090957330905
+  tps: 911.4823069983329
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 674.3946195119299
-  tps: 929.97034207393
+  dps: 666.9620084885445
+  tps: 919.6826309703201
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 601.2664450494447
-  tps: 825.4383746006054
+  dps: 604.6469675483042
+  tps: 829.049832309978
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 601.2664450494447
-  tps: 825.4383746006054
+  dps: 604.6469675483042
+  tps: 829.049832309978
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 601.2664450494447
-  tps: 825.4383746006054
+  dps: 604.6469675483042
+  tps: 829.049832309978
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 601.2664450494447
-  tps: 825.4383746006054
+  dps: 604.6469675483042
+  tps: 829.049832309978
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WastewalkerArmor"
  value: {
-  dps: 549.6667712070455
-  tps: 741.7095482809966
+  dps: 544.0038111541395
+  tps: 742.049371582036
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WindhawkArmor"
  value: {
-  dps: 569.6493431832127
-  tps: 785.5174881745623
+  dps: 557.9539950843391
+  tps: 774.1982754846365
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WrathofSpellfire"
  value: {
-  dps: 559.9065218621487
-  tps: 761.3668595795934
+  dps: 561.8650930913943
+  tps: 760.5232360497495
  }
 }
 dps_results: {
  key: "TestFeralTank-Average-Default"
  value: {
-  dps: 734.5739335617259
-  tps: 1038.3387810996471
-  dtps: 722.5144716967287
+  dps: 725.9898342182664
+  tps: 1025.3473603914624
+  dtps: 722.5332063268546
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 936.2197464626609
-  tps: 1717.8861944744924
+  dps: 893.4137262627506
+  tps: 1648.9673450960963
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 714.9671177652037
-  tps: 986.0499385760277
+  dps: 708.2960167168168
+  tps: 977.0320710285672
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 825.6209406580031
-  tps: 1154.6307502247575
+  dps: 810.8579153584766
+  tps: 1132.9565427010457
  }
 }
 dps_results: {
@@ -669,8 +669,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 838.0201539176265
-  tps: 1177.607121985425
+  dps: 827.992305138618
+  tps: 1158.823822639032
   dtps: 677.4824203840016
  }
 }

--- a/sim/druid/tank/presets.go
+++ b/sim/druid/tank/presets.go
@@ -64,7 +64,6 @@ var FullConsumes = &proto.Consumes{
 	BattleElixir:    proto.BattleElixir_ElixirOfMajorAgility,
 	Food:            proto.Food_FoodGrilledMudfish,
 	DefaultPotion:   proto.Potions_HastePotion,
-	MainHandImbue:   proto.WeaponImbue_WeaponImbueAdamantiteWeightstone,
 	DefaultConjured: proto.Conjured_ConjuredDarkRune,
 }
 

--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -102,7 +102,7 @@ dps_results: {
  key: "TestHunter-AllItems-BlackBowoftheBetrayer-32336"
  value: {
   dps: 4927.073805368419
-  tps: 4181.9159606368075
+  tps: 4181.915960636808
  }
 }
 dps_results: {
@@ -137,27 +137,27 @@ dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
   dps: 5231.675613427372
-  tps: 4485.195638053547
+  tps: 4485.195638053546
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Death-42990"
  value: {
   dps: 5269.3403355440405
-  tps: 4520.847787386081
+  tps: 4520.84778738608
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 5220.816578835593
+  dps: 5220.816578835594
   tps: 4475.588706092871
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 5220.816578835593
+  dps: 5220.816578835594
   tps: 4475.588706092871
  }
 }
@@ -172,7 +172,7 @@ dps_results: {
  key: "TestHunter-AllItems-Defender'sCode-40257"
  value: {
   dps: 5129.776122300924
-  tps: 4380.135088746966
+  tps: 4380.135088746965
  }
 }
 dps_results: {
@@ -186,7 +186,7 @@ dps_results: {
  key: "TestHunter-AllItems-DesolationBattlegear"
  value: {
   dps: 4083.8666736816713
-  tps: 3443.7988008501284
+  tps: 3443.7988008501293
  }
 }
 dps_results: {
@@ -206,7 +206,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5225.7743559049195
+  dps: 5225.77435590492
   tps: 4469.814906681099
  }
 }
@@ -221,7 +221,7 @@ dps_results: {
  key: "TestHunter-AllItems-EnigmaticStarflareDiamond"
  value: {
   dps: 5221.8884297259765
-  tps: 4463.988046889231
+  tps: 4463.98804688923
  }
 }
 dps_results: {
@@ -241,7 +241,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5221.660613759027
+  dps: 5221.660613759026
   tps: 4473.094907118765
  }
 }
@@ -277,7 +277,7 @@ dps_results: {
  key: "TestHunter-AllItems-FuturesightRune-38763"
  value: {
   dps: 5129.776122300924
-  tps: 4380.135088746966
+  tps: 4380.135088746965
  }
 }
 dps_results: {
@@ -312,7 +312,7 @@ dps_results: {
  key: "TestHunter-AllItems-ImpassiveStarflareDiamond"
  value: {
   dps: 5221.8884297259765
-  tps: 4463.988046889231
+  tps: 4463.98804688923
  }
 }
 dps_results: {
@@ -347,7 +347,7 @@ dps_results: {
  key: "TestHunter-AllItems-Lavanthor'sTalisman-37872"
  value: {
   dps: 5129.776122300924
-  tps: 4380.135088746966
+  tps: 4380.135088746965
  }
 }
 dps_results: {
@@ -360,7 +360,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 3883.165817272244
+  dps: 3883.1658172722446
   tps: 3279.4254656260396
  }
 }
@@ -388,8 +388,8 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5131.411101979388
-  tps: 4380.2736242714
+  dps: 5131.411101979387
+  tps: 4380.273624271399
  }
 }
 dps_results: {
@@ -424,7 +424,7 @@ dps_results: {
  key: "TestHunter-AllItems-PrimalIntent"
  value: {
   dps: 4848.948201165079
-  tps: 4138.323537773205
+  tps: 4138.323537773204
  }
 }
 dps_results: {
@@ -465,7 +465,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-RiftStalkerArmor"
  value: {
-  dps: 4309.82077952812
+  dps: 4309.8207795281205
   tps: 3648.304050647154
  }
 }
@@ -473,7 +473,7 @@ dps_results: {
  key: "TestHunter-AllItems-RuneofRepulsion-40372"
  value: {
   dps: 5129.776122300924
-  tps: 4380.135088746966
+  tps: 4380.135088746965
  }
 }
 dps_results: {
@@ -487,7 +487,7 @@ dps_results: {
  key: "TestHunter-AllItems-SealofthePantheon-36993"
  value: {
   dps: 5129.776122300924
-  tps: 4380.135088746966
+  tps: 4380.135088746965
  }
 }
 dps_results: {
@@ -507,15 +507,15 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5119.722075629108
-  tps: 4363.5729017707945
+  dps: 5119.722075629107
+  tps: 4363.572901770794
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SparkofLife-37657"
  value: {
-  dps: 5240.31338509742
-  tps: 4485.083722983987
+  dps: 5240.313385097419
+  tps: 4485.083722983985
  }
 }
 dps_results: {
@@ -549,7 +549,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5234.97991326051
+  dps: 5234.979913260511
   tps: 4478.751957092757
  }
 }
@@ -633,7 +633,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 4858.973548961637
+  dps: 4858.973548961638
   tps: 4169.979392318319
  }
 }
@@ -648,7 +648,7 @@ dps_results: {
  key: "TestHunter-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
   dps: 5791.775348727544
-  tps: 5043.782200631913
+  tps: 5043.782200631914
  }
 }
 dps_results: {
@@ -669,7 +669,7 @@ dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-AOE-FullBuffs-LongMultiTarget"
  value: {
   dps: 14689.508870707601
-  tps: 14765.511563114673
+  tps: 14765.511563114671
  }
 }
 dps_results: {
@@ -683,13 +683,13 @@ dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-AOE-FullBuffs-ShortSingleTarget"
  value: {
   dps: 6163.398936182473
-  tps: 5319.6678520615005
+  tps: 5319.6678520615
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10317.374391897849
+  dps: 10317.374391897853
   tps: 11036.505021438717
  }
 }
@@ -752,22 +752,22 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5105.4453030209115
-  tps: 5557.291000519428
+  dps: 5105.445303020911
+  tps: 5557.291000519427
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5105.4453030209115
+  dps: 5105.445303020911
   tps: 4392.206044052767
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6278.595172777209
-  tps: 5418.544347529072
+  dps: 6278.595172777208
+  tps: 5418.544347529071
  }
 }
 dps_results: {
@@ -809,7 +809,7 @@ dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-ShortSingleTarget"
  value: {
   dps: 6080.797709650876
-  tps: 5241.002825690454
+  tps: 5241.002825690453
  }
 }
 dps_results: {
@@ -836,14 +836,14 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14782.648013918675
-  tps: 14811.394262233318
+  dps: 14782.64801391867
+  tps: 14811.394262233312
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5364.548295805753
+  dps: 5364.548295805752
   tps: 4608.345910500354
  }
 }
@@ -907,14 +907,14 @@ dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-NoBuffs-LongSingleTarget"
  value: {
   dps: 2917.81986535385
-  tps: 2151.866244476306
+  tps: 2151.8662444763054
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-NoBuffs-ShortSingleTarget"
  value: {
   dps: 3491.426879392675
-  tps: 2567.4953946486253
+  tps: 2567.495394648625
  }
 }
 dps_results: {
@@ -955,7 +955,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3989.4882965736238
+  dps: 3989.488296573624
   tps: 3588.1607063192387
  }
 }

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -74,56 +74,56 @@ dps_results: {
  key: "TestArcane-AllItems-BracingEarthsiegeDiamond"
  value: {
   dps: 6345.307285592661
-  tps: 3823.9165991346904
+  tps: 3823.9165991346918
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 6262.637736204144
+  dps: 6262.637736204146
   tps: 3852.450711053995
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6487.594850607997
+  dps: 6487.594850607998
   tps: 3985.432825571004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6272.160133765569
-  tps: 3856.1719954655478
+  dps: 6272.160133765572
+  tps: 3856.171995465548
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6347.430058579503
-  tps: 3922.960369596719
+  dps: 6347.430058579504
+  tps: 3922.96036959672
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6167.881977469027
-  tps: 3784.5254403668064
+  dps: 6167.881977469029
+  tps: 3784.525440366807
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6167.881977469027
-  tps: 3784.5254403668064
+  dps: 6167.881977469029
+  tps: 3784.525440366807
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6213.240191577108
-  tps: 3813.3519010998884
+  dps: 6213.240191577109
+  tps: 3813.351901099889
  }
 }
 dps_results: {
@@ -137,7 +137,7 @@ dps_results: {
  key: "TestArcane-AllItems-Defender'sCode-40257"
  value: {
   dps: 6213.184672128053
-  tps: 3821.9857490623835
+  tps: 3821.9857490623845
  }
 }
 dps_results: {
@@ -171,7 +171,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6326.944012160122
+  dps: 6326.944012160123
   tps: 3889.042322502278
  }
 }
@@ -186,21 +186,21 @@ dps_results: {
  key: "TestArcane-AllItems-ExtractofNecromanticPower-40373"
  value: {
   dps: 6267.815229833923
-  tps: 3853.5650531065594
+  tps: 3853.5650531065608
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeoftheBroodmother-45308"
  value: {
   dps: 6445.914371945645
-  tps: 3960.4245383735915
+  tps: 3960.424538373592
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6404.93596916376
-  tps: 3935.837496704462
+  dps: 6404.935969163761
+  tps: 3935.837496704463
  }
 }
 dps_results: {
@@ -235,7 +235,7 @@ dps_results: {
  key: "TestArcane-AllItems-FuturesightRune-38763"
  value: {
   dps: 6354.6316186197555
-  tps: 3904.8649744739123
+  tps: 3904.864974473913
  }
 }
 dps_results: {
@@ -248,7 +248,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6326.944012160122
+  dps: 6326.944012160123
   tps: 3889.042322502278
  }
 }
@@ -256,14 +256,14 @@ dps_results: {
  key: "TestArcane-AllItems-IncisorFragment-37723"
  value: {
   dps: 6213.184672128053
-  tps: 3821.9857490623835
+  tps: 3821.9857490623845
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InfusedColdstoneRune-35935"
  value: {
   dps: 6294.717108132512
-  tps: 3870.9052106650597
+  tps: 3870.9052106650606
  }
 }
 dps_results: {
@@ -298,14 +298,14 @@ dps_results: {
  key: "TestArcane-AllItems-Lavanthor'sTalisman-37872"
  value: {
   dps: 6213.184672128053
-  tps: 3821.9857490623835
+  tps: 3821.9857490623845
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6305.949069013
-  tps: 3874.8557186411153
+  dps: 6305.949069013001
+  tps: 3874.8557186411163
  }
 }
 dps_results: {
@@ -325,8 +325,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6216.4797287028105
-  tps: 3823.9664812939036
+  dps: 6216.479728702811
+  tps: 3823.9664812939054
  }
 }
 dps_results: {
@@ -367,8 +367,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6621.378009651297
-  tps: 4142.1434922960125
+  dps: 6621.378009651298
+  tps: 4142.143492296013
  }
 }
 dps_results: {
@@ -382,7 +382,7 @@ dps_results: {
  key: "TestArcane-AllItems-RelentlessEarthsiegeDiamond"
  value: {
   dps: 6463.339946492252
-  tps: 3970.8798831015565
+  tps: 3970.879883101557
  }
 }
 dps_results: {
@@ -396,21 +396,21 @@ dps_results: {
  key: "TestArcane-AllItems-RuneofRepulsion-40372"
  value: {
   dps: 6213.184672128053
-  tps: 3821.9857490623835
+  tps: 3821.9857490623845
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SealofthePantheon-36993"
  value: {
   dps: 6213.184672128053
-  tps: 3821.9857490623835
+  tps: 3821.9857490623845
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 6258.314940735584
-  tps: 3847.8648796475563
+  dps: 6258.314940735585
+  tps: 3847.864879647558
  }
 }
 dps_results: {
@@ -431,7 +431,7 @@ dps_results: {
  key: "TestArcane-AllItems-SparkofLife-37657"
  value: {
   dps: 6375.695058220138
-  tps: 3918.9810668703017
+  tps: 3918.981066870303
  }
 }
 dps_results: {
@@ -472,8 +472,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-TheTwinStars"
  value: {
-  dps: 6124.150869057885
-  tps: 3765.896667634326
+  dps: 6124.150869057886
+  tps: 3765.896667634327
  }
 }
 dps_results: {
@@ -486,15 +486,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6419.594667570338
-  tps: 3946.497998381915
+  dps: 6419.594667570339
+  tps: 3946.4979983819153
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6419.594667570338
-  tps: 3946.497998381915
+  dps: 6419.594667570339
+  tps: 3946.4979983819153
  }
 }
 dps_results: {
@@ -528,7 +528,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-WrathofSpellfire"
  value: {
-  dps: 5719.978017684619
+  dps: 5719.97801768462
   tps: 3522.541548673196
  }
 }
@@ -542,7 +542,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10587.176744466504
+  dps: 10587.176744466506
   tps: 8605.50951349203
  }
 }
@@ -556,15 +556,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2063.620075219359
-  tps: 1382.9521515343915
+  dps: 2063.6200752193595
+  tps: 1382.9521515343918
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-LongMultiTarget"
  value: {
   dps: 5921.569599439032
-  tps: 5242.416691569398
+  tps: 5242.416691569399
  }
 }
 dps_results: {
@@ -584,14 +584,14 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6487.594850607997
+  dps: 6487.594850607998
   tps: 5750.075214488913
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6487.594850607997
+  dps: 6487.594850607998
   tps: 3985.432825571004
  }
 }
@@ -599,20 +599,20 @@ dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-ShortSingleTarget"
  value: {
   dps: 8425.850154710923
-  tps: 5158.679206821355
+  tps: 5158.679206821356
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3033.190919858424
-  tps: 3105.626798116537
+  dps: 3033.1909198584244
+  tps: 3105.6267981165374
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3033.190919858424
+  dps: 3033.1909198584244
   tps: 1884.2001642251294
  }
 }
@@ -626,7 +626,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6487.594850607997
+  dps: 6487.594850607998
   tps: 3985.432825571004
  }
 }

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -60,7 +60,7 @@ dps_results: {
  key: "TestFire-AllItems-Bandit'sInsignia-40371"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
@@ -80,7 +80,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 5600.923481148909
+  dps: 5600.92348114891
   tps: 4136.3241982581585
  }
 }
@@ -88,14 +88,14 @@ dps_results: {
  key: "TestFire-AllItems-ChaoticSkyflareDiamond"
  value: {
   dps: 5826.97766371634
-  tps: 4305.2203397069
+  tps: 4305.220339706901
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
   dps: 5701.083391043068
-  tps: 4187.825933906026
+  tps: 4187.825933906027
  }
 }
 dps_results: {
@@ -122,8 +122,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 5672.073437271773
-  tps: 4156.716762951544
+  dps: 5672.073437271774
+  tps: 4156.716762951545
  }
 }
 dps_results: {
@@ -137,7 +137,7 @@ dps_results: {
  key: "TestFire-AllItems-Defender'sCode-40257"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
@@ -185,15 +185,15 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5667.478338309164
-  tps: 4187.570747883181
+  dps: 5667.478338309165
+  tps: 4187.570747883182
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeoftheBroodmother-45308"
  value: {
   dps: 5888.96137807099
-  tps: 4322.785233684812
+  tps: 4322.785233684813
  }
 }
 dps_results: {
@@ -228,14 +228,14 @@ dps_results: {
  key: "TestFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuturesightRune-38763"
  value: {
   dps: 5691.298304786616
-  tps: 4198.863370410997
+  tps: 4198.863370410998
  }
 }
 dps_results: {
@@ -256,7 +256,7 @@ dps_results: {
  key: "TestFire-AllItems-IncisorFragment-37723"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
@@ -290,7 +290,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-KirinTorGarb"
  value: {
-  dps: 5368.955064531987
+  dps: 5368.955064531986
   tps: 4029.106096959583
  }
 }
@@ -298,7 +298,7 @@ dps_results: {
  key: "TestFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
@@ -318,15 +318,15 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5610.225685998534
-  tps: 4130.39068257808
+  dps: 5610.2256859985355
+  tps: 4130.3906825780805
  }
 }
 dps_results: {
  key: "TestFire-AllItems-OfferingofSacrifice-37638"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
@@ -361,7 +361,7 @@ dps_results: {
  key: "TestFire-AllItems-PurifiedShardoftheGods"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
@@ -374,14 +374,14 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 5981.20006296626
+  dps: 5981.200062966261
   tps: 4442.960555610569
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5812.028650513724
+  dps: 5812.028650513725
   tps: 4295.204742793979
  }
 }
@@ -396,35 +396,35 @@ dps_results: {
  key: "TestFire-AllItems-RuneofRepulsion-40372"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SealofthePantheon-36993"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Serrah'sStar-37559"
  value: {
   dps: 5655.927197720664
-  tps: 4162.998387845535
+  tps: 4162.998387845537
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShinyShardoftheGods"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
@@ -437,7 +437,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 5002.145110510676
+  dps: 5002.145110510675
   tps: 3752.3600546355715
  }
 }
@@ -486,14 +486,14 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5766.338208426632
+  dps: 5766.338208426633
   tps: 4250.811287618575
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5766.338208426632
+  dps: 5766.338208426633
   tps: 4250.811287618575
  }
 }
@@ -528,7 +528,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-WrathofSpellfire"
  value: {
-  dps: 5009.80147543582
+  dps: 5009.801475435821
   tps: 3741.2966277216765
  }
 }
@@ -536,7 +536,7 @@ dps_results: {
  key: "TestFire-Average-Default"
  value: {
   dps: 5864.452801386802
-  tps: 4327.39215289721
+  tps: 4327.3921528972105
  }
 }
 dps_results: {
@@ -556,7 +556,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1939.9261744669882
+  dps: 1939.926174466988
   tps: 1583.9321857828847
  }
 }
@@ -592,14 +592,14 @@ dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongSingleTarget"
  value: {
   dps: 5826.97766371634
-  tps: 4305.2203397069
+  tps: 4305.220339706901
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7079.0045846545545
-  tps: 5200.125470607173
+  tps: 5200.125470607175
  }
 }
 dps_results: {
@@ -612,7 +612,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2626.2512904215178
+  dps: 2626.251290421518
   tps: 2028.3735983291074
  }
 }
@@ -627,6 +627,6 @@ dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
   dps: 5826.97766371634
-  tps: 4305.2203397069
+  tps: 4305.220339706901
  }
 }

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -66,7 +66,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 4853.5591523598005
+  dps: 4853.559152359801
   tps: 4194.018502922067
  }
 }
@@ -80,7 +80,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 4742.220106402009
+  dps: 4742.22010640201
   tps: 4102.5400198631005
  }
 }
@@ -192,7 +192,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 4965.787607368109
+  dps: 4965.78760736811
   tps: 4297.01299704247
  }
 }
@@ -200,7 +200,7 @@ dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
   dps: 4895.010344916379
-  tps: 4235.274912777698
+  tps: 4235.274912777699
  }
 }
 dps_results: {
@@ -220,7 +220,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-FrostfireGarb"
  value: {
-  dps: 4176.9506318806225
+  dps: 4176.950631880622
   tps: 3618.0954372630667
  }
 }
@@ -234,8 +234,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 4784.682340668028
-  tps: 4134.9282389989985
+  dps: 4784.682340668029
+  tps: 4134.928238999
  }
 }
 dps_results: {
@@ -269,7 +269,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 4828.160405002485
+  dps: 4828.160405002486
   tps: 4176.354794816964
  }
 }
@@ -290,7 +290,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-KirinTorGarb"
  value: {
-  dps: 4629.745030603914
+  dps: 4629.7450306039145
   tps: 4013.961376992234
  }
 }
@@ -305,14 +305,14 @@ dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
   dps: 4690.022840884916
-  tps: 4047.854225634973
+  tps: 4047.8542256349733
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Mana-EtchedRegalia"
  value: {
   dps: 3694.1989025303496
-  tps: 3191.883549700605
+  tps: 3191.8835497006053
  }
 }
 dps_results: {
@@ -375,14 +375,14 @@ dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
   dps: 5036.82429432388
-  tps: 4373.968985923484
+  tps: 4373.968985923485
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
   dps: 4949.261679703826
-  tps: 4280.152810627829
+  tps: 4280.15281062783
  }
 }
 dps_results: {
@@ -473,7 +473,7 @@ dps_results: {
  key: "TestFrost-AllItems-TheTwinStars"
  value: {
   dps: 4707.777105723877
-  tps: 4073.2303846597547
+  tps: 4073.2303846597556
  }
 }
 dps_results: {
@@ -528,14 +528,14 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-WrathofSpellfire"
  value: {
-  dps: 4531.423465296236
+  dps: 4531.423465296235
   tps: 3927.4989540454103
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 4928.086854457934
+  dps: 4928.086854457936
   tps: 4269.413924357902
  }
 }
@@ -598,15 +598,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6177.231178229034
-  tps: 5213.4446900475
+  dps: 6177.231178229035
+  tps: 5213.444690047501
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongMultiTarget"
  value: {
   dps: 3019.516846715552
-  tps: 3342.7846137162924
+  tps: 3342.7846137162933
  }
 }
 dps_results: {

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -430,8 +430,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-LightswornBattlegear"
  value: {
-  dps: 151.41947227733047
-  tps: 151.41947227733047
+  dps: 151.4194722773305
+  tps: 151.4194722773305
  }
 }
 dps_results: {

--- a/sim/paladin/protection/presets.go
+++ b/sim/paladin/protection/presets.go
@@ -64,7 +64,6 @@ var FullConsumes = &proto.Consumes{
 	Food:            proto.Food_FoodBlackenedBasilisk,
 	DefaultPotion:   proto.Potions_SuperManaPotion,
 	DefaultConjured: proto.Conjured_ConjuredDarkRune,
-	MainHandImbue:   proto.WeaponImbue_WeaponImbueSuperiorWizardOil,
 }
 
 var FullDebuffs = &proto.Debuffs{

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -94,7 +94,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 2943.5891940437677
+  dps: 2943.589194043768
   tps: 2698.0744365778364
  }
 }
@@ -199,7 +199,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2905.8615061607575
+  dps: 2905.861506160757
   tps: 2663.9779545760616
  }
 }
@@ -284,7 +284,7 @@ dps_results: {
  key: "TestRetribution-AllItems-FuriousGladiator'sLibramofFortitude-42853"
  value: {
   dps: 2988.8394123719227
-  tps: 2739.664854108091
+  tps: 2739.6648541080904
  }
 }
 dps_results: {
@@ -361,7 +361,7 @@ dps_results: {
  key: "TestRetribution-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
   dps: 2919.0934285018575
-  tps: 2679.8010633846366
+  tps: 2679.801063384637
  }
 }
 dps_results: {
@@ -381,7 +381,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-LibramofDivineJudgement-33503"
  value: {
-  dps: 2910.457568343836
+  dps: 2910.4575683438366
   tps: 2673.348203388601
  }
 }
@@ -395,7 +395,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-LibramofReciprocation-40706"
  value: {
-  dps: 2910.457568343836
+  dps: 2910.4575683438366
   tps: 2673.348203388601
  }
 }
@@ -480,7 +480,7 @@ dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthsiegeDiamond"
  value: {
   dps: 2919.0934285018575
-  tps: 2679.8010633846366
+  tps: 2679.801063384637
  }
 }
 dps_results: {
@@ -613,14 +613,14 @@ dps_results: {
  key: "TestRetribution-AllItems-StrengthoftheClefthoof"
  value: {
   dps: 2575.2041586186187
-  tps: 2385.4285415103814
+  tps: 2385.428541510382
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyflareDiamond"
  value: {
   dps: 2919.0934285018575
-  tps: 2679.8010633846366
+  tps: 2679.801063384637
  }
 }
 dps_results: {
@@ -640,7 +640,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-TheTwinStars"
  value: {
-  dps: 2862.5913725925657
+  dps: 2862.591372592566
   tps: 2627.0722567968887
  }
 }
@@ -689,7 +689,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-TomeoftheLightbringer-32368"
  value: {
-  dps: 2910.457568343836
+  dps: 2910.4575683438366
   tps: 2673.348203388601
  }
 }
@@ -766,7 +766,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P4-Retribution Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3174.529811736848
+  dps: 3174.5298117368475
   tps: 2946.667090786764
  }
 }

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -73,7 +73,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-AvatarRegalia"
  value: {
-  dps: 1498.2112638671192
+  dps: 1498.2112638671188
   tps: 1093.138981547591
  }
 }
@@ -241,7 +241,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1763.2700198878993
+  dps: 1763.2700198878997
   tps: 1282.066910938451
  }
 }
@@ -270,7 +270,7 @@ dps_results: {
  key: "TestShadow-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
   dps: 1798.3172757883526
-  tps: 1308.6180463887604
+  tps: 1308.6180463887606
  }
 }
 dps_results: {
@@ -473,7 +473,7 @@ dps_results: {
  key: "TestShadow-AllItems-SpellstrikeInfusion"
  value: {
   dps: 1538.1695694085838
-  tps: 1116.9842295630485
+  tps: 1116.9842295630492
  }
 }
 dps_results: {
@@ -535,14 +535,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1763.2700198878993
+  dps: 1763.2700198878997
   tps: 1282.066910938451
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1763.2700198878993
+  dps: 1763.2700198878997
   tps: 1282.066910938451
  }
 }
@@ -612,7 +612,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1109.3023999235434
+  dps: 1109.3023999235431
   tps: 753.9765948692204
  }
 }
@@ -781,7 +781,7 @@ dps_results: {
  key: "TestShadow-Settings-Draenei-P3-Clipping-NoBuffs-ShortSingleTarget"
  value: {
   dps: 1826.2782098410123
-  tps: 1281.2485412082804
+  tps: 1281.2485412082806
  }
 }
 dps_results: {
@@ -808,21 +808,21 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Draenei-P3-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 595.9742775024453
+  dps: 595.9742775024451
   tps: 615.7387471541977
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P3-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 595.9742775024453
+  dps: 595.9742775024451
   tps: 427.6735804875316
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P3-Ideal-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1692.606271546317
+  dps: 1692.6062715463165
   tps: 1179.9969148794921
  }
 }
@@ -850,14 +850,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 289.1618551502138
+  dps: 289.16185515021374
   tps: 355.46850882530623
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 289.1618551502138
+  dps: 289.16185515021374
   tps: 201.62709215863993
  }
 }
@@ -892,21 +892,21 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 306.4800934665208
+  dps: 306.4800934665209
   tps: 366.4671306016254
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 306.4800934665208
+  dps: 306.4800934665209
   tps: 212.62571393495915
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1384.4836307646965
+  dps: 1384.4836307646967
   tps: 956.374037165954
  }
 }
@@ -1032,7 +1032,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-P3-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1793.506596730807
+  dps: 1793.5065967308067
   tps: 1258.4960504373598
  }
 }
@@ -1061,7 +1061,7 @@ dps_results: {
  key: "TestShadow-Settings-NightElf-P3-Ideal-NoBuffs-LongMultiTarget"
  value: {
   dps: 594.0715096077599
-  tps: 614.573238691484
+  tps: 614.5732386914838
  }
 }
 dps_results: {
@@ -1243,7 +1243,7 @@ dps_results: {
  key: "TestShadow-Settings-Undead-P3-Basic-NoBuffs-ShortSingleTarget"
  value: {
   dps: 1225.232547510231
-  tps: 834.7765932540581
+  tps: 834.7765932540582
  }
 }
 dps_results: {
@@ -1285,7 +1285,7 @@ dps_results: {
  key: "TestShadow-Settings-Undead-P3-Clipping-NoBuffs-ShortSingleTarget"
  value: {
   dps: 1788.0754188117382
-  tps: 1255.3863721076605
+  tps: 1255.3863721076607
  }
 }
 dps_results: {
@@ -1312,14 +1312,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Undead-P3-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 588.027218930109
+  dps: 588.0272189301089
   tps: 609.7700945306493
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P3-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 588.027218930109
+  dps: 588.0272189301089
   tps: 422.4886778639833
  }
 }

--- a/sim/priest/shadow/presets.go
+++ b/sim/priest/shadow/presets.go
@@ -57,7 +57,6 @@ var FullConsumes = &proto.Consumes{
 	DefaultPotion:   proto.Potions_SuperManaPotion,
 	PrepopPotion:    proto.Potions_PotionOfWildMagic,
 	DefaultConjured: proto.Conjured_ConjuredDarkRune,
-	MainHandImbue:   proto.WeaponImbue_WeaponImbueBrilliantWizardOil,
 }
 
 var FullDebuffs = &proto.Debuffs{

--- a/sim/priest/smite/TestSmite.results
+++ b/sim/priest/smite/TestSmite.results
@@ -60,7 +60,7 @@ dps_results: {
  key: "TestSmite-AllItems-AshtongueTalismanofAcumen-32490"
  value: {
   dps: 826.5775090516761
-  tps: 763.9088540765154
+  tps: 763.9088540765152
  }
 }
 dps_results: {
@@ -80,14 +80,14 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 844.0988476623331
+  dps: 844.0988476623334
   tps: 780.1712018663959
  }
 }
@@ -102,7 +102,7 @@ dps_results: {
  key: "TestSmite-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
   dps: 809.8501479685415
-  tps: 750.0659546451732
+  tps: 750.0659546451731
  }
 }
 dps_results: {
@@ -115,7 +115,7 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 914.5688111420164
+  dps: 914.5688111420162
   tps: 863.3149450096641
  }
 }
@@ -129,28 +129,28 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 853.2478798787719
+  dps: 853.2478798787721
   tps: 790.5103265678217
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 662.3636444771797
-  tps: 600.1051648867161
+  dps: 662.3636444771796
+  tps: 600.1051648867162
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 662.3636444771797
-  tps: 600.1051648867161
+  dps: 662.3636444771796
+  tps: 600.1051648867162
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 718.6582674739419
+  dps: 718.658267473942
   tps: 654.527874874103
  }
 }
@@ -164,8 +164,8 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-Defender'sCode-40257"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
@@ -186,7 +186,7 @@ dps_results: {
  key: "TestSmite-AllItems-EmberSkyflareDiamond"
  value: {
   dps: 844.9721722084671
-  tps: 781.1104939926973
+  tps: 781.1104939926975
  }
 }
 dps_results: {
@@ -213,7 +213,7 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 841.9677318226638
+  dps: 841.9677318226641
   tps: 779.2532933843102
  }
 }
@@ -248,8 +248,8 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
@@ -291,21 +291,21 @@ dps_results: {
  key: "TestSmite-AllItems-IncarnateRaiment"
  value: {
   dps: 686.2079154600981
-  tps: 639.7702039465862
+  tps: 639.7702039465863
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-IncisorFragment-37723"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-InfusedColdstoneRune-35935"
  value: {
   dps: 823.9903053916069
-  tps: 762.1846255835027
+  tps: 762.1846255835026
  }
 }
 dps_results: {
@@ -325,15 +325,15 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 848.4171618032817
-  tps: 785.7670347186732
+  dps: 848.4171618032818
+  tps: 785.7670347186734
  }
 }
 dps_results: {
@@ -353,8 +353,8 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
@@ -388,15 +388,15 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ReignoftheDead-47316"
  value: {
   dps: 884.006344203752
-  tps: 816.3153281862326
+  tps: 816.3153281862327
  }
 }
 dps_results: {
@@ -423,8 +423,8 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
@@ -437,8 +437,8 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
@@ -451,15 +451,15 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
@@ -591,7 +591,7 @@ dps_results: {
 dps_results: {
  key: "TestSmite-Settings-Undead-P3-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1322.0303921093634
+  dps: 1322.0303921093637
   tps: 1272.426169507613
  }
 }

--- a/sim/priest/smite/presets.go
+++ b/sim/priest/smite/presets.go
@@ -41,7 +41,6 @@ var FullConsumes = &proto.Consumes{
 	Food:            proto.Food_FoodBlackenedBasilisk,
 	DefaultPotion:   proto.Potions_SuperManaPotion,
 	DefaultConjured: proto.Conjured_ConjuredDarkRune,
-	MainHandImbue:   proto.WeaponImbue_WeaponImbueBrilliantWizardOil,
 }
 
 var FullDebuffs = &proto.Debuffs{

--- a/sim/raid_bench_test.go
+++ b/sim/raid_bench_test.go
@@ -35,7 +35,6 @@ var castersWithElemental = &proto.Party{
 				},
 			},
 			Consumes: &proto.Consumes{
-				MainHandImbue: proto.WeaponImbue_WeaponImbueBrilliantWizardOil,
 				DefaultPotion: proto.Potions_SuperManaPotion,
 			},
 			Buffs: &proto.IndividualBuffs{
@@ -60,7 +59,6 @@ var castersWithElemental = &proto.Party{
 				},
 			},
 			Consumes: &proto.Consumes{
-				MainHandImbue: proto.WeaponImbue_WeaponImbueSuperiorWizardOil,
 				DefaultPotion: proto.Potions_SuperManaPotion,
 			},
 			Buffs: &proto.IndividualBuffs{
@@ -92,7 +90,6 @@ var castersWithElemental = &proto.Party{
 				},
 			},
 			Consumes: &proto.Consumes{
-				MainHandImbue: proto.WeaponImbue_WeaponImbueBrilliantWizardOil,
 				DefaultPotion: proto.Potions_SuperManaPotion,
 			},
 			Buffs: &proto.IndividualBuffs{
@@ -117,7 +114,6 @@ var castersWithElemental = &proto.Party{
 				},
 			},
 			Consumes: &proto.Consumes{
-				MainHandImbue: proto.WeaponImbue_WeaponImbueBrilliantWizardOil,
 				DefaultPotion: proto.Potions_SuperManaPotion,
 			},
 			Buffs: &proto.IndividualBuffs{
@@ -151,7 +147,6 @@ var castersWithResto = &proto.Party{
 				},
 			},
 			Consumes: &proto.Consumes{
-				MainHandImbue: proto.WeaponImbue_WeaponImbueBrilliantWizardOil,
 				DefaultPotion: proto.Potions_SuperManaPotion,
 			},
 			Buffs: &proto.IndividualBuffs{
@@ -176,7 +171,6 @@ var castersWithResto = &proto.Party{
 				},
 			},
 			Consumes: &proto.Consumes{
-				MainHandImbue: proto.WeaponImbue_WeaponImbueSuperiorWizardOil,
 				DefaultPotion: proto.Potions_SuperManaPotion,
 			},
 			Buffs: &proto.IndividualBuffs{
@@ -201,7 +195,6 @@ var castersWithResto = &proto.Party{
 				},
 			},
 			Consumes: &proto.Consumes{
-				MainHandImbue: proto.WeaponImbue_WeaponImbueBrilliantWizardOil,
 				DefaultPotion: proto.Potions_SuperManaPotion,
 			},
 			Buffs: &proto.IndividualBuffs{

--- a/sim/rogue/TestMutilate.results
+++ b/sim/rogue/TestMutilate.results
@@ -52,630 +52,630 @@ character_stats_results: {
 dps_results: {
  key: "TestMutilate-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 1632.042838288781
-  tps: 1158.750415185034
+  dps: 1743.4003842334464
+  tps: 1237.8142728057462
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AssassinationArmor"
  value: {
-  dps: 1488.6855753349093
-  tps: 1056.9667584877852
+  dps: 1552.798813388618
+  tps: 1102.4871575059187
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1641.6403162780953
-  tps: 1165.5646245574478
+  dps: 1734.9650114384774
+  tps: 1231.8251581213185
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1710.5994531150845
-  tps: 1214.52561171171
+  dps: 1811.6301955106276
+  tps: 1286.2574388125463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1641.31281198035
-  tps: 1165.3320965060486
+  dps: 1738.4705464496678
+  tps: 1234.3140879792638
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1641.6403162780953
-  tps: 1142.2533320662992
+  dps: 1734.9650114384774
+  tps: 1207.1886549588921
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 1643.4412973294814
-  tps: 1166.843321103931
+  dps: 1735.235287953641
+  tps: 1232.0170544470843
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1651.9130909275573
-  tps: 1172.8582945585663
+  dps: 1750.6675383173945
+  tps: 1242.9739522053492
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1639.4508823029223
-  tps: 1164.0101264350744
+  dps: 1743.997132617431
+  tps: 1238.237964158376
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1676.3857538580949
-  tps: 1190.2338852392465
+  dps: 1785.581229552723
+  tps: 1267.7626729824326
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 1698.0339722646145
-  tps: 1205.6041203078757
+  dps: 1793.4349877464356
+  tps: 1273.3388412999693
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 1708.5583146346448
-  tps: 1213.0764033905973
+  dps: 1805.1589417300906
+  tps: 1281.662848628364
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 1666.258837695223
-  tps: 1183.0437747636076
+  dps: 1760.8157743236734
+  tps: 1250.1791997698085
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1635.1622665954396
-  tps: 1160.9652092827616
+  dps: 1736.606886781118
+  tps: 1232.9908896145932
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Deathmantle"
  value: {
-  dps: 1602.5264887058468
-  tps: 1137.7938069811498
+  dps: 1696.8203109013289
+  tps: 1204.7424207399424
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1609.3023184510316
-  tps: 1142.6046461002315
+  dps: 1707.116571844092
+  tps: 1212.052766009305
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1642.8086024085624
-  tps: 1166.3941077100794
+  dps: 1736.2406069493688
+  tps: 1232.7308309340517
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1641.6403162780953
-  tps: 1165.5646245574478
+  dps: 1734.9650114384774
+  tps: 1231.8251581213185
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1641.6403162780953
-  tps: 1165.5646245574478
+  dps: 1734.9650114384774
+  tps: 1231.8251581213185
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1641.31281198035
-  tps: 1165.3320965060486
+  dps: 1738.4705464496678
+  tps: 1234.3140879792638
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1648.844083672937
-  tps: 1170.6792994077846
+  dps: 1733.0659151357945
+  tps: 1230.4767997464137
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1641.6403162780953
-  tps: 1165.5646245574478
+  dps: 1734.9650114384774
+  tps: 1231.8251581213185
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1661.1532743601215
-  tps: 1179.4188247956859
+  dps: 1749.5691547724632
+  tps: 1242.1940998884484
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1633.703164504916
-  tps: 1159.9292467984899
+  dps: 1738.3218531979255
+  tps: 1234.208515770527
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1630.2659694198253
-  tps: 1157.4888382880754
+  dps: 1739.128304474778
+  tps: 1234.7810961770922
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1641.6403162780953
-  tps: 1165.5646245574478
+  dps: 1734.9650114384774
+  tps: 1231.8251581213185
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1641.6403162780953
-  tps: 1165.5646245574478
+  dps: 1734.9650114384774
+  tps: 1231.8251581213185
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1709.3115902138186
-  tps: 1213.6112290518108
+  dps: 1810.2522980033398
+  tps: 1285.2791315823706
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1609.3023184510316
-  tps: 1142.6046461002315
+  dps: 1707.116571844092
+  tps: 1212.052766009305
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1609.3023184510316
-  tps: 1142.6046461002315
+  dps: 1707.116571844092
+  tps: 1212.052766009305
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1641.31281198035
-  tps: 1165.3320965060486
+  dps: 1738.4705464496678
+  tps: 1234.3140879792638
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1648.844083672937
-  tps: 1170.6792994077846
+  dps: 1733.0659151357945
+  tps: 1230.4767997464137
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1736.0706989584219
-  tps: 1232.6101962604794
+  dps: 1839.0531509915618
+  tps: 1305.7277372040087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 1618.1608756462533
-  tps: 1148.8942217088388
+  dps: 1717.5793984180073
+  tps: 1219.4813728767845
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1641.6403162780953
-  tps: 1165.5646245574478
+  dps: 1734.9650114384774
+  tps: 1231.8251581213185
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1655.142108256899
-  tps: 1175.150896862398
+  dps: 1748.8190143546913
+  tps: 1241.661500191831
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1609.3023184510316
-  tps: 1142.6046461002315
+  dps: 1707.116571844092
+  tps: 1212.052766009305
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1609.3023184510316
-  tps: 1142.6046461002315
+  dps: 1707.116571844092
+  tps: 1212.052766009305
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1346.8591490648994
-  tps: 956.2699958360793
+  dps: 1418.0792252293245
+  tps: 1006.8362499128204
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1663.2988518125844
-  tps: 1180.9421847869332
+  dps: 1760.1521856912218
+  tps: 1249.7080518407665
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Netherblade"
  value: {
-  dps: 1558.1381900502336
-  tps: 1106.2781149356642
+  dps: 1634.6524159451365
+  tps: 1160.6032153210463
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1609.3023184510316
-  tps: 1142.6046461002315
+  dps: 1707.116571844092
+  tps: 1212.052766009305
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1652.5703383561736
-  tps: 1173.3249402328836
+  dps: 1746.1801566563663
+  tps: 1239.7879112260189
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1655.142108256899
-  tps: 1175.150896862398
+  dps: 1748.8190143546913
+  tps: 1241.661500191831
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1641.6403162780953
-  tps: 1165.5646245574478
+  dps: 1734.9650114384774
+  tps: 1231.8251581213185
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1641.6403162780953
-  tps: 1165.5646245574478
+  dps: 1734.9650114384774
+  tps: 1231.8251581213185
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PrimalIntent"
  value: {
-  dps: 1625.267877024547
-  tps: 1153.9401926874282
+  dps: 1721.0371410081539
+  tps: 1221.9363701157895
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1609.3023184510316
-  tps: 1142.6046461002315
+  dps: 1707.116571844092
+  tps: 1212.052766009305
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1742.6754079553477
-  tps: 1237.2995396482959
+  dps: 1848.9672843435615
+  tps: 1312.766771883928
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1759.312589640732
-  tps: 1249.1119386449188
+  dps: 1866.5765006885376
+  tps: 1325.2693154888611
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1664.6031010424183
-  tps: 1181.8682017401168
+  dps: 1756.7700730653075
+  tps: 1247.3067518763678
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1641.6403162780953
-  tps: 1165.5646245574478
+  dps: 1734.9650114384774
+  tps: 1231.8251581213185
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1609.3023184510316
-  tps: 1142.6046461002315
+  dps: 1707.116571844092
+  tps: 1212.052766009305
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1609.3023184510316
-  tps: 1142.6046461002315
+  dps: 1707.116571844092
+  tps: 1212.052766009305
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 1619.1516648190218
-  tps: 1149.5976820215046
+  dps: 1718.857795002455
+  tps: 1220.3890344517426
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1609.3023184510316
-  tps: 1142.6046461002315
+  dps: 1707.116571844092
+  tps: 1212.052766009305
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1609.3023184510316
-  tps: 1142.6046461002315
+  dps: 1707.116571844092
+  tps: 1212.052766009305
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Slayer'sArmor"
  value: {
-  dps: 1719.9168704230422
-  tps: 1221.14097800036
+  dps: 1806.759370318956
+  tps: 1282.7991529264593
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SparkofLife-37657"
  value: {
-  dps: 1635.8283009490974
-  tps: 1161.4380936738587
+  dps: 1730.0482635866908
+  tps: 1228.3342671465502
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1504.4237603682238
-  tps: 1068.1408698614391
+  dps: 1591.5653378963593
+  tps: 1130.0113899064145
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1451.414880174134
-  tps: 1030.5045649236342
+  dps: 1520.1323041575495
+  tps: 1079.2939359518607
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1655.142108256899
-  tps: 1175.150896862398
+  dps: 1748.8190143546913
+  tps: 1241.661500191831
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1652.5703383561736
-  tps: 1173.3249402328836
+  dps: 1746.1801566563663
+  tps: 1239.7879112260189
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1648.0697410299067
-  tps: 1170.1295161312335
+  dps: 1741.5621556842932
+  tps: 1236.5091305358487
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheTwinStars"
  value: {
-  dps: 1589.0339276953605
-  tps: 1128.2140886637053
+  dps: 1682.108978356732
+  tps: 1194.2973746332796
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1655.6908594810534
-  tps: 1175.5405102315478
+  dps: 1747.4476604341228
+  tps: 1240.6878389082271
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1710.7962139315728
-  tps: 1214.6653118914153
+  dps: 1821.1069580853218
+  tps: 1292.9859402405777
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1717.5530615029165
-  tps: 1219.4626736670696
+  dps: 1816.6393858871331
+  tps: 1289.813963979864
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1641.6403162780953
-  tps: 1165.5646245574478
+  dps: 1734.9650114384774
+  tps: 1231.8251581213185
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1641.6403162780953
-  tps: 1165.5646245574478
+  dps: 1734.9650114384774
+  tps: 1231.8251581213185
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1641.6403162780953
-  tps: 1165.5646245574478
+  dps: 1734.9650114384774
+  tps: 1231.8251581213185
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1641.6403162780953
-  tps: 1165.5646245574478
+  dps: 1734.9650114384774
+  tps: 1231.8251581213185
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 1736.4976251436342
-  tps: 1232.91331385198
+  dps: 1823.8142903876287
+  tps: 1294.908146175216
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WastewalkerArmor"
  value: {
-  dps: 1497.1212718608012
-  tps: 1062.95610302117
+  dps: 1572.5430494020297
+  tps: 1116.5055650754412
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WindhawkArmor"
  value: {
-  dps: 1502.2760046987544
-  tps: 1066.6159633361144
+  dps: 1592.284079240473
+  tps: 1130.521696260736
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WrathofSpellfire"
  value: {
-  dps: 1510.4919764970343
-  tps: 1072.4493033128954
+  dps: 1589.4866356273237
+  tps: 1128.5355112954
  }
 }
 dps_results: {
  key: "TestMutilate-Average-Default"
  value: {
-  dps: 1646.2077490168292
-  tps: 1168.8075018019513
+  dps: 1740.956754656216
+  tps: 1236.0792958059083
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2126.790438664989
-  tps: 1510.021211452142
+  dps: 2238.9925254779246
+  tps: 1589.6846930893264
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1660.0517638850804
-  tps: 1178.6367523584072
+  dps: 1752.241774882074
+  tps: 1244.0916601662723
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1864.0110557237008
-  tps: 1323.447849563827
+  dps: 1962.8602321271592
+  tps: 1393.6307648102834
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 449.30386624688924
-  tps: 319.0057450352913
+  dps: 1091.7070979422977
+  tps: 775.1120395390316
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 449.30386624688924
-  tps: 319.0057450352913
+  dps: 1091.7070979422977
+  tps: 775.1120395390316
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 473.87245328559686
-  tps: 336.4494418327738
+  dps: 1106.0792154235003
+  tps: 785.3162429506851
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2124.1198204611146
-  tps: 1508.1250725273917
+  dps: 2239.100315350764
+  tps: 1589.7612238990425
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1657.2108205298646
-  tps: 1176.6196825762033
+  dps: 1752.349720887683
+  tps: 1244.168301830255
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1864.4055293864647
-  tps: 1323.7279258643896
+  dps: 1962.93378679061
+  tps: 1393.6829886213327
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 449.38651365913995
-  tps: 319.0644246979893
+  dps: 1091.9068381444997
+  tps: 775.2538550825943
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 449.38651365913995
-  tps: 319.0644246979893
+  dps: 1091.9068381444997
+  tps: 775.2538550825943
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 474.0013726015276
-  tps: 336.5409745470846
+  dps: 1106.3347279214013
+  tps: 785.4976568241949
  }
 }
 dps_results: {
  key: "TestMutilate-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1472.3460685888638
-  tps: 1045.3657086980932
+  dps: 1556.890837014992
+  tps: 1105.3924942806443
  }
 }

--- a/sim/rogue/TestRogue.results
+++ b/sim/rogue/TestRogue.results
@@ -19,10 +19,10 @@ character_stats_results: {
   final_stats: 12.227
   final_stats: 0
   final_stats: 0
-  final_stats: 2807.8
+  final_stats: 2920.112
   final_stats: 455.95
   final_stats: 903.8943601924234
-  final_stats: 0
+  final_stats: 327.9
   final_stats: 0
   final_stats: 120.5675
   final_stats: 0
@@ -33,7 +33,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3
+  final_stats: 274.5
   final_stats: 0
   final_stats: 0
   final_stats: 8903
@@ -52,728 +52,728 @@ character_stats_results: {
 dps_results: {
  key: "TestRogue-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 1837.4404194049598
-  tps: 1304.5826977775207
+  dps: 2321.441978017465
+  tps: 1648.2238043924003
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AssassinationArmor"
  value: {
-  dps: 1661.057588065365
-  tps: 1179.3508875264092
+  dps: 2088.4687066370802
+  tps: 1482.8127817123266
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1851.466678987285
-  tps: 1314.5413420809712
+  dps: 2296.051429033032
+  tps: 1630.196514613453
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1917.235157985647
-  tps: 1361.2369621698092
+  dps: 2397.5226361604427
+  tps: 1702.2410716739141
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1857.1615373629816
-  tps: 1318.584691527716
+  dps: 2309.7466173334315
+  tps: 1639.9200983067362
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1851.466678987285
-  tps: 1288.2505152393517
+  dps: 2296.051429033032
+  tps: 1597.5925843211842
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 1844.5563708791583
-  tps: 1309.6350233242015
+  dps: 2319.522866956222
+  tps: 1646.8612355389178
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1868.3670972551367
-  tps: 1326.540639051146
+  dps: 2327.533244345174
+  tps: 1652.5486034850733
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1839.8920209116263
-  tps: 1306.323334847254
+  dps: 2337.305133986739
+  tps: 1659.486645130585
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1879.460674056445
-  tps: 1334.417078580075
+  dps: 2371.6149599511155
+  tps: 1683.8466215652927
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 1899.2909822254321
-  tps: 1348.4965973800565
+  dps: 2397.7000245817253
+  tps: 1702.3670174530253
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 1912.8786025230943
-  tps: 1358.1438077913967
+  dps: 2423.8762342655778
+  tps: 1720.9521263285599
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 1863.4736299026886
-  tps: 1323.0662772309083
+  dps: 2353.1897367849388
+  tps: 1670.764713117306
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1833.817234008418
-  tps: 1302.0102361459763
+  dps: 2325.7810699507213
+  tps: 1651.3045596650122
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Deathmantle"
  value: {
-  dps: 1785.07457316603
-  tps: 1267.4029469478812
+  dps: 2267.522825864552
+  tps: 1609.941206363832
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1807.2086835288167
-  tps: 1283.1181653054587
+  dps: 2275.191193417107
+  tps: 1615.385747326146
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1858.0806343429667
-  tps: 1319.2372503835054
+  dps: 2311.86583265597
+  tps: 1641.4247411857389
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1851.466678987285
-  tps: 1314.5413420809712
+  dps: 2296.051429033032
+  tps: 1630.196514613453
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1851.466678987285
-  tps: 1314.5413420809712
+  dps: 2296.051429033032
+  tps: 1630.196514613453
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1857.1615373629816
-  tps: 1318.584691527716
+  dps: 2309.7466173334315
+  tps: 1639.9200983067362
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1856.227201870241
-  tps: 1317.9213133278702
+  dps: 2307.295462612875
+  tps: 1638.179778455141
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1851.466678987285
-  tps: 1314.5413420809712
+  dps: 2296.051429033032
+  tps: 1630.196514613453
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1863.7277355795256
-  tps: 1323.2466922614626
+  dps: 2354.717835530346
+  tps: 1671.8496632265455
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1835.0746714210138
-  tps: 1302.903016708919
+  dps: 2330.4734166533362
+  tps: 1654.636125823869
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1831.2094247976515
-  tps: 1300.158691606332
+  dps: 2321.937934913275
+  tps: 1648.5759337884247
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1851.466678987285
-  tps: 1314.5413420809712
+  dps: 2296.051429033032
+  tps: 1630.196514613453
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1851.466678987285
-  tps: 1314.5413420809712
+  dps: 2296.051429033032
+  tps: 1630.196514613453
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1920.3665901003556
-  tps: 1363.460278971252
+  dps: 2415.5001925070983
+  tps: 1715.0051366800392
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1807.2086835288167
-  tps: 1283.1181653054587
+  dps: 2275.191193417107
+  tps: 1615.385747326146
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1807.2086835288167
-  tps: 1283.1181653054587
+  dps: 2275.191193417107
+  tps: 1615.385747326146
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1857.1615373629816
-  tps: 1318.584691527716
+  dps: 2309.7466173334315
+  tps: 1639.9200983067362
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1856.227201870241
-  tps: 1317.9213133278702
+  dps: 2307.295462612875
+  tps: 1638.179778455141
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1956.6910541664959
-  tps: 1389.2506484582123
+  dps: 2458.0915803865564
+  tps: 1745.2450220744554
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 1817.5887513213297
-  tps: 1290.488013438144
+  dps: 2296.228882918859
+  tps: 1630.3225068723905
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1851.466678987285
-  tps: 1314.5413420809712
+  dps: 2296.051429033032
+  tps: 1630.196514613453
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1866.7999095697237
-  tps: 1325.4279357945038
+  dps: 2314.7929630596414
+  tps: 1643.503003772345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1807.2086835288167
-  tps: 1283.1181653054587
+  dps: 2275.191193417107
+  tps: 1615.385747326146
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1807.2086835288167
-  tps: 1283.1181653054587
+  dps: 2275.191193417107
+  tps: 1615.385747326146
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1500.1795110680346
-  tps: 1065.1274528583053
+  dps: 1906.9900255890159
+  tps: 1353.9629181682012
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1879.6481959086218
-  tps: 1334.5502190951204
+  dps: 2352.4150494784794
+  tps: 1670.2146851297207
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Netherblade"
  value: {
-  dps: 1766.2937544459141
-  tps: 1254.068565656599
+  dps: 2187.333301967571
+  tps: 1553.0066443969758
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1807.2086835288167
-  tps: 1283.1181653054587
+  dps: 2275.191193417107
+  tps: 1615.385747326146
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1863.879294220688
-  tps: 1323.354298896688
+  dps: 2311.223147054573
+  tps: 1640.9684344087468
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1866.7999095697237
-  tps: 1325.4279357945038
+  dps: 2314.7929630596414
+  tps: 1643.503003772345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1851.466678987285
-  tps: 1314.5413420809712
+  dps: 2296.051429033032
+  tps: 1630.196514613453
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1851.466678987285
-  tps: 1314.5413420809712
+  dps: 2296.051429033032
+  tps: 1630.196514613453
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PrimalIntent"
  value: {
-  dps: 1823.8506498499348
-  tps: 1294.933961393453
+  dps: 2289.1879670367475
+  tps: 1625.32345659609
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1807.2086835288167
-  tps: 1283.1181653054587
+  dps: 2275.191193417107
+  tps: 1615.385747326146
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1940.149679315267
-  tps: 1377.5062723138394
+  dps: 2412.3016430460784
+  tps: 1712.734166562716
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1956.6838471739284
-  tps: 1389.2455314934887
+  dps: 2429.436111387643
+  tps: 1724.8996390852267
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1873.7022472194185
-  tps: 1330.3285955257875
+  dps: 2330.587537292412
+  tps: 1654.7171514776123
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1851.466678987285
-  tps: 1314.5413420809712
+  dps: 2296.051429033032
+  tps: 1630.196514613453
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1807.2086835288167
-  tps: 1283.1181653054587
+  dps: 2275.191193417107
+  tps: 1615.385747326146
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1807.2086835288167
-  tps: 1283.1181653054587
+  dps: 2275.191193417107
+  tps: 1615.385747326146
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 1819.892253350487
-  tps: 1292.123499878845
+  dps: 2300.2951202856466
+  tps: 1633.2095354028093
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1807.2086835288167
-  tps: 1283.1181653054587
+  dps: 2275.191193417107
+  tps: 1615.385747326146
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1807.2086835288167
-  tps: 1283.1181653054587
+  dps: 2275.191193417107
+  tps: 1615.385747326146
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Slayer'sArmor"
  value: {
-  dps: 1939.5509580574246
-  tps: 1377.0811802207718
+  dps: 2442.739486416964
+  tps: 1734.3450353560445
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SparkofLife-37657"
  value: {
-  dps: 1847.7013718592539
-  tps: 1311.8679740200691
+  dps: 2298.0021004867967
+  tps: 1631.5814913456256
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1685.4986456091933
-  tps: 1196.7040383825274
+  dps: 2125.4051935197995
+  tps: 1509.0376873990583
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1613.8483801770694
-  tps: 1145.8323499257194
+  dps: 2029.2412927167302
+  tps: 1440.761317828878
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1866.7999095697237
-  tps: 1325.4279357945038
+  dps: 2314.7929630596414
+  tps: 1643.503003772345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1863.879294220688
-  tps: 1323.354298896688
+  dps: 2311.223147054573
+  tps: 1640.9684344087468
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1858.768217359874
-  tps: 1319.7254343255106
+  dps: 2304.975969045704
+  tps: 1636.5329380224491
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheFistsofFury"
  value: {
-  dps: 1740.5944686352007
-  tps: 1235.822072730993
+  dps: 2372.773249269002
+  tps: 1684.669006980992
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 2027.4348776228937
-  tps: 1439.478763112254
+  dps: 2492.958429957774
+  tps: 1770.0004852700192
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinStars"
  value: {
-  dps: 1782.8657580796346
-  tps: 1265.8346882365408
+  dps: 2231.089444340503
+  tps: 1584.0735054817571
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1863.5892276601248
-  tps: 1323.1483516386872
+  dps: 2309.880586535559
+  tps: 1640.0152164402468
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1935.2309060408909
-  tps: 1374.0139432890314
+  dps: 2399.8145958397818
+  tps: 1703.868363046245
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1939.8221104004078
-  tps: 1377.2736983842883
+  dps: 2419.2821672407194
+  tps: 1717.6903387409116
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1851.466678987285
-  tps: 1314.5413420809712
+  dps: 2296.051429033032
+  tps: 1630.196514613453
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1851.466678987285
-  tps: 1314.5413420809712
+  dps: 2296.051429033032
+  tps: 1630.196514613453
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1851.466678987285
-  tps: 1314.5413420809712
+  dps: 2296.051429033032
+  tps: 1630.196514613453
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1851.466678987285
-  tps: 1314.5413420809712
+  dps: 2296.051429033032
+  tps: 1630.196514613453
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 1959.2820158067775
-  tps: 1391.0902312228109
+  dps: 2450.12099086897
+  tps: 1739.5859035169683
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WastewalkerArmor"
  value: {
-  dps: 1676.3993177323478
-  tps: 1190.2435155899673
+  dps: 2097.183110088511
+  tps: 1489.0000081628432
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WindhawkArmor"
  value: {
-  dps: 1689.2421259148637
-  tps: 1199.3619093995533
+  dps: 2126.4766643607336
+  tps: 1509.7984316961197
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WrathofSpellfire"
  value: {
-  dps: 1685.7281739078212
-  tps: 1196.867003474552
+  dps: 2132.1173218977356
+  tps: 1513.803298547392
  }
 }
 dps_results: {
  key: "TestRogue-Average-Default"
  value: {
-  dps: 1855.3418042840656
-  tps: 1317.2926810416852
+  dps: 2304.514607402963
+  tps: 1636.2053712560967
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2510.9258460522465
-  tps: 1782.7573506970953
+  dps: 3042.123966015598
+  tps: 2159.908015871075
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1848.2949118028137
-  tps: 1312.2893873799987
+  dps: 2319.610050687627
+  tps: 1646.9231359882147
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2221.0069703222043
-  tps: 1576.9149489287654
+  dps: 2709.4652152626954
+  tps: 1923.720302836514
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 720.3740856005586
-  tps: 511.4656007763965
+  dps: 1468.0003463081252
+  tps: 1042.2802458787685
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 620.6294977026948
-  tps: 440.64694336891324
+  dps: 1322.4078711302277
+  tps: 938.9095885024611
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 720.0919610600923
-  tps: 511.26529235266537
+  dps: 1462.4288319171496
+  tps: 1038.324470661176
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2542.382707846527
-  tps: 1805.0917225710346
+  dps: 2425.273713326733
+  tps: 1721.9443364619801
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1878.338464370831
-  tps: 1333.6203097032903
+  dps: 1779.402919945012
+  tps: 1263.3760731609584
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2203.5466674175923
-  tps: 1564.5181338664902
+  dps: 2132.3134013056124
+  tps: 1513.9425149269841
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-LongMultiTarget"
  value: {
-  dps: 695.5886916843631
-  tps: 493.8679710958977
+  dps: 1072.326368901406
+  tps: 761.3517219199986
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 596.7574822432364
-  tps: 423.69781239269776
+  dps: 983.2393478556178
+  tps: 698.099936977489
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 708.6755017155219
-  tps: 503.1596062180205
+  dps: 1058.7768677690572
+  tps: 751.7315761160307
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2520.7916088173133
-  tps: 1789.7620422602922
+  dps: 3064.7682084128865
+  tps: 2175.9854279731494
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1868.8779022197791
-  tps: 1326.9033105760439
+  dps: 2322.816226809589
+  tps: 1649.1995210348082
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2243.4806070671107
-  tps: 1592.8712310176484
+  dps: 2701.8199996649055
+  tps: 1918.2921997620826
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 730.4107831672068
-  tps: 518.5916560487168
+  dps: 1480.072616601706
+  tps: 1050.8515577872113
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 622.3992404195143
-  tps: 441.9034606978551
+  dps: 1332.3426302943446
+  tps: 945.9632675089848
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 728.8132905344448
-  tps: 517.4574362794558
+  dps: 1465.6957909214966
+  tps: 1040.6440115542625
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2551.677529369215
-  tps: 1811.6910458521422
+  dps: 2440.0885613624005
+  tps: 1732.4628785673042
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1893.349581021736
-  tps: 1344.2782025254323
+  dps: 1796.1306989800073
+  tps: 1275.2527962758045
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2226.0946859252085
-  tps: 1580.5272270068986
+  dps: 2159.579917538284
+  tps: 1533.3017414521814
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-LongMultiTarget"
  value: {
-  dps: 701.899158203146
-  tps: 498.34840232423386
+  dps: 1089.630490843797
+  tps: 773.6376484990959
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 599.4525872596718
-  tps: 425.61133695436695
+  dps: 991.363764202429
+  tps: 703.8682725837247
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 704.5976301030677
-  tps: 500.2643173731781
+  dps: 1068.8929866908707
+  tps: 758.914020550518
  }
 }
 dps_results: {
  key: "TestRogue-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1673.4283918855497
-  tps: 1188.1341582387402
+  dps: 2108.7195775252467
+  tps: 1497.1909000429255
  }
 }

--- a/sim/rogue/backstab.go
+++ b/sim/rogue/backstab.go
@@ -32,7 +32,7 @@ func (rogue *Rogue) registerBackstabSpell() {
 			BonusCritRating: 10 * core.CritRatingPerCritChance * float64(rogue.Talents.PuncturingWounds),
 			// All of these use "Apply Aura: Modifies Damage/Healing Done", and stack additively (up to 142%).
 			DamageMultiplier: 1 +
-				0.04*float64(rogue.Talents.Opportunity) +
+				0.1*float64(rogue.Talents.Opportunity) +
 				0.02*float64(rogue.Talents.Aggression) +
 				core.TernaryFloat64(rogue.Talents.SurpriseAttacks, 0.1, 0) +
 				core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0),

--- a/sim/rogue/envenom.go
+++ b/sim/rogue/envenom.go
@@ -41,7 +41,8 @@ func (rogue *Rogue) makeEnvenom(comboPoints int32) *core.Spell {
 			ThreatMultiplier: 1,
 			BaseDamage: core.BaseDamageConfig{
 				Calculator: func(sim *core.Simulation, hitEffect *core.SpellEffect, spell *core.Spell) float64 {
-					deadlyPoisonStacks := rogue.DeadlyPoisonDot.GetStacks()
+					target := hitEffect.Target
+					deadlyPoisonStacks := rogue.DeadlyPoisonDots[target.Index].GetStacks()
 					doses := float64(core.MinInt32(deadlyPoisonStacks, comboPoints))
 					return baseDamage*doses + apRatio*doses*hitEffect.MeleeAttackPower(spell.Unit)
 				},
@@ -49,13 +50,14 @@ func (rogue *Rogue) makeEnvenom(comboPoints int32) *core.Spell {
 			},
 			OutcomeApplier: rogue.OutcomeFuncMeleeSpecialHitAndCrit(rogue.MeleeCritMultiplier(true, false)),
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+				target := spellEffect.Target
 				if spellEffect.Landed() {
 					rogue.ApplyFinisher(sim, spell)
 					rogue.ApplyCutToTheChase(sim)
-					deadlyPoisonStacks := rogue.DeadlyPoisonDot.GetStacks()
+					deadlyPoisonStacks := rogue.DeadlyPoisonDots[target.Index].GetStacks()
 					doses := core.MinInt32(deadlyPoisonStacks, comboPoints)
 					if chanceToRetainStacks < 1 && sim.RandomFloat("Master Poisoner") > float64(chanceToRetainStacks) {
-						rogue.DeadlyPoisonDot.Cancel(sim)
+						rogue.DeadlyPoisonDots[target.Index].Cancel(sim)
 					}
 					rogue.EnvenomAura.Duration = time.Second * time.Duration(1+doses)
 					rogue.EnvenomAura.Activate(sim)

--- a/sim/rogue/envenom.go
+++ b/sim/rogue/envenom.go
@@ -50,6 +50,7 @@ func (rogue *Rogue) makeEnvenom(comboPoints int32) *core.Spell {
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if spellEffect.Landed() {
 					rogue.ApplyFinisher(sim, spell)
+					rogue.ApplyCutToTheChase(sim)
 					deadlyPoisonStacks := rogue.DeadlyPoisonDot.GetStacks()
 					doses := core.MinInt32(deadlyPoisonStacks, comboPoints)
 					chanceToRetainStacks := rogue.Talents.MasterPoisoner / 3.0

--- a/sim/rogue/eviscerate.go
+++ b/sim/rogue/eviscerate.go
@@ -54,6 +54,7 @@ func (rogue *Rogue) makeEviscerate(comboPoints int32) *core.Spell {
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if spellEffect.Landed() {
 					rogue.ApplyFinisher(sim, spell)
+					rogue.ApplyCutToTheChase(sim)
 				} else {
 					if refundAmount > 0 {
 						rogue.AddEnergy(sim, spell.CurCast.Cost*refundAmount, rogue.QuickRecoveryMetrics)

--- a/sim/rogue/eviscerate.go
+++ b/sim/rogue/eviscerate.go
@@ -11,7 +11,7 @@ import (
 func (rogue *Rogue) makeEviscerate(comboPoints int32) *core.Spell {
 	baseDamage := 127.0 +
 		(370+core.TernaryFloat64(rogue.HasSetBonus(ItemSetDeathmantle, 2), 40, 0))*float64(comboPoints)
-	apRatio := 0.03 * float64(comboPoints)
+	apRatio := 0.05 * float64(comboPoints)
 	cost := 35.0
 	if rogue.HasSetBonus(ItemSetAssassination, 4) {
 		cost -= 10

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/wowsims/wotlk/sim/core"
+	"github.com/wowsims/wotlk/sim/core/proto"
 	"github.com/wowsims/wotlk/sim/core/stats"
 )
 
@@ -11,9 +12,9 @@ var MHOutcome = core.OutcomeHit
 var OHOutcome = core.OutcomeHit
 
 func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
-	actionID := core.ActionID{SpellID: 34419}
+	actionID := core.ActionID{SpellID: 48665}
 	if !isMH {
-		actionID = core.ActionID{SpellID: 34418}
+		actionID = core.ActionID{SpellID: 48664}
 	}
 
 	effect := core.SpellEffect{
@@ -25,7 +26,7 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 			core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0),
 		ThreatMultiplier: 1,
 
-		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 101, 1, false),
+		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 181, 1, false),
 		OutcomeApplier: rogue.OutcomeFuncMeleeSpecialCritOnly(rogue.MeleeCritMultiplier(isMH, true)),
 
 		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
@@ -34,12 +35,11 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 			} else {
 				OHOutcome = spellEffect.Outcome
 			}
-			return
 		},
 	}
 	if !isMH {
 		effect.ProcMask = core.ProcMaskMeleeOHSpecial
-		effect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 101, 1+0.1*float64(rogue.Talents.DualWieldSpecialization), false)
+		effect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 181, 1+0.1*float64(rogue.Talents.DualWieldSpecialization), false)
 	}
 
 	effect.BaseDamage = core.WrapBaseDamageConfig(effect.BaseDamage, func(oldCalculator core.BaseDamageCalculator) core.BaseDamageCalculator {
@@ -47,7 +47,7 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 			normalDamage := oldCalculator(sim, spellEffect, spell)
 			// TODO: Add support for all poison effects
 			if rogue.DeadlyPoisonDot.IsActive() {
-				return normalDamage * 1.5
+				return normalDamage * 1.2
 			} else {
 				return normalDamage
 			}
@@ -57,7 +57,7 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 	return rogue.RegisterSpell(core.SpellConfig{
 		ActionID:    actionID,
 		SpellSchool: core.SpellSchoolPhysical,
-		Flags:       core.SpellFlagMeleeMetrics,
+		Flags:       core.SpellFlagMeleeMetrics | SpellFlagRogueAbility,
 
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(effect),
 	})
@@ -68,10 +68,13 @@ func (rogue *Rogue) registerMutilateSpell() {
 	ohHitSpell := rogue.newMutilateHitSpell(false)
 
 	baseCost := 60.0
+	if rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfMutilate) {
+		baseCost -= 5
+	}
 	refundAmount := baseCost * 0.8
 
 	rogue.Mutilate = rogue.RegisterSpell(core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: 34413},
+		ActionID:    core.ActionID{SpellID: 48666},
 		SpellSchool: core.SpellSchoolPhysical,
 		Flags:       core.SpellFlagMeleeMetrics | SpellFlagBuilder,
 

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -22,7 +22,7 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 
 		BonusCritRating: 5 * core.CritRatingPerCritChance * float64(rogue.Talents.PuncturingWounds),
 		DamageMultiplier: 1 +
-			0.04*float64(rogue.Talents.Opportunity) +
+			0.1*float64(rogue.Talents.Opportunity) +
 			core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0),
 		ThreatMultiplier: 1,
 

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -46,7 +46,7 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 		return func(sim *core.Simulation, spellEffect *core.SpellEffect, spell *core.Spell) float64 {
 			normalDamage := oldCalculator(sim, spellEffect, spell)
 			// TODO: Add support for all poison effects
-			if rogue.DeadlyPoisonDot.IsActive() {
+			if rogue.DeadlyPoisonDots[spellEffect.Target.Index].IsActive() {
 				return normalDamage * 1.2
 			} else {
 				return normalDamage

--- a/sim/rogue/overkill.go
+++ b/sim/rogue/overkill.go
@@ -1,0 +1,47 @@
+package rogue
+
+import (
+	"time"
+
+	"github.com/wowsims/wotlk/sim/core"
+)
+
+var OverkillActionID = core.ActionID{SpellID: 58426}
+
+func (rogue *Rogue) registerOverkillCD() {
+	if !rogue.Talents.Overkill {
+		return
+	}
+	rogue.OverkillAura = rogue.RegisterAura(core.Aura{
+		Label:    "Overkill",
+		ActionID: OverkillActionID,
+		Duration: time.Second * 20,
+		OnGain: func(aura *core.Aura, sim *core.Simulation) {
+			rogue.EnergyTickMultiplier *= 1.3
+		},
+		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
+			rogue.EnergyTickMultiplier *= 1 / 1.3
+		},
+	})
+	overkillSpell := rogue.RegisterSpell(core.SpellConfig{
+		ActionID: OverkillActionID,
+		Cast: core.CastConfig{
+			CD: core.Cooldown{
+				Timer:    rogue.NewTimer(),
+				Duration: time.Minute * 3,
+			},
+		},
+		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
+			rogue.OverkillAura.Activate(sim)
+		},
+	})
+
+	rogue.AddMajorCooldown(core.MajorCooldown{
+		Spell: overkillSpell,
+		Type:  core.CooldownTypeDPS,
+		ShouldActivate: func(s *core.Simulation, c *core.Character) bool {
+			return rogue.CurrentEnergy() < 50
+		},
+	})
+
+}

--- a/sim/rogue/poisons.go
+++ b/sim/rogue/poisons.go
@@ -13,18 +13,17 @@ func (rogue *Rogue) applyPoisons() {
 	rogue.applyInstantPoison()
 }
 
+var DeadlyPoisonActionID = core.ActionID{SpellID: 57973}
+
 func (rogue *Rogue) registerDeadlyPoisonSpell() {
-	actionID := core.ActionID{SpellID: 57973}
 
 	rogue.DeadlyPoison = rogue.RegisterSpell(core.SpellConfig{
-		ActionID:    actionID,
+		ActionID:    DeadlyPoisonActionID,
 		SpellSchool: core.SpellSchoolNature,
-
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
-			ProcMask:            core.ProcMaskEmpty,
-			BonusSpellHitRating: 5 * core.SpellHitRatingPerHitChance * float64(rogue.Talents.Precision),
-			ThreatMultiplier:    1,
-			OutcomeApplier:      rogue.OutcomeFuncMagicHit(),
+			ProcMask:         core.ProcMaskEmpty,
+			ThreatMultiplier: 1,
+			OutcomeApplier:   rogue.OutcomeFuncMagicHit(),
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if spellEffect.Landed() {
 					if rogue.DeadlyPoisonDot.IsActive() {
@@ -34,7 +33,7 @@ func (rogue *Rogue) registerDeadlyPoisonSpell() {
 								case proto.Rogue_Options_DeadlyPoison:
 									rogue.DeadlyPoisonDot.Refresh(sim)
 								case proto.Rogue_Options_InstantPoison:
-									rogue.InstantPoison.Cast(sim, spellEffect.Target)
+									rogue.InstantPoison[1].Cast(sim, spellEffect.Target)
 								}
 							}
 							if rogue.LastDeadlyPoisonProcMask.Matches(core.ProcMaskMeleeOH) {
@@ -42,7 +41,7 @@ func (rogue *Rogue) registerDeadlyPoisonSpell() {
 								case proto.Rogue_Options_DeadlyPoison:
 									rogue.DeadlyPoisonDot.Refresh(sim)
 								case proto.Rogue_Options_InstantPoison:
-									rogue.InstantPoison.Cast(sim, spellEffect.Target)
+									rogue.InstantPoison[1].Cast(sim, spellEffect.Target)
 								}
 							}
 						}
@@ -61,22 +60,29 @@ func (rogue *Rogue) registerDeadlyPoisonSpell() {
 	target := rogue.CurrentTarget
 	dotAura := target.RegisterAura(core.Aura{
 		Label:     "DeadlyPoison-" + strconv.Itoa(int(rogue.Index)),
-		ActionID:  actionID,
+		ActionID:  DeadlyPoisonActionID,
 		MaxStacks: 5,
 		Duration:  time.Second * 12,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			if rogue.Talents.SavageCombat < 1 {
-				return
+			if rogue.Talents.SavageCombat > 0 {
+				savageCombatAura := core.SavageCombatAura(target, rogue.Talents.SavageCombat)
+				savageCombatAura.Activate(sim)
 			}
-			savageCombatAura := core.SavageCombatAura(target, rogue.Talents.SavageCombat)
-			savageCombatAura.Activate(sim)
+			if rogue.Talents.MasterPoisoner > 0 {
+				masterPoisonerAura := core.MasterPoisonerDebuff(target, float64(rogue.Talents.MasterPoisoner))
+				masterPoisonerAura.Duration = core.NeverExpires
+				masterPoisonerAura.Activate(sim)
+			}
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			if rogue.Talents.SavageCombat < 1 {
-				return
+			if rogue.Talents.SavageCombat > 0 {
+				savageCombatAura := core.SavageCombatAura(target, rogue.Talents.SavageCombat)
+				savageCombatAura.Deactivate(sim)
 			}
-			savageCombatAura := core.SavageCombatAura(target, rogue.Talents.SavageCombat)
-			savageCombatAura.Deactivate(sim)
+			if rogue.Talents.MasterPoisoner > 0 {
+				masterPoisonerAura := core.MasterPoisonerDebuff(target, float64(rogue.Talents.MasterPoisoner))
+				masterPoisonerAura.Deactivate(sim)
+			}
 		},
 	})
 	rogue.DeadlyPoisonDot = core.NewDot(core.Dot{
@@ -88,18 +94,21 @@ func (rogue *Rogue) registerDeadlyPoisonSpell() {
 			ProcMask:         core.ProcMaskPeriodicDamage,
 			DamageMultiplier: 1 + []float64{0.0, 0.07, 0.14, 0.20}[rogue.Talents.VilePoisons],
 			ThreatMultiplier: 1,
-			IsPeriodic:       true,
-			BaseDamage: core.MultiplyByStacks(
-				core.BaseDamageConfig{
-					Calculator: func(sim *core.Simulation, hitEffect *core.SpellEffect, spell *core.Spell) float64 {
-						return 74 + hitEffect.MeleeAttackPower(spell.Unit)*0.03
-					},
-					TargetSpellCoefficient: 1,
+			IsPeriodic:       false,
+			BaseDamage: core.MultiplyByStacks(core.BaseDamageConfig{
+				Calculator: func(sim *core.Simulation, hitEffect *core.SpellEffect, spell *core.Spell) float64 {
+					return 74 + hitEffect.MeleeAttackPower(spell.Unit)*0.03
 				},
-				dotAura),
+				TargetSpellCoefficient: 1,
+			}, dotAura),
 			OutcomeApplier: rogue.OutcomeFuncTickMagicHitAndCrit(rogue.SpellCritMultiplier()),
 		})),
 	})
+}
+
+func (rogue *Rogue) procDeadlyPoison(sim *core.Simulation, spellEffect *core.SpellEffect) {
+	rogue.LastDeadlyPoisonProcMask = spellEffect.ProcMask
+	rogue.DeadlyPoison.Cast(sim, rogue.CurrentTarget)
 }
 
 func (rogue *Rogue) applyDeadlyPoison() {
@@ -110,9 +119,6 @@ func (rogue *Rogue) applyDeadlyPoison() {
 	if procMask == core.ProcMaskUnknown {
 		return
 	}
-
-	procChance := 0.3 + 0.04*float64(rogue.Talents.ImprovedPoisons)
-
 	rogue.RegisterAura(core.Aura{
 		Label:    "Deadly Poison",
 		Duration: core.NeverExpires,
@@ -123,18 +129,25 @@ func (rogue *Rogue) applyDeadlyPoison() {
 			if !spellEffect.Landed() || !spellEffect.ProcMask.Matches(procMask) {
 				return
 			}
-			if sim.RandomFloat("Deadly Poison") > procChance {
+			if sim.RandomFloat("Deadly Poison") > rogue.GetDeadlyPoisonProcChance(procMask) {
 				return
 			}
-			rogue.LastDeadlyPoisonProcMask = spellEffect.ProcMask
-			rogue.DeadlyPoison.Cast(sim, spellEffect.Target)
+			rogue.procDeadlyPoison(sim, spellEffect)
 		},
 	})
 }
 
-func (rogue *Rogue) registerInstantPoisonSpell() {
-	rogue.InstantPoison = rogue.RegisterSpell(core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: 57968},
+type InstantPoisonProcSource int
+
+const (
+	NormalProc InstantPoisonProcSource = iota
+	DeadlyProc
+	ShivProc
+)
+
+func (rogue *Rogue) makeInstantPoison(procSource InstantPoisonProcSource) *core.Spell {
+	return rogue.RegisterSpell(core.SpellConfig{
+		ActionID:    core.ActionID{SpellID: 57968, Tag: int32(procSource)},
 		SpellSchool: core.SpellSchoolNature,
 
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
@@ -150,6 +163,35 @@ func (rogue *Rogue) registerInstantPoisonSpell() {
 			OutcomeApplier: rogue.OutcomeFuncMagicHitAndCrit(rogue.SpellCritMultiplier()),
 		}),
 	})
+
+}
+
+func (rogue *Rogue) registerInstantPoisonSpell() {
+	rogue.InstantPoison = [3]*core.Spell{
+		rogue.makeInstantPoison(NormalProc),
+		rogue.makeInstantPoison(DeadlyProc),
+		rogue.makeInstantPoison(ShivProc),
+	}
+}
+
+func (rogue *Rogue) GetDeadlyPoisonProcChance(mask core.ProcMask) float64 {
+	if mask.Matches(core.ProcMaskMeleeMH) && rogue.Options.MhImbue != proto.Rogue_Options_DeadlyPoison {
+		return 0.0
+	}
+	if mask.Matches(core.ProcMaskMeleeOH) && rogue.Options.OhImbue != proto.Rogue_Options_DeadlyPoison {
+		return 0.0
+	}
+	return 0.3 + 0.04*float64(rogue.Talents.ImprovedPoisons) + rogue.DeadlyPoisonProcChanceBonus
+}
+
+func (rogue *Rogue) GetInstantPoisonProcChance(mask core.ProcMask) float64 {
+	if mask.Matches(core.ProcMaskMeleeMH) && rogue.Options.MhImbue == proto.Rogue_Options_InstantPoison {
+		return (rogue.GetMHWeapon().SwingSpeed * 8.57 * (1 + float64(rogue.Talents.ImprovedPoisons)*0.1 + rogue.InstantPoisonProcChanceBonus)) / 60
+	}
+	if mask.Matches(core.ProcMaskMeleeOH) && rogue.Options.OhImbue == proto.Rogue_Options_InstantPoison {
+		return (rogue.GetOHWeapon().SwingSpeed * 8.57 * (1 + float64(rogue.Talents.ImprovedPoisons)*0.1 + rogue.InstantPoisonProcChanceBonus)) / 60
+	}
+	return 0.0
 }
 
 func (rogue *Rogue) applyInstantPoison() {
@@ -159,15 +201,6 @@ func (rogue *Rogue) applyInstantPoison() {
 
 	if procMask == core.ProcMaskUnknown {
 		return
-	}
-
-	var mhProcChance float64
-	var ohProcChance float64
-	if rogue.Options.MhImbue == proto.Rogue_Options_InstantPoison {
-		mhProcChance = (rogue.GetMHWeapon().SwingSpeed * 8.57 * (1 + float64(rogue.Talents.ImprovedPoisons)*0.1)) / 60
-	}
-	if rogue.Options.OhImbue == proto.Rogue_Options_InstantPoison {
-		ohProcChance = (rogue.GetOHWeapon().SwingSpeed * 8.57 * (1 + float64(rogue.Talents.ImprovedPoisons)*0.1)) / 60
 	}
 
 	rogue.RegisterAura(core.Aura{
@@ -180,17 +213,10 @@ func (rogue *Rogue) applyInstantPoison() {
 			if !spellEffect.Landed() || !spellEffect.ProcMask.Matches(procMask) {
 				return
 			}
-			if spellEffect.ProcMask.Matches(core.ProcMaskMeleeMH) && sim.RandomFloat("Instant Poison") > mhProcChance {
+			if sim.RandomFloat("Instant Poison") > rogue.GetInstantPoisonProcChance(procMask) {
 				return
 			}
-			if spellEffect.ProcMask.Matches(core.ProcMaskMeleeOH) && sim.RandomFloat("Instant Poison") > ohProcChance {
-				return
-			}
-			rogue.procInstantPoison(sim, spellEffect)
+			rogue.InstantPoison[0].Cast(sim, spellEffect.Target)
 		},
 	})
-}
-
-func (rogue *Rogue) procInstantPoison(sim *core.Simulation, spellEffect *core.SpellEffect) {
-	rogue.InstantPoison.Cast(sim, spellEffect.Target)
 }

--- a/sim/rogue/poisons.go
+++ b/sim/rogue/poisons.go
@@ -30,18 +30,18 @@ func (rogue *Rogue) registerDeadlyPoisonSpell() {
 					if rogue.DeadlyPoisonDot.IsActive() {
 						if rogue.DeadlyPoisonDot.GetStacks() == 5 {
 							if rogue.LastDeadlyPoisonProcMask.Matches(core.ProcMaskMeleeMH) {
-								switch rogue.Consumes.OffHandImbue {
-								case proto.WeaponImbue_WeaponImbueRogueDeadlyPoison:
+								switch rogue.Options.OhImbue {
+								case proto.Rogue_Options_DeadlyPoison:
 									rogue.DeadlyPoisonDot.Refresh(sim)
-								case proto.WeaponImbue_WeaponImbueRogueInstantPoison:
+								case proto.Rogue_Options_InstantPoison:
 									rogue.InstantPoison.Cast(sim, spellEffect.Target)
 								}
 							}
 							if rogue.LastDeadlyPoisonProcMask.Matches(core.ProcMaskMeleeOH) {
-								switch rogue.Consumes.MainHandImbue {
-								case proto.WeaponImbue_WeaponImbueRogueDeadlyPoison:
+								switch rogue.Options.MhImbue {
+								case proto.Rogue_Options_DeadlyPoison:
 									rogue.DeadlyPoisonDot.Refresh(sim)
-								case proto.WeaponImbue_WeaponImbueRogueInstantPoison:
+								case proto.Rogue_Options_InstantPoison:
 									rogue.InstantPoison.Cast(sim, spellEffect.Target)
 								}
 							}
@@ -104,8 +104,8 @@ func (rogue *Rogue) registerDeadlyPoisonSpell() {
 
 func (rogue *Rogue) applyDeadlyPoison() {
 	procMask := core.GetMeleeProcMaskForHands(
-		rogue.Consumes.MainHandImbue == proto.WeaponImbue_WeaponImbueRogueDeadlyPoison,
-		rogue.Consumes.OffHandImbue == proto.WeaponImbue_WeaponImbueRogueDeadlyPoison)
+		rogue.Options.MhImbue == proto.Rogue_Options_DeadlyPoison,
+		rogue.Options.OhImbue == proto.Rogue_Options_DeadlyPoison)
 
 	if procMask == core.ProcMaskUnknown {
 		return
@@ -154,8 +154,8 @@ func (rogue *Rogue) registerInstantPoisonSpell() {
 
 func (rogue *Rogue) applyInstantPoison() {
 	procMask := core.GetMeleeProcMaskForHands(
-		rogue.Consumes.MainHandImbue == proto.WeaponImbue_WeaponImbueRogueInstantPoison,
-		rogue.Consumes.OffHandImbue == proto.WeaponImbue_WeaponImbueRogueInstantPoison)
+		rogue.Options.MhImbue == proto.Rogue_Options_InstantPoison,
+		rogue.Options.OhImbue == proto.Rogue_Options_InstantPoison)
 
 	if procMask == core.ProcMaskUnknown {
 		return
@@ -163,10 +163,10 @@ func (rogue *Rogue) applyInstantPoison() {
 
 	var mhProcChance float64
 	var ohProcChance float64
-	if rogue.Consumes.MainHandImbue == proto.WeaponImbue_WeaponImbueRogueInstantPoison {
+	if rogue.Options.MhImbue == proto.Rogue_Options_InstantPoison {
 		mhProcChance = (rogue.GetMHWeapon().SwingSpeed * 8.57 * (1 + float64(rogue.Talents.ImprovedPoisons)*0.1)) / 60
 	}
-	if rogue.Consumes.OffHandImbue == proto.WeaponImbue_WeaponImbueRogueInstantPoison {
+	if rogue.Options.OhImbue == proto.Rogue_Options_InstantPoison {
 		ohProcChance = (rogue.GetOHWeapon().SwingSpeed * 8.57 * (1 + float64(rogue.Talents.ImprovedPoisons)*0.1)) / 60
 	}
 

--- a/sim/rogue/presets.go
+++ b/sim/rogue/presets.go
@@ -116,8 +116,6 @@ var FullIndividualBuffs = &proto.IndividualBuffs{
 }
 
 var FullConsumes = &proto.Consumes{
-	MainHandImbue:   proto.WeaponImbue_WeaponImbueRogueInstantPoison,
-	OffHandImbue:    proto.WeaponImbue_WeaponImbueRogueDeadlyPoison,
 	Flask:           proto.Flask_FlaskOfRelentlessAssault,
 	DefaultPotion:   proto.Potions_HastePotion,
 	DefaultConjured: proto.Conjured_ConjuredRogueThistleTea,

--- a/sim/rogue/presets.go
+++ b/sim/rogue/presets.go
@@ -209,7 +209,10 @@ var basicRotation = &proto.Rogue_Rotation{
 	MinComboPointsForDamageFinisher: 3,
 }
 
-var basicOptions = &proto.Rogue_Options{}
+var basicOptions = &proto.Rogue_Options{
+	MhImbue: proto.Rogue_Options_DeadlyPoison,
+	OhImbue: proto.Rogue_Options_InstantPoison,
+}
 
 var FullRaidBuffs = &proto.RaidBuffs{
 	GiftOfTheWild:   proto.TristateEffect_TristateEffectImproved,

--- a/sim/rogue/presets.go
+++ b/sim/rogue/presets.go
@@ -6,26 +6,111 @@ import (
 )
 
 var CombatTalents = &proto.RogueTalents{
-	Malice:              5,
-	Ruthlessness:        3,
-	Murder:              2,
-	RelentlessStrikes:   5,
-	ImprovedExposeArmor: 2,
-	Lethality:           5,
-	VilePoisons:         2,
+	Malice:          5,
+	Ruthlessness:    3,
+	BloodSpatter:    2,
+	Lethality:       5,
+	VilePoisons:     2,
+	ImprovedPoisons: 3,
 
 	ImprovedSinisterStrike:  2,
-	ImprovedSliceAndDice:    3,
-	Precision:               5,
 	DualWieldSpecialization: 5,
+	ImprovedSliceAndDice:    2,
+	Precision:               5,
+	Endurance:               1,
+	CloseQuartersCombat:     5,
+	LightningReflexes:       3,
+	Aggression:              5,
 	BladeFlurry:             true,
-	HackAndSlash:            5,
 	WeaponExpertise:         2,
-	Aggression:              3,
-	Vitality:                2,
+	BladeTwisting:           2,
+	Vitality:                3,
 	AdrenalineRush:          true,
 	CombatPotency:           5,
 	SurpriseAttacks:         true,
+	SavageCombat:            2,
+	PreyOnTheWeak:           5,
+	KillingSpree:            true,
+}
+
+var CombatNoLethalityTalents = &proto.RogueTalents{
+	Malice:          5,
+	Ruthlessness:    3,
+	BloodSpatter:    2,
+	VilePoisons:     2,
+	ImprovedPoisons: 3,
+
+	ImprovedSinisterStrike:  2,
+	DualWieldSpecialization: 5,
+	ImprovedSliceAndDice:    2,
+	Precision:               5,
+	Endurance:               1,
+	CloseQuartersCombat:     5,
+	LightningReflexes:       3,
+	Aggression:              5,
+	BladeFlurry:             true,
+	WeaponExpertise:         2,
+	BladeTwisting:           2,
+	Vitality:                3,
+	AdrenalineRush:          true,
+	CombatPotency:           5,
+	SurpriseAttacks:         true,
+	SavageCombat:            2,
+	PreyOnTheWeak:           5,
+	KillingSpree:            true,
+}
+
+var CombatNoPotWTalents = &proto.RogueTalents{
+	Malice:          5,
+	Ruthlessness:    3,
+	BloodSpatter:    2,
+	Lethality:       5,
+	VilePoisons:     2,
+	ImprovedPoisons: 3,
+
+	ImprovedSinisterStrike:  2,
+	DualWieldSpecialization: 5,
+	ImprovedSliceAndDice:    2,
+	Precision:               5,
+	Endurance:               1,
+	CloseQuartersCombat:     5,
+	LightningReflexes:       3,
+	Aggression:              5,
+	BladeFlurry:             true,
+	WeaponExpertise:         2,
+	BladeTwisting:           2,
+	Vitality:                3,
+	AdrenalineRush:          true,
+	CombatPotency:           5,
+	SurpriseAttacks:         true,
+	SavageCombat:            2,
+	KillingSpree:            true,
+}
+
+var CombatNoLethalityNoPotWTalents = &proto.RogueTalents{
+	Malice:          5,
+	Ruthlessness:    3,
+	BloodSpatter:    2,
+	VilePoisons:     2,
+	ImprovedPoisons: 3,
+
+	ImprovedSinisterStrike:  2,
+	DualWieldSpecialization: 5,
+	ImprovedSliceAndDice:    2,
+	Precision:               5,
+	Endurance:               1,
+	CloseQuartersCombat:     5,
+	LightningReflexes:       3,
+	Aggression:              5,
+	BladeFlurry:             true,
+	WeaponExpertise:         2,
+	BladeTwisting:           2,
+	Vitality:                3,
+	AdrenalineRush:          true,
+	CombatPotency:           5,
+	SurpriseAttacks:         true,
+	SavageCombat:            2,
+	KillingSpree:            true,
 }
 
 var MutilateTalents = &proto.RogueTalents{
@@ -70,6 +155,30 @@ var HemoTalents = &proto.RogueTalents{
 var PlayerOptionsBasic = &proto.Player_Rogue{
 	Rogue: &proto.Rogue{
 		Talents:  CombatTalents,
+		Options:  basicOptions,
+		Rotation: basicRotation,
+	},
+}
+
+var PlayerOptionsNoLethality = &proto.Player_Rogue{
+	Rogue: &proto.Rogue{
+		Talents:  CombatNoLethalityTalents,
+		Options:  basicOptions,
+		Rotation: basicRotation,
+	},
+}
+
+var PlayerOptionsNoPotW = &proto.Player_Rogue{
+	Rogue: &proto.Rogue{
+		Talents:  CombatNoPotWTalents,
+		Options:  basicOptions,
+		Rotation: basicRotation,
+	},
+}
+
+var PlayerOptionsNoLethalityNoPotW = &proto.Player_Rogue{
+	Rogue: &proto.Rogue{
+		Talents:  CombatNoLethalityNoPotWTalents,
 		Options:  basicOptions,
 		Rotation: basicRotation,
 	},
@@ -219,6 +328,180 @@ var P1Gear = items.EquipmentSpecFromJsonString(`{"items": [
 		"id": 28772
 	}
 ]}`)
+var GearWithoutRED = items.EquipmentSpecFromJsonString(`{"items": [
+	{
+	  "id": 37293,
+	  "enchant": 44879,
+	  "gems": [
+		41339,
+		40088
+	  ]
+	},
+	{
+	  "id": 37861
+	},
+	{
+	  "id": 37139,
+	  "enchant": 44871,
+	  "gems": [
+		36766
+	  ]
+	},
+	{
+	  "id": 36947,
+	  "enchant": 55002
+	},
+	{
+	  "id": 37165,
+	  "enchant": 44489,
+	  "gems": [
+		40044,
+		36766
+	  ]
+	},
+	{
+	  "id": 44203,
+	  "enchant": 44484,
+	  "gems": [
+		0
+	  ]
+	},
+	{
+	  "id": 37409,
+	  "enchant": 54999,
+	  "gems": [
+		0
+	  ]
+	},
+	{
+	  "id": 37194,
+	  "gems": [
+		40014,
+		40157
+	  ]
+	},
+	{
+	  "id": 37644,
+	  "enchant": 38374
+	},
+	{
+	  "id": 44297,
+	  "enchant": 55016
+	},
+	{
+	  "id": 43251,
+	  "gems": [
+		40136
+	  ]
+	},
+	{
+	  "id": 37642
+	},
+	{
+	  "id": 37390
+	},
+	{
+	  "id": 37166
+	},
+	{
+	  "id": 37693,
+	  "enchant": 44492
+	},
+	{
+	  "id": 37856,
+	  "enchant": 44492
+	},
+	{
+	  "id": 37191
+	}
+  ]}`)
+var GearWithRED = items.EquipmentSpecFromJsonString(`{"items": [
+	{
+	  "id": 37293,
+	  "enchant": 44879,
+	  "gems": [
+		41398,
+		40088
+	  ]
+	},
+	{
+	  "id": 37861
+	},
+	{
+	  "id": 37139,
+	  "enchant": 44871,
+	  "gems": [
+		36766
+	  ]
+	},
+	{
+	  "id": 36947,
+	  "enchant": 55002
+	},
+	{
+	  "id": 37165,
+	  "enchant": 44489,
+	  "gems": [
+		40044,
+		36766
+	  ]
+	},
+	{
+	  "id": 44203,
+	  "enchant": 44484,
+	  "gems": [
+		0
+	  ]
+	},
+	{
+	  "id": 37409,
+	  "enchant": 54999,
+	  "gems": [
+		0
+	  ]
+	},
+	{
+	  "id": 37194,
+	  "gems": [
+		40014,
+		40157
+	  ]
+	},
+	{
+	  "id": 37644,
+	  "enchant": 38374
+	},
+	{
+	  "id": 44297,
+	  "enchant": 55016
+	},
+	{
+	  "id": 43251,
+	  "gems": [
+		40136
+	  ]
+	},
+	{
+	  "id": 37642
+	},
+	{
+	  "id": 37390
+	},
+	{
+	  "id": 37166
+	},
+	{
+	  "id": 37693,
+	  "enchant": 44492
+	},
+	{
+	  "id": 37856,
+	  "enchant": 44492
+	},
+	{
+	  "id": 37191
+	}
+  ]}`)
 var MutilateP1Gear = items.EquipmentSpecFromJsonString(`{"items": [
 	{
 		"id": 29044,

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -244,7 +244,7 @@ func NewRogue(character core.Character, options proto.Player) *Rogue {
 		}
 	}
 
-	if rogue.Consumes.OffHandImbue != proto.WeaponImbue_WeaponImbueRogueDeadlyPoison {
+	if rogue.Options.OhImbue != proto.Rogue_Options_DeadlyPoison {
 		rogue.Rotation.UseShiv = false
 	}
 

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -57,7 +57,7 @@ type Rogue struct {
 	Backstab       *core.Spell
 	DeadlyPoison   *core.Spell
 	Hemorrhage     *core.Spell
-	InstantPoison  *core.Spell
+	InstantPoison  [3]*core.Spell
 	Mutilate       *core.Spell
 	Shiv           *core.Spell
 	SinisterStrike *core.Spell
@@ -68,9 +68,11 @@ type Rogue struct {
 	Rupture      [6]*core.Spell
 	SliceAndDice [6]*core.Spell
 
-	LastDeadlyPoisonProcMask core.ProcMask
-	DeadlyPoisonDot          *core.Dot
-	RuptureDot               *core.Dot
+	LastDeadlyPoisonProcMask     core.ProcMask
+	DeadlyPoisonProcChanceBonus  float64
+	InstantPoisonProcChanceBonus float64
+	DeadlyPoisonDot              *core.Dot
+	RuptureDot                   *core.Dot
 
 	AdrenalineRushAura  *core.Aura
 	BladeFlurryAura     *core.Aura
@@ -141,7 +143,6 @@ func (rogue *Rogue) Initialize() {
 	rogue.registerSliceAndDice()
 
 	rogue.registerThistleTeaCD()
-	rogue.applyPoisons()
 
 	switch rogue.Rotation.Builder {
 	case proto.Rogue_Rotation_SinisterStrike:
@@ -203,6 +204,7 @@ func NewRogue(character core.Character, options proto.Player) *Rogue {
 		Options:   *rogueOptions.Options,
 		Rotation:  *rogueOptions.Rotation,
 	}
+	rogue.applyPoisons()
 
 	// Passive rogue threat reduction: https://wotlk.wowhead.com/spell=21184/rogue-passive-dnd
 	rogue.PseudoStats.ThreatMultiplier *= 0.71

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -180,27 +180,17 @@ func (rogue *Rogue) Reset(sim *core.Simulation) {
 func (rogue *Rogue) MeleeCritMultiplier(isMH bool, applyLethality bool) float64 {
 	primaryModifier := rogue.murderMultiplier()
 	secondaryModifier := 0.0
-
+	preyModifier := rogue.preyOnTheWeakMultiplier(rogue.CurrentTarget)
 	if applyLethality {
 		secondaryModifier += 0.06 * float64(rogue.Talents.Lethality)
 	}
-
-	// TODO: Use the following predicate if/when health values are modeled
-	//if rogue.CurrentTarget != nil && rogue.CurrentTarget.HasHealthBar() && rogue.CurrentTarget.CurrentHealthPercent() < rogue.CurrentHealthPercent() {
-	if rogue.Talents.PreyOnTheWeak > 0 {
-		secondaryModifier *= (1 + 0.04*float64(rogue.Talents.PreyOnTheWeak))
-		primaryModifier *= (1 + 0.04*float64(rogue.Talents.PreyOnTheWeak))
-	}
-	if rogue.Character.HasMetaGemEquipped(34220) ||
-		rogue.Character.HasMetaGemEquipped(32409) ||
-		rogue.Character.HasMetaGemEquipped(41285) ||
-		rogue.Character.HasMetaGemEquipped(41398) {
-		primaryModifier *= 1.03
-	}
-	return (2.0 + secondaryModifier) * primaryModifier
+	primaryModifier *= preyModifier
+	return rogue.Character.MeleeCritMultiplier(primaryModifier, secondaryModifier)
 }
 func (rogue *Rogue) SpellCritMultiplier() float64 {
-	return rogue.Character.SpellCritMultiplier(rogue.murderMultiplier(), 0)
+	primaryModifier := rogue.preyOnTheWeakMultiplier(rogue.CurrentTarget)
+	primaryModifier *= rogue.murderMultiplier()
+	return rogue.Character.SpellCritMultiplier(primaryModifier, 0)
 }
 
 func NewRogue(character core.Character, options proto.Player) *Rogue {

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -78,6 +78,7 @@ type Rogue struct {
 	AdrenalineRushAura  *core.Aura
 	BladeFlurryAura     *core.Aura
 	DeathmantleProcAura *core.Aura
+	EnvenomAura         *core.Aura
 	ExposeArmorAura     *core.Aura
 	HungerForBloodAura  *core.Aura
 	KillingSpreeAura    *core.Aura
@@ -133,7 +134,6 @@ func (rogue *Rogue) Initialize() {
 
 	rogue.registerBackstabSpell()
 	rogue.registerDeadlyPoisonSpell()
-	rogue.registerEnvenom()
 	rogue.registerEviscerate()
 	rogue.registerExposeArmorSpell()
 	rogue.registerHemorrhageSpell()
@@ -145,6 +145,10 @@ func (rogue *Rogue) Initialize() {
 	rogue.registerSliceAndDice()
 
 	rogue.registerThistleTeaCD()
+
+	if rogue.Rotation.UseEnvenom {
+		rogue.registerEnvenom()
+	}
 
 	switch rogue.Rotation.Builder {
 	case proto.Rogue_Rotation_SinisterStrike:

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -266,6 +266,16 @@ func NewRogue(character core.Character, options proto.Player) *Rogue {
 	return rogue
 }
 
+func (rogue *Rogue) ApplyCutToTheChase(sim *core.Simulation) {
+	if rogue.Talents.CutToTheChase > 0 && rogue.SliceAndDiceAura.IsActive() {
+		chanceToRefresh := float64(rogue.Talents.CutToTheChase) * 0.2
+		if chanceToRefresh == 1 || sim.RandomFloat("Cut to the Chase") < chanceToRefresh {
+			rogue.SliceAndDiceAura.Duration = rogue.sliceAndDiceDurations[5]
+			rogue.SliceAndDiceAura.Activate(sim)
+		}
+	}
+}
+
 func init() {
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceBloodElf, Class: proto.Class_ClassRogue}] = stats.Stats{
 		stats.Health:    3524,

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -159,7 +159,7 @@ func (rogue *Rogue) Initialize() {
 
 	rogue.finishingMoveEffectApplier = rogue.makeFinishingMoveEffectApplier()
 
-	rogue.energyPerSecondAvg = core.EnergyPerTick / core.EnergyTickDuration.Seconds()
+	rogue.energyPerSecondAvg = (core.EnergyPerTick*rogue.EnergyTickMultiplier)/core.EnergyTickDuration.Seconds() + 5.0
 
 	// TODO: Currently assumes default combat spec.
 	expectedComboPointsAfterFinisher := 0

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -77,6 +77,7 @@ type Rogue struct {
 	DeathmantleProcAura *core.Aura
 	ExposeArmorAura     *core.Aura
 	KillingSpreeAura    *core.Aura
+	OverkillAura        *core.Aura
 	SliceAndDiceAura    *core.Aura
 
 	QuickRecoveryMetrics *core.ResourceMetrics

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -72,7 +72,7 @@ type Rogue struct {
 	LastDeadlyPoisonProcMask     core.ProcMask
 	DeadlyPoisonProcChanceBonus  float64
 	InstantPoisonProcChanceBonus float64
-	DeadlyPoisonDot              *core.Dot
+	DeadlyPoisonDots             []*core.Dot
 	RuptureDot                   *core.Dot
 
 	AdrenalineRushAura  *core.Aura

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -26,9 +26,9 @@ func RegisterRogue() {
 }
 
 const (
-	SpellFlagBuilder      = core.SpellFlagAgentReserved1
-	SpellFlagFinisher     = core.SpellFlagAgentReserved2
-	SpellFlagRogueAbility = SpellFlagBuilder | SpellFlagFinisher
+	SpellFlagBuilder      = core.SpellFlagAgentReserved2
+	SpellFlagFinisher     = core.SpellFlagAgentReserved3
+	SpellFlagRogueAbility = SpellFlagBuilder | SpellFlagFinisher | core.SpellFlagAgentReserved1
 )
 
 type Rogue struct {
@@ -57,6 +57,7 @@ type Rogue struct {
 	Backstab       *core.Spell
 	DeadlyPoison   *core.Spell
 	Hemorrhage     *core.Spell
+	HungerForBlood *core.Spell
 	InstantPoison  [3]*core.Spell
 	Mutilate       *core.Spell
 	Shiv           *core.Spell
@@ -78,6 +79,7 @@ type Rogue struct {
 	BladeFlurryAura     *core.Aura
 	DeathmantleProcAura *core.Aura
 	ExposeArmorAura     *core.Aura
+	HungerForBloodAura  *core.Aura
 	KillingSpreeAura    *core.Aura
 	OverkillAura        *core.Aura
 	SliceAndDiceAura    *core.Aura

--- a/sim/rogue/rogue_test.go
+++ b/sim/rogue/rogue_test.go
@@ -114,7 +114,7 @@ func GenerateCriticalDamageMultiplierTestCase(
 		actualMultiplier = rog.MeleeCritMultiplier(true, false)
 	}
 	t.Run(testName, func(t *testing.T) {
-		if expectedMultiplier != actualMultiplier {
+		if !core.WithinToleranceFloat64(expectedMultiplier, actualMultiplier, 0.0001) {
 			t.Logf("Crit damage multiplier for %s expected %f but was %f", testName, expectedMultiplier, actualMultiplier)
 			t.Fail()
 		}

--- a/sim/rogue/rotation.go
+++ b/sim/rogue/rotation.go
@@ -379,7 +379,7 @@ func (rogue *Rogue) canPoolEnergy(sim *core.Simulation, energy float64) bool {
 }
 
 func (rogue *Rogue) castBuilder(sim *core.Simulation, target *core.Unit) {
-	if rogue.Rotation.UseShiv && rogue.DeadlyPoisonDot.IsActive() && rogue.DeadlyPoisonDot.RemainingDuration(sim) < time.Second*2 && rogue.CurrentEnergy() >= rogue.Shiv.DefaultCast.Cost {
+	if rogue.Rotation.UseShiv && rogue.DeadlyPoisonDots[target.Index].IsActive() && rogue.DeadlyPoisonDots[target.Index].RemainingDuration(sim) < time.Second*2 && rogue.CurrentEnergy() >= rogue.Shiv.DefaultCast.Cost {
 		rogue.Shiv.Cast(sim, target)
 	} else {
 		rogue.Builder.Cast(sim, target)

--- a/sim/rogue/rotation.go
+++ b/sim/rogue/rotation.go
@@ -327,7 +327,7 @@ func (rogue *Rogue) doPlanNone(sim *core.Simulation) {
 }
 
 func (rogue *Rogue) canPoolEnergy(sim *core.Simulation, energy float64) bool {
-	return sim.GetRemainingDuration() >= time.Second*6 && energy <= 50 && ((rogue.AdrenalineRushAura == nil || !rogue.AdrenalineRushAura.IsActive()) || energy <= 30)
+	return sim.GetRemainingDuration() >= time.Second*6 && energy <= 85 && ((rogue.AdrenalineRushAura == nil || !rogue.AdrenalineRushAura.IsActive()) || energy <= 70)
 }
 
 func (rogue *Rogue) castBuilder(sim *core.Simulation, target *core.Unit) {
@@ -339,9 +339,12 @@ func (rogue *Rogue) castBuilder(sim *core.Simulation, target *core.Unit) {
 }
 
 func (rogue *Rogue) tryUseDamageFinisher(sim *core.Simulation, energy float64, comboPoints int32) bool {
+	newRuptureDuration := core.MinDuration(rogue.RuptureDuration(comboPoints), sim.GetRemainingDuration())
+	if rogue.RuptureDot.IsActive() {
+		newRuptureDuration -= core.MinDuration(rogue.RuptureDot.RemainingDuration(sim), sim.GetRemainingDuration())
+	}
 	if rogue.Rotation.UseRupture &&
-		!rogue.RuptureDot.IsActive() &&
-		sim.GetRemainingDuration() >= rogue.RuptureDuration(comboPoints) &&
+		newRuptureDuration >= time.Second*10 &&
 		(sim.GetNumTargets() == 1 || (rogue.BladeFlurryAura == nil || !rogue.BladeFlurryAura.IsActive())) {
 		if energy >= RuptureEnergyCost || rogue.DeathmantleProcAura.IsActive() {
 			rogue.Rupture[comboPoints].Cast(sim, rogue.CurrentTarget)

--- a/sim/rogue/shiv.go
+++ b/sim/rogue/shiv.go
@@ -40,10 +40,10 @@ func (rogue *Rogue) registerShivSpell() {
 				if spellEffect.Landed() {
 					rogue.AddComboPoints(sim, 1, spell.ComboPointMetrics())
 
-					switch rogue.Consumes.OffHandImbue {
-					case proto.WeaponImbue_WeaponImbueRogueDeadlyPoison:
+					switch rogue.Options.OhImbue {
+					case proto.Rogue_Options_DeadlyPoison:
 						rogue.DeadlyPoison.Cast(sim, spellEffect.Target)
-					case proto.WeaponImbue_WeaponImbueRogueInstantPoison:
+					case proto.Rogue_Options_InstantPoison:
 						rogue.procInstantPoison(sim, spellEffect)
 					}
 				}

--- a/sim/rogue/shiv.go
+++ b/sim/rogue/shiv.go
@@ -44,7 +44,7 @@ func (rogue *Rogue) registerShivSpell() {
 					case proto.Rogue_Options_DeadlyPoison:
 						rogue.DeadlyPoison.Cast(sim, spellEffect.Target)
 					case proto.Rogue_Options_InstantPoison:
-						rogue.procInstantPoison(sim, spellEffect)
+						rogue.InstantPoison[2].Cast(sim, spellEffect.Target)
 					}
 				}
 			},

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -104,6 +104,14 @@ func (rogue *Rogue) murderMultiplier() float64 {
 	}
 }
 
+func (rogue *Rogue) preyOnTheWeakMultiplier(target *core.Unit) float64 {
+	// TODO: Use the following predicate if/when health values are modeled
+	//if rogue.CurrentTarget != nil &&
+	//rogue.CurrentTarget.HasHealthBar() &&
+	//rogue.CurrentTarget.CurrentHealthPercent() < rogue.CurrentHealthPercent()
+	return (1 + 0.04*float64(rogue.Talents.PreyOnTheWeak))
+}
+
 func (rogue *Rogue) registerColdBloodCD() {
 	if !rogue.Talents.ColdBlood {
 		return

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -42,6 +42,8 @@ func (rogue *Rogue) ApplyTalents() {
 
 	rogue.PseudoStats.AgentReserved1DamageDealtMultiplier *= (1 + float64(rogue.Talents.FindWeakness)*0.02)
 
+	rogue.registerOverkillCD()
+	rogue.registerHungerForBlood()
 	rogue.registerColdBloodCD()
 	rogue.registerBladeFlurryCD()
 	rogue.registerAdrenalineRushCD()
@@ -54,23 +56,6 @@ func (rogue *Rogue) makeFinishingMoveEffectApplier() func(sim *core.Simulation, 
 
 	relentlessStrikes := rogue.Talents.RelentlessStrikes
 	relentlessStrikesMetrics := rogue.NewEnergyMetrics(core.ActionID{SpellID: 14179})
-
-	var fwAura *core.Aura
-	findWeaknessMultiplier := 1.0 + 0.02*float64(rogue.Talents.FindWeakness)
-	if findWeaknessMultiplier != 1 {
-		fwAura = rogue.GetOrRegisterAura(core.Aura{
-			Label:    "Find Weakness",
-			ActionID: core.ActionID{SpellID: 31242},
-			Duration: time.Second * 10,
-			OnGain: func(aura *core.Aura, sim *core.Simulation) {
-				aura.Unit.PseudoStats.AgentReserved1DamageDealtMultiplier *= findWeaknessMultiplier
-			},
-			OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-				aura.Unit.PseudoStats.AgentReserved1DamageDealtMultiplier /= findWeaknessMultiplier
-			},
-		})
-	}
-
 	netherblade4pc := rogue.HasSetBonus(ItemSetNetherblade, 4)
 	netherblade4pcMetrics := rogue.NewComboPointMetrics(core.ActionID{SpellID: 37168})
 
@@ -82,12 +67,9 @@ func (rogue *Rogue) makeFinishingMoveEffectApplier() func(sim *core.Simulation, 
 			rogue.AddComboPoints(sim, 1, netherblade4pcMetrics)
 		}
 		if relentlessStrikes > 0 {
-			if numPoints == 5 || sim.RandomFloat("RelentlessStrikes") < 0.2*float64(numPoints) {
+			if sim.RandomFloat("RelentlessStrikes") < 0.04*float64(numPoints) {
 				rogue.AddEnergy(sim, 25, relentlessStrikesMetrics)
 			}
-		}
-		if fwAura != nil {
-			fwAura.Activate(sim)
 		}
 	}
 }
@@ -97,12 +79,45 @@ func (rogue *Rogue) applyMurder() {
 }
 
 func (rogue *Rogue) murderMultiplier() float64 {
-	switch rogue.CurrentTarget.MobType {
-	case proto.MobType_MobTypeHumanoid, proto.MobType_MobTypeBeast, proto.MobType_MobTypeGiant, proto.MobType_MobTypeDragonkin:
-		return 1.0 + 0.01*float64(rogue.Talents.Murder)
-	default:
-		return 1
+	return 1.0 + 0.02*float64(rogue.Talents.Murder)
+}
+
+func (rogue *Rogue) registerHungerForBlood() {
+	if !rogue.Talents.HungerForBlood {
+		return
 	}
+	actionID := core.ActionID{SpellID: 51662}
+	multiplier := 1.05
+	if rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfHungerForBlood) {
+		multiplier += 0.03
+	}
+	rogue.HungerForBloodAura = rogue.RegisterAura(core.Aura{
+		Label:    "Hunger for Blood",
+		ActionID: actionID,
+		Duration: time.Minute,
+		OnGain: func(aura *core.Aura, sim *core.Simulation) {
+			rogue.PseudoStats.DamageDealtMultiplier *= multiplier
+		},
+		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
+			rogue.PseudoStats.DamageDealtMultiplier *= 1 / multiplier
+		},
+	})
+
+	rogue.HungerForBlood = rogue.RegisterSpell(core.SpellConfig{
+		ActionID:     actionID,
+		ResourceType: stats.Energy,
+		BaseCost:     15,
+		Cast: core.CastConfig{
+			DefaultCast: core.Cast{
+				Cost: 15,
+				GCD:  time.Second,
+			},
+		},
+		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
+			rogue.HungerForBloodAura.Activate(sim)
+		},
+	})
+
 }
 
 func (rogue *Rogue) preyOnTheWeakMultiplier(target *core.Unit) float64 {

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -55,7 +55,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.7216994259893499
+  weights: 1.7216994259893545
   weights: 0
   weights: 0.6899960812406744
   weights: 0
@@ -67,7 +67,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0.9646277049934724
-  weights: 0.8875967433603638
+  weights: 0.8875967433603682
   weights: 0
   weights: 0
   weights: 0
@@ -104,7 +104,7 @@ dps_results: {
  key: "TestElemental-AllItems-AshtongueTalismanofVision-32491"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
@@ -118,7 +118,7 @@ dps_results: {
  key: "TestElemental-AllItems-Bandit'sInsignia-40371"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
@@ -131,7 +131,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2748.3016277864044
+  dps: 2748.301627786404
   tps: 2115.5614467706973
  }
 }
@@ -167,13 +167,13 @@ dps_results: {
  key: "TestElemental-AllItems-CycloneHarness"
  value: {
   dps: 1783.8386923095209
-  tps: 1431.8757766105173
+  tps: 1431.875776610517
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CycloneRegalia"
  value: {
-  dps: 2105.4451332442454
+  dps: 2105.445133244246
   tps: 1671.5573088832941
  }
 }
@@ -187,22 +187,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2883.314896905512
+  dps: 2883.3148969055114
   tps: 2273.195435716966
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 2704.7702013474795
-  tps: 2113.8945445589916
+  dps: 2704.77020134748
+  tps: 2113.894544558992
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 2704.7702013474795
-  tps: 2113.8945445589916
+  dps: 2704.77020134748
+  tps: 2113.894544558992
  }
 }
 dps_results: {
@@ -216,14 +216,14 @@ dps_results: {
  key: "TestElemental-AllItems-DeathKnight'sAnguish-38212"
  value: {
   dps: 2781.2707548962157
-  tps: 2185.6406305103023
+  tps: 2185.640630510303
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Defender'sCode-40257"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
@@ -236,7 +236,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2764.3947215201283
+  dps: 2764.3947215201274
   tps: 2167.8697599289053
  }
 }
@@ -278,7 +278,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2782.519337345478
+  dps: 2782.5193373454777
   tps: 2178.6916074420083
  }
 }
@@ -293,13 +293,13 @@ dps_results: {
  key: "TestElemental-AllItems-ExtractofNecromanticPower-40373"
  value: {
   dps: 2854.977684726765
-  tps: 2242.2243858683405
+  tps: 2242.224385868341
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2903.09888545844
+  dps: 2903.0988854584402
   tps: 2274.7715686449746
  }
 }
@@ -327,7 +327,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2748.3016277864044
+  dps: 2748.301627786404
   tps: 2158.251754859516
  }
 }
@@ -342,7 +342,7 @@ dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sBattlegear"
  value: {
   dps: 1958.287862463448
-  tps: 1553.6025789322396
+  tps: 1553.6025789322393
  }
 }
 dps_results: {
@@ -356,7 +356,7 @@ dps_results: {
  key: "TestElemental-AllItems-FuryoftheFiveFlights-40431"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
@@ -370,14 +370,14 @@ dps_results: {
  key: "TestElemental-AllItems-Gladiator'sEarthshaker"
  value: {
   dps: 2297.534631311503
-  tps: 1811.8491635096373
+  tps: 1811.8491635096368
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
   dps: 2921.253655723981
-  tps: 2288.4627574346882
+  tps: 2288.4627574346887
  }
 }
 dps_results: {
@@ -390,7 +390,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2782.519337345478
+  dps: 2782.5193373454777
   tps: 2178.6916074420083
  }
 }
@@ -411,7 +411,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 3126.274672485019
+  dps: 3126.274672485018
   tps: 2448.338531520568
  }
 }
@@ -426,14 +426,14 @@ dps_results: {
  key: "TestElemental-AllItems-Lavanthor'sTalisman-37872"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MajesticDragonFigurine-40430"
  value: {
   dps: 2789.792791872217
-  tps: 2185.5000475138395
+  tps: 2185.50004751384
  }
 }
 dps_results: {
@@ -446,7 +446,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2832.328763697961
+  dps: 2832.328763697962
   tps: 2225.1704274806925
  }
 }
@@ -461,7 +461,7 @@ dps_results: {
  key: "TestElemental-AllItems-NetherscaleArmor"
  value: {
   dps: 2354.025599383508
-  tps: 1863.0824115447545
+  tps: 1863.0824115447547
  }
 }
 dps_results: {
@@ -489,7 +489,7 @@ dps_results: {
  key: "TestElemental-AllItems-OfferingofSacrifice-37638"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
@@ -531,7 +531,7 @@ dps_results: {
  key: "TestElemental-AllItems-PurifiedShardoftheGods"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
@@ -551,8 +551,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2806.471982931794
-  tps: 2204.7695841663626
+  dps: 2806.4719829317946
+  tps: 2204.769584166363
  }
 }
 dps_results: {
@@ -566,20 +566,20 @@ dps_results: {
  key: "TestElemental-AllItems-RuneofRepulsion-40372"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SealofthePantheon-36993"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 2804.486465922195
+  dps: 2804.4864659221953
   tps: 2193.7024020586987
  }
 }
@@ -587,21 +587,21 @@ dps_results: {
  key: "TestElemental-AllItems-ShinyShardoftheGods"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkycallTotem-33506"
  value: {
   dps: 2815.0988712130556
-  tps: 2220.2342132978674
+  tps: 2220.234213297867
  }
 }
 dps_results: {
@@ -671,7 +671,7 @@ dps_results: {
  key: "TestElemental-AllItems-TheFistsofFury"
  value: {
   dps: 2204.4384623651413
-  tps: 1744.051053787202
+  tps: 1744.0510537872021
  }
 }
 dps_results: {
@@ -726,7 +726,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2748.3016277864044
+  dps: 2748.301627786404
   tps: 2158.251754859516
  }
 }
@@ -768,7 +768,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2748.3016277864044
+  dps: 2748.301627786404
   tps: 2158.251754859516
  }
 }
@@ -811,7 +811,7 @@ dps_results: {
  key: "TestElemental-Average-Default"
  value: {
   dps: 2810.9877031543547
-  tps: 2203.372751615126
+  tps: 2203.3727516151257
  }
 }
 dps_results: {
@@ -825,7 +825,7 @@ dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-LongSingleTarget"
  value: {
   dps: 2802.2786630386277
-  tps: 2198.0622177836335
+  tps: 2198.062217783633
  }
 }
 dps_results: {
@@ -846,13 +846,13 @@ dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-LongSingleTarget"
  value: {
   dps: 1494.924773947619
-  tps: 1198.0374584563888
+  tps: 1198.037458456389
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3445.0711611361658
+  dps: 3445.0711611361667
   tps: 2642.0508516835753
  }
 }
@@ -873,7 +873,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3951.0846653991985
+  dps: 3951.0846653991966
   tps: 3091.023468077532
  }
 }
@@ -887,15 +887,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1528.2534693649566
-  tps: 1232.0047510821573
+  dps: 1528.253469364957
+  tps: 1232.0047510821576
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3515.9359488668297
-  tps: 2751.092807275862
+  dps: 3515.9359488668306
+  tps: 2751.0928072758625
  }
 }
 dps_results: {

--- a/sim/shaman/elemental/presets.go
+++ b/sim/shaman/elemental/presets.go
@@ -62,7 +62,6 @@ var FullConsumes = &proto.Consumes{
 	Food:            proto.Food_FoodBlackenedBasilisk,
 	DefaultPotion:   proto.Potions_SuperManaPotion,
 	PrepopPotion:    proto.Potions_DestructionPotion,
-	MainHandImbue:   proto.WeaponImbue_WeaponImbueBrilliantWizardOil,
 	DefaultConjured: proto.Conjured_ConjuredDarkRune,
 }
 

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -88,7 +88,7 @@ dps_results: {
  key: "TestEnhancement-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
   dps: 5501.999546097223
-  tps: 4182.179266846324
+  tps: 4182.179266846325
  }
 }
 dps_results: {
@@ -101,7 +101,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-CataclysmRegalia"
  value: {
-  dps: 4071.341862975318
+  dps: 4071.3418629753187
   tps: 3080.599536873654
  }
 }
@@ -143,28 +143,28 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 5606.1871338675855
-  tps: 4256.68032266832
+  dps: 5606.187133867586
+  tps: 4256.680322668321
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 5637.505550513135
+  dps: 5637.505550513136
   tps: 4279.47383715688
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 5530.802319565726
+  dps: 5530.802319565725
   tps: 4197.361137188475
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5510.536808199895
+  dps: 5510.536808199894
   tps: 4181.597482398585
  }
 }
@@ -200,7 +200,7 @@ dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterGarb"
  value: {
   dps: 4479.148684298044
-  tps: 3410.4305907761745
+  tps: 3410.4305907761736
  }
 }
 dps_results: {
@@ -213,7 +213,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5529.175648643035
+  dps: 5529.175648643036
   tps: 4206.611661403285
  }
 }
@@ -241,7 +241,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5580.870646745833
+  dps: 5580.870646745832
   tps: 4247.2458803710715
  }
 }
@@ -262,7 +262,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-FelstalkerArmor"
  value: {
-  dps: 4791.165225007501
+  dps: 4791.165225007502
   tps: 3621.964107551449
  }
 }
@@ -270,7 +270,7 @@ dps_results: {
  key: "TestEnhancement-AllItems-ForgeEmber-37660"
  value: {
   dps: 5549.633191498228
-  tps: 4216.965497542519
+  tps: 4216.96549754252
  }
 }
 dps_results: {
@@ -325,7 +325,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5524.4841435164435
+  dps: 5524.484143516444
   tps: 4207.226649422244
  }
 }
@@ -346,14 +346,14 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5760.906012541735
+  dps: 5760.9060125417345
   tps: 4363.559329049061
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 5504.515755942516
+  dps: 5504.515755942517
   tps: 4184.580857876983
  }
 }
@@ -410,7 +410,7 @@ dps_results: {
  key: "TestEnhancement-AllItems-NetherstrikeArmor"
  value: {
   dps: 4783.5733908215625
-  tps: 3618.4444511989727
+  tps: 3618.4444511989736
  }
 }
 dps_results: {
@@ -423,7 +423,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Nobundo'sRegalia"
  value: {
-  dps: 4652.803064533295
+  dps: 4652.803064533296
   tps: 3532.8067710477508
  }
 }
@@ -465,7 +465,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-PrimalIntent"
  value: {
-  dps: 4862.8821733163995
+  dps: 4862.882173316401
   tps: 3674.7648635268147
  }
 }
@@ -479,7 +479,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 5763.227331652478
+  dps: 5763.227331652476
   tps: 4434.955451998995
  }
 }
@@ -556,15 +556,15 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterRegalia"
  value: {
-  dps: 3775.946984892834
-  tps: 2863.4318995625085
+  dps: 3775.9469848928347
+  tps: 2863.4318995625094
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SparkofLife-37657"
  value: {
   dps: 5534.325256178775
-  tps: 4195.884869746174
+  tps: 4195.884869746175
  }
 }
 dps_results: {
@@ -627,13 +627,13 @@ dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sBattlegear"
  value: {
   dps: 4835.728181649833
-  tps: 3704.0530923357
+  tps: 3704.053092335701
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sRegalia"
  value: {
-  dps: 4652.803064533295
+  dps: 4652.803064533296
   tps: 3532.8067710477508
  }
 }
@@ -732,7 +732,7 @@ dps_results: {
  key: "TestEnhancement-AllItems-WindhawkArmor"
  value: {
   dps: 4750.017943803542
-  tps: 3599.9717005300818
+  tps: 3599.971700530081
  }
 }
 dps_results: {
@@ -774,7 +774,7 @@ dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
   dps: 5576.454842428504
-  tps: 4227.252023370978
+  tps: 4227.252023370977
  }
 }
 dps_results: {

--- a/sim/warlock/TestWarlock.results
+++ b/sim/warlock/TestWarlock.results
@@ -95,13 +95,13 @@ dps_results: {
  key: "TestWarlock-AllItems-DarkCoven'sRegalia"
  value: {
   dps: 5840.608966897828
-  tps: 5220.555324060732
+  tps: 5220.555324060733
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-DeathbringerGarb"
  value: {
-  dps: 6421.0306270582505
+  dps: 6421.030627058252
   tps: 5786.639579280071
  }
 }
@@ -158,7 +158,7 @@ dps_results: {
  key: "TestWarlock-AllItems-ForlornStarflareDiamond"
  value: {
   dps: 6589.258643086365
-  tps: 5943.039389373921
+  tps: 5943.03938937392
  }
 }
 dps_results: {
@@ -206,14 +206,14 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-AllItems-MaleficRaiment"
  value: {
-  dps: 4987.345567941501
+  dps: 4987.345567941502
   tps: 4405.829570086444
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-OblivionRaiment"
  value: {
-  dps: 5034.85935915649
+  dps: 5034.8593591564895
   tps: 4470.98776859191
  }
 }
@@ -312,14 +312,14 @@ dps_results: {
  key: "TestWarlock-AllItems-TirelessStarflareDiamond"
  value: {
   dps: 6589.258643086365
-  tps: 5943.039389373921
+  tps: 5943.03938937392
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-TrenchantEarthshatterDiamond"
  value: {
   dps: 6589.258643086365
-  tps: 5943.039389373921
+  tps: 5943.03938937392
  }
 }
 dps_results: {
@@ -333,7 +333,7 @@ dps_results: {
  key: "TestWarlock-AllItems-VoidStarTalisman-30449"
  value: {
   dps: 6601.818535753667
-  tps: 5962.360553145986
+  tps: 5962.360553145987
  }
 }
 dps_results: {
@@ -361,7 +361,7 @@ dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-FullBuffs-LongSingleTarget"
  value: {
   dps: 5862.769365658436
-  tps: 5208.944264644961
+  tps: 5208.9442646449625
  }
 }
 dps_results: {
@@ -395,22 +395,22 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Demonology Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9592.907252602681
-  tps: 10757.27491924601
+  dps: 9592.907252602678
+  tps: 10757.274919246009
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Demonology Warlock-FullBuffs-LongSingleTarget"
  value: {
   dps: 6194.508052358772
-  tps: 5189.2702820645445
+  tps: 5189.270282064543
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Demonology Warlock-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7377.1953945042405
-  tps: 6088.968892181743
+  tps: 6088.9688921817415
  }
 }
 dps_results: {
@@ -430,7 +430,7 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Demonology Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3629.9160347077027
+  dps: 3629.9160347077022
   tps: 3199.896133430082
  }
 }

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -52,7 +52,7 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
@@ -109,20 +109,20 @@ dps_results: {
  key: "TestArms-AllItems-ChaoticSkyflareDiamond"
  value: {
   dps: 690.342952916727
-  tps: 742.2671797089617
+  tps: 742.2671797089616
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 687.0699568104575
+  dps: 687.0699568104574
   tps: 738.1583142560463
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 737.4390006509186
+  dps: 737.4390006509185
   tps: 788.7538433711
  }
 }
@@ -130,13 +130,13 @@ dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-42987"
  value: {
   dps: 748.5704942016481
-  tps: 802.1083735483356
+  tps: 802.1083735483354
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 750.9923084048083
+  dps: 750.9923084048081
   tps: 806.1964524718369
  }
 }
@@ -157,7 +157,7 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Defender'sCode-40257"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
@@ -241,7 +241,7 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 696.489188124745
+  dps: 696.4891881247449
   tps: 749.366175038643
  }
 }
@@ -297,14 +297,14 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-FuturesightRune-38763"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
@@ -353,14 +353,14 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
@@ -375,13 +375,13 @@ dps_results: {
  key: "TestArms-AllItems-MeteoriteWhetstone-37390"
  value: {
   dps: 708.6994286094914
-  tps: 763.0375902885916
+  tps: 763.0375902885914
  }
 }
 dps_results: {
  key: "TestArms-AllItems-NetherscaleArmor"
  value: {
-  dps: 654.5489903818047
+  dps: 654.5489903818045
   tps: 705.4715955370937
  }
 }
@@ -395,7 +395,7 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
@@ -445,20 +445,20 @@ dps_results: {
  key: "TestArms-AllItems-PrimalIntent"
  value: {
   dps: 694.0400851906077
-  tps: 746.1396642905114
+  tps: 746.1396642905113
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 798.6422492373852
+  dps: 798.642249237385
   tps: 851.1502650958164
  }
 }
@@ -472,7 +472,7 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 695.4226021856897
+  dps: 695.4226021856896
   tps: 750.0113151462817
  }
 }
@@ -486,14 +486,14 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
@@ -507,14 +507,14 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
@@ -522,21 +522,21 @@ dps_results: {
  key: "TestArms-AllItems-SparkofLife-37657"
  value: {
   dps: 679.8901691951643
-  tps: 731.7061715632788
+  tps: 731.7061715632786
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SpellstrikeInfusion"
  value: {
   dps: 610.7167817557395
-  tps: 659.2852399507541
+  tps: 659.2852399507542
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StrengthoftheClefthoof"
  value: {
   dps: 596.9292706411017
-  tps: 644.1483887464565
+  tps: 644.1483887464564
  }
 }
 dps_results: {
@@ -571,7 +571,7 @@ dps_results: {
  key: "TestArms-AllItems-TheTwinBladesofAzzinoth"
  value: {
   dps: 847.491289128345
-  tps: 912.2333030332708
+  tps: 912.2333030332705
  }
 }
 dps_results: {
@@ -598,8 +598,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 722.6514407847246
-  tps: 777.0297538431445
+  dps: 722.6514407847245
+  tps: 777.0297538431444
  }
 }
 dps_results: {
@@ -654,8 +654,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-WindhawkArmor"
  value: {
-  dps: 625.6798786063523
-  tps: 675.7520004729698
+  dps: 625.6798786063522
+  tps: 675.7520004729697
  }
 }
 dps_results: {
@@ -668,21 +668,21 @@ dps_results: {
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 699.3729254659295
+  dps: 699.3729254659294
   tps: 751.7294490243414
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 693.877694960622
+  dps: 693.8776949606217
   tps: 835.3175775452825
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 693.877694960622
+  dps: 693.8776949606217
   tps: 746.6509108786158
  }
 }
@@ -725,7 +725,7 @@ dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
   dps: 687.881381760796
-  tps: 740.4688717852794
+  tps: 740.4688717852792
  }
 }
 dps_results: {
@@ -738,22 +738,22 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 454.8561114307178
+  dps: 454.85611143071776
   tps: 585.5460833137431
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 454.8561114307178
+  dps: 454.85611143071776
   tps: 496.056083313743
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 469.4346890124881
-  tps: 513.4337699063794
+  dps: 469.434689012488
+  tps: 513.4337699063793
  }
 }
 dps_results: {

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -95,7 +95,7 @@ dps_results: {
  key: "TestFury-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
   dps: 592.8009641218976
-  tps: 650.5607974552307
+  tps: 650.5607974552306
  }
 }
 dps_results: {
@@ -116,13 +116,13 @@ dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
   dps: 600.3803541468993
-  tps: 658.1670208135662
+  tps: 658.167020813566
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 637.1455426016778
+  dps: 637.1455426016776
   tps: 695.121042601678
  }
 }
@@ -235,7 +235,7 @@ dps_results: {
  key: "TestFury-AllItems-ExtractofNecromanticPower-40373"
  value: {
   dps: 627.7459277740459
-  tps: 685.4924277740461
+  tps: 685.492427774046
  }
 }
 dps_results: {
@@ -255,7 +255,7 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-FelstalkerArmor"
  value: {
-  dps: 568.2993531752267
+  dps: 568.2993531752265
   tps: 626.0303531752264
  }
 }
@@ -325,8 +325,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-IncisorFragment-37723"
  value: {
-  dps: 658.8866671068022
-  tps: 718.5931671068024
+  dps: 658.8866671068021
+  tps: 718.5931671068022
  }
 }
 dps_results: {
@@ -375,21 +375,21 @@ dps_results: {
  key: "TestFury-AllItems-MeteoriteWhetstone-37390"
  value: {
   dps: 611.3199423412218
-  tps: 670.5656090078884
+  tps: 670.5656090078883
  }
 }
 dps_results: {
  key: "TestFury-AllItems-NetherscaleArmor"
  value: {
-  dps: 562.2275813440052
-  tps: 619.4380813440052
+  dps: 562.2275813440053
+  tps: 619.4380813440051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-NetherstrikeArmor"
  value: {
   dps: 536.9321905710096
-  tps: 593.2476905710096
+  tps: 593.2476905710095
  }
 }
 dps_results: {
@@ -473,7 +473,7 @@ dps_results: {
  key: "TestFury-AllItems-RelentlessEarthsiegeDiamond"
  value: {
   dps: 603.5578020150303
-  tps: 662.3886353483639
+  tps: 662.3886353483638
  }
 }
 dps_results: {
@@ -563,14 +563,14 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 639.3276727817776
-  tps: 701.0885061151109
+  dps: 639.3276727817774
+  tps: 701.0885061151108
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 690.3034041643816
+  dps: 690.3034041643814
   tps: 753.5402374977148
  }
 }
@@ -592,14 +592,14 @@ dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50351"
  value: {
   dps: 616.8097589653944
-  tps: 677.1434256320613
+  tps: 677.1434256320612
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50706"
  value: {
   dps: 610.5930370137376
-  tps: 670.733370347071
+  tps: 670.7333703470708
  }
 }
 dps_results: {
@@ -654,14 +654,14 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-WindhawkArmor"
  value: {
-  dps: 530.1267840129134
+  dps: 530.1267840129133
   tps: 586.1419506795801
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WrathofSpellfire"
  value: {
-  dps: 524.0982678104274
+  dps: 524.0982678104273
   tps: 579.6852678104275
  }
 }
@@ -717,21 +717,21 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 594.4120325066559
-  tps: 778.9440325066562
+  dps: 594.4120325066558
+  tps: 778.944032506656
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 594.4120325066559
+  dps: 594.4120325066558
   tps: 652.4990325066558
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 649.1542689612011
+  dps: 649.154268961201
   tps: 714.8351022945344
  }
 }
@@ -753,7 +753,7 @@ dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
   dps: 418.63014656286396
-  tps: 476.4459798961972
+  tps: 476.44597989619706
  }
 }
 dps_results: {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -173,7 +173,7 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 415.63630934574576
+  dps: 415.6363093457459
   tps: 696.7281831423963
  }
 }
@@ -243,7 +243,7 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DoomplateBattlegear"
  value: {
-  dps: 374.63707945935425
+  dps: 374.63707945935414
   tps: 620.986397976083
  }
 }
@@ -307,7 +307,7 @@ dps_results: {
  key: "TestProtectionWarrior-AllItems-FelstalkerArmor"
  value: {
   dps: 378.40396054871866
-  tps: 639.5740184319866
+  tps: 639.5740184319864
  }
 }
 dps_results: {
@@ -376,7 +376,7 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IncisorFragment-37723"
  value: {
-  dps: 427.24820501754647
+  dps: 427.2482050175466
   tps: 718.2370572815331
  }
 }
@@ -397,7 +397,7 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 385.1375151454891
+  dps: 385.13751514548915
   tps: 649.8312391022729
  }
 }
@@ -432,7 +432,7 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NetherscaleArmor"
  value: {
-  dps: 379.36368767067995
+  dps: 379.36368767068
   tps: 641.216515027686
  }
 }
@@ -440,7 +440,7 @@ dps_results: {
  key: "TestProtectionWarrior-AllItems-NetherstrikeArmor"
  value: {
   dps: 359.8104267318414
-  tps: 608.5341699783539
+  tps: 608.5341699783538
  }
 }
 dps_results: {
@@ -460,21 +460,21 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 472.0484723798277
+  dps: 472.04847237982756
   tps: 776.3823410535274
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 381.80307965093834
+  dps: 381.8030796509383
   tps: 643.9350115597582
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 385.1375151454891
+  dps: 385.13751514548915
   tps: 649.8312391022729
  }
 }
@@ -579,7 +579,7 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 369.88214247711966
+  dps: 369.8821424771196
   tps: 626.6846363124808
  }
 }
@@ -593,21 +593,21 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 385.1375151454891
+  dps: 385.13751514548915
   tps: 649.8312391022729
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 381.80307965093834
+  dps: 381.8030796509383
   tps: 643.9350115597582
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 382.5167192186355
+  dps: 382.51671921863544
   tps: 645.9176691304491
  }
 }
@@ -621,7 +621,7 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 641.6012722463583
+  dps: 641.6012722463582
   tps: 1070.673157030087
  }
 }
@@ -629,7 +629,7 @@ dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinStars"
  value: {
   dps: 371.2334459343444
-  tps: 627.3863396832761
+  tps: 627.386339683276
  }
 }
 dps_results: {
@@ -685,20 +685,20 @@ dps_results: {
  key: "TestProtectionWarrior-AllItems-WarbringerArmor"
  value: {
   dps: 353.7709609305612
-  tps: 587.6469155191205
+  tps: 587.6469155191204
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarbringerBattlegear"
  value: {
-  dps: 409.12762686724193
+  dps: 409.1276268672419
   tps: 684.561775019348
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WastewalkerArmor"
  value: {
-  dps: 377.23006071929433
+  dps: 377.2300607192942
   tps: 626.7821590264141
  }
 }
@@ -706,7 +706,7 @@ dps_results: {
  key: "TestProtectionWarrior-AllItems-WindhawkArmor"
  value: {
   dps: 355.5900676719965
-  tps: 602.0299518136959
+  tps: 602.0299518136958
  }
 }
 dps_results: {
@@ -769,7 +769,7 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 447.45826723592444
+  dps: 447.4582672359244
   tps: 896.2915568446731
  }
 }

--- a/ui/core/components/icon_inputs.ts
+++ b/ui/core/components/icon_inputs.ts
@@ -15,7 +15,6 @@ import { PetFood } from '../proto/common.js';
 import { Potions } from '../proto/common.js';
 import { Spec } from '../proto/common.js';
 import { TristateEffect } from '../proto/common.js';
-import { WeaponImbue } from '../proto/common.js';
 import { Party } from '../party.js';
 import { Player } from '../player.js';
 import { Raid } from '../raid.js';
@@ -475,35 +474,6 @@ export const FillerExplosiveInput = makeConsumeInput('fillerExplosive', [
 	{ actionId: ActionId.fromItemId(41119), value: Explosive.ExplosiveSaroniteBomb },
 	{ actionId: ActionId.fromItemId(40771), value: Explosive.ExplosiveCobaltFragBomb },
 ] as Array<IconEnumValueConfig<Player<any>, Explosive>>);
-
-export function makeWeaponImbueInput(isMainHand: boolean, options: Array<WeaponImbue>): InputHelpers.TypedIconEnumPickerConfig<Player<any>, WeaponImbue> {
-	const allOptions = [
-		{ actionId: ActionId.fromItemId(18262), value: WeaponImbue.WeaponImbueElementalSharpeningStone },
-		{ actionId: ActionId.fromItemId(20749), value: WeaponImbue.WeaponImbueBrilliantWizardOil },
-		{ actionId: ActionId.fromItemId(22522), value: WeaponImbue.WeaponImbueSuperiorWizardOil },
-		{ actionId: ActionId.fromItemId(34539), value: WeaponImbue.WeaponImbueRighteousWeaponCoating },
-		{
-			actionId: ActionId.fromItemId(23529), value: WeaponImbue.WeaponImbueAdamantiteSharpeningStone,
-			showWhen: (player: Player<any>) => !(isMainHand ? player.getGear().hasBluntMHWeapon() : player.getGear().hasBluntOHWeapon()),
-		},
-		{
-			actionId: ActionId.fromItemId(28421), value: WeaponImbue.WeaponImbueAdamantiteWeightstone,
-			showWhen: (player: Player<any>) => (isMainHand ? player.getGear().hasBluntMHWeapon() : player.getGear().hasBluntOHWeapon()),
-		},
-		{ actionId: ActionId.fromSpellId(27186), value: WeaponImbue.WeaponImbueRogueDeadlyPoison },
-		{ actionId: ActionId.fromSpellId(26891), value: WeaponImbue.WeaponImbueRogueInstantPoison },
-		{ actionId: ActionId.fromSpellId(25505), value: WeaponImbue.WeaponImbueShamanWindfury },
-		{ actionId: ActionId.fromSpellId(58790), value: WeaponImbue.WeaponImbueShamanFlametongue },
-		{ actionId: ActionId.fromSpellId(25500), value: WeaponImbue.WeaponImbueShamanFrostbrand },
-	];
-	if (isMainHand) {
-		const config = makeConsumeInputFactory('mainHandImbue', allOptions)(options);
-		config.changedEvent = (player: Player<any>) => TypedEvent.onAny([player.getRaid()?.changeEmitter || player.consumesChangeEmitter]);
-		return config;
-	} else {
-		return makeConsumeInputFactory('offHandImbue', allOptions)(options);
-	}
-}
 
 function makeConsumeInputFactory<T extends number>(consumesFieldName: keyof Consumes, allOptions: Array<IconEnumValueConfig<Player<any>, T>>, onSet?: (eventID: EventID, player: Player<any>, newValue: T) => void): (options: Array<T>) => InputHelpers.TypedIconEnumPickerConfig<Player<any>, T> {
 	return (options: Array<T>) => {

--- a/ui/core/individual_sim_ui.ts
+++ b/ui/core/individual_sim_ui.ts
@@ -65,7 +65,6 @@ import { Stats } from './proto_utils/stats.js';
 import { shattFactionNames } from './proto_utils/names.js';
 import { Target } from './target.js';
 import { Target as TargetProto } from './proto/common.js';
-import { WeaponImbue } from './proto/common.js';
 import { addRaidSimAction, RaidSimResultsManager } from './components/raid_sim_action.js';
 import { addStatWeightsAction } from './components/stat_weights_action.js';
 import { equalsOrBothNull, getEnumValues } from './utils.js';

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -17,7 +17,6 @@ import {
     Spec,
     Faction,
     Stat,
-    WeaponImbue,
     WeaponType,
 } from './proto/common.js';
 
@@ -417,28 +416,6 @@ export class Player<SpecType extends Spec> {
         //}
 
         TypedEvent.freezeAllAndDo(() => {
-            // If we swapped between sharp/blunt weapon types, then also swap between
-            // sharpening/weightstones.
-            const consumes = this.getConsumes();
-            let consumesChanged = false;
-            if (consumes.mainHandImbue == WeaponImbue.WeaponImbueAdamantiteSharpeningStone && newGear.hasBluntMHWeapon()) {
-                consumes.mainHandImbue = WeaponImbue.WeaponImbueAdamantiteWeightstone;
-                consumesChanged = true;
-            } else if (consumes.mainHandImbue == WeaponImbue.WeaponImbueAdamantiteWeightstone && newGear.hasSharpMHWeapon()) {
-                consumes.mainHandImbue = WeaponImbue.WeaponImbueAdamantiteSharpeningStone;
-                consumesChanged = true;
-            }
-            if (consumes.offHandImbue == WeaponImbue.WeaponImbueAdamantiteSharpeningStone && newGear.hasBluntOHWeapon()) {
-                consumes.offHandImbue = WeaponImbue.WeaponImbueAdamantiteWeightstone;
-                consumesChanged = true;
-            } else if (consumes.offHandImbue == WeaponImbue.WeaponImbueAdamantiteWeightstone && newGear.hasSharpOHWeapon()) {
-                consumes.offHandImbue = WeaponImbue.WeaponImbueAdamantiteSharpeningStone;
-                consumesChanged = true;
-            }
-            if (consumesChanged) {
-                this.setConsumes(eventID, consumes);
-            }
-
             this.gear = newGear;
             this.gearChangeEmitter.emit(eventID);
             //this.setCooldowns(eventID, newCooldowns);

--- a/ui/core/proto_utils/action_id.ts
+++ b/ui/core/proto_utils/action_id.ts
@@ -220,6 +220,13 @@ export class ActionId {
             case 'Slice and Dice':
                 if (this.tag) name += ` (${this.tag} CP)`;
                 break;
+            case 'Instant Poison IX':
+                if (this.tag == 1) {
+                    name += ' (Deadly)'
+                } else if (this.tag == 2) {
+                    name += ' (Shiv)'
+                }
+                break;
             case 'Chain Lightning':
             case 'Lightning Bolt':
                 if (this.tag) name += ' (LO)';

--- a/ui/elemental_shaman/presets.ts
+++ b/ui/elemental_shaman/presets.ts
@@ -6,7 +6,6 @@ import { Food } from '../core/proto/common.js';
 import { Glyphs } from '../core/proto/common.js';
 import { Potions } from '../core/proto/common.js';
 import { SavedTalents } from '../core/proto/ui.js';
-import { WeaponImbue } from '../core/proto/common.js';
 
 import { ElementalShaman_Rotation as ElementalShamanRotation, ElementalShaman_Options as ElementalShamanOptions, ShamanShield, ShamanMajorGlyph, ShamanMinorGlyph } from '../core/proto/shaman.js';
 import { ElementalShaman_Rotation_RotationType as RotationType } from '../core/proto/shaman.js';
@@ -62,7 +61,6 @@ export const DefaultConsumes = Consumes.create({
 	defaultPotion: Potions.RunicManaPotion,
 	flask: Flask.FlaskOfTheFrostWyrm,
 	food: Food.FoodFishFeast,
-	mainHandImbue: WeaponImbue.WeaponImbueShamanFlametongue,
 });
 
 

--- a/ui/enhancement_shaman/inputs.ts
+++ b/ui/enhancement_shaman/inputs.ts
@@ -2,7 +2,6 @@ import { BooleanPicker } from '../core/components/boolean_picker.js';
 import { EnumPicker } from '../core/components/enum_picker.js';
 import { IconEnumPicker, IconEnumPickerConfig } from '../core/components/icon_enum_picker.js';
 import { IconPickerConfig } from '../core/components/icon_picker.js';
-import { makeWeaponImbueInput } from '../core/components/icon_inputs.js';
 import {
 	AirTotem,
 	EarthTotem,
@@ -15,7 +14,6 @@ import {
     ShamanSyncType
 } from '../core/proto/shaman.js';
 import { Spec } from '../core/proto/common.js';
-import { WeaponImbue } from '../core/proto/common.js';
 import { ActionId } from '../core/proto_utils/action_id.js';
 import { Player } from '../core/player.js';
 import { Sim } from '../core/sim.js';

--- a/ui/enhancement_shaman/sim.ts
+++ b/ui/enhancement_shaman/sim.ts
@@ -15,7 +15,6 @@ import { Stats } from '../core/proto_utils/stats.js';
 import { Sim } from '../core/sim.js';
 import { IndividualSimUI } from '../core/individual_sim_ui.js';
 import { TotemsSection } from '../core/components/totem_inputs.js';
-import { WeaponImbue } from '../core/proto/common.js';
 
 import { EnhancementShaman, EnhancementShaman_Rotation as EnhancementShamanRotation, EnhancementShaman_Options as EnhancementShamanOptions } from '../core/proto/shaman.js';
 

--- a/ui/feral_druid/presets.ts
+++ b/ui/feral_druid/presets.ts
@@ -4,7 +4,6 @@ import { Food } from '../core/proto/common.js';
 import { EquipmentSpec } from '../core/proto/common.js';
 import { Potions } from '../core/proto/common.js';
 import { Conjured } from '../core/proto/common.js';
-import { WeaponImbue } from '../core/proto/common.js';
 import { SavedTalents } from '../core/proto/ui.js';
 
 import { FeralDruid_Rotation as FeralDruidRotation, FeralDruid_Options as FeralDruidOptions } from '../core/proto/druid.js';
@@ -43,7 +42,6 @@ export const DefaultOptions = FeralDruidOptions.create({
 export const DefaultConsumes = Consumes.create({
 	battleElixir: BattleElixir.ElixirOfMajorAgility,
 	food: Food.FoodGrilledMudfish,
-	mainHandImbue: WeaponImbue.WeaponImbueAdamantiteWeightstone,
 	defaultPotion: Potions.HastePotion,
 	defaultConjured: Conjured.ConjuredDarkRune,
 });

--- a/ui/mage/presets.ts
+++ b/ui/mage/presets.ts
@@ -7,7 +7,6 @@ import { Glyphs } from '../core/proto/common.js';
 import { ItemSpec } from '../core/proto/common.js';
 import { Potions } from '../core/proto/common.js';
 import { Spec } from '../core/proto/common.js';
-import { WeaponImbue } from '../core/proto/common.js';
 import { Faction } from '../core/proto/common.js';
 import { SavedTalents } from '../core/proto/ui.js';
 import { Player } from '../core/player.js';

--- a/ui/protection_paladin/presets.ts
+++ b/ui/protection_paladin/presets.ts
@@ -6,7 +6,6 @@ import { Glyphs } from '../core/proto/common.js';
 import { ItemSpec } from '../core/proto/common.js';
 import { Potions } from '../core/proto/common.js';
 import { Spec } from '../core/proto/common.js';
-import { WeaponImbue } from '../core/proto/common.js';
 import { Faction } from '../core/proto/common.js';
 import { SavedTalents } from '../core/proto/ui.js';
 import { Player } from '../core/player.js';
@@ -59,7 +58,6 @@ export const DefaultConsumes = Consumes.create({
 	flask: Flask.FlaskOfBlindingLight,
 	food: Food.FoodFishermansFeast,
 	defaultPotion: Potions.IronshieldPotion,
-	mainHandImbue: WeaponImbue.WeaponImbueSuperiorWizardOil,
 });
 
 export const P1_PRESET = {

--- a/ui/protection_warrior/presets.ts
+++ b/ui/protection_warrior/presets.ts
@@ -3,7 +3,6 @@ import { EquipmentSpec } from '../core/proto/common.js';
 import { Flask } from '../core/proto/common.js';
 import { Food } from '../core/proto/common.js';
 import { Potions } from '../core/proto/common.js';
-import { WeaponImbue } from '../core/proto/common.js';
 import { SavedTalents } from '../core/proto/ui.js';
 
 import {
@@ -60,8 +59,6 @@ export const DefaultConsumes = Consumes.create({
 	flask: Flask.FlaskOfFortification,
 	food: Food.FoodFishermansFeast,
 	defaultPotion: Potions.IronshieldPotion,
-	mainHandImbue: WeaponImbue.WeaponImbueAdamantiteSharpeningStone,
-	offHandImbue: WeaponImbue.WeaponImbueAdamantiteSharpeningStone,
 });
 
 export const P1_BALANCED_PRESET = {

--- a/ui/raid/presets.ts
+++ b/ui/raid/presets.ts
@@ -332,10 +332,10 @@ export const playerPresets: Array<PresetSpecSettings<any>> = [
 		defaultGear: {
 			[Faction.Unknown]: {},
 			[Faction.Alliance]: {
-				1: RoguePresets.P1_PRESET.gear,
+				1: RoguePresets.PRERAID_PRESET.gear,
 			},
 			[Faction.Horde]: {
-				1: RoguePresets.P1_PRESET.gear,
+				1: RoguePresets.PRERAID_PRESET.gear,
 			},
 		},
 		tooltip: 'Combat Rogue',

--- a/ui/retribution_paladin/presets.ts
+++ b/ui/retribution_paladin/presets.ts
@@ -7,7 +7,6 @@ import { Glyphs } from '../core/proto/common.js';
 import { ItemSpec } from '../core/proto/common.js';
 import { Potions } from '../core/proto/common.js';
 import { Spec } from '../core/proto/common.js';
-import { WeaponImbue } from '../core/proto/common.js';
 import { Faction } from '../core/proto/common.js';
 import { SavedTalents } from '../core/proto/ui.js';
 import { Player } from '../core/player.js';

--- a/ui/rogue/inputs.ts
+++ b/ui/rogue/inputs.ts
@@ -1,13 +1,35 @@
 import { Spec } from '../core/proto/common.js';
+import { ActionId } from '../core/proto_utils/action_id.js';
 
 import * as InputHelpers from '../core/components/input_helpers.js';
 
 import {
 	Rogue_Rotation_Builder as Builder,
+	Rogue_Options_PoisonImbue as Poison,
 } from '../core/proto/rogue.js';
 
 // Configuration for spec-specific UI elements on the settings tab.
 // These don't need to be in a separate file but it keeps things cleaner.
+
+export const MainHandImbue = InputHelpers.makeSpecOptionsEnumIconInput<Spec.SpecRogue, Poison>({
+	fieldName: 'mhImbue',
+	numColumns: 1,
+	values: [
+		{ color: 'grey', value: Poison.NoPoison },
+		{ actionId: ActionId.fromItemId(43233), value: Poison.DeadlyPoison },
+		{ actionId: ActionId.fromItemId(43231), value: Poison.InstantPoison },
+	],
+});
+
+export const OffHandImbue = InputHelpers.makeSpecOptionsEnumIconInput<Spec.SpecRogue, Poison>({
+	fieldName: 'ohImbue',
+	numColumns: 1,
+	values: [
+		{ color: 'grey', value: Poison.NoPoison },
+		{ actionId: ActionId.fromItemId(43233), value: Poison.DeadlyPoison },
+		{ actionId: ActionId.fromItemId(43231), value: Poison.InstantPoison },
+	],
+});
 
 export const RogueRotationConfig = {
 	inputs: [

--- a/ui/rogue/inputs.ts
+++ b/ui/rogue/inputs.ts
@@ -34,6 +34,11 @@ export const RogueRotationConfig = {
 			labelTooltip: 'Uses Rupture over Eviscerate when appropriate.',
 		}),
 		InputHelpers.makeRotationBooleanInput<Spec.SpecRogue>({
+			fieldName: 'useEnvenom',
+			label: 'Use Envenom',
+			labelTooltip: 'Uses Envenom over Eviscerate when appropriate.',
+		}),
+		InputHelpers.makeRotationBooleanInput<Spec.SpecRogue>({
 			fieldName: 'useShiv',
 			label: 'Use Shiv',
 			labelTooltip: 'Uses Shiv in place of the selected builder if Deadly Poison is about to expire. Requires Deadly Poison in the off-hand.',

--- a/ui/rogue/presets.ts
+++ b/ui/rogue/presets.ts
@@ -5,7 +5,6 @@ import { Consumes } from '../core/proto/common.js';
 import { EquipmentSpec } from '../core/proto/common.js';
 import { Food } from '../core/proto/common.js';
 import { Potions } from '../core/proto/common.js';
-import { WeaponImbue } from '../core/proto/common.js';
 import { SavedTalents } from '../core/proto/ui.js';
 
 import {
@@ -45,8 +44,6 @@ export const DefaultConsumes = Consumes.create({
 	defaultConjured: Conjured.ConjuredRogueThistleTea,
 	battleElixir: BattleElixir.ElixirOfDeadlyStrikes,
 	food: Food.FoodFishFeast,
-	mainHandImbue: WeaponImbue.WeaponImbueRogueInstantPoison,
-	offHandImbue: WeaponImbue.WeaponImbueRogueDeadlyPoison,
 });
 
 export const P1_PRESET = {

--- a/ui/rogue/presets.ts
+++ b/ui/rogue/presets.ts
@@ -1,9 +1,10 @@
-import { BattleElixir } from '../core/proto/common.js';
+import { BattleElixir, Flask } from '../core/proto/common.js';
 import { Conjured } from '../core/proto/common.js';
 import { Consumes } from '../core/proto/common.js';
 
 import { EquipmentSpec } from '../core/proto/common.js';
 import { Food } from '../core/proto/common.js';
+import { Glyphs } from '../core/proto/common.js';
 import { Potions } from '../core/proto/common.js';
 import { SavedTalents } from '../core/proto/ui.js';
 
@@ -11,125 +12,146 @@ import {
 	Rogue_Rotation as RogueRotation,
 	Rogue_Rotation_Builder as Builder,
 	Rogue_Options as RogueOptions,
+  Rogue_Options_PoisonImbue as Poison,
+  RogueMajorGlyph,
 } from '../core/proto/rogue.js';
 
 import * as Tooltips from '../core/constants/tooltips.js';
-
-// Preset options for this spec.
-// Eventually we will import these values for the raid sim too, so its good to
-// keep them in a separate file.
 
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/wotlk/talent-calc and copy the numbers in the url.
 export const CombatTalents = {
 	name: 'Combat',
 	data: SavedTalents.create({
-		talentsString: '00532000532-0252051000035015223100501251',
+		talentsString: '00532000523-0252051050035010223100501251',
+    glyphs: Glyphs.create({
+      major1: RogueMajorGlyph.GlyphOfKillingSpree,
+      major2: RogueMajorGlyph.GlyphOfTricksOfTheTrade,
+      major3: RogueMajorGlyph.GlyphOfRupture,
+    })
+	}),
+};
+
+export const AssassinationTalents = {
+	name: 'Assassination',
+	data: SavedTalents.create({
+		talentsString: '005303005352100520103331051-005005003-502',
+    glyphs: Glyphs.create({
+      major1: RogueMajorGlyph.GlyphOfMutilate,
+      major2: RogueMajorGlyph.GlyphOfTricksOfTheTrade,
+      major3: RogueMajorGlyph.GlyphOfHungerForBlood,
+    })
 	}),
 };
 
 export const DefaultRotation = RogueRotation.create({
-	builder: Builder.Auto,
+	builder: Builder.SinisterStrike,
 	maintainExposeArmor: false,
 	useRupture: true,
-	useShiv: true,
+	useShiv: false,
+	useEnvenom: false,
 	minComboPointsForDamageFinisher: 3,
 });
 
 export const DefaultOptions = RogueOptions.create({
+  mhImbue: Poison.DeadlyPoison,
+  ohImbue: Poison.InstantPoison,
 });
 
 export const DefaultConsumes = Consumes.create({
 	defaultPotion: Potions.PotionOfSpeed,
 	defaultConjured: Conjured.ConjuredRogueThistleTea,
-	battleElixir: BattleElixir.ElixirOfDeadlyStrikes,
-	food: Food.FoodFishFeast,
+  flask: Flask.FlaskOfEndlessRage,
+	food: Food.FoodMegaMammothMeal,
 });
 
-export const P1_PRESET = {
-	name: 'P1 Preset',
+export const PRERAID_PRESET = {
+	name: 'Pre-Raid Combat',
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
 	gear: EquipmentSpec.fromJsonString(`{"items": [
-        {
-          "id": 37293,
-          "enchant": 44879,
-          "gems": [
-            41398,
-            40088
-          ]
-        },
-        {
-          "id": 37861
-        },
-        {
-          "id": 37139,
-          "enchant": 44871,
-          "gems": [
-            24061
-          ]
-        },
-        {
-          "id": 36947,
-          "enchant": 55002
-        },
-        {
-          "id": 44303,
-          "enchant": 44623
-        },
-        {
-          "id": 44203,
-          "enchant": 60616,
-          "gems": [
-            0
-          ]
-        },
-        {
-          "id": 37409,
-          "enchant": 60668,
-          "gems": [
-            0
-          ]
-        },
-        {
-          "id": 37194,
-          "gems": [
-            40014,
-            0
-          ]
-        },
-        {
-          "id": 37644,
-          "enchant": 38374
-        },
-        {
-          "id": 44297,
-          "enchant": 28279
-        },
-        {
-          "id": 43251,
-          "gems": [
-            0
-          ]
-        },
-        {
-          "id": 37642
-        },
-        {
-          "id": 37390
-        },
-        {
-          "id": 37166
-        },
-        {
-          "id": 37693,
-          "enchant": 22559
-        },
-        {
-          "id": 37856,
-          "enchant": 22559
-        },
-        {
-          "id": 37191
-        }
-      ]}`),
+    {
+      "id": 42550,
+      "enchant": 44879,
+      "gems": [
+        41398,
+        40058
+      ]
+    },
+    {
+      "id": 40678
+    },
+    {
+      "id": 43481,
+      "enchant": 44871
+    },
+    {
+      "id": 38614,
+      "enchant": 55002
+    },
+    {
+      "id": 39558,
+      "enchant": 44489,
+      "gems": [
+        40003,
+        42702
+      ]
+    },
+    {
+      "id": 34448,
+      "enchant": 44484,
+      "gems": [
+        40003,
+        0
+      ]
+    },
+    {
+      "id": 39560,
+      "enchant": 54999,
+      "gems": [
+        40058,
+        0
+      ]
+    },
+    {
+      "id": 40694,
+      "gems": [
+        40003,
+        40003
+      ]
+    },
+    {
+      "id": 37644,
+      "enchant": 38374
+    },
+    {
+      "id": 34575,
+      "enchant": 55016,
+      "gems": [
+        40003
+      ]
+    },
+    {
+      "id": 40586
+    },
+    {
+      "id": 37642
+    },
+    {
+      "id": 40684
+    },
+    {
+      "id": 44253
+    },
+    {
+      "id": 37856,
+      "enchant": 44492
+    },
+    {
+      "id": 37667,
+      "enchant": 44492
+    },
+    {
+      "id": 43612
+    }
+  ]}`),
 };

--- a/ui/rogue/sim.ts
+++ b/ui/rogue/sim.ts
@@ -1,4 +1,4 @@
-import { RaidBuffs } from '../core/proto/common.js';
+import { Race, RaidBuffs } from '../core/proto/common.js';
 import { PartyBuffs } from '../core/proto/common.js';
 import { IndividualBuffs } from '../core/proto/common.js';
 import { Debuffs } from '../core/proto/common.js';
@@ -78,7 +78,7 @@ export class RogueSimUI extends IndividualSimUI<Spec.SpecRogue> {
 
 			defaults: {
 				// Default equipped gear.
-				gear: Presets.P1_PRESET.gear,
+				gear: Presets.PRERAID_PRESET.gear,
 				// Default EP weights for sorting gear in the gear picker.
 				epWeights: Stats.fromMap({
 					[Stat.StatAgility]: 2.214,
@@ -104,8 +104,11 @@ export class RogueSimUI extends IndividualSimUI<Spec.SpecRogue> {
 					bloodlust: true,
 					strengthOfEarthTotem: TristateEffect.TristateEffectImproved,
 					icyTalons: true,
-					battleShout: TristateEffect.TristateEffectImproved,
 					leaderOfThePack: TristateEffect.TristateEffectImproved,
+					abominationsMight: true,
+					swiftRetribution: true,
+					elementalOath: true,
+					sanctifiedRetribution: true,
 				}),
 				partyBuffs: PartyBuffs.create({
 				}),
@@ -114,26 +117,29 @@ export class RogueSimUI extends IndividualSimUI<Spec.SpecRogue> {
 					blessingOfMight: TristateEffect.TristateEffectImproved,
 				}),
 				debuffs: Debuffs.create({
+					heartOfTheCrusader: true,
 					mangle: true,
 					sunderArmor: true,
-					curseOfWeakness: TristateEffect.TristateEffectMissing,
 					faerieFire: TristateEffect.TristateEffectImproved,
-					misery: true,
-					savageCombat: false,
+					shadowMastery: true,
+					earthAndMoon: true,
+					bloodFrenzy: true,
 				}),
 			},
 
 			// IconInputs to include in the 'Player' section on the settings tab.
 			playerIconInputs: [
+				RogueInputs.MainHandImbue,
+				RogueInputs.OffHandImbue,
 			],
-			//	weaponImbues: [
-			//		WeaponImbue.WeaponImbueRogueDeadlyPoison,
-			//		WeaponImbue.WeaponImbueRogueInstantPoison,
-			//	],
 			// Inputs to include in the 'Rotation' section on the settings tab.
 			rotationInputs: RogueInputs.RogueRotationConfig,
 			// Buff and Debuff inputs to include/exclude, overriding the EP-based defaults.
 			includeBuffDebuffInputs: [
+				IconInputs.SpellCritBuff,
+				IconInputs.SpellCritDebuff,
+				IconInputs.SpellHitDebuff,
+				IconInputs.SpellDamageDebuff
 			],
 			excludeBuffDebuffInputs: [
 			],
@@ -141,7 +147,7 @@ export class RogueSimUI extends IndividualSimUI<Spec.SpecRogue> {
 			otherInputs: {
 				inputs: [
 					OtherInputs.StartingConjured,
-					OtherInputs.NumStartingConjured,
+					OtherInputs.PrepopPotion,
 					OtherInputs.TankAssignment,
 					OtherInputs.InFrontOfTarget,
 				],
@@ -157,10 +163,11 @@ export class RogueSimUI extends IndividualSimUI<Spec.SpecRogue> {
 				// Preset talents that the user can quickly select.
 				talents: [
 					Presets.CombatTalents,
+					Presets.AssassinationTalents,
 				],
 				// Preset gear configurations that the user can quickly select.
 				gear: [
-					Presets.P1_PRESET,
+					Presets.PRERAID_PRESET,
 				],
 			},
 		});

--- a/ui/rogue/sim.ts
+++ b/ui/rogue/sim.ts
@@ -15,7 +15,6 @@ import { Stats } from '../core/proto_utils/stats.js';
 import { Sim } from '../core/sim.js';
 import { IndividualSimUI } from '../core/individual_sim_ui.js';
 import { EventID, TypedEvent } from '../core/typed_event.js';
-import { WeaponImbue } from '../core/proto/common.js';
 
 import { Rogue, Rogue_Rotation as RogueRotation, Rogue_Options as RogueOptions } from '../core/proto/rogue.js';
 

--- a/ui/shadow_priest/presets.ts
+++ b/ui/shadow_priest/presets.ts
@@ -5,7 +5,6 @@ import { Food } from '../core/proto/common.js';
 import { Glyphs } from '../core/proto/common.js';
 import { ItemSpec } from '../core/proto/common.js';
 import { Potions } from '../core/proto/common.js';
-import { WeaponImbue } from '../core/proto/common.js';
 import { Faction } from '../core/proto/common.js';
 import { RaidBuffs } from '../core/proto/common.js';
 import { IndividualBuffs } from '../core/proto/common.js';

--- a/ui/smite_priest/presets.ts
+++ b/ui/smite_priest/presets.ts
@@ -3,7 +3,6 @@ import { EquipmentSpec } from '../core/proto/common.js';
 import { Flask } from '../core/proto/common.js';
 import { Food } from '../core/proto/common.js';
 import { Potions } from '../core/proto/common.js';
-import { WeaponImbue } from '../core/proto/common.js';
 import { SavedTalents } from '../core/proto/ui.js';
 
 import { SmitePriest_Rotation as Rotation, SmitePriest_Options as Options, SmitePriest_Rotation_RotationType } from '../core/proto/priest.js';
@@ -41,7 +40,6 @@ export const DefaultOptions = Options.create({
 export const DefaultConsumes = Consumes.create({
 	flask: Flask.FlaskOfBlindingLight,
 	food: Food.FoodBlackenedBasilisk,
-	mainHandImbue: WeaponImbue.WeaponImbueSuperiorWizardOil,
 	defaultPotion: Potions.SuperManaPotion,
 });
 

--- a/ui/warrior/presets.ts
+++ b/ui/warrior/presets.ts
@@ -6,7 +6,6 @@ import { Glyphs } from '../core/proto/common.js';
 import { ItemSpec } from '../core/proto/common.js';
 import { Potions } from '../core/proto/common.js';
 import { Spec } from '../core/proto/common.js';
-import { WeaponImbue } from '../core/proto/common.js';
 import { Faction } from '../core/proto/common.js';
 import { SavedTalents } from '../core/proto/ui.js';
 import { Player } from '../core/player.js';


### PR DESCRIPTION
Several different updates in this change including:

1. Creating rogue specific imbues for poisons and cleaning up generic weapon imbues
2. Implementing Assassination
3. Progress on the two big combat spec issues: Rotation & Crit damage multipliers
4. UI updates including to prepare for alpha

Updating the rotation included updating the energy tick constants which is like the naive way of making the energy bar behave like it should in WotLK (at least with respect to ticks). There are potential performance considerations here but I kind of want to punt on that for now as I think it is more of a blocker for the raid sim.

The crit damage multiplier changes mainly undo a hack I had in place to match the sheet. The values I'm getting now are in line with data from beta and go back to using the generic crit damage multiplier formula.

The rotation changes are just minor tweaks to try and get casts closer to what the theoretical ideal ones that show up in Simon's sheet. 