### PR TITLE
tailor or jc + engi configs added

### DIFF
--- a/ui/warlock/presets.ts
+++ b/ui/warlock/presets.ts
@@ -401,8 +401,8 @@ export const P1_PreBiS = {
     }
   `),
 }
-export const P1_BiS_14 = {
-  name: 'P1 Preset',
+export const P1_BiS_Tailor_Engineer = {
+  name: 'P1 BiS (Tailor/Engineer)',
   tooltip: WarlockTooltips.BIS_TOOLTIP,
   enableWhen: (player: Player<Spec.SpecWarlock>) => player.getRotation().type == RotationType.Demonology || player.getRotation().type == RotationType.Destruction,
   gear: EquipmentSpec.fromJsonString(`
@@ -501,8 +501,109 @@ export const P1_BiS_14 = {
   `),
 }
 
-export const P1_BiS = {
-	name: 'P1 Affliction',
+export const P1_BiS_JC_Engineer = {
+  name: 'P1 BiS (JC/Engineer)',
+  tooltip: WarlockTooltips.BIS_TOOLTIP,
+  enableWhen: (player: Player<Spec.SpecWarlock>) => player.getRotation().type == RotationType.Demonology || player.getRotation().type == RotationType.Destruction,
+  gear: EquipmentSpec.fromJsonString(`
+    {"items":
+      [
+        {
+          "id": 40421,
+          "enchant": 44877,
+          "gems": [
+            41285,
+            42156
+          ]
+        },
+        {
+          "id": 44661,
+          "gems": [
+            40099
+          ]
+        },
+        {
+          "id": 40424,
+          "enchant": 44874,
+          "gems": [
+            42144
+          ]
+        },
+        {
+          "id": 44005,
+          "enchant": 63765,
+          "gems": [
+            40099
+          ]
+        },
+        {
+          "id": 40423,
+          "enchant": 44489,
+          "gems": [
+            42144,
+            40014
+          ]
+        },
+        {
+          "id": 44008,
+          "enchant": 44498,
+          "gems": [
+            39998,
+            0
+          ]
+        },
+        {
+          "id": 40420,
+          "enchant": 54999,
+          "gems": [
+            39998,
+            0
+          ]
+        },
+        {
+          "id": 40561,
+          "gems": [
+            40014
+          ]
+        },
+        {
+          "id": 40560,
+          "enchant": 41602
+        },
+        {
+          "id": 40558,
+          "enchant": 55016
+        },
+        {
+          "id": 40399
+        },
+        {
+          "id": 40719
+        },
+        {
+          "id": 40432
+        },
+        {
+          "id": 40255
+        },
+        {
+          "id": 40396,
+          "enchant": 44487
+        },
+        {
+          "id": 39766
+        },
+        {
+          "id": 39712
+        }
+      ]
+    }
+  `),
+}
+
+// will have only rare gems, but a Lightweave Embroidery on cloak.
+export const P1_BiS_Aff_Tailor_Engineer = {
+	name: 'P1 Affliction BiS (Tailor/Engineer)',
 	tooltip: WarlockTooltips.BIS_TOOLTIP,
   enableWhen: (player: Player<Spec.SpecWarlock>) => player.getRotation().type == RotationType.Affliction,
 	gear: EquipmentSpec.fromJsonString(`
@@ -600,6 +701,109 @@ export const P1_BiS = {
     }
   `),
 }
+
+//will have 3 42144, Runed Dragon's Eye JC gems and 63765 Springy Arachnoweave on cloak
+// for simplicity, the first 3 red gem slots are changed.
+export const P1_BiS_Aff_JC_Engineer = {
+	name: 'P1 Affliction BiS (JC/Engineer)',
+	tooltip: WarlockTooltips.BIS_TOOLTIP,
+  enableWhen: (player: Player<Spec.SpecWarlock>) => player.getRotation().type == RotationType.Affliction,
+	gear: EquipmentSpec.fromJsonString(`
+    {"items":
+      [
+        {
+          "id": 40421,
+          "enchant": 44877,
+          "gems": [
+            41285,
+            40051
+          ]
+        },
+        {
+          "id": 44661,
+          "gems": [
+            40026
+          ]
+        },
+        {
+          "id": 40424,
+          "enchant": 44874,
+          "gems": [
+            42144
+          ]
+        },
+        {
+          "id": 44005,
+          "enchant": 63765,
+          "gems": [
+            40026
+          ]
+        },
+        {
+          "id": 40423,
+          "enchant": 44489,
+          "gems": [
+            42144,
+            40051
+          ]
+        },
+        {
+          "id": 44008,
+          "enchant": 44498,
+          "gems": [
+            42144,
+            0
+          ]
+        },
+        {
+          "id": 40420,
+          "enchant": 54999,
+          "gems": [
+            39998,
+            0
+          ]
+        },
+        {
+          "id": 40561,
+          "gems": [
+            39998
+          ]
+        },
+        {
+          "id": 40560,
+          "enchant": 41602
+        },
+        {
+          "id": 40558,
+          "enchant": 55016
+        },
+        {
+          "id": 40399
+        },
+        {
+          "id": 40719
+        },
+        {
+          "id": 40432
+        },
+        {
+          "id": 40255
+        },
+        {
+          "id": 40396,
+          "enchant": 44487
+        },
+        {
+          "id": 39766
+        },
+        {
+          "id": 39712
+        }
+      ]
+    }
+  `),
+}
+
 export const P1_PreBiS_14 = {
   name: 'Pre-Raid Preset',
   tooltip: WarlockTooltips.BIS_TOOLTIP,

--- a/ui/warlock/sim.ts
+++ b/ui/warlock/sim.ts
@@ -158,8 +158,11 @@ export class WarlockSimUI extends IndividualSimUI<Spec.SpecWarlock> {
 					Presets.SWP_BIS,
 					Presets.P1_PreBiS,
 					Presets.P1_PreBiS_14,
-					Presets.P1_BiS,
-					Presets.P1_BiS_14,
+					Presets.P1_BiS_Aff_Tailor_Engineer,
+					Presets.P1_BiS_Aff_JC_Engineer,
+					Presets.P1_BiS_JC_Engineer,
+					Presets.P1_BiS_Tailor_Engineer,
+
 				],
 			},
 		});


### PR DESCRIPTION
### What does this branch do?
This branch divides the P1 BiS options based on the most popular spec combinations, which are often a huge debate topic in Warlock discord. (check: https://discord.com/channels/253210018697052162/987449814600003604) 

With this change, for both affliction and demo / destro specs, users will have access to both Tailor Engi and JC Engi gear presets to help them test and compare the benefits gained from each combination.
### List of Added Presets
**Affliction : Tailor & Engineer**
- Back slot item has [Lightweave Embroidery](https://www.wowhead.com/wotlk/spell=55642/lightweave-embroidery) .

**Affliction : JC & Engineer**
- Back slot has [Springy Arachnoweave](https://www.wowhead.com/wotlk/spell=63765/springy-arachnoweave).
- Gem slots has 3 extra [Runed Dragon's Eye ](https://www.wowhead.com/wotlk/item=42144/runed-dragons-eye) gems. (Shoulder - Chest - Bracers)

**Demonology & Destruction: Tailor & Engineer**
-  Back slot item has [Lightweave Embroidery](https://www.wowhead.com/wotlk/spell=55642/lightweave-embroidery) .

**Demonology & Destruction: JC & Engineer**
- Back slot has [Springy Arachnoweave](https://www.wowhead.com/wotlk/spell=63765/springy-arachnoweave).
- Gem slots has 2 extra [Runed Dragon's Eye](https://www.wowhead.com/wotlk/item=42144/runed-dragons-eye) gems.
- Gem slots have 1 extra [Rigid Dragon's Eye](https://www.wowhead.com/wotlk/item=42156/rigid-dragons-eye)
(Reds : Shoulder - Chest - Yellow : Head)
_Dev note:It could be that other JC gem combinations could yield better results, especially subbing talent points int Suppression to make use of more JC SP gems. This requires further experimentation._