### PR TITLE
Adds Fan of Knives, Cleans up some existing Rogue abilities, Simplifies Rogue rotation

### DIFF
--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -19,7 +19,7 @@ character_stats_results: {
   final_stats: 810
   final_stats: 339
   final_stats: 0
-  final_stats: 6140.412299999999
+  final_stats: 6140.412299999998
   final_stats: 361.16
   final_stats: 1606.0794
   final_stats: 339
@@ -52,8 +52,8 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5933.14307383478
-  tps: 4054.408755952047
+  dps: 5933.143073834779
+  tps: 4054.4087559520462
  }
 }
 dps_results: {
@@ -66,22 +66,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5947.345098373517
+  dps: 5947.3450983735165
   tps: 4061.666798813153
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5928.483183163079
-  tps: 3970.0689609053065
+  dps: 5928.48318316308
+  tps: 3970.0689609053056
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 5747.035242229608
-  tps: 3937.3385129820767
+  dps: 5747.035242229609
+  tps: 3937.338512982077
  }
 }
 dps_results: {
@@ -94,14 +94,14 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6077.926468265273
-  tps: 4152.137552586058
+  dps: 6077.926468265272
+  tps: 4152.137552586057
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5724.666363933061
+  dps: 5724.66636393306
   tps: 3895.130994084461
  }
 }
@@ -116,7 +116,7 @@ dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44253"
  value: {
   dps: 5887.096350796718
-  tps: 3994.498156998682
+  tps: 3994.498156998681
  }
 }
 dps_results: {
@@ -143,8 +143,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 6014.350489123349
-  tps: 4084.412021364385
+  dps: 6014.350489123348
+  tps: 4084.4120213643846
  }
 }
 dps_results: {
@@ -158,63 +158,63 @@ dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
   dps: 5658.93619503708
-  tps: 3850.503811029258
+  tps: 3850.503811029259
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DesolationBattlegear"
  value: {
   dps: 4410.482822908813
-  tps: 3044.2730249695187
+  tps: 3044.2730249695182
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5952.137740544179
+  dps: 5952.137740544177
   tps: 4064.5423841155507
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DoomplateBattlegear"
  value: {
-  dps: 4603.073596731178
-  tps: 3162.891774587565
+  dps: 4603.073596731179
+  tps: 3162.891774587566
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5928.483183163079
-  tps: 4051.0907764339863
+  dps: 5928.48318316308
+  tps: 4051.0907764339854
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5928.483183163079
-  tps: 4051.0907764339863
+  dps: 5928.48318316308
+  tps: 4051.0907764339854
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5947.345098373517
+  dps: 5947.3450983735165
   tps: 4061.666798813153
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5943.890940481561
-  tps: 4059.5943040779807
+  dps: 5943.8909404815595
+  tps: 4059.5943040779794
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5928.483183163079
-  tps: 4051.0907764339863
+  dps: 5928.48318316308
+  tps: 4051.0907764339854
  }
 }
 dps_results: {
@@ -241,7 +241,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-FelstalkerArmor"
  value: {
-  dps: 5142.994400894467
+  dps: 5142.994400894468
   tps: 3534.305843208065
  }
 }
@@ -262,28 +262,28 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5928.483183163079
-  tps: 4051.0907764339863
+  dps: 5928.48318316308
+  tps: 4051.0907764339854
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5928.483183163079
-  tps: 4051.0907764339863
+  dps: 5928.48318316308
+  tps: 4051.0907764339854
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
   dps: 6022.600124122917
-  tps: 4089.4738671650935
+  tps: 4089.473867165093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5828.478986502489
+  dps: 5828.478986502488
   tps: 3970.1948345025858
  }
 }
@@ -291,42 +291,42 @@ dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
   dps: 5644.116483607359
-  tps: 3840.008296718888
+  tps: 3840.0082967188887
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 5997.366314005294
-  tps: 4073.923878361517
+  dps: 5997.366314005293
+  tps: 4073.923878361516
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
   dps: 5644.116483607359
-  tps: 3840.008296718888
+  tps: 3840.0082967188887
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5947.345098373517
+  dps: 5947.3450983735165
   tps: 4061.666798813153
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5943.890940481561
-  tps: 4059.5943040779807
+  dps: 5943.8909404815595
+  tps: 4059.5943040779794
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6025.619417157555
-  tps: 4118.111966997001
+  dps: 6025.619417157557
+  tps: 4118.111966997002
  }
 }
 dps_results: {
@@ -339,8 +339,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5928.483183163079
-  tps: 4051.0907764339863
+  dps: 5928.48318316308
+  tps: 4051.0907764339854
  }
 }
 dps_results: {
@@ -354,14 +354,14 @@ dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
   dps: 5644.116483607359
-  tps: 3840.008296718888
+  tps: 3840.0082967188887
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
   dps: 5644.116483607359
-  tps: 3840.008296718888
+  tps: 3840.0082967188887
  }
 }
 dps_results: {
@@ -375,7 +375,7 @@ dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
   dps: 5734.548039395488
-  tps: 3918.9029230523674
+  tps: 3918.902923052368
  }
 }
 dps_results: {
@@ -388,7 +388,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-NetherstrikeArmor"
  value: {
-  dps: 5048.337158034935
+  dps: 5048.337158034936
   tps: 3438.1639523259096
  }
 }
@@ -402,8 +402,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5948.266924451888
-  tps: 4065.2049549762755
+  dps: 5948.266924451889
+  tps: 4065.204954976275
  }
 }
 dps_results: {
@@ -416,29 +416,29 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5928.483183163079
-  tps: 4051.0907764339863
+  dps: 5928.48318316308
+  tps: 4051.0907764339854
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5928.483183163079
-  tps: 4051.0907764339863
+  dps: 5928.48318316308
+  tps: 4051.0907764339854
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PrimalIntent"
  value: {
   dps: 5156.874748423414
-  tps: 3533.549900881308
+  tps: 3533.549900881307
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
   dps: 5644.116483607359
-  tps: 3840.008296718888
+  tps: 3840.0082967188887
  }
 }
 dps_results: {
@@ -466,21 +466,21 @@ dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
   dps: 6032.224698289079
-  tps: 4095.379353932586
+  tps: 4095.379353932585
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5928.483183163079
-  tps: 4051.0907764339863
+  dps: 5928.48318316308
+  tps: 4051.0907764339854
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
   dps: 5644.116483607359
-  tps: 3840.008296718888
+  tps: 3840.0082967188887
  }
 }
 dps_results: {
@@ -515,7 +515,7 @@ dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
   dps: 5657.603518655713
-  tps: 3849.333333256892
+  tps: 3849.3333332568923
  }
 }
 dps_results: {
@@ -529,13 +529,13 @@ dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
   dps: 5644.116483607359
-  tps: 3840.008296718888
+  tps: 3840.0082967188887
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 5983.077754651382
+  dps: 5983.07775465138
   tps: 4066.8003214179544
  }
 }
@@ -557,7 +557,7 @@ dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
   dps: 5644.116483607359
-  tps: 3840.008296718888
+  tps: 3840.0082967188887
  }
 }
 dps_results: {
@@ -578,7 +578,7 @@ dps_results: {
  key: "TestFrost-AllItems-StrengthoftheClefthoof"
  value: {
   dps: 4875.584978533493
-  tps: 3350.6667969387295
+  tps: 3350.66679693873
  }
 }
 dps_results: {
@@ -591,15 +591,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5948.266924451888
-  tps: 4065.2049549762755
+  dps: 5948.266924451889
+  tps: 4065.204954976275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5940.120678038851
-  tps: 4059.3932344000377
+  dps: 5940.120678038849
+  tps: 4059.3932344000386
  }
 }
 dps_results: {
@@ -612,7 +612,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 4799.127132471208
+  dps: 4799.127132471209
   tps: 3315.556627302817
  }
 }
@@ -620,14 +620,14 @@ dps_results: {
  key: "TestFrost-AllItems-TheTwinStars"
  value: {
   dps: 5704.488293156757
-  tps: 3879.2403253904945
+  tps: 3879.2403253904936
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
   dps: 5973.102314125506
-  tps: 4059.1027923608444
+  tps: 4059.102792360844
  }
 }
 dps_results: {
@@ -647,36 +647,36 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5928.483183163079
-  tps: 4051.0907764339863
+  dps: 5928.48318316308
+  tps: 4051.0907764339854
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5928.483183163079
-  tps: 4051.0907764339863
+  dps: 5928.48318316308
+  tps: 4051.0907764339854
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5928.483183163079
-  tps: 4051.0907764339863
+  dps: 5928.48318316308
+  tps: 4051.0907764339854
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5928.483183163079
-  tps: 4051.0907764339863
+  dps: 5928.48318316308
+  tps: 4051.0907764339854
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WastewalkerArmor"
  value: {
   dps: 4426.691097232286
-  tps: 3037.830188533513
+  tps: 3037.8301885335127
  }
 }
 dps_results: {
@@ -689,21 +689,21 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 6043.224211621838
-  tps: 4102.128481666865
+  dps: 6043.224211621839
+  tps: 4102.128481666864
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathofSpellfire"
  value: {
-  dps: 4968.827554596094
+  dps: 4968.827554596093
   tps: 3411.1752349953545
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 5967.734753776191
+  dps: 5967.73475377619
   tps: 4076.7655810322644
  }
 }
@@ -718,14 +718,14 @@ dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
   dps: 5964.460674134017
-  tps: 4084.7822640679383
+  tps: 4084.782264067939
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
   dps: 6895.7633290311405
-  tps: 4404.875561235627
+  tps: 4404.875561235628
  }
 }
 dps_results: {
@@ -760,20 +760,20 @@ dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
   dps: 5973.102314125506
-  tps: 4059.1027923608444
+  tps: 4059.102792360844
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6843.90334170846
-  tps: 4320.173140639116
+  dps: 6843.903341708459
+  tps: 4320.173140639115
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8556.475225214357
+  dps: 8556.475225214355
   tps: 5464.211794449454
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -19,7 +19,7 @@ character_stats_results: {
   final_stats: 947.73
   final_stats: 339
   final_stats: 0
-  final_stats: 5715.748544000002
+  final_stats: 5715.748544000001
   final_stats: 361.16
   final_stats: 1743.8093999999999
   final_stats: 339
@@ -52,8 +52,8 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
@@ -66,14 +66,14 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7804.3378624850175
-  tps: 5555.98335081436
+  dps: 7804.337862485016
+  tps: 5555.983350814359
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7802.885078581344
+  dps: 7802.885078581343
   tps: 5411.037327985644
  }
 }
@@ -87,15 +87,15 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BurningRage"
  value: {
-  dps: 6543.135161595624
-  tps: 4590.393647249711
+  dps: 6543.135161595623
+  tps: 4590.39364724971
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7871.677147252516
-  tps: 5626.124246770797
+  dps: 7871.677147252512
+  tps: 5626.124246770795
  }
 }
 dps_results: {
@@ -143,8 +143,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7897.264895363242
-  tps: 5605.748383807864
+  dps: 7897.264895363241
+  tps: 5605.748383807862
  }
 }
 dps_results: {
@@ -165,14 +165,14 @@ dps_results: {
  key: "TestUnholy-AllItems-DesolationBattlegear"
  value: {
   dps: 5813.337035360382
-  tps: 4094.230039080913
+  tps: 4094.230039080912
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7809.1967871748
-  tps: 5551.425531628587
+  dps: 7809.196787174797
+  tps: 5551.425531628585
  }
 }
 dps_results: {
@@ -185,36 +185,36 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7804.3378624850175
-  tps: 5555.98335081436
+  dps: 7804.337862485016
+  tps: 5555.983350814359
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7797.414143367435
+  dps: 7797.414143367432
   tps: 5527.182467052329
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
@@ -235,21 +235,21 @@ dps_results: {
  key: "TestUnholy-AllItems-FaithinFelsteel"
  value: {
   dps: 6476.596891787629
-  tps: 4502.465375953943
+  tps: 4502.465375953945
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FelstalkerArmor"
  value: {
-  dps: 6738.956461616597
-  tps: 4730.235047676157
+  dps: 6738.956461616595
+  tps: 4730.235047676155
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FlameGuard"
  value: {
   dps: 6123.319461567808
-  tps: 4259.177869512493
+  tps: 4259.177869512494
  }
 }
 dps_results: {
@@ -262,15 +262,15 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
@@ -297,7 +297,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7783.725154078258
+  dps: 7783.725154078257
   tps: 5571.0677801197035
  }
 }
@@ -311,14 +311,14 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7804.3378624850175
-  tps: 5555.98335081436
+  dps: 7804.337862485016
+  tps: 5555.983350814359
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7797.414143367435
+  dps: 7797.414143367432
   tps: 5527.182467052329
  }
 }
@@ -326,7 +326,7 @@ dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
   dps: 7669.716070328643
-  tps: 5513.395112864991
+  tps: 5513.3951128649915
  }
 }
 dps_results: {
@@ -339,15 +339,15 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
   dps: 7837.243082794557
-  tps: 5549.909373127393
+  tps: 5549.909373127394
  }
 }
 dps_results: {
@@ -367,7 +367,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 5573.606391533362
+  dps: 5573.606391533361
   tps: 3932.7467530740773
  }
 }
@@ -382,7 +382,7 @@ dps_results: {
  key: "TestUnholy-AllItems-NetherscaleArmor"
  value: {
   dps: 6801.160426903179
-  tps: 4797.453787508371
+  tps: 4797.45378750837
  }
 }
 dps_results: {
@@ -403,34 +403,34 @@ dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
   dps: 7830.698701039658
-  tps: 5544.491713714528
+  tps: 5544.491713714526
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
   dps: 7837.243082794557
-  tps: 5549.909373127393
+  tps: 5549.909373127394
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PrimalIntent"
  value: {
-  dps: 6855.427914842197
+  dps: 6855.4279148421965
   tps: 4816.036453151809
  }
 }
@@ -458,8 +458,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7862.286920853039
-  tps: 5590.403719406483
+  dps: 7862.286920853037
+  tps: 5590.403719406482
  }
 }
 dps_results: {
@@ -472,8 +472,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
@@ -486,21 +486,21 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6915.214221309494
-  tps: 4861.382235941387
+  dps: 6915.214221309495
+  tps: 4861.382235941385
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6390.736948320038
+  dps: 6390.736948320037
   tps: 4444.8813275373
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7877.253239390748
+  dps: 7877.253239390749
   tps: 5673.456450204843
  }
 }
@@ -535,22 +535,22 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7861.921962682422
-  tps: 5553.799728031313
+  dps: 7861.92196268242
+  tps: 5553.799728031312
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8052.878675774002
+  dps: 8052.878675774
   tps: 5705.257440572538
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7921.1018459690295
-  tps: 5606.289241410178
+  dps: 7921.101845969026
+  tps: 5606.289241410175
  }
 }
 dps_results: {
@@ -585,20 +585,20 @@ dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
   dps: 7837.243082794557
-  tps: 5549.909373127393
+  tps: 5549.909373127394
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
   dps: 7830.698701039658
-  tps: 5544.491713714528
+  tps: 5544.491713714526
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7819.246032968588
+  dps: 7819.2460329685855
   tps: 5535.010809742007
  }
 }
@@ -619,22 +619,22 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinStars"
  value: {
-  dps: 7442.103452467995
+  dps: 7442.103452467994
   tps: 5267.265193590394
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7904.285051364536
-  tps: 5559.249622864902
+  dps: 7904.2850513645335
+  tps: 5559.2496228649015
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
   dps: 7554.148801709125
-  tps: 5382.370193755188
+  tps: 5382.370193755187
  }
 }
 dps_results: {
@@ -647,35 +647,35 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7802.885078581344
-  tps: 5521.466661209841
+  dps: 7802.885078581343
+  tps: 5521.46666120984
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WastewalkerArmor"
  value: {
-  dps: 5844.155135073192
+  dps: 5844.15513507319
   tps: 4118.6710266167765
  }
 }
@@ -683,14 +683,14 @@ dps_results: {
  key: "TestUnholy-AllItems-WindhawkArmor"
  value: {
   dps: 6618.649099768123
-  tps: 4644.301586105541
+  tps: 4644.30158610554
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
   dps: 7958.826887493671
-  tps: 5652.771299361434
+  tps: 5652.771299361432
  }
 }
 dps_results: {
@@ -703,14 +703,14 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 7881.415756346828
-  tps: 5537.584441726819
+  dps: 7881.415756346826
+  tps: 5537.584441726818
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 32453.703816390916
+  dps: 32453.703816390924
   tps: 25490.39870633385
  }
 }
@@ -718,7 +718,7 @@ dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
   dps: 7753.441636068655
-  tps: 5525.704112720006
+  tps: 5525.704112720007
  }
 }
 dps_results: {
@@ -732,7 +732,7 @@ dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
   dps: 20344.405601144277
-  tps: 16562.08321035403
+  tps: 16562.083210354027
  }
 }
 dps_results: {
@@ -752,15 +752,15 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 32716.640049215144
-  tps: 25623.13443276902
+  dps: 32716.640049215126
+  tps: 25623.13443276901
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7904.285051364536
-  tps: 5559.249622864902
+  dps: 7904.2850513645335
+  tps: 5559.2496228649015
  }
 }
 dps_results: {
@@ -780,7 +780,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4021.968827110262
+  dps: 4021.9688271102627
   tps: 3274.884131396898
  }
 }
@@ -794,7 +794,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7510.298214773958
-  tps: 5251.276374151244
+  dps: 7510.298214773955
+  tps: 5251.2763741512435
  }
 }

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -67,7 +67,7 @@ dps_results: {
  key: "TestBalance-AllItems-Bandit'sInsignia-40371"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
@@ -87,7 +87,7 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 790.0394811819181
+  dps: 790.0394811819182
   tps: 785.8321186435279
  }
 }
@@ -144,7 +144,7 @@ dps_results: {
  key: "TestBalance-AllItems-Defender'sCode-40257"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
@@ -192,7 +192,7 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 837.7560022220556
+  dps: 837.7560022220557
   tps: 832.5941192628625
  }
 }
@@ -228,13 +228,13 @@ dps_results: {
  key: "TestBalance-AllItems-FuryoftheFiveFlights-40431"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuturesightRune-38763"
  value: {
-  dps: 817.2892983570878
+  dps: 817.2892983570877
   tps: 812.5742994751945
  }
 }
@@ -262,8 +262,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 861.4587894217129
-  tps: 855.8211740518603
+  dps: 861.4587894217127
+  tps: 855.8211740518606
  }
 }
 dps_results: {
@@ -284,7 +284,7 @@ dps_results: {
  key: "TestBalance-AllItems-IncisorFragment-37723"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
@@ -298,7 +298,7 @@ dps_results: {
  key: "TestBalance-AllItems-InsightfulEarthsiegeDiamond"
  value: {
   dps: 879.4973910940975
-  tps: 878.1787836907973
+  tps: 878.1787836907972
  }
 }
 dps_results: {
@@ -312,7 +312,7 @@ dps_results: {
  key: "TestBalance-AllItems-Lavanthor'sTalisman-37872"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
@@ -326,7 +326,7 @@ dps_results: {
  key: "TestBalance-AllItems-MajesticDragonFigurine-40430"
  value: {
   dps: 866.3971888920347
-  tps: 861.1056855327754
+  tps: 861.1056855327755
  }
 }
 dps_results: {
@@ -375,7 +375,7 @@ dps_results: {
  key: "TestBalance-AllItems-OfferingofSacrifice-37638"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
@@ -409,7 +409,7 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-PrimalIntent"
  value: {
-  dps: 673.0975417467082
+  dps: 673.0975417467081
   tps: 670.9586146636886
  }
 }
@@ -417,13 +417,13 @@ dps_results: {
  key: "TestBalance-AllItems-PurifiedShardoftheGods"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 873.8562231855442
+  dps: 873.8562231855443
   tps: 867.8968258070815
  }
 }
@@ -431,7 +431,7 @@ dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47477"
  value: {
   dps: 884.04733883803
-  tps: 877.8841191465175
+  tps: 877.8841191465174
  }
 }
 dps_results: {
@@ -452,14 +452,14 @@ dps_results: {
  key: "TestBalance-AllItems-RuneofRepulsion-40372"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SealofthePantheon-36993"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
@@ -473,20 +473,20 @@ dps_results: {
  key: "TestBalance-AllItems-ShinyShardoftheGods"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
   dps: 789.73733557163
-  tps: 785.5341492787787
+  tps: 785.5341492787788
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SparkofLife-37657"
  value: {
-  dps: 847.641984397768
+  dps: 847.6419843977683
   tps: 842.5248184617274
  }
 }
@@ -500,7 +500,7 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 646.8492086485306
+  dps: 646.8492086485307
   tps: 645.1654748941419
  }
 }
@@ -528,7 +528,7 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-TheTwinStars"
  value: {
-  dps: 808.4152583538465
+  dps: 808.4152583538468
   tps: 803.7052036053512
  }
 }
@@ -536,7 +536,7 @@ dps_results: {
  key: "TestBalance-AllItems-ThunderheartHarness"
  value: {
   dps: 521.1151212538555
-  tps: 520.9903459140266
+  tps: 520.9903459140268
  }
 }
 dps_results: {
@@ -620,7 +620,7 @@ dps_results: {
  key: "TestBalance-Average-Default"
  value: {
   dps: 796.1994695726255
-  tps: 791.5230203862071
+  tps: 791.523020386207
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -19,7 +19,7 @@ character_stats_results: {
   final_stats: 136.07698329321138
   final_stats: 0
   final_stats: 0
-  final_stats: 5223.381240000001
+  final_stats: 5223.3812400000015
   final_stats: 135
   final_stats: 2412.5963143999998
   final_stats: 0
@@ -52,8 +52,8 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 1813.9183061867152
-  tps: 1311.5625641174045
+  dps: 1813.9183061867147
+  tps: 1311.5625641174042
  }
 }
 dps_results: {
@@ -108,7 +108,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1837.339690621278
+  dps: 1837.3396906212772
   tps: 1328.0478837021474
  }
 }
@@ -116,28 +116,28 @@ dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
   dps: 1813.8151205417357
-  tps: 1311.4893023094692
+  tps: 1311.489302309469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1863.1979238462695
+  dps: 1863.1979238462693
   tps: 1346.3687268608915
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1841.5390764747694
-  tps: 1331.1553037367735
+  dps: 1841.5390764747692
+  tps: 1331.1553037367732
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
   dps: 1837.8270725572297
-  tps: 1328.4847748766733
+  tps: 1328.484774876673
  }
 }
 dps_results: {
@@ -157,8 +157,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-IdolofTerror-33509"
  value: {
-  dps: 1796.7140986787679
-  tps: 1299.3475767867624
+  dps: 1796.7140986787683
+  tps: 1299.3475767867626
  }
 }
 dps_results: {
@@ -171,7 +171,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 1796.9321296020323
+  dps: 1796.9321296020328
   tps: 1299.5023787422801
  }
 }
@@ -179,7 +179,7 @@ dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
   dps: 1813.8151205417357
-  tps: 1311.4893023094692
+  tps: 1311.489302309469
  }
 }
 dps_results: {
@@ -193,20 +193,20 @@ dps_results: {
  key: "TestFeral-AllItems-InfusedColdstoneRune-35935"
  value: {
   dps: 1826.193295740642
-  tps: 1320.159804988908
+  tps: 1320.1598049889078
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
   dps: 1813.8151205417357
-  tps: 1311.4893023094692
+  tps: 1311.489302309469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LivingRootoftheWildheart-30664"
  value: {
-  dps: 1834.6243346945218
+  dps: 1834.6243346945216
   tps: 1326.2638443579474
  }
 }
@@ -214,7 +214,7 @@ dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
   dps: 1836.3821660027934
-  tps: 1327.5497833493218
+  tps: 1327.5497833493216
  }
 }
 dps_results: {
@@ -241,7 +241,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1866.4439576366658
+  dps: 1866.4439576366653
   tps: 1349.2054584943444
  }
 }
@@ -263,13 +263,13 @@ dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
   dps: 1813.8151205417357
-  tps: 1311.4893023094692
+  tps: 1311.489302309469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PrimalIntent"
  value: {
-  dps: 1738.6022526925747
+  dps: 1738.6022526925742
   tps: 1257.367602772768
  }
 }
@@ -277,13 +277,13 @@ dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
   dps: 1813.8151205417357
-  tps: 1311.4893023094692
+  tps: 1311.489302309469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1995.892565042997
+  dps: 1995.8925650429967
   tps: 1440.7642879053642
  }
 }
@@ -291,21 +291,21 @@ dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
   dps: 2018.6263990726989
-  tps: 1456.905310066453
+  tps: 1456.9053100664528
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
   dps: 1813.8151205417357
-  tps: 1311.4893023094692
+  tps: 1311.489302309469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
   dps: 1813.8151205417357
-  tps: 1311.4893023094692
+  tps: 1311.489302309469
  }
 }
 dps_results: {
@@ -319,20 +319,20 @@ dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
   dps: 1813.8151205417357
-  tps: 1311.4893023094692
+  tps: 1311.489302309469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
   dps: 1813.8151205417357
-  tps: 1311.4893023094692
+  tps: 1311.489302309469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 1894.810310035538
+  dps: 1894.8103100355377
   tps: 1369.5401103741328
  }
 }
@@ -374,14 +374,14 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1884.7374654335708
+  dps: 1884.7374654335704
   tps: 1362.901346642653
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1891.6017646122018
+  dps: 1891.6017646122014
   tps: 1367.8694678243648
  }
 }
@@ -417,7 +417,7 @@ dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
   dps: 1848.8945136369337
-  tps: 1786.3264391789573
+  tps: 1786.3264391789576
  }
 }
 dps_results: {
@@ -431,7 +431,7 @@ dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
   dps: 2064.7503917885306
-  tps: 1495.5625642533132
+  tps: 1495.5625642533137
  }
 }
 dps_results: {

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -73,42 +73,42 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 606.5642313902339
-  tps: 834.7309987198138
+  dps: 606.5642313902338
+  tps: 834.7309987198136
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BracingEarthsiegeDiamond"
  value: {
   dps: 596.7529655216897
-  tps: 805.0452170499972
+  tps: 805.045217049997
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
   dps: 633.4195031066085
-  tps: 877.0187298269317
+  tps: 877.0187298269315
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 618.5924135255606
+  dps: 618.5924135255603
   tps: 855.0965598526176
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 634.7094739498045
+  dps: 634.7094739498044
   tps: 879.2457698486672
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 660.1233528512943
+  dps: 660.1233528512942
   tps: 906.3119080925641
  }
 }
@@ -136,7 +136,7 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 631.7118173214128
+  dps: 631.7118173214127
   tps: 868.9061403682741
  }
 }
@@ -171,15 +171,15 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 606.5642313902339
-  tps: 834.7309987198138
+  dps: 606.5642313902338
+  tps: 834.7309987198136
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticStarflareDiamond"
  value: {
   dps: 593.8684331918985
-  tps: 817.0504400661674
+  tps: 817.0504400661673
  }
 }
 dps_results: {
@@ -242,7 +242,7 @@ dps_results: {
  key: "TestFeralTank-AllItems-IdolofTerror-33509"
  value: {
   dps: 626.1142623156562
-  tps: 863.0946711833524
+  tps: 863.0946711833521
  }
 }
 dps_results: {
@@ -269,15 +269,15 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 606.5642313902339
-  tps: 834.7309987198138
+  dps: 606.5642313902338
+  tps: 834.7309987198136
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveStarflareDiamond"
  value: {
   dps: 593.8684331918985
-  tps: 817.0504400661674
+  tps: 817.0504400661673
  }
 }
 dps_results: {
@@ -354,7 +354,7 @@ dps_results: {
  key: "TestFeralTank-AllItems-MeteoriteWhetstone-37390"
  value: {
   dps: 639.603891856246
-  tps: 883.7713386386391
+  tps: 883.7713386386389
  }
 }
 dps_results: {
@@ -423,8 +423,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 732.6565956532495
-  tps: 1007.3899362726606
+  dps: 732.6565956532493
+  tps: 1007.3899362726604
  }
 }
 dps_results: {
@@ -487,20 +487,20 @@ dps_results: {
  key: "TestFeralTank-AllItems-SparkofLife-37657"
  value: {
   dps: 631.3469352169157
-  tps: 870.2576683857596
+  tps: 870.2576683857594
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 534.5442074932972
+  dps: 534.5442074932973
   tps: 742.7362624465189
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 524.51015606172
+  dps: 524.5101560617201
   tps: 724.5606984202115
  }
 }
@@ -550,7 +550,7 @@ dps_results: {
  key: "TestFeralTank-AllItems-ThunderingSkyflareDiamond"
  value: {
   dps: 607.5089836748265
-  tps: 836.5819721633177
+  tps: 836.5819721633176
  }
 }
 dps_results: {
@@ -642,7 +642,7 @@ dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
   dps: 808.916824939321
-  tps: 1129.6569591294501
+  tps: 1129.65695912945
  }
 }
 dps_results: {

--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -102,7 +102,7 @@ dps_results: {
  key: "TestHunter-AllItems-BlackBowoftheBetrayer-32336"
  value: {
   dps: 4927.073805368419
-  tps: 4181.9159606368075
+  tps: 4181.915960636808
  }
 }
 dps_results: {
@@ -137,27 +137,27 @@ dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
   dps: 5231.675613427372
-  tps: 4485.195638053547
+  tps: 4485.195638053546
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Death-42990"
  value: {
   dps: 5269.3403355440405
-  tps: 4520.847787386081
+  tps: 4520.84778738608
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 5220.816578835593
+  dps: 5220.816578835594
   tps: 4475.588706092871
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 5220.816578835593
+  dps: 5220.816578835594
   tps: 4475.588706092871
  }
 }
@@ -172,7 +172,7 @@ dps_results: {
  key: "TestHunter-AllItems-Defender'sCode-40257"
  value: {
   dps: 5129.776122300924
-  tps: 4380.135088746966
+  tps: 4380.135088746965
  }
 }
 dps_results: {
@@ -186,7 +186,7 @@ dps_results: {
  key: "TestHunter-AllItems-DesolationBattlegear"
  value: {
   dps: 4083.8666736816713
-  tps: 3443.7988008501284
+  tps: 3443.7988008501293
  }
 }
 dps_results: {
@@ -206,7 +206,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5225.7743559049195
+  dps: 5225.77435590492
   tps: 4469.814906681099
  }
 }
@@ -221,7 +221,7 @@ dps_results: {
  key: "TestHunter-AllItems-EnigmaticStarflareDiamond"
  value: {
   dps: 5221.8884297259765
-  tps: 4463.988046889231
+  tps: 4463.98804688923
  }
 }
 dps_results: {
@@ -241,7 +241,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5221.660613759027
+  dps: 5221.660613759026
   tps: 4473.094907118765
  }
 }
@@ -277,7 +277,7 @@ dps_results: {
  key: "TestHunter-AllItems-FuturesightRune-38763"
  value: {
   dps: 5129.776122300924
-  tps: 4380.135088746966
+  tps: 4380.135088746965
  }
 }
 dps_results: {
@@ -312,7 +312,7 @@ dps_results: {
  key: "TestHunter-AllItems-ImpassiveStarflareDiamond"
  value: {
   dps: 5221.8884297259765
-  tps: 4463.988046889231
+  tps: 4463.98804688923
  }
 }
 dps_results: {
@@ -347,7 +347,7 @@ dps_results: {
  key: "TestHunter-AllItems-Lavanthor'sTalisman-37872"
  value: {
   dps: 5129.776122300924
-  tps: 4380.135088746966
+  tps: 4380.135088746965
  }
 }
 dps_results: {
@@ -360,7 +360,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 3883.165817272244
+  dps: 3883.1658172722446
   tps: 3279.4254656260396
  }
 }
@@ -388,8 +388,8 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5131.411101979388
-  tps: 4380.2736242714
+  dps: 5131.411101979387
+  tps: 4380.273624271399
  }
 }
 dps_results: {
@@ -424,7 +424,7 @@ dps_results: {
  key: "TestHunter-AllItems-PrimalIntent"
  value: {
   dps: 4848.948201165079
-  tps: 4138.323537773205
+  tps: 4138.323537773204
  }
 }
 dps_results: {
@@ -465,7 +465,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-RiftStalkerArmor"
  value: {
-  dps: 4309.82077952812
+  dps: 4309.8207795281205
   tps: 3648.304050647154
  }
 }
@@ -473,7 +473,7 @@ dps_results: {
  key: "TestHunter-AllItems-RuneofRepulsion-40372"
  value: {
   dps: 5129.776122300924
-  tps: 4380.135088746966
+  tps: 4380.135088746965
  }
 }
 dps_results: {
@@ -487,7 +487,7 @@ dps_results: {
  key: "TestHunter-AllItems-SealofthePantheon-36993"
  value: {
   dps: 5129.776122300924
-  tps: 4380.135088746966
+  tps: 4380.135088746965
  }
 }
 dps_results: {
@@ -507,15 +507,15 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5119.722075629108
-  tps: 4363.5729017707945
+  dps: 5119.722075629107
+  tps: 4363.572901770794
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SparkofLife-37657"
  value: {
-  dps: 5240.31338509742
-  tps: 4485.083722983987
+  dps: 5240.313385097419
+  tps: 4485.083722983985
  }
 }
 dps_results: {
@@ -549,7 +549,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5234.97991326051
+  dps: 5234.979913260511
   tps: 4478.751957092757
  }
 }
@@ -633,7 +633,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 4858.973548961637
+  dps: 4858.973548961638
   tps: 4169.979392318319
  }
 }
@@ -648,7 +648,7 @@ dps_results: {
  key: "TestHunter-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
   dps: 5791.775348727544
-  tps: 5043.782200631913
+  tps: 5043.782200631914
  }
 }
 dps_results: {
@@ -669,7 +669,7 @@ dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-AOE-FullBuffs-LongMultiTarget"
  value: {
   dps: 14689.508870707601
-  tps: 14765.511563114673
+  tps: 14765.511563114671
  }
 }
 dps_results: {
@@ -683,13 +683,13 @@ dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-AOE-FullBuffs-ShortSingleTarget"
  value: {
   dps: 6163.398936182473
-  tps: 5319.6678520615005
+  tps: 5319.6678520615
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10317.374391897849
+  dps: 10317.374391897853
   tps: 11036.505021438717
  }
 }
@@ -752,22 +752,22 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5105.4453030209115
-  tps: 5557.291000519428
+  dps: 5105.445303020911
+  tps: 5557.291000519427
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5105.4453030209115
+  dps: 5105.445303020911
   tps: 4392.206044052767
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6278.595172777209
-  tps: 5418.544347529072
+  dps: 6278.595172777208
+  tps: 5418.544347529071
  }
 }
 dps_results: {
@@ -809,7 +809,7 @@ dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-ShortSingleTarget"
  value: {
   dps: 6080.797709650876
-  tps: 5241.002825690454
+  tps: 5241.002825690453
  }
 }
 dps_results: {
@@ -836,14 +836,14 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14782.648013918675
-  tps: 14811.394262233318
+  dps: 14782.64801391867
+  tps: 14811.394262233312
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5364.548295805753
+  dps: 5364.548295805752
   tps: 4608.345910500354
  }
 }
@@ -907,14 +907,14 @@ dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-NoBuffs-LongSingleTarget"
  value: {
   dps: 2917.81986535385
-  tps: 2151.866244476306
+  tps: 2151.8662444763054
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-NoBuffs-ShortSingleTarget"
  value: {
   dps: 3491.426879392675
-  tps: 2567.4953946486253
+  tps: 2567.495394648625
  }
 }
 dps_results: {
@@ -955,7 +955,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3989.4882965736238
+  dps: 3989.488296573624
   tps: 3588.1607063192387
  }
 }

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -74,56 +74,56 @@ dps_results: {
  key: "TestArcane-AllItems-BracingEarthsiegeDiamond"
  value: {
   dps: 6345.307285592661
-  tps: 3823.9165991346904
+  tps: 3823.9165991346918
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 6262.637736204144
+  dps: 6262.637736204146
   tps: 3852.450711053995
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6487.594850607997
+  dps: 6487.594850607998
   tps: 3985.432825571004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6272.160133765569
-  tps: 3856.1719954655478
+  dps: 6272.160133765572
+  tps: 3856.171995465548
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6347.430058579503
-  tps: 3922.960369596719
+  dps: 6347.430058579504
+  tps: 3922.96036959672
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6167.881977469027
-  tps: 3784.5254403668064
+  dps: 6167.881977469029
+  tps: 3784.525440366807
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6167.881977469027
-  tps: 3784.5254403668064
+  dps: 6167.881977469029
+  tps: 3784.525440366807
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6213.240191577108
-  tps: 3813.3519010998884
+  dps: 6213.240191577109
+  tps: 3813.351901099889
  }
 }
 dps_results: {
@@ -137,7 +137,7 @@ dps_results: {
  key: "TestArcane-AllItems-Defender'sCode-40257"
  value: {
   dps: 6213.184672128053
-  tps: 3821.9857490623835
+  tps: 3821.9857490623845
  }
 }
 dps_results: {
@@ -171,7 +171,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6326.944012160122
+  dps: 6326.944012160123
   tps: 3889.042322502278
  }
 }
@@ -186,21 +186,21 @@ dps_results: {
  key: "TestArcane-AllItems-ExtractofNecromanticPower-40373"
  value: {
   dps: 6267.815229833923
-  tps: 3853.5650531065594
+  tps: 3853.5650531065608
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeoftheBroodmother-45308"
  value: {
   dps: 6445.914371945645
-  tps: 3960.4245383735915
+  tps: 3960.424538373592
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6404.93596916376
-  tps: 3935.837496704462
+  dps: 6404.935969163761
+  tps: 3935.837496704463
  }
 }
 dps_results: {
@@ -235,7 +235,7 @@ dps_results: {
  key: "TestArcane-AllItems-FuturesightRune-38763"
  value: {
   dps: 6354.6316186197555
-  tps: 3904.8649744739123
+  tps: 3904.864974473913
  }
 }
 dps_results: {
@@ -248,7 +248,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6326.944012160122
+  dps: 6326.944012160123
   tps: 3889.042322502278
  }
 }
@@ -256,14 +256,14 @@ dps_results: {
  key: "TestArcane-AllItems-IncisorFragment-37723"
  value: {
   dps: 6213.184672128053
-  tps: 3821.9857490623835
+  tps: 3821.9857490623845
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InfusedColdstoneRune-35935"
  value: {
   dps: 6294.717108132512
-  tps: 3870.9052106650597
+  tps: 3870.9052106650606
  }
 }
 dps_results: {
@@ -298,14 +298,14 @@ dps_results: {
  key: "TestArcane-AllItems-Lavanthor'sTalisman-37872"
  value: {
   dps: 6213.184672128053
-  tps: 3821.9857490623835
+  tps: 3821.9857490623845
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6305.949069013
-  tps: 3874.8557186411153
+  dps: 6305.949069013001
+  tps: 3874.8557186411163
  }
 }
 dps_results: {
@@ -325,8 +325,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6216.4797287028105
-  tps: 3823.9664812939036
+  dps: 6216.479728702811
+  tps: 3823.9664812939054
  }
 }
 dps_results: {
@@ -367,8 +367,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6621.378009651297
-  tps: 4142.1434922960125
+  dps: 6621.378009651298
+  tps: 4142.143492296013
  }
 }
 dps_results: {
@@ -382,7 +382,7 @@ dps_results: {
  key: "TestArcane-AllItems-RelentlessEarthsiegeDiamond"
  value: {
   dps: 6463.339946492252
-  tps: 3970.8798831015565
+  tps: 3970.879883101557
  }
 }
 dps_results: {
@@ -396,21 +396,21 @@ dps_results: {
  key: "TestArcane-AllItems-RuneofRepulsion-40372"
  value: {
   dps: 6213.184672128053
-  tps: 3821.9857490623835
+  tps: 3821.9857490623845
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SealofthePantheon-36993"
  value: {
   dps: 6213.184672128053
-  tps: 3821.9857490623835
+  tps: 3821.9857490623845
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 6258.314940735584
-  tps: 3847.8648796475563
+  dps: 6258.314940735585
+  tps: 3847.864879647558
  }
 }
 dps_results: {
@@ -431,7 +431,7 @@ dps_results: {
  key: "TestArcane-AllItems-SparkofLife-37657"
  value: {
   dps: 6375.695058220138
-  tps: 3918.9810668703017
+  tps: 3918.981066870303
  }
 }
 dps_results: {
@@ -472,8 +472,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-TheTwinStars"
  value: {
-  dps: 6124.150869057885
-  tps: 3765.896667634326
+  dps: 6124.150869057886
+  tps: 3765.896667634327
  }
 }
 dps_results: {
@@ -486,15 +486,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6419.594667570338
-  tps: 3946.497998381915
+  dps: 6419.594667570339
+  tps: 3946.4979983819153
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6419.594667570338
-  tps: 3946.497998381915
+  dps: 6419.594667570339
+  tps: 3946.4979983819153
  }
 }
 dps_results: {
@@ -528,7 +528,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-WrathofSpellfire"
  value: {
-  dps: 5719.978017684619
+  dps: 5719.97801768462
   tps: 3522.541548673196
  }
 }
@@ -542,7 +542,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10587.176744466504
+  dps: 10587.176744466506
   tps: 8605.50951349203
  }
 }
@@ -556,15 +556,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2063.620075219359
-  tps: 1382.9521515343915
+  dps: 2063.6200752193595
+  tps: 1382.9521515343918
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-LongMultiTarget"
  value: {
   dps: 5921.569599439032
-  tps: 5242.416691569398
+  tps: 5242.416691569399
  }
 }
 dps_results: {
@@ -584,14 +584,14 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6487.594850607997
+  dps: 6487.594850607998
   tps: 5750.075214488913
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6487.594850607997
+  dps: 6487.594850607998
   tps: 3985.432825571004
  }
 }
@@ -599,20 +599,20 @@ dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-ShortSingleTarget"
  value: {
   dps: 8425.850154710923
-  tps: 5158.679206821355
+  tps: 5158.679206821356
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3033.190919858424
-  tps: 3105.626798116537
+  dps: 3033.1909198584244
+  tps: 3105.6267981165374
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3033.190919858424
+  dps: 3033.1909198584244
   tps: 1884.2001642251294
  }
 }
@@ -626,7 +626,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6487.594850607997
+  dps: 6487.594850607998
   tps: 3985.432825571004
  }
 }

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -60,7 +60,7 @@ dps_results: {
  key: "TestFire-AllItems-Bandit'sInsignia-40371"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
@@ -80,7 +80,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 5600.923481148909
+  dps: 5600.92348114891
   tps: 4136.3241982581585
  }
 }
@@ -88,14 +88,14 @@ dps_results: {
  key: "TestFire-AllItems-ChaoticSkyflareDiamond"
  value: {
   dps: 5826.97766371634
-  tps: 4305.2203397069
+  tps: 4305.220339706901
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
   dps: 5701.083391043068
-  tps: 4187.825933906026
+  tps: 4187.825933906027
  }
 }
 dps_results: {
@@ -122,8 +122,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 5672.073437271773
-  tps: 4156.716762951544
+  dps: 5672.073437271774
+  tps: 4156.716762951545
  }
 }
 dps_results: {
@@ -137,7 +137,7 @@ dps_results: {
  key: "TestFire-AllItems-Defender'sCode-40257"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
@@ -185,15 +185,15 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5667.478338309164
-  tps: 4187.570747883181
+  dps: 5667.478338309165
+  tps: 4187.570747883182
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeoftheBroodmother-45308"
  value: {
   dps: 5888.96137807099
-  tps: 4322.785233684812
+  tps: 4322.785233684813
  }
 }
 dps_results: {
@@ -228,14 +228,14 @@ dps_results: {
  key: "TestFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuturesightRune-38763"
  value: {
   dps: 5691.298304786616
-  tps: 4198.863370410997
+  tps: 4198.863370410998
  }
 }
 dps_results: {
@@ -256,7 +256,7 @@ dps_results: {
  key: "TestFire-AllItems-IncisorFragment-37723"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
@@ -290,7 +290,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-KirinTorGarb"
  value: {
-  dps: 5368.955064531987
+  dps: 5368.955064531986
   tps: 4029.106096959583
  }
 }
@@ -298,7 +298,7 @@ dps_results: {
  key: "TestFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
@@ -318,15 +318,15 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5610.225685998534
-  tps: 4130.39068257808
+  dps: 5610.2256859985355
+  tps: 4130.3906825780805
  }
 }
 dps_results: {
  key: "TestFire-AllItems-OfferingofSacrifice-37638"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
@@ -361,7 +361,7 @@ dps_results: {
  key: "TestFire-AllItems-PurifiedShardoftheGods"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
@@ -374,14 +374,14 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 5981.20006296626
+  dps: 5981.200062966261
   tps: 4442.960555610569
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5812.028650513724
+  dps: 5812.028650513725
   tps: 4295.204742793979
  }
 }
@@ -396,35 +396,35 @@ dps_results: {
  key: "TestFire-AllItems-RuneofRepulsion-40372"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SealofthePantheon-36993"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Serrah'sStar-37559"
  value: {
   dps: 5655.927197720664
-  tps: 4162.998387845535
+  tps: 4162.998387845537
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShinyShardoftheGods"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
   dps: 5533.440404318748
-  tps: 4092.5708527359325
+  tps: 4092.570852735934
  }
 }
 dps_results: {
@@ -437,7 +437,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 5002.145110510676
+  dps: 5002.145110510675
   tps: 3752.3600546355715
  }
 }
@@ -486,14 +486,14 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5766.338208426632
+  dps: 5766.338208426633
   tps: 4250.811287618575
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5766.338208426632
+  dps: 5766.338208426633
   tps: 4250.811287618575
  }
 }
@@ -528,7 +528,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-WrathofSpellfire"
  value: {
-  dps: 5009.80147543582
+  dps: 5009.801475435821
   tps: 3741.2966277216765
  }
 }
@@ -536,7 +536,7 @@ dps_results: {
  key: "TestFire-Average-Default"
  value: {
   dps: 5864.452801386802
-  tps: 4327.39215289721
+  tps: 4327.3921528972105
  }
 }
 dps_results: {
@@ -556,7 +556,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1939.9261744669882
+  dps: 1939.926174466988
   tps: 1583.9321857828847
  }
 }
@@ -592,14 +592,14 @@ dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongSingleTarget"
  value: {
   dps: 5826.97766371634
-  tps: 4305.2203397069
+  tps: 4305.220339706901
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7079.0045846545545
-  tps: 5200.125470607173
+  tps: 5200.125470607175
  }
 }
 dps_results: {
@@ -612,7 +612,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2626.2512904215178
+  dps: 2626.251290421518
   tps: 2028.3735983291074
  }
 }
@@ -627,6 +627,6 @@ dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
   dps: 5826.97766371634
-  tps: 4305.2203397069
+  tps: 4305.220339706901
  }
 }

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -66,7 +66,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 4853.5591523598005
+  dps: 4853.559152359801
   tps: 4194.018502922067
  }
 }
@@ -80,7 +80,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 4742.220106402009
+  dps: 4742.22010640201
   tps: 4102.5400198631005
  }
 }
@@ -192,7 +192,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 4965.787607368109
+  dps: 4965.78760736811
   tps: 4297.01299704247
  }
 }
@@ -200,7 +200,7 @@ dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
   dps: 4895.010344916379
-  tps: 4235.274912777698
+  tps: 4235.274912777699
  }
 }
 dps_results: {
@@ -220,7 +220,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-FrostfireGarb"
  value: {
-  dps: 4176.9506318806225
+  dps: 4176.950631880622
   tps: 3618.0954372630667
  }
 }
@@ -234,8 +234,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 4784.682340668028
-  tps: 4134.9282389989985
+  dps: 4784.682340668029
+  tps: 4134.928238999
  }
 }
 dps_results: {
@@ -269,7 +269,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 4828.160405002485
+  dps: 4828.160405002486
   tps: 4176.354794816964
  }
 }
@@ -290,7 +290,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-KirinTorGarb"
  value: {
-  dps: 4629.745030603914
+  dps: 4629.7450306039145
   tps: 4013.961376992234
  }
 }
@@ -305,14 +305,14 @@ dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
   dps: 4690.022840884916
-  tps: 4047.854225634973
+  tps: 4047.8542256349733
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Mana-EtchedRegalia"
  value: {
   dps: 3694.1989025303496
-  tps: 3191.883549700605
+  tps: 3191.8835497006053
  }
 }
 dps_results: {
@@ -375,14 +375,14 @@ dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
   dps: 5036.82429432388
-  tps: 4373.968985923484
+  tps: 4373.968985923485
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
   dps: 4949.261679703826
-  tps: 4280.152810627829
+  tps: 4280.15281062783
  }
 }
 dps_results: {
@@ -473,7 +473,7 @@ dps_results: {
  key: "TestFrost-AllItems-TheTwinStars"
  value: {
   dps: 4707.777105723877
-  tps: 4073.2303846597547
+  tps: 4073.2303846597556
  }
 }
 dps_results: {
@@ -528,14 +528,14 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-WrathofSpellfire"
  value: {
-  dps: 4531.423465296236
+  dps: 4531.423465296235
   tps: 3927.4989540454103
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 4928.086854457934
+  dps: 4928.086854457936
   tps: 4269.413924357902
  }
 }
@@ -598,15 +598,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6177.231178229034
-  tps: 5213.4446900475
+  dps: 6177.231178229035
+  tps: 5213.444690047501
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongMultiTarget"
  value: {
   dps: 3019.516846715552
-  tps: 3342.7846137162924
+  tps: 3342.7846137162933
  }
 }
 dps_results: {

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -430,8 +430,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-LightswornBattlegear"
  value: {
-  dps: 151.41947227733047
-  tps: 151.41947227733047
+  dps: 151.4194722773305
+  tps: 151.4194722773305
  }
 }
 dps_results: {

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -94,7 +94,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 2946.28204579606
+  dps: 2946.2820457960606
   tps: 2698.744916781771
  }
 }
@@ -234,7 +234,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2953.0130219534776
+  dps: 2953.013021953478
   tps: 2700.416180495447
  }
 }
@@ -276,7 +276,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2883.5264406770934
+  dps: 2883.526440677093
   tps: 2646.2440778524006
  }
 }
@@ -298,7 +298,7 @@ dps_results: {
  key: "TestRetribution-AllItems-FuturesightRune-38763"
  value: {
   dps: 2902.9108045627845
-  tps: 2661.0289605098155
+  tps: 2661.028960509816
  }
 }
 dps_results: {
@@ -360,8 +360,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2902.345517517734
-  tps: 2662.4508717956796
+  dps: 2902.3455175177346
+  tps: 2662.4508717956805
  }
 }
 dps_results: {
@@ -473,14 +473,14 @@ dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthshatterDiamond"
  value: {
   dps: 2897.9945465600244
-  tps: 2658.772641142459
+  tps: 2658.7726411424587
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2902.345517517734
-  tps: 2662.4508717956796
+  dps: 2902.3455175177346
+  tps: 2662.4508717956805
  }
 }
 dps_results: {
@@ -549,7 +549,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2900.79758134824
+  dps: 2900.7975813482394
   tps: 2661.2378672791447
  }
 }
@@ -619,15 +619,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2902.345517517734
-  tps: 2662.4508717956796
+  dps: 2902.3455175177346
+  tps: 2662.4508717956805
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftStarflareDiamond"
  value: {
   dps: 2897.9945465600244
-  tps: 2658.772641142459
+  tps: 2658.7726411424587
  }
 }
 dps_results: {
@@ -675,7 +675,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2883.5264406770934
+  dps: 2883.526440677093
   tps: 2646.2440778524006
  }
 }
@@ -696,7 +696,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2883.5264406770934
+  dps: 2883.526440677093
   tps: 2646.2440778524006
  }
 }
@@ -746,7 +746,7 @@ dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
   dps: 2935.4453681937325
-  tps: 2693.626416462468
+  tps: 2693.6264164624677
  }
 }
 dps_results: {

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -73,7 +73,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-AvatarRegalia"
  value: {
-  dps: 1498.2112638671192
+  dps: 1498.2112638671188
   tps: 1093.138981547591
  }
 }
@@ -241,7 +241,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1763.2700198878993
+  dps: 1763.2700198878997
   tps: 1282.066910938451
  }
 }
@@ -270,7 +270,7 @@ dps_results: {
  key: "TestShadow-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
   dps: 1798.3172757883526
-  tps: 1308.6180463887604
+  tps: 1308.6180463887606
  }
 }
 dps_results: {
@@ -473,7 +473,7 @@ dps_results: {
  key: "TestShadow-AllItems-SpellstrikeInfusion"
  value: {
   dps: 1538.1695694085838
-  tps: 1116.9842295630485
+  tps: 1116.9842295630492
  }
 }
 dps_results: {
@@ -535,14 +535,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1763.2700198878993
+  dps: 1763.2700198878997
   tps: 1282.066910938451
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1763.2700198878993
+  dps: 1763.2700198878997
   tps: 1282.066910938451
  }
 }
@@ -612,7 +612,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1109.3023999235434
+  dps: 1109.3023999235431
   tps: 753.9765948692204
  }
 }
@@ -781,7 +781,7 @@ dps_results: {
  key: "TestShadow-Settings-Draenei-P3-Clipping-NoBuffs-ShortSingleTarget"
  value: {
   dps: 1826.2782098410123
-  tps: 1281.2485412082804
+  tps: 1281.2485412082806
  }
 }
 dps_results: {
@@ -808,21 +808,21 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Draenei-P3-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 595.9742775024453
+  dps: 595.9742775024451
   tps: 615.7387471541977
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P3-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 595.9742775024453
+  dps: 595.9742775024451
   tps: 427.6735804875316
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P3-Ideal-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1692.606271546317
+  dps: 1692.6062715463165
   tps: 1179.9969148794921
  }
 }
@@ -850,14 +850,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 289.1618551502138
+  dps: 289.16185515021374
   tps: 355.46850882530623
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 289.1618551502138
+  dps: 289.16185515021374
   tps: 201.62709215863993
  }
 }
@@ -892,21 +892,21 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 306.4800934665208
+  dps: 306.4800934665209
   tps: 366.4671306016254
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 306.4800934665208
+  dps: 306.4800934665209
   tps: 212.62571393495915
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1384.4836307646965
+  dps: 1384.4836307646967
   tps: 956.374037165954
  }
 }
@@ -1032,7 +1032,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-P3-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1793.506596730807
+  dps: 1793.5065967308067
   tps: 1258.4960504373598
  }
 }
@@ -1061,7 +1061,7 @@ dps_results: {
  key: "TestShadow-Settings-NightElf-P3-Ideal-NoBuffs-LongMultiTarget"
  value: {
   dps: 594.0715096077599
-  tps: 614.573238691484
+  tps: 614.5732386914838
  }
 }
 dps_results: {
@@ -1243,7 +1243,7 @@ dps_results: {
  key: "TestShadow-Settings-Undead-P3-Basic-NoBuffs-ShortSingleTarget"
  value: {
   dps: 1225.232547510231
-  tps: 834.7765932540581
+  tps: 834.7765932540582
  }
 }
 dps_results: {
@@ -1285,7 +1285,7 @@ dps_results: {
  key: "TestShadow-Settings-Undead-P3-Clipping-NoBuffs-ShortSingleTarget"
  value: {
   dps: 1788.0754188117382
-  tps: 1255.3863721076605
+  tps: 1255.3863721076607
  }
 }
 dps_results: {
@@ -1312,14 +1312,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Undead-P3-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 588.027218930109
+  dps: 588.0272189301089
   tps: 609.7700945306493
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P3-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 588.027218930109
+  dps: 588.0272189301089
   tps: 422.4886778639833
  }
 }

--- a/sim/priest/smite/TestSmite.results
+++ b/sim/priest/smite/TestSmite.results
@@ -60,7 +60,7 @@ dps_results: {
  key: "TestSmite-AllItems-AshtongueTalismanofAcumen-32490"
  value: {
   dps: 826.5775090516761
-  tps: 763.9088540765154
+  tps: 763.9088540765152
  }
 }
 dps_results: {
@@ -80,14 +80,14 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 844.0988476623331
+  dps: 844.0988476623334
   tps: 780.1712018663959
  }
 }
@@ -102,7 +102,7 @@ dps_results: {
  key: "TestSmite-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
   dps: 809.8501479685415
-  tps: 750.0659546451732
+  tps: 750.0659546451731
  }
 }
 dps_results: {
@@ -115,7 +115,7 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 914.5688111420164
+  dps: 914.5688111420162
   tps: 863.3149450096641
  }
 }
@@ -129,28 +129,28 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 853.2478798787719
+  dps: 853.2478798787721
   tps: 790.5103265678217
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 662.3636444771797
-  tps: 600.1051648867161
+  dps: 662.3636444771796
+  tps: 600.1051648867162
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 662.3636444771797
-  tps: 600.1051648867161
+  dps: 662.3636444771796
+  tps: 600.1051648867162
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 718.6582674739419
+  dps: 718.658267473942
   tps: 654.527874874103
  }
 }
@@ -164,8 +164,8 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-Defender'sCode-40257"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
@@ -186,7 +186,7 @@ dps_results: {
  key: "TestSmite-AllItems-EmberSkyflareDiamond"
  value: {
   dps: 844.9721722084671
-  tps: 781.1104939926973
+  tps: 781.1104939926975
  }
 }
 dps_results: {
@@ -213,7 +213,7 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 841.9677318226638
+  dps: 841.9677318226641
   tps: 779.2532933843102
  }
 }
@@ -248,8 +248,8 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
@@ -291,21 +291,21 @@ dps_results: {
  key: "TestSmite-AllItems-IncarnateRaiment"
  value: {
   dps: 686.2079154600981
-  tps: 639.7702039465862
+  tps: 639.7702039465863
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-IncisorFragment-37723"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-InfusedColdstoneRune-35935"
  value: {
   dps: 823.9903053916069
-  tps: 762.1846255835027
+  tps: 762.1846255835026
  }
 }
 dps_results: {
@@ -325,15 +325,15 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 848.4171618032817
-  tps: 785.7670347186732
+  dps: 848.4171618032818
+  tps: 785.7670347186734
  }
 }
 dps_results: {
@@ -353,8 +353,8 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
@@ -388,15 +388,15 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ReignoftheDead-47316"
  value: {
   dps: 884.006344203752
-  tps: 816.3153281862326
+  tps: 816.3153281862327
  }
 }
 dps_results: {
@@ -423,8 +423,8 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
@@ -437,8 +437,8 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
@@ -451,15 +451,15 @@ dps_results: {
 dps_results: {
  key: "TestSmite-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 808.2526965339482
-  tps: 748.2825805467871
+  dps: 808.2526965339483
+  tps: 748.2825805467872
  }
 }
 dps_results: {
@@ -591,7 +591,7 @@ dps_results: {
 dps_results: {
  key: "TestSmite-Settings-Undead-P3-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1322.0303921093634
+  dps: 1322.0303921093637
   tps: 1272.426169507613
  }
 }

--- a/sim/rogue/TestMutilate.results
+++ b/sim/rogue/TestMutilate.results
@@ -52,630 +52,630 @@ character_stats_results: {
 dps_results: {
  key: "TestMutilate-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 1732.010291664749
-  tps: 1229.7273070819715
+  dps: 1822.861909607011
+  tps: 1294.2319558209774
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AssassinationArmor"
  value: {
-  dps: 1535.8957492380757
-  tps: 1090.4859819590338
+  dps: 1631.7842651220471
+  tps: 1158.566828236653
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1722.1298555089284
-  tps: 1222.712197411339
+  dps: 1796.8048300302933
+  tps: 1275.731429321508
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1798.0774777935126
-  tps: 1276.6350092333944
+  dps: 1877.3102142955352
+  tps: 1332.8902521498303
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1728.1121793629168
-  tps: 1226.9596473476709
+  dps: 1811.133862938795
+  tps: 1285.9050426865438
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1722.1298555089284
-  tps: 1198.2579534631127
+  dps: 1796.8048300302933
+  tps: 1250.2168007350779
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 1722.558500745238
-  tps: 1223.0165355291185
+  dps: 1814.1700023337235
+  tps: 1288.0607016569431
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1740.011414706942
-  tps: 1235.4081044419286
+  dps: 1823.2183701613558
+  tps: 1294.4850428145621
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1732.1664621989853
-  tps: 1229.8381881612793
+  dps: 1822.9885119790306
+  tps: 1294.3218435051112
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1773.066811689095
-  tps: 1258.8774362992567
+  dps: 1863.396495799984
+  tps: 1323.011512017988
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 1780.6659968510903
-  tps: 1264.2728577642738
+  dps: 1866.7516078797787
+  tps: 1325.3936415946423
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 1794.0848916066739
-  tps: 1273.8002730407375
+  dps: 1891.8323733777675
+  tps: 1343.2009850982142
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 1747.9770154908285
-  tps: 1241.0636809984883
+  dps: 1833.448157429423
+  tps: 1301.7481917748898
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1724.7913508790339
-  tps: 1224.601859124113
+  dps: 1829.0492427925733
+  tps: 1298.6249623827266
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Deathmantle"
  value: {
-  dps: 1678.7398586601837
-  tps: 1191.9052996487296
+  dps: 1790.5090479424111
+  tps: 1271.2614240391115
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1695.1415970879978
-  tps: 1203.5505339324777
+  dps: 1774.654713854318
+  tps: 1260.004846836565
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1725.8131603832717
-  tps: 1225.3273438721221
+  dps: 1812.9386999986418
+  tps: 1287.186476999035
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1722.1298555089284
-  tps: 1222.712197411339
+  dps: 1796.8048300302933
+  tps: 1275.731429321508
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1722.1298555089284
-  tps: 1222.712197411339
+  dps: 1796.8048300302933
+  tps: 1275.731429321508
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1728.1121793629168
-  tps: 1226.9596473476709
+  dps: 1811.133862938795
+  tps: 1285.9050426865438
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1720.707559526636
-  tps: 1221.702367263911
+  dps: 1809.325002255313
+  tps: 1284.6207516012719
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1722.1298555089284
-  tps: 1222.712197411339
+  dps: 1796.8048300302933
+  tps: 1275.731429321508
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1736.7055622856192
-  tps: 1233.0609492227898
+  dps: 1850.4808395542573
+  tps: 1313.8413960835219
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1727.6802320350203
-  tps: 1226.652964744864
+  dps: 1821.1813511966516
+  tps: 1293.0387593496223
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1728.1371511610037
-  tps: 1226.977377324312
+  dps: 1810.1445028676367
+  tps: 1285.2025970360214
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1722.1298555089284
-  tps: 1222.712197411339
+  dps: 1796.8048300302933
+  tps: 1275.731429321508
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1722.1298555089284
-  tps: 1222.712197411339
+  dps: 1796.8048300302933
+  tps: 1275.731429321508
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1798.5692804006853
-  tps: 1276.9841890844857
+  dps: 1879.6695613878924
+  tps: 1334.5653885854026
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1695.1415970879978
-  tps: 1203.5505339324777
+  dps: 1774.654713854318
+  tps: 1260.004846836565
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1695.1415970879978
-  tps: 1203.5505339324777
+  dps: 1774.654713854318
+  tps: 1260.004846836565
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1728.1121793629168
-  tps: 1226.9596473476709
+  dps: 1811.133862938795
+  tps: 1285.9050426865438
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1720.707559526636
-  tps: 1221.702367263911
+  dps: 1809.325002255313
+  tps: 1284.6207516012719
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1825.6453729974637
-  tps: 1296.208214828199
+  dps: 1900.9481796277928
+  tps: 1349.6732075357327
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 1700.634356151809
-  tps: 1207.450392867784
+  dps: 1796.3183496859972
+  tps: 1275.3860282770577
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1722.1298555089284
-  tps: 1222.712197411339
+  dps: 1796.8048300302933
+  tps: 1275.731429321508
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1736.011369215871
-  tps: 1232.568072143268
+  dps: 1810.8892699735115
+  tps: 1285.731381681193
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1695.1415970879978
-  tps: 1203.5505339324777
+  dps: 1774.654713854318
+  tps: 1260.004846836565
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1695.1415970879978
-  tps: 1203.5505339324777
+  dps: 1774.654713854318
+  tps: 1260.004846836565
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1401.381867300754
-  tps: 994.9811257835356
+  dps: 1498.797236413158
+  tps: 1064.1460378533425
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1751.3407969673262
-  tps: 1243.451965846801
+  dps: 1850.1211631218553
+  tps: 1313.586025816517
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Netherblade"
  value: {
-  dps: 1617.5867565360452
-  tps: 1148.4865971405918
+  dps: 1726.286486925348
+  tps: 1225.663405716997
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1695.1415970879978
-  tps: 1203.5505339324777
+  dps: 1774.654713854318
+  tps: 1260.004846836565
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1733.36727136693
-  tps: 1230.69076267052
+  dps: 1808.2065195081366
+  tps: 1283.8266288507766
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1736.011369215871
-  tps: 1232.568072143268
+  dps: 1810.8892699735115
+  tps: 1285.731381681193
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1722.1298555089284
-  tps: 1222.712197411339
+  dps: 1796.8048300302933
+  tps: 1275.731429321508
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1722.1298555089284
-  tps: 1222.712197411339
+  dps: 1796.8048300302933
+  tps: 1275.731429321508
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PrimalIntent"
  value: {
-  dps: 1707.5807628090886
-  tps: 1212.3823415944528
+  dps: 1799.5577267121776
+  tps: 1277.6859859656458
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1695.1415970879978
-  tps: 1203.5505339324777
+  dps: 1774.654713854318
+  tps: 1260.004846836565
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1837.0128680778475
-  tps: 1304.2791363352712
+  dps: 1910.3999228254725
+  tps: 1356.3839452060843
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1854.5231943923839
-  tps: 1316.711468018592
+  dps: 1927.3709109864799
+  tps: 1368.4333468004
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1743.6432590741624
-  tps: 1237.9867139426544
+  dps: 1826.543654849103
+  tps: 1296.845994942862
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1722.1298555089284
-  tps: 1222.712197411339
+  dps: 1796.8048300302933
+  tps: 1275.731429321508
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1695.1415970879978
-  tps: 1203.5505339324777
+  dps: 1774.654713854318
+  tps: 1260.004846836565
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1695.1415970879978
-  tps: 1203.5505339324777
+  dps: 1774.654713854318
+  tps: 1260.004846836565
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 1703.0755146107986
-  tps: 1209.1836153736665
+  dps: 1798.6294008646596
+  tps: 1277.0268746139081
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1695.1415970879978
-  tps: 1203.5505339324777
+  dps: 1774.654713854318
+  tps: 1260.004846836565
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1695.1415970879978
-  tps: 1203.5505339324777
+  dps: 1774.654713854318
+  tps: 1260.004846836565
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Slayer'sArmor"
  value: {
-  dps: 1788.464145754975
-  tps: 1269.8095434860322
+  dps: 1883.7033718868902
+  tps: 1337.429394039692
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SparkofLife-37657"
  value: {
-  dps: 1716.6942679246445
-  tps: 1218.8529302264972
+  dps: 1814.5532872323765
+  tps: 1288.3328339349869
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1574.4403295695772
-  tps: 1117.8526339943994
+  dps: 1668.5642568091505
+  tps: 1184.680622334496
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1509.6297702794604
-  tps: 1071.8371368984176
+  dps: 1602.1380777621891
+  tps: 1137.5180352111543
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1736.011369215871
-  tps: 1232.568072143268
+  dps: 1810.8892699735115
+  tps: 1285.731381681193
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1733.36727136693
-  tps: 1230.69076267052
+  dps: 1808.2065195081366
+  tps: 1283.8266288507766
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1728.7401001312817
-  tps: 1227.4054710932103
+  dps: 1803.51170619373
+  tps: 1280.4933113975492
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TheTwinStars"
  value: {
-  dps: 1671.8994493962296
-  tps: 1187.0486090713227
+  dps: 1747.4726434598717
+  tps: 1240.7055768565087
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1736.2299126456223
-  tps: 1232.7232379783911
+  dps: 1826.1733700468285
+  tps: 1296.5830927332477
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1808.796710069252
-  tps: 1284.2456641491685
+  dps: 1886.50243524567
+  tps: 1339.4167290244252
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1807.374463728072
-  tps: 1283.235869246931
+  dps: 1909.6515310783896
+  tps: 1355.8525870656563
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1722.1298555089284
-  tps: 1222.712197411339
+  dps: 1796.8048300302933
+  tps: 1275.731429321508
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1722.1298555089284
-  tps: 1222.712197411339
+  dps: 1796.8048300302933
+  tps: 1275.731429321508
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1722.1298555089284
-  tps: 1222.712197411339
+  dps: 1796.8048300302933
+  tps: 1275.731429321508
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1722.1298555089284
-  tps: 1222.712197411339
+  dps: 1796.8048300302933
+  tps: 1275.731429321508
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 1811.2855990585426
-  tps: 1286.012775331565
+  dps: 1902.5053625877215
+  tps: 1350.7788074372818
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WastewalkerArmor"
  value: {
-  dps: 1556.2065194261834
-  tps: 1104.9066287925907
+  dps: 1652.4113357482117
+  tps: 1173.2120483812305
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WindhawkArmor"
  value: {
-  dps: 1579.9489752637803
-  tps: 1121.7637724372848
+  dps: 1678.9046135657547
+  tps: 1192.0222756316869
  }
 }
 dps_results: {
  key: "TestMutilate-AllItems-WrathofSpellfire"
  value: {
-  dps: 1577.9340461197123
-  tps: 1120.333172744996
+  dps: 1671.145942371762
+  tps: 1186.5136190839517
  }
 }
 dps_results: {
  key: "TestMutilate-Average-Default"
  value: {
-  dps: 1729.3115467542118
-  tps: 1227.8111981954892
+  dps: 1820.8282657253726
+  tps: 1292.7880686650158
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2226.1312897135113
-  tps: 1580.553215696593
+  dps: 7070.1973757471005
+  tps: 5019.840136780442
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1739.107768583524
-  tps: 1234.7665156943017
+  dps: 1827.8718032063164
+  tps: 1297.788980276484
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1954.020814538058
-  tps: 1387.3547783220208
+  dps: 2015.0268914908315
+  tps: 1430.66909295849
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1080.5125150208837
-  tps: 767.1638856648277
+  dps: 5216.425903184928
+  tps: 3703.6623912613045
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1080.5125150208837
-  tps: 767.1638856648277
+  dps: 1135.6594131577415
+  tps: 806.3181833419968
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-BloodElf-P1 Mutilate-Mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1094.5761560727783
-  tps: 777.1490708116728
+  dps: 1127.7720641808935
+  tps: 800.7181655684345
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2226.239928486167
-  tps: 1580.6303492251786
+  dps: 7071.126566495972
+  tps: 5020.499862212125
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1739.2164338198738
-  tps: 1234.84366801211
+  dps: 1820.830873117992
+  tps: 1292.7899199137742
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1954.095935102349
-  tps: 1387.4081139226673
+  dps: 2014.6159091419704
+  tps: 1430.3772954907986
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1080.71295530938
-  tps: 767.3061982696593
+  dps: 5217.180218671725
+  tps: 3704.1979552569455
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1080.71295530938
-  tps: 767.3061982696593
+  dps: 1135.8266864133582
+  tps: 806.4369473534841
  }
 }
 dps_results: {
  key: "TestMutilate-Settings-Human-P1 Mutilate-Mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1094.832663356264
-  tps: 777.3311909829476
+  dps: 1127.3731729617025
+  tps: 800.434952802809
  }
 }
 dps_results: {
  key: "TestMutilate-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1545.874158398242
-  tps: 1097.5706524627517
+  dps: 1630.4841020968217
+  tps: 1157.6437124887432
  }
 }

--- a/sim/rogue/TestRogue.results
+++ b/sim/rogue/TestRogue.results
@@ -52,728 +52,728 @@ character_stats_results: {
 dps_results: {
  key: "TestRogue-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 2327.867858356183
-  tps: 1652.7861794328905
+  dps: 2274.067646578654
+  tps: 1614.5880290708449
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AssassinationArmor"
  value: {
-  dps: 2088.46870663708
-  tps: 1482.8127817123266
+  dps: 2017.133591746393
+  tps: 1432.1648501399386
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2253.422878514643
+  tps: 1599.9302437453957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2404.5986431793085
-  tps: 1707.2650366573082
+  dps: 2355.2535364666933
+  tps: 1672.2300108913525
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 2316.1353895997077
-  tps: 1644.456126615792
+  dps: 2264.2064010344025
+  tps: 1607.5865447344254
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1601.8734685108188
+  dps: 2253.422878514643
+  tps: 1567.9316388704885
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 2324.3599808543804
-  tps: 1650.2955864066098
+  dps: 2271.927020807102
+  tps: 1613.0681847730425
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2333.89405356963
-  tps: 1657.0647780344377
+  dps: 2281.014542410632
+  tps: 1619.5203251115488
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2343.9615823915874
-  tps: 1664.2127234980278
+  dps: 2293.954178759394
+  tps: 1628.7074669191697
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2372.713886851482
-  tps: 1684.626859664552
+  dps: 2329.8708610463955
+  tps: 1654.2083113429405
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 2404.3834244465097
-  tps: 1707.112231357022
+  dps: 2349.969088438565
+  tps: 1668.4780527913813
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 2430.559338369872
-  tps: 1725.6971302426089
+  dps: 2375.5688551447574
+  tps: 1686.6538871527778
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 2359.759023628594
-  tps: 1675.4289067763016
+  dps: 2306.319274557357
+  tps: 1637.4866849357236
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 2331.678979070443
-  tps: 1655.492075140015
+  dps: 2283.7841324020874
+  tps: 1621.4867340054825
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Deathmantle"
  value: {
-  dps: 2267.522825864552
-  tps: 1609.941206363832
+  dps: 2225.3135767725876
+  tps: 1579.9726395085372
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Defender'sCode-40257"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2232.727269528389
+  tps: 1585.2363613651564
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2318.242216496491
-  tps: 1645.9519737125083
+  dps: 2266.2227748380237
+  tps: 1609.0181701349961
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2253.422878514643
+  tps: 1599.9302437453957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2253.422878514643
+  tps: 1599.9302437453957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 2316.1353895997077
-  tps: 1644.456126615792
+  dps: 2264.2064010344025
+  tps: 1607.5865447344254
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2313.6455526880263
-  tps: 1642.6883424084986
+  dps: 2262.2228517940566
+  tps: 1606.1782247737806
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2253.422878514643
+  tps: 1599.9302437453957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2362.4204536234024
-  tps: 1677.318522072616
+  dps: 2315.6264992543033
+  tps: 1644.094814470555
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2337.194615079628
-  tps: 1659.4081767065363
+  dps: 2286.4735586272186
+  tps: 1623.396226625325
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2328.924853445166
-  tps: 1653.536645946068
+  dps: 2278.1976148039876
+  tps: 1617.5203065108317
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2253.422878514643
+  tps: 1599.9302437453957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2253.422878514643
+  tps: 1599.9302437453957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2422.291664721549
-  tps: 1719.8270819522993
+  dps: 2370.3881996515875
+  tps: 1682.975621752627
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2232.727269528389
+  tps: 1585.2363613651564
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2232.727269528389
+  tps: 1585.2363613651564
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 2316.1353895997077
-  tps: 1644.456126615792
+  dps: 2264.2064010344025
+  tps: 1607.5865447344254
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2313.6455526880263
-  tps: 1642.6883424084986
+  dps: 2262.2228517940566
+  tps: 1606.1782247737806
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2464.695221041232
-  tps: 1749.9336069392753
+  dps: 2408.0473960072404
+  tps: 1709.713651165141
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 2303.048838945097
-  tps: 1635.1646756510188
+  dps: 2251.9222151060712
+  tps: 1598.8647727253108
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2253.422878514643
+  tps: 1599.9302437453957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2320.986696420988
-  tps: 1647.9005544589018
+  dps: 2271.7861012364992
+  tps: 1612.9681318779142
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2232.727269528389
+  tps: 1585.2363613651564
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2232.727269528389
+  tps: 1585.2363613651564
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1906.9900255890159
-  tps: 1353.9629181682012
+  dps: 1851.1440526401889
+  tps: 1314.3122773745342
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2357.1165201646754
-  tps: 1673.5527293169193
+  dps: 2310.027102824216
+  tps: 1640.1192430051935
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Netherblade"
  value: {
-  dps: 2187.333301967571
-  tps: 1553.0066443969758
+  dps: 2156.975240550001
+  tps: 1531.452420790501
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2232.727269528389
+  tps: 1585.2363613651564
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 2317.409019513585
-  tps: 1645.3604038546443
+  dps: 2268.2883445275747
+  tps: 1610.484724614577
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2320.986696420988
-  tps: 1647.9005544589018
+  dps: 2271.7861012364992
+  tps: 1612.9681318779142
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2253.422878514643
+  tps: 1599.9302437453957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2253.422878514643
+  tps: 1599.9302437453957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PrimalIntent"
  value: {
-  dps: 2297.3973064571787
-  tps: 1631.1520875845963
+  dps: 2245.642877218496
+  tps: 1594.4064428251318
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2232.727269528389
+  tps: 1585.2363613651564
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 2417.278869584934
-  tps: 1716.2679974053033
+  dps: 2370.306746273849
+  tps: 1682.917789854433
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 2434.4672878594165
-  tps: 1728.471774380186
+  dps: 2387.654573369156
+  tps: 1695.2347470921009
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2336.753559856877
-  tps: 1659.0950274983825
+  dps: 2284.6790259581417
+  tps: 1622.1221084302808
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2253.422878514643
+  tps: 1599.9302437453957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2232.727269528389
+  tps: 1585.2363613651564
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2232.727269528389
+  tps: 1585.2363613651564
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 2307.1160478684146
-  tps: 1638.0523939865743
+  dps: 2255.774301427041
+  tps: 1601.5997540131991
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2232.727269528389
+  tps: 1585.2363613651564
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2281.6176939568095
-  tps: 1619.9485627093345
+  dps: 2232.727269528389
+  tps: 1585.2363613651564
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Slayer'sArmor"
  value: {
-  dps: 2442.739486416964
-  tps: 1734.3450353560445
+  dps: 2390.251949094885
+  tps: 1697.0788838573676
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SparkofLife-37657"
  value: {
-  dps: 2300.5914102982115
-  tps: 1633.4199013117304
+  dps: 2258.383457438299
+  tps: 1603.452254781193
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 2125.4051935197995
-  tps: 1509.0376873990583
+  dps: 2070.178427375092
+  tps: 1469.8266834363153
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 2033.8619020198998
-  tps: 1444.0419504341291
+  dps: 1980.9987873294017
+  tps: 1406.5091390038751
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2320.986696420988
-  tps: 1647.9005544589018
+  dps: 2271.7861012364992
+  tps: 1612.9681318779142
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 2317.409019513585
-  tps: 1645.3604038546443
+  dps: 2268.2883445275747
+  tps: 1610.484724614577
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2311.148084925625
-  tps: 1640.9151402971936
+  dps: 2262.1672702869546
+  tps: 1606.1387619037378
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheFistsofFury"
  value: {
-  dps: 2380.135084338308
-  tps: 1689.8959098801988
+  dps: 2330.3267097659527
+  tps: 1654.5319639338263
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 2494.9575870113213
-  tps: 1771.4198867780367
+  dps: 2425.7332751441777
+  tps: 1722.270625352366
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinStars"
  value: {
-  dps: 2237.873606793513
-  tps: 1588.8902608233936
+  dps: 2180.200308205862
+  tps: 1547.942218826161
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 2315.9819936374174
-  tps: 1644.347215482566
+  dps: 2283.4147868670293
+  tps: 1621.2244986755904
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2405.473766903376
-  tps: 1707.8863745013975
+  dps: 2356.3033749397678
+  tps: 1672.9753962072355
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2425.8150368706774
-  tps: 1722.3286761781815
+  dps: 2373.872173928722
+  tps: 1685.4492434893928
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2253.422878514643
+  tps: 1599.9302437453957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2253.422878514643
+  tps: 1599.9302437453957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2253.422878514643
+  tps: 1599.9302437453957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2302.2038926571117
-  tps: 1634.56476378655
+  dps: 2253.422878514643
+  tps: 1599.9302437453957
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 2456.6367975146068
-  tps: 1744.212126235371
+  dps: 2403.0506450106227
+  tps: 1706.165957957542
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WastewalkerArmor"
  value: {
-  dps: 2097.183110088511
-  tps: 1489.0000081628432
+  dps: 2054.6202933455265
+  tps: 1458.7804082753237
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WindhawkArmor"
  value: {
-  dps: 2133.630712716767
-  tps: 1514.8778060289046
+  dps: 2076.660989821094
+  tps: 1474.4293027729761
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WrathofSpellfire"
  value: {
-  dps: 2135.8530197388145
-  tps: 1516.4556440145577
+  dps: 2073.9193729537187
+  tps: 1472.4827547971397
  }
 }
 dps_results: {
  key: "TestRogue-Average-Default"
  value: {
-  dps: 2310.650788604967
-  tps: 1640.5620599095223
+  dps: 2265.1541033133253
+  tps: 1608.2594133524667
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3049.1223553594236
-  tps: 2164.876872305191
+  dps: 26823.053857536994
+  tps: 19044.368238851217
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2325.692287630807
-  tps: 1651.2415242178727
+  dps: 2267.687690970888
+  tps: 1610.0582605893308
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2715.659827981758
-  tps: 1928.118477867048
+  dps: 2689.778456842725
+  tps: 1909.7427043583345
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1476.979840978357
-  tps: 1048.655687094633
+  dps: 20171.604011881383
+  tps: 14321.83884843563
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1325.1188386385288
-  tps: 940.8343754333553
+  dps: 1413.7697992968692
+  tps: 1003.7765575007767
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1463.6715145585597
-  tps: 1039.2067753365777
+  dps: 1557.2299683315723
+  tps: 1105.633277515416
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2426.073402961181
-  tps: 1722.512116102438
+  dps: 21127.413408753167
+  tps: 15000.463520214873
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1780.200770631655
-  tps: 1263.9425471484751
+  dps: 1703.4687446454889
+  tps: 1209.4628086982968
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2135.182047446109
-  tps: 1515.9792536867371
+  dps: 2062.3761172312134
+  tps: 1464.2870432341613
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1072.992921681861
-  tps: 761.8249743941212
+  dps: 15894.21855390638
+  tps: 11284.895173273606
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 979.6884284912114
-  tps: 695.5787842287602
+  dps: 1033.5433160566151
+  tps: 733.8157544001969
  }
 }
 dps_results: {
  key: "TestRogue-Settings-BloodElf-P1-Hemo-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1064.39536194558
-  tps: 755.7207069813617
+  dps: 1096.4384470028037
+  tps: 778.4712973719907
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3069.723647425527
-  tps: 2179.5037896721246
+  dps: 26993.545762967533
+  tps: 19165.417491707274
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2328.972537352957
-  tps: 1653.5705015205992
+  dps: 2277.946159510245
+  tps: 1617.3417732522737
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2720.736130135015
-  tps: 1931.7226523958611
+  dps: 2716.4426913598627
+  tps: 1928.6743108655023
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1481.1474839725297
-  tps: 1051.6147136204963
+  dps: 20302.346156373955
+  tps: 14414.665771025491
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1332.19454311772
-  tps: 945.8581256135816
+  dps: 1421.7493091397262
+  tps: 1009.442009489206
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1470.9123016101728
-  tps: 1044.3477341432224
+  dps: 1531.4119380957186
+  tps: 1087.3024760479602
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2442.0095592267085
-  tps: 1733.8267870509626
+  dps: 21319.111509669987
+  tps: 15136.56917186562
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1801.5353108781005
-  tps: 1279.0900707234514
+  dps: 1729.9201639516923
+  tps: 1228.2433164057015
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2160.310165952521
-  tps: 1533.82021782629
+  dps: 2062.5178983854667
+  tps: 1464.3877078536814
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1094.2006438652134
-  tps: 776.8824571443013
+  dps: 16017.097413111589
+  tps: 11372.139163309263
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 993.3133994027423
-  tps: 705.252513575947
+  dps: 1037.9087915290722
+  tps: 736.9152419856412
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-P1-Hemo-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1071.8876009107662
-  tps: 761.0401966466438
+  dps: 1102.623511408405
+  tps: 782.8626930999674
  }
 }
 dps_results: {
  key: "TestRogue-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2113.69516311298
-  tps: 1500.7235658102152
+  dps: 2056.28473731352
+  tps: 1459.9621634925988
  }
 }

--- a/sim/rogue/envenom.go
+++ b/sim/rogue/envenom.go
@@ -77,11 +77,11 @@ func (rogue *Rogue) registerEnvenom() {
 		ActionID: core.ActionID{SpellID: 57993},
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			rogue.DeadlyPoisonProcChanceBonus += 0.15
-			rogue.InstantPoisonProcChanceBonus += 0.75
+			rogue.UpdateInstantPoisonPPM(0.75)
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			rogue.DeadlyPoisonProcChanceBonus -= 0.15
-			rogue.InstantPoisonProcChanceBonus -= 0.75
+			rogue.UpdateInstantPoisonPPM(0.0)
 		},
 	})
 	rogue.Envenom = [6]*core.Spell{

--- a/sim/rogue/expose_armor.go
+++ b/sim/rogue/expose_armor.go
@@ -39,9 +39,6 @@ func (rogue *Rogue) registerExposeArmorSpell() {
 				if spellEffect.Landed() {
 					rogue.ExposeArmorAura.Activate(sim)
 					rogue.ApplyFinisher(sim, spell)
-					if sim.GetRemainingDuration() <= time.Second*30 {
-						rogue.doneEA = true
-					}
 				} else {
 					if refundAmount > 0 {
 						rogue.AddEnergy(sim, spell.CurCast.Cost*refundAmount, rogue.QuickRecoveryMetrics)
@@ -50,8 +47,4 @@ func (rogue *Rogue) registerExposeArmorSpell() {
 			},
 		}),
 	})
-}
-
-func (rogue *Rogue) MaintainingExpose(target *core.Unit) bool {
-	return !rogue.doneEA && (rogue.Talents.ImprovedExposeArmor == 2 || !target.HasActiveAura(core.SunderArmorAuraLabel))
 }

--- a/sim/rogue/fan_of_knives.go
+++ b/sim/rogue/fan_of_knives.go
@@ -1,0 +1,75 @@
+package rogue
+
+import (
+	"time"
+
+	"github.com/wowsims/wotlk/sim/core"
+	"github.com/wowsims/wotlk/sim/core/proto"
+	"github.com/wowsims/wotlk/sim/core/stats"
+)
+
+var FanOfKnivesActionID = core.ActionID{SpellID: 51723}
+
+func (rogue *Rogue) makeFanOfKnifesWeaponHitEffect(isMH bool) core.SpellEffect {
+	var procMask core.ProcMask
+	var baseDamageConfig core.BaseDamageConfig
+	if isMH {
+		weaponMultiplier := core.TernaryFloat64(rogue.Equip[proto.ItemSlot_ItemSlotMainHand].WeaponType == proto.WeaponType_WeaponTypeDagger, 1.05, 0.7)
+		procMask = core.ProcMaskMeleeMHSpecial
+		baseDamageConfig = core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 0, 1, weaponMultiplier, false)
+
+	} else {
+		weaponMultiplier := core.TernaryFloat64(rogue.Equip[proto.ItemSlot_ItemSlotOffHand].WeaponType == proto.WeaponType_WeaponTypeDagger, 1.05, 0.7)
+		weaponMultiplier += 0.1 * float64(rogue.Talents.DualWieldSpecialization)
+		procMask = core.ProcMaskMeleeOHSpecial
+		baseDamageConfig = core.BaseDamageConfigMeleeWeapon(core.OffHand, false, 0, 1, weaponMultiplier, false)
+	}
+	return core.SpellEffect{
+		ProcMask:         procMask,
+		DamageMultiplier: 1 + core.TernaryFloat64(rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfFanOfKnives), 0.2, 0.0),
+		ThreatMultiplier: 1,
+		BaseDamage:       baseDamageConfig,
+		OutcomeApplier:   rogue.OutcomeFuncMeleeSpecialHitAndCrit(rogue.MeleeCritMultiplier(isMH, false)),
+	}
+
+}
+
+func (rogue *Rogue) registerFanOfKnives() {
+	mhWeaponHitSpell := rogue.RegisterSpell(core.SpellConfig{
+		ActionID:     FanOfKnivesActionID.WithTag(1),
+		SpellSchool:  core.SpellSchoolPhysical,
+		Flags:        core.SpellFlagMeleeMetrics | SpellFlagRogueAbility,
+		ApplyEffects: core.ApplyEffectFuncDirectDamage(rogue.makeFanOfKnifesWeaponHitEffect(true)),
+	})
+	ohWeaponHitSpell := rogue.RegisterSpell(core.SpellConfig{
+		ActionID:     FanOfKnivesActionID.WithTag(2),
+		SpellSchool:  core.SpellSchoolPhysical,
+		Flags:        core.SpellFlagMeleeMetrics | SpellFlagRogueAbility,
+		ApplyEffects: core.ApplyEffectFuncDirectDamage(rogue.makeFanOfKnifesWeaponHitEffect(false)),
+	})
+	energyCost := 50.0
+
+	rogue.FanOfKnifes = rogue.RegisterSpell(core.SpellConfig{
+		ActionID:     FanOfKnivesActionID,
+		SpellSchool:  core.SpellSchoolPhysical,
+		Flags:        core.SpellFlagNoMetrics | SpellFlagBuilder,
+		ResourceType: stats.Energy,
+		BaseCost:     energyCost,
+		Cast: core.CastConfig{
+			DefaultCast: core.Cast{
+				Cost: energyCost,
+				GCD:  time.Second,
+			},
+			IgnoreHaste: true,
+		},
+		ApplyEffects: core.ApplyEffectFuncAOEDamage(rogue.Env, core.SpellEffect{
+			ProcMask:         core.ProcMaskEmpty,
+			ThreatMultiplier: 1,
+			OutcomeApplier:   rogue.OutcomeFuncAlwaysHit(),
+			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+				mhWeaponHitSpell.Cast(sim, spellEffect.Target)
+				ohWeaponHitSpell.Cast(sim, spellEffect.Target)
+			},
+		}),
+	})
+}

--- a/sim/rogue/killing_spree.go
+++ b/sim/rogue/killing_spree.go
@@ -1,39 +1,47 @@
 package rogue
 
 import (
+	"math"
 	"time"
 
 	"github.com/wowsims/wotlk/sim/core"
 	"github.com/wowsims/wotlk/sim/core/proto"
 )
 
-func (rogue *Rogue) makeKillingSpreeAttackSpell() *core.Spell {
-	baseEffectMH := core.SpellEffect{
-		ProcMask:         core.ProcMaskMeleeMHSpecial,
+func (rogue *Rogue) makeKillingSpreedWeaponSwingEffect(isMh bool) core.SpellEffect {
+	var procMask core.ProcMask
+	var baseMultiplier float64
+	var hand core.Hand
+	if isMh {
+		procMask = core.ProcMaskMeleeMHSpecial
+		baseMultiplier = 1
+		hand = core.MainHand
+	} else {
+		procMask = core.ProcMaskMeleeOHSpecial
+		baseMultiplier = 1 + 0.1*float64(rogue.Talents.DualWieldSpecialization)
+		hand = core.OffHand
+	}
+	return core.SpellEffect{
+		ProcMask:         procMask,
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
-		BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 0, 1, 1, true),
-		OutcomeApplier:   rogue.OutcomeFuncMeleeWeaponSpecialHitAndCrit(rogue.MeleeCritMultiplier(true, true)),
+		BaseDamage:       core.BaseDamageConfigMeleeWeapon(hand, true, 0, baseMultiplier, 1, true),
+		OutcomeApplier:   rogue.OutcomeFuncMeleeWeaponSpecialHitAndCrit(rogue.MeleeCritMultiplier(isMh, false)),
 	}
-	baseEffectMH.Target = rogue.CurrentTarget
-	baseEffectOH := core.SpellEffect{
-		ProcMask:         core.ProcMaskMeleeOHSpecial,
-		DamageMultiplier: 1,
-		ThreatMultiplier: 1,
-		BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, 1+0.05*float64(rogue.Talents.DualWieldSpecialization), 1, true),
-		OutcomeApplier:   rogue.OutcomeFuncMeleeWeaponSpecialHitAndCrit(rogue.MeleeCritMultiplier(true, true)),
-	}
-	baseEffectOH.Target = rogue.CurrentTarget
-	killingSpreeAttackSpell := rogue.GetOrRegisterSpell(core.SpellConfig{
+}
+func (rogue *Rogue) registerKillingSpreeSpell() {
+	mhWeaponSwing := rogue.GetOrRegisterSpell(core.SpellConfig{
 		ActionID:     core.ActionID{SpellID: 51690, Tag: 1},
 		SpellSchool:  core.SpellSchoolPhysical,
 		Flags:        core.SpellFlagMeleeMetrics,
-		ApplyEffects: core.ApplyEffectFuncDamageMultiple([]core.SpellEffect{baseEffectMH, baseEffectOH}),
+		ApplyEffects: core.ApplyEffectFuncDirectDamage(rogue.makeKillingSpreedWeaponSwingEffect(true)),
 	})
-	return killingSpreeAttackSpell
-}
-func (rogue *Rogue) registerKillingSpreeSpell() {
-	attackSpell := rogue.makeKillingSpreeAttackSpell()
+	ohWeaponSwing := rogue.GetOrRegisterSpell(core.SpellConfig{
+		ActionID:     core.ActionID{SpellID: 51690, Tag: 2},
+		SpellSchool:  core.SpellSchoolPhysical,
+		Flags:        core.SpellFlagMeleeMetrics,
+		ApplyEffects: core.ApplyEffectFuncDirectDamage(rogue.makeKillingSpreedWeaponSwingEffect(false)),
+	})
 	rogue.KillingSpreeAura = rogue.RegisterAura(core.Aura{
 		Label:    "Killing Spree",
 		ActionID: core.ActionID{SpellID: 51690},
@@ -43,13 +51,21 @@ func (rogue *Rogue) registerKillingSpreeSpell() {
 			// This first attack could/should? be implemented as an immediate tick
 			// but there is currently an issue causing the periodic action
 			// to only fire once when this flag is set
-			attackSpell.Cast(sim, rogue.CurrentTarget)
+			mhWeaponSwing.Cast(sim, rogue.CurrentTarget)
+			ohWeaponSwing.Cast(sim, rogue.CurrentTarget)
 			core.StartPeriodicAction(sim, core.PeriodicActionOptions{
 				Period:          time.Millisecond * 500,
 				NumTicks:        4,
 				TickImmediately: false,
 				OnAction: func(s *core.Simulation) {
-					attackSpell.Cast(sim, rogue.CurrentTarget)
+					targetCount := sim.GetNumTargets()
+					target := rogue.CurrentTarget
+					if targetCount > 1 {
+						newTargetIndex := int32(math.Ceil(float64(targetCount)*sim.RandomFloat("Killing Spree"))) - 1
+						target = sim.GetTargetUnit(newTargetIndex)
+					}
+					mhWeaponSwing.Cast(sim, target)
+					ohWeaponSwing.Cast(sim, target)
 				},
 			})
 		},

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -70,11 +70,11 @@ type Rogue struct {
 	Rupture      [6]*core.Spell
 	SliceAndDice [6]*core.Spell
 
-	LastDeadlyPoisonProcMask     core.ProcMask
-	DeadlyPoisonProcChanceBonus  float64
-	InstantPoisonProcChanceBonus float64
-	DeadlyPoisonDots             []*core.Dot
-	RuptureDot                   *core.Dot
+	LastDeadlyPoisonProcMask    core.ProcMask
+	DeadlyPoisonProcChanceBonus float64
+	InstantPoisonPPMM           core.PPMManager
+	DeadlyPoisonDots            []*core.Dot
+	RuptureDot                  *core.Dot
 
 	AdrenalineRushAura  *core.Aura
 	BladeFlurryAura     *core.Aura
@@ -212,7 +212,6 @@ func NewRogue(character core.Character, options proto.Player) *Rogue {
 		Options:   *rogueOptions.Options,
 		Rotation:  *rogueOptions.Rotation,
 	}
-	rogue.applyPoisons()
 
 	// Passive rogue threat reduction: https://wotlk.wowhead.com/spell=21184/rogue-passive-dnd
 	rogue.PseudoStats.ThreatMultiplier *= 0.71
@@ -266,6 +265,7 @@ func NewRogue(character core.Character, options proto.Player) *Rogue {
 		OffHand:        rogue.WeaponFromOffHand(0),  // Set crit multiplier later when we have targets.
 		AutoSwingMelee: true,
 	})
+	rogue.applyPoisons()
 
 	rogue.AddStatDependency(stats.Strength, stats.AttackPower, 1.0+1)
 	rogue.AddStatDependency(stats.Agility, stats.AttackPower, 1.0+1)

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -56,6 +56,7 @@ type Rogue struct {
 
 	Backstab       *core.Spell
 	DeadlyPoison   *core.Spell
+	FanOfKnifes    *core.Spell
 	Hemorrhage     *core.Spell
 	HungerForBlood *core.Spell
 	InstantPoison  [3]*core.Spell
@@ -136,6 +137,7 @@ func (rogue *Rogue) Initialize() {
 	rogue.registerDeadlyPoisonSpell()
 	rogue.registerEviscerate()
 	rogue.registerExposeArmorSpell()
+	rogue.registerFanOfKnives()
 	rogue.registerHemorrhageSpell()
 	rogue.registerInstantPoisonSpell()
 	rogue.registerMutilateSpell()

--- a/sim/rogue/rotation.go
+++ b/sim/rogue/rotation.go
@@ -1,6 +1,7 @@
 package rogue
 
 import (
+	"math"
 	"time"
 
 	"github.com/wowsims/wotlk/sim/core"
@@ -18,395 +19,87 @@ const (
 	PlanMaximalSlice
 )
 
-func (rogue *Rogue) OnGCDReady(sim *core.Simulation) {
-	rogue.doRotation(sim)
-}
-
-func (rogue *Rogue) doAssassinationRotation(sim *core.Simulation) {
-	switch rogue.plan {
-	case PlanNone:
-		rogue.doAssassinationNone(sim)
-	case PlanSliceASAP:
-		rogue.doPlanSliceASAP(sim)
-	case PlanOpener:
-		rogue.doPlanSliceASAP(sim)
+func (rogue *Rogue) OnEnergyGain(sim *core.Simulation) {
+	rogue.TryUseCooldowns(sim)
+	if rogue.GCD.IsReady(sim) {
+		rogue.rotation(sim)
 	}
 }
 
-func (rogue *Rogue) doRotation(sim *core.Simulation) {
+func (rogue *Rogue) OnGCDReady(sim *core.Simulation) {
+	rogue.rotation(sim)
+}
+
+func (rogue *Rogue) rotation(sim *core.Simulation) {
 	if rogue.KillingSpreeAura.IsActive() {
 		rogue.DoNothing()
 		return
 	}
-	if rogue.Rotation.UseEnvenom {
-		rogue.doAssassinationRotation(sim)
+	var spell *core.Spell
+	if sim.GetNumTargets() > 1 {
+		spell = rogue.multiTargetChooseSpell(sim)
 	} else {
-		switch rogue.plan {
-		case PlanNone:
-			rogue.doPlanNone(sim)
-		case PlanSliceASAP:
-			rogue.doPlanSliceASAP(sim)
-		case PlanMaximalSlice:
-			rogue.doPlanMaximalSlice(sim)
-		case PlanExposeArmor:
-			rogue.doPlanExposeArmor(sim)
-		case PlanFillBeforeEA:
-			rogue.doPlanFillBeforeEA(sim)
-		case PlanFillBeforeSND:
-			rogue.doPlanFillBeforeSND(sim)
-		case PlanOpener:
-			rogue.doPlanOpener(sim)
-		}
+		spell = rogue.singleTargetChooseSpell(sim)
 	}
-
-	// If rogue decided to not use GCD, mark exsplicitly this is ok.
+	spell.Cast(sim, rogue.CurrentTarget)
 	if rogue.GCD.IsReady(sim) {
 		rogue.DoNothing()
 	}
 }
 
-// Opening rotation.
-func (rogue *Rogue) doPlanOpener(sim *core.Simulation) {
-	// Can add other opener logic here if we want.
-	rogue.plan = PlanSliceASAP
-	rogue.doPlanSliceASAP(sim)
+func (rogue *Rogue) multiTargetChooseSpell(sim *core.Simulation) *core.Spell {
+	return rogue.FanOfKnifes
 }
 
-// Cast SND as the next finisher, using no more builders than necessary.
-func (rogue *Rogue) doPlanSliceASAP(sim *core.Simulation) {
-	if rogue.doneSND {
-		rogue.plan = PlanNone
-		rogue.doPlanNone(sim)
-		return
+func (rogue *Rogue) singleTargetChooseSpell(sim *core.Simulation) *core.Spell {
+	sliceRemaining := rogue.SliceAndDiceAura.RemainingDuration(sim)
+	eaRemaining := time.Second * math.MaxInt32
+	refreshThreshold := time.Second * 0
+	if rogue.Rotation.MaintainExposeArmor {
+		eaRemaining = rogue.ExposeArmorAura.RemainingDuration(sim)
 	}
-
-	energy := rogue.CurrentEnergy()
-	comboPoints := rogue.ComboPoints()
-	target := rogue.CurrentTarget
-	sndTimeRemaining := rogue.SliceAndDiceAura.RemainingDuration(sim)
-
-	if comboPoints > 0 {
-		if energy >= SliceAndDiceEnergyCost || rogue.DeathmantleProcAura.IsActive() {
-			if rogue.canPoolEnergy(sim, energy) && sndTimeRemaining > time.Second*2 {
-				return
-			}
-			rogue.SliceAndDice[comboPoints].Cast(sim, nil)
-			if rogue.disabledMCDs != nil {
-				rogue.EnableAllCooldowns(rogue.disabledMCDs)
-				rogue.disabledMCDs = nil
-			}
-			rogue.plan = PlanNone
-		}
-		return
-	} else {
-		if energy >= rogue.Builder.DefaultCast.Cost {
-			rogue.castBuilder(sim, target)
-		}
-	}
-}
-
-// Get the biggest Slice we can, but still leaving time for EA if necessary.
-func (rogue *Rogue) doPlanMaximalSlice(sim *core.Simulation) {
-	if rogue.doneSND {
-		rogue.plan = PlanNone
-		rogue.doPlanNone(sim)
-		return
-	}
-
-	energy := rogue.CurrentEnergy()
-	comboPoints := rogue.ComboPoints()
-	target := rogue.CurrentTarget
-	sndTimeRemaining := rogue.SliceAndDiceAura.RemainingDuration(sim)
-
-	remainingSimDuration := sim.GetRemainingDuration()
-	if rogue.sliceAndDiceDurations[comboPoints] >= remainingSimDuration {
-		if energy >= SliceAndDiceEnergyCost || rogue.DeathmantleProcAura.IsActive() {
-			if rogue.canPoolEnergy(sim, energy) && sndTimeRemaining > time.Second*2 {
-				return
-			}
-			rogue.SliceAndDice[comboPoints].Cast(sim, nil)
-			rogue.plan = PlanNone
-		}
-		return
-	}
-
-	if sndTimeRemaining <= time.Second && comboPoints > 0 {
-		if energy >= SliceAndDiceEnergyCost || rogue.DeathmantleProcAura.IsActive() {
-			rogue.SliceAndDice[comboPoints].Cast(sim, nil)
-			rogue.plan = PlanNone
-		}
-		return
-	}
-
-	if rogue.MaintainingExpose(target) {
-		eaTimeRemaining := rogue.ExposeArmorAura.RemainingDuration(sim)
-		if rogue.eaBuildTime+buildTimeBuffer > eaTimeRemaining {
-			// Cast our slice and start prepping for EA.
-			if comboPoints == 0 {
-				rogue.plan = PlanExposeArmor
-				rogue.doPlanExposeArmor(sim)
-				return
-			}
-			if energy >= SliceAndDiceEnergyCost || rogue.DeathmantleProcAura.IsActive() {
-				if rogue.canPoolEnergy(sim, energy) && sndTimeRemaining > time.Second*2 {
-					return
-				}
-				rogue.SliceAndDice[comboPoints].Cast(sim, nil)
-				rogue.plan = PlanExposeArmor
-				return
-			}
+	cp := rogue.ComboPoints()
+	if sliceRemaining <= refreshThreshold {
+		if cp > 0 {
+			return rogue.SliceAndDice[cp]
 		} else {
-			if comboPoints == 5 {
-				if energy >= SliceAndDiceEnergyCost || rogue.DeathmantleProcAura.IsActive() {
-					if rogue.canPoolEnergy(sim, energy) && sndTimeRemaining > time.Second*2 {
-						return
-					}
-					rogue.SliceAndDice[comboPoints].Cast(sim, nil)
-					rogue.plan = PlanFillBeforeEA
-					return
-				}
-			} else if energy >= rogue.Builder.DefaultCast.Cost {
-				rogue.castBuilder(sim, target)
-			}
-		}
-	} else {
-		if comboPoints == 5 {
-			if energy >= SliceAndDiceEnergyCost || rogue.DeathmantleProcAura.IsActive() {
-				if rogue.canPoolEnergy(sim, energy) && sndTimeRemaining > time.Second*2 {
-					return
-				}
-				rogue.SliceAndDice[comboPoints].Cast(sim, nil)
-				rogue.plan = PlanFillBeforeSND
-				return
-			}
-		} else if energy >= rogue.Builder.DefaultCast.Cost {
-			rogue.castBuilder(sim, target)
+			return rogue.Builder
 		}
 	}
-}
-
-// Build towards and cast a 5 pt Expose Armor.
-func (rogue *Rogue) doPlanExposeArmor(sim *core.Simulation) {
-	if rogue.doneEA {
-		rogue.plan = PlanNone
-		rogue.doPlanNone(sim)
-		return
-	}
-
-	energy := rogue.CurrentEnergy()
-	comboPoints := rogue.ComboPoints()
-	target := rogue.CurrentTarget
-
-	if comboPoints == 5 {
-		if energy >= rogue.ExposeArmor.DefaultCast.Cost || rogue.DeathmantleProcAura.IsActive() {
-			eaTimeRemaining := rogue.ExposeArmorAura.RemainingDuration(sim)
-			if rogue.canPoolEnergy(sim, energy) && eaTimeRemaining > time.Second*2 {
-				return
-			}
-			rogue.ExposeArmor.Cast(sim, target)
-			rogue.plan = PlanNone
-		}
-		return
-	} else {
-		if energy >= rogue.Builder.DefaultCast.Cost {
-			rogue.castBuilder(sim, target)
-		}
-	}
-}
-
-// Optional dps finisher followed by EA.
-func (rogue *Rogue) doPlanFillBeforeEA(sim *core.Simulation) {
-	energy := rogue.CurrentEnergy()
-	comboPoints := rogue.ComboPoints()
-	target := rogue.CurrentTarget
-	eaTimeRemaining := rogue.ExposeArmorAura.RemainingDuration(sim)
-
-	if rogue.eaBuildTime+buildTimeBuffer > eaTimeRemaining {
-		// Cast our finisher and start prepping for EA.
-		if comboPoints == 0 {
-			rogue.plan = PlanExposeArmor
-			rogue.doPlanExposeArmor(sim)
-			return
+	if rogue.Rotation.MaintainExposeArmor && rogue.ExposeArmorAura.RemainingDuration(sim) <= refreshThreshold {
+		if cp > 0 {
+			return rogue.ExposeArmor
 		} else {
-			if comboPoints < rogue.Rotation.MinComboPointsForDamageFinisher {
-				rogue.plan = PlanExposeArmor
-				return
-			}
-			if rogue.tryUseDamageFinisher(sim, energy, comboPoints) {
-				rogue.plan = PlanExposeArmor
-				return
-			}
-		}
-	} else {
-		if comboPoints == 5 {
-			rogue.tryUseDamageFinisher(sim, energy, comboPoints)
-		} else if energy >= rogue.Builder.DefaultCast.Cost {
-			rogue.castBuilder(sim, target)
+			return rogue.Builder
 		}
 	}
+	if rogue.disabledMCDs != nil {
+		rogue.EnableAllCooldowns(rogue.disabledMCDs)
+		rogue.disabledMCDs = nil
+	}
+	cpGained := rogue.expectedComboPoints(core.MinDuration(sliceRemaining, eaRemaining))
+	if (cp+cpGained) < 5 && rogue.Talents.CutToTheChase < 1 {
+		return rogue.Builder
+	}
+	if rogue.Talents.HungerForBlood && rogue.HungerForBloodAura.RemainingDuration(sim) <= refreshThreshold {
+		// TODO : needs to have a bleed
+		return rogue.HungerForBlood
+	}
+	if rogue.Rotation.UseEnvenom && rogue.EnvenomAura.RemainingDuration(sim) <= refreshThreshold {
+		if cp > 2 {
+			return rogue.Envenom[cp]
+		}
+	}
+	if rogue.Rotation.UseRupture && rogue.RuptureDot.RemainingDuration(sim) <= refreshThreshold {
+		if cp > 0 {
+			return rogue.Rupture[cp]
+		}
+	}
+	return rogue.Builder
 }
 
-// Optional dps finisher followed by SND.
-func (rogue *Rogue) doPlanFillBeforeSND(sim *core.Simulation) {
-	energy := rogue.CurrentEnergy()
-	comboPoints := rogue.ComboPoints()
-	target := rogue.CurrentTarget
-	sndTimeRemaining := rogue.SliceAndDiceAura.RemainingDuration(sim)
-
-	if !rogue.doneSND && rogue.eaBuildTime+buildTimeBuffer > sndTimeRemaining {
-		// Cast our finisher and start prepping for SND.
-		if comboPoints == 0 {
-			rogue.plan = PlanMaximalSlice
-			rogue.doPlanMaximalSlice(sim)
-			return
-		} else {
-			if comboPoints < rogue.Rotation.MinComboPointsForDamageFinisher {
-				rogue.plan = PlanMaximalSlice
-				return
-			}
-			if rogue.tryUseDamageFinisher(sim, energy, comboPoints) {
-				rogue.plan = PlanMaximalSlice
-				return
-			}
-		}
-	} else {
-		if comboPoints == 5 || (comboPoints > 0 && sim.GetRemainingDuration() < time.Second*2) {
-			rogue.tryUseDamageFinisher(sim, energy, comboPoints)
-		} else if energy >= rogue.Builder.DefaultCast.Cost {
-			rogue.castBuilder(sim, target)
-		}
-	}
-}
-
-func (rogue *Rogue) doAssassinationNone(sim *core.Simulation) {
-	energy := rogue.CurrentEnergy()
-	if energy < 15 {
-		return
-	}
-	comboPoints := rogue.ComboPoints()
-	sndTimeRemaining := rogue.SliceAndDiceAura.RemainingDuration(sim)
-	if sndTimeRemaining <= 0 {
-		rogue.plan = PlanSliceASAP
-		return
-	}
-	hungerTimeRemaining := rogue.HungerForBloodAura.RemainingDuration(sim)
-	if hungerTimeRemaining < time.Second*2 {
-		rogue.HungerForBlood.Cast(sim, nil)
-		rogue.plan = PlanNone
-		return
-	}
-	envenomTimeRemaining := rogue.GetAura("Envenom").RemainingDuration(sim)
-	if envenomTimeRemaining <= time.Second*1 && comboPoints >= rogue.Rotation.MinComboPointsForDamageFinisher {
-		if energy >= rogue.Envenom[comboPoints].DefaultCast.Cost {
-			rogue.Envenom[comboPoints].Cast(sim, rogue.CurrentTarget)
-			rogue.plan = PlanNone
-			return
-		}
-	}
-	if comboPoints <= 3 {
-		if energy >= rogue.Builder.BaseCost {
-			rogue.Builder.Cast(sim, rogue.CurrentTarget)
-			rogue.plan = PlanNone
-		}
-	}
-}
-
-func (rogue *Rogue) doPlanNone(sim *core.Simulation) {
-	energy := rogue.CurrentEnergy()
-	if energy < 25 {
-		// No ability costs < 25 energy so just wait.
-		return
-	}
-
-	comboPoints := rogue.ComboPoints()
-	target := rogue.CurrentTarget
-
-	if comboPoints == 0 {
-		// No option other than using a builder.
-		if energy >= rogue.Builder.DefaultCast.Cost {
-			rogue.castBuilder(sim, target)
-		}
-		return
-	}
-
-	sndTimeRemaining := rogue.SliceAndDiceAura.RemainingDuration(sim)
-
-	if !rogue.MaintainingExpose(target) {
-		if rogue.doneSND || sndTimeRemaining > rogue.eaBuildTime+buildTimeBuffer {
-			rogue.plan = PlanFillBeforeSND
-			rogue.doPlanFillBeforeSND(sim)
-		} else {
-			rogue.plan = PlanMaximalSlice
-			rogue.doPlanMaximalSlice(sim)
-		}
-		return
-	}
-
-	eaTimeRemaining := rogue.ExposeArmorAura.RemainingDuration(sim)
-	energyForEANext := rogue.Builder.DefaultCast.Cost*float64(5-comboPoints) + rogue.ExposeArmor.DefaultCast.Cost
-	eaNextBuildTime := core.MaxDuration(0, time.Duration(((energyForEANext-energy)/rogue.energyPerSecondAvg)*float64(time.Second)))
-	spareTime := core.MaxDuration(0, eaTimeRemaining-eaNextBuildTime)
-	if spareTime <= buildTimeBuffer {
-		rogue.plan = PlanExposeArmor
-		rogue.doPlanExposeArmor(sim)
-		return
-	}
-
-	if sndTimeRemaining == 0 {
-		rogue.plan = PlanSliceASAP
-		rogue.doPlanSliceASAP(sim)
-		return
-	}
-
-	if sndTimeRemaining > eaTimeRemaining {
-		rogue.plan = PlanFillBeforeEA
-		rogue.doPlanFillBeforeEA(sim)
-		return
-	}
-
-	if rogue.doneSND {
-		rogue.plan = PlanFillBeforeSND
-		rogue.doPlanFillBeforeSND(sim)
-		return
-	}
-
-	rogue.plan = PlanMaximalSlice
-	rogue.doPlanMaximalSlice(sim)
-}
-
-func (rogue *Rogue) canPoolEnergy(sim *core.Simulation, energy float64) bool {
-	return sim.GetRemainingDuration() >= time.Second*6 && energy <= 85 && ((rogue.AdrenalineRushAura == nil || !rogue.AdrenalineRushAura.IsActive()) || energy <= 70)
-}
-
-func (rogue *Rogue) castBuilder(sim *core.Simulation, target *core.Unit) {
-	if rogue.Rotation.UseShiv && rogue.DeadlyPoisonDots[target.Index].IsActive() && rogue.DeadlyPoisonDots[target.Index].RemainingDuration(sim) < time.Second*2 && rogue.CurrentEnergy() >= rogue.Shiv.DefaultCast.Cost {
-		rogue.Shiv.Cast(sim, target)
-	} else {
-		rogue.Builder.Cast(sim, target)
-	}
-}
-
-func (rogue *Rogue) tryUseDamageFinisher(sim *core.Simulation, energy float64, comboPoints int32) bool {
-	newRuptureDuration := core.MinDuration(rogue.RuptureDuration(comboPoints), sim.GetRemainingDuration())
-	if rogue.RuptureDot.IsActive() {
-		newRuptureDuration -= core.MinDuration(rogue.RuptureDot.RemainingDuration(sim), sim.GetRemainingDuration())
-	}
-	if rogue.Rotation.UseRupture &&
-		newRuptureDuration >= time.Second*10 &&
-		(sim.GetNumTargets() == 1 || (rogue.BladeFlurryAura == nil || !rogue.BladeFlurryAura.IsActive())) {
-		if energy >= RuptureEnergyCost || rogue.DeathmantleProcAura.IsActive() {
-			rogue.Rupture[comboPoints].Cast(sim, rogue.CurrentTarget)
-		}
-		return true
-	}
-	if rogue.Rotation.UseEnvenom &&
-		energy >= rogue.Envenom[comboPoints].DefaultCast.Cost {
-		rogue.Envenom[comboPoints].Cast(sim, rogue.CurrentTarget)
-		return true
-	}
-	if energy >= rogue.Eviscerate[comboPoints].DefaultCast.Cost || rogue.DeathmantleProcAura.IsActive() {
-		rogue.Eviscerate[comboPoints].Cast(sim, rogue.CurrentTarget)
-		return true
-	}
-	return false
+func (rogue *Rogue) expectedComboPoints(duration time.Duration) int32 {
+	expectedEnergyGain := rogue.energyPerSecondAvg * duration.Seconds()
+	builderCasts := core.MinFloat((rogue.CurrentEnergy()+expectedEnergyGain)/rogue.Builder.DefaultCast.Cost, duration.Seconds())
+	return int32(math.Floor(builderCasts) * rogue.BuilderComboPoints)
 }

--- a/sim/rogue/slice_and_dice.go
+++ b/sim/rogue/slice_and_dice.go
@@ -37,12 +37,7 @@ func (rogue *Rogue) makeSliceAndDice(comboPoints int32) *core.Spell {
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
 			rogue.SliceAndDiceAura.Duration = duration
 			rogue.SliceAndDiceAura.Activate(sim)
-
 			rogue.ApplyFinisher(sim, spell)
-
-			if duration >= sim.GetRemainingDuration() {
-				rogue.doneSND = true
-			}
 		},
 	})
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -55,7 +55,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.7216994259893499
+  weights: 1.7216994259893545
   weights: 0
   weights: 0.6899960812406744
   weights: 0
@@ -67,7 +67,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0.9646277049934724
-  weights: 0.8875967433603638
+  weights: 0.8875967433603682
   weights: 0
   weights: 0
   weights: 0
@@ -104,7 +104,7 @@ dps_results: {
  key: "TestElemental-AllItems-AshtongueTalismanofVision-32491"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
@@ -118,7 +118,7 @@ dps_results: {
  key: "TestElemental-AllItems-Bandit'sInsignia-40371"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
@@ -131,7 +131,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2748.3016277864044
+  dps: 2748.301627786404
   tps: 2115.5614467706973
  }
 }
@@ -167,13 +167,13 @@ dps_results: {
  key: "TestElemental-AllItems-CycloneHarness"
  value: {
   dps: 1783.8386923095209
-  tps: 1431.8757766105173
+  tps: 1431.875776610517
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CycloneRegalia"
  value: {
-  dps: 2105.4451332442454
+  dps: 2105.445133244246
   tps: 1671.5573088832941
  }
 }
@@ -187,22 +187,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2883.314896905512
+  dps: 2883.3148969055114
   tps: 2273.195435716966
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 2704.7702013474795
-  tps: 2113.8945445589916
+  dps: 2704.77020134748
+  tps: 2113.894544558992
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 2704.7702013474795
-  tps: 2113.8945445589916
+  dps: 2704.77020134748
+  tps: 2113.894544558992
  }
 }
 dps_results: {
@@ -216,14 +216,14 @@ dps_results: {
  key: "TestElemental-AllItems-DeathKnight'sAnguish-38212"
  value: {
   dps: 2781.2707548962157
-  tps: 2185.6406305103023
+  tps: 2185.640630510303
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Defender'sCode-40257"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
@@ -236,7 +236,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2764.3947215201283
+  dps: 2764.3947215201274
   tps: 2167.8697599289053
  }
 }
@@ -278,7 +278,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2782.519337345478
+  dps: 2782.5193373454777
   tps: 2178.6916074420083
  }
 }
@@ -293,13 +293,13 @@ dps_results: {
  key: "TestElemental-AllItems-ExtractofNecromanticPower-40373"
  value: {
   dps: 2854.977684726765
-  tps: 2242.2243858683405
+  tps: 2242.224385868341
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2903.09888545844
+  dps: 2903.0988854584402
   tps: 2274.7715686449746
  }
 }
@@ -327,7 +327,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2748.3016277864044
+  dps: 2748.301627786404
   tps: 2158.251754859516
  }
 }
@@ -342,7 +342,7 @@ dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sBattlegear"
  value: {
   dps: 1958.287862463448
-  tps: 1553.6025789322396
+  tps: 1553.6025789322393
  }
 }
 dps_results: {
@@ -356,7 +356,7 @@ dps_results: {
  key: "TestElemental-AllItems-FuryoftheFiveFlights-40431"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
@@ -370,14 +370,14 @@ dps_results: {
  key: "TestElemental-AllItems-Gladiator'sEarthshaker"
  value: {
   dps: 2297.534631311503
-  tps: 1811.8491635096373
+  tps: 1811.8491635096368
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
   dps: 2921.253655723981
-  tps: 2288.4627574346882
+  tps: 2288.4627574346887
  }
 }
 dps_results: {
@@ -390,7 +390,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2782.519337345478
+  dps: 2782.5193373454777
   tps: 2178.6916074420083
  }
 }
@@ -411,7 +411,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 3126.274672485019
+  dps: 3126.274672485018
   tps: 2448.338531520568
  }
 }
@@ -426,14 +426,14 @@ dps_results: {
  key: "TestElemental-AllItems-Lavanthor'sTalisman-37872"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MajesticDragonFigurine-40430"
  value: {
   dps: 2789.792791872217
-  tps: 2185.5000475138395
+  tps: 2185.50004751384
  }
 }
 dps_results: {
@@ -446,7 +446,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2832.328763697961
+  dps: 2832.328763697962
   tps: 2225.1704274806925
  }
 }
@@ -461,7 +461,7 @@ dps_results: {
  key: "TestElemental-AllItems-NetherscaleArmor"
  value: {
   dps: 2354.025599383508
-  tps: 1863.0824115447545
+  tps: 1863.0824115447547
  }
 }
 dps_results: {
@@ -489,7 +489,7 @@ dps_results: {
  key: "TestElemental-AllItems-OfferingofSacrifice-37638"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
@@ -531,7 +531,7 @@ dps_results: {
  key: "TestElemental-AllItems-PurifiedShardoftheGods"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
@@ -551,8 +551,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2806.471982931794
-  tps: 2204.7695841663626
+  dps: 2806.4719829317946
+  tps: 2204.769584166363
  }
 }
 dps_results: {
@@ -566,20 +566,20 @@ dps_results: {
  key: "TestElemental-AllItems-RuneofRepulsion-40372"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SealofthePantheon-36993"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 2804.486465922195
+  dps: 2804.4864659221953
   tps: 2193.7024020586987
  }
 }
@@ -587,21 +587,21 @@ dps_results: {
  key: "TestElemental-AllItems-ShinyShardoftheGods"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
   dps: 2782.3735922455307
-  tps: 2182.091095310583
+  tps: 2182.0910953105836
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkycallTotem-33506"
  value: {
   dps: 2815.0988712130556
-  tps: 2220.2342132978674
+  tps: 2220.234213297867
  }
 }
 dps_results: {
@@ -671,7 +671,7 @@ dps_results: {
  key: "TestElemental-AllItems-TheFistsofFury"
  value: {
   dps: 2204.4384623651413
-  tps: 1744.051053787202
+  tps: 1744.0510537872021
  }
 }
 dps_results: {
@@ -726,7 +726,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2748.3016277864044
+  dps: 2748.301627786404
   tps: 2158.251754859516
  }
 }
@@ -768,7 +768,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2748.3016277864044
+  dps: 2748.301627786404
   tps: 2158.251754859516
  }
 }
@@ -811,7 +811,7 @@ dps_results: {
  key: "TestElemental-Average-Default"
  value: {
   dps: 2810.9877031543547
-  tps: 2203.372751615126
+  tps: 2203.3727516151257
  }
 }
 dps_results: {
@@ -825,7 +825,7 @@ dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-LongSingleTarget"
  value: {
   dps: 2802.2786630386277
-  tps: 2198.0622177836335
+  tps: 2198.062217783633
  }
 }
 dps_results: {
@@ -846,13 +846,13 @@ dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-LongSingleTarget"
  value: {
   dps: 1494.924773947619
-  tps: 1198.0374584563888
+  tps: 1198.037458456389
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3445.0711611361658
+  dps: 3445.0711611361667
   tps: 2642.0508516835753
  }
 }
@@ -873,7 +873,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3951.0846653991985
+  dps: 3951.0846653991966
   tps: 3091.023468077532
  }
 }
@@ -887,15 +887,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1528.2534693649566
-  tps: 1232.0047510821573
+  dps: 1528.253469364957
+  tps: 1232.0047510821576
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3515.9359488668297
-  tps: 2751.092807275862
+  dps: 3515.9359488668306
+  tps: 2751.0928072758625
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -53,13 +53,13 @@ dps_results: {
  key: "TestEnhancement-AllItems-AshtongueTalismanofVision-32491"
  value: {
   dps: 5534.980402681259
-  tps: 4213.520252562444
+  tps: 4213.520252562443
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5471.957746992054
+  dps: 5471.957746992053
   tps: 4157.2344396909375
  }
 }
@@ -67,7 +67,7 @@ dps_results: {
  key: "TestEnhancement-AllItems-Bandit'sInsignia-40371"
  value: {
   dps: 5603.896080980421
-  tps: 4268.964127554569
+  tps: 4268.96412755457
  }
 }
 dps_results: {
@@ -122,7 +122,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-CycloneRegalia"
  value: {
-  dps: 4001.3734701437083
+  dps: 4001.373470143709
   tps: 3024.4878124129114
  }
 }
@@ -179,7 +179,7 @@ dps_results: {
  key: "TestEnhancement-AllItems-DesolationBattlegear"
  value: {
   dps: 4025.9643525100596
-  tps: 3039.0671044275196
+  tps: 3039.0671044275186
  }
 }
 dps_results: {
@@ -206,7 +206,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5471.957746992054
+  dps: 5471.957746992053
   tps: 4157.2344396909375
  }
 }
@@ -234,7 +234,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5471.957746992054
+  dps: 5471.957746992053
   tps: 4157.2344396909375
  }
 }
@@ -297,7 +297,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 4892.478497691955
+  dps: 4892.478497691956
   tps: 3710.165430752864
  }
 }
@@ -360,8 +360,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5536.027802679959
-  tps: 4206.884341462212
+  dps: 5536.0278026799615
+  tps: 4206.884341462213
  }
 }
 dps_results: {
@@ -388,7 +388,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 3914.09413692203
+  dps: 3914.094136922031
   tps: 2951.17509954986
  }
 }
@@ -409,8 +409,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-NetherstrikeArmor"
  value: {
-  dps: 4809.981743822616
-  tps: 3649.8731562413764
+  dps: 4809.981743822617
+  tps: 3649.873156241377
  }
 }
 dps_results: {
@@ -451,14 +451,14 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5471.957746992054
+  dps: 5471.957746992053
   tps: 4157.2344396909375
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5471.957746992054
+  dps: 5471.957746992053
   tps: 4157.2344396909375
  }
 }
@@ -479,8 +479,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 5743.563974554747
-  tps: 4430.314849173475
+  dps: 5743.563974554746
+  tps: 4430.314849173476
  }
 }
 dps_results: {
@@ -613,7 +613,7 @@ dps_results: {
  key: "TestEnhancement-AllItems-TheFistsofFury"
  value: {
   dps: 4321.350753656601
-  tps: 3150.111110358302
+  tps: 3150.1111103583016
  }
 }
 dps_results: {
@@ -626,7 +626,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 4819.74637105141
+  dps: 4819.746371051411
   tps: 3686.0899382774587
  }
 }
@@ -725,7 +725,7 @@ dps_results: {
  key: "TestEnhancement-AllItems-WastewalkerArmor"
  value: {
   dps: 3992.6412973467536
-  tps: 3007.156692461238
+  tps: 3007.1566924612375
  }
 }
 dps_results: {
@@ -766,14 +766,14 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14098.774449083789
+  dps: 14098.77444908379
   tps: 11455.988469512407
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5570.303418678048
+  dps: 5570.303418678049
   tps: 4222.079637465782
  }
 }
@@ -808,7 +808,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14126.154018482048
+  dps: 14126.154018482044
   tps: 11463.217669660913
  }
 }

--- a/sim/warlock/TestWarlock.results
+++ b/sim/warlock/TestWarlock.results
@@ -95,13 +95,13 @@ dps_results: {
  key: "TestWarlock-AllItems-DarkCoven'sRegalia"
  value: {
   dps: 5840.608966897828
-  tps: 5220.555324060732
+  tps: 5220.555324060733
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-DeathbringerGarb"
  value: {
-  dps: 6421.0306270582505
+  dps: 6421.030627058252
   tps: 5786.639579280071
  }
 }
@@ -158,7 +158,7 @@ dps_results: {
  key: "TestWarlock-AllItems-ForlornStarflareDiamond"
  value: {
   dps: 6589.258643086365
-  tps: 5943.039389373921
+  tps: 5943.03938937392
  }
 }
 dps_results: {
@@ -206,14 +206,14 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-AllItems-MaleficRaiment"
  value: {
-  dps: 4987.345567941501
+  dps: 4987.345567941502
   tps: 4405.829570086444
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-OblivionRaiment"
  value: {
-  dps: 5034.85935915649
+  dps: 5034.8593591564895
   tps: 4470.98776859191
  }
 }
@@ -312,14 +312,14 @@ dps_results: {
  key: "TestWarlock-AllItems-TirelessStarflareDiamond"
  value: {
   dps: 6589.258643086365
-  tps: 5943.039389373921
+  tps: 5943.03938937392
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-TrenchantEarthshatterDiamond"
  value: {
   dps: 6589.258643086365
-  tps: 5943.039389373921
+  tps: 5943.03938937392
  }
 }
 dps_results: {
@@ -333,7 +333,7 @@ dps_results: {
  key: "TestWarlock-AllItems-VoidStarTalisman-30449"
  value: {
   dps: 6601.818535753667
-  tps: 5962.360553145986
+  tps: 5962.360553145987
  }
 }
 dps_results: {
@@ -361,7 +361,7 @@ dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-FullBuffs-LongSingleTarget"
  value: {
   dps: 5862.769365658436
-  tps: 5208.944264644961
+  tps: 5208.9442646449625
  }
 }
 dps_results: {
@@ -395,22 +395,22 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Demonology Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9592.907252602681
-  tps: 10757.27491924601
+  dps: 9592.907252602678
+  tps: 10757.274919246009
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Demonology Warlock-FullBuffs-LongSingleTarget"
  value: {
   dps: 6194.508052358772
-  tps: 5189.2702820645445
+  tps: 5189.270282064543
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Demonology Warlock-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7377.1953945042405
-  tps: 6088.968892181743
+  tps: 6088.9688921817415
  }
 }
 dps_results: {
@@ -430,7 +430,7 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Demonology Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3629.9160347077027
+  dps: 3629.9160347077022
   tps: 3199.896133430082
  }
 }

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -52,7 +52,7 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
@@ -109,20 +109,20 @@ dps_results: {
  key: "TestArms-AllItems-ChaoticSkyflareDiamond"
  value: {
   dps: 690.342952916727
-  tps: 742.2671797089617
+  tps: 742.2671797089616
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 687.0699568104575
+  dps: 687.0699568104574
   tps: 738.1583142560463
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 737.7997612147475
+  dps: 737.7997612147474
   tps: 789.1146039349289
  }
 }
@@ -130,13 +130,13 @@ dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-42987"
  value: {
   dps: 748.5704942016481
-  tps: 802.1083735483356
+  tps: 802.1083735483354
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 750.9923084048083
+  dps: 750.9923084048081
   tps: 806.1964524718369
  }
 }
@@ -157,7 +157,7 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Defender'sCode-40257"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
@@ -241,7 +241,7 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 696.489188124745
+  dps: 696.4891881247449
   tps: 749.366175038643
  }
 }
@@ -297,14 +297,14 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-FuturesightRune-38763"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
@@ -353,14 +353,14 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
@@ -375,13 +375,13 @@ dps_results: {
  key: "TestArms-AllItems-MeteoriteWhetstone-37390"
  value: {
   dps: 708.6994286094914
-  tps: 763.0375902885916
+  tps: 763.0375902885914
  }
 }
 dps_results: {
  key: "TestArms-AllItems-NetherscaleArmor"
  value: {
-  dps: 654.5489903818047
+  dps: 654.5489903818045
   tps: 705.4715955370937
  }
 }
@@ -395,7 +395,7 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
@@ -445,13 +445,13 @@ dps_results: {
  key: "TestArms-AllItems-PrimalIntent"
  value: {
   dps: 694.0400851906077
-  tps: 746.1396642905114
+  tps: 746.1396642905113
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
@@ -465,14 +465,14 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 815.5843208472094
+  dps: 815.5843208472091
   tps: 868.0923367056405
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 695.4226021856897
+  dps: 695.4226021856896
   tps: 750.0113151462817
  }
 }
@@ -486,14 +486,14 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
@@ -507,14 +507,14 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 678.9266776048723
+  dps: 678.9266776048721
   tps: 731.4346934633033
  }
 }
@@ -522,21 +522,21 @@ dps_results: {
  key: "TestArms-AllItems-SparkofLife-37657"
  value: {
   dps: 679.8901691951643
-  tps: 731.7061715632788
+  tps: 731.7061715632786
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SpellstrikeInfusion"
  value: {
   dps: 610.7167817557395
-  tps: 659.2852399507541
+  tps: 659.2852399507542
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StrengthoftheClefthoof"
  value: {
   dps: 596.9292706411017
-  tps: 644.1483887464565
+  tps: 644.1483887464564
  }
 }
 dps_results: {
@@ -571,7 +571,7 @@ dps_results: {
  key: "TestArms-AllItems-TheTwinBladesofAzzinoth"
  value: {
   dps: 847.491289128345
-  tps: 912.2333030332708
+  tps: 912.2333030332705
  }
 }
 dps_results: {
@@ -598,8 +598,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 722.6514407847246
-  tps: 777.0297538431445
+  dps: 722.6514407847245
+  tps: 777.0297538431444
  }
 }
 dps_results: {
@@ -654,8 +654,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-WindhawkArmor"
  value: {
-  dps: 625.6798786063523
-  tps: 675.7520004729698
+  dps: 625.6798786063522
+  tps: 675.7520004729697
  }
 }
 dps_results: {
@@ -668,21 +668,21 @@ dps_results: {
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 699.3729254659295
+  dps: 699.3729254659294
   tps: 751.7294490243414
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 693.877694960622
+  dps: 693.8776949606217
   tps: 835.3175775452825
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 693.877694960622
+  dps: 693.8776949606217
   tps: 746.6509108786158
  }
 }
@@ -725,7 +725,7 @@ dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
   dps: 687.881381760796
-  tps: 740.4688717852794
+  tps: 740.4688717852792
  }
 }
 dps_results: {
@@ -738,22 +738,22 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 454.8561114307178
+  dps: 454.85611143071776
   tps: 585.5460833137431
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 454.8561114307178
+  dps: 454.85611143071776
   tps: 496.056083313743
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 469.4346890124881
-  tps: 513.4337699063794
+  dps: 469.434689012488
+  tps: 513.4337699063793
  }
 }
 dps_results: {

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -95,7 +95,7 @@ dps_results: {
  key: "TestFury-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
   dps: 592.8009641218976
-  tps: 650.5607974552307
+  tps: 650.5607974552306
  }
 }
 dps_results: {
@@ -116,13 +116,13 @@ dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
   dps: 600.3803541468993
-  tps: 658.1670208135662
+  tps: 658.167020813566
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 637.4735067506132
+  dps: 637.473506750613
   tps: 695.4490067506133
  }
 }
@@ -235,7 +235,7 @@ dps_results: {
  key: "TestFury-AllItems-ExtractofNecromanticPower-40373"
  value: {
   dps: 627.9448282026596
-  tps: 685.6913282026596
+  tps: 685.6913282026595
  }
 }
 dps_results: {
@@ -255,7 +255,7 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-FelstalkerArmor"
  value: {
-  dps: 568.2993531752267
+  dps: 568.2993531752265
   tps: 626.0303531752264
  }
 }
@@ -325,8 +325,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-IncisorFragment-37723"
  value: {
-  dps: 658.8866671068022
-  tps: 718.5931671068024
+  dps: 658.8866671068021
+  tps: 718.5931671068022
  }
 }
 dps_results: {
@@ -375,21 +375,21 @@ dps_results: {
  key: "TestFury-AllItems-MeteoriteWhetstone-37390"
  value: {
   dps: 611.3199423412218
-  tps: 670.5656090078884
+  tps: 670.5656090078883
  }
 }
 dps_results: {
  key: "TestFury-AllItems-NetherscaleArmor"
  value: {
-  dps: 562.2275813440052
-  tps: 619.4380813440052
+  dps: 562.2275813440053
+  tps: 619.4380813440051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-NetherstrikeArmor"
  value: {
   dps: 536.9321905710096
-  tps: 593.2476905710096
+  tps: 593.2476905710095
  }
 }
 dps_results: {
@@ -459,7 +459,7 @@ dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47316"
  value: {
   dps: 660.5793639131905
-  tps: 717.3410305798571
+  tps: 717.341030579857
  }
 }
 dps_results: {
@@ -473,7 +473,7 @@ dps_results: {
  key: "TestFury-AllItems-RelentlessEarthsiegeDiamond"
  value: {
   dps: 603.5578020150303
-  tps: 662.3886353483639
+  tps: 662.3886353483638
  }
 }
 dps_results: {
@@ -570,7 +570,7 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 690.3034041643816
+  dps: 690.3034041643814
   tps: 753.5402374977148
  }
 }
@@ -592,14 +592,14 @@ dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50351"
  value: {
   dps: 616.8097589653944
-  tps: 677.1434256320613
+  tps: 677.1434256320612
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50706"
  value: {
   dps: 610.5930370137376
-  tps: 670.733370347071
+  tps: 670.7333703470708
  }
 }
 dps_results: {
@@ -654,14 +654,14 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-WindhawkArmor"
  value: {
-  dps: 530.1267840129134
+  dps: 530.1267840129133
   tps: 586.1419506795801
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WrathofSpellfire"
  value: {
-  dps: 524.0982678104274
+  dps: 524.0982678104273
   tps: 579.6852678104275
  }
 }
@@ -717,21 +717,21 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 594.4120325066559
-  tps: 778.9440325066562
+  dps: 594.4120325066558
+  tps: 778.944032506656
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 594.4120325066559
+  dps: 594.4120325066558
   tps: 652.4990325066558
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 649.1542689612011
+  dps: 649.154268961201
   tps: 714.8351022945344
  }
 }
@@ -753,7 +753,7 @@ dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
   dps: 418.63014656286396
-  tps: 476.4459798961972
+  tps: 476.44597989619706
  }
 }
 dps_results: {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -52,7 +52,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 0.24206771734737914
+  weights: 0.24206771734738025
   weights: 0
   weights: 0
   weights: 0
@@ -160,7 +160,7 @@ dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticSkyflareDiamond"
  value: {
   dps: 388.4936094579546
-  tps: 655.0153394819943
+  tps: 655.0153394819941
  }
 }
 dps_results: {
@@ -243,7 +243,7 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DoomplateBattlegear"
  value: {
-  dps: 374.63707945935425
+  dps: 374.63707945935414
   tps: 620.986397976083
  }
 }
@@ -306,7 +306,7 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FelstalkerArmor"
  value: {
-  dps: 378.89888923769854
+  dps: 378.8988892376986
   tps: 640.1844526182696
  }
 }
@@ -377,7 +377,7 @@ dps_results: {
  key: "TestProtectionWarrior-AllItems-IncisorFragment-37723"
  value: {
   dps: 426.72337485173665
-  tps: 717.8627186343829
+  tps: 717.862718634383
  }
 }
 dps_results: {
@@ -460,7 +460,7 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 472.0484723798277
+  dps: 472.04847237982756
   tps: 776.3823410535274
  }
 }
@@ -468,7 +468,7 @@ dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthshatterDiamond"
  value: {
   dps: 381.74665679196625
-  tps: 644.191566211902
+  tps: 644.1915662119019
  }
 }
 dps_results: {
@@ -517,7 +517,7 @@ dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47477"
  value: {
   dps: 459.6266461849626
-  tps: 762.5153487679319
+  tps: 762.515348767932
  }
 }
 dps_results: {
@@ -579,7 +579,7 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 369.88214247711966
+  dps: 369.8821424771196
   tps: 626.6846363124808
  }
 }
@@ -601,7 +601,7 @@ dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftStarflareDiamond"
  value: {
   dps: 381.74665679196625
-  tps: 644.191566211902
+  tps: 644.1915662119019
  }
 }
 dps_results: {
@@ -615,14 +615,14 @@ dps_results: {
  key: "TestProtectionWarrior-AllItems-TheFistsofFury"
  value: {
   dps: 586.4514418184632
-  tps: 980.1179947985177
+  tps: 980.1179947985178
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
   dps: 630.0041844321315
-  tps: 1051.691286319226
+  tps: 1051.6912863192256
  }
 }
 dps_results: {
@@ -635,7 +635,7 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 380.9385503332065
+  dps: 380.93855033320654
   tps: 643.3292243040429
  }
 }
@@ -685,20 +685,20 @@ dps_results: {
  key: "TestProtectionWarrior-AllItems-WarbringerArmor"
  value: {
   dps: 353.7709609305612
-  tps: 587.6469155191205
+  tps: 587.6469155191204
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarbringerBattlegear"
  value: {
-  dps: 409.12762686724193
+  dps: 409.1276268672419
   tps: 684.561775019348
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WastewalkerArmor"
  value: {
-  dps: 377.23006071929433
+  dps: 377.2300607192942
   tps: 626.7821590264141
  }
 }
@@ -763,7 +763,7 @@ dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
   dps: 169.60423426112266
-  tps: 311.4844059074732
+  tps: 311.48440590747316
  }
 }
 dps_results: {

--- a/ui/core/proto_utils/action_id.ts
+++ b/ui/core/proto_utils/action_id.ts
@@ -228,6 +228,7 @@ export class ActionId {
                 }
                 break;
             case 'Fan of Knives':
+            case 'Killing Spree':
                 if (this.tag == 1) {
                     name += ' (Main Hand)'
                 } else if (this.tag == 2) {

--- a/ui/core/proto_utils/action_id.ts
+++ b/ui/core/proto_utils/action_id.ts
@@ -227,6 +227,13 @@ export class ActionId {
                     name += ' (Shiv)'
                 }
                 break;
+            case 'Fan of Knives':
+                if (this.tag == 1) {
+                    name += ' (Main Hand)'
+                } else if (this.tag == 2) {
+                    name += ' (Off Hand)'
+                }
+                break;
             case 'Chain Lightning':
             case 'Lightning Bolt':
                 if (this.tag) name += ' (LO)';


### PR DESCRIPTION
Adds Fan of knives ability for rogue
Updates Killing spree code to show separate metrics for mh/oh attacks
Switches instant poison proc logic to use PPMManager
Simplifies rotation logic in preparation for future updates there (still produces results within ~7% of the casts in the reference sheet)