### PR TITLE
Fix talented bonuses to Off Hand

### DIFF
--- a/sim/common/wotlk/enchant_effects.go
+++ b/sim/common/wotlk/enchant_effects.go
@@ -357,9 +357,9 @@ func init() {
 	})
 
 	newRazoriceHitSpell := func(character *core.Character, isMH bool) *core.Spell {
-		baseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, false, 0, 1.0, true)
+		baseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, false, 0, 1.0, 1.0, true)
 		if !isMH {
-			baseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, false, 0, 1.0, true)
+			baseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, false, 0, 1.0, 1.0, true)
 		}
 
 		return character.RegisterSpell(core.SpellConfig{

--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -572,10 +572,17 @@ type PPMManager struct {
 	mhProcChance     float64
 	ohProcChance     float64
 	rangedProcChance float64
+	procMask         ProcMask
 }
 
 // Returns whether the effect procced.
 func (ppmm *PPMManager) Proc(sim *Simulation, procMask ProcMask, label string) bool {
+	// Without this procs that can proc only from white attacks
+	// are still procing from specials
+	if !procMask.Matches(ppmm.procMask) {
+		return false
+	}
+
 	if procMask.Matches(ProcMaskMeleeMH) {
 		return ppmm.mhProcChance > 0 && sim.RandomFloat(label) < ppmm.mhProcChance
 	} else if procMask.Matches(ProcMaskMeleeOH) {
@@ -592,6 +599,7 @@ func (aa *AutoAttacks) NewPPMManager(ppm float64, procMask ProcMask) PPMManager 
 	}
 
 	ppmm := PPMManager{}
+	ppmm.procMask = procMask
 	if procMask.Matches(ProcMaskMeleeMH) {
 		ppmm.mhProcChance = ppm * aa.MH.SwingSpeed / 60.0
 	}

--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -225,14 +225,14 @@ func (unit *Unit) EnableAutoAttacks(agent Agent, options AutoAttackOptions) {
 			ProcMask:         ProcMaskMeleeMHAuto,
 			DamageMultiplier: 1,
 			ThreatMultiplier: 1,
-			BaseDamage:       BaseDamageConfigMeleeWeapon(MainHand, false, 0, 1, true),
+			BaseDamage:       BaseDamageConfigMeleeWeapon(MainHand, false, 0, 1, 1, true),
 			OutcomeApplier:   unit.OutcomeFuncMeleeWhite(options.MainHand.CritMultiplier),
 		}
 		unit.AutoAttacks.OHEffect = SpellEffect{
 			ProcMask:         ProcMaskMeleeOHAuto,
 			DamageMultiplier: 1,
 			ThreatMultiplier: 1,
-			BaseDamage:       BaseDamageConfigMeleeWeapon(OffHand, false, 0, 1, true),
+			BaseDamage:       BaseDamageConfigMeleeWeapon(OffHand, false, 0, 1, 1, true),
 			OutcomeApplier:   unit.OutcomeFuncMeleeWhite(options.OffHand.CritMultiplier),
 		}
 		unit.AutoAttacks.RangedEffect = SpellEffect{

--- a/sim/core/spell_damage.go
+++ b/sim/core/spell_damage.go
@@ -157,7 +157,7 @@ func BaseDamageFuncMeleeWeapon(hand Hand, normalized bool, flatBonus float64, ba
 			return func(sim *Simulation, hitEffect *SpellEffect, spell *Spell) float64 {
 				damage := spell.Unit.AutoAttacks.MH.CalculateWeaponDamage(
 					sim, hitEffect.MeleeAttackPower(spell.Unit)+hitEffect.MeleeAttackPowerOnTarget())
-				damage += flatBonus
+				damage = damage*baseMultiplier + flatBonus
 				if includeBonusWeaponDamage {
 					damage += hitEffect.BonusWeaponDamage(spell.Unit)
 				}
@@ -167,7 +167,7 @@ func BaseDamageFuncMeleeWeapon(hand Hand, normalized bool, flatBonus float64, ba
 			return func(sim *Simulation, hitEffect *SpellEffect, spell *Spell) float64 {
 				damage := spell.Unit.AutoAttacks.OH.CalculateWeaponDamage(
 					sim, hitEffect.MeleeAttackPower(spell.Unit)+2*hitEffect.MeleeAttackPowerOnTarget())
-				damage = damage*0.5 + flatBonus
+				damage = damage*0.5*baseMultiplier + flatBonus
 				if includeBonusWeaponDamage {
 					damage += hitEffect.BonusWeaponDamage(spell.Unit)
 				}

--- a/sim/core/spell_damage.go
+++ b/sim/core/spell_damage.go
@@ -126,7 +126,7 @@ type Hand bool
 const MainHand Hand = true
 const OffHand Hand = false
 
-func BaseDamageFuncMeleeWeapon(hand Hand, normalized bool, flatBonus float64, weaponMultiplier float64, includeBonusWeaponDamage bool) BaseDamageCalculator {
+func BaseDamageFuncMeleeWeapon(hand Hand, normalized bool, flatBonus float64, baseMultiplier float64, weaponMultiplier float64, includeBonusWeaponDamage bool) BaseDamageCalculator {
 	// Bonus weapon damage applies after OH penalty: https://www.youtube.com/watch?v=bwCIU87hqTs
 	// TODO not all weapon damage based attacks "scale" with +bonusWeaponDamage (e.g. Devastate, Shiv, Mutilate don't)
 	// ... but for other's, BonusAttackPowerOnTarget only applies to weapon damage based attacks
@@ -135,7 +135,7 @@ func BaseDamageFuncMeleeWeapon(hand Hand, normalized bool, flatBonus float64, we
 			return func(sim *Simulation, hitEffect *SpellEffect, spell *Spell) float64 {
 				damage := spell.Unit.AutoAttacks.MH.CalculateNormalizedWeaponDamage(
 					sim, hitEffect.MeleeAttackPower(spell.Unit)+hitEffect.MeleeAttackPowerOnTarget())
-				damage += flatBonus
+				damage = damage*baseMultiplier + flatBonus
 				if includeBonusWeaponDamage {
 					damage += hitEffect.BonusWeaponDamage(spell.Unit)
 				}
@@ -145,7 +145,7 @@ func BaseDamageFuncMeleeWeapon(hand Hand, normalized bool, flatBonus float64, we
 			return func(sim *Simulation, hitEffect *SpellEffect, spell *Spell) float64 {
 				damage := spell.Unit.AutoAttacks.OH.CalculateNormalizedWeaponDamage(
 					sim, hitEffect.MeleeAttackPower(spell.Unit)+2*hitEffect.MeleeAttackPowerOnTarget())
-				damage = damage*0.5 + flatBonus
+				damage = damage*0.5*baseMultiplier + flatBonus
 				if includeBonusWeaponDamage {
 					damage += hitEffect.BonusWeaponDamage(spell.Unit)
 				}
@@ -176,8 +176,8 @@ func BaseDamageFuncMeleeWeapon(hand Hand, normalized bool, flatBonus float64, we
 		}
 	}
 }
-func BaseDamageConfigMeleeWeapon(hand Hand, normalized bool, flatBonus float64, weaponMultiplier float64, includeBonusWeaponDamage bool) BaseDamageConfig {
-	calculator := BaseDamageFuncMeleeWeapon(hand, normalized, flatBonus, weaponMultiplier, includeBonusWeaponDamage)
+func BaseDamageConfigMeleeWeapon(hand Hand, normalized bool, flatBonus float64, baseMultiplier float64, weaponMultiplier float64, includeBonusWeaponDamage bool) BaseDamageConfig {
+	calculator := BaseDamageFuncMeleeWeapon(hand, normalized, flatBonus, baseMultiplier, weaponMultiplier, includeBonusWeaponDamage)
 	if includeBonusWeaponDamage {
 		return BuildBaseDamageConfig(calculator, 1)
 	} else {

--- a/sim/deathknight/blood_strike.go
+++ b/sim/deathknight/blood_strike.go
@@ -8,9 +8,9 @@ import (
 var BloodStrikeActionID = core.ActionID{SpellID: 49930}
 
 func (dk *Deathknight) newBloodStrikeSpell(isMH bool, onhit func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect)) *RuneSpell {
-	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 764.0, 0.4, true)
+	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 764.0, 1.0, 0.4, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 764.0, 0.4*dk.nervesOfColdSteelBonus(), true)
+		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 764.0, dk.nervesOfColdSteelBonus(), 0.4, true)
 	}
 
 	diseaseMulti := dk.diseaseMultiplier(0.125)

--- a/sim/deathknight/death_strike.go
+++ b/sim/deathknight/death_strike.go
@@ -10,9 +10,9 @@ var DeathStrikeActionID = core.ActionID{SpellID: 49924}
 
 func (dk *Deathknight) newDeathStrikeSpell(isMH bool, onhit func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect)) *RuneSpell {
 	bonusBaseDamage := dk.sigilOfAwarenessBonus(dk.DeathStrike)
-	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 297.0+bonusBaseDamage, 0.75, true)
+	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 297.0+bonusBaseDamage, 1.0, 0.75, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 297.0+bonusBaseDamage, 0.75*dk.nervesOfColdSteelBonus(), true)
+		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 297.0+bonusBaseDamage, dk.nervesOfColdSteelBonus(), 0.75, true)
 	}
 
 	effect := core.SpellEffect{

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -52,749 +52,749 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5959.755573600383
-  tps: 4115.578852401762
+  dps: 6116.211561160386
+  tps: 4209.452444937763
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5868.123486289042
-  tps: 4048.353052636909
+  dps: 6023.011606847074
+  tps: 4141.285924971728
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5973.168327794343
-  tps: 4124.267365023159
+  dps: 6130.110285150908
+  tps: 4218.432539437099
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5955.10532208071
-  tps: 4029.980655121618
+  dps: 6111.418235399478
+  tps: 4121.8926481530525
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 5704.902351693503
-  tps: 3935.7908253798146
+  dps: 5858.052304374713
+  tps: 4027.6807969885404
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BurningRage"
  value: {
-  dps: 4915.741756902368
-  tps: 3446.0244652602837
+  dps: 5037.991246834967
+  tps: 3519.374159219841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6109.410831122626
-  tps: 4220.993635201443
+  dps: 6269.533869848281
+  tps: 4317.067458436836
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5717.906813384927
-  tps: 3951.210247352189
+  dps: 5870.999204121855
+  tps: 4043.0656817943445
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5818.538014137614
-  tps: 3996.657233513039
+  dps: 5972.001369190723
+  tps: 4088.735246544904
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 5877.034341610397
-  tps: 4052.522919560711
+  dps: 6034.6213168712875
+  tps: 4147.075104717245
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 5819.82229314686
-  tps: 4017.878506869164
+  dps: 5975.066964888878
+  tps: 4111.025309914376
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 5473.630457307782
-  tps: 3832.029176943415
+  dps: 5618.261075959857
+  tps: 3918.8075481346614
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 5011.913272802895
-  tps: 3476.6697329618646
+  dps: 5137.51184745235
+  tps: 3552.028877751538
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 6006.5201058598395
-  tps: 4145.359952055267
+  dps: 6167.485268248394
+  tps: 4241.939049488399
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5701.517473766898
-  tps: 3939.3288618860724
+  dps: 5854.251079622742
+  tps: 4030.9690253995786
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5653.09312450891
-  tps: 3910.199956180274
+  dps: 5803.601834362374
+  tps: 4000.5051820923545
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DesolationBattlegear"
  value: {
-  dps: 4438.741809503006
-  tps: 3095.876448116436
+  dps: 4548.246786805708
+  tps: 3161.579434498058
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5977.263532109964
-  tps: 4126.724487612531
+  dps: 6134.4404492249605
+  tps: 4221.030637881532
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DoomplateBattlegear"
  value: {
-  dps: 4599.96275319089
-  tps: 3201.3392733384594
+  dps: 4711.713738002539
+  tps: 3268.3898642254476
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5955.10532208071
-  tps: 4112.225158287365
+  dps: 6111.418235399478
+  tps: 4206.0129062786245
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5955.10532208071
-  tps: 4112.225158287365
+  dps: 6111.418235399478
+  tps: 4206.0129062786245
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5973.168327794343
-  tps: 4124.267365023159
+  dps: 6130.110285150908
+  tps: 4218.432539437099
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5970.44307619794
-  tps: 4122.632214065318
+  dps: 6127.368658223312
+  tps: 4216.787563280542
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5955.10532208071
-  tps: 4112.225158287365
+  dps: 6111.418235399478
+  tps: 4206.0129062786245
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5784.213262839217
-  tps: 3988.848718467424
+  dps: 5936.1524150198975
+  tps: 4080.012209775831
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5705.06672995806
-  tps: 3943.5629663532936
+  dps: 5857.63569567707
+  tps: 4035.1043457847
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FaithinFelsteel"
  value: {
-  dps: 4835.359716851899
-  tps: 3370.4631336119687
+  dps: 4956.020582694007
+  tps: 3442.8596531172343
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FelstalkerArmor"
  value: {
-  dps: 5128.279644012095
-  tps: 3563.8504990583524
+  dps: 5257.306303101815
+  tps: 3641.2664945121846
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FlameGuard"
  value: {
-  dps: 4619.3362133815845
-  tps: 3213.5114946073795
+  dps: 4734.6095657607675
+  tps: 3282.675506034889
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5691.844306053587
-  tps: 3934.6120933926604
+  dps: 5844.036692589486
+  tps: 4025.9275253141996
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5955.10532208071
-  tps: 4112.225158287365
+  dps: 6111.418235399478
+  tps: 4206.0129062786245
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5955.10532208071
-  tps: 4112.225158287365
+  dps: 6111.418235399478
+  tps: 4206.0129062786245
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 6014.814043100581
-  tps: 4150.460416028813
+  dps: 6176.03380244809
+  tps: 4247.192271637317
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5821.8274786935435
-  tps: 4031.6010450181493
+  dps: 5977.640592178954
+  tps: 4125.088913109395
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5638.357017725623
-  tps: 3899.562964544789
+  dps: 5788.401915958942
+  tps: 3989.58990348478
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 5989.672568473141
-  tps: 4135.147196270174
+  dps: 6150.0417480136
+  tps: 4231.368703994449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5638.357017725623
-  tps: 3899.562964544789
+  dps: 5788.401915958942
+  tps: 3989.58990348478
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5973.168327794343
-  tps: 4124.267365023159
+  dps: 6130.110285150908
+  tps: 4218.432539437099
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5970.44307619794
-  tps: 4122.632214065318
+  dps: 6127.368658223312
+  tps: 4216.787563280542
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6072.758604597261
-  tps: 4187.276992105186
+  dps: 6242.880950545319
+  tps: 4289.35039967402
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 5679.437091601061
-  tps: 3942.302866246803
+  dps: 5832.677449789754
+  tps: 4034.247081160017
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5955.10532208071
-  tps: 4112.225158287365
+  dps: 6111.418235399478
+  tps: 4206.0129062786245
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5979.584002967773
-  tps: 4129.899585453875
+  dps: 6136.647681480478
+  tps: 4224.1377925615
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5638.357017725623
-  tps: 3899.562964544789
+  dps: 5788.401915958942
+  tps: 3989.58990348478
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5638.357017725623
-  tps: 3899.562964544789
+  dps: 5788.401915958942
+  tps: 3989.58990348478
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 4222.407167562936
-  tps: 2955.914823219166
+  dps: 4324.074610929346
+  tps: 3016.9152892390116
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5762.923969165003
-  tps: 3969.0279170900067
+  dps: 5920.334599012864
+  tps: 4063.474294998724
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NetherscaleArmor"
  value: {
-  dps: 5160.233615480332
-  tps: 3593.7291231059803
+  dps: 5290.345610037913
+  tps: 3671.796319840528
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NetherstrikeArmor"
  value: {
-  dps: 5030.867485134327
-  tps: 3476.220624777003
+  dps: 5159.674706278759
+  tps: 3553.504957463663
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5647.892145644219
-  tps: 3906.4457238383375
+  dps: 5798.23715727881
+  tps: 3996.6527308190925
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5974.921397084521
-  tps: 4126.53302789835
+  dps: 6131.8420727031435
+  tps: 4220.685433269523
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5979.584002967773
-  tps: 4129.899585453875
+  dps: 6136.647681480478
+  tps: 4224.1377925615
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5955.10532208071
-  tps: 4112.225158287365
+  dps: 6111.418235399478
+  tps: 4206.0129062786245
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5955.10532208071
-  tps: 4112.225158287365
+  dps: 6111.418235399478
+  tps: 4206.0129062786245
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PrimalIntent"
  value: {
-  dps: 5182.344067571753
-  tps: 3586.3488133528745
+  dps: 5317.040754530507
+  tps: 3667.1668255281284
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5638.357017725623
-  tps: 3899.562964544789
+  dps: 5788.401915958942
+  tps: 3989.58990348478
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 5970.078019305012
-  tps: 4103.253217368898
+  dps: 6120.571623158436
+  tps: 4193.549379680952
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6010.203814320444
-  tps: 4127.328694378159
+  dps: 6160.697418173868
+  tps: 4217.624856690212
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6106.27854866002
-  tps: 4217.955699143575
+  dps: 6266.409406590447
+  tps: 4314.034213901833
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 6024.49030321478
-  tps: 4156.410957331283
+  dps: 6186.007092347733
+  tps: 4253.321030811054
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5955.10532208071
-  tps: 4112.225158287365
+  dps: 6111.418235399478
+  tps: 4206.0129062786245
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5638.357017725623
-  tps: 3899.562964544789
+  dps: 5788.401915958942
+  tps: 3989.58990348478
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 5328.3947671911865
-  tps: 3665.682961459888
+  dps: 5463.886242617389
+  tps: 3746.977846715609
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 4885.966394521005
-  tps: 3416.2143829688102
+  dps: 5007.186484770537
+  tps: 3488.946437118529
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 5815.876887393501
-  tps: 4044.6256516359344
+  dps: 5971.4852749195825
+  tps: 4137.990684151582
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 5110.584525122047
-  tps: 3548.9783969534487
+  dps: 5238.006327971538
+  tps: 3625.431478663144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5651.923709951171
-  tps: 3909.166464849762
+  dps: 5802.4318759673015
+  tps: 3999.4713644594412
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 5681.745282241966
-  tps: 3925.16009781526
+  dps: 5833.484898527491
+  tps: 4016.2038675865756
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5638.357017725623
-  tps: 3899.562964544789
+  dps: 5788.401915958942
+  tps: 3989.58990348478
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 5973.845025965564
-  tps: 4124.7177915532375
+  dps: 6133.8422496748235
+  tps: 4220.716125778792
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 6274.286019254744
-  tps: 4337.354587608389
+  dps: 6443.44738203602
+  tps: 4438.851405277154
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 6295.435040349507
-  tps: 4355.729733245114
+  dps: 6465.337334131458
+  tps: 4457.671109514284
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5638.357017725623
-  tps: 3899.562964544789
+  dps: 5788.401915958942
+  tps: 3989.58990348478
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 5701.034944544737
-  tps: 3928.0244414703534
+  dps: 5854.843837399759
+  tps: 4020.3097771833664
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 5095.506095995442
-  tps: 3521.363735634146
+  dps: 5227.631350729625
+  tps: 3600.6388884746557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 4900.835738052423
-  tps: 3399.741984979635
+  dps: 5024.87065084038
+  tps: 3474.16293265241
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5979.584002967773
-  tps: 4129.899585453875
+  dps: 6136.647681480478
+  tps: 4224.1377925615
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5974.921397084521
-  tps: 4126.53302789835
+  dps: 6131.8420727031435
+  tps: 4220.685433269523
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5966.761836788835
-  tps: 4120.641552176179
+  dps: 6123.432257342812
+  tps: 4214.643804508565
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 5395.002856775807
-  tps: 3747.0625050569142
+  dps: 5538.24630060656
+  tps: 3833.0085713553663
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 4872.741672154606
-  tps: 3408.039168455228
+  dps: 4992.405356570352
+  tps: 3479.837379104674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinStars"
  value: {
-  dps: 5688.736701013888
-  tps: 3926.618142226853
+  dps: 5836.151421491786
+  tps: 4015.0669745135906
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5965.050419656129
-  tps: 4119.857632187535
+  dps: 6124.742597249917
+  tps: 4215.672938743807
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5821.707414321079
-  tps: 3997.9432408151615
+  dps: 5982.03492668962
+  tps: 4094.1397482362872
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5843.59171231375
-  tps: 4025.871926284667
+  dps: 6004.3968390633345
+  tps: 4122.355002334416
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5955.10532208071
-  tps: 4112.225158287365
+  dps: 6111.418235399478
+  tps: 4206.0129062786245
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5955.10532208071
-  tps: 4112.225158287365
+  dps: 6111.418235399478
+  tps: 4206.0129062786245
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5955.10532208071
-  tps: 4112.225158287365
+  dps: 6111.418235399478
+  tps: 4206.0129062786245
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5955.10532208071
-  tps: 4112.225158287365
+  dps: 6111.418235399478
+  tps: 4206.0129062786245
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WastewalkerArmor"
  value: {
-  dps: 4400.967524908572
-  tps: 3071.8838560282984
+  dps: 4510.49328409006
+  tps: 3137.599311537191
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WindhawkArmor"
  value: {
-  dps: 5003.828700724822
-  tps: 3455.9850379010786
+  dps: 5131.599806694531
+  tps: 3532.6477014829043
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 6035.5488862024395
-  tps: 4163.211575962678
+  dps: 6197.4051379473285
+  tps: 4260.325327009613
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathofSpellfire"
  value: {
-  dps: 5002.664026825698
-  tps: 3464.761023002114
+  dps: 5127.770983201366
+  tps: 3539.8251968275144
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 5942.074884920354
-  tps: 4099.053250459106
+  dps: 6101.78546876318
+  tps: 4194.879600764811
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13020.37426220324
-  tps: 8357.028197046897
+  dps: 13181.594579211396
+  tps: 8453.76038725179
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6013.598044636536
-  tps: 4144.192740423199
+  dps: 6175.203105486263
+  tps: 4241.155776933035
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6837.450291949467
-  tps: 4360.127379254725
+  dps: 7028.20005624071
+  tps: 4474.5772378294705
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8640.47364462672
-  tps: 5542.534024025472
+  dps: 8725.820004387006
+  tps: 5593.7418398816435
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3519.213668286422
-  tps: 2463.5903641504783
+  dps: 3603.926646741677
+  tps: 2514.418151223632
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3680.994659945488
-  tps: 2377.2774210678176
+  dps: 3766.362457949549
+  tps: 2428.4980998702545
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12994.414751659335
-  tps: 8326.322959331295
+  dps: 13156.007637394403
+  tps: 8423.278690772338
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5965.050419656129
-  tps: 4119.857632187535
+  dps: 6124.742597249917
+  tps: 4215.672938743807
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6873.915464258697
-  tps: 4345.774728872776
+  dps: 7067.765297729345
+  tps: 4462.084628955164
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8613.468737365434
-  tps: 5514.782038321442
+  dps: 8698.331661705372
+  tps: 5565.699792925405
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3519.228859750065
-  tps: 2455.790095996793
+  dps: 3603.77116162519
+  tps: 2506.515477121867
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3805.2913025066314
-  tps: 2466.9818771326322
+  dps: 3887.259870783041
+  tps: 2516.1630180984776
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5661.72264676491
-  tps: 3946.1528858684383
+  dps: 5805.282971155681
+  tps: 4032.289080502902
  }
 }

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -52,749 +52,749 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6116.211561160386
-  tps: 4209.452444937763
+  dps: 5933.14307383478
+  tps: 4054.408755952047
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6023.011606847074
-  tps: 4141.285924971728
+  dps: 5806.292896605477
+  tps: 3990.6832158400844
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6130.110285150908
-  tps: 4218.432539437099
+  dps: 5947.345098373517
+  tps: 4061.666798813153
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6111.418235399478
-  tps: 4121.8926481530525
+  dps: 5928.483183163079
+  tps: 3970.0689609053065
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 5858.052304374713
-  tps: 4027.6807969885404
+  dps: 5747.035242229608
+  tps: 3937.3385129820767
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BurningRage"
  value: {
-  dps: 5037.991246834967
-  tps: 3519.374159219841
+  dps: 4875.609454318498
+  tps: 3357.441457680109
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6269.533869848281
-  tps: 4317.067458436836
+  dps: 6077.926468265273
+  tps: 4152.137552586058
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5870.999204121855
-  tps: 4043.0656817943445
+  dps: 5724.666363933061
+  tps: 3895.130994084461
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5972.001369190723
-  tps: 4088.735246544904
+  dps: 5835.523598659418
+  tps: 3967.653693566813
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6034.6213168712875
-  tps: 4147.075104717245
+  dps: 5887.096350796718
+  tps: 3994.498156998682
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 5975.066964888878
-  tps: 4111.025309914376
+  dps: 5827.117301431279
+  tps: 3958.458555861513
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 5618.261075959857
-  tps: 3918.8075481346614
+  dps: 5592.434990087458
+  tps: 3827.77596910444
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 5137.51184745235
-  tps: 3552.028877751538
+  dps: 4981.8661017242675
+  tps: 3447.7309155653834
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 6167.485268248394
-  tps: 4241.939049488399
+  dps: 6014.350489123349
+  tps: 4084.412021364385
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5854.251079622742
-  tps: 4030.9690253995786
+  dps: 5709.649375008927
+  tps: 3888.1145142995374
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5803.601834362374
-  tps: 4000.5051820923545
+  dps: 5658.93619503708
+  tps: 3850.503811029258
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DesolationBattlegear"
  value: {
-  dps: 4548.246786805708
-  tps: 3161.579434498058
+  dps: 4410.482822908813
+  tps: 3044.2730249695187
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6134.4404492249605
-  tps: 4221.030637881532
+  dps: 5952.137740544179
+  tps: 4064.5423841155507
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DoomplateBattlegear"
  value: {
-  dps: 4711.713738002539
-  tps: 3268.3898642254476
+  dps: 4603.073596731178
+  tps: 3162.891774587565
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6111.418235399478
-  tps: 4206.0129062786245
+  dps: 5928.483183163079
+  tps: 4051.0907764339863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6111.418235399478
-  tps: 4206.0129062786245
+  dps: 5928.483183163079
+  tps: 4051.0907764339863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6130.110285150908
-  tps: 4218.432539437099
+  dps: 5947.345098373517
+  tps: 4061.666798813153
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6127.368658223312
-  tps: 4216.787563280542
+  dps: 5943.890940481561
+  tps: 4059.5943040779807
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6111.418235399478
-  tps: 4206.0129062786245
+  dps: 5928.483183163079
+  tps: 4051.0907764339863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5936.1524150198975
-  tps: 4080.012209775831
+  dps: 5788.417643267572
+  tps: 3960.505780037972
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5857.63569567707
-  tps: 4035.1043457847
+  dps: 5710.4800403922945
+  tps: 3884.557568155359
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FaithinFelsteel"
  value: {
-  dps: 4956.020582694007
-  tps: 3442.8596531172343
+  dps: 4827.170782421891
+  tps: 3337.974469496626
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FelstalkerArmor"
  value: {
-  dps: 5257.306303101815
-  tps: 3641.2664945121846
+  dps: 5142.994400894467
+  tps: 3534.305843208065
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FlameGuard"
  value: {
-  dps: 4734.6095657607675
-  tps: 3282.675506034889
+  dps: 4642.657005964109
+  tps: 3203.2099070450704
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5844.036692589486
-  tps: 4025.9275253141996
+  dps: 5701.000565969623
+  tps: 3879.2292718640374
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6111.418235399478
-  tps: 4206.0129062786245
+  dps: 5928.483183163079
+  tps: 4051.0907764339863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6111.418235399478
-  tps: 4206.0129062786245
+  dps: 5928.483183163079
+  tps: 4051.0907764339863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 6176.03380244809
-  tps: 4247.192271637317
+  dps: 6022.600124122917
+  tps: 4089.4738671650935
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5977.640592178954
-  tps: 4125.088913109395
+  dps: 5828.478986502489
+  tps: 3970.1948345025858
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5788.401915958942
-  tps: 3989.58990348478
+  dps: 5644.116483607359
+  tps: 3840.008296718888
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 6150.0417480136
-  tps: 4231.368703994449
+  dps: 5997.366314005294
+  tps: 4073.923878361517
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5788.401915958942
-  tps: 3989.58990348478
+  dps: 5644.116483607359
+  tps: 3840.008296718888
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6130.110285150908
-  tps: 4218.432539437099
+  dps: 5947.345098373517
+  tps: 4061.666798813153
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6127.368658223312
-  tps: 4216.787563280542
+  dps: 5943.890940481561
+  tps: 4059.5943040779807
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6242.880950545319
-  tps: 4289.35039967402
+  dps: 6025.619417157555
+  tps: 4118.111966997001
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 5832.677449789754
-  tps: 4034.247081160017
+  dps: 5629.039739936715
+  tps: 3870.293034515881
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6111.418235399478
-  tps: 4206.0129062786245
+  dps: 5928.483183163079
+  tps: 4051.0907764339863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6136.647681480478
-  tps: 4224.1377925615
+  dps: 5952.921922402196
+  tps: 4068.5259381626965
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5788.401915958942
-  tps: 3989.58990348478
+  dps: 5644.116483607359
+  tps: 3840.008296718888
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5788.401915958942
-  tps: 3989.58990348478
+  dps: 5644.116483607359
+  tps: 3840.008296718888
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 4324.074610929346
-  tps: 3016.9152892390116
+  dps: 4187.897382955288
+  tps: 2883.8166288496827
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5920.334599012864
-  tps: 4063.474294998724
+  dps: 5734.548039395488
+  tps: 3918.9029230523674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NetherscaleArmor"
  value: {
-  dps: 5290.345610037913
-  tps: 3671.796319840528
+  dps: 5177.9290608866895
+  tps: 3566.461265760469
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NetherstrikeArmor"
  value: {
-  dps: 5159.674706278759
-  tps: 3553.504957463663
+  dps: 5048.337158034935
+  tps: 3438.1639523259096
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5798.23715727881
-  tps: 3996.6527308190925
+  dps: 5653.705708650121
+  tps: 3846.7995118608933
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6131.8420727031435
-  tps: 4220.685433269523
+  dps: 5948.266924451888
+  tps: 4065.2049549762755
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6136.647681480478
-  tps: 4224.1377925615
+  dps: 5952.921922402196
+  tps: 4068.5259381626965
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6111.418235399478
-  tps: 4206.0129062786245
+  dps: 5928.483183163079
+  tps: 4051.0907764339863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6111.418235399478
-  tps: 4206.0129062786245
+  dps: 5928.483183163079
+  tps: 4051.0907764339863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PrimalIntent"
  value: {
-  dps: 5317.040754530507
-  tps: 3667.1668255281284
+  dps: 5156.874748423414
+  tps: 3533.549900881308
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5788.401915958942
-  tps: 3989.58990348478
+  dps: 5644.116483607359
+  tps: 3840.008296718888
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6120.571623158436
-  tps: 4193.549379680952
+  dps: 6041.960009451874
+  tps: 4110.634184104851
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6160.697418173868
-  tps: 4217.624856690212
+  dps: 6082.04859884029
+  tps: 4134.687337737902
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6266.409406590447
-  tps: 4314.034213901833
+  dps: 6075.0859398251505
+  tps: 4150.524812011795
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 6186.007092347733
-  tps: 4253.321030811054
+  dps: 6032.224698289079
+  tps: 4095.379353932586
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6111.418235399478
-  tps: 4206.0129062786245
+  dps: 5928.483183163079
+  tps: 4051.0907764339863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5788.401915958942
-  tps: 3989.58990348478
+  dps: 5644.116483607359
+  tps: 3840.008296718888
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 5463.886242617389
-  tps: 3746.977846715609
+  dps: 5403.295421041041
+  tps: 3707.6268646524795
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 5007.186484770537
-  tps: 3488.946437118529
+  dps: 4872.440588593106
+  tps: 3356.688966475345
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 5971.4852749195825
-  tps: 4137.990684151582
+  dps: 5869.6409688281265
+  tps: 4017.1430218897176
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 5238.006327971538
-  tps: 3625.431478663144
+  dps: 5123.813946533694
+  tps: 3519.129823148315
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5802.4318759673015
-  tps: 3999.4713644594412
+  dps: 5657.603518655713
+  tps: 3849.333333256892
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 5833.484898527491
-  tps: 4016.2038675865756
+  dps: 5690.555521215816
+  tps: 3871.453425057344
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5788.401915958942
-  tps: 3989.58990348478
+  dps: 5644.116483607359
+  tps: 3840.008296718888
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 6133.8422496748235
-  tps: 4220.716125778792
+  dps: 5983.077754651382
+  tps: 4066.8003214179544
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 6443.44738203602
-  tps: 4438.851405277154
+  dps: 6279.833498654352
+  tps: 4271.466179867913
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 6465.337334131458
-  tps: 4457.671109514284
+  dps: 6306.104376339087
+  tps: 4292.626342294361
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5788.401915958942
-  tps: 3989.58990348478
+  dps: 5644.116483607359
+  tps: 3840.008296718888
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 5854.843837399759
-  tps: 4020.3097771833664
+  dps: 5662.830040924954
+  tps: 3877.0832055474116
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 5227.631350729625
-  tps: 3600.6388884746557
+  dps: 5163.486538395517
+  tps: 3538.077822784876
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 5024.87065084038
-  tps: 3474.16293265241
+  dps: 4875.584978533493
+  tps: 3350.6667969387295
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6136.647681480478
-  tps: 4224.1377925615
+  dps: 5952.921922402196
+  tps: 4068.5259381626965
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6131.8420727031435
-  tps: 4220.685433269523
+  dps: 5948.266924451888
+  tps: 4065.2049549762755
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6123.432257342812
-  tps: 4214.643804508565
+  dps: 5940.120678038851
+  tps: 4059.3932344000377
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 5538.24630060656
-  tps: 3833.0085713553663
+  dps: 5420.432276847563
+  tps: 3714.4401283693123
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 4992.405356570352
-  tps: 3479.837379104674
+  dps: 4799.127132471208
+  tps: 3315.556627302817
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinStars"
  value: {
-  dps: 5836.151421491786
-  tps: 4015.0669745135906
+  dps: 5704.488293156757
+  tps: 3879.2403253904945
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6124.742597249917
-  tps: 4215.672938743807
+  dps: 5973.102314125506
+  tps: 4059.1027923608444
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5982.03492668962
-  tps: 4094.1397482362872
+  dps: 5833.656862605274
+  tps: 4000.1181971852034
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6004.3968390633345
-  tps: 4122.355002334416
+  dps: 5868.417549118281
+  tps: 3989.212360555174
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6111.418235399478
-  tps: 4206.0129062786245
+  dps: 5928.483183163079
+  tps: 4051.0907764339863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6111.418235399478
-  tps: 4206.0129062786245
+  dps: 5928.483183163079
+  tps: 4051.0907764339863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6111.418235399478
-  tps: 4206.0129062786245
+  dps: 5928.483183163079
+  tps: 4051.0907764339863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6111.418235399478
-  tps: 4206.0129062786245
+  dps: 5928.483183163079
+  tps: 4051.0907764339863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WastewalkerArmor"
  value: {
-  dps: 4510.49328409006
-  tps: 3137.599311537191
+  dps: 4426.691097232286
+  tps: 3037.830188533513
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WindhawkArmor"
  value: {
-  dps: 5131.599806694531
-  tps: 3532.6477014829043
+  dps: 5024.137692548402
+  tps: 3420.275103601774
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 6197.4051379473285
-  tps: 4260.325327009613
+  dps: 6043.224211621838
+  tps: 4102.128481666865
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathofSpellfire"
  value: {
-  dps: 5127.770983201366
-  tps: 3539.8251968275144
+  dps: 4968.827554596094
+  tps: 3411.1752349953545
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 6101.78546876318
-  tps: 4194.879600764811
+  dps: 5967.734753776191
+  tps: 4076.7655810322644
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13181.594579211396
-  tps: 8453.76038725179
+  dps: 12821.354133153469
+  tps: 8169.755223780585
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6175.203105486263
-  tps: 4241.155776933035
+  dps: 5964.460674134017
+  tps: 4084.7822640679383
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7028.20005624071
-  tps: 4474.5772378294705
+  dps: 6895.7633290311405
+  tps: 4404.875561235627
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8725.820004387006
-  tps: 5593.7418398816435
+  dps: 8695.143971598376
+  tps: 5537.087935157133
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3603.926646741677
-  tps: 2514.418151223632
+  dps: 3483.5172777772104
+  tps: 2411.3967294939757
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3766.362457949549
-  tps: 2428.4980998702545
+  dps: 3610.71120854654
+  tps: 2302.026259269259
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13156.007637394403
-  tps: 8423.278690772338
+  dps: 12459.451420836875
+  tps: 7981.880728763523
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6124.742597249917
-  tps: 4215.672938743807
+  dps: 5973.102314125506
+  tps: 4059.1027923608444
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7067.765297729345
-  tps: 4462.084628955164
+  dps: 6843.90334170846
+  tps: 4320.173140639116
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8698.331661705372
-  tps: 5565.699792925405
+  dps: 8556.475225214357
+  tps: 5464.211794449454
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3603.77116162519
-  tps: 2506.515477121867
+  dps: 3530.0218341675863
+  tps: 2429.0046713136667
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3887.259870783041
-  tps: 2516.1630180984776
+  dps: 3678.1639044799495
+  tps: 2336.921549584985
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5805.282971155681
-  tps: 4032.289080502902
+  dps: 5608.126269295113
+  tps: 3885.4032363538035
  }
 }

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -52,749 +52,749 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6211.976063715282
-  tps: 4266.9111464707
+  dps: 5959.755573600383
+  tps: 4115.578852401762
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6118.445948373662
-  tps: 4198.54652988768
+  dps: 5868.123486289042
+  tps: 4048.353052636909
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6226.101791267299
-  tps: 4276.027443106933
+  dps: 5973.168327794343
+  tps: 4124.267365023159
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6207.182737954374
-  tps: 4178.202175655332
+  dps: 5955.10532208071
+  tps: 4029.980655121618
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 5953.991017224088
-  tps: 4085.244024698165
+  dps: 5704.902351693503
+  tps: 3935.7908253798146
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BurningRage"
  value: {
-  dps: 5126.111140326318
-  tps: 3572.2460953146538
+  dps: 4915.741756902368
+  tps: 3446.0244652602837
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6368.356445481233
-  tps: 4376.361003816606
+  dps: 6109.410831122626
+  tps: 4220.993635201443
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5966.216559308088
-  tps: 4100.196094906084
+  dps: 5717.906813384927
+  tps: 3951.210247352189
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6069.09242706932
-  tps: 4146.989881272063
+  dps: 5818.538014137614
+  tps: 3996.657233513039
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6129.232637920238
-  tps: 4203.841897346617
+  dps: 5877.034341610397
+  tps: 4052.522919560711
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6068.703295136393
-  tps: 4167.207108062885
+  dps: 5819.82229314686
+  tps: 4017.878506869164
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 5708.233481247749
-  tps: 3972.7909913073963
+  dps: 5473.630457307782
+  tps: 3832.029176943415
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 5222.996770610409
-  tps: 3603.3198316463727
+  dps: 5011.913272802895
+  tps: 3476.6697329618646
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 6261.121598495909
-  tps: 4298.120847636908
+  dps: 6006.5201058598395
+  tps: 4145.359952055267
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5949.238261337456
-  tps: 4087.961334428409
+  dps: 5701.517473766898
+  tps: 3939.3288618860724
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5897.238164609889
-  tps: 4056.686980240863
+  dps: 5653.09312450891
+  tps: 3910.199956180274
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DesolationBattlegear"
  value: {
-  dps: 4635.234246933085
-  tps: 3213.7719105744845
+  dps: 4438.741809503006
+  tps: 3095.876448116436
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6230.540456065099
-  tps: 4278.690641985614
+  dps: 5977.263532109964
+  tps: 4126.724487612531
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DoomplateBattlegear"
  value: {
-  dps: 4799.059490819689
-  tps: 3320.7973159157386
+  dps: 4599.96275319089
+  tps: 3201.3392733384594
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6207.182737954374
-  tps: 4263.4716078115625
+  dps: 5955.10532208071
+  tps: 4112.225158287365
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6207.182737954374
-  tps: 4263.4716078115625
+  dps: 5955.10532208071
+  tps: 4112.225158287365
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6226.101791267299
-  tps: 4276.027443106933
+  dps: 5973.168327794343
+  tps: 4124.267365023159
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6223.3393695062405
-  tps: 4274.369990050299
+  dps: 5970.44307619794
+  tps: 4122.632214065318
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6207.182737954374
-  tps: 4263.4716078115625
+  dps: 5955.10532208071
+  tps: 4112.225158287365
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6032.157157898052
-  tps: 4137.615055502723
+  dps: 5784.213262839217
+  tps: 3988.848718467424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5952.570379585004
-  tps: 4092.065156129461
+  dps: 5705.06672995806
+  tps: 3943.5629663532936
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FaithinFelsteel"
  value: {
-  dps: 5044.741901328472
-  tps: 3496.0924442979135
+  dps: 4835.359716851899
+  tps: 3370.4631336119687
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FelstalkerArmor"
  value: {
-  dps: 5348.348335009942
-  tps: 3695.891713657062
+  dps: 5128.279644012095
+  tps: 3563.8504990583524
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FlameGuard"
  value: {
-  dps: 4821.5121469929345
-  tps: 3334.817054774188
+  dps: 4619.3362133815845
+  tps: 3213.5114946073795
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5938.648013638436
-  tps: 4082.6943179435702
+  dps: 5691.844306053587
+  tps: 3934.6120933926604
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6207.182737954374
-  tps: 4263.4716078115625
+  dps: 5955.10532208071
+  tps: 4112.225158287365
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6207.182737954374
-  tps: 4263.4716078115625
+  dps: 5955.10532208071
+  tps: 4112.225158287365
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 6269.6701326956045
-  tps: 4303.3740697858275
+  dps: 6014.814043100581
+  tps: 4150.460416028813
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6071.276922426468
-  tps: 4181.270711257904
+  dps: 5821.8274786935435
+  tps: 4031.6010450181493
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5882.0382462064545
-  tps: 4045.7717016332876
+  dps: 5638.357017725623
+  tps: 3899.562964544789
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 6243.678078261115
-  tps: 4287.550502142958
+  dps: 5989.672568473141
+  tps: 4135.147196270174
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5882.0382462064545
-  tps: 4045.7717016332876
+  dps: 5638.357017725623
+  tps: 3899.562964544789
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6226.101791267299
-  tps: 4276.027443106933
+  dps: 5973.168327794343
+  tps: 4124.267365023159
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6223.3393695062405
-  tps: 4274.369990050299
+  dps: 5970.44307619794
+  tps: 4122.632214065318
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6342.847695221297
-  tps: 4349.330446479607
+  dps: 6072.758604597261
+  tps: 4187.276992105186
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 5926.843510383396
-  tps: 4090.7467175162033
+  dps: 5679.437091601061
+  tps: 3942.302866246803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6207.182737954374
-  tps: 4263.4716078115625
+  dps: 5955.10532208071
+  tps: 4112.225158287365
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6232.412184035373
-  tps: 4281.596494094438
+  dps: 5979.584002967773
+  tps: 4129.899585453875
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5882.0382462064545
-  tps: 4045.7717016332876
+  dps: 5638.357017725623
+  tps: 3899.562964544789
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5882.0382462064545
-  tps: 4045.7717016332876
+  dps: 5638.357017725623
+  tps: 3899.562964544789
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 4409.707274949843
-  tps: 3068.29488765131
+  dps: 4222.407167562936
+  tps: 2955.914823219166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6015.939493341988
-  tps: 4120.837231596196
+  dps: 5762.923969165003
+  tps: 3969.0279170900067
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NetherscaleArmor"
  value: {
-  dps: 5381.556602663722
-  tps: 3726.522915416014
+  dps: 5160.233615480332
+  tps: 3593.7291231059803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NetherstrikeArmor"
  value: {
-  dps: 5251.465214228204
-  tps: 3608.5792622333297
+  dps: 5030.867485134327
+  tps: 3476.220624777003
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5891.873487526325
-  tps: 4052.8345289676013
+  dps: 5647.892145644219
+  tps: 3906.4457238383375
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6227.606575258041
-  tps: 4278.14413480246
+  dps: 5974.921397084521
+  tps: 4126.53302789835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6232.412184035373
-  tps: 4281.596494094438
+  dps: 5979.584002967773
+  tps: 4129.899585453875
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6207.182737954374
-  tps: 4263.4716078115625
+  dps: 5955.10532208071
+  tps: 4112.225158287365
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6207.182737954374
-  tps: 4263.4716078115625
+  dps: 5955.10532208071
+  tps: 4112.225158287365
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PrimalIntent"
  value: {
-  dps: 5408.735459386838
-  tps: 3722.1836484419255
+  dps: 5182.344067571753
+  tps: 3586.3488133528745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5882.0382462064545
-  tps: 4045.7717016332876
+  dps: 5638.357017725623
+  tps: 3899.562964544789
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6216.169703517566
-  tps: 4250.9082278964315
+  dps: 5970.078019305012
+  tps: 4103.253217368898
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6256.295498532998
-  tps: 4274.9837049056905
+  dps: 6010.203814320444
+  tps: 4127.328694378159
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6365.2099396999265
-  tps: 4373.3145337675205
+  dps: 6106.27854866002
+  tps: 4217.955699143575
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 6279.643422595249
-  tps: 4309.502828959563
+  dps: 6024.49030321478
+  tps: 4156.410957331283
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6207.182737954374
-  tps: 4263.4716078115625
+  dps: 5955.10532208071
+  tps: 4112.225158287365
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5882.0382462064545
-  tps: 4045.7717016332876
+  dps: 5638.357017725623
+  tps: 3899.562964544789
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 5558.257418719668
-  tps: 3803.600552376977
+  dps: 5328.3947671911865
+  tps: 3665.682961459888
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 5092.828063620992
-  tps: 3540.3313844288036
+  dps: 4885.966394521005
+  tps: 3416.2143829688102
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 6067.823663222752
-  tps: 4195.793717133486
+  dps: 5815.876887393501
+  tps: 4044.6256516359344
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 5322.450700705076
-  tps: 3676.098102303267
+  dps: 5110.584525122047
+  tps: 3548.9783969534487
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5896.068206214816
-  tps: 4055.65316260795
+  dps: 5651.923709951171
+  tps: 3909.166464849762
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 5927.785136227966
-  tps: 4072.784010206861
+  dps: 5681.745282241966
+  tps: 3925.16009781526
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5882.0382462064545
-  tps: 4045.7717016332876
+  dps: 5638.357017725623
+  tps: 3899.562964544789
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 6227.692684137084
-  tps: 4277.026386456148
+  dps: 5973.845025965564
+  tps: 4124.7177915532375
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 6537.083712283535
-  tps: 4495.0332034256635
+  dps: 6274.286019254744
+  tps: 4337.354587608389
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 6558.973664378971
-  tps: 4513.852907662793
+  dps: 6295.435040349507
+  tps: 4355.729733245114
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5882.0382462064545
-  tps: 4045.7717016332876
+  dps: 5638.357017725623
+  tps: 3899.562964544789
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 5949.741221269289
-  tps: 4077.248207505084
+  dps: 5701.034944544737
+  tps: 3928.0244414703534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 5317.235452934181
-  tps: 3654.40134979739
+  dps: 5095.506095995442
+  tps: 3521.363735634146
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 5113.779457077607
-  tps: 3527.5082163947445
+  dps: 4900.835738052423
+  tps: 3399.741984979635
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6232.412184035373
-  tps: 4281.596494094438
+  dps: 5979.584002967773
+  tps: 4129.899585453875
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6227.606575258041
-  tps: 4278.14413480246
+  dps: 5974.921397084521
+  tps: 4126.53302789835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6219.196759897707
-  tps: 4272.102506041503
+  dps: 5966.761836788835
+  tps: 4120.641552176179
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 5627.6766644544305
-  tps: 3886.666789664089
+  dps: 5395.002856775807
+  tps: 3747.0625050569142
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 5076.787606146444
-  tps: 3530.466728850332
+  dps: 4872.741672154606
+  tps: 3408.039168455228
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinStars"
  value: {
-  dps: 5930.054106539871
-  tps: 4071.408585542442
+  dps: 5688.736701013888
+  tps: 3926.618142226853
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6218.378927497433
-  tps: 4271.854736892318
+  dps: 5965.050419656129
+  tps: 4119.857632187535
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6077.411883990325
-  tps: 4151.365922616711
+  dps: 5821.707414321079
+  tps: 3997.9432408151615
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6100.210480513355
-  tps: 4179.843187204429
+  dps: 5843.59171231375
+  tps: 4025.871926284667
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6207.182737954374
-  tps: 4263.4716078115625
+  dps: 5955.10532208071
+  tps: 4112.225158287365
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6207.182737954374
-  tps: 4263.4716078115625
+  dps: 5955.10532208071
+  tps: 4112.225158287365
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6207.182737954374
-  tps: 4263.4716078115625
+  dps: 5955.10532208071
+  tps: 4112.225158287365
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6207.182737954374
-  tps: 4263.4716078115625
+  dps: 5955.10532208071
+  tps: 4112.225158287365
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WastewalkerArmor"
  value: {
-  dps: 4596.10857363649
-  tps: 3188.9684852650507
+  dps: 4400.967524908572
+  tps: 3071.8838560282984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WindhawkArmor"
  value: {
-  dps: 5223.087487714485
-  tps: 3587.540310094876
+  dps: 5003.828700724822
+  tps: 3455.9850379010786
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 6291.041468194844
-  tps: 4316.507125158122
+  dps: 6035.5488862024395
+  tps: 4163.211575962678
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathofSpellfire"
  value: {
-  dps: 5220.565328019977
-  tps: 3595.501803718682
+  dps: 5002.664026825698
+  tps: 3464.761023002114
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 6196.088424196191
-  tps: 4251.461374024605
+  dps: 5942.074884920354
+  tps: 4099.053250459106
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13279.57585160005
-  tps: 8512.549150684981
+  dps: 13020.37426220324
+  tps: 8357.028197046897
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6270.614308731281
-  tps: 4298.402498880047
+  dps: 6013.598044636536
+  tps: 4144.192740423199
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7128.345252143656
-  tps: 4534.664355371237
+  dps: 6837.450291949467
+  tps: 4360.127379254725
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8802.145876421473
-  tps: 5639.537363102323
+  dps: 8640.47364462672
+  tps: 5542.534024025472
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3677.7839177375695
-  tps: 2558.732513821168
+  dps: 3519.213668286422
+  tps: 2463.5903641504783
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3843.229437816656
-  tps: 2474.618287790518
+  dps: 3680.994659945488
+  tps: 2377.2774210678176
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13253.024764730982
-  tps: 8481.488967174288
+  dps: 12994.414751659335
+  tps: 8326.322959331295
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6218.378927497433
-  tps: 4271.854736892318
+  dps: 5965.050419656129
+  tps: 4119.857632187535
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7165.9521550029
-  tps: 4520.996743319299
+  dps: 6873.915464258697
+  tps: 4345.774728872776
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8773.75140392588
-  tps: 5610.951638257714
+  dps: 8613.468737365434
+  tps: 5514.782038321442
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3678.1560073523824
-  tps: 2551.1463845581834
+  dps: 3519.228859750065
+  tps: 2455.790095996793
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3962.8155184546085
-  tps: 2561.4964067014184
+  dps: 3805.2913025066314
+  tps: 2466.9818771326322
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5904.290007642033
-  tps: 4091.693302394713
+  dps: 5661.72264676491
+  tps: 3946.1528858684383
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -52,749 +52,749 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7611.951382560018
-  tps: 5366.359316401328
+  dps: 7802.885078581344
+  tps: 5521.466661209841
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7349.203213466353
-  tps: 5197.1804342099085
+  dps: 7533.965947759626
+  tps: 5347.267288463528
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7613.180489960066
-  tps: 5400.470787919572
+  dps: 7804.3378624850175
+  tps: 5555.98335081436
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7611.951382560018
-  tps: 5259.032130073303
+  dps: 7802.885078581344
+  tps: 5411.037327985644
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 7159.944611390216
-  tps: 5113.3112322496845
+  dps: 7341.430459712297
+  tps: 5260.935867965227
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BurningRage"
  value: {
-  dps: 6392.774723133518
-  tps: 4468.16351648219
+  dps: 6543.135161595624
+  tps: 4590.393647249711
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7677.111913110627
-  tps: 5467.83629559084
+  dps: 7871.677147252516
+  tps: 5626.124246770797
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7267.718530722846
-  tps: 5168.960427698352
+  dps: 7450.980659623301
+  tps: 5317.835761784899
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7298.332112672162
-  tps: 5160.315308121526
+  dps: 7481.361812777279
+  tps: 5309.058459758069
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 7541.213534531767
-  tps: 5300.14743369648
+  dps: 7730.805490915317
+  tps: 5454.320539221092
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7487.739210307285
-  tps: 5247.397895272341
+  dps: 7672.82736134303
+  tps: 5398.15835775647
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7184.842605273938
-  tps: 5071.260132084631
+  dps: 7361.649715599788
+  tps: 5214.85003811721
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 6389.447545200024
-  tps: 4441.090131855088
+  dps: 6541.37638236049
+  tps: 4564.570048584255
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7704.121853639766
-  tps: 5448.440021258683
+  dps: 7897.264895363242
+  tps: 5605.748383807864
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7073.075988483504
-  tps: 5142.400143386923
+  dps: 7256.002206170488
+  tps: 5291.0133032846115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7158.463916158634
-  tps: 5066.3758408899685
+  dps: 7337.05276485784
+  tps: 5211.722867867796
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DesolationBattlegear"
  value: {
-  dps: 5678.2443181220215
-  tps: 3984.442681668633
+  dps: 5813.337035360382
+  tps: 4094.230039080913
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7617.8810442098375
-  tps: 5395.787592161701
+  dps: 7809.1967871748
+  tps: 5551.425531628587
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DoomplateBattlegear"
  value: {
-  dps: 5863.260818687957
-  tps: 4104.475285069407
+  dps: 6001.284342869416
+  tps: 4216.707367841578
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7611.951382560018
-  tps: 5366.359316401328
+  dps: 7802.885078581344
+  tps: 5521.466661209841
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7611.951382560018
-  tps: 5366.359316401328
+  dps: 7802.885078581344
+  tps: 5521.466661209841
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7613.180489960066
-  tps: 5400.470787919572
+  dps: 7804.3378624850175
+  tps: 5555.98335081436
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7606.242940501271
-  tps: 5371.661077007788
+  dps: 7797.414143367435
+  tps: 5527.182467052329
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7611.951382560018
-  tps: 5366.359316401328
+  dps: 7802.885078581344
+  tps: 5521.466661209841
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7244.972216293647
-  tps: 5144.7770554735125
+  dps: 7429.186736076235
+  tps: 5294.57339520072
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7226.780678492857
-  tps: 5139.891505006652
+  dps: 7410.098771212497
+  tps: 5288.840225686654
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FaithinFelsteel"
  value: {
-  dps: 6326.990605250892
-  tps: 4380.8906987904675
+  dps: 6476.596891787629
+  tps: 4502.465375953943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FelstalkerArmor"
  value: {
-  dps: 6577.385321484735
-  tps: 4598.82738717643
+  dps: 6738.956461616597
+  tps: 4730.235047676157
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FlameGuard"
  value: {
-  dps: 5984.762589498341
-  tps: 4146.3702591667425
+  dps: 6123.319461567808
+  tps: 4259.177869512493
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7207.1906579442
-  tps: 5131.108614640218
+  dps: 7390.182306468002
+  tps: 5279.794087269637
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7611.951382560018
-  tps: 5366.359316401328
+  dps: 7802.885078581344
+  tps: 5521.466661209841
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7611.951382560018
-  tps: 5366.359316401328
+  dps: 7802.885078581344
+  tps: 5521.466661209841
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7721.215164625656
-  tps: 5461.472178058254
+  dps: 7914.854035971936
+  tps: 5619.183502537453
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7326.0624204932365
-  tps: 5274.706989783317
+  dps: 7512.124115626112
+  tps: 5426.115251344912
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7158.463916158634
-  tps: 5066.3758408899685
+  dps: 7337.05276485784
+  tps: 5211.722867867796
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7591.689089730769
-  tps: 5414.657849417903
+  dps: 7783.725154078258
+  tps: 5571.0677801197035
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7122.392914431757
-  tps: 5066.3758408899685
+  dps: 7300.981763130965
+  tps: 5211.722867867796
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7613.180489960066
-  tps: 5400.470787919572
+  dps: 7804.3378624850175
+  tps: 5555.98335081436
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7606.242940501271
-  tps: 5371.661077007788
+  dps: 7797.414143367435
+  tps: 5527.182467052329
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7468.0007002096845
-  tps: 5349.4863059257195
+  dps: 7669.716070328643
+  tps: 5513.395112864991
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 7120.232886393553
-  tps: 5060.251670521072
+  dps: 7301.828006109575
+  tps: 5207.7191228508655
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7611.951382560018
-  tps: 5366.359316401328
+  dps: 7802.885078581344
+  tps: 5521.466661209841
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7645.314450620703
-  tps: 5393.994683697776
+  dps: 7837.243082794557
+  tps: 5549.909373127393
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7159.593805354448
-  tps: 5066.3758408899685
+  dps: 7338.182654053655
+  tps: 5211.722867867796
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7122.392914431757
-  tps: 5066.3758408899685
+  dps: 7300.981763130965
+  tps: 5211.722867867796
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 5446.616401567002
-  tps: 3829.3878248444844
+  dps: 5573.606391533362
+  tps: 3932.7467530740773
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7444.970568202298
-  tps: 5205.243095211148
+  dps: 7635.326475029762
+  tps: 5360.166320475018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NetherscaleArmor"
  value: {
-  dps: 6639.52973806707
-  tps: 4665.975223957078
+  dps: 6801.160426903179
+  tps: 4797.453787508371
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NetherstrikeArmor"
  value: {
-  dps: 6499.105519819279
-  tps: 4547.721430774175
+  dps: 6656.134484092385
+  tps: 4675.405730214969
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7161.861414766073
-  tps: 5066.3758408899685
+  dps: 7340.450263465279
+  tps: 5211.722867867796
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7638.959580513905
-  tps: 5388.730804212741
+  dps: 7830.698701039658
+  tps: 5544.491713714528
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7645.314450620703
-  tps: 5393.994683697776
+  dps: 7837.243082794557
+  tps: 5549.909373127393
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7611.951382560018
-  tps: 5366.359316401328
+  dps: 7802.885078581344
+  tps: 5521.466661209841
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7611.951382560018
-  tps: 5366.359316401328
+  dps: 7802.885078581344
+  tps: 5521.466661209841
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PrimalIntent"
  value: {
-  dps: 6690.477669506169
-  tps: 4681.629870744544
+  dps: 6855.427914842197
+  tps: 4816.036453151809
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7175.813708325446
-  tps: 5066.3758408899685
+  dps: 7354.40255702465
+  tps: 5211.722867867796
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7465.599417336377
-  tps: 5288.134163841273
+  dps: 7645.295830937054
+  tps: 5434.285956549412
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7504.002924590331
-  tps: 5319.213326520035
+  dps: 7683.69933819101
+  tps: 5465.365119228174
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7667.707895303312
-  tps: 5432.107007409569
+  dps: 7862.286920853039
+  tps: 5590.403719406483
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7741.157360775856
-  tps: 5476.676360991086
+  dps: 7935.374700015413
+  tps: 5634.857807721979
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7611.951382560018
-  tps: 5366.359316401328
+  dps: 7802.885078581344
+  tps: 5521.466661209841
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7158.463916158634
-  tps: 5066.3758408899685
+  dps: 7337.05276485784
+  tps: 5211.722867867796
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6751.883588615945
-  tps: 4728.452019143059
+  dps: 6915.214221309494
+  tps: 4861.382235941387
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6245.993126501162
-  tps: 4327.2727633147215
+  dps: 6390.736948320038
+  tps: 4444.8813275373
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7682.059440665222
-  tps: 5514.667441824312
+  dps: 7877.253239390748
+  tps: 5673.456450204843
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6918.819785597601
-  tps: 4785.549807328888
+  dps: 7080.571761940805
+  tps: 4917.029178542554
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7158.463916158634
-  tps: 5066.3758408899685
+  dps: 7337.05276485784
+  tps: 5211.722867867796
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 7252.177651685926
-  tps: 5118.03286692365
+  dps: 7434.807369369708
+  tps: 5266.370842629938
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7175.813708325446
-  tps: 5066.3758408899685
+  dps: 7354.40255702465
+  tps: 5211.722867867796
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7669.711785667476
-  tps: 5397.237101602249
+  dps: 7861.921962682422
+  tps: 5553.799728031313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7856.584378264359
-  tps: 5545.437927490101
+  dps: 8052.878675774002
+  tps: 5705.257440572538
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7728.184916365199
-  tps: 5449.186524646256
+  dps: 7921.1018459690295
+  tps: 5606.289241410178
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7146.431871409572
-  tps: 5066.3758408899685
+  dps: 7325.020720108779
+  tps: 5211.722867867796
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 7259.315308414621
-  tps: 5156.335417925514
+  dps: 7445.727887504257
+  tps: 5307.842902654206
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 6684.18207652788
-  tps: 4672.350151072749
+  dps: 6846.469157753631
+  tps: 4804.446242204531
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 6392.1127135879515
-  tps: 4386.463091668022
+  dps: 6546.138726386333
+  tps: 4511.7970440142435
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7645.314450620703
-  tps: 5393.994683697776
+  dps: 7837.243082794557
+  tps: 5549.909373127393
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7638.959580513905
-  tps: 5388.730804212741
+  dps: 7830.698701039658
+  tps: 5544.491713714528
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7627.83855782701
-  tps: 5379.519015113923
+  dps: 7819.246032968588
+  tps: 5535.010809742007
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7243.719117482071
-  tps: 5186.504291651382
+  dps: 7423.749996197197
+  tps: 5333.081023314668
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6509.209535758869
-  tps: 4499.430639311309
+  dps: 6659.214383152392
+  tps: 4621.262623442014
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinStars"
  value: {
-  dps: 7261.898252874547
-  tps: 5120.348999845597
+  dps: 7442.103452467995
+  tps: 5267.265193590394
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7713.621157755093
-  tps: 5403.956069965829
+  dps: 7904.285051364536
+  tps: 5559.249622864902
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7360.736752410652
-  tps: 5225.003965763925
+  dps: 7554.148801709125
+  tps: 5382.370193755188
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7408.022119384821
-  tps: 5246.979236252611
+  dps: 7600.274529364682
+  tps: 5403.295294371268
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7611.951382560018
-  tps: 5366.359316401328
+  dps: 7802.885078581344
+  tps: 5521.466661209841
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7611.951382560018
-  tps: 5366.359316401328
+  dps: 7802.885078581344
+  tps: 5521.466661209841
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7611.951382560018
-  tps: 5366.359316401328
+  dps: 7802.885078581344
+  tps: 5521.466661209841
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7611.951382560018
-  tps: 5366.359316401328
+  dps: 7802.885078581344
+  tps: 5521.466661209841
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WastewalkerArmor"
  value: {
-  dps: 5708.579099251429
-  tps: 4008.4009247467357
+  dps: 5844.155135073192
+  tps: 4118.6710266167765
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WindhawkArmor"
  value: {
-  dps: 6462.373223648379
-  tps: 4517.018159162787
+  dps: 6618.649099768123
+  tps: 4644.301586105541
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7763.948442090373
-  tps: 5494.052570057178
+  dps: 7958.826887493671
+  tps: 5652.771299361434
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathofSpellfire"
  value: {
-  dps: 6318.607431101873
-  tps: 4445.961180686249
+  dps: 6470.184401537966
+  tps: 4569.160488256575
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 7688.7735318805335
-  tps: 5380.795149692931
+  dps: 7881.415756346828
+  tps: 5537.584441726819
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 32263.416455934785
-  tps: 25335.401274261785
+  dps: 32453.703816390916
+  tps: 25490.39870633385
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7557.776862779405
-  tps: 5366.500784217855
+  dps: 7753.441636068655
+  tps: 5525.704112720006
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11886.707854744207
-  tps: 5686.778573281006
+  dps: 12107.945126424875
+  tps: 5874.295402462807
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 20260.937149379384
-  tps: 16494.47587960714
+  dps: 20344.405601144277
+  tps: 16562.08321035403
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3839.1708884600935
-  tps: 3162.258294898261
+  dps: 3924.0745129496718
+  tps: 3231.0384418957497
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5219.19037676144
-  tps: 3115.0032452267033
+  dps: 5305.781864445282
+  tps: 3187.9434809205277
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 32527.06149658722
-  tps: 25469.06574115237
+  dps: 32716.640049215144
+  tps: 25623.13443276902
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7713.621157755093
-  tps: 5403.956069965829
+  dps: 7904.285051364536
+  tps: 5559.249622864902
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12477.29011592562
-  tps: 5810.069554788877
+  dps: 12699.330233196726
+  tps: 5998.945424450699
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 20427.660856239694
-  tps: 16573.9717691168
+  dps: 20511.621748322952
+  tps: 16642.0345879835
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3936.589624539716
-  tps: 3205.6506733722117
+  dps: 4021.968827110262
+  tps: 3274.884131396898
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5441.240024822593
-  tps: 3087.8565892107335
+  dps: 5524.625811026497
+  tps: 3158.328213718501
  }
 }
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7337.381554144957
-  tps: 5110.427067583671
+  dps: 7510.298214773958
+  tps: 5251.276374151244
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -52,749 +52,749 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7611.951382560018
+  tps: 5366.359316401328
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7533.965947759626
-  tps: 5347.267288463528
+  dps: 7349.203213466353
+  tps: 5197.1804342099085
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7804.3378624850175
-  tps: 5555.98335081436
+  dps: 7613.180489960066
+  tps: 5400.470787919572
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5411.037327985644
+  dps: 7611.951382560018
+  tps: 5259.032130073303
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 7341.430459712297
-  tps: 5260.935867965227
+  dps: 7159.944611390216
+  tps: 5113.3112322496845
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BurningRage"
  value: {
-  dps: 6543.135161595624
-  tps: 4590.393647249711
+  dps: 6392.774723133518
+  tps: 4468.16351648219
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7871.677147252516
-  tps: 5626.124246770797
+  dps: 7677.111913110627
+  tps: 5467.83629559084
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7450.980659623301
-  tps: 5317.835761784899
+  dps: 7267.718530722846
+  tps: 5168.960427698352
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7481.361812777279
-  tps: 5309.058459758069
+  dps: 7298.332112672162
+  tps: 5160.315308121526
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 7730.805490915317
-  tps: 5454.320539221092
+  dps: 7541.213534531767
+  tps: 5300.14743369648
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7672.82736134303
-  tps: 5398.15835775647
+  dps: 7487.739210307285
+  tps: 5247.397895272341
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7361.649715599788
-  tps: 5214.85003811721
+  dps: 7184.842605273938
+  tps: 5071.260132084631
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 6541.37638236049
-  tps: 4564.570048584255
+  dps: 6389.447545200024
+  tps: 4441.090131855088
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7897.264895363242
-  tps: 5605.748383807864
+  dps: 7704.121853639766
+  tps: 5448.440021258683
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7256.002206170488
-  tps: 5291.0133032846115
+  dps: 7073.075988483504
+  tps: 5142.400143386923
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7337.05276485784
-  tps: 5211.722867867796
+  dps: 7158.463916158634
+  tps: 5066.3758408899685
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DesolationBattlegear"
  value: {
-  dps: 5813.337035360382
-  tps: 4094.230039080913
+  dps: 5678.2443181220215
+  tps: 3984.442681668633
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7809.1967871748
-  tps: 5551.425531628587
+  dps: 7617.8810442098375
+  tps: 5395.787592161701
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DoomplateBattlegear"
  value: {
-  dps: 6001.284342869416
-  tps: 4216.707367841578
+  dps: 5863.260818687957
+  tps: 4104.475285069407
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7611.951382560018
+  tps: 5366.359316401328
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7611.951382560018
+  tps: 5366.359316401328
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7804.3378624850175
-  tps: 5555.98335081436
+  dps: 7613.180489960066
+  tps: 5400.470787919572
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7797.414143367435
-  tps: 5527.182467052329
+  dps: 7606.242940501271
+  tps: 5371.661077007788
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7611.951382560018
+  tps: 5366.359316401328
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7429.186736076235
-  tps: 5294.57339520072
+  dps: 7244.972216293647
+  tps: 5144.7770554735125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7410.098771212497
-  tps: 5288.840225686654
+  dps: 7226.780678492857
+  tps: 5139.891505006652
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FaithinFelsteel"
  value: {
-  dps: 6476.596891787629
-  tps: 4502.465375953943
+  dps: 6326.990605250892
+  tps: 4380.8906987904675
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FelstalkerArmor"
  value: {
-  dps: 6738.956461616597
-  tps: 4730.235047676157
+  dps: 6577.385321484735
+  tps: 4598.82738717643
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FlameGuard"
  value: {
-  dps: 6123.319461567808
-  tps: 4259.177869512493
+  dps: 5984.762589498341
+  tps: 4146.3702591667425
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7390.182306468002
-  tps: 5279.794087269637
+  dps: 7207.1906579442
+  tps: 5131.108614640218
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7611.951382560018
+  tps: 5366.359316401328
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7611.951382560018
+  tps: 5366.359316401328
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7914.854035971936
-  tps: 5619.183502537453
+  dps: 7721.215164625656
+  tps: 5461.472178058254
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7512.124115626112
-  tps: 5426.115251344912
+  dps: 7326.0624204932365
+  tps: 5274.706989783317
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7337.05276485784
-  tps: 5211.722867867796
+  dps: 7158.463916158634
+  tps: 5066.3758408899685
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7783.725154078258
-  tps: 5571.0677801197035
+  dps: 7591.689089730769
+  tps: 5414.657849417903
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7300.981763130965
-  tps: 5211.722867867796
+  dps: 7122.392914431757
+  tps: 5066.3758408899685
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7804.3378624850175
-  tps: 5555.98335081436
+  dps: 7613.180489960066
+  tps: 5400.470787919572
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7797.414143367435
-  tps: 5527.182467052329
+  dps: 7606.242940501271
+  tps: 5371.661077007788
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7669.716070328643
-  tps: 5513.395112864991
+  dps: 7468.0007002096845
+  tps: 5349.4863059257195
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 7301.828006109575
-  tps: 5207.7191228508655
+  dps: 7120.232886393553
+  tps: 5060.251670521072
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7611.951382560018
+  tps: 5366.359316401328
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7837.243082794557
-  tps: 5549.909373127393
+  dps: 7645.314450620703
+  tps: 5393.994683697776
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7338.182654053655
-  tps: 5211.722867867796
+  dps: 7159.593805354448
+  tps: 5066.3758408899685
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7300.981763130965
-  tps: 5211.722867867796
+  dps: 7122.392914431757
+  tps: 5066.3758408899685
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 5573.606391533362
-  tps: 3932.7467530740773
+  dps: 5446.616401567002
+  tps: 3829.3878248444844
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7635.326475029762
-  tps: 5360.166320475018
+  dps: 7444.970568202298
+  tps: 5205.243095211148
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NetherscaleArmor"
  value: {
-  dps: 6801.160426903179
-  tps: 4797.453787508371
+  dps: 6639.52973806707
+  tps: 4665.975223957078
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NetherstrikeArmor"
  value: {
-  dps: 6656.134484092385
-  tps: 4675.405730214969
+  dps: 6499.105519819279
+  tps: 4547.721430774175
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7340.450263465279
-  tps: 5211.722867867796
+  dps: 7161.861414766073
+  tps: 5066.3758408899685
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7830.698701039658
-  tps: 5544.491713714528
+  dps: 7638.959580513905
+  tps: 5388.730804212741
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7837.243082794557
-  tps: 5549.909373127393
+  dps: 7645.314450620703
+  tps: 5393.994683697776
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7611.951382560018
+  tps: 5366.359316401328
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7611.951382560018
+  tps: 5366.359316401328
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PrimalIntent"
  value: {
-  dps: 6855.427914842197
-  tps: 4816.036453151809
+  dps: 6690.477669506169
+  tps: 4681.629870744544
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7354.40255702465
-  tps: 5211.722867867796
+  dps: 7175.813708325446
+  tps: 5066.3758408899685
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7645.295830937054
-  tps: 5434.285956549412
+  dps: 7465.599417336377
+  tps: 5288.134163841273
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7683.69933819101
-  tps: 5465.365119228174
+  dps: 7504.002924590331
+  tps: 5319.213326520035
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7862.286920853039
-  tps: 5590.403719406483
+  dps: 7667.707895303312
+  tps: 5432.107007409569
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7935.374700015413
-  tps: 5634.857807721979
+  dps: 7741.157360775856
+  tps: 5476.676360991086
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7611.951382560018
+  tps: 5366.359316401328
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7337.05276485784
-  tps: 5211.722867867796
+  dps: 7158.463916158634
+  tps: 5066.3758408899685
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6915.214221309494
-  tps: 4861.382235941387
+  dps: 6751.883588615945
+  tps: 4728.452019143059
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6390.736948320038
-  tps: 4444.8813275373
+  dps: 6245.993126501162
+  tps: 4327.2727633147215
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7877.253239390748
-  tps: 5673.456450204843
+  dps: 7682.059440665222
+  tps: 5514.667441824312
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7080.571761940805
-  tps: 4917.029178542554
+  dps: 6918.819785597601
+  tps: 4785.549807328888
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7337.05276485784
-  tps: 5211.722867867796
+  dps: 7158.463916158634
+  tps: 5066.3758408899685
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 7434.807369369708
-  tps: 5266.370842629938
+  dps: 7252.177651685926
+  tps: 5118.03286692365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7354.40255702465
-  tps: 5211.722867867796
+  dps: 7175.813708325446
+  tps: 5066.3758408899685
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7861.921962682422
-  tps: 5553.799728031313
+  dps: 7669.711785667476
+  tps: 5397.237101602249
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8052.878675774002
-  tps: 5705.257440572538
+  dps: 7856.584378264359
+  tps: 5545.437927490101
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7921.1018459690295
-  tps: 5606.289241410178
+  dps: 7728.184916365199
+  tps: 5449.186524646256
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7325.020720108779
-  tps: 5211.722867867796
+  dps: 7146.431871409572
+  tps: 5066.3758408899685
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 7445.727887504257
-  tps: 5307.842902654206
+  dps: 7259.315308414621
+  tps: 5156.335417925514
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 6846.469157753631
-  tps: 4804.446242204531
+  dps: 6684.18207652788
+  tps: 4672.350151072749
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 6546.138726386333
-  tps: 4511.7970440142435
+  dps: 6392.1127135879515
+  tps: 4386.463091668022
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7837.243082794557
-  tps: 5549.909373127393
+  dps: 7645.314450620703
+  tps: 5393.994683697776
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7830.698701039658
-  tps: 5544.491713714528
+  dps: 7638.959580513905
+  tps: 5388.730804212741
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7819.246032968588
-  tps: 5535.010809742007
+  dps: 7627.83855782701
+  tps: 5379.519015113923
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7423.749996197197
-  tps: 5333.081023314668
+  dps: 7243.719117482071
+  tps: 5186.504291651382
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6659.214383152392
-  tps: 4621.262623442014
+  dps: 6509.209535758869
+  tps: 4499.430639311309
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinStars"
  value: {
-  dps: 7442.103452467995
-  tps: 5267.265193590394
+  dps: 7261.898252874547
+  tps: 5120.348999845597
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7904.285051364536
-  tps: 5559.249622864902
+  dps: 7713.621157755093
+  tps: 5403.956069965829
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7554.148801709125
-  tps: 5382.370193755188
+  dps: 7360.736752410652
+  tps: 5225.003965763925
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7600.274529364682
-  tps: 5403.295294371268
+  dps: 7408.022119384821
+  tps: 5246.979236252611
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7611.951382560018
+  tps: 5366.359316401328
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7611.951382560018
+  tps: 5366.359316401328
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7611.951382560018
+  tps: 5366.359316401328
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7611.951382560018
+  tps: 5366.359316401328
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WastewalkerArmor"
  value: {
-  dps: 5844.155135073192
-  tps: 4118.6710266167765
+  dps: 5708.579099251429
+  tps: 4008.4009247467357
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WindhawkArmor"
  value: {
-  dps: 6618.649099768123
-  tps: 4644.301586105541
+  dps: 6462.373223648379
+  tps: 4517.018159162787
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7958.826887493671
-  tps: 5652.771299361434
+  dps: 7763.948442090373
+  tps: 5494.052570057178
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathofSpellfire"
  value: {
-  dps: 6470.184401537966
-  tps: 4569.160488256575
+  dps: 6318.607431101873
+  tps: 4445.961180686249
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 7881.415756346828
-  tps: 5537.584441726819
+  dps: 7688.7735318805335
+  tps: 5380.795149692931
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 32453.703816390916
-  tps: 25490.39870633385
+  dps: 32263.416455934785
+  tps: 25335.401274261785
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7753.441636068655
-  tps: 5525.704112720006
+  dps: 7557.776862779405
+  tps: 5366.500784217855
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12107.945126424875
-  tps: 5874.295402462807
+  dps: 11886.707854744207
+  tps: 5686.778573281006
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 20344.405601144277
-  tps: 16562.08321035403
+  dps: 20260.937149379384
+  tps: 16494.47587960714
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3924.0745129496718
-  tps: 3231.0384418957497
+  dps: 3839.1708884600935
+  tps: 3162.258294898261
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5305.781864445282
-  tps: 3187.9434809205277
+  dps: 5219.19037676144
+  tps: 3115.0032452267033
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 32716.640049215144
-  tps: 25623.13443276902
+  dps: 32527.06149658722
+  tps: 25469.06574115237
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7904.285051364536
-  tps: 5559.249622864902
+  dps: 7713.621157755093
+  tps: 5403.956069965829
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12699.330233196726
-  tps: 5998.945424450699
+  dps: 12477.29011592562
+  tps: 5810.069554788877
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 20511.621748322952
-  tps: 16642.0345879835
+  dps: 20427.660856239694
+  tps: 16573.9717691168
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4021.968827110262
-  tps: 3274.884131396898
+  dps: 3936.589624539716
+  tps: 3205.6506733722117
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5524.625811026497
-  tps: 3158.328213718501
+  dps: 5441.240024822593
+  tps: 3087.8565892107335
  }
 }
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7510.298214773958
-  tps: 5251.276374151244
+  dps: 7337.381554144957
+  tps: 5110.427067583671
  }
 }

--- a/sim/deathknight/frost_strike.go
+++ b/sim/deathknight/frost_strike.go
@@ -10,9 +10,9 @@ var FrostStrikeActionID = core.ActionID{SpellID: 55268}
 
 func (dk *Deathknight) newFrostStrikeHitSpell(isMH bool, onhit func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect)) *RuneSpell {
 	baseDamage := 250.0 + dk.sigilOfTheVengefulHeartFrostStrike()
-	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, baseDamage, 0.55, true)
+	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, baseDamage, 1.0, 0.55, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, baseDamage, 0.55*dk.nervesOfColdSteelBonus(), true)
+		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, baseDamage, dk.nervesOfColdSteelBonus(), 0.55, true)
 	}
 
 	effect := core.SpellEffect{

--- a/sim/deathknight/ghoul_pet_abilities.go
+++ b/sim/deathknight/ghoul_pet_abilities.go
@@ -70,7 +70,7 @@ func (ghoulPet *GhoulPet) newClaw() PetAbility {
 				ProcMask:         core.ProcMaskMeleeMHSpecial,
 				DamageMultiplier: 1,
 				ThreatMultiplier: 1,
-				BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 0, 1.5, true),
+				BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 0, 1.0, 1.5, true),
 				OutcomeApplier:   ghoulPet.OutcomeFuncMeleeSpecialHitAndCrit(2),
 			}),
 		}),

--- a/sim/deathknight/obliterate.go
+++ b/sim/deathknight/obliterate.go
@@ -11,9 +11,9 @@ var ObliterateActionID = core.ActionID{SpellID: 51425}
 
 func (dk *Deathknight) newObliterateHitSpell(isMH bool, onhit func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect)) *RuneSpell {
 	bonusBaseDamage := dk.sigilOfAwarenessBonus(dk.Obliterate)
-	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 584.0+bonusBaseDamage, 0.8, true)
+	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 584.0+bonusBaseDamage, 1.0, 0.8, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 584.0+bonusBaseDamage, 0.8*dk.nervesOfColdSteelBonus(), true)
+		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 584.0+bonusBaseDamage, dk.nervesOfColdSteelBonus(), 0.8, true)
 	}
 
 	diseaseMulti := dk.diseaseMultiplier(0.125)

--- a/sim/deathknight/plague_strike.go
+++ b/sim/deathknight/plague_strike.go
@@ -8,9 +8,9 @@ import (
 var PlagueStrikeActionID = core.ActionID{SpellID: 49921}
 
 func (dk *Deathknight) newPlagueStrikeSpell(isMH bool, onhit func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect)) *RuneSpell {
-	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 378.0, 0.5, true)
+	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 378.0, 1.0, 0.5, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 378.0, 0.5*dk.nervesOfColdSteelBonus(), true)
+		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 378.0, dk.nervesOfColdSteelBonus(), 0.5, true)
 	}
 
 	outbreakBonus := 1.0 + 0.1*float64(dk.Talents.Outbreak)

--- a/sim/deathknight/scourge_strike.go
+++ b/sim/deathknight/scourge_strike.go
@@ -37,7 +37,7 @@ func (dk *Deathknight) registerScourgeStrikeSpell() {
 
 	shadowDamageSpell := dk.registerScourgeStrikeShadowDamageSpell()
 	bonusBaseDamage := dk.sigilOfAwarenessBonus(dk.ScourgeStrike) + dk.sigilOfArthriticBindingBonus()
-	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 800.0+bonusBaseDamage, 0.7, true)
+	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 800.0+bonusBaseDamage, 1.0, 0.7, true)
 	outbreakBonus := []float64{1.0, 1.07, 1.13, 1.2}[dk.Talents.Outbreak]
 	rpGain := 15.0 + 2.5*float64(dk.Talents.Dirge) + dk.scourgeborneBattlegearRunicPowerBonus()
 

--- a/sim/deathknight/talents_frost.go
+++ b/sim/deathknight/talents_frost.go
@@ -30,7 +30,7 @@ func (dk *Deathknight) ApplyFrostTalents() {
 	// Nerves Of Cold Steel
 	if dk.Equip[proto.ItemSlot_ItemSlotMainHand].HandType == proto.HandType_HandTypeMainHand || dk.Equip[proto.ItemSlot_ItemSlotMainHand].HandType == proto.HandType_HandTypeOneHand {
 		dk.AddStat(stats.MeleeHit, core.MeleeHitRatingPerHitChance*float64(dk.Talents.NervesOfColdSteel))
-		dk.AutoAttacks.OHEffect.BaseDamage.Calculator = core.BaseDamageFuncMeleeWeapon(core.OffHand, false, 0, dk.nervesOfColdSteelBonus(), true)
+		dk.AutoAttacks.OHEffect.BaseDamage.Calculator = core.BaseDamageFuncMeleeWeapon(core.OffHand, false, 0, dk.nervesOfColdSteelBonus(), 1.0, true)
 	}
 
 	// Icy Talons

--- a/sim/deathknight/talents_unholy.go
+++ b/sim/deathknight/talents_unholy.go
@@ -175,8 +175,8 @@ func (dk *Deathknight) applyBloodCakedBlade() {
 }
 
 func (dk *Deathknight) bloodCakedBladeHit(isMh bool) *core.Spell {
-	mhBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, false, 0, 1.0, true)
-	ohBaseDamage := core.BaseDamageFuncMeleeWeapon(core.OffHand, false, 0, 1.0*dk.nervesOfColdSteelBonus(), true)
+	mhBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, false, 0, 1.0, 1.0, true)
+	ohBaseDamage := core.BaseDamageFuncMeleeWeapon(core.OffHand, false, 0, dk.nervesOfColdSteelBonus(), 1.0, true)
 
 	procMask := core.ProcMaskMeleeOHSpecial
 	if isMh {

--- a/sim/druid/mangle.go
+++ b/sim/druid/mangle.go
@@ -45,7 +45,7 @@ func (druid *Druid) registerMangleBearSpell() {
 			ThreatMultiplier: (1.5 / 1.15) *
 				core.TernaryFloat64(druid.InForm(Bear) && druid.HasSetBonus(ItemSetThunderheartHarness, 2), 1.15, 1),
 
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 155/1.15, 1.15, true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 155/1.15, 1.0, 1.15, true),
 			OutcomeApplier: druid.OutcomeFuncMeleeSpecialHitAndCrit(druid.MeleeCritMultiplier()),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
@@ -92,7 +92,7 @@ func (druid *Druid) registerMangleCatSpell() {
 			DamageMultiplier: 1 + 0.1*float64(druid.Talents.SavageFury),
 			ThreatMultiplier: 1,
 
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 264/1.6, 1.6, true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 264/1.6, 1.0, 1.6, true),
 			OutcomeApplier: druid.OutcomeFuncMeleeSpecialHitAndCrit(druid.MeleeCritMultiplier()),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {

--- a/sim/druid/maul.go
+++ b/sim/druid/maul.go
@@ -37,7 +37,7 @@ func (druid *Druid) registerMaulSpell(rageThreshold float64) {
 			ThreatMultiplier: 1,
 			FlatThreatBonus:  344,
 
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, baseDamage, 1, true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, baseDamage, 1, 1, true),
 			OutcomeApplier: druid.OutcomeFuncMeleeSpecialHitAndCrit(druid.MeleeCritMultiplier()),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {

--- a/sim/druid/shred.go
+++ b/sim/druid/shred.go
@@ -39,7 +39,7 @@ func (druid *Druid) registerShredSpell() {
 			ThreatMultiplier: 1,
 
 			BaseDamage: core.WrapBaseDamageConfig(
-				core.BaseDamageConfigMeleeWeapon(core.MainHand, false, flatDamageBonus/2.25, 2.25, true),
+				core.BaseDamageConfigMeleeWeapon(core.MainHand, false, flatDamageBonus/2.25, 1.0, 2.25, true),
 				func(oldCalculator core.BaseDamageCalculator) core.BaseDamageCalculator {
 					return func(sim *core.Simulation, spellEffect *core.SpellEffect, spell *core.Spell) float64 {
 						normalDamage := oldCalculator(sim, spellEffect, spell)

--- a/sim/hunter/raptor_strike.go
+++ b/sim/hunter/raptor_strike.go
@@ -36,7 +36,7 @@ func (hunter *Hunter) registerRaptorStrikeSpell() {
 			DamageMultiplier: 1,
 			ThreatMultiplier: 1,
 
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 170, 1, true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 170, 1, 1, true),
 			OutcomeApplier: hunter.OutcomeFuncMeleeSpecialHitAndCrit(hunter.critMultiplier(false, false, hunter.CurrentTarget)),
 		}),
 	})

--- a/sim/paladin/crusader_strike.go
+++ b/sim/paladin/crusader_strike.go
@@ -29,7 +29,7 @@ func (paladin *Paladin) registerCrusaderStrikeSpell() {
 				Cost: baseCost *
 					(1 - 0.02*float64(paladin.Talents.Benediction)) *
 					core.TernaryFloat64(paladin.HasMajorGlyph(proto.PaladinMajorGlyph_GlyphOfCrusaderStrike), 0.8, 1),
-				GCD:  core.GCDDefault,
+				GCD: core.GCDDefault,
 			},
 			IgnoreHaste: true, // cs is on phys gcd, which cannot be hasted
 			CD: core.Cooldown{
@@ -50,6 +50,7 @@ func (paladin *Paladin) registerCrusaderStrikeSpell() {
 				true, // cs is subject to normalisation
 				core.TernaryFloat64(paladin.Equip[proto.ItemSlot_ItemSlotRanged].ID == 31033, 36, 0)+ // Libram of Righteous Power
 					core.TernaryFloat64(paladin.Equip[proto.ItemSlot_ItemSlotRanged].ID == 40191, 79, 0), // Libram of Radiance
+				1.0,
 				(0.75), // base multiplier's .75, can be improved by sanctity (15%), taow (10%) & pvp gloves (5%), stacking additively
 				true,
 			),

--- a/sim/paladin/divine_storm.go
+++ b/sim/paladin/divine_storm.go
@@ -29,6 +29,7 @@ func (paladin *Paladin) registerDivineStormSpell() {
 			core.TernaryFloat64(paladin.Equip[proto.ItemSlot_ItemSlotRanged].ID == 45510, 235, 0)+ // Libram of Discord
 				core.TernaryFloat64(paladin.Equip[proto.ItemSlot_ItemSlotRanged].ID == 38362, 81, 0), // Venture Co. Libram of Retribution
 			// (much akin to what stuff like hs or ms have intrinsically)
+			1.0,
 			(1.1), // base 1.1 multiplier, can be further improved by 10% via taow for a grand total of 1.21. NOTE: Unlike cs, ds tooltip IS NOT updated to reflect this.
 			true,
 		),

--- a/sim/paladin/soc.go
+++ b/sim/paladin/soc.go
@@ -51,6 +51,7 @@ func (paladin *Paladin) registerSealOfCommandSpellAndAura() {
 				core.MainHand,
 				false,
 				0,
+				1.0,
 				(0.19),
 				true,
 			), func(oldCalculator core.BaseDamageCalculator) core.BaseDamageCalculator {
@@ -74,6 +75,7 @@ func (paladin *Paladin) registerSealOfCommandSpellAndAura() {
 			core.MainHand,
 			false,
 			0,
+			1,
 			(0.36),
 			true,
 		),

--- a/sim/paladin/sov.go
+++ b/sim/paladin/sov.go
@@ -119,7 +119,7 @@ func (paladin *Paladin) registerSealOfVengeanceSpellAndAura() {
 			ProcMask:         core.ProcMaskEmpty,
 			DamageMultiplier: baseMultiplier,
 			ThreatMultiplier: 1,
-			BaseDamage:       core.MultiplyByStacks(core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 0, damagePerStack, false), dot.Aura),
+			BaseDamage:       core.MultiplyByStacks(core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 0, 1, damagePerStack, false), dot.Aura),
 			OutcomeApplier:   paladin.OutcomeFuncMeleeSpecialCritOnly(paladin.MeleeCritMultiplier()), // can't miss if melee swing landed, but can crit
 		}),
 	})

--- a/sim/rogue/TestMutilate.results
+++ b/sim/rogue/TestMutilate.results
@@ -52,630 +52,630 @@ character_stats_results: {
 dps_results: {
  key: "TestMutilate-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 1644.3773976405314
-  tps: 1167.5079523247773
+  dps: 1732.010291664749
+  tps: 1229.7273070819715
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AssassinationArmor"
  value: {
-  dps: 1457.4177418321162
-  tps: 1034.766596700802
+  dps: 1535.8957492380757
+  tps: 1090.4859819590338
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1634.9277503594196
-  tps: 1160.7987027551876
+  dps: 1722.1298555089284
+  tps: 1222.712197411339
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1709.516171611474
-  tps: 1213.7564818441465
+  dps: 1798.0774777935126
+  tps: 1276.6350092333944
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1640.230590518568
-  tps: 1164.5637192681827
+  dps: 1728.1121793629168
+  tps: 1226.9596473476709
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1634.9277503594196
-  tps: 1137.5827287000839
+  dps: 1722.1298555089284
+  tps: 1198.2579534631127
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 1634.3978886572504
-  tps: 1160.4225009466475
+  dps: 1722.558500745238
+  tps: 1223.0165355291185
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1651.1396998133464
-  tps: 1172.3091868674753
+  dps: 1740.011414706942
+  tps: 1235.4081044419286
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1644.4922332531617
-  tps: 1167.5894856097443
+  dps: 1732.1664621989853
+  tps: 1229.8381881612793
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1686.2296405204318
-  tps: 1197.223044769506
+  dps: 1773.066811689095
+  tps: 1258.8774362992567
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 1690.2388688004783
-  tps: 1200.0695968483394
+  dps: 1780.6659968510903
+  tps: 1264.2728577642738
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 1701.372395296632
-  tps: 1207.9744006606084
+  dps: 1794.0848916066739
+  tps: 1273.8002730407375
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 1659.6467653027607
-  tps: 1178.3492033649602
+  dps: 1747.9770154908285
+  tps: 1241.0636809984883
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1638.6064206726637
-  tps: 1163.4105586775909
+  dps: 1724.7913508790339
+  tps: 1224.601859124113
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Deathmantle"
  value: {
-  dps: 1595.280229177878
-  tps: 1132.6489627162932
+  dps: 1678.7398586601837
+  tps: 1191.9052996487296
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1610.538280983482
-  tps: 1143.4821794982715
+  dps: 1695.1415970879978
+  tps: 1203.5505339324777
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1636.9090510441913
-  tps: 1162.2054262413753
+  dps: 1725.8131603832717
+  tps: 1225.3273438721221
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1634.9277503594196
-  tps: 1160.7987027551876
+  dps: 1722.1298555089284
+  tps: 1222.712197411339
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1634.9277503594196
-  tps: 1160.7987027551876
+  dps: 1722.1298555089284
+  tps: 1222.712197411339
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1640.230590518568
-  tps: 1164.5637192681827
+  dps: 1728.1121793629168
+  tps: 1226.9596473476709
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1633.0659398228195
-  tps: 1159.4768172742013
+  dps: 1720.707559526636
+  tps: 1221.702367263911
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1634.9277503594196
-  tps: 1160.7987027551876
+  dps: 1722.1298555089284
+  tps: 1222.712197411339
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1649.6576479554685
-  tps: 1171.2569300483824
+  dps: 1736.7055622856192
+  tps: 1233.0609492227898
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1640.8245632485916
-  tps: 1164.9854399064998
+  dps: 1727.6802320350203
+  tps: 1226.652964744864
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1641.7249519975055
-  tps: 1165.6247159182287
+  dps: 1728.1371511610037
+  tps: 1226.977377324312
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1634.9277503594196
-  tps: 1160.7987027551876
+  dps: 1722.1298555089284
+  tps: 1222.712197411339
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1634.9277503594196
-  tps: 1160.7987027551876
+  dps: 1722.1298555089284
+  tps: 1222.712197411339
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1707.394007069713
-  tps: 1212.2497450194955
+  dps: 1798.5692804006853
+  tps: 1276.9841890844857
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1610.538280983482
-  tps: 1143.4821794982715
+  dps: 1695.1415970879978
+  tps: 1203.5505339324777
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1610.538280983482
-  tps: 1143.4821794982715
+  dps: 1695.1415970879978
+  tps: 1203.5505339324777
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1640.230590518568
-  tps: 1164.5637192681827
+  dps: 1728.1121793629168
+  tps: 1226.9596473476709
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1633.0659398228195
-  tps: 1159.4768172742013
+  dps: 1720.707559526636
+  tps: 1221.702367263911
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1729.8705014545744
-  tps: 1228.2080560327472
+  dps: 1825.6453729974637
+  tps: 1296.208214828199
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 1615.3427839167987
-  tps: 1146.8933765809268
+  dps: 1700.634356151809
+  tps: 1207.450392867784
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1634.9277503594196
-  tps: 1160.7987027551876
+  dps: 1722.1298555089284
+  tps: 1222.712197411339
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1647.9121685784273
-  tps: 1170.0176396906836
+  dps: 1736.011369215871
+  tps: 1232.568072143268
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1610.538280983482
-  tps: 1143.4821794982715
+  dps: 1695.1415970879978
+  tps: 1203.5505339324777
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1610.538280983482
-  tps: 1143.4821794982715
+  dps: 1695.1415970879978
+  tps: 1203.5505339324777
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1333.3277067761614
-  tps: 946.6626718110747
+  dps: 1401.381867300754
+  tps: 994.9811257835356
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1661.3717994739113
-  tps: 1179.5739776264763
+  dps: 1751.3407969673262
+  tps: 1243.451965846801
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Netherblade"
  value: {
-  dps: 1536.1602034364162
-  tps: 1090.6737444398552
+  dps: 1617.5867565360452
+  tps: 1148.4865971405918
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1610.538280983482
-  tps: 1143.4821794982715
+  dps: 1695.1415970879978
+  tps: 1203.5505339324777
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1645.4389460605216
-  tps: 1168.2616517029699
+  dps: 1733.36727136693
+  tps: 1230.69076267052
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1647.9121685784273
-  tps: 1170.0176396906836
+  dps: 1736.011369215871
+  tps: 1232.568072143268
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1634.9277503594196
-  tps: 1160.7987027551876
+  dps: 1722.1298555089284
+  tps: 1222.712197411339
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1634.9277503594196
-  tps: 1160.7987027551876
+  dps: 1722.1298555089284
+  tps: 1222.712197411339
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PrimalIntent"
  value: {
-  dps: 1619.2484608547998
-  tps: 1149.666407206908
+  dps: 1707.5807628090886
+  tps: 1212.3823415944528
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1610.538280983482
-  tps: 1143.4821794982715
+  dps: 1695.1415970879978
+  tps: 1203.5505339324777
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1752.4095519733314
-  tps: 1244.2107819010646
+  dps: 1837.0128680778475
+  tps: 1304.2791363352712
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1769.9198782878684
-  tps: 1256.6431135843861
+  dps: 1854.5231943923839
+  tps: 1316.711468018592
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1654.7335902512064
-  tps: 1174.860849078356
+  dps: 1743.6432590741624
+  tps: 1237.9867139426544
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1634.9277503594196
-  tps: 1160.7987027551876
+  dps: 1722.1298555089284
+  tps: 1222.712197411339
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1610.538280983482
-  tps: 1143.4821794982715
+  dps: 1695.1415970879978
+  tps: 1203.5505339324777
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1610.538280983482
-  tps: 1143.4821794982715
+  dps: 1695.1415970879978
+  tps: 1203.5505339324777
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 1618.073614296561
-  tps: 1148.8322661505576
+  dps: 1703.0755146107986
+  tps: 1209.1836153736665
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1610.538280983482
-  tps: 1143.4821794982715
+  dps: 1695.1415970879978
+  tps: 1203.5505339324777
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1610.538280983482
-  tps: 1143.4821794982715
+  dps: 1695.1415970879978
+  tps: 1203.5505339324777
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Slayer'sArmor"
  value: {
-  dps: 1694.8717094471806
-  tps: 1203.358913707498
+  dps: 1788.464145754975
+  tps: 1269.8095434860322
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SparkofLife-37657"
  value: {
-  dps: 1629.4172489196922
-  tps: 1156.8862467329807
+  dps: 1716.6942679246445
+  tps: 1218.8529302264972
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1494.2756433898633
-  tps: 1060.935706806802
+  dps: 1574.4403295695772
+  tps: 1117.8526339943994
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1434.020094110026
-  tps: 1018.1542668181195
+  dps: 1509.6297702794604
+  tps: 1071.8371368984176
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1647.9121685784273
-  tps: 1170.0176396906836
+  dps: 1736.011369215871
+  tps: 1232.568072143268
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1645.4389460605216
-  tps: 1168.2616517029699
+  dps: 1733.36727136693
+  tps: 1230.69076267052
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1641.110806654185
-  tps: 1165.1886727244719
+  dps: 1728.7401001312817
+  tps: 1227.4054710932103
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheTwinStars"
  value: {
-  dps: 1587.9136457822515
-  tps: 1127.4186885053982
+  dps: 1671.8994493962296
+  tps: 1187.0486090713227
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1647.2260949400347
-  tps: 1169.5305274074246
+  dps: 1736.2299126456223
+  tps: 1232.7232379783911
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1717.5072369127447
-  tps: 1219.4301382080484
+  dps: 1808.796710069252
+  tps: 1284.2456641491685
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1715.8519233627935
-  tps: 1218.254865587583
+  dps: 1807.374463728072
+  tps: 1283.235869246931
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1634.9277503594196
-  tps: 1160.7987027551876
+  dps: 1722.1298555089284
+  tps: 1222.712197411339
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1634.9277503594196
-  tps: 1160.7987027551876
+  dps: 1722.1298555089284
+  tps: 1222.712197411339
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1634.9277503594196
-  tps: 1160.7987027551876
+  dps: 1722.1298555089284
+  tps: 1222.712197411339
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1634.9277503594196
-  tps: 1160.7987027551876
+  dps: 1722.1298555089284
+  tps: 1222.712197411339
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 1714.894031824901
-  tps: 1217.574762595679
+  dps: 1811.2855990585426
+  tps: 1286.012775331565
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WastewalkerArmor"
  value: {
-  dps: 1476.9741150573095
-  tps: 1048.6516216906898
+  dps: 1556.2065194261834
+  tps: 1104.9066287925907
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WindhawkArmor"
  value: {
-  dps: 1499.5455611461684
-  tps: 1064.67734841378
+  dps: 1579.9489752637803
+  tps: 1121.7637724372848
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WrathofSpellfire"
  value: {
-  dps: 1498.8795952671849
-  tps: 1064.2045126397015
+  dps: 1577.9340461197123
+  tps: 1120.333172744996
  }
 }
 dps_results: {
  key: "TestMutilate-Average-Default"
  value: {
-  dps: 1641.093929728374
-  tps: 1165.1766901071458
+  dps: 1729.3115467542118
+  tps: 1227.8111981954892
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2137.5478240432944
-  tps: 1517.658955070739
+  dps: 2226.1312897135113
+  tps: 1580.553215696593
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1650.5243029133067
-  tps: 1171.8722550684474
+  dps: 1739.107768583524
+  tps: 1234.7665156943017
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1847.6174632490463
-  tps: 1311.8083989068227
+  dps: 1954.020814538058
+  tps: 1387.3547783220208
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1034.3319994281824
-  tps: 734.3757195940099
+  dps: 1080.5125150208837
+  tps: 767.1638856648277
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1034.3319994281824
-  tps: 734.3757195940099
+  dps: 1080.5125150208837
+  tps: 767.1638856648277
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1048.5242374144661
-  tps: 744.452208564271
+  dps: 1094.5761560727783
+  tps: 777.1490708116728
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2137.6682978804834
-  tps: 1517.7444914951434
+  dps: 2226.239928486167
+  tps: 1580.6303492251786
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1650.64480321419
-  tps: 1171.9578102820747
+  dps: 1739.2164338198738
+  tps: 1234.84366801211
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1847.6643380674966
-  tps: 1311.8416800279222
+  dps: 1954.095935102349
+  tps: 1387.4081139226673
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1034.5174658760875
-  tps: 734.5074007720216
+  dps: 1080.71295530938
+  tps: 767.3061982696593
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1034.5174658760875
-  tps: 734.5074007720216
+  dps: 1080.71295530938
+  tps: 767.3061982696593
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1048.7659890658233
-  tps: 744.6238522367345
+  dps: 1094.832663356264
+  tps: 777.3311909829476
  }
 }
 dps_results: {
  key: "TestMutilate-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1470.393921458401
-  tps: 1043.9796842354644
+  dps: 1545.874158398242
+  tps: 1097.5706524627517
  }
 }

--- a/sim/rogue/TestMutilate.results
+++ b/sim/rogue/TestMutilate.results
@@ -52,630 +52,630 @@ character_stats_results: {
 dps_results: {
  key: "TestMutilate-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 1749.3399027305118
-  tps: 1242.0313309386624
+  dps: 1644.3773976405314
+  tps: 1167.5079523247773
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AssassinationArmor"
  value: {
-  dps: 1552.7988133886179
-  tps: 1102.4871575059187
+  dps: 1457.4177418321162
+  tps: 1034.766596700802
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1738.9370970347604
-  tps: 1234.6453388946798
+  dps: 1634.9277503594196
+  tps: 1160.7987027551876
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1815.056213300392
-  tps: 1288.689911443279
+  dps: 1709.516171611474
+  tps: 1213.7564818441465
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1744.5923067961717
-  tps: 1238.6605378252816
+  dps: 1640.230590518568
+  tps: 1164.5637192681827
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1738.9370970347604
-  tps: 1209.9524321167867
+  dps: 1634.9277503594196
+  tps: 1137.5827287000839
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 1739.5159928823334
-  tps: 1235.0563549464562
+  dps: 1634.3978886572504
+  tps: 1160.4225009466475
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1756.7737038581986
-  tps: 1247.3093297393202
+  dps: 1651.1396998133464
+  tps: 1172.3091868674753
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1749.5820924154498
-  tps: 1242.203285614969
+  dps: 1644.4922332531617
+  tps: 1167.5894856097443
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1790.1605062015828
-  tps: 1271.013959403123
+  dps: 1686.2296405204318
+  tps: 1197.223044769506
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 1797.8749720745259
-  tps: 1276.491230172913
+  dps: 1690.2388688004783
+  tps: 1200.0695968483394
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 1811.4077834172215
-  tps: 1286.0995262262268
+  dps: 1701.372395296632
+  tps: 1207.9744006606084
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 1765.1859907142637
-  tps: 1253.2820534071275
+  dps: 1659.6467653027607
+  tps: 1178.3492033649602
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1742.015279191377
-  tps: 1236.8308482258767
+  dps: 1638.6064206726637
+  tps: 1163.4105586775909
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Deathmantle"
  value: {
-  dps: 1696.8203109013289
-  tps: 1204.7424207399424
+  dps: 1595.280229177878
+  tps: 1132.6489627162932
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1712.1203325948768
-  tps: 1215.6054361423624
+  dps: 1610.538280983482
+  tps: 1143.4821794982715
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1742.5711379750726
-  tps: 1237.2255079623008
+  dps: 1636.9090510441913
+  tps: 1162.2054262413753
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1738.9370970347604
-  tps: 1234.6453388946798
+  dps: 1634.9277503594196
+  tps: 1160.7987027551876
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1738.9370970347604
-  tps: 1234.6453388946798
+  dps: 1634.9277503594196
+  tps: 1160.7987027551876
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1744.5923067961717
-  tps: 1238.6605378252816
+  dps: 1640.230590518568
+  tps: 1164.5637192681827
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1737.509036083154
-  tps: 1233.6314156190392
+  dps: 1633.0659398228195
+  tps: 1159.4768172742013
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1738.9370970347604
-  tps: 1234.6453388946798
+  dps: 1634.9277503594196
+  tps: 1160.7987027551876
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1753.8135396510413
-  tps: 1245.207613152239
+  dps: 1649.6576479554685
+  tps: 1171.2569300483824
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1744.7717343468562
-  tps: 1238.787931386267
+  dps: 1640.8245632485916
+  tps: 1164.9854399064998
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1745.6903213552928
-  tps: 1239.440128162257
+  dps: 1641.7249519975055
+  tps: 1165.6247159182287
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1738.9370970347604
-  tps: 1234.6453388946798
+  dps: 1634.9277503594196
+  tps: 1160.7987027551876
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1738.9370970347604
-  tps: 1234.6453388946798
+  dps: 1634.9277503594196
+  tps: 1160.7987027551876
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1815.5480159075646
-  tps: 1289.0390912943699
+  dps: 1707.394007069713
+  tps: 1212.2497450194955
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1712.1203325948768
-  tps: 1215.6054361423624
+  dps: 1610.538280983482
+  tps: 1143.4821794982715
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1712.1203325948768
-  tps: 1215.6054361423624
+  dps: 1610.538280983482
+  tps: 1143.4821794982715
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1744.5923067961717
-  tps: 1238.6605378252816
+  dps: 1640.230590518568
+  tps: 1164.5637192681827
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1737.509036083154
-  tps: 1233.6314156190392
+  dps: 1633.0659398228195
+  tps: 1159.4768172742013
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1844.192082950076
-  tps: 1309.3763788945537
+  dps: 1729.8705014545744
+  tps: 1228.2080560327472
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 1717.6514764756976
-  tps: 1219.5325482977446
+  dps: 1615.3427839167987
+  tps: 1146.8933765809268
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1738.9370970347604
-  tps: 1234.6453388946798
+  dps: 1634.9277503594196
+  tps: 1160.7987027551876
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1752.818610741703
-  tps: 1244.5012136266091
+  dps: 1647.9121685784273
+  tps: 1170.0176396906836
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1712.1203325948768
-  tps: 1215.6054361423624
+  dps: 1610.538280983482
+  tps: 1143.4821794982715
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1712.1203325948768
-  tps: 1215.6054361423624
+  dps: 1610.538280983482
+  tps: 1143.4821794982715
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1418.0792252293245
-  tps: 1006.8362499128204
+  dps: 1333.3277067761614
+  tps: 946.6626718110747
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1768.4289686491793
-  tps: 1255.5845677409163
+  dps: 1661.3717994739113
+  tps: 1179.5739776264763
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Netherblade"
  value: {
-  dps: 1634.6524159451365
-  tps: 1160.6032153210463
+  dps: 1536.1602034364162
+  tps: 1090.6737444398552
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1712.1203325948768
-  tps: 1215.6054361423624
+  dps: 1610.538280983482
+  tps: 1143.4821794982715
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1750.174512892762
-  tps: 1242.6239041538606
+  dps: 1645.4389460605216
+  tps: 1168.2616517029699
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1752.818610741703
-  tps: 1244.5012136266091
+  dps: 1647.9121685784273
+  tps: 1170.0176396906836
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1738.9370970347604
-  tps: 1234.6453388946798
+  dps: 1634.9277503594196
+  tps: 1160.7987027551876
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1738.9370970347604
-  tps: 1234.6453388946798
+  dps: 1634.9277503594196
+  tps: 1160.7987027551876
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PrimalIntent"
  value: {
-  dps: 1724.6053554405414
-  tps: 1224.4698023627848
+  dps: 1619.2484608547998
+  tps: 1149.666407206908
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1712.1203325948768
-  tps: 1215.6054361423624
+  dps: 1610.538280983482
+  tps: 1143.4821794982715
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1853.9894109275149
-  tps: 1316.3324817585353
+  dps: 1752.4095519733314
+  tps: 1244.2107819010646
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1871.4997372420523
-  tps: 1328.7648134418564
+  dps: 1769.9198782878684
+  tps: 1256.6431135843861
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1760.7510598173699
-  tps: 1250.1332524703319
+  dps: 1654.7335902512064
+  tps: 1174.860849078356
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1738.9370970347604
-  tps: 1234.6453388946798
+  dps: 1634.9277503594196
+  tps: 1160.7987027551876
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1712.1203325948768
-  tps: 1215.6054361423624
+  dps: 1610.538280983482
+  tps: 1143.4821794982715
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1712.1203325948768
-  tps: 1215.6054361423624
+  dps: 1610.538280983482
+  tps: 1143.4821794982715
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 1720.091471248963
-  tps: 1221.2649445867635
+  dps: 1618.073614296561
+  tps: 1148.8322661505576
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1712.1203325948768
-  tps: 1215.6054361423624
+  dps: 1610.538280983482
+  tps: 1143.4821794982715
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1712.1203325948768
-  tps: 1215.6054361423624
+  dps: 1610.538280983482
+  tps: 1143.4821794982715
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Slayer'sArmor"
  value: {
-  dps: 1806.759370318956
-  tps: 1282.7991529264593
+  dps: 1694.8717094471806
+  tps: 1203.358913707498
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SparkofLife-37657"
  value: {
-  dps: 1734.0529113826174
-  tps: 1231.177567081658
+  dps: 1629.4172489196922
+  tps: 1156.8862467329807
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1591.5653378963593
-  tps: 1130.0113899064145
+  dps: 1494.2756433898633
+  tps: 1060.935706806802
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1526.4338074160416
-  tps: 1083.76800326539
+  dps: 1434.020094110026
+  tps: 1018.1542668181195
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1752.818610741703
-  tps: 1244.5012136266091
+  dps: 1647.9121685784273
+  tps: 1170.0176396906836
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1750.174512892762
-  tps: 1242.6239041538606
+  dps: 1645.4389460605216
+  tps: 1168.2616517029699
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1745.5473416571137
-  tps: 1239.338612576551
+  dps: 1641.110806654185
+  tps: 1165.1886727244719
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheTwinStars"
  value: {
-  dps: 1689.3166048584953
-  tps: 1199.4147894495313
+  dps: 1587.9136457822515
+  tps: 1127.4186885053982
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1752.9941484362764
-  tps: 1244.6258453897558
+  dps: 1647.2260949400347
+  tps: 1169.5305274074246
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1826.0116081085685
-  tps: 1296.4682417570832
+  dps: 1717.5072369127447
+  tps: 1219.4301382080484
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1824.30858443655
-  tps: 1295.2590949499502
+  dps: 1715.8519233627935
+  tps: 1218.254865587583
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1738.9370970347604
-  tps: 1234.6453388946798
+  dps: 1634.9277503594196
+  tps: 1160.7987027551876
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1738.9370970347604
-  tps: 1234.6453388946798
+  dps: 1634.9277503594196
+  tps: 1160.7987027551876
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1738.9370970347604
-  tps: 1234.6453388946798
+  dps: 1634.9277503594196
+  tps: 1160.7987027551876
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1738.9370970347604
-  tps: 1234.6453388946798
+  dps: 1634.9277503594196
+  tps: 1160.7987027551876
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 1830.7088113449656
-  tps: 1299.803256054925
+  dps: 1714.894031824901
+  tps: 1217.574762595679
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WastewalkerArmor"
  value: {
-  dps: 1572.5430494020297
-  tps: 1116.5055650754412
+  dps: 1476.9741150573095
+  tps: 1048.6516216906898
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WindhawkArmor"
  value: {
-  dps: 1596.6096106910677
-  tps: 1133.5928235906588
+  dps: 1499.5455611461684
+  tps: 1064.67734841378
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WrathofSpellfire"
  value: {
-  dps: 1594.9528948220977
-  tps: 1132.4165553236894
+  dps: 1498.8795952671849
+  tps: 1064.2045126397015
  }
 }
 dps_results: {
  key: "TestMutilate-Average-Default"
  value: {
-  dps: 1746.3342571318672
-  tps: 1239.8973225636248
+  dps: 1641.093929728374
+  tps: 1165.1766901071458
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2243.2445383384033
-  tps: 1592.7036222202664
+  dps: 2137.5478240432944
+  tps: 1517.658955070739
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1756.2155693267318
-  tps: 1246.9130542219793
+  dps: 1650.5243029133067
+  tps: 1171.8722550684474
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1972.2944814115504
-  tps: 1400.3290818022003
+  dps: 1847.6174632490463
+  tps: 1311.8083989068227
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1095.1864817270398
-  tps: 777.5824020261989
+  dps: 1034.3319994281824
+  tps: 734.3757195940099
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1095.1864817270398
-  tps: 777.5824020261989
+  dps: 1034.3319994281824
+  tps: 734.3757195940099
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1111.1710579575524
-  tps: 788.9314511498621
+  dps: 1048.5242374144661
+  tps: 744.452208564271
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2243.35317711106
-  tps: 1592.7807557488527
+  dps: 2137.6682978804834
+  tps: 1517.7444914951434
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1756.3242345630817
-  tps: 1246.9902065397876
+  dps: 1650.64480321419
+  tps: 1171.9578102820747
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1972.3696019758413
-  tps: 1400.382417402847
+  dps: 1847.6643380674966
+  tps: 1311.8416800279222
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1095.3869220155366
-  tps: 777.7247146310303
+  dps: 1034.5174658760875
+  tps: 734.5074007720216
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1095.3869220155366
-  tps: 777.7247146310303
+  dps: 1034.5174658760875
+  tps: 734.5074007720216
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1111.4275652410383
-  tps: 789.1135713211372
+  dps: 1048.7659890658233
+  tps: 744.6238522367345
  }
 }
 dps_results: {
  key: "TestMutilate-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1562.1199766070172
-  tps: 1109.105183390982
+  dps: 1470.393921458401
+  tps: 1043.9796842354644
  }
 }

--- a/sim/rogue/TestRogue.results
+++ b/sim/rogue/TestRogue.results
@@ -52,728 +52,728 @@ character_stats_results: {
 dps_results: {
  key: "TestRogue-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 2327.867858356183
-  tps: 1652.7861794328905
+  dps: 2220.7866705307115
+  tps: 1576.7585360768055
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AssassinationArmor"
  value: {
-  dps: 2088.46870663708
-  tps: 1482.8127817123266
+  dps: 1994.2645318957257
+  tps: 1415.9278176459652
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2194.9117713709106
+  tps: 1558.387357673347
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2404.5986431793085
-  tps: 1707.2650366573082
+  dps: 2296.195237715265
+  tps: 1630.2986187778383
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 2316.1353895997077
-  tps: 1644.456126615792
+  dps: 2208.206307434425
+  tps: 1567.8264782784415
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1601.8734685108188
+  dps: 2194.9117713709106
+  tps: 1527.2196105198796
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 2324.3599808543804
-  tps: 1650.2955864066098
+  dps: 2218.3886371060935
+  tps: 1575.0559323453258
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2333.89405356963
-  tps: 1657.0647780344377
+  dps: 2224.634217076724
+  tps: 1579.4902941244736
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2343.9615823915874
-  tps: 1664.2127234980278
+  dps: 2237.3085464815276
+  tps: 1588.4890680018848
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2372.713886851482
-  tps: 1684.626859664552
+  dps: 2266.340960615401
+  tps: 1609.1020820369351
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 2404.3834244465097
-  tps: 1707.112231357022
+  dps: 2293.235828330417
+  tps: 1628.1974381145963
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 2430.559338369872
-  tps: 1725.6971302426089
+  dps: 2317.55739675723
+  tps: 1645.465751697633
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 2359.759023628594
-  tps: 1675.4289067763016
+  dps: 2251.272779221073
+  tps: 1598.4036732469613
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 2331.678979070443
-  tps: 1655.492075140015
+  dps: 2225.490698917027
+  tps: 1580.0983962310893
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Deathmantle"
  value: {
-  dps: 2267.522825864552
-  tps: 1609.941206363832
+  dps: 2164.729127340917
+  tps: 1536.9576804120518
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Defender'sCode-40257"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2178.2269274641126
+  tps: 1546.5411184995203
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2318.242216496491
-  tps: 1645.9519737125083
+  dps: 2210.1324463633255
+  tps: 1569.1940369179608
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2194.9117713709106
+  tps: 1558.387357673347
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2194.9117713709106
+  tps: 1558.387357673347
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 2316.1353895997077
-  tps: 1644.456126615792
+  dps: 2208.206307434425
+  tps: 1567.8264782784415
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2313.6455526880263
-  tps: 1642.6883424084986
+  dps: 2205.8611166008736
+  tps: 1566.1613927866197
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2194.9117713709106
+  tps: 1558.387357673347
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2362.4204536234024
-  tps: 1677.318522072616
+  dps: 2255.920712638467
+  tps: 1601.7037059733118
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2337.194615079628
-  tps: 1659.4081767065363
+  dps: 2230.921102633304
+  tps: 1583.953982869646
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2328.924853445166
-  tps: 1653.536645946068
+  dps: 2223.2042867102873
+  tps: 1578.4750435643039
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2194.9117713709106
+  tps: 1558.387357673347
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2194.9117713709106
+  tps: 1558.387357673347
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2422.291664721549
-  tps: 1719.8270819522993
+  dps: 2310.582537320406
+  tps: 1640.5136014974883
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2178.2269274641126
+  tps: 1546.5411184995203
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2178.2269274641126
+  tps: 1546.5411184995203
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 2316.1353895997077
-  tps: 1644.456126615792
+  dps: 2208.206307434425
+  tps: 1567.8264782784415
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2313.6455526880263
-  tps: 1642.6883424084986
+  dps: 2205.8611166008736
+  tps: 1566.1613927866197
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2464.695221041232
-  tps: 1749.9336069392753
+  dps: 2347.5627250803946
+  tps: 1666.7695348070806
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 2303.048838945097
-  tps: 1635.1646756510188
+  dps: 2198.640569974751
+  tps: 1561.0348046820734
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2194.9117713709106
+  tps: 1558.387357673347
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2320.986696420988
-  tps: 1647.9005544589018
+  dps: 2212.5525704021543
+  tps: 1570.9123249855295
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2178.2269274641126
+  tps: 1546.5411184995203
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2178.2269274641126
+  tps: 1546.5411184995203
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1906.9900255890159
-  tps: 1353.9629181682012
+  dps: 1824.8567789235942
+  tps: 1295.6483130357515
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2357.1165201646754
-  tps: 1673.5527293169193
+  dps: 2246.703416810679
+  tps: 1595.159425935582
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Netherblade"
  value: {
-  dps: 2187.333301967571
-  tps: 1553.0066443969758
+  dps: 2088.4626845201915
+  tps: 1482.8085060093358
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2178.2269274641126
+  tps: 1546.5411184995203
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 2317.409019513585
-  tps: 1645.3604038546443
+  dps: 2209.1924182057282
+  tps: 1568.526616926066
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2320.986696420988
-  tps: 1647.9005544589018
+  dps: 2212.5525704021543
+  tps: 1570.9123249855295
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2194.9117713709106
+  tps: 1558.387357673347
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2194.9117713709106
+  tps: 1558.387357673347
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PrimalIntent"
  value: {
-  dps: 2297.3973064571787
-  tps: 1631.1520875845963
+  dps: 2189.8711281780115
+  tps: 1554.8085010063874
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2178.2269274641126
+  tps: 1546.5411184995203
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 2417.278869584934
-  tps: 1716.2679974053033
+  dps: 2313.8899571911434
+  tps: 1642.8618696057124
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 2434.4672878594165
-  tps: 1728.471774380186
+  dps: 2331.078375465627
+  tps: 1655.065646580595
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2336.753559856877
-  tps: 1659.0950274983825
+  dps: 2227.1672440358243
+  tps: 1581.288743265435
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2194.9117713709106
+  tps: 1558.387357673347
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2178.2269274641126
+  tps: 1546.5411184995203
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2178.2269274641126
+  tps: 1546.5411184995203
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 2307.1160478684146
-  tps: 1638.0523939865743
+  dps: 2202.474785491999
+  tps: 1563.7570976993188
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2178.2269274641126
+  tps: 1546.5411184995203
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2178.2269274641126
+  tps: 1546.5411184995203
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Slayer'sArmor"
  value: {
-  dps: 2442.739486416964
-  tps: 1734.3450353560445
+  dps: 2325.8427569442347
+  tps: 1651.3483574304057
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SparkofLife-37657"
  value: {
-  dps: 2300.5914102982115
-  tps: 1633.4199013117304
+  dps: 2194.395126664597
+  tps: 1558.0205399318638
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 2125.4051935197995
-  tps: 1509.0376873990583
+  dps: 2029.7285165753285
+  tps: 1441.107246768484
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 2033.8619020198998
-  tps: 1444.0419504341291
+  dps: 1941.650443916876
+  tps: 1378.571815180982
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2320.986696420988
-  tps: 1647.9005544589018
+  dps: 2212.5525704021543
+  tps: 1570.9123249855295
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 2317.409019513585
-  tps: 1645.3604038546443
+  dps: 2209.1924182057282
+  tps: 1568.526616926066
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2311.148084925625
-  tps: 1640.9151402971936
+  dps: 2203.3121518619796
+  tps: 1564.351627822005
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheFistsofFury"
  value: {
-  dps: 2380.135084338308
-  tps: 1689.8959098801988
+  dps: 2262.1729004598296
+  tps: 1606.142759326479
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 2494.9575870113213
-  tps: 1771.4198867780367
+  dps: 2370.697223685027
+  tps: 1683.1950288163687
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinStars"
  value: {
-  dps: 2237.873606793513
-  tps: 1588.8902608233936
+  dps: 2136.3658447487023
+  tps: 1516.8197497715785
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 2315.9819936374174
-  tps: 1644.347215482566
+  dps: 2208.1642497197654
+  tps: 1567.7966173010332
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2405.473766903376
-  tps: 1707.8863745013975
+  dps: 2296.188993119166
+  tps: 1630.2941851146081
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2425.8150368706774
-  tps: 1722.3286761781815
+  dps: 2315.959557646479
+  tps: 1644.3312859290004
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2194.9117713709106
+  tps: 1558.387357673347
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2194.9117713709106
+  tps: 1558.387357673347
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2194.9117713709106
+  tps: 1558.387357673347
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2194.9117713709106
+  tps: 1558.387357673347
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 2456.6367975146068
-  tps: 1744.212126235371
+  dps: 2339.1426867510904
+  tps: 1660.7913075932743
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WastewalkerArmor"
  value: {
-  dps: 2097.183110088511
-  tps: 1489.0000081628432
+  dps: 2001.0667448570562
+  tps: 1420.75738884851
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WindhawkArmor"
  value: {
-  dps: 2133.630712716767
-  tps: 1514.8778060289046
+  dps: 2036.5012382301436
+  tps: 1445.9158791434013
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WrathofSpellfire"
  value: {
-  dps: 2135.8530197388145
-  tps: 1516.4556440145577
+  dps: 2038.8194252513986
+  tps: 1447.5617919284925
  }
 }
 dps_results: {
  key: "TestRogue-Average-Default"
  value: {
-  dps: 2310.650788604967
-  tps: 1640.5620599095223
+  dps: 2203.673321513949
+  tps: 1564.6080582749005
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3049.1223553594236
-  tps: 2164.876872305191
+  dps: 2922.4678997704004
+  tps: 2074.952208836984
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2325.692287630807
-  tps: 1651.2415242178727
+  dps: 2219.4675809692826
+  tps: 1575.8219824881903
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2715.659827981758
-  tps: 1928.118477867048
+  dps: 2585.4631239905593
+  tps: 1835.6788180332974
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1476.979840978357
-  tps: 1048.655687094633
+  dps: 1411.7205910455245
+  tps: 1002.3216196423222
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1325.1188386385288
-  tps: 940.8343754333553
+  dps: 1269.7002963113268
+  tps: 901.4872103810419
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1463.6715145585597
-  tps: 1039.2067753365777
+  dps: 1408.1094484355272
+  tps: 999.7577083892244
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2426.073402961181
-  tps: 1722.512116102438
+  dps: 2324.6152259519304
+  tps: 1650.4768104258703
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1780.200770631655
-  tps: 1263.9425471484751
+  dps: 1695.3448803583815
+  tps: 1203.6948650544507
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2135.182047446109
-  tps: 1515.9792536867371
+  dps: 2031.7863807038127
+  tps: 1442.5683302997068
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1072.992921681861
-  tps: 761.8249743941212
+  dps: 1022.9178653016322
+  tps: 726.2716843641592
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 979.6884284912114
-  tps: 695.5787842287602
+  dps: 937.2394372605031
+  tps: 665.4400004549576
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1064.39536194558
-  tps: 755.7207069813617
+  dps: 1020.3975695347957
+  tps: 724.4822743697052
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3069.723647425527
-  tps: 2179.5037896721246
+  dps: 2941.237817719236
+  tps: 2088.2788505806575
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2328.972537352957
-  tps: 1653.5705015205992
+  dps: 2219.830781177303
+  tps: 1576.079854635885
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2720.736130135015
-  tps: 1931.7226523958611
+  dps: 2590.6850891489885
+  tps: 1839.386413295782
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1481.1474839725297
-  tps: 1051.6147136204963
+  dps: 1416.0047759918384
+  tps: 1005.3633909542059
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1332.19454311772
-  tps: 945.8581256135816
+  dps: 1277.0318374010972
+  tps: 906.6926045547792
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1470.9123016101728
-  tps: 1044.3477341432224
+  dps: 1415.1944333593751
+  tps: 1004.788047685156
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2442.0095592267085
-  tps: 1733.8267870509626
+  dps: 2341.2644746236974
+  tps: 1662.2977769828253
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1801.5353108781005
-  tps: 1279.0900707234514
+  dps: 1715.9766624163399
+  tps: 1218.343430315601
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2160.310165952521
-  tps: 1533.82021782629
+  dps: 2055.992213031178
+  tps: 1459.7544712521365
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1094.2006438652134
-  tps: 776.8824571443013
+  dps: 1044.0238117904705
+  tps: 741.2569063712341
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 993.3133994027423
-  tps: 705.252513575947
+  dps: 950.2186049630185
+  tps: 674.6552095237432
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1071.8876009107662
-  tps: 761.0401966466438
+  dps: 1027.8458217953046
+  tps: 729.7705334746663
  }
 }
 dps_results: {
  key: "TestRogue-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2113.69516311298
-  tps: 1500.7235658102152
+  dps: 2018.0609535185063
+  tps: 1432.8232769981391
  }
 }

--- a/sim/rogue/TestRogue.results
+++ b/sim/rogue/TestRogue.results
@@ -52,728 +52,728 @@ character_stats_results: {
 dps_results: {
  key: "TestRogue-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 2220.7866705307115
-  tps: 1576.7585360768055
+  dps: 2327.867858356183
+  tps: 1652.7861794328905
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AssassinationArmor"
  value: {
-  dps: 1994.2645318957257
-  tps: 1415.9278176459652
+  dps: 2088.46870663708
+  tps: 1482.8127817123266
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 2194.9117713709106
-  tps: 1558.387357673347
+  dps: 2302.2038926571117
+  tps: 1634.56476378655
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2296.195237715265
-  tps: 1630.2986187778383
+  dps: 2404.5986431793085
+  tps: 1707.2650366573082
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 2208.206307434425
-  tps: 1567.8264782784415
+  dps: 2316.1353895997077
+  tps: 1644.456126615792
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2194.9117713709106
-  tps: 1527.2196105198796
+  dps: 2302.2038926571117
+  tps: 1601.8734685108188
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 2218.3886371060935
-  tps: 1575.0559323453258
+  dps: 2324.3599808543804
+  tps: 1650.2955864066098
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2224.634217076724
-  tps: 1579.4902941244736
+  dps: 2333.89405356963
+  tps: 1657.0647780344377
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2237.3085464815276
-  tps: 1588.4890680018848
+  dps: 2343.9615823915874
+  tps: 1664.2127234980278
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2266.340960615401
-  tps: 1609.1020820369351
+  dps: 2372.713886851482
+  tps: 1684.626859664552
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 2293.235828330417
-  tps: 1628.1974381145963
+  dps: 2404.3834244465097
+  tps: 1707.112231357022
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 2317.55739675723
-  tps: 1645.465751697633
+  dps: 2430.559338369872
+  tps: 1725.6971302426089
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 2251.272779221073
-  tps: 1598.4036732469613
+  dps: 2359.759023628594
+  tps: 1675.4289067763016
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 2225.490698917027
-  tps: 1580.0983962310893
+  dps: 2331.678979070443
+  tps: 1655.492075140015
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Deathmantle"
  value: {
-  dps: 2164.729127340917
-  tps: 1536.9576804120518
+  dps: 2267.522825864552
+  tps: 1609.941206363832
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Defender'sCode-40257"
  value: {
-  dps: 2178.2269274641126
-  tps: 1546.5411184995203
+  dps: 2281.6176939568095
+  tps: 1619.9485627093345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2210.1324463633255
-  tps: 1569.1940369179608
+  dps: 2318.242216496491
+  tps: 1645.9519737125083
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 2194.9117713709106
-  tps: 1558.387357673347
+  dps: 2302.2038926571117
+  tps: 1634.56476378655
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2194.9117713709106
-  tps: 1558.387357673347
+  dps: 2302.2038926571117
+  tps: 1634.56476378655
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 2208.206307434425
-  tps: 1567.8264782784415
+  dps: 2316.1353895997077
+  tps: 1644.456126615792
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2205.8611166008736
-  tps: 1566.1613927866197
+  dps: 2313.6455526880263
+  tps: 1642.6883424084986
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 2194.9117713709106
-  tps: 1558.387357673347
+  dps: 2302.2038926571117
+  tps: 1634.56476378655
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2255.920712638467
-  tps: 1601.7037059733118
+  dps: 2362.4204536234024
+  tps: 1677.318522072616
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2230.921102633304
-  tps: 1583.953982869646
+  dps: 2337.194615079628
+  tps: 1659.4081767065363
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2223.2042867102873
-  tps: 1578.4750435643039
+  dps: 2328.924853445166
+  tps: 1653.536645946068
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2194.9117713709106
-  tps: 1558.387357673347
+  dps: 2302.2038926571117
+  tps: 1634.56476378655
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2194.9117713709106
-  tps: 1558.387357673347
+  dps: 2302.2038926571117
+  tps: 1634.56476378655
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2310.582537320406
-  tps: 1640.5136014974883
+  dps: 2422.291664721549
+  tps: 1719.8270819522993
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2178.2269274641126
-  tps: 1546.5411184995203
+  dps: 2281.6176939568095
+  tps: 1619.9485627093345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 2178.2269274641126
-  tps: 1546.5411184995203
+  dps: 2281.6176939568095
+  tps: 1619.9485627093345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 2208.206307434425
-  tps: 1567.8264782784415
+  dps: 2316.1353895997077
+  tps: 1644.456126615792
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2205.8611166008736
-  tps: 1566.1613927866197
+  dps: 2313.6455526880263
+  tps: 1642.6883424084986
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2347.5627250803946
-  tps: 1666.7695348070806
+  dps: 2464.695221041232
+  tps: 1749.9336069392753
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 2198.640569974751
-  tps: 1561.0348046820734
+  dps: 2303.048838945097
+  tps: 1635.1646756510188
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 2194.9117713709106
-  tps: 1558.387357673347
+  dps: 2302.2038926571117
+  tps: 1634.56476378655
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2212.5525704021543
-  tps: 1570.9123249855295
+  dps: 2320.986696420988
+  tps: 1647.9005544589018
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2178.2269274641126
-  tps: 1546.5411184995203
+  dps: 2281.6176939568095
+  tps: 1619.9485627093345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 2178.2269274641126
-  tps: 1546.5411184995203
+  dps: 2281.6176939568095
+  tps: 1619.9485627093345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1824.8567789235942
-  tps: 1295.6483130357515
+  dps: 1906.9900255890159
+  tps: 1353.9629181682012
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2246.703416810679
-  tps: 1595.159425935582
+  dps: 2357.1165201646754
+  tps: 1673.5527293169193
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Netherblade"
  value: {
-  dps: 2088.4626845201915
-  tps: 1482.8085060093358
+  dps: 2187.333301967571
+  tps: 1553.0066443969758
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2178.2269274641126
-  tps: 1546.5411184995203
+  dps: 2281.6176939568095
+  tps: 1619.9485627093345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 2209.1924182057282
-  tps: 1568.526616926066
+  dps: 2317.409019513585
+  tps: 1645.3604038546443
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2212.5525704021543
-  tps: 1570.9123249855295
+  dps: 2320.986696420988
+  tps: 1647.9005544589018
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 2194.9117713709106
-  tps: 1558.387357673347
+  dps: 2302.2038926571117
+  tps: 1634.56476378655
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 2194.9117713709106
-  tps: 1558.387357673347
+  dps: 2302.2038926571117
+  tps: 1634.56476378655
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PrimalIntent"
  value: {
-  dps: 2189.8711281780115
-  tps: 1554.8085010063874
+  dps: 2297.3973064571787
+  tps: 1631.1520875845963
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2178.2269274641126
-  tps: 1546.5411184995203
+  dps: 2281.6176939568095
+  tps: 1619.9485627093345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 2313.8899571911434
-  tps: 1642.8618696057124
+  dps: 2417.278869584934
+  tps: 1716.2679974053033
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 2331.078375465627
-  tps: 1655.065646580595
+  dps: 2434.4672878594165
+  tps: 1728.471774380186
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2227.1672440358243
-  tps: 1581.288743265435
+  dps: 2336.753559856877
+  tps: 1659.0950274983825
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2194.9117713709106
-  tps: 1558.387357673347
+  dps: 2302.2038926571117
+  tps: 1634.56476378655
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2178.2269274641126
-  tps: 1546.5411184995203
+  dps: 2281.6176939568095
+  tps: 1619.9485627093345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2178.2269274641126
-  tps: 1546.5411184995203
+  dps: 2281.6176939568095
+  tps: 1619.9485627093345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 2202.474785491999
-  tps: 1563.7570976993188
+  dps: 2307.1160478684146
+  tps: 1638.0523939865743
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2178.2269274641126
-  tps: 1546.5411184995203
+  dps: 2281.6176939568095
+  tps: 1619.9485627093345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2178.2269274641126
-  tps: 1546.5411184995203
+  dps: 2281.6176939568095
+  tps: 1619.9485627093345
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Slayer'sArmor"
  value: {
-  dps: 2325.8427569442347
-  tps: 1651.3483574304057
+  dps: 2442.739486416964
+  tps: 1734.3450353560445
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SparkofLife-37657"
  value: {
-  dps: 2194.395126664597
-  tps: 1558.0205399318638
+  dps: 2300.5914102982115
+  tps: 1633.4199013117304
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 2029.7285165753285
-  tps: 1441.107246768484
+  dps: 2125.4051935197995
+  tps: 1509.0376873990583
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1941.650443916876
-  tps: 1378.571815180982
+  dps: 2033.8619020198998
+  tps: 1444.0419504341291
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2212.5525704021543
-  tps: 1570.9123249855295
+  dps: 2320.986696420988
+  tps: 1647.9005544589018
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 2209.1924182057282
-  tps: 1568.526616926066
+  dps: 2317.409019513585
+  tps: 1645.3604038546443
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2203.3121518619796
-  tps: 1564.351627822005
+  dps: 2311.148084925625
+  tps: 1640.9151402971936
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheFistsofFury"
  value: {
-  dps: 2262.1729004598296
-  tps: 1606.142759326479
+  dps: 2380.135084338308
+  tps: 1689.8959098801988
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 2370.697223685027
-  tps: 1683.1950288163687
+  dps: 2494.9575870113213
+  tps: 1771.4198867780367
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinStars"
  value: {
-  dps: 2136.3658447487023
-  tps: 1516.8197497715785
+  dps: 2237.873606793513
+  tps: 1588.8902608233936
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 2208.1642497197654
-  tps: 1567.7966173010332
+  dps: 2315.9819936374174
+  tps: 1644.347215482566
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2296.188993119166
-  tps: 1630.2941851146081
+  dps: 2405.473766903376
+  tps: 1707.8863745013975
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2315.959557646479
-  tps: 1644.3312859290004
+  dps: 2425.8150368706774
+  tps: 1722.3286761781815
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2194.9117713709106
-  tps: 1558.387357673347
+  dps: 2302.2038926571117
+  tps: 1634.56476378655
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2194.9117713709106
-  tps: 1558.387357673347
+  dps: 2302.2038926571117
+  tps: 1634.56476378655
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2194.9117713709106
-  tps: 1558.387357673347
+  dps: 2302.2038926571117
+  tps: 1634.56476378655
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2194.9117713709106
-  tps: 1558.387357673347
+  dps: 2302.2038926571117
+  tps: 1634.56476378655
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 2339.1426867510904
-  tps: 1660.7913075932743
+  dps: 2456.6367975146068
+  tps: 1744.212126235371
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WastewalkerArmor"
  value: {
-  dps: 2001.0667448570562
-  tps: 1420.75738884851
+  dps: 2097.183110088511
+  tps: 1489.0000081628432
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WindhawkArmor"
  value: {
-  dps: 2036.5012382301436
-  tps: 1445.9158791434013
+  dps: 2133.630712716767
+  tps: 1514.8778060289046
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WrathofSpellfire"
  value: {
-  dps: 2038.8194252513986
-  tps: 1447.5617919284925
+  dps: 2135.8530197388145
+  tps: 1516.4556440145577
  }
 }
 dps_results: {
  key: "TestRogue-Average-Default"
  value: {
-  dps: 2203.673321513949
-  tps: 1564.6080582749005
+  dps: 2310.650788604967
+  tps: 1640.5620599095223
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2922.4678997704004
-  tps: 2074.952208836984
+  dps: 3049.1223553594236
+  tps: 2164.876872305191
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2219.4675809692826
-  tps: 1575.8219824881903
+  dps: 2325.692287630807
+  tps: 1651.2415242178727
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2585.4631239905593
-  tps: 1835.6788180332974
+  dps: 2715.659827981758
+  tps: 1928.118477867048
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1411.7205910455245
-  tps: 1002.3216196423222
+  dps: 1476.979840978357
+  tps: 1048.655687094633
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1269.7002963113268
-  tps: 901.4872103810419
+  dps: 1325.1188386385288
+  tps: 940.8343754333553
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1408.1094484355272
-  tps: 999.7577083892244
+  dps: 1463.6715145585597
+  tps: 1039.2067753365777
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2324.6152259519304
-  tps: 1650.4768104258703
+  dps: 2426.073402961181
+  tps: 1722.512116102438
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1695.3448803583815
-  tps: 1203.6948650544507
+  dps: 1780.200770631655
+  tps: 1263.9425471484751
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2031.7863807038127
-  tps: 1442.5683302997068
+  dps: 2135.182047446109
+  tps: 1515.9792536867371
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1022.9178653016322
-  tps: 726.2716843641592
+  dps: 1072.992921681861
+  tps: 761.8249743941212
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 937.2394372605031
-  tps: 665.4400004549576
+  dps: 979.6884284912114
+  tps: 695.5787842287602
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1020.3975695347957
-  tps: 724.4822743697052
+  dps: 1064.39536194558
+  tps: 755.7207069813617
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2941.237817719236
-  tps: 2088.2788505806575
+  dps: 3069.723647425527
+  tps: 2179.5037896721246
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2219.830781177303
-  tps: 1576.079854635885
+  dps: 2328.972537352957
+  tps: 1653.5705015205992
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2590.6850891489885
-  tps: 1839.386413295782
+  dps: 2720.736130135015
+  tps: 1931.7226523958611
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1416.0047759918384
-  tps: 1005.3633909542059
+  dps: 1481.1474839725297
+  tps: 1051.6147136204963
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1277.0318374010972
-  tps: 906.6926045547792
+  dps: 1332.19454311772
+  tps: 945.8581256135816
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1415.1944333593751
-  tps: 1004.788047685156
+  dps: 1470.9123016101728
+  tps: 1044.3477341432224
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2341.2644746236974
-  tps: 1662.2977769828253
+  dps: 2442.0095592267085
+  tps: 1733.8267870509626
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1715.9766624163399
-  tps: 1218.343430315601
+  dps: 1801.5353108781005
+  tps: 1279.0900707234514
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2055.992213031178
-  tps: 1459.7544712521365
+  dps: 2160.310165952521
+  tps: 1533.82021782629
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1044.0238117904705
-  tps: 741.2569063712341
+  dps: 1094.2006438652134
+  tps: 776.8824571443013
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 950.2186049630185
-  tps: 674.6552095237432
+  dps: 993.3133994027423
+  tps: 705.252513575947
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1027.8458217953046
-  tps: 729.7705334746663
+  dps: 1071.8876009107662
+  tps: 761.0401966466438
  }
 }
 dps_results: {
  key: "TestRogue-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2018.0609535185063
-  tps: 1432.8232769981391
+  dps: 2113.69516311298
+  tps: 1500.7235658102152
  }
 }

--- a/sim/rogue/backstab.go
+++ b/sim/rogue/backstab.go
@@ -38,7 +38,7 @@ func (rogue *Rogue) registerBackstabSpell() {
 				core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0),
 			ThreatMultiplier: 1,
 
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 170, 1.5+0.01*float64(rogue.Talents.SinisterCalling), true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 170, 1.0, 1.5+0.01*float64(rogue.Talents.SinisterCalling), true),
 			OutcomeApplier: rogue.OutcomeFuncMeleeSpecialHitAndCrit(rogue.MeleeCritMultiplier(true, true)),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {

--- a/sim/rogue/hemorrhage.go
+++ b/sim/rogue/hemorrhage.go
@@ -58,7 +58,7 @@ func (rogue *Rogue) registerHemorrhageSpell() {
 			DamageMultiplier: 1 +
 				core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0),
 			ThreatMultiplier: 1,
-			BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 0, 1.1+0.01*float64(rogue.Talents.SinisterCalling), true),
+			BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 0, 1.0, 1.1+0.01*float64(rogue.Talents.SinisterCalling), true),
 			OutcomeApplier:   rogue.OutcomeFuncMeleeSpecialHitAndCrit(rogue.MeleeCritMultiplier(true, true)),
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if spellEffect.Landed() {

--- a/sim/rogue/killing_spree.go
+++ b/sim/rogue/killing_spree.go
@@ -12,7 +12,7 @@ func (rogue *Rogue) makeKillingSpreeAttackSpell() *core.Spell {
 		ProcMask:         core.ProcMaskMeleeMHSpecial,
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
-		BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 0, 1, true),
+		BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 0, 1, 1, true),
 		OutcomeApplier:   rogue.OutcomeFuncMeleeWeaponSpecialHitAndCrit(rogue.MeleeCritMultiplier(true, true)),
 	}
 	baseEffectMH.Target = rogue.CurrentTarget
@@ -20,7 +20,7 @@ func (rogue *Rogue) makeKillingSpreeAttackSpell() *core.Spell {
 		ProcMask:         core.ProcMaskMeleeOHSpecial,
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
-		BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, 1+0.05*float64(rogue.Talents.DualWieldSpecialization), true),
+		BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, 1, 1+0.05*float64(rogue.Talents.DualWieldSpecialization), true),
 		OutcomeApplier:   rogue.OutcomeFuncMeleeWeaponSpecialHitAndCrit(rogue.MeleeCritMultiplier(true, true)),
 	}
 	baseEffectOH.Target = rogue.CurrentTarget

--- a/sim/rogue/killing_spree.go
+++ b/sim/rogue/killing_spree.go
@@ -20,7 +20,7 @@ func (rogue *Rogue) makeKillingSpreeAttackSpell() *core.Spell {
 		ProcMask:         core.ProcMaskMeleeOHSpecial,
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
-		BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, 1, 1+0.05*float64(rogue.Talents.DualWieldSpecialization), true),
+		BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, 1+0.05*float64(rogue.Talents.DualWieldSpecialization), 1, true),
 		OutcomeApplier:   rogue.OutcomeFuncMeleeWeaponSpecialHitAndCrit(rogue.MeleeCritMultiplier(true, true)),
 	}
 	baseEffectOH.Target = rogue.CurrentTarget

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -26,7 +26,7 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 			core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0),
 		ThreatMultiplier: 1,
 
-		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 181, 1, false),
+		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 181, 1, 1, false),
 		OutcomeApplier: rogue.OutcomeFuncMeleeSpecialCritOnly(rogue.MeleeCritMultiplier(isMH, true)),
 
 		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
@@ -39,7 +39,7 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 	}
 	if !isMH {
 		effect.ProcMask = core.ProcMaskMeleeOHSpecial
-		effect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 181, 1+0.1*float64(rogue.Talents.DualWieldSpecialization), false)
+		effect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 181, 1+0.1*float64(rogue.Talents.DualWieldSpecialization), 1, false)
 	}
 
 	effect.BaseDamage = core.WrapBaseDamageConfig(effect.BaseDamage, func(oldCalculator core.BaseDamageCalculator) core.BaseDamageCalculator {

--- a/sim/rogue/shiv.go
+++ b/sim/rogue/shiv.go
@@ -34,7 +34,7 @@ func (rogue *Rogue) registerShivSpell() {
 			ProcMask:         core.ProcMaskMeleeOHSpecial,
 			DamageMultiplier: 1 + core.TernaryFloat64(rogue.Talents.SurpriseAttacks, 0.1, 0),
 			ThreatMultiplier: 1,
-			BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, 1+0.1*float64(rogue.Talents.DualWieldSpecialization), false),
+			BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, 1, 1+0.1*float64(rogue.Talents.DualWieldSpecialization), false),
 			OutcomeApplier:   rogue.OutcomeFuncMeleeSpecialHitAndCrit(rogue.MeleeCritMultiplier(false, true)),
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if spellEffect.Landed() {

--- a/sim/rogue/shiv.go
+++ b/sim/rogue/shiv.go
@@ -34,7 +34,7 @@ func (rogue *Rogue) registerShivSpell() {
 			ProcMask:         core.ProcMaskMeleeOHSpecial,
 			DamageMultiplier: 1 + core.TernaryFloat64(rogue.Talents.SurpriseAttacks, 0.1, 0),
 			ThreatMultiplier: 1,
-			BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, 1, 1+0.1*float64(rogue.Talents.DualWieldSpecialization), false),
+			BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, 1+0.1*float64(rogue.Talents.DualWieldSpecialization), 1, false),
 			OutcomeApplier:   rogue.OutcomeFuncMeleeSpecialHitAndCrit(rogue.MeleeCritMultiplier(false, true)),
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if spellEffect.Landed() {

--- a/sim/rogue/sinister_strike.go
+++ b/sim/rogue/sinister_strike.go
@@ -41,7 +41,7 @@ func (rogue *Rogue) registerSinisterStrikeSpell() {
 				core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0),
 			ThreatMultiplier: 1,
 			BonusCritRating:  []float64{0, 2, 4, 6}[rogue.Talents.TurnTheTables] * core.CritRatingPerCritChance,
-			BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 180, 1, true),
+			BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 180, 1, 1, true),
 			OutcomeApplier:   rogue.OutcomeFuncMeleeSpecialHitAndCrit(rogue.MeleeCritMultiplier(true, true)),
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if spellEffect.Landed() {

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -25,7 +25,7 @@ func (rogue *Rogue) ApplyTalents() {
 	rogue.AddStat(stats.ArmorPenetration, core.ArmorPenPerPercentArmor*3*float64(rogue.Talents.SerratedBlades))
 
 	if rogue.Talents.DualWieldSpecialization > 0 {
-		rogue.AutoAttacks.OHEffect.BaseDamage.Calculator = core.BaseDamageFuncMeleeWeapon(core.OffHand, false, 0, 1+0.1*float64(rogue.Talents.DualWieldSpecialization), true)
+		rogue.AutoAttacks.OHEffect.BaseDamage.Calculator = core.BaseDamageFuncMeleeWeapon(core.OffHand, false, 0, 1+0.1*float64(rogue.Talents.DualWieldSpecialization), 1.0, true)
 	}
 
 	if rogue.Talents.Deadliness > 0 {

--- a/sim/shaman/lavalash.go
+++ b/sim/shaman/lavalash.go
@@ -63,7 +63,7 @@ func (shaman *Shaman) newLavaLashSpell() *core.Spell {
 				core.TernaryFloat64(shaman.HasSetBonus(ItemSetWorldbreakerBattlegear, 2), 1.2, 1),
 			ThreatMultiplier: 1 - (0.1/3)*float64(shaman.Talents.ElementalPrecision),
 
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.OffHand, false, flatDamageBonus, 1, true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.OffHand, false, flatDamageBonus, 1, 1, true),
 			OutcomeApplier: shaman.OutcomeFuncMeleeSpecialHitAndCrit(shaman.ElementalCritMultiplier(0)),
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if !spellEffect.Landed() { //TODO: verify that it actually needs to hit

--- a/sim/shaman/stormstrike.go
+++ b/sim/shaman/stormstrike.go
@@ -58,10 +58,10 @@ func (shaman *Shaman) newStormstrikeHitSpell(isMH bool) *core.Spell {
 
 	if isMH {
 		effect.ProcMask = core.ProcMaskMeleeMHSpecial
-		effect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.MainHand, false, flatDamageBonus, 1, true)
+		effect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.MainHand, false, flatDamageBonus, 1, 1, true)
 	} else {
 		effect.ProcMask = core.ProcMaskMeleeOHSpecial
-		effect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.OffHand, false, flatDamageBonus, 1, true)
+		effect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.OffHand, false, flatDamageBonus, 1, 1, true)
 	}
 
 	return shaman.RegisterSpell(core.SpellConfig{

--- a/sim/shaman/weapon_imbues.go
+++ b/sim/shaman/weapon_imbues.go
@@ -33,10 +33,10 @@ func (shaman *Shaman) newWindfuryImbueSpell(isMH bool) *core.Spell {
 	weaponDamageMultiplier := 1 + math.Round(float64(shaman.Talents.ElementalWeapons)*13.33)/100
 	if isMH {
 		actionID.Tag = 1
-		baseEffect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 0, weaponDamageMultiplier, true)
+		baseEffect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 0, 1, weaponDamageMultiplier, true)
 	} else {
 		actionID.Tag = 2
-		baseEffect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.OffHand, false, 0, weaponDamageMultiplier, true)
+		baseEffect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.OffHand, false, 0, 1, weaponDamageMultiplier, true)
 
 		// For whatever reason, OH penalty does not apply to the bonus AP from WF OH
 		// hits. Implement this by doubling the AP bonus we provide.

--- a/sim/warlock/pet_abilities.go
+++ b/sim/warlock/pet_abilities.go
@@ -107,7 +107,7 @@ func (wp *WarlockPet) newCleave() *core.Spell {
 			ProcMask:         core.ProcMaskMeleeMHSpecial,
 			DamageMultiplier: 1.0,
 			ThreatMultiplier: 1,
-			BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 78, 1.0, true),
+			BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 78, 1.0, 1.0, true),
 			OutcomeApplier:   wp.OutcomeFuncMeleeSpecialHitAndCrit(2),
 		}),
 	})

--- a/sim/warrior/devastate.go
+++ b/sim/warrior/devastate.go
@@ -9,7 +9,7 @@ func (warrior *Warrior) registerDevastateSpell() {
 	cost := 15.0 - float64(warrior.Talents.ImprovedSunderArmor) - float64(warrior.Talents.FocusedRage)
 	refundAmount := cost * 0.8
 
-	normalBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 0, 0.5, true)
+	normalBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 0, 1.0, 0.5, true)
 
 	warrior.Devastate = warrior.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 30022},

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -52,714 +52,714 @@ character_stats_results: {
 dps_results: {
  key: "TestFury-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 570.247242652956
-  tps: 627.0089093196226
+  dps: 541.9544158058202
+  tps: 597.0762491391536
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 580.4138615828382
-  tps: 638.3510282495049
+  dps: 542.9242715563244
+  tps: 598.2167715563243
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 635.6379123466256
-  tps: 693.6457456799587
+  dps: 598.5431149607141
+  tps: 654.4056149607142
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 577.8754197200522
-  tps: 635.5670863867189
+  dps: 551.2296992590601
+  tps: 607.17619925906
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BoldArmor"
  value: {
-  dps: 497.79892127587965
-  tps: 551.7847546092132
+  dps: 461.19976176455486
+  tps: 512.7350950978881
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 580.4138615828382
-  tps: 625.7170910178481
+  dps: 542.9242715563244
+  tps: 586.3854194585311
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 592.8009641218976
-  tps: 650.5607974552307
+  dps: 551.0614790206439
+  tps: 606.345979020644
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BurningRage"
  value: {
-  dps: 551.6610652117595
-  tps: 608.3040652117595
+  dps: 510.0821362633842
+  tps: 564.2514695967176
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 593.1236263863117
-  tps: 651.2267930529782
+  dps: 550.6395578917122
+  tps: 606.2223912250455
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 600.3803541468993
-  tps: 658.1670208135662
+  dps: 561.2125986243343
+  tps: 616.9694319576676
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 637.4735067506132
-  tps: 695.4490067506133
+  dps: 596.3272120235399
+  tps: 651.8175453568732
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 635.0696969265198
-  tps: 694.0088635931862
+  dps: 602.1421648074123
+  tps: 658.6508314740788
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 643.3730190640281
-  tps: 702.9500190640281
+  dps: 601.6771043368077
+  tps: 658.8272710034743
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 614.0029029591509
-  tps: 672.2184029591508
+  dps: 572.4957475483569
+  tps: 628.6214142150235
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 589.1532821391402
-  tps: 646.5851154724736
+  dps: 547.0225779605418
+  tps: 602.0490779605418
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Defender'sCode-40257"
  value: {
-  dps: 570.247242652956
-  tps: 627.0089093196226
+  dps: 541.9544158058202
+  tps: 597.0762491391536
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DesolationBattlegear"
  value: {
-  dps: 490.05274329396235
-  tps: 544.5969099606289
+  dps: 465.53529326685765
+  tps: 518.0304599335243
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestroyerArmor"
  value: {
-  dps: 488.2354794114032
-  tps: 541.7849794114034
+  dps: 462.2527219157396
+  tps: 514.2097219157396
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestroyerBattlegear"
  value: {
-  dps: 546.945153708378
-  tps: 603.4801537083781
+  dps: 513.0676902800859
+  tps: 567.3195236134192
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 581.3551770807054
-  tps: 639.2975104140387
+  dps: 552.6997238526063
+  tps: 608.6760571859397
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DoomplateBattlegear"
  value: {
-  dps: 505.81804414618256
-  tps: 560.7647108128492
+  dps: 473.92842398140937
+  tps: 526.633090648076
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 580.4138615828382
-  tps: 638.3510282495049
+  dps: 542.9242715563244
+  tps: 598.2167715563243
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 580.4138615828382
-  tps: 638.3510282495049
+  dps: 542.9242715563244
+  tps: 598.2167715563243
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 577.8754197200522
-  tps: 635.5670863867189
+  dps: 551.2296992590601
+  tps: 607.17619925906
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 577.5525280273051
-  tps: 635.3195280273051
+  dps: 542.7343153824644
+  tps: 598.3734820491311
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 580.4138615828382
-  tps: 638.3510282495049
+  dps: 542.9242715563244
+  tps: 598.2167715563243
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 627.9448282026596
-  tps: 685.6913282026596
+  dps: 586.1542615548601
+  tps: 641.6079282215268
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 590.3625017310179
-  tps: 647.9785017310179
+  dps: 558.6626132782685
+  tps: 614.4341132782683
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FaithinFelsteel"
  value: {
-  dps: 496.5105594712724
-  tps: 550.3768928046059
+  dps: 467.27722616345056
+  tps: 519.5020594967839
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FelstalkerArmor"
  value: {
-  dps: 568.2993531752267
-  tps: 626.0303531752264
+  dps: 524.5118170663939
+  tps: 579.6139837330609
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FlameGuard"
  value: {
-  dps: 477.80154356649757
-  tps: 531.3387102331641
+  dps: 453.9812536572411
+  tps: 505.8687536572412
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForgeEmber-37660"
  value: {
-  dps: 591.6161435644796
-  tps: 649.458476897813
+  dps: 554.2974124632553
+  tps: 609.7324124632552
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 580.4138615828382
-  tps: 638.3510282495049
+  dps: 542.9242715563244
+  tps: 598.2167715563243
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 580.4138615828382
-  tps: 638.3510282495049
+  dps: 542.9242715563244
+  tps: 598.2167715563243
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 617.5534862048349
-  tps: 676.0773195381682
+  dps: 575.5037853660443
+  tps: 631.5267853660446
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuturesightRune-38763"
  value: {
-  dps: 570.247242652956
-  tps: 627.0089093196226
+  dps: 541.9544158058202
+  tps: 597.0762491391536
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 570.247242652956
-  tps: 627.0089093196226
+  dps: 541.9544158058202
+  tps: 597.0762491391536
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 577.8754197200522
-  tps: 635.5670863867189
+  dps: 551.2296992590601
+  tps: 607.17619925906
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 577.5525280273051
-  tps: 635.3195280273051
+  dps: 542.7343153824644
+  tps: 598.3734820491311
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IncisorFragment-37723"
  value: {
-  dps: 658.8866671068022
-  tps: 718.5931671068024
+  dps: 615.8496142150458
+  tps: 672.6787808817126
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 583.9682250207479
-  tps: 641.3943916874146
+  dps: 548.7816274569641
+  tps: 603.9806274569639
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 580.4138615828382
-  tps: 638.3510282495049
+  dps: 542.9242715563244
+  tps: 598.2167715563243
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 586.8913143840796
-  tps: 645.0209810507462
+  dps: 550.1451591548436
+  tps: 605.7396591548435
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 570.247242652956
-  tps: 627.0089093196226
+  dps: 541.9544158058202
+  tps: 597.0762491391536
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 570.247242652956
-  tps: 627.0089093196226
+  dps: 541.9544158058202
+  tps: 597.0762491391536
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 452.44105530461366
-  tps: 504.71988863794695
+  dps: 424.8314358459732
+  tps: 475.24660251263987
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 611.3199423412218
-  tps: 670.5656090078884
+  dps: 561.988995649245
+  tps: 618.322995649245
  }
 }
 dps_results: {
  key: "TestFury-AllItems-NetherscaleArmor"
  value: {
-  dps: 562.2275813440052
-  tps: 619.4380813440052
+  dps: 536.1121130734633
+  tps: 591.9026130734633
  }
 }
 dps_results: {
  key: "TestFury-AllItems-NetherstrikeArmor"
  value: {
-  dps: 536.9321905710096
-  tps: 593.2476905710096
+  dps: 497.86999439562396
+  tps: 551.7213277289574
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 570.247242652956
-  tps: 627.0089093196226
+  dps: 541.9544158058202
+  tps: 597.0762491391536
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtArmor"
  value: {
-  dps: 465.10599503000265
-  tps: 517.6476616966695
+  dps: 440.90061653792134
+  tps: 491.97594987125467
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 604.7982629315928
-  tps: 663.6534295982594
+  dps: 572.8697586079165
+  tps: 629.7507586079164
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 588.9859549826615
-  tps: 647.2777883159948
+  dps: 540.8762765354841
+  tps: 596.4919432021509
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 586.8913143840796
-  tps: 645.0209810507462
+  dps: 550.1451591548436
+  tps: 605.7396591548435
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 580.4138615828382
-  tps: 638.3510282495049
+  dps: 542.9242715563244
+  tps: 598.2167715563243
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 580.4138615828382
-  tps: 638.3510282495049
+  dps: 542.9242715563244
+  tps: 598.2167715563243
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PrimalIntent"
  value: {
-  dps: 590.5077740406853
-  tps: 648.526440707352
+  dps: 548.814125568452
+  tps: 604.8834589017854
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 570.247242652956
-  tps: 627.0089093196226
+  dps: 541.9544158058202
+  tps: 597.0762491391536
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 660.5793639131905
-  tps: 717.3410305798571
+  dps: 636.4979458217547
+  tps: 691.6197791550879
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 671.8580566981121
-  tps: 728.6197233647789
+  dps: 648.3023280724939
+  tps: 703.424161405827
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 603.5578020150303
-  tps: 662.3886353483639
+  dps: 556.5921016736013
+  tps: 612.5609350069345
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 580.4138615828382
-  tps: 638.3510282495049
+  dps: 542.9242715563244
+  tps: 598.2167715563243
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 570.247242652956
-  tps: 627.0089093196226
+  dps: 541.9544158058202
+  tps: 597.0762491391536
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 570.247242652956
-  tps: 627.0089093196226
+  dps: 541.9544158058202
+  tps: 597.0762491391536
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 587.8673519301522
-  tps: 645.6128519301519
+  dps: 543.538722832588
+  tps: 598.4895561659214
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 570.247242652956
-  tps: 627.0089093196226
+  dps: 541.9544158058202
+  tps: 597.0762491391536
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 570.247242652956
-  tps: 627.0089093196226
+  dps: 541.9544158058202
+  tps: 597.0762491391536
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SparkofLife-37657"
  value: {
-  dps: 591.2675871435931
-  tps: 649.4509204769265
+  dps: 548.2561716317848
+  tps: 603.9261716317849
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 525.5127182942017
-  tps: 581.2713849608684
+  dps: 498.98760443677037
+  tps: 552.8362711034372
  }
 }
 dps_results: {
  key: "TestFury-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 503.87765587727034
-  tps: 558.4729892106037
+  dps: 480.7682760221554
+  tps: 533.9627760221554
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 586.8913143840796
-  tps: 645.0209810507462
+  dps: 550.1451591548436
+  tps: 605.7396591548435
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 588.9859549826615
-  tps: 647.2777883159948
+  dps: 540.8762765354841
+  tps: 596.4919432021509
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 585.6038775667789
-  tps: 643.6748775667792
+  dps: 543.7138927124064
+  tps: 599.2785593790729
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 639.435372402742
-  tps: 701.1962057360753
+  dps: 597.8603339004786
+  tps: 657.0638339004786
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 690.3034041643816
-  tps: 753.5402374977148
+  dps: 655.8983557219738
+  tps: 717.060189055307
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinStars"
  value: {
-  dps: 564.5063978431108
-  tps: 621.3378978431108
+  dps: 533.478968291207
+  tps: 588.2539682912069
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 583.4687864450509
-  tps: 641.6477864450509
+  dps: 547.1386576986932
+  tps: 603.0909910320267
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 616.8097589653944
-  tps: 677.1434256320613
+  dps: 577.7624024771603
+  tps: 635.5649024771603
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 610.5930370137376
-  tps: 670.733370347071
+  dps: 573.5848012761373
+  tps: 631.1221346094707
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 580.4138615828382
-  tps: 638.3510282495049
+  dps: 542.9242715563244
+  tps: 598.2167715563243
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 580.4138615828382
-  tps: 638.3510282495049
+  dps: 542.9242715563244
+  tps: 598.2167715563243
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 580.4138615828382
-  tps: 638.3510282495049
+  dps: 542.9242715563244
+  tps: 598.2167715563243
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 580.4138615828382
-  tps: 638.3510282495049
+  dps: 542.9242715563244
+  tps: 598.2167715563243
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WarbringerArmor"
  value: {
-  dps: 481.90936947208957
-  tps: 535.3832028054228
+  dps: 449.77669274899364
+  tps: 501.1428594156604
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WarbringerBattlegear"
  value: {
-  dps: 549.3748050515153
-  tps: 607.6081383848485
+  dps: 506.03828621185824
+  tps: 561.3641195451917
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WastewalkerArmor"
  value: {
-  dps: 512.0686069673189
-  tps: 567.546606967319
+  dps: 483.97041149167643
+  tps: 537.7369114916764
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WindhawkArmor"
  value: {
-  dps: 530.1267840129134
-  tps: 586.1419506795801
+  dps: 507.44599433751665
+  tps: 561.9934943375167
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WrathofSpellfire"
  value: {
-  dps: 524.0982678104274
-  tps: 579.6852678104275
+  dps: 501.2802613191531
+  tps: 555.5009279858198
  }
 }
 dps_results: {
  key: "TestFury-Average-Default"
  value: {
-  dps: 601.1168120002122
-  tps: 659.5760112613564
+  dps: 563.2249542226458
+  tps: 619.3747326301716
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 589.8803045231705
-  tps: 774.5996378565036
+  dps: 553.8044464470498
+  tps: 736.0264464470498
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 589.8803045231705
-  tps: 648.1388045231704
+  dps: 553.8044464470498
+  tps: 609.5814464470498
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 655.3655795696111
-  tps: 721.6464129029442
+  dps: 604.6050049325656
+  tps: 667.8741715992326
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 387.3104204387475
-  tps: 564.2727537720809
+  dps: 365.3956881200195
+  tps: 540.4926881200196
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 387.3104204387475
-  tps: 438.2235871054143
+  dps: 365.3956881200195
+  tps: 414.55435478668625
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 419.84096908492955
-  tps: 478.9268024182629
+  dps: 402.4466462761631
+  tps: 459.0883129428297
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 594.4120325066559
-  tps: 778.9440325066562
+  dps: 549.0716707279178
+  tps: 730.8826707279176
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 594.4120325066559
-  tps: 652.4990325066558
+  dps: 549.0716707279178
+  tps: 604.6593373945844
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 649.1542689612011
-  tps: 714.8351022945344
+  dps: 627.0603638833769
+  tps: 690.8770305500436
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 389.4775744803818
-  tps: 566.043574480382
+  dps: 360.924860805836
+  tps: 534.972860805836
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 389.4775744803818
-  tps: 440.2002411470485
+  dps: 360.924860805836
+  tps: 409.572860805836
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 418.63014656286396
-  tps: 476.4459798961972
+  dps: 402.8706877420868
+  tps: 459.1906877420867
  }
 }
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 504.39766619395834
-  tps: 557.6524995272915
+  dps: 481.03154457249184
+  tps: 532.5637112391585
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -52,714 +52,714 @@ character_stats_results: {
 dps_results: {
  key: "TestFury-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 541.9544158058202
-  tps: 597.0762491391536
+  dps: 570.247242652956
+  tps: 627.0089093196226
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 542.9242715563244
-  tps: 598.2167715563243
+  dps: 580.4138615828382
+  tps: 638.3510282495049
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 598.5431149607141
-  tps: 654.4056149607142
+  dps: 635.6379123466256
+  tps: 693.6457456799587
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 551.2296992590601
-  tps: 607.17619925906
+  dps: 577.8754197200522
+  tps: 635.5670863867189
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BoldArmor"
  value: {
-  dps: 461.19976176455486
-  tps: 512.7350950978881
+  dps: 497.79892127587965
+  tps: 551.7847546092132
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 542.9242715563244
-  tps: 586.3854194585311
+  dps: 580.4138615828382
+  tps: 625.7170910178481
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 551.0614790206439
-  tps: 606.345979020644
+  dps: 592.8009641218976
+  tps: 650.5607974552307
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BurningRage"
  value: {
-  dps: 510.0821362633842
-  tps: 564.2514695967176
+  dps: 551.6610652117595
+  tps: 608.3040652117595
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 550.6395578917122
-  tps: 606.2223912250455
+  dps: 593.1236263863117
+  tps: 651.2267930529782
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 561.2125986243343
-  tps: 616.9694319576676
+  dps: 600.3803541468993
+  tps: 658.1670208135662
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 596.3272120235399
-  tps: 651.8175453568732
+  dps: 637.4735067506132
+  tps: 695.4490067506133
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 602.1421648074123
-  tps: 658.6508314740788
+  dps: 635.0696969265198
+  tps: 694.0088635931862
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 601.6771043368077
-  tps: 658.8272710034743
+  dps: 643.3730190640281
+  tps: 702.9500190640281
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 572.4957475483569
-  tps: 628.6214142150235
+  dps: 614.0029029591509
+  tps: 672.2184029591508
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 547.0225779605418
-  tps: 602.0490779605418
+  dps: 589.1532821391402
+  tps: 646.5851154724736
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Defender'sCode-40257"
  value: {
-  dps: 541.9544158058202
-  tps: 597.0762491391536
+  dps: 570.247242652956
+  tps: 627.0089093196226
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DesolationBattlegear"
  value: {
-  dps: 465.53529326685765
-  tps: 518.0304599335243
+  dps: 490.05274329396235
+  tps: 544.5969099606289
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestroyerArmor"
  value: {
-  dps: 462.2527219157396
-  tps: 514.2097219157396
+  dps: 488.2354794114032
+  tps: 541.7849794114034
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestroyerBattlegear"
  value: {
-  dps: 513.0676902800859
-  tps: 567.3195236134192
+  dps: 546.945153708378
+  tps: 603.4801537083781
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 552.6997238526063
-  tps: 608.6760571859397
+  dps: 581.3551770807054
+  tps: 639.2975104140387
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DoomplateBattlegear"
  value: {
-  dps: 473.92842398140937
-  tps: 526.633090648076
+  dps: 505.81804414618256
+  tps: 560.7647108128492
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 542.9242715563244
-  tps: 598.2167715563243
+  dps: 580.4138615828382
+  tps: 638.3510282495049
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 542.9242715563244
-  tps: 598.2167715563243
+  dps: 580.4138615828382
+  tps: 638.3510282495049
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 551.2296992590601
-  tps: 607.17619925906
+  dps: 577.8754197200522
+  tps: 635.5670863867189
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 542.7343153824644
-  tps: 598.3734820491311
+  dps: 577.5525280273051
+  tps: 635.3195280273051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 542.9242715563244
-  tps: 598.2167715563243
+  dps: 580.4138615828382
+  tps: 638.3510282495049
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 586.1542615548601
-  tps: 641.6079282215268
+  dps: 627.9448282026596
+  tps: 685.6913282026596
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 558.6626132782685
-  tps: 614.4341132782683
+  dps: 590.3625017310179
+  tps: 647.9785017310179
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FaithinFelsteel"
  value: {
-  dps: 467.27722616345056
-  tps: 519.5020594967839
+  dps: 496.5105594712724
+  tps: 550.3768928046059
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FelstalkerArmor"
  value: {
-  dps: 524.5118170663939
-  tps: 579.6139837330609
+  dps: 568.2993531752267
+  tps: 626.0303531752264
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FlameGuard"
  value: {
-  dps: 453.9812536572411
-  tps: 505.8687536572412
+  dps: 477.80154356649757
+  tps: 531.3387102331641
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForgeEmber-37660"
  value: {
-  dps: 554.2974124632553
-  tps: 609.7324124632552
+  dps: 591.6161435644796
+  tps: 649.458476897813
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 542.9242715563244
-  tps: 598.2167715563243
+  dps: 580.4138615828382
+  tps: 638.3510282495049
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 542.9242715563244
-  tps: 598.2167715563243
+  dps: 580.4138615828382
+  tps: 638.3510282495049
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 575.5037853660443
-  tps: 631.5267853660446
+  dps: 617.5534862048349
+  tps: 676.0773195381682
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuturesightRune-38763"
  value: {
-  dps: 541.9544158058202
-  tps: 597.0762491391536
+  dps: 570.247242652956
+  tps: 627.0089093196226
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 541.9544158058202
-  tps: 597.0762491391536
+  dps: 570.247242652956
+  tps: 627.0089093196226
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 551.2296992590601
-  tps: 607.17619925906
+  dps: 577.8754197200522
+  tps: 635.5670863867189
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 542.7343153824644
-  tps: 598.3734820491311
+  dps: 577.5525280273051
+  tps: 635.3195280273051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IncisorFragment-37723"
  value: {
-  dps: 615.8496142150458
-  tps: 672.6787808817126
+  dps: 658.8866671068022
+  tps: 718.5931671068024
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 548.7816274569641
-  tps: 603.9806274569639
+  dps: 583.9682250207479
+  tps: 641.3943916874146
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 542.9242715563244
-  tps: 598.2167715563243
+  dps: 580.4138615828382
+  tps: 638.3510282495049
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 550.1451591548436
-  tps: 605.7396591548435
+  dps: 586.8913143840796
+  tps: 645.0209810507462
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 541.9544158058202
-  tps: 597.0762491391536
+  dps: 570.247242652956
+  tps: 627.0089093196226
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 541.9544158058202
-  tps: 597.0762491391536
+  dps: 570.247242652956
+  tps: 627.0089093196226
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 424.8314358459732
-  tps: 475.24660251263987
+  dps: 452.44105530461366
+  tps: 504.71988863794695
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 561.988995649245
-  tps: 618.322995649245
+  dps: 611.3199423412218
+  tps: 670.5656090078884
  }
 }
 dps_results: {
  key: "TestFury-AllItems-NetherscaleArmor"
  value: {
-  dps: 536.1121130734633
-  tps: 591.9026130734633
+  dps: 562.2275813440052
+  tps: 619.4380813440052
  }
 }
 dps_results: {
  key: "TestFury-AllItems-NetherstrikeArmor"
  value: {
-  dps: 497.86999439562396
-  tps: 551.7213277289574
+  dps: 536.9321905710096
+  tps: 593.2476905710096
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 541.9544158058202
-  tps: 597.0762491391536
+  dps: 570.247242652956
+  tps: 627.0089093196226
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtArmor"
  value: {
-  dps: 440.90061653792134
-  tps: 491.97594987125467
+  dps: 465.10599503000265
+  tps: 517.6476616966695
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 572.8697586079165
-  tps: 629.7507586079164
+  dps: 604.7982629315928
+  tps: 663.6534295982594
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 540.8762765354841
-  tps: 596.4919432021509
+  dps: 588.9859549826615
+  tps: 647.2777883159948
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 550.1451591548436
-  tps: 605.7396591548435
+  dps: 586.8913143840796
+  tps: 645.0209810507462
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 542.9242715563244
-  tps: 598.2167715563243
+  dps: 580.4138615828382
+  tps: 638.3510282495049
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 542.9242715563244
-  tps: 598.2167715563243
+  dps: 580.4138615828382
+  tps: 638.3510282495049
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PrimalIntent"
  value: {
-  dps: 548.814125568452
-  tps: 604.8834589017854
+  dps: 590.5077740406853
+  tps: 648.526440707352
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 541.9544158058202
-  tps: 597.0762491391536
+  dps: 570.247242652956
+  tps: 627.0089093196226
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 636.4979458217547
-  tps: 691.6197791550879
+  dps: 660.5793639131905
+  tps: 717.3410305798571
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 648.3023280724939
-  tps: 703.424161405827
+  dps: 671.8580566981121
+  tps: 728.6197233647789
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 556.5921016736013
-  tps: 612.5609350069345
+  dps: 603.5578020150303
+  tps: 662.3886353483639
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 542.9242715563244
-  tps: 598.2167715563243
+  dps: 580.4138615828382
+  tps: 638.3510282495049
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 541.9544158058202
-  tps: 597.0762491391536
+  dps: 570.247242652956
+  tps: 627.0089093196226
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 541.9544158058202
-  tps: 597.0762491391536
+  dps: 570.247242652956
+  tps: 627.0089093196226
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 543.538722832588
-  tps: 598.4895561659214
+  dps: 587.8673519301522
+  tps: 645.6128519301519
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 541.9544158058202
-  tps: 597.0762491391536
+  dps: 570.247242652956
+  tps: 627.0089093196226
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 541.9544158058202
-  tps: 597.0762491391536
+  dps: 570.247242652956
+  tps: 627.0089093196226
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SparkofLife-37657"
  value: {
-  dps: 548.2561716317848
-  tps: 603.9261716317849
+  dps: 591.2675871435931
+  tps: 649.4509204769265
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 498.98760443677037
-  tps: 552.8362711034372
+  dps: 525.5127182942017
+  tps: 581.2713849608684
  }
 }
 dps_results: {
  key: "TestFury-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 480.7682760221554
-  tps: 533.9627760221554
+  dps: 503.87765587727034
+  tps: 558.4729892106037
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 550.1451591548436
-  tps: 605.7396591548435
+  dps: 586.8913143840796
+  tps: 645.0209810507462
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 540.8762765354841
-  tps: 596.4919432021509
+  dps: 588.9859549826615
+  tps: 647.2777883159948
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 543.7138927124064
-  tps: 599.2785593790729
+  dps: 585.6038775667789
+  tps: 643.6748775667792
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 597.8603339004786
-  tps: 657.0638339004786
+  dps: 639.435372402742
+  tps: 701.1962057360753
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 655.8983557219738
-  tps: 717.060189055307
+  dps: 690.3034041643816
+  tps: 753.5402374977148
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinStars"
  value: {
-  dps: 533.478968291207
-  tps: 588.2539682912069
+  dps: 564.5063978431108
+  tps: 621.3378978431108
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 547.1386576986932
-  tps: 603.0909910320267
+  dps: 583.4687864450509
+  tps: 641.6477864450509
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 577.7624024771603
-  tps: 635.5649024771603
+  dps: 616.8097589653944
+  tps: 677.1434256320613
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 573.5848012761373
-  tps: 631.1221346094707
+  dps: 610.5930370137376
+  tps: 670.733370347071
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 542.9242715563244
-  tps: 598.2167715563243
+  dps: 580.4138615828382
+  tps: 638.3510282495049
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 542.9242715563244
-  tps: 598.2167715563243
+  dps: 580.4138615828382
+  tps: 638.3510282495049
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 542.9242715563244
-  tps: 598.2167715563243
+  dps: 580.4138615828382
+  tps: 638.3510282495049
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 542.9242715563244
-  tps: 598.2167715563243
+  dps: 580.4138615828382
+  tps: 638.3510282495049
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WarbringerArmor"
  value: {
-  dps: 449.77669274899364
-  tps: 501.1428594156604
+  dps: 481.90936947208957
+  tps: 535.3832028054228
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WarbringerBattlegear"
  value: {
-  dps: 506.03828621185824
-  tps: 561.3641195451917
+  dps: 549.3748050515153
+  tps: 607.6081383848485
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WastewalkerArmor"
  value: {
-  dps: 483.97041149167643
-  tps: 537.7369114916764
+  dps: 512.0686069673189
+  tps: 567.546606967319
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WindhawkArmor"
  value: {
-  dps: 507.44599433751665
-  tps: 561.9934943375167
+  dps: 530.1267840129134
+  tps: 586.1419506795801
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WrathofSpellfire"
  value: {
-  dps: 501.2802613191531
-  tps: 555.5009279858198
+  dps: 524.0982678104274
+  tps: 579.6852678104275
  }
 }
 dps_results: {
  key: "TestFury-Average-Default"
  value: {
-  dps: 563.2249542226458
-  tps: 619.3747326301716
+  dps: 601.1168120002122
+  tps: 659.5760112613564
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 553.8044464470498
-  tps: 736.0264464470498
+  dps: 589.8803045231705
+  tps: 774.5996378565036
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 553.8044464470498
-  tps: 609.5814464470498
+  dps: 589.8803045231705
+  tps: 648.1388045231704
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 604.6050049325656
-  tps: 667.8741715992326
+  dps: 655.3655795696111
+  tps: 721.6464129029442
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 365.3956881200195
-  tps: 540.4926881200196
+  dps: 387.3104204387475
+  tps: 564.2727537720809
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 365.3956881200195
-  tps: 414.55435478668625
+  dps: 387.3104204387475
+  tps: 438.2235871054143
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 402.4466462761631
-  tps: 459.0883129428297
+  dps: 419.84096908492955
+  tps: 478.9268024182629
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 549.0716707279178
-  tps: 730.8826707279176
+  dps: 594.4120325066559
+  tps: 778.9440325066562
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 549.0716707279178
-  tps: 604.6593373945844
+  dps: 594.4120325066559
+  tps: 652.4990325066558
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 627.0603638833769
-  tps: 690.8770305500436
+  dps: 649.1542689612011
+  tps: 714.8351022945344
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 360.924860805836
-  tps: 534.972860805836
+  dps: 389.4775744803818
+  tps: 566.043574480382
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 360.924860805836
-  tps: 409.572860805836
+  dps: 389.4775744803818
+  tps: 440.2002411470485
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 402.8706877420868
-  tps: 459.1906877420867
+  dps: 418.63014656286396
+  tps: 476.4459798961972
  }
 }
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 481.03154457249184
-  tps: 532.5637112391585
+  dps: 504.39766619395834
+  tps: 557.6524995272915
  }
 }

--- a/sim/warrior/heroic_strike_cleave.go
+++ b/sim/warrior/heroic_strike_cleave.go
@@ -31,7 +31,7 @@ func (warrior *Warrior) registerHeroicStrikeSpell() {
 			FlatThreatBonus:  194,
 			BonusCritRating:  float64(warrior.Talents.Incite) * 5 * core.CritRatingPerCritChance,
 
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 495, 1, true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 495, 1, 1, true),
 			OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(true)),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
@@ -55,7 +55,7 @@ func (warrior *Warrior) registerCleaveSpell() {
 		FlatThreatBonus:  125,
 		BonusCritRating:  float64(warrior.Talents.Incite) * 5 * core.CritRatingPerCritChance,
 
-		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, flatDamageBonus, 1, true),
+		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, flatDamageBonus, 1, 1, true),
 		OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(true)),
 	}
 

--- a/sim/warrior/mortal_strike.go
+++ b/sim/warrior/mortal_strike.go
@@ -42,7 +42,7 @@ func (warrior *Warrior) registerMortalStrikeSpell(cdTimer *core.Timer, rageThres
 				core.TernaryFloat64(warrior.HasSetBonus(ItemSetOnslaughtBattlegear, 4), 1.05, 1),
 			ThreatMultiplier: 1,
 
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 80, 1, true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 80, 1, 1, true),
 			OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(true)),
 
 			OnInit: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {

--- a/sim/warrior/overpower.go
+++ b/sim/warrior/overpower.go
@@ -31,7 +31,7 @@ func (warrior *Warrior) registerOverpowerSpell(cdTimer *core.Timer) {
 		ThreatMultiplier: 0.75,
 		BonusCritRating:  25 * core.CritRatingPerCritChance * float64(warrior.Talents.ImprovedOverpower),
 
-		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 35, 1, true),
+		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 35, 1, 1, true),
 		OutcomeApplier: warrior.OutcomeFuncMeleeSpecialNoBlockDodgeParry(warrior.critMultiplier(true)),
 
 		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {

--- a/sim/warrior/slam.go
+++ b/sim/warrior/slam.go
@@ -35,7 +35,7 @@ func (warrior *Warrior) registerSlamSpell() {
 			ThreatMultiplier: 1,
 			FlatThreatBonus:  70,
 
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 250, 1, true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 250, 1, 1, true),
 			OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(true)),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -18,7 +18,7 @@ func (warrior *Warrior) ApplyTalents() {
 	warrior.PseudoStats.DodgeReduction += 0.01 * float64(warrior.Talents.WeaponMastery)
 
 	if warrior.Talents.DualWieldSpecialization > 0 {
-		warrior.AutoAttacks.OHEffect.BaseDamage.Calculator = core.BaseDamageFuncMeleeWeapon(core.OffHand, false, 0, 1+0.05*float64(warrior.Talents.DualWieldSpecialization), true)
+		warrior.AutoAttacks.OHEffect.BaseDamage.Calculator = core.BaseDamageFuncMeleeWeapon(core.OffHand, false, 0, 1+0.05*float64(warrior.Talents.DualWieldSpecialization), 1.0, true)
 	}
 
 	if warrior.Talents.StrengthOfArms > 0 {

--- a/sim/warrior/whirlwind.go
+++ b/sim/warrior/whirlwind.go
@@ -19,7 +19,7 @@ func (warrior *Warrior) registerWhirlwindSpell() {
 		DamageMultiplier: 1 + 0.02*float64(warrior.Talents.UnendingFury),
 		ThreatMultiplier: 1.25,
 
-		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 0, 1, true),
+		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 0, 1, 1, true),
 		OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(true)),
 	}
 	baseEffectOH := core.SpellEffect{
@@ -28,7 +28,7 @@ func (warrior *Warrior) registerWhirlwindSpell() {
 		DamageMultiplier: 1 + 0.02*float64(warrior.Talents.UnendingFury)*0.01*float64(warrior.Talents.ImprovedWhirlwind),
 		ThreatMultiplier: 1.25,
 
-		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, 1+0.05*float64(warrior.Talents.DualWieldSpecialization), true),
+		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, 1+0.05*float64(warrior.Talents.DualWieldSpecialization), 1, true),
 		OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(true)),
 	}
 


### PR DESCRIPTION
The application of talents that give bonus multiplier to your OH was applied in the wrong place.
Added a new parameter to the physical damage functions for an extra base multiplier to properly assign the bonus
This change affected only Dks, Rogues and Warriors

Note: Also fixes procs not taking into account the proc mas they were registered with (fixes properly proccing only on autos or specials if required)