### PR TITLE
Dk crash fix

### DIFF
--- a/sim/core/racials.go
+++ b/sim/core/racials.go
@@ -17,7 +17,6 @@ func applyRaceEffects(agent Agent) {
 		character.PseudoStats.ReducedFrostHitTakenChance += 0.02
 		character.PseudoStats.ReducedNatureHitTakenChance += 0.02
 		character.PseudoStats.ReducedShadowHitTakenChance += 0.02
-		// TODO: Add major cooldown: arcane torrent
 
 		actionID := ActionID{SpellID: 50613}
 
@@ -75,7 +74,6 @@ func applyRaceEffects(agent Agent) {
 			5*ExpertisePerQuarterPercentReduction,
 			[]proto.WeaponType{proto.WeaponType_WeaponTypeMace})
 
-		// TODO: Stoneform
 		actionID := ActionID{SpellID: 20594}
 
 		statDep := character.NewDynamicMultiplyStat(stats.Armor, 1.1)

--- a/sim/deathknight/dps/rotation_frost.go
+++ b/sim/deathknight/dps/rotation_frost.go
@@ -126,14 +126,26 @@ func (dk *DpsDeathknight) castAllMajorCooldowns(sim *core.Simulation) {
 }
 
 func (dk *DpsDeathknight) RotationActionCallback_UA_Frost(sim *core.Simulation, target *core.Unit, s *deathknight.Sequence) time.Duration {
-	casted := dk.UnbreakableArmor.Cast(sim, target)
+	if dk.UnbreakableArmor != nil {
+		casted := dk.UnbreakableArmor.Cast(sim, target)
 
-	if casted {
-		dk.castAllMajorCooldowns(sim)
-		s.ConditionalAdvance(casted)
-		return sim.CurrentTime
+		if casted {
+			dk.castAllMajorCooldowns(sim)
+			s.ConditionalAdvance(casted)
+			return sim.CurrentTime
+		} else {
+			s.ConditionalAdvance(casted)
+			return -1
+		}
 	} else {
-		s.ConditionalAdvance(casted)
-		return -1
+		casted := dk.BloodStrike.Cast(sim, target)
+		if casted {
+			dk.castAllMajorCooldowns(sim)
+			s.ConditionalAdvance(casted)
+			return sim.CurrentTime
+		} else {
+			s.ConditionalAdvance(casted)
+			return -1
+		}
 	}
 }

--- a/sim/deathknight/dps/rotation_frost_sub_blood.go
+++ b/sim/deathknight/dps/rotation_frost_sub_blood.go
@@ -337,8 +337,14 @@ func (dk *DpsDeathknight) RotationActionCallback_FrostSubBlood_Obli_Check(sim *c
 
 func (dk *DpsDeathknight) RotationActionCallback_FrostSubBlood_SequenceRotation(sim *core.Simulation, target *core.Unit, s *deathknight.Sequence) time.Duration {
 	s.Clear().
-		NewAction(dk.RotationActionCallback_FrostSubBlood_FS_Dump).
-		NewAction(dk.RotationActionCallback_FrostSubBlood_UA_Check)
+		NewAction(dk.RotationActionCallback_FrostSubBlood_FS_Dump)
+
+	if dk.UnbreakableArmor != nil {
+		s.NewAction(dk.RotationActionCallback_FrostSubBlood_UA_Check)
+	} else {
+		s.NewAction(dk.RotationActionCallback_FrostSubBlood_Obli_Check)
+	}
+
 	return sim.CurrentTime
 }
 

--- a/sim/deathknight/rotation.go
+++ b/sim/deathknight/rotation.go
@@ -65,12 +65,6 @@ func (dk *Deathknight) RotationActionCallback_HS(sim *core.Simulation, target *c
 	return -1
 }
 
-func (dk *Deathknight) RotationActionCallback_UA(sim *core.Simulation, target *core.Unit, s *Sequence) time.Duration {
-	casted := dk.UnbreakableArmor.Cast(sim, target)
-	s.ConditionalAdvance(casted)
-	return sim.CurrentTime
-}
-
 func (dk *Deathknight) RotationActionCallback_BT(sim *core.Simulation, target *core.Unit, s *Sequence) time.Duration {
 	casted := dk.BloodTap.Cast(sim, target)
 	s.ConditionalAdvance(casted)


### PR DESCRIPTION
- Fixed crash issue Crash Report 259158363 #773 and Crash Report -1952536294 #640, both relating to not talenting Unbreakable Armor, while this is... a weird decision, I've updated the rotation to just blood strike instead of UA if UA is not talented.
- Removed Stoneform and Arcane Torrent TODO's from the racials.go file, as they're implemented.