### PR TITLE
Corruption reapplication and dots reapplication in execute

### DIFF
--- a/sim/warlock/warlock.go
+++ b/sim/warlock/warlock.go
@@ -65,6 +65,9 @@ type Warlock struct {
 	EmpoweredImpAura       *core.Aura
 
 	GlyphOfLifeTapAura *core.Aura
+
+	CorrShadowMult float64
+	CorrDmgMult    float64
 }
 
 func (warlock *Warlock) GetCharacter() *core.Character {


### PR DESCRIPTION
- Updated execute dot reapplication timings to half of duration. DPCT of dots/2 is > drain soul DPCT in execute, so added that logic to dot reapplication during execute
 - Added a tracker on corruption modifiers to see if it's worth to reapply at DE with TotT. If the total dmg modifier delta is >10% for a potentially new corruption then reapply (should only occur when DE is active or with TotT scenarios)