### PR TITLE
build: small fixes

### DIFF
--- a/makefile
+++ b/makefile
@@ -48,7 +48,7 @@ $(OUT_DIR)/bundle/.dirstamp: \
 	touch $@
 
 $(OUT_DIR)/sim_worker.js: ui/worker/sim_worker.js
-	cat $(GOROOT)/misc/wasm/wasm_exec.js > $(OUT_DIR)/sim_worker.js
+	cat '$(GOROOT)/misc/wasm/wasm_exec.js' > $(OUT_DIR)/sim_worker.js
 	cat ui/worker/sim_worker.js >> $(OUT_DIR)/sim_worker.js
 
 $(OUT_DIR)/net_worker.js: ui/worker/net_worker.js
@@ -111,9 +111,9 @@ wasm: $(OUT_DIR)/lib.wasm
 $(OUT_DIR)/lib.wasm: sim/wasm/* sim/core/proto/api.pb.go $(filter-out sim/core/items/all_items.go, $(call rwildcard,sim,*.go))
 	@echo "Starting webassembly compile now..."
 	@if GOOS=js GOARCH=wasm go build -o ./$(OUT_DIR)/lib.wasm ./sim/wasm/; then \
-		echo "\033[1;32mWASM compile successful.\033[0m"; \
+		printf "\033[1;32mWASM compile successful.\033[0m\n"; \
 	else \
-		echo "\033[1;31mWASM COMPILE FAILED\033[0m"; \
+		printf "\033[1;31mWASM COMPILE FAILED\033[0m\n"; \
 		exit 1; \
 	fi
 	
@@ -146,9 +146,9 @@ wowsimwotlk: binary_dist devserver
 devserver: sim/core/proto/api.pb.go sim/web/main.go binary_dist/dist.go
 	@echo "Starting server compile now..."
 	@if go build -o wowsimwotlk ./sim/web/main.go; then \
-		echo "\033[1;32mBuild Completed Succeessfully\033[0m"; \
+		printf "\033[1;32mBuild Completed Succeessfully\033[0m\n"; \
 	else \
-		echo "\033[1;31mBUILD FAILED\033[0m"; \
+		printf "\033[1;31mBUILD FAILED\033[0m\n"; \
 		exit 1; \
 	fi
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,7 +11,7 @@ export default defineConfig(({ command, mode }) => ({
 		sourcemap: command === "serve" ? "inline" : "false",
 		target: ["es2020"],
 		rollupOptions: {
-			input: glob.sync(path.resolve(__dirname, "ui", "**/index.html")),
+			input: glob.sync(path.resolve(__dirname, "ui", "**/index.html").replace(/\\/g, "/")),
 			output: {
 				assetFileNames: () => "bundle/[name]-[hash].style.css",
 				entryFileNames: () => "bundle/[name]-[hash].entry.js",


### PR DESCRIPTION
 - fixes 'GOROOT' with space in path
 - fixes glob.sync breaking on windows path slash
 - fix makefile color printing

Found from getting this working on windows, the `replaceAll` is probably the only 'odd' thing, otherwise nothing should cause any issues on other platforms to my knowledge. I understand if you're not interested in supporting this, but with this i was able to 'finagle' native windows with msys2 to handle makefile command