### PR TITLE
[Procs] Prevent crashes when trying to register item auras more than …

### DIFF
--- a/sim/common/wotlk/proc_helpers.go
+++ b/sim/common/wotlk/proc_helpers.go
@@ -117,7 +117,7 @@ func MakeProcTriggerAura(unit *core.Unit, config ProcTrigger) *core.Aura {
 
 	applyProcTriggerCallback(unit, &aura, config)
 
-	return unit.RegisterAura(aura)
+	return unit.GetOrRegisterAura(aura)
 }
 
 func NewItemEffectWithHeroic(f func(isHeroic bool)) {


### PR DESCRIPTION
…once (due to duplicate items)