### PR TITLE
Rogue rotation work + some testing infrastructure to support it

### DIFF
--- a/proto/test.proto
+++ b/proto/test.proto
@@ -18,6 +18,10 @@ message DpsTestResult {
 	double hps = 4;
 }
 
+message CastsTestResult {
+	map<string, double> casts = 1;
+}
+
 message TestSuiteResult {
 	// Maps test names to their results.
 	map<string, CharacterStatsTestResult> character_stats_results = 2;
@@ -27,4 +31,6 @@ message TestSuiteResult {
 
 	// Maps test names to their results.
 	map<string, DpsTestResult> dps_results = 1;
+
+	map<string, CastsTestResult> casts_results = 4;
 }

--- a/sim/core/energy.go
+++ b/sim/core/energy.go
@@ -34,10 +34,15 @@ type energyBar struct {
 }
 
 func (unit *Unit) EnableEnergyBar(maxEnergy float64, onEnergyGain OnEnergyGain) {
+
 	unit.energyBar = energyBar{
-		unit:                 unit,
-		maxEnergy:            MaxFloat(100, maxEnergy),
-		onEnergyGain:         onEnergyGain,
+		unit:      unit,
+		maxEnergy: MaxFloat(100, maxEnergy),
+		onEnergyGain: func(sim *Simulation) {
+			if !unit.IsWaitingForEnergy() || unit.DoneWaitingForEnergy(sim) {
+				onEnergyGain(sim)
+			}
+		},
 		EnergyTickMultiplier: 1,
 		regenMetrics:         unit.NewEnergyMetrics(ActionID{OtherID: proto.OtherAction_OtherActionEnergyRegen}),
 		EnergyRefundMetrics:  unit.NewEnergyMetrics(ActionID{OtherID: proto.OtherAction_OtherActionRefund}),

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -115,8 +115,9 @@ type Unit struct {
 	hardcastAction *PendingAction
 
 	// Fields related to waiting for certain events to happen.
-	waitingForMana float64
-	waitStartTime  time.Duration
+	waitingForEnergy float64
+	waitingForMana   float64
+	waitStartTime    time.Duration
 
 	// Cached mana return values per tick.
 	manaTickWhileCasting    float64

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -52,924 +52,924 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7011.39391
-  tps: 4978.08968
+  dps: 7120.97128
+  tps: 5055.88961
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AssassinationArmor"
  value: {
-  dps: 5312.36795
-  tps: 3771.78124
+  dps: 5467.28659
+  tps: 3881.77348
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7050.4738
-  tps: 5005.8364
+  dps: 7157.23015
+  tps: 5081.6334
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7097.76276
-  tps: 5039.41156
+  dps: 7211.41863
+  tps: 5120.10723
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7066.80018
-  tps: 5017.42813
+  dps: 7193.46334
+  tps: 5107.35897
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6381.01652
-  tps: 4530.52173
+  dps: 6464.03023
+  tps: 4589.46147
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7050.4738
-  tps: 4905.71967
+  dps: 7157.23015
+  tps: 4980.00074
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 7018.73692
-  tps: 4983.30322
+  dps: 7085.31196
+  tps: 5030.57149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7182.19623
-  tps: 5099.35932
+  dps: 7308.36321
+  tps: 5188.93788
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7002.48227
-  tps: 4971.76241
+  dps: 7143.68266
+  tps: 5072.01469
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7045.12509
-  tps: 5002.03881
+  dps: 7166.53415
+  tps: 5088.23925
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 7144.7603
-  tps: 5072.77981
+  dps: 7269.52149
+  tps: 5161.36026
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7060.54191
-  tps: 5012.98475
+  dps: 7182.46928
+  tps: 5099.55319
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7023.3622
-  tps: 4986.58716
+  dps: 7131.44799
+  tps: 5063.32807
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathmantle"
  value: {
-  dps: 5607.65681
-  tps: 3981.43633
+  dps: 5784.82743
+  tps: 4107.22748
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6879.65449
-  tps: 4884.55468
+  dps: 6986.14741
+  tps: 4960.16466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7066.33377
-  tps: 5017.09698
+  dps: 7168.34184
+  tps: 5089.52271
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7050.4738
-  tps: 5005.8364
+  dps: 7157.23015
+  tps: 5081.6334
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7050.4738
-  tps: 5005.8364
+  dps: 7157.23015
+  tps: 5081.6334
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7066.80018
-  tps: 5017.42813
+  dps: 7193.46334
+  tps: 5107.35897
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7047.15599
-  tps: 5003.48075
+  dps: 7183.26797
+  tps: 5100.12026
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7050.4738
-  tps: 5005.8364
+  dps: 7157.23015
+  tps: 5081.6334
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6991.47887
-  tps: 4963.95
+  dps: 7155.67003
+  tps: 5080.52572
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6987.25653
-  tps: 4960.95213
+  dps: 7094.82848
+  tps: 5037.32822
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7001.69973
-  tps: 4971.20681
+  dps: 7076.85746
+  tps: 5024.5688
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7050.4738
-  tps: 5005.8364
+  dps: 7157.23015
+  tps: 5081.6334
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7050.4738
-  tps: 5005.8364
+  dps: 7157.23015
+  tps: 5081.6334
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7146.03326
-  tps: 5073.68362
+  dps: 7261.58891
+  tps: 5155.72812
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6879.65449
-  tps: 4884.55468
+  dps: 6986.14741
+  tps: 4960.16466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 6954.82483
-  tps: 4937.92563
+  dps: 7110.06624
+  tps: 5048.14703
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6879.65449
-  tps: 4884.55468
+  dps: 6986.14741
+  tps: 4960.16466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7066.80018
-  tps: 5017.42813
+  dps: 7193.46334
+  tps: 5107.35897
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7047.15599
-  tps: 5003.48075
+  dps: 7183.26797
+  tps: 5100.12026
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7080.59726
-  tps: 5027.22406
+  dps: 7161.93674
+  tps: 5084.97509
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 6925.47638
-  tps: 4917.08823
+  dps: 7027.56518
+  tps: 4989.57128
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7050.4738
-  tps: 5005.8364
+  dps: 7157.23015
+  tps: 5081.6334
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7085.79404
-  tps: 5030.91377
+  dps: 7193.66313
+  tps: 5107.50082
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6879.65449
-  tps: 4884.55468
+  dps: 6986.14741
+  tps: 4960.16466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6879.65449
-  tps: 4884.55468
+  dps: 6986.14741
+  tps: 4960.16466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 4750.60063
-  tps: 3372.92645
+  dps: 4837.42256
+  tps: 3434.57002
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7117.40318
-  tps: 5053.35626
+  dps: 7230.49183
+  tps: 5133.6492
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Netherblade"
  value: {
-  dps: 5284.24365
-  tps: 3751.81299
+  dps: 5342.96398
+  tps: 3793.50442
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6879.65449
-  tps: 4884.55468
+  dps: 6986.14741
+  tps: 4960.16466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7079.06637
-  tps: 5026.13713
+  dps: 7186.72351
+  tps: 5102.57369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7085.79404
-  tps: 5030.91377
+  dps: 7193.66313
+  tps: 5107.50082
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7050.4738
-  tps: 5005.8364
+  dps: 7157.23015
+  tps: 5081.6334
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7050.4738
-  tps: 5005.8364
+  dps: 7157.23015
+  tps: 5081.6334
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PrimalIntent"
  value: {
-  dps: 6322.30284
-  tps: 4488.83502
+  dps: 6409.37321
+  tps: 4550.65498
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6879.65449
-  tps: 4884.55468
+  dps: 6986.14741
+  tps: 4960.16466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7205.19167
-  tps: 5115.68608
+  dps: 7309.09479
+  tps: 5189.4573
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7245.49797
-  tps: 5144.30356
+  dps: 7348.87414
+  tps: 5217.70064
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7248.47234
-  tps: 5146.41536
+  dps: 7315.98803
+  tps: 5194.3515
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7050.4738
-  tps: 5005.8364
+  dps: 7157.23015
+  tps: 5081.6334
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6879.65449
-  tps: 4884.55468
+  dps: 6986.14741
+  tps: 4960.16466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6879.65449
-  tps: 4884.55468
+  dps: 6986.14741
+  tps: 4960.16466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 6954.23313
-  tps: 4937.50552
+  dps: 7024.30799
+  tps: 4987.25867
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 6621.3022
-  tps: 4701.12456
+  dps: 6827.99366
+  tps: 4847.8755
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6879.65449
-  tps: 4884.55468
+  dps: 6986.14741
+  tps: 4960.16466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6879.65449
-  tps: 4884.55468
+  dps: 6986.14741
+  tps: 4960.16466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 5173.85947
-  tps: 3673.44022
+  dps: 5254.31979
+  tps: 3730.56705
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 7018.01223
-  tps: 4982.78869
+  dps: 7086.40432
+  tps: 5031.34707
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 6033.45855
-  tps: 4283.75557
+  dps: 6088.66045
+  tps: 4322.94892
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StormshroudArmor"
  value: {
-  dps: 5539.07627
-  tps: 3930.03411
+  dps: 5641.46817
+  tps: 4002.81269
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 5567.28922
-  tps: 3952.77535
+  dps: 5668.75614
+  tps: 4024.81686
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7085.79404
-  tps: 5030.91377
+  dps: 7193.66313
+  tps: 5107.50082
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7079.06637
-  tps: 5026.13713
+  dps: 7186.72351
+  tps: 5102.57369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7067.29296
-  tps: 5017.778
+  dps: 7174.57918
+  tps: 5093.95122
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6626.14113
-  tps: 4704.5602
+  dps: 6685.5784
+  tps: 4746.76066
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheFistsofFury"
  value: {
-  dps: 6053.66335
-  tps: 4298.10098
+  dps: 6076.90564
+  tps: 4314.603
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheTwinStars"
  value: {
-  dps: 6659.98454
-  tps: 4728.58902
+  dps: 6736.88644
+  tps: 4783.18937
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7106.89036
-  tps: 5045.89215
+  dps: 7194.85406
+  tps: 5108.34638
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7218.99579
-  tps: 5125.48701
+  dps: 7337.80895
+  tps: 5209.84435
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7302.18746
-  tps: 5184.55309
+  dps: 7382.78408
+  tps: 5241.7767
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7050.4738
-  tps: 5005.8364
+  dps: 7157.23015
+  tps: 5081.6334
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7050.4738
-  tps: 5005.8364
+  dps: 7157.23015
+  tps: 5081.6334
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7050.4738
-  tps: 5005.8364
+  dps: 7157.23015
+  tps: 5081.6334
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7050.4738
-  tps: 5005.8364
+  dps: 7157.23015
+  tps: 5081.6334
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6164.23939
-  tps: 4376.60997
+  dps: 6192.2071
+  tps: 4396.46704
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 7300.61843
-  tps: 5183.43909
+  dps: 7398.41052
+  tps: 5252.87147
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WastewalkerArmor"
  value: {
-  dps: 5115.4923
-  tps: 3631.99953
+  dps: 5207.45836
+  tps: 3697.29543
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WindhawkArmor"
  value: {
-  dps: 6048.67636
-  tps: 4294.56022
+  dps: 6110.43392
+  tps: 4338.40809
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WrathofSpellfire"
  value: {
-  dps: 5812.11351
-  tps: 4126.60059
+  dps: 5869.16683
+  tps: 4167.10845
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 7113.92799
-  tps: 5050.88887
+  dps: 7256.37648
+  tps: 5152.0273
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25722.38641
-  tps: 18262.89435
+  dps: 26065.88123
+  tps: 18506.77567
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7248.47234
-  tps: 5146.41536
+  dps: 7315.98803
+  tps: 5194.3515
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8051.54695
-  tps: 5716.59833
+  dps: 8300.96904
+  tps: 5893.68802
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15060.72176
-  tps: 10693.11245
+  dps: 15276.55551
+  tps: 10846.35441
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3671.22359
-  tps: 2606.56875
+  dps: 3721.899
+  tps: 2642.54829
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3596.67525
-  tps: 2553.63943
+  dps: 3704.06983
+  tps: 2629.88958
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15735.17667
-  tps: 11171.97544
+  dps: 15871.23295
+  tps: 11268.5754
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5057.93378
-  tps: 3591.13298
+  dps: 4507.74944
+  tps: 3200.50211
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5873.32599
-  tps: 4170.06145
+  dps: 5336.32411
+  tps: 3788.79012
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8947.68031
-  tps: 6352.85302
+  dps: 9005.7538
+  tps: 6394.0852
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2388.89359
-  tps: 1696.11445
+  dps: 2143.56782
+  tps: 1521.93315
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2439.08966
-  tps: 1731.75366
+  dps: 2216.05864
+  tps: 1573.40163
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25722.38641
-  tps: 18262.89435
+  dps: 26065.88123
+  tps: 18506.77567
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7248.47234
-  tps: 5146.41536
+  dps: 7315.98803
+  tps: 5194.3515
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8051.54695
-  tps: 5716.59833
+  dps: 8300.96904
+  tps: 5893.68802
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15060.72176
-  tps: 10693.11245
+  dps: 15276.55551
+  tps: 10846.35441
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3671.22359
-  tps: 2606.56875
+  dps: 3721.899
+  tps: 2642.54829
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3596.67525
-  tps: 2553.63943
+  dps: 3704.06983
+  tps: 2629.88958
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19943.49563
-  tps: 14159.8819
+  dps: 20130.5241
+  tps: 14292.67211
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4798.3624
-  tps: 3406.8373
+  dps: 4725.86952
+  tps: 3355.36736
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5288.63475
-  tps: 3754.93068
+  dps: 5377.08062
+  tps: 3817.72724
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12849.45595
-  tps: 9123.11372
+  dps: 12951.12082
+  tps: 9195.29578
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2455.77684
-  tps: 1743.60156
+  dps: 2435.8514
+  tps: 1729.45449
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2428.46642
-  tps: 1724.21116
+  dps: 2481.74965
+  tps: 1762.04225
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25914.72529
-  tps: 18399.45495
+  dps: 26216.58675
+  tps: 18613.77659
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7281.045
-  tps: 5169.54195
+  dps: 7370.80272
+  tps: 5233.26993
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8144.12219
-  tps: 5782.32676
+  dps: 8399.84926
+  tps: 5963.89297
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15147.15618
-  tps: 10754.48089
+  dps: 15302.66201
+  tps: 10864.89003
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3676.37866
-  tps: 2610.22885
+  dps: 3749.01156
+  tps: 2661.79821
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3647.73143
-  tps: 2589.88932
+  dps: 3719.55761
+  tps: 2640.8859
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15834.17104
-  tps: 11242.26144
+  dps: 15947.80976
+  tps: 11322.94493
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5099.64941
-  tps: 3620.75108
+  dps: 4539.4059
+  tps: 3222.97819
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5943.57766
-  tps: 4219.94014
+  dps: 5400.47168
+  tps: 3834.3349
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8998.28871
-  tps: 6388.78498
+  dps: 9041.5193
+  tps: 6419.4787
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2406.86442
-  tps: 1708.87374
+  dps: 2157.35181
+  tps: 1531.71979
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2466.7445
-  tps: 1751.3886
+  dps: 2223.81175
+  tps: 1578.90634
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25914.72529
-  tps: 18399.45495
+  dps: 26216.58675
+  tps: 18613.77659
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7281.045
-  tps: 5169.54195
+  dps: 7370.80272
+  tps: 5233.26993
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8144.12219
-  tps: 5782.32676
+  dps: 8399.84926
+  tps: 5963.89297
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15147.15618
-  tps: 10754.48089
+  dps: 15302.66201
+  tps: 10864.89003
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3676.37866
-  tps: 2610.22885
+  dps: 3749.01156
+  tps: 2661.79821
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3647.73143
-  tps: 2589.88932
+  dps: 3719.55761
+  tps: 2640.8859
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20011.50649
-  tps: 14208.16961
+  dps: 20214.85244
+  tps: 14352.54523
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4825.94525
-  tps: 3426.42113
+  dps: 4752.57987
+  tps: 3374.33171
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5348.74527
-  tps: 3797.60914
+  dps: 5439.60209
+  tps: 3862.11748
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12920.09801
-  tps: 9173.26959
+  dps: 13015.5232
+  tps: 9241.02147
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2467.91061
-  tps: 1752.21653
+  dps: 2465.65302
+  tps: 1750.61364
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2429.71609
-  tps: 1725.09842
+  dps: 2524.27841
+  tps: 1792.23767
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6621.30626
-  tps: 4701.12745
+  dps: 6759.74107
+  tps: 4799.41616
  }
 }

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -52,924 +52,924 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7137.69141
-  tps: 5067.7609
+  dps: 7011.39391
+  tps: 4978.08968
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AssassinationArmor"
  value: {
-  dps: 5410.99161
-  tps: 3841.80404
+  dps: 5312.36795
+  tps: 3771.78124
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7153.94071
-  tps: 5079.2979
+  dps: 7050.4738
+  tps: 5005.8364
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7197.50192
-  tps: 5110.22636
+  dps: 7097.76276
+  tps: 5039.41156
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7179.88992
-  tps: 5097.72184
+  dps: 7066.80018
+  tps: 5017.42813
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6455.99415
-  tps: 4583.75585
+  dps: 6381.01652
+  tps: 4530.52173
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7153.94071
-  tps: 4977.71195
+  dps: 7050.4738
+  tps: 4905.71967
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 7092.38506
-  tps: 5035.5934
+  dps: 7018.73692
+  tps: 4983.30322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7294.98297
-  tps: 5179.43791
+  dps: 7182.19623
+  tps: 5099.35932
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7116.84225
-  tps: 5052.958
+  dps: 7002.48227
+  tps: 4971.76241
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7175.10898
-  tps: 5094.32737
+  dps: 7045.12509
+  tps: 5002.03881
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 7236.89329
-  tps: 5138.19424
+  dps: 7144.7603
+  tps: 5072.77981
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7150.34259
-  tps: 5076.74324
+  dps: 7060.54191
+  tps: 5012.98475
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7115.59339
-  tps: 5052.07131
+  dps: 7023.3622
+  tps: 4986.58716
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathmantle"
  value: {
-  dps: 5758.66059
-  tps: 4088.64902
+  dps: 5607.65681
+  tps: 3981.43633
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6970.73844
-  tps: 4949.2243
+  dps: 6879.65449
+  tps: 4884.55468
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7209.26433
-  tps: 5118.57768
+  dps: 7066.33377
+  tps: 5017.09698
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7153.94071
-  tps: 5079.2979
+  dps: 7050.4738
+  tps: 5005.8364
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7153.94071
-  tps: 5079.2979
+  dps: 7050.4738
+  tps: 5005.8364
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7179.88992
-  tps: 5097.72184
+  dps: 7066.80018
+  tps: 5017.42813
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7172.30849
-  tps: 5092.33903
+  dps: 7047.15599
+  tps: 5003.48075
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7153.94071
-  tps: 5079.2979
+  dps: 7050.4738
+  tps: 5005.8364
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7138.26003
-  tps: 5068.16462
+  dps: 6991.47887
+  tps: 4963.95
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7097.84245
-  tps: 5039.46814
+  dps: 6987.25653
+  tps: 4960.95213
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7048.38841
-  tps: 5004.35577
+  dps: 7001.69973
+  tps: 4971.20681
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7153.94071
-  tps: 5079.2979
+  dps: 7050.4738
+  tps: 5005.8364
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7153.94071
-  tps: 5079.2979
+  dps: 7050.4738
+  tps: 5005.8364
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7245.03459
-  tps: 5143.97456
+  dps: 7146.03326
+  tps: 5073.68362
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6970.73844
-  tps: 4949.2243
+  dps: 6879.65449
+  tps: 4884.55468
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7111.66881
-  tps: 5049.28485
+  dps: 6954.82483
+  tps: 4937.92563
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6970.73844
-  tps: 4949.2243
+  dps: 6879.65449
+  tps: 4884.55468
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7179.88992
-  tps: 5097.72184
+  dps: 7066.80018
+  tps: 5017.42813
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7172.30849
-  tps: 5092.33903
+  dps: 7047.15599
+  tps: 5003.48075
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7179.3897
-  tps: 5097.36669
+  dps: 7080.59726
+  tps: 5027.22406
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 7019.83421
-  tps: 4984.08229
+  dps: 6925.47638
+  tps: 4917.08823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7153.94071
-  tps: 5079.2979
+  dps: 7050.4738
+  tps: 5005.8364
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7190.35704
-  tps: 5105.1535
+  dps: 7085.79404
+  tps: 5030.91377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6970.73844
-  tps: 4949.2243
+  dps: 6879.65449
+  tps: 4884.55468
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6970.73844
-  tps: 4949.2243
+  dps: 6879.65449
+  tps: 4884.55468
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 4821.24279
-  tps: 3423.08238
+  dps: 4750.60063
+  tps: 3372.92645
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7258.8989
-  tps: 5153.81822
+  dps: 7117.40318
+  tps: 5053.35626
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Netherblade"
  value: {
-  dps: 5297.23354
-  tps: 3761.03582
+  dps: 5284.24365
+  tps: 3751.81299
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6970.73844
-  tps: 4949.2243
+  dps: 6879.65449
+  tps: 4884.55468
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7183.42059
-  tps: 5100.22862
+  dps: 7079.06637
+  tps: 5026.13713
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7190.35704
-  tps: 5105.1535
+  dps: 7085.79404
+  tps: 5030.91377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7153.94071
-  tps: 5079.2979
+  dps: 7050.4738
+  tps: 5005.8364
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7153.94071
-  tps: 5079.2979
+  dps: 7050.4738
+  tps: 5005.8364
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PrimalIntent"
  value: {
-  dps: 6370.99333
-  tps: 4523.40526
+  dps: 6322.30284
+  tps: 4488.83502
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6970.73844
-  tps: 4949.2243
+  dps: 6879.65449
+  tps: 4884.55468
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7300.81764
-  tps: 5183.58052
+  dps: 7205.19167
+  tps: 5115.68608
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7341.51331
-  tps: 5212.47445
+  dps: 7245.49797
+  tps: 5144.30356
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7274.36581
-  tps: 5164.79972
+  dps: 7248.47234
+  tps: 5146.41536
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7153.94071
-  tps: 5079.2979
+  dps: 7050.4738
+  tps: 5005.8364
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6970.73844
-  tps: 4949.2243
+  dps: 6879.65449
+  tps: 4884.55468
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6970.73844
-  tps: 4949.2243
+  dps: 6879.65449
+  tps: 4884.55468
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 7054.65942
-  tps: 5008.80819
+  dps: 6954.23313
+  tps: 4937.50552
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 6803.4488
-  tps: 4830.44865
+  dps: 6621.3022
+  tps: 4701.12456
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6970.73844
-  tps: 4949.2243
+  dps: 6879.65449
+  tps: 4884.55468
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6970.73844
-  tps: 4949.2243
+  dps: 6879.65449
+  tps: 4884.55468
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 5263.49497
-  tps: 3737.08143
+  dps: 5173.85947
+  tps: 3673.44022
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 7079.17578
-  tps: 5026.2148
+  dps: 7018.01223
+  tps: 4982.78869
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 6100.56222
-  tps: 4331.39917
+  dps: 6033.45855
+  tps: 4283.75557
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StormshroudArmor"
  value: {
-  dps: 5630.79944
-  tps: 3995.21672
+  dps: 5539.07627
+  tps: 3930.03411
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 5689.97751
-  tps: 4039.88403
+  dps: 5567.28922
+  tps: 3952.77535
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7190.35704
-  tps: 5105.1535
+  dps: 7085.79404
+  tps: 5030.91377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7183.42059
-  tps: 5100.22862
+  dps: 7079.06637
+  tps: 5026.13713
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7171.28182
-  tps: 5091.61009
+  dps: 7067.29296
+  tps: 5017.778
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6643.248
-  tps: 4716.70608
+  dps: 6626.14113
+  tps: 4704.5602
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheFistsofFury"
  value: {
-  dps: 4957.94922
-  tps: 3520.14395
+  dps: 6053.66335
+  tps: 4298.10098
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheTwinStars"
  value: {
-  dps: 6733.21204
-  tps: 4780.58055
+  dps: 6659.98454
+  tps: 4728.58902
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7221.23155
-  tps: 5127.0744
+  dps: 7106.89036
+  tps: 5045.89215
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7322.28954
-  tps: 5198.82558
+  dps: 7218.99579
+  tps: 5125.48701
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7366.75025
-  tps: 5230.39268
+  dps: 7302.18746
+  tps: 5184.55309
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7153.94071
-  tps: 5079.2979
+  dps: 7050.4738
+  tps: 5005.8364
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7153.94071
-  tps: 5079.2979
+  dps: 7050.4738
+  tps: 5005.8364
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7153.94071
-  tps: 5079.2979
+  dps: 7050.4738
+  tps: 5005.8364
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7153.94071
-  tps: 5079.2979
+  dps: 7050.4738
+  tps: 5005.8364
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6202.48633
-  tps: 4403.76529
+  dps: 6164.23939
+  tps: 4376.60997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 7439.94571
-  tps: 5282.36146
+  dps: 7300.61843
+  tps: 5183.43909
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WastewalkerArmor"
  value: {
-  dps: 5210.16536
-  tps: 3699.21741
+  dps: 5115.4923
+  tps: 3631.99953
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WindhawkArmor"
  value: {
-  dps: 6112.51952
-  tps: 4339.88886
+  dps: 6048.67636
+  tps: 4294.56022
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WrathofSpellfire"
  value: {
-  dps: 5831.16021
-  tps: 4140.12375
+  dps: 5812.11351
+  tps: 4126.60059
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 7242.27275
-  tps: 5142.01365
+  dps: 7113.92799
+  tps: 5050.88887
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25934.1735
-  tps: 18413.26318
+  dps: 25722.38641
+  tps: 18262.89435
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7274.36581
-  tps: 5164.79972
+  dps: 7248.47234
+  tps: 5146.41536
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8289.24227
-  tps: 5885.36201
+  dps: 8051.54695
+  tps: 5716.59833
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15157.07727
-  tps: 10761.52486
+  dps: 15060.72176
+  tps: 10693.11245
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3707.13565
-  tps: 2632.06631
+  dps: 3671.22359
+  tps: 2606.56875
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3694.57623
-  tps: 2623.14913
+  dps: 3596.67525
+  tps: 2553.63943
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15853.76894
-  tps: 11256.17595
+  dps: 15735.17667
+  tps: 11171.97544
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4505.69208
-  tps: 3199.04138
+  dps: 5057.93378
+  tps: 3591.13298
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5361.68732
-  tps: 3806.798
+  dps: 5873.32599
+  tps: 4170.06145
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9010.8599
-  tps: 6397.71053
+  dps: 8947.68031
+  tps: 6352.85302
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2148.6179
-  tps: 1525.51871
+  dps: 2388.89359
+  tps: 1696.11445
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2210.21122
-  tps: 1569.24997
+  dps: 2439.08966
+  tps: 1731.75366
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25934.1735
-  tps: 18413.26318
+  dps: 25722.38641
+  tps: 18262.89435
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7274.36581
-  tps: 5164.79972
+  dps: 7248.47234
+  tps: 5146.41536
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8289.24227
-  tps: 5885.36201
+  dps: 8051.54695
+  tps: 5716.59833
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15157.07727
-  tps: 10761.52486
+  dps: 15060.72176
+  tps: 10693.11245
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3707.13565
-  tps: 2632.06631
+  dps: 3671.22359
+  tps: 2606.56875
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3694.57623
-  tps: 2623.14913
+  dps: 3596.67525
+  tps: 2553.63943
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20100.91888
-  tps: 14271.6524
+  dps: 19943.49563
+  tps: 14159.8819
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4704.43836
-  tps: 3340.15123
+  dps: 4798.3624
+  tps: 3406.8373
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5369.27857
-  tps: 3812.18778
+  dps: 5288.63475
+  tps: 3754.93068
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12990.16066
-  tps: 9223.01407
+  dps: 12849.45595
+  tps: 9123.11372
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2431.06548
-  tps: 1726.05649
+  dps: 2455.77684
+  tps: 1743.60156
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2472.1024
-  tps: 1755.1927
+  dps: 2428.46642
+  tps: 1724.21116
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26156.47378
-  tps: 18571.09638
+  dps: 25914.72529
+  tps: 18399.45495
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7342.94132
-  tps: 5213.48834
+  dps: 7281.045
+  tps: 5169.54195
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8388.15393
-  tps: 5955.58929
+  dps: 8144.12219
+  tps: 5782.32676
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15228.80243
-  tps: 10812.44972
+  dps: 15147.15618
+  tps: 10754.48089
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3737.28947
-  tps: 2653.47553
+  dps: 3676.37866
+  tps: 2610.22885
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3733.76467
-  tps: 2650.97292
+  dps: 3647.73143
+  tps: 2589.88932
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15927.78321
-  tps: 11308.72608
+  dps: 15834.17104
+  tps: 11242.26144
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4532.27651
-  tps: 3217.91632
+  dps: 5099.64941
+  tps: 3620.75108
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5425.62798
-  tps: 3852.19587
+  dps: 5943.57766
+  tps: 4219.94014
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9075.89622
-  tps: 6443.88631
+  dps: 8998.28871
+  tps: 6388.78498
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2150.82352
-  tps: 1527.0847
+  dps: 2406.86442
+  tps: 1708.87374
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2226.13932
-  tps: 1580.55891
+  dps: 2466.7445
+  tps: 1751.3886
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26156.47378
-  tps: 18571.09638
+  dps: 25914.72529
+  tps: 18399.45495
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7342.94132
-  tps: 5213.48834
+  dps: 7281.045
+  tps: 5169.54195
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8388.15393
-  tps: 5955.58929
+  dps: 8144.12219
+  tps: 5782.32676
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15228.80243
-  tps: 10812.44972
+  dps: 15147.15618
+  tps: 10754.48089
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3737.28947
-  tps: 2653.47553
+  dps: 3676.37866
+  tps: 2610.22885
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3733.76467
-  tps: 2650.97292
+  dps: 3647.73143
+  tps: 2589.88932
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20214.96004
-  tps: 14352.62163
+  dps: 20011.50649
+  tps: 14208.16961
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4720.87766
-  tps: 3351.82314
+  dps: 4825.94525
+  tps: 3426.42113
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5431.04015
-  tps: 3856.03851
+  dps: 5348.74527
+  tps: 3797.60914
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13036.37931
-  tps: 9255.82931
+  dps: 12920.09801
+  tps: 9173.26959
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2450.08949
-  tps: 1739.56354
+  dps: 2467.91061
+  tps: 1752.21653
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2508.46427
-  tps: 1781.00963
+  dps: 2429.71609
+  tps: 1725.09842
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6761.72326
-  tps: 4800.82351
+  dps: 6621.30626
+  tps: 4701.12745
  }
 }

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -52,931 +52,931 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 6335.78402
-  tps: 4498.40665
+  dps: 6267.61497
+  tps: 4450.00663
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AssassinationArmor"
  value: {
-  dps: 4774.72883
-  tps: 3390.05747
+  dps: 4725.23692
+  tps: 3354.91822
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6371.949
-  tps: 4524.08379
+  dps: 6306.33247
+  tps: 4477.49606
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6446.79354
-  tps: 4577.22341
+  dps: 6386.45909
+  tps: 4534.38595
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6397.65137
-  tps: 4542.33247
+  dps: 6331.35424
+  tps: 4495.26151
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BonescytheBattlegear"
  value: {
-  dps: 5909.47424
-  tps: 4195.72671
+  dps: 5862.51332
+  tps: 4162.38446
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6371.949
-  tps: 4433.60212
+  dps: 6306.33247
+  tps: 4387.94614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 6337.37813
-  tps: 4499.53848
+  dps: 6285.97739
+  tps: 4463.04395
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6512.72542
-  tps: 4624.03504
+  dps: 6445.24223
+  tps: 4576.12198
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6371.7895
-  tps: 4523.97055
+  dps: 6304.96866
+  tps: 4476.52775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6406.47254
-  tps: 4548.5955
+  dps: 6341.83046
+  tps: 4502.69963
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6461.21503
-  tps: 4587.46267
+  dps: 6397.92689
+  tps: 4542.5281
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6384.25413
-  tps: 4532.82043
+  dps: 6321.48719
+  tps: 4488.25591
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6349.96936
-  tps: 4508.47825
+  dps: 6280.25234
+  tps: 4458.97916
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathmantle"
  value: {
-  dps: 5048.81036
-  tps: 3584.65535
+  dps: 5025.92395
+  tps: 3568.40601
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6248.60628
-  tps: 4436.51046
+  dps: 6186.17084
+  tps: 4392.18129
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6402.24708
-  tps: 4545.59542
+  dps: 6335.13098
+  tps: 4497.943
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6371.949
-  tps: 4524.08379
+  dps: 6306.33247
+  tps: 4477.49606
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6371.949
-  tps: 4524.08379
+  dps: 6306.33247
+  tps: 4477.49606
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6397.65137
-  tps: 4542.33247
+  dps: 6331.35424
+  tps: 4495.26151
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6392.09957
-  tps: 4538.39069
+  dps: 6327.46868
+  tps: 4492.50277
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6371.949
-  tps: 4524.08379
+  dps: 6306.33247
+  tps: 4477.49606
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6392.16971
-  tps: 4538.4405
+  dps: 6327.5468
+  tps: 4492.55823
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6353.03446
-  tps: 4510.65446
+  dps: 6285.75083
+  tps: 4462.88309
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6335.2222
-  tps: 4498.00776
+  dps: 6267.44676
+  tps: 4449.8872
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6371.949
-  tps: 4524.08379
+  dps: 6306.33247
+  tps: 4477.49606
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6371.949
-  tps: 4524.08379
+  dps: 6306.33247
+  tps: 4477.49606
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6493.2097
-  tps: 4610.17889
+  dps: 6428.94601
+  tps: 4564.55167
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6248.60628
-  tps: 4436.51046
+  dps: 6186.17084
+  tps: 4392.18129
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Gladiator'sVestments"
  value: {
-  dps: 6516.69549
-  tps: 4626.8538
+  dps: 6440.15125
+  tps: 4572.50739
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6248.60628
-  tps: 4436.51046
+  dps: 6186.17084
+  tps: 4392.18129
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6397.65137
-  tps: 4542.33247
+  dps: 6331.35424
+  tps: 4495.26151
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6392.09957
-  tps: 4538.39069
+  dps: 6327.46868
+  tps: 4492.50277
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6425.57204
-  tps: 4562.15615
+  dps: 6369.86435
+  tps: 4522.60369
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 6280.05606
-  tps: 4458.83981
+  dps: 6224.58776
+  tps: 4419.45731
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6371.949
-  tps: 4524.08379
+  dps: 6306.33247
+  tps: 4477.49606
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6404.23918
-  tps: 4547.00982
+  dps: 6338.39001
+  tps: 4500.25691
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6248.60628
-  tps: 4436.51046
+  dps: 6186.17084
+  tps: 4392.18129
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6248.60628
-  tps: 4436.51046
+  dps: 6186.17084
+  tps: 4392.18129
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 4455.90097
-  tps: 3163.68969
+  dps: 4428.35466
+  tps: 3144.13181
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6444.98859
-  tps: 4575.9419
+  dps: 6392.09453
+  tps: 4538.38712
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Netherblade"
  value: {
-  dps: 4939.30449
-  tps: 3506.90619
+  dps: 4933.68444
+  tps: 3502.91596
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6248.60628
-  tps: 4436.51046
+  dps: 6186.17084
+  tps: 4392.18129
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6398.08867
-  tps: 4542.64295
+  dps: 6332.28381
+  tps: 4495.92151
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6404.23918
-  tps: 4547.00982
+  dps: 6338.39001
+  tps: 4500.25691
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6371.949
-  tps: 4524.08379
+  dps: 6306.33247
+  tps: 4477.49606
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6371.949
-  tps: 4524.08379
+  dps: 6306.33247
+  tps: 4477.49606
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PrimalIntent"
  value: {
-  dps: 5852.0325
-  tps: 4154.94308
+  dps: 5835.37514
+  tps: 4143.11635
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6248.60628
-  tps: 4436.51046
+  dps: 6186.17084
+  tps: 4392.18129
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6563.41751
-  tps: 4660.02643
+  dps: 6498.88447
+  tps: 4614.20797
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6602.74223
-  tps: 4687.94699
+  dps: 6538.01139
+  tps: 4641.98809
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6513.63639
-  tps: 4624.68184
+  dps: 6447.1848
+  tps: 4577.50121
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6371.949
-  tps: 4524.08379
+  dps: 6306.33247
+  tps: 4477.49606
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6248.60628
-  tps: 4436.51046
+  dps: 6186.17084
+  tps: 4392.18129
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6248.60628
-  tps: 4436.51046
+  dps: 6186.17084
+  tps: 4392.18129
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 6296.13957
-  tps: 4470.25909
+  dps: 6231.28686
+  tps: 4424.21367
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 5983.12725
-  tps: 4248.02035
+  dps: 5973.13388
+  tps: 4240.92506
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6248.60628
-  tps: 4436.51046
+  dps: 6186.17084
+  tps: 4392.18129
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6248.60628
-  tps: 4436.51046
+  dps: 6186.17084
+  tps: 4392.18129
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Slayer'sArmor"
  value: {
-  dps: 4867.51917
-  tps: 3455.93861
+  dps: 4826.56702
+  tps: 3426.86259
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SparkofLife-37657"
  value: {
-  dps: 6331.03694
-  tps: 4495.03623
+  dps: 6283.51971
+  tps: 4461.29899
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 5606.50229
-  tps: 3980.61663
+  dps: 5580.30121
+  tps: 3962.01386
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StormshroudArmor"
  value: {
-  dps: 5041.0928
-  tps: 3576.63916
+  dps: 5017.21951
+  tps: 3559.69201
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 5269.43792
-  tps: 3741.30092
+  dps: 5212.73665
+  tps: 3701.04302
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6404.23918
-  tps: 4547.00982
+  dps: 6338.39001
+  tps: 4500.25691
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6398.08867
-  tps: 4542.64295
+  dps: 6332.28381
+  tps: 4495.92151
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6387.32528
-  tps: 4535.00095
+  dps: 6321.59797
+  tps: 4488.33456
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6155.51166
-  tps: 4370.41328
+  dps: 6103.25458
+  tps: 4333.31075
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheFistsofFury"
  value: {
-  dps: 5650.20396
-  tps: 4011.64481
+  dps: 5632.80729
+  tps: 3999.29318
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5790.87397
-  tps: 4111.52052
+  dps: 5780.86689
+  tps: 4104.41549
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinStars"
  value: {
-  dps: 6068.36582
-  tps: 4308.53973
+  dps: 6011.17332
+  tps: 4267.93306
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6431.56159
-  tps: 4566.40873
+  dps: 6369.37336
+  tps: 4522.25509
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6534.17099
-  tps: 4639.2614
+  dps: 6494.72063
+  tps: 4611.25164
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6553.3829
-  tps: 4652.90186
+  dps: 6502.61402
+  tps: 4616.85595
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6371.949
-  tps: 4524.08379
+  dps: 6306.33247
+  tps: 4477.49606
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6371.949
-  tps: 4524.08379
+  dps: 6306.33247
+  tps: 4477.49606
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6371.949
-  tps: 4524.08379
+  dps: 6306.33247
+  tps: 4477.49606
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6371.949
-  tps: 4524.08379
+  dps: 6306.33247
+  tps: 4477.49606
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 5590.81425
-  tps: 3969.47812
+  dps: 5565.08678
+  tps: 3951.21161
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 6711.47177
-  tps: 4765.14496
+  dps: 6662.90991
+  tps: 4730.66604
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WastewalkerArmor"
  value: {
-  dps: 4810.57796
-  tps: 3415.51035
+  dps: 4764.5427
+  tps: 3382.82532
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WindhawkArmor"
  value: {
-  dps: 5601.53262
-  tps: 3977.08816
+  dps: 5557.21436
+  tps: 3945.62219
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WrathofSpellfire"
  value: {
-  dps: 5415.31807
-  tps: 3844.87583
+  dps: 5363.44707
+  tps: 3808.04742
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 6436.76796
-  tps: 4570.10525
+  dps: 6385.17586
+  tps: 4533.47486
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14279.00246
-  tps: 10138.09175
+  dps: 14241.67959
+  tps: 10111.59251
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5514.47426
-  tps: 3915.27673
+  dps: 5458.30246
+  tps: 3875.39475
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6631.59973
-  tps: 4708.43581
+  dps: 6644.44035
+  tps: 4717.55265
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8718.23795
-  tps: 6189.94894
+  dps: 8739.4939
+  tps: 6205.04067
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2566.25348
-  tps: 1822.03997
+  dps: 2527.8495
+  tps: 1794.77314
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2751.68996
-  tps: 1953.69987
+  dps: 2748.65218
+  tps: 1951.54305
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19523.29107
-  tps: 13861.53666
+  dps: 19465.16128
+  tps: 13820.26451
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6513.63639
-  tps: 4624.68184
+  dps: 6447.1848
+  tps: 4577.50121
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7563.38944
-  tps: 5370.0065
+  dps: 7589.43632
+  tps: 5388.49979
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12287.95041
-  tps: 8724.44479
+  dps: 12332.09703
+  tps: 8755.78889
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3212.82872
-  tps: 2281.10839
+  dps: 3176.21909
+  tps: 2255.11555
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3360.05932
-  tps: 2385.64212
+  dps: 3347.82612
+  tps: 2376.95654
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19523.29107
-  tps: 13861.53666
+  dps: 19465.16128
+  tps: 13820.26451
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6513.63639
-  tps: 4624.68184
+  dps: 6447.1848
+  tps: 4577.50121
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7563.38944
-  tps: 5370.0065
+  dps: 7589.43632
+  tps: 5388.49979
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12287.95041
-  tps: 8724.44479
+  dps: 12332.09703
+  tps: 8755.78889
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3212.82872
-  tps: 2281.10839
+  dps: 3176.21909
+  tps: 2255.11555
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3360.05932
-  tps: 2385.64212
+  dps: 3347.82612
+  tps: 2376.95654
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18231.02373
-  tps: 12944.02685
+  dps: 18224.65557
+  tps: 12939.50545
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4801.37958
-  tps: 3408.9795
+  dps: 4745.55503
+  tps: 3369.34407
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5544.98682
-  tps: 3936.94064
+  dps: 5576.65668
+  tps: 3959.42624
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11969.85131
-  tps: 8498.59443
+  dps: 12033.49015
+  tps: 8543.77801
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2391.40881
-  tps: 1697.90025
+  dps: 2356.32477
+  tps: 1672.99058
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2525.90056
-  tps: 1793.3894
+  dps: 2520.28428
+  tps: 1789.40184
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14407.77291
-  tps: 10229.51876
+  dps: 14369.10508
+  tps: 10202.0646
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5558.87818
-  tps: 3946.80351
+  dps: 5502.2303
+  tps: 3906.58351
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6718.59825
-  tps: 4770.20476
+  dps: 6736.1752
+  tps: 4782.68439
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8806.99091
-  tps: 6252.96354
+  dps: 8827.10756
+  tps: 6267.24637
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2590.56243
-  tps: 1839.29932
+  dps: 2552.50661
+  tps: 1812.27969
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2792.98617
-  tps: 1983.02018
+  dps: 2791.1183
+  tps: 1981.69399
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19676.78996
-  tps: 13970.52087
+  dps: 19619.02937
+  tps: 13929.51085
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6565.69459
-  tps: 4661.64316
+  dps: 6498.98081
+  tps: 4614.27638
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7663.79468
-  tps: 5441.29422
+  dps: 7694.25396
+  tps: 5462.92031
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12397.87566
-  tps: 8802.49172
+  dps: 12442.79819
+  tps: 8834.38672
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3242.34653
-  tps: 2302.06604
+  dps: 3206.2675
+  tps: 2276.44993
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3409.77353
-  tps: 2420.9392
+  dps: 3399.58924
+  tps: 2413.70836
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19676.78996
-  tps: 13970.52087
+  dps: 19619.02937
+  tps: 13929.51085
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6565.69459
-  tps: 4661.64316
+  dps: 6498.98081
+  tps: 4614.27638
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7663.79468
-  tps: 5441.29422
+  dps: 7694.25396
+  tps: 5462.92031
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12397.87566
-  tps: 8802.49172
+  dps: 12442.79819
+  tps: 8834.38672
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3242.34653
-  tps: 2302.06604
+  dps: 3206.2675
+  tps: 2276.44993
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3409.77353
-  tps: 2420.9392
+  dps: 3399.58924
+  tps: 2413.70836
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18373.41119
-  tps: 13045.12195
+  dps: 18366.35061
+  tps: 13040.10893
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4838.66715
-  tps: 3435.45367
+  dps: 4782.27903
+  tps: 3395.41811
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5615.37712
-  tps: 3986.91775
+  dps: 5651.85756
+  tps: 4012.81887
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12074.5663
-  tps: 8572.94207
+  dps: 12139.13112
+  tps: 8618.7831
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2413.16855
-  tps: 1713.34967
+  dps: 2378.28584
+  tps: 1688.58295
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2562.21087
-  tps: 1819.16972
+  dps: 2557.85541
+  tps: 1816.07734
  }
 }
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6237.80951
-  tps: 4428.84475
+  dps: 6183.02801
+  tps: 4389.94989
  }
 }

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -52,589 +52,589 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 6267.61497
-  tps: 4450.00663
+  dps: 6299.77565
+  tps: 4472.84071
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AssassinationArmor"
  value: {
-  dps: 4725.23692
-  tps: 3354.91822
+  dps: 4733.66092
+  tps: 3360.89926
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6306.33247
-  tps: 4477.49606
+  dps: 6335.97035
+  tps: 4498.53895
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6386.45909
-  tps: 4534.38595
+  dps: 6413.77642
+  tps: 4553.78126
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6331.35424
-  tps: 4495.26151
+  dps: 6360.59734
+  tps: 4516.02411
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BonescytheBattlegear"
  value: {
-  dps: 5862.51332
-  tps: 4162.38446
+  dps: 5863.20616
+  tps: 4162.87637
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6306.33247
-  tps: 4387.94614
+  dps: 6335.97035
+  tps: 4408.56817
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 6285.97739
-  tps: 4463.04395
+  dps: 6291.19973
+  tps: 4466.75181
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6445.24223
-  tps: 4576.12198
+  dps: 6475.13812
+  tps: 4597.34807
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6304.96866
-  tps: 4476.52775
+  dps: 6333.41644
+  tps: 4496.72567
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6341.83046
-  tps: 4502.69963
+  dps: 6367.49921
+  tps: 4520.92444
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6397.92689
-  tps: 4542.5281
+  dps: 6427.29472
+  tps: 4563.37925
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6321.48719
-  tps: 4488.25591
+  dps: 6350.63368
+  tps: 4508.94991
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6280.25234
-  tps: 4458.97916
+  dps: 6309.11736
+  tps: 4479.47332
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathmantle"
  value: {
-  dps: 5025.92395
-  tps: 3568.40601
+  dps: 5032.12742
+  tps: 3572.81047
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6186.17084
-  tps: 4392.18129
+  dps: 6214.53092
+  tps: 4412.31695
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6335.13098
-  tps: 4497.943
+  dps: 6365.55156
+  tps: 4519.5416
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6306.33247
-  tps: 4477.49606
+  dps: 6335.97035
+  tps: 4498.53895
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6306.33247
-  tps: 4477.49606
+  dps: 6335.97035
+  tps: 4498.53895
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6331.35424
-  tps: 4495.26151
+  dps: 6360.59734
+  tps: 4516.02411
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6327.46868
-  tps: 4492.50277
+  dps: 6355.98786
+  tps: 4512.75138
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6306.33247
-  tps: 4477.49606
+  dps: 6335.97035
+  tps: 4498.53895
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6327.5468
-  tps: 4492.55823
+  dps: 6355.48659
+  tps: 4512.39548
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6285.75083
-  tps: 4462.88309
+  dps: 6312.88878
+  tps: 4482.15103
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6267.44676
-  tps: 4449.8872
+  dps: 6295.19524
+  tps: 4469.58862
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6306.33247
-  tps: 4477.49606
+  dps: 6335.97035
+  tps: 4498.53895
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6306.33247
-  tps: 4477.49606
+  dps: 6335.97035
+  tps: 4498.53895
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6428.94601
-  tps: 4564.55167
+  dps: 6458.0559
+  tps: 4585.21969
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6186.17084
-  tps: 4392.18129
+  dps: 6214.53092
+  tps: 4412.31695
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Gladiator'sVestments"
  value: {
-  dps: 6440.15125
-  tps: 4572.50739
+  dps: 6447.21753
+  tps: 4577.52444
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6186.17084
-  tps: 4392.18129
+  dps: 6214.53092
+  tps: 4412.31695
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6331.35424
-  tps: 4495.26151
+  dps: 6360.59734
+  tps: 4516.02411
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6327.46868
-  tps: 4492.50277
+  dps: 6355.98786
+  tps: 4512.75138
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6369.86435
-  tps: 4522.60369
+  dps: 6370.87128
+  tps: 4523.31861
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 6224.58776
-  tps: 4419.45731
+  dps: 6221.35456
+  tps: 4417.16174
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6306.33247
-  tps: 4477.49606
+  dps: 6335.97035
+  tps: 4498.53895
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6338.39001
-  tps: 4500.25691
+  dps: 6368.12076
+  tps: 4521.36574
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6186.17084
-  tps: 4392.18129
+  dps: 6214.53092
+  tps: 4412.31695
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6186.17084
-  tps: 4392.18129
+  dps: 6214.53092
+  tps: 4412.31695
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 4428.35466
-  tps: 3144.13181
+  dps: 4425.17359
+  tps: 3141.87325
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6392.09453
-  tps: 4538.38712
+  dps: 6407.86378
+  tps: 4549.58328
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Netherblade"
  value: {
-  dps: 4933.68444
-  tps: 3502.91596
+  dps: 4909.6506
+  tps: 3485.85192
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6186.17084
-  tps: 4392.18129
+  dps: 6214.53092
+  tps: 4412.31695
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6332.28381
-  tps: 4495.92151
+  dps: 6361.99688
+  tps: 4517.01778
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6338.39001
-  tps: 4500.25691
+  dps: 6368.12076
+  tps: 4521.36574
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6306.33247
-  tps: 4477.49606
+  dps: 6335.97035
+  tps: 4498.53895
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6306.33247
-  tps: 4477.49606
+  dps: 6335.97035
+  tps: 4498.53895
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PrimalIntent"
  value: {
-  dps: 5835.37514
-  tps: 4143.11635
+  dps: 5849.11512
+  tps: 4152.87174
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6186.17084
-  tps: 4392.18129
+  dps: 6214.53092
+  tps: 4412.31695
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6498.88447
-  tps: 4614.20797
+  dps: 6526.83102
+  tps: 4634.05002
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6538.01139
-  tps: 4641.98809
+  dps: 6565.37973
+  tps: 4661.41961
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6447.1848
-  tps: 4577.50121
+  dps: 6477.13841
+  tps: 4598.76827
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6306.33247
-  tps: 4477.49606
+  dps: 6335.97035
+  tps: 4498.53895
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6186.17084
-  tps: 4392.18129
+  dps: 6214.53092
+  tps: 4412.31695
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6186.17084
-  tps: 4392.18129
+  dps: 6214.53092
+  tps: 4412.31695
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 6231.28686
-  tps: 4424.21367
+  dps: 6260.58857
+  tps: 4445.01788
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 5973.13388
-  tps: 4240.92506
+  dps: 5977.1235
+  tps: 4243.75769
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6186.17084
-  tps: 4392.18129
+  dps: 6214.53092
+  tps: 4412.31695
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6186.17084
-  tps: 4392.18129
+  dps: 6214.53092
+  tps: 4412.31695
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Slayer'sArmor"
  value: {
-  dps: 4826.56702
-  tps: 3426.86259
+  dps: 4839.56911
+  tps: 3436.09407
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SparkofLife-37657"
  value: {
-  dps: 6283.51971
-  tps: 4461.29899
+  dps: 6294.01198
+  tps: 4468.7485
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 5580.30121
-  tps: 3962.01386
+  dps: 5581.00208
+  tps: 3962.51148
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StormshroudArmor"
  value: {
-  dps: 5017.21951
-  tps: 3559.69201
+  dps: 5032.21552
+  tps: 3570.34172
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 5212.73665
-  tps: 3701.04302
+  dps: 5207.84867
+  tps: 3697.57255
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6338.39001
-  tps: 4500.25691
+  dps: 6368.12076
+  tps: 4521.36574
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6332.28381
-  tps: 4495.92151
+  dps: 6361.99688
+  tps: 4517.01778
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6321.59797
-  tps: 4488.33456
+  dps: 6351.28007
+  tps: 4509.40885
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6103.25458
-  tps: 4333.31075
+  dps: 6110.67486
+  tps: 4338.57915
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheFistsofFury"
  value: {
-  dps: 5632.80729
-  tps: 3999.29318
+  dps: 5640.10024
+  tps: 4004.47117
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5780.86689
-  tps: 4104.41549
+  dps: 5759.14758
+  tps: 4088.99478
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinStars"
  value: {
-  dps: 6011.17332
-  tps: 4267.93306
+  dps: 6009.62638
+  tps: 4266.83473
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6369.37336
-  tps: 4522.25509
+  dps: 6371.50927
+  tps: 4523.77158
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6494.72063
-  tps: 4611.25164
+  dps: 6473.96028
+  tps: 4596.5118
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6502.61402
-  tps: 4616.85595
+  dps: 6524.85915
+  tps: 4632.65
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6306.33247
-  tps: 4477.49606
+  dps: 6335.97035
+  tps: 4498.53895
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6306.33247
-  tps: 4477.49606
+  dps: 6335.97035
+  tps: 4498.53895
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6306.33247
-  tps: 4477.49606
+  dps: 6335.97035
+  tps: 4498.53895
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6306.33247
-  tps: 4477.49606
+  dps: 6335.97035
+  tps: 4498.53895
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 5565.08678
-  tps: 3951.21161
+  dps: 5543.44657
+  tps: 3935.84707
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 6662.90991
-  tps: 4730.66604
+  dps: 6665.80295
+  tps: 4732.7201
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WastewalkerArmor"
  value: {
-  dps: 4764.5427
-  tps: 3382.82532
+  dps: 4767.37695
+  tps: 3384.83764
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WindhawkArmor"
  value: {
-  dps: 5557.21436
-  tps: 3945.62219
+  dps: 5562.77005
+  tps: 3949.56673
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WrathofSpellfire"
  value: {
-  dps: 5363.44707
-  tps: 3808.04742
+  dps: 5379.46792
+  tps: 3819.42222
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 6385.17586
-  tps: 4533.47486
+  dps: 6383.97946
+  tps: 4532.62542
  }
 }
 dps_results: {
@@ -647,15 +647,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5458.30246
-  tps: 3875.39475
+  dps: 5484.33322
+  tps: 3893.87658
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6644.44035
-  tps: 4717.55265
+  dps: 6693.72588
+  tps: 4752.54537
  }
 }
 dps_results: {
@@ -668,15 +668,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2527.8495
-  tps: 1794.77314
+  dps: 2538.87257
+  tps: 1802.59952
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2748.65218
-  tps: 1951.54305
+  dps: 2761.92665
+  tps: 1960.96792
  }
 }
 dps_results: {
@@ -689,15 +689,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6447.1848
-  tps: 4577.50121
+  dps: 6477.13841
+  tps: 4598.76827
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7589.43632
-  tps: 5388.49979
+  dps: 7598.90089
+  tps: 5395.21963
  }
 }
 dps_results: {
@@ -710,15 +710,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3176.21909
-  tps: 2255.11555
+  dps: 3184.6709
+  tps: 2261.11634
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3347.82612
-  tps: 2376.95654
+  dps: 3364.24631
+  tps: 2388.61488
  }
 }
 dps_results: {
@@ -731,15 +731,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6447.1848
-  tps: 4577.50121
+  dps: 6477.13841
+  tps: 4598.76827
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7589.43632
-  tps: 5388.49979
+  dps: 7598.90089
+  tps: 5395.21963
  }
 }
 dps_results: {
@@ -752,15 +752,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3176.21909
-  tps: 2255.11555
+  dps: 3184.6709
+  tps: 2261.11634
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3347.82612
-  tps: 2376.95654
+  dps: 3364.24631
+  tps: 2388.61488
  }
 }
 dps_results: {
@@ -773,15 +773,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4745.55503
-  tps: 3369.34407
+  dps: 4766.98996
+  tps: 3384.56287
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5576.65668
-  tps: 3959.42624
+  dps: 5591.85331
+  tps: 3970.21585
  }
 }
 dps_results: {
@@ -794,15 +794,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2356.32477
-  tps: 1672.99058
+  dps: 2363.07548
+  tps: 1677.78359
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2520.28428
-  tps: 1789.40184
+  dps: 2533.58473
+  tps: 1798.84516
  }
 }
 dps_results: {
@@ -815,15 +815,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5502.2303
-  tps: 3906.58351
+  dps: 5529.92158
+  tps: 3926.24432
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6736.1752
-  tps: 4782.68439
+  dps: 6784.006
+  tps: 4816.64426
  }
 }
 dps_results: {
@@ -836,15 +836,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2552.50661
-  tps: 1812.27969
+  dps: 2563.50964
+  tps: 1820.09185
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2791.1183
-  tps: 1981.69399
+  dps: 2804.37214
+  tps: 1991.10422
  }
 }
 dps_results: {
@@ -857,15 +857,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6498.98081
-  tps: 4614.27638
+  dps: 6529.51206
+  tps: 4635.95356
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7694.25396
-  tps: 5462.92031
+  dps: 7702.57305
+  tps: 5468.82687
  }
 }
 dps_results: {
@@ -878,15 +878,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3206.2675
-  tps: 2276.44993
+  dps: 3214.60039
+  tps: 2282.36628
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3399.58924
-  tps: 2413.70836
+  dps: 3414.39318
+  tps: 2424.21916
  }
 }
 dps_results: {
@@ -899,15 +899,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6498.98081
-  tps: 4614.27638
+  dps: 6529.51206
+  tps: 4635.95356
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7694.25396
-  tps: 5462.92031
+  dps: 7702.57305
+  tps: 5468.82687
  }
 }
 dps_results: {
@@ -920,15 +920,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3206.2675
-  tps: 2276.44993
+  dps: 3214.60039
+  tps: 2282.36628
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3399.58924
-  tps: 2413.70836
+  dps: 3414.39318
+  tps: 2424.21916
  }
 }
 dps_results: {
@@ -941,15 +941,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4782.27903
-  tps: 3395.41811
+  dps: 4804.11618
+  tps: 3410.92249
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5651.85756
-  tps: 4012.81887
+  dps: 5664.73195
+  tps: 4021.95969
  }
 }
 dps_results: {
@@ -962,21 +962,21 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2378.28584
-  tps: 1688.58295
+  dps: 2384.69404
+  tps: 1693.13277
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2557.85541
-  tps: 1816.07734
+  dps: 2570.05938
+  tps: 1824.74216
  }
 }
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6183.02801
-  tps: 4389.94989
+  dps: 6182.80232
+  tps: 4389.78965
  }
 }

--- a/sim/rogue/TestRotation.results
+++ b/sim/rogue/TestRotation.results
@@ -11,7 +11,7 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 423.3
+   value: 423.2
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
@@ -39,19 +39,19 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 53.4
+   value: 39.9
   }
   casts: {
    key: "spell_id:48665"
-   value: 53.4
+   value: 39.9
   }
   casts: {
    key: "spell_id:48666"
-   value: 53.4
+   value: 39.9
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0
+   value: 0.1
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -95,7 +95,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:51662"
-   value: 5.1
+   value: 6.4
   }
   casts: {
    key: "spell_id:51723"
@@ -111,11 +111,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 170.4
+   value: 157.7
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 313.6
+   value: 299.9
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -123,7 +123,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 318.6
+   value: 304.9
   }
   casts: {
    key: "spell_id:57975"
@@ -139,23 +139,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:1"
-   value: 5.7
+   value: 32.8
   }
   casts: {
    key: "spell_id:57993 tag:2"
-   value: 2.6
+   value: 2.8
   }
   casts: {
    key: "spell_id:57993 tag:3"
-   value: 17
+   value: 16.3
   }
   casts: {
    key: "spell_id:57993 tag:4"
-   value: 16.2
+   value: 3.9
   }
   casts: {
    key: "spell_id:57993 tag:5"
-   value: 1
+   value: 0
   }
   casts: {
    key: "spell_id:58426"
@@ -167,7 +167,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:1"
-   value: 0
+   value: 0.1
   }
   casts: {
    key: "spell_id:6774 tag:2"
@@ -179,31 +179,31 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:4"
-   value: 0
+   value: 0.1
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 0
+   value: 0.6
   }
   casts: {
    key: "spell_id:8647 tag:1"
-   value: 3.1
+   value: 6.8
   }
   casts: {
    key: "spell_id:8647 tag:2"
-   value: 1
+   value: 2
   }
   casts: {
    key: "spell_id:8647 tag:3"
-   value: 6.7
+   value: 10.2
   }
   casts: {
    key: "spell_id:8647 tag:4"
-   value: 5.4
+   value: 1.9
   }
   casts: {
    key: "spell_id:8647 tag:5"
-   value: 0.4
+   value: 0.1
   }
  }
 }
@@ -248,19 +248,19 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 52.6
+   value: 40.7
   }
   casts: {
    key: "spell_id:48665"
-   value: 52.6
+   value: 40.7
   }
   casts: {
    key: "spell_id:48666"
-   value: 52.6
+   value: 40.7
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0
+   value: 0.2
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -316,15 +316,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57934 tag:1"
-   value: 8.1
+   value: 8.2
   }
   casts: {
    key: "spell_id:57968"
-   value: 181
+   value: 170.8
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 321.1
+   value: 310.7
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -332,7 +332,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 326.1
+   value: 315.7
   }
   casts: {
    key: "spell_id:57975"
@@ -348,23 +348,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:1"
-   value: 1.6
+   value: 27.3
   }
   casts: {
    key: "spell_id:57993 tag:2"
-   value: 3.3
+   value: 4.2
   }
   casts: {
    key: "spell_id:57993 tag:3"
-   value: 21.4
+   value: 24.3
   }
   casts: {
    key: "spell_id:57993 tag:4"
-   value: 23.9
+   value: 10.5
   }
   casts: {
    key: "spell_id:57993 tag:5"
-   value: 1.1
+   value: 0.2
   }
   casts: {
    key: "spell_id:58426"
@@ -384,7 +384,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 0.9
+   value: 0.8
   }
   casts: {
    key: "spell_id:6774 tag:4"
@@ -429,11 +429,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 422.5
+   value: 420.9
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 328.7
+   value: 327.5
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -457,27 +457,27 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 66.4
+   value: 62.9
   }
   casts: {
    key: "spell_id:48665"
-   value: 66.4
+   value: 62.9
   }
   casts: {
    key: "spell_id:48666"
-   value: 66.4
+   value: 62.9
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0
+   value: 1
   }
   casts: {
    key: "spell_id:48668 tag:2"
-   value: 0
+   value: 0.1
   }
   casts: {
    key: "spell_id:48668 tag:3"
-   value: 0
+   value: 0.3
   }
   casts: {
    key: "spell_id:48668 tag:4"
@@ -485,7 +485,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:5"
-   value: 0
+   value: 5.2
   }
   casts: {
    key: "spell_id:48672"
@@ -493,27 +493,27 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 0.8
+   value: 0.9
   }
   casts: {
    key: "spell_id:48672 tag:2"
-   value: 0.5
+   value: 0.7
   }
   casts: {
    key: "spell_id:48672 tag:3"
-   value: 2.9
+   value: 4.6
   }
   casts: {
    key: "spell_id:48672 tag:4"
-   value: 2.9
+   value: 4.6
   }
   casts: {
    key: "spell_id:48672 tag:5"
-   value: 14.8
+   value: 14.3
   }
   casts: {
    key: "spell_id:51662"
-   value: 5.2
+   value: 5.4
   }
   casts: {
    key: "spell_id:51723"
@@ -525,15 +525,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57934 tag:1"
-   value: 8.1
+   value: 8.2
   }
   casts: {
    key: "spell_id:57968"
-   value: 136.2
+   value: 134.5
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 256.9
+   value: 257.5
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -541,7 +541,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 261.9
+   value: 262.5
   }
   casts: {
    key: "spell_id:57975"
@@ -585,15 +585,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:1"
-   value: 1.2
+   value: 3.9
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 0.7
+   value: 1
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 4.5
+   value: 5.9
   }
   casts: {
    key: "spell_id:6774 tag:4"
@@ -601,7 +601,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 7.9
+   value: 1.4
   }
   casts: {
    key: "spell_id:8647 tag:1"
@@ -666,19 +666,19 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 54.4
+   value: 43
   }
   casts: {
    key: "spell_id:48665"
-   value: 54.4
+   value: 43
   }
   casts: {
    key: "spell_id:48666"
-   value: 54.4
+   value: 43
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0
+   value: 0.2
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -738,11 +738,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 183.8
+   value: 173.7
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 326
+   value: 316.2
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -750,7 +750,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 331
+   value: 321.2
   }
   casts: {
    key: "spell_id:57975"
@@ -766,23 +766,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:1"
-   value: 1.4
+   value: 26.2
   }
   casts: {
    key: "spell_id:57993 tag:2"
-   value: 3.3
+   value: 4.3
   }
   casts: {
    key: "spell_id:57993 tag:3"
-   value: 22.1
+   value: 24.8
   }
   casts: {
    key: "spell_id:57993 tag:4"
-   value: 24.7
+   value: 12.1
   }
   casts: {
    key: "spell_id:57993 tag:5"
-   value: 1.3
+   value: 0.3
   }
   casts: {
    key: "spell_id:58426"
@@ -875,19 +875,19 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 52.6
+   value: 40.7
   }
   casts: {
    key: "spell_id:48665"
-   value: 52.6
+   value: 40.7
   }
   casts: {
    key: "spell_id:48666"
-   value: 52.6
+   value: 40.7
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0
+   value: 0.2
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -943,15 +943,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57934 tag:1"
-   value: 8.1
+   value: 8.2
   }
   casts: {
    key: "spell_id:57968"
-   value: 181
+   value: 170.8
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 321.1
+   value: 310.7
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -959,7 +959,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 326.1
+   value: 315.7
   }
   casts: {
    key: "spell_id:57975"
@@ -975,23 +975,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:1"
-   value: 1.6
+   value: 27.3
   }
   casts: {
    key: "spell_id:57993 tag:2"
-   value: 3.3
+   value: 4.2
   }
   casts: {
    key: "spell_id:57993 tag:3"
-   value: 21.4
+   value: 24.3
   }
   casts: {
    key: "spell_id:57993 tag:4"
-   value: 23.9
+   value: 10.5
   }
   casts: {
    key: "spell_id:57993 tag:5"
-   value: 1.1
+   value: 0.2
   }
   casts: {
    key: "spell_id:58426"
@@ -1011,7 +1011,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 0.9
+   value: 0.8
   }
   casts: {
    key: "spell_id:6774 tag:4"
@@ -1084,19 +1084,19 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 54.6
+   value: 43.2
   }
   casts: {
    key: "spell_id:48665"
-   value: 54.6
+   value: 43.2
   }
   casts: {
    key: "spell_id:48666"
-   value: 54.6
+   value: 43.2
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0
+   value: 0.2
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -1140,7 +1140,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:51662"
-   value: 5.3
+   value: 5.2
   }
   casts: {
    key: "spell_id:51723"
@@ -1156,11 +1156,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 182.8
+   value: 172.8
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 325.2
+   value: 315.5
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -1168,7 +1168,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 330.2
+   value: 320.5
   }
   casts: {
    key: "spell_id:57975"
@@ -1184,23 +1184,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:1"
-   value: 1.4
+   value: 26.1
   }
   casts: {
    key: "spell_id:57993 tag:2"
-   value: 3.3
+   value: 4.3
   }
   casts: {
    key: "spell_id:57993 tag:3"
-   value: 21.8
-  }
-  casts: {
-   key: "spell_id:57993 tag:4"
    value: 24.5
   }
   casts: {
+   key: "spell_id:57993 tag:4"
+   value: 11.7
+  }
+  casts: {
    key: "spell_id:57993 tag:5"
-   value: 1.1
+   value: 0.2
   }
   casts: {
    key: "spell_id:58426"
@@ -1220,7 +1220,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 0.8
+   value: 0.9
   }
   casts: {
    key: "spell_id:6774 tag:4"
@@ -1248,7 +1248,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:8647 tag:5"
-   value: 0
+   value: 0.1
   }
  }
 }
@@ -1265,11 +1265,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 475
+   value: 475.8
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 369.6
+   value: 370.2
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -1293,7 +1293,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48638"
-   value: 86.8
+   value: 81.4
   }
   casts: {
    key: "spell_id:48664"
@@ -1309,7 +1309,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0
+   value: 0.5
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -1325,7 +1325,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:5"
-   value: 0
+   value: 0.2
   }
   casts: {
    key: "spell_id:48672"
@@ -1333,23 +1333,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 13.1
+   value: 19.7
   }
   casts: {
    key: "spell_id:48672 tag:2"
-   value: 3.6
+   value: 3.2
   }
   casts: {
    key: "spell_id:48672 tag:3"
-   value: 3.1
+   value: 1.9
   }
   casts: {
    key: "spell_id:48672 tag:4"
-   value: 1.8
+   value: 0.9
   }
   casts: {
    key: "spell_id:48672 tag:5"
-   value: 1.6
+   value: 0.6
   }
   casts: {
    key: "spell_id:51690"
@@ -1377,11 +1377,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 112.7
+   value: 112.8
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 231.3
+   value: 233.1
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -1389,7 +1389,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 236.3
+   value: 238.1
   }
   casts: {
    key: "spell_id:57975"
@@ -1409,19 +1409,19 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:1"
-   value: 9.1
+   value: 6.6
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 4
+   value: 4.4
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 2.4
+   value: 3.1
   }
   casts: {
    key: "spell_id:6774 tag:4"
-   value: 1.3
+   value: 1.8
   }
   casts: {
    key: "spell_id:6774 tag:5"
@@ -1429,23 +1429,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:8647 tag:1"
-   value: 11.3
+   value: 16.1
   }
   casts: {
    key: "spell_id:8647 tag:2"
-   value: 5.6
+   value: 6.7
   }
   casts: {
    key: "spell_id:8647 tag:3"
-   value: 3.8
+   value: 4
   }
   casts: {
    key: "spell_id:8647 tag:4"
-   value: 1.4
+   value: 1.3
   }
   casts: {
    key: "spell_id:8647 tag:5"
-   value: 1.2
+   value: 0.5
   }
  }
 }
@@ -1462,11 +1462,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 475
+   value: 475.1
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 369.6
+   value: 369.7
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -1490,7 +1490,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48638"
-   value: 101.1
+   value: 96.9
   }
   casts: {
    key: "spell_id:48664"
@@ -1506,7 +1506,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0
+   value: 1.2
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -1522,7 +1522,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:5"
-   value: 0
+   value: 1.3
   }
   casts: {
    key: "spell_id:48672"
@@ -1530,23 +1530,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 3.9
+   value: 5.9
   }
   casts: {
    key: "spell_id:48672 tag:2"
-   value: 2.2
+   value: 3.4
   }
   casts: {
    key: "spell_id:48672 tag:3"
-   value: 3.7
+   value: 5.5
   }
   casts: {
    key: "spell_id:48672 tag:4"
-   value: 4.4
+   value: 5.3
   }
   casts: {
    key: "spell_id:48672 tag:5"
-   value: 8.1
+   value: 5
   }
   casts: {
    key: "spell_id:51690"
@@ -1574,11 +1574,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 112.6
+   value: 112.7
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 227.3
+   value: 227.7
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -1586,7 +1586,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 232.3
+   value: 232.7
   }
   casts: {
    key: "spell_id:57975"
@@ -1606,23 +1606,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:1"
-   value: 5.5
+   value: 5.3
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 2.5
+   value: 2.9
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 2.4
+   value: 2.8
   }
   casts: {
    key: "spell_id:6774 tag:4"
-   value: 2.3
+   value: 2.5
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 2.4
+   value: 1.7
   }
   casts: {
    key: "spell_id:8647 tag:1"
@@ -1659,11 +1659,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 476.3
+   value: 470.1
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 370.6
+   value: 365.8
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -1687,7 +1687,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48638"
-   value: 103.9
+   value: 40.3
   }
   casts: {
    key: "spell_id:48664"
@@ -1703,7 +1703,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0
+   value: 77.2
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -1719,7 +1719,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:5"
-   value: 14.3
+   value: 0
   }
   casts: {
    key: "spell_id:48672"
@@ -1767,15 +1767,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57934 tag:1"
-   value: 8.2
+   value: 8.5
   }
   casts: {
    key: "spell_id:57968"
-   value: 113
+   value: 111.6
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 225.3
+   value: 222.8
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -1783,7 +1783,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 230.4
+   value: 227.8
   }
   casts: {
    key: "spell_id:57975"
@@ -1803,23 +1803,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:1"
-   value: 2.1
+   value: 21.5
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 2.2
+   value: 0
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 1.9
+   value: 0
   }
   casts: {
    key: "spell_id:6774 tag:4"
-   value: 1.9
+   value: 0
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 5
+   value: 0
   }
   casts: {
    key: "spell_id:8647 tag:1"
@@ -1884,7 +1884,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48638"
-   value: 104.4
+   value: 100.2
   }
   casts: {
    key: "spell_id:48664"
@@ -1900,7 +1900,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0
+   value: 1.2
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -1916,7 +1916,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:5"
-   value: 0
+   value: 1.4
   }
   casts: {
    key: "spell_id:48672"
@@ -1924,23 +1924,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 3.6
+   value: 5.6
   }
   casts: {
    key: "spell_id:48672 tag:2"
-   value: 1.9
+   value: 3
   }
   casts: {
    key: "spell_id:48672 tag:3"
-   value: 3.3
+   value: 5.1
   }
   casts: {
    key: "spell_id:48672 tag:4"
-   value: 4.4
+   value: 5.3
   }
   casts: {
    key: "spell_id:48672 tag:5"
-   value: 9
+   value: 5.9
   }
   casts: {
    key: "spell_id:51690"
@@ -1972,7 +1972,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 228.7
+   value: 229.2
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -1980,7 +1980,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 233.7
+   value: 234.2
   }
   casts: {
    key: "spell_id:57975"
@@ -2004,19 +2004,19 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 2.5
+   value: 2.7
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 2.3
+   value: 2.8
   }
   casts: {
    key: "spell_id:6774 tag:4"
-   value: 2.2
+   value: 2.5
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 2.5
+   value: 1.8
   }
   casts: {
    key: "spell_id:8647 tag:1"
@@ -2053,11 +2053,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 475
+   value: 475.1
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 369.6
+   value: 369.7
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -2081,7 +2081,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48638"
-   value: 101.1
+   value: 96.9
   }
   casts: {
    key: "spell_id:48664"
@@ -2097,7 +2097,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0
+   value: 1.2
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -2113,7 +2113,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:5"
-   value: 0
+   value: 1.3
   }
   casts: {
    key: "spell_id:48672"
@@ -2121,23 +2121,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 3.9
+   value: 5.9
   }
   casts: {
    key: "spell_id:48672 tag:2"
-   value: 2.2
+   value: 3.4
   }
   casts: {
    key: "spell_id:48672 tag:3"
-   value: 3.7
+   value: 5.5
   }
   casts: {
    key: "spell_id:48672 tag:4"
-   value: 4.4
+   value: 5.3
   }
   casts: {
    key: "spell_id:48672 tag:5"
-   value: 8.1
+   value: 5
   }
   casts: {
    key: "spell_id:51690"
@@ -2165,11 +2165,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 112.6
+   value: 112.7
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 227.3
+   value: 227.7
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -2177,7 +2177,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 232.3
+   value: 232.7
   }
   casts: {
    key: "spell_id:57975"
@@ -2197,23 +2197,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:1"
-   value: 5.5
+   value: 5.3
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 2.5
+   value: 2.9
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 2.4
+   value: 2.8
   }
   casts: {
    key: "spell_id:6774 tag:4"
-   value: 2.3
+   value: 2.5
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 2.4
+   value: 1.7
   }
   casts: {
    key: "spell_id:8647 tag:1"
@@ -2250,11 +2250,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 475.8
+   value: 475.7
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 370.2
+   value: 370.1
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -2278,7 +2278,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48638"
-   value: 104.1
+   value: 99.8
   }
   casts: {
    key: "spell_id:48664"
@@ -2294,7 +2294,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0
+   value: 1.2
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -2310,7 +2310,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:5"
-   value: 0
+   value: 1.2
   }
   casts: {
    key: "spell_id:48672"
@@ -2318,23 +2318,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 3.1
+   value: 5.5
   }
   casts: {
    key: "spell_id:48672 tag:2"
-   value: 2.1
+   value: 3.2
   }
   casts: {
    key: "spell_id:48672 tag:3"
-   value: 3.5
+   value: 5
   }
   casts: {
    key: "spell_id:48672 tag:4"
-   value: 4.3
+   value: 5.2
   }
   casts: {
    key: "spell_id:48672 tag:5"
-   value: 8.7
+   value: 5.6
   }
   casts: {
    key: "spell_id:51690"
@@ -2366,7 +2366,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 228.8
+   value: 229.2
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -2374,7 +2374,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 233.8
+   value: 234.2
   }
   casts: {
    key: "spell_id:57975"
@@ -2398,19 +2398,19 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 2.4
+   value: 2.9
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 2.1
+   value: 2.5
   }
   casts: {
    key: "spell_id:6774 tag:4"
-   value: 1.9
+   value: 2.3
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 2.8
+   value: 1.8
   }
   casts: {
    key: "spell_id:8647 tag:1"

--- a/sim/rogue/TestRotation.results
+++ b/sim/rogue/TestRotation.results
@@ -1,0 +1,2436 @@
+casts_results: {
+ key: "TestRotation-Casts-Assassination Maintain Expose No Tricks Primary"
+ value: {
+  casts: {
+   key: "item_id:40211"
+   value: 1
+  }
+  casts: {
+   key: "item_id:7676"
+   value: 1
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:1"
+   value: 423.3
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:2"
+   value: 329.3
+  }
+  casts: {
+   key: "other_id:OtherActionShoot"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:14177"
+   value: 2
+  }
+  casts: {
+   key: "spell_id:26863"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:26864"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48638"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48664"
+   value: 53.4
+  }
+  casts: {
+   key: "spell_id:48665"
+   value: 53.4
+  }
+  casts: {
+   key: "spell_id:48666"
+   value: 53.4
+  }
+  casts: {
+   key: "spell_id:48668 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:51662"
+   value: 5.1
+  }
+  casts: {
+   key: "spell_id:51723"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:54758"
+   value: 5
+  }
+  casts: {
+   key: "spell_id:57934 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57968"
+   value: 170.4
+  }
+  casts: {
+   key: "spell_id:57968 tag:1"
+   value: 313.6
+  }
+  casts: {
+   key: "spell_id:57968 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57973"
+   value: 318.6
+  }
+  casts: {
+   key: "spell_id:57975"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57993 tag:1"
+   value: 5.7
+  }
+  casts: {
+   key: "spell_id:57993 tag:2"
+   value: 2.6
+  }
+  casts: {
+   key: "spell_id:57993 tag:3"
+   value: 17
+  }
+  casts: {
+   key: "spell_id:57993 tag:4"
+   value: 16.2
+  }
+  casts: {
+   key: "spell_id:57993 tag:5"
+   value: 1
+  }
+  casts: {
+   key: "spell_id:58426"
+   value: 2
+  }
+  casts: {
+   key: "spell_id:5938"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:2"
+   value: 0.2
+  }
+  casts: {
+   key: "spell_id:6774 tag:3"
+   value: 0.9
+  }
+  casts: {
+   key: "spell_id:6774 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:1"
+   value: 3.1
+  }
+  casts: {
+   key: "spell_id:8647 tag:2"
+   value: 1
+  }
+  casts: {
+   key: "spell_id:8647 tag:3"
+   value: 6.7
+  }
+  casts: {
+   key: "spell_id:8647 tag:4"
+   value: 5.4
+  }
+  casts: {
+   key: "spell_id:8647 tag:5"
+   value: 0.4
+  }
+ }
+}
+casts_results: {
+ key: "TestRotation-Casts-Assassination No Expose Maintain Tricks Primary"
+ value: {
+  casts: {
+   key: "item_id:40211"
+   value: 1
+  }
+  casts: {
+   key: "item_id:7676"
+   value: 1
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:1"
+   value: 423.3
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:2"
+   value: 329.3
+  }
+  casts: {
+   key: "other_id:OtherActionShoot"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:14177"
+   value: 2
+  }
+  casts: {
+   key: "spell_id:26863"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:26864"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48638"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48664"
+   value: 52.6
+  }
+  casts: {
+   key: "spell_id:48665"
+   value: 52.6
+  }
+  casts: {
+   key: "spell_id:48666"
+   value: 52.6
+  }
+  casts: {
+   key: "spell_id:48668 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:51662"
+   value: 5.5
+  }
+  casts: {
+   key: "spell_id:51723"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:54758"
+   value: 5
+  }
+  casts: {
+   key: "spell_id:57934 tag:1"
+   value: 8.1
+  }
+  casts: {
+   key: "spell_id:57968"
+   value: 181
+  }
+  casts: {
+   key: "spell_id:57968 tag:1"
+   value: 321.1
+  }
+  casts: {
+   key: "spell_id:57968 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57973"
+   value: 326.1
+  }
+  casts: {
+   key: "spell_id:57975"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57993 tag:1"
+   value: 1.6
+  }
+  casts: {
+   key: "spell_id:57993 tag:2"
+   value: 3.3
+  }
+  casts: {
+   key: "spell_id:57993 tag:3"
+   value: 21.4
+  }
+  casts: {
+   key: "spell_id:57993 tag:4"
+   value: 23.9
+  }
+  casts: {
+   key: "spell_id:57993 tag:5"
+   value: 1.1
+  }
+  casts: {
+   key: "spell_id:58426"
+   value: 2
+  }
+  casts: {
+   key: "spell_id:5938"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:2"
+   value: 0.2
+  }
+  casts: {
+   key: "spell_id:6774 tag:3"
+   value: 0.9
+  }
+  casts: {
+   key: "spell_id:6774 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:5"
+   value: 0
+  }
+ }
+}
+casts_results: {
+ key: "TestRotation-Casts-Assassination No Expose Maintain Tricks Secondary"
+ value: {
+  casts: {
+   key: "item_id:40211"
+   value: 1
+  }
+  casts: {
+   key: "item_id:7676"
+   value: 1
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:1"
+   value: 422.5
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:2"
+   value: 328.7
+  }
+  casts: {
+   key: "other_id:OtherActionShoot"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:14177"
+   value: 2
+  }
+  casts: {
+   key: "spell_id:26863"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:26864"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48638"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48664"
+   value: 66.4
+  }
+  casts: {
+   key: "spell_id:48665"
+   value: 66.4
+  }
+  casts: {
+   key: "spell_id:48666"
+   value: 66.4
+  }
+  casts: {
+   key: "spell_id:48668 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:1"
+   value: 0.8
+  }
+  casts: {
+   key: "spell_id:48672 tag:2"
+   value: 0.5
+  }
+  casts: {
+   key: "spell_id:48672 tag:3"
+   value: 2.9
+  }
+  casts: {
+   key: "spell_id:48672 tag:4"
+   value: 2.9
+  }
+  casts: {
+   key: "spell_id:48672 tag:5"
+   value: 14.8
+  }
+  casts: {
+   key: "spell_id:51662"
+   value: 5.2
+  }
+  casts: {
+   key: "spell_id:51723"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:54758"
+   value: 5
+  }
+  casts: {
+   key: "spell_id:57934 tag:1"
+   value: 8.1
+  }
+  casts: {
+   key: "spell_id:57968"
+   value: 136.2
+  }
+  casts: {
+   key: "spell_id:57968 tag:1"
+   value: 256.9
+  }
+  casts: {
+   key: "spell_id:57968 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57973"
+   value: 261.9
+  }
+  casts: {
+   key: "spell_id:57975"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57993 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57993 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57993 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57993 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57993 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:58426"
+   value: 2
+  }
+  casts: {
+   key: "spell_id:5938"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:1"
+   value: 1.2
+  }
+  casts: {
+   key: "spell_id:6774 tag:2"
+   value: 0.7
+  }
+  casts: {
+   key: "spell_id:6774 tag:3"
+   value: 4.5
+  }
+  casts: {
+   key: "spell_id:6774 tag:4"
+   value: 3.4
+  }
+  casts: {
+   key: "spell_id:6774 tag:5"
+   value: 7.9
+  }
+  casts: {
+   key: "spell_id:8647 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:5"
+   value: 0
+  }
+ }
+}
+casts_results: {
+ key: "TestRotation-Casts-Assassination No Expose No Tricks Primary"
+ value: {
+  casts: {
+   key: "item_id:40211"
+   value: 1
+  }
+  casts: {
+   key: "item_id:7676"
+   value: 1
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:1"
+   value: 423.3
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:2"
+   value: 329.3
+  }
+  casts: {
+   key: "other_id:OtherActionShoot"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:14177"
+   value: 2
+  }
+  casts: {
+   key: "spell_id:26863"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:26864"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48638"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48664"
+   value: 54.4
+  }
+  casts: {
+   key: "spell_id:48665"
+   value: 54.4
+  }
+  casts: {
+   key: "spell_id:48666"
+   value: 54.4
+  }
+  casts: {
+   key: "spell_id:48668 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:51662"
+   value: 5.5
+  }
+  casts: {
+   key: "spell_id:51723"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:54758"
+   value: 5
+  }
+  casts: {
+   key: "spell_id:57934 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57968"
+   value: 183.8
+  }
+  casts: {
+   key: "spell_id:57968 tag:1"
+   value: 326
+  }
+  casts: {
+   key: "spell_id:57968 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57973"
+   value: 331
+  }
+  casts: {
+   key: "spell_id:57975"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57993 tag:1"
+   value: 1.4
+  }
+  casts: {
+   key: "spell_id:57993 tag:2"
+   value: 3.3
+  }
+  casts: {
+   key: "spell_id:57993 tag:3"
+   value: 22.1
+  }
+  casts: {
+   key: "spell_id:57993 tag:4"
+   value: 24.7
+  }
+  casts: {
+   key: "spell_id:57993 tag:5"
+   value: 1.3
+  }
+  casts: {
+   key: "spell_id:58426"
+   value: 2
+  }
+  casts: {
+   key: "spell_id:5938"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:2"
+   value: 0.2
+  }
+  casts: {
+   key: "spell_id:6774 tag:3"
+   value: 0.8
+  }
+  casts: {
+   key: "spell_id:6774 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:5"
+   value: 0
+  }
+ }
+}
+casts_results: {
+ key: "TestRotation-Casts-Assassination No Expose One Tricks Primary"
+ value: {
+  casts: {
+   key: "item_id:40211"
+   value: 1
+  }
+  casts: {
+   key: "item_id:7676"
+   value: 1
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:1"
+   value: 423.3
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:2"
+   value: 329.3
+  }
+  casts: {
+   key: "other_id:OtherActionShoot"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:14177"
+   value: 2
+  }
+  casts: {
+   key: "spell_id:26863"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:26864"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48638"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48664"
+   value: 52.6
+  }
+  casts: {
+   key: "spell_id:48665"
+   value: 52.6
+  }
+  casts: {
+   key: "spell_id:48666"
+   value: 52.6
+  }
+  casts: {
+   key: "spell_id:48668 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:51662"
+   value: 5.5
+  }
+  casts: {
+   key: "spell_id:51723"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:54758"
+   value: 5
+  }
+  casts: {
+   key: "spell_id:57934 tag:1"
+   value: 8.1
+  }
+  casts: {
+   key: "spell_id:57968"
+   value: 181
+  }
+  casts: {
+   key: "spell_id:57968 tag:1"
+   value: 321.1
+  }
+  casts: {
+   key: "spell_id:57968 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57973"
+   value: 326.1
+  }
+  casts: {
+   key: "spell_id:57975"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57993 tag:1"
+   value: 1.6
+  }
+  casts: {
+   key: "spell_id:57993 tag:2"
+   value: 3.3
+  }
+  casts: {
+   key: "spell_id:57993 tag:3"
+   value: 21.4
+  }
+  casts: {
+   key: "spell_id:57993 tag:4"
+   value: 23.9
+  }
+  casts: {
+   key: "spell_id:57993 tag:5"
+   value: 1.1
+  }
+  casts: {
+   key: "spell_id:58426"
+   value: 2
+  }
+  casts: {
+   key: "spell_id:5938"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:2"
+   value: 0.2
+  }
+  casts: {
+   key: "spell_id:6774 tag:3"
+   value: 0.9
+  }
+  casts: {
+   key: "spell_id:6774 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:5"
+   value: 0
+  }
+ }
+}
+casts_results: {
+ key: "TestRotation-Casts-Assassination One Expose No Tricks Primary"
+ value: {
+  casts: {
+   key: "item_id:40211"
+   value: 1
+  }
+  casts: {
+   key: "item_id:7676"
+   value: 1
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:1"
+   value: 423.3
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:2"
+   value: 329.3
+  }
+  casts: {
+   key: "other_id:OtherActionShoot"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:14177"
+   value: 2
+  }
+  casts: {
+   key: "spell_id:26863"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:26864"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48638"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48664"
+   value: 54.6
+  }
+  casts: {
+   key: "spell_id:48665"
+   value: 54.6
+  }
+  casts: {
+   key: "spell_id:48666"
+   value: 54.6
+  }
+  casts: {
+   key: "spell_id:48668 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:51662"
+   value: 5.3
+  }
+  casts: {
+   key: "spell_id:51723"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:54758"
+   value: 5
+  }
+  casts: {
+   key: "spell_id:57934 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57968"
+   value: 182.8
+  }
+  casts: {
+   key: "spell_id:57968 tag:1"
+   value: 325.2
+  }
+  casts: {
+   key: "spell_id:57968 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57973"
+   value: 330.2
+  }
+  casts: {
+   key: "spell_id:57975"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57993 tag:1"
+   value: 1.4
+  }
+  casts: {
+   key: "spell_id:57993 tag:2"
+   value: 3.3
+  }
+  casts: {
+   key: "spell_id:57993 tag:3"
+   value: 21.8
+  }
+  casts: {
+   key: "spell_id:57993 tag:4"
+   value: 24.5
+  }
+  casts: {
+   key: "spell_id:57993 tag:5"
+   value: 1.1
+  }
+  casts: {
+   key: "spell_id:58426"
+   value: 2
+  }
+  casts: {
+   key: "spell_id:5938"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:2"
+   value: 0.2
+  }
+  casts: {
+   key: "spell_id:6774 tag:3"
+   value: 0.8
+  }
+  casts: {
+   key: "spell_id:6774 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:3"
+   value: 0.4
+  }
+  casts: {
+   key: "spell_id:8647 tag:4"
+   value: 0.5
+  }
+  casts: {
+   key: "spell_id:8647 tag:5"
+   value: 0
+  }
+ }
+}
+casts_results: {
+ key: "TestRotation-Casts-Combat Maintain Expose No Tricks Primary"
+ value: {
+  casts: {
+   key: "item_id:40211"
+   value: 1
+  }
+  casts: {
+   key: "item_id:7676"
+   value: 1
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:1"
+   value: 475
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:2"
+   value: 369.6
+  }
+  casts: {
+   key: "other_id:OtherActionShoot"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:13750"
+   value: 1
+  }
+  casts: {
+   key: "spell_id:13877"
+   value: 3
+  }
+  casts: {
+   key: "spell_id:26863"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:26864"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48638"
+   value: 86.8
+  }
+  casts: {
+   key: "spell_id:48664"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48665"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48666"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:1"
+   value: 13.1
+  }
+  casts: {
+   key: "spell_id:48672 tag:2"
+   value: 3.6
+  }
+  casts: {
+   key: "spell_id:48672 tag:3"
+   value: 3.1
+  }
+  casts: {
+   key: "spell_id:48672 tag:4"
+   value: 1.8
+  }
+  casts: {
+   key: "spell_id:48672 tag:5"
+   value: 1.6
+  }
+  casts: {
+   key: "spell_id:51690"
+   value: 3
+  }
+  casts: {
+   key: "spell_id:51690 tag:1"
+   value: 15
+  }
+  casts: {
+   key: "spell_id:51690 tag:2"
+   value: 15
+  }
+  casts: {
+   key: "spell_id:51723"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:54758"
+   value: 5
+  }
+  casts: {
+   key: "spell_id:57934 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57968"
+   value: 112.7
+  }
+  casts: {
+   key: "spell_id:57968 tag:1"
+   value: 231.3
+  }
+  casts: {
+   key: "spell_id:57968 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57973"
+   value: 236.3
+  }
+  casts: {
+   key: "spell_id:57975"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:5938"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:1"
+   value: 9.1
+  }
+  casts: {
+   key: "spell_id:6774 tag:2"
+   value: 4
+  }
+  casts: {
+   key: "spell_id:6774 tag:3"
+   value: 2.4
+  }
+  casts: {
+   key: "spell_id:6774 tag:4"
+   value: 1.3
+  }
+  casts: {
+   key: "spell_id:6774 tag:5"
+   value: 0.7
+  }
+  casts: {
+   key: "spell_id:8647 tag:1"
+   value: 11.3
+  }
+  casts: {
+   key: "spell_id:8647 tag:2"
+   value: 5.6
+  }
+  casts: {
+   key: "spell_id:8647 tag:3"
+   value: 3.8
+  }
+  casts: {
+   key: "spell_id:8647 tag:4"
+   value: 1.4
+  }
+  casts: {
+   key: "spell_id:8647 tag:5"
+   value: 1.2
+  }
+ }
+}
+casts_results: {
+ key: "TestRotation-Casts-Combat No Expose Maintain Tricks Primary"
+ value: {
+  casts: {
+   key: "item_id:40211"
+   value: 1
+  }
+  casts: {
+   key: "item_id:7676"
+   value: 1
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:1"
+   value: 475
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:2"
+   value: 369.6
+  }
+  casts: {
+   key: "other_id:OtherActionShoot"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:13750"
+   value: 1
+  }
+  casts: {
+   key: "spell_id:13877"
+   value: 3
+  }
+  casts: {
+   key: "spell_id:26863"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:26864"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48638"
+   value: 101.1
+  }
+  casts: {
+   key: "spell_id:48664"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48665"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48666"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:1"
+   value: 3.9
+  }
+  casts: {
+   key: "spell_id:48672 tag:2"
+   value: 2.2
+  }
+  casts: {
+   key: "spell_id:48672 tag:3"
+   value: 3.7
+  }
+  casts: {
+   key: "spell_id:48672 tag:4"
+   value: 4.4
+  }
+  casts: {
+   key: "spell_id:48672 tag:5"
+   value: 8.1
+  }
+  casts: {
+   key: "spell_id:51690"
+   value: 3
+  }
+  casts: {
+   key: "spell_id:51690 tag:1"
+   value: 15
+  }
+  casts: {
+   key: "spell_id:51690 tag:2"
+   value: 15
+  }
+  casts: {
+   key: "spell_id:51723"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:54758"
+   value: 5
+  }
+  casts: {
+   key: "spell_id:57934 tag:1"
+   value: 8.2
+  }
+  casts: {
+   key: "spell_id:57968"
+   value: 112.6
+  }
+  casts: {
+   key: "spell_id:57968 tag:1"
+   value: 227.3
+  }
+  casts: {
+   key: "spell_id:57968 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57973"
+   value: 232.3
+  }
+  casts: {
+   key: "spell_id:57975"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:5938"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:1"
+   value: 5.5
+  }
+  casts: {
+   key: "spell_id:6774 tag:2"
+   value: 2.5
+  }
+  casts: {
+   key: "spell_id:6774 tag:3"
+   value: 2.4
+  }
+  casts: {
+   key: "spell_id:6774 tag:4"
+   value: 2.3
+  }
+  casts: {
+   key: "spell_id:6774 tag:5"
+   value: 2.4
+  }
+  casts: {
+   key: "spell_id:8647 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:5"
+   value: 0
+  }
+ }
+}
+casts_results: {
+ key: "TestRotation-Casts-Combat No Expose Maintain Tricks Secondary"
+ value: {
+  casts: {
+   key: "item_id:40211"
+   value: 1
+  }
+  casts: {
+   key: "item_id:7676"
+   value: 1
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:1"
+   value: 476.3
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:2"
+   value: 370.6
+  }
+  casts: {
+   key: "other_id:OtherActionShoot"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:13750"
+   value: 1
+  }
+  casts: {
+   key: "spell_id:13877"
+   value: 3
+  }
+  casts: {
+   key: "spell_id:26863"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:26864"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48638"
+   value: 103.9
+  }
+  casts: {
+   key: "spell_id:48664"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48665"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48666"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:5"
+   value: 14.3
+  }
+  casts: {
+   key: "spell_id:48672"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:51690"
+   value: 3
+  }
+  casts: {
+   key: "spell_id:51690 tag:1"
+   value: 15
+  }
+  casts: {
+   key: "spell_id:51690 tag:2"
+   value: 15
+  }
+  casts: {
+   key: "spell_id:51723"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:54758"
+   value: 5
+  }
+  casts: {
+   key: "spell_id:57934 tag:1"
+   value: 8.2
+  }
+  casts: {
+   key: "spell_id:57968"
+   value: 113
+  }
+  casts: {
+   key: "spell_id:57968 tag:1"
+   value: 225.3
+  }
+  casts: {
+   key: "spell_id:57968 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57973"
+   value: 230.4
+  }
+  casts: {
+   key: "spell_id:57975"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:5938"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:1"
+   value: 2.1
+  }
+  casts: {
+   key: "spell_id:6774 tag:2"
+   value: 2.2
+  }
+  casts: {
+   key: "spell_id:6774 tag:3"
+   value: 1.9
+  }
+  casts: {
+   key: "spell_id:6774 tag:4"
+   value: 1.9
+  }
+  casts: {
+   key: "spell_id:6774 tag:5"
+   value: 5
+  }
+  casts: {
+   key: "spell_id:8647 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:5"
+   value: 0
+  }
+ }
+}
+casts_results: {
+ key: "TestRotation-Casts-Combat No Expose No Tricks Primary"
+ value: {
+  casts: {
+   key: "item_id:40211"
+   value: 1
+  }
+  casts: {
+   key: "item_id:7676"
+   value: 1
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:1"
+   value: 475.8
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:2"
+   value: 370.2
+  }
+  casts: {
+   key: "other_id:OtherActionShoot"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:13750"
+   value: 1
+  }
+  casts: {
+   key: "spell_id:13877"
+   value: 3
+  }
+  casts: {
+   key: "spell_id:26863"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:26864"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48638"
+   value: 104.4
+  }
+  casts: {
+   key: "spell_id:48664"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48665"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48666"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:1"
+   value: 3.6
+  }
+  casts: {
+   key: "spell_id:48672 tag:2"
+   value: 1.9
+  }
+  casts: {
+   key: "spell_id:48672 tag:3"
+   value: 3.3
+  }
+  casts: {
+   key: "spell_id:48672 tag:4"
+   value: 4.4
+  }
+  casts: {
+   key: "spell_id:48672 tag:5"
+   value: 9
+  }
+  casts: {
+   key: "spell_id:51690"
+   value: 3
+  }
+  casts: {
+   key: "spell_id:51690 tag:1"
+   value: 15
+  }
+  casts: {
+   key: "spell_id:51690 tag:2"
+   value: 15
+  }
+  casts: {
+   key: "spell_id:51723"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:54758"
+   value: 5
+  }
+  casts: {
+   key: "spell_id:57934 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57968"
+   value: 112.9
+  }
+  casts: {
+   key: "spell_id:57968 tag:1"
+   value: 228.7
+  }
+  casts: {
+   key: "spell_id:57968 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57973"
+   value: 233.7
+  }
+  casts: {
+   key: "spell_id:57975"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:5938"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:1"
+   value: 5.5
+  }
+  casts: {
+   key: "spell_id:6774 tag:2"
+   value: 2.5
+  }
+  casts: {
+   key: "spell_id:6774 tag:3"
+   value: 2.3
+  }
+  casts: {
+   key: "spell_id:6774 tag:4"
+   value: 2.2
+  }
+  casts: {
+   key: "spell_id:6774 tag:5"
+   value: 2.5
+  }
+  casts: {
+   key: "spell_id:8647 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:5"
+   value: 0
+  }
+ }
+}
+casts_results: {
+ key: "TestRotation-Casts-Combat No Expose One Tricks Primary"
+ value: {
+  casts: {
+   key: "item_id:40211"
+   value: 1
+  }
+  casts: {
+   key: "item_id:7676"
+   value: 1
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:1"
+   value: 475
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:2"
+   value: 369.6
+  }
+  casts: {
+   key: "other_id:OtherActionShoot"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:13750"
+   value: 1
+  }
+  casts: {
+   key: "spell_id:13877"
+   value: 3
+  }
+  casts: {
+   key: "spell_id:26863"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:26864"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48638"
+   value: 101.1
+  }
+  casts: {
+   key: "spell_id:48664"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48665"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48666"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:1"
+   value: 3.9
+  }
+  casts: {
+   key: "spell_id:48672 tag:2"
+   value: 2.2
+  }
+  casts: {
+   key: "spell_id:48672 tag:3"
+   value: 3.7
+  }
+  casts: {
+   key: "spell_id:48672 tag:4"
+   value: 4.4
+  }
+  casts: {
+   key: "spell_id:48672 tag:5"
+   value: 8.1
+  }
+  casts: {
+   key: "spell_id:51690"
+   value: 3
+  }
+  casts: {
+   key: "spell_id:51690 tag:1"
+   value: 15
+  }
+  casts: {
+   key: "spell_id:51690 tag:2"
+   value: 15
+  }
+  casts: {
+   key: "spell_id:51723"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:54758"
+   value: 5
+  }
+  casts: {
+   key: "spell_id:57934 tag:1"
+   value: 8.2
+  }
+  casts: {
+   key: "spell_id:57968"
+   value: 112.6
+  }
+  casts: {
+   key: "spell_id:57968 tag:1"
+   value: 227.3
+  }
+  casts: {
+   key: "spell_id:57968 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57973"
+   value: 232.3
+  }
+  casts: {
+   key: "spell_id:57975"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:5938"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:1"
+   value: 5.5
+  }
+  casts: {
+   key: "spell_id:6774 tag:2"
+   value: 2.5
+  }
+  casts: {
+   key: "spell_id:6774 tag:3"
+   value: 2.4
+  }
+  casts: {
+   key: "spell_id:6774 tag:4"
+   value: 2.3
+  }
+  casts: {
+   key: "spell_id:6774 tag:5"
+   value: 2.4
+  }
+  casts: {
+   key: "spell_id:8647 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:5"
+   value: 0
+  }
+ }
+}
+casts_results: {
+ key: "TestRotation-Casts-Combat One Expose No Tricks Primary"
+ value: {
+  casts: {
+   key: "item_id:40211"
+   value: 1
+  }
+  casts: {
+   key: "item_id:7676"
+   value: 1
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:1"
+   value: 475.8
+  }
+  casts: {
+   key: "other_id:OtherActionAttack tag:2"
+   value: 370.2
+  }
+  casts: {
+   key: "other_id:OtherActionShoot"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:13750"
+   value: 1
+  }
+  casts: {
+   key: "spell_id:13877"
+   value: 3
+  }
+  casts: {
+   key: "spell_id:26863"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:26864"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48638"
+   value: 104.1
+  }
+  casts: {
+   key: "spell_id:48664"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48665"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48666"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:3"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48668 tag:5"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:48672 tag:1"
+   value: 3.1
+  }
+  casts: {
+   key: "spell_id:48672 tag:2"
+   value: 2.1
+  }
+  casts: {
+   key: "spell_id:48672 tag:3"
+   value: 3.5
+  }
+  casts: {
+   key: "spell_id:48672 tag:4"
+   value: 4.3
+  }
+  casts: {
+   key: "spell_id:48672 tag:5"
+   value: 8.7
+  }
+  casts: {
+   key: "spell_id:51690"
+   value: 3
+  }
+  casts: {
+   key: "spell_id:51690 tag:1"
+   value: 15
+  }
+  casts: {
+   key: "spell_id:51690 tag:2"
+   value: 15
+  }
+  casts: {
+   key: "spell_id:51723"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:54758"
+   value: 5
+  }
+  casts: {
+   key: "spell_id:57934 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57968"
+   value: 112.9
+  }
+  casts: {
+   key: "spell_id:57968 tag:1"
+   value: 228.8
+  }
+  casts: {
+   key: "spell_id:57968 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57973"
+   value: 233.8
+  }
+  casts: {
+   key: "spell_id:57975"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:57975 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:5938"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:6774 tag:1"
+   value: 5.9
+  }
+  casts: {
+   key: "spell_id:6774 tag:2"
+   value: 2.4
+  }
+  casts: {
+   key: "spell_id:6774 tag:3"
+   value: 2.1
+  }
+  casts: {
+   key: "spell_id:6774 tag:4"
+   value: 1.9
+  }
+  casts: {
+   key: "spell_id:6774 tag:5"
+   value: 2.8
+  }
+  casts: {
+   key: "spell_id:8647 tag:1"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:2"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:3"
+   value: 1
+  }
+  casts: {
+   key: "spell_id:8647 tag:4"
+   value: 0
+  }
+  casts: {
+   key: "spell_id:8647 tag:5"
+   value: 0
+  }
+ }
+}

--- a/sim/rogue/envenom.go
+++ b/sim/rogue/envenom.go
@@ -44,7 +44,7 @@ func (rogue *Rogue) makeEnvenom(comboPoints int32) *core.Spell {
 			BaseDamage: core.BaseDamageConfig{
 				Calculator: func(sim *core.Simulation, hitEffect *core.SpellEffect, spell *core.Spell) float64 {
 					target := hitEffect.Target
-					deadlyPoisonStacks := rogue.DeadlyPoisonDots[target.Index].GetStacks()
+					deadlyPoisonStacks := rogue.deadlyPoisonDots[target.Index].GetStacks()
 					doses := float64(core.MinInt32(deadlyPoisonStacks, comboPoints))
 					return baseDamage*doses + apRatio*doses*hitEffect.MeleeAttackPower(spell.Unit)
 				},
@@ -56,10 +56,10 @@ func (rogue *Rogue) makeEnvenom(comboPoints int32) *core.Spell {
 				if spellEffect.Landed() {
 					rogue.ApplyFinisher(sim, spell)
 					rogue.ApplyCutToTheChase(sim)
-					deadlyPoisonStacks := rogue.DeadlyPoisonDots[target.Index].GetStacks()
+					deadlyPoisonStacks := rogue.deadlyPoisonDots[target.Index].GetStacks()
 					doses := core.MinInt32(deadlyPoisonStacks, comboPoints)
 					if chanceToRetainStacks < 1 && sim.RandomFloat("Master Poisoner") > float64(chanceToRetainStacks) {
-						rogue.DeadlyPoisonDots[target.Index].Cancel(sim)
+						rogue.deadlyPoisonDots[target.Index].Cancel(sim)
 					}
 					rogue.EnvenomAura.Duration = time.Second * time.Duration(1+doses)
 					rogue.EnvenomAura.Activate(sim)
@@ -78,11 +78,11 @@ func (rogue *Rogue) registerEnvenom() {
 		Label:    "Envenom",
 		ActionID: core.ActionID{SpellID: 57993},
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			rogue.DeadlyPoisonProcChanceBonus += 0.15
+			rogue.deadlyPoisonProcChanceBonus += 0.15
 			rogue.UpdateInstantPoisonPPM(0.75)
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			rogue.DeadlyPoisonProcChanceBonus -= 0.15
+			rogue.deadlyPoisonProcChanceBonus -= 0.15
 			rogue.UpdateInstantPoisonPPM(0.0)
 		},
 	})

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -50,7 +50,7 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 		return func(sim *core.Simulation, spellEffect *core.SpellEffect, spell *core.Spell) float64 {
 			normalDamage := oldCalculator(sim, spellEffect, spell)
 			// TODO: Add support for all poison effects
-			if rogue.DeadlyPoisonDots[spellEffect.Target.Index].IsActive() || rogue.woundPoisonDebuffAuras[spellEffect.Target.Index].IsActive() {
+			if rogue.deadlyPoisonDots[spellEffect.Target.Index].IsActive() || rogue.woundPoisonDebuffAuras[spellEffect.Target.Index].IsActive() {
 				return normalDamage * 1.2
 			} else {
 				return normalDamage

--- a/sim/rogue/poisons.go
+++ b/sim/rogue/poisons.go
@@ -42,10 +42,10 @@ func (rogue *Rogue) registerDeadlyPoisonSpell() {
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				target := spellEffect.Target
 				if spellEffect.Landed() {
-					dot := rogue.DeadlyPoisonDots[target.Index]
+					dot := rogue.deadlyPoisonDots[target.Index]
 					if dot.IsActive() {
 						if dot.GetStacks() == 5 {
-							if rogue.LastDeadlyPoisonProcMask.Matches(core.ProcMaskMeleeMH) {
+							if rogue.lastDeadlyPoisonProcMask.Matches(core.ProcMaskMeleeMH) {
 								switch rogue.Options.OhImbue {
 								case proto.Rogue_Options_DeadlyPoison:
 									dot.Refresh(sim)
@@ -55,7 +55,7 @@ func (rogue *Rogue) registerDeadlyPoisonSpell() {
 									rogue.WoundPoison[1].Cast(sim, target)
 								}
 							}
-							if rogue.LastDeadlyPoisonProcMask.Matches(core.ProcMaskMeleeOH) {
+							if rogue.lastDeadlyPoisonProcMask.Matches(core.ProcMaskMeleeOH) {
 								switch rogue.Options.MhImbue {
 								case proto.Rogue_Options_DeadlyPoison:
 									dot.Refresh(sim)
@@ -73,7 +73,7 @@ func (rogue *Rogue) registerDeadlyPoisonSpell() {
 						dot.SetStacks(sim, 1)
 					}
 				}
-				rogue.LastDeadlyPoisonProcMask = core.ProcMaskEmpty
+				rogue.lastDeadlyPoisonProcMask = core.ProcMaskEmpty
 			},
 		}),
 	})
@@ -132,12 +132,12 @@ func (rogue *Rogue) registerDeadlyPoisonSpell() {
 		}
 		// Would like to do this for the snapshotting but it also shots the aura
 		//dot.TickEffects = core.TickFuncSnapshot(target, deadlyPoisonTickEffect)
-		rogue.DeadlyPoisonDots = append(rogue.DeadlyPoisonDots, dot)
+		rogue.deadlyPoisonDots = append(rogue.deadlyPoisonDots, dot)
 	}
 }
 
 func (rogue *Rogue) procDeadlyPoison(sim *core.Simulation, spellEffect *core.SpellEffect) {
-	rogue.LastDeadlyPoisonProcMask = spellEffect.ProcMask
+	rogue.lastDeadlyPoisonProcMask = spellEffect.ProcMask
 	rogue.DeadlyPoison.Cast(sim, spellEffect.Target)
 }
 
@@ -311,7 +311,7 @@ func (rogue *Rogue) GetDeadlyPoisonProcChance(mask core.ProcMask) float64 {
 	if mask.Matches(core.ProcMaskMeleeOH) && rogue.Options.OhImbue != proto.Rogue_Options_DeadlyPoison {
 		return 0.0
 	}
-	return 0.3 + 0.04*float64(rogue.Talents.ImprovedPoisons) + rogue.DeadlyPoisonProcChanceBonus
+	return 0.3 + 0.04*float64(rogue.Talents.ImprovedPoisons) + rogue.deadlyPoisonProcChanceBonus
 }
 
 func (rogue *Rogue) UpdateInstantPoisonPPM(bonusChance float64) {
@@ -320,7 +320,7 @@ func (rogue *Rogue) UpdateInstantPoisonPPM(bonusChance float64) {
 		rogue.Options.OhImbue == proto.Rogue_Options_InstantPoison)
 
 	ppm := 8.57 * (1 + float64(rogue.Talents.ImprovedPoisons)*0.1 + bonusChance)
-	rogue.InstantPoisonPPMM = rogue.AutoAttacks.NewPPMManager(ppm, procMask)
+	rogue.instantPoisonPPMM = rogue.AutoAttacks.NewPPMManager(ppm, procMask)
 }
 
 func (rogue *Rogue) applyInstantPoison() {
@@ -342,7 +342,7 @@ func (rogue *Rogue) applyInstantPoison() {
 			if !spellEffect.Landed() || !spellEffect.ProcMask.Matches(procMask) {
 				return
 			}
-			if rogue.InstantPoisonPPMM.Proc(sim, spellEffect.ProcMask, "Instant Poison") {
+			if rogue.instantPoisonPPMM.Proc(sim, spellEffect.ProcMask, "Instant Poison") {
 				rogue.InstantPoison[0].Cast(sim, spellEffect.Target)
 			}
 		},

--- a/sim/rogue/presets.go
+++ b/sim/rogue/presets.go
@@ -1,6 +1,7 @@
 package rogue
 
 import (
+	"github.com/wowsims/wotlk/sim/core"
 	"github.com/wowsims/wotlk/sim/core/items"
 	"github.com/wowsims/wotlk/sim/core/proto"
 )
@@ -138,6 +139,106 @@ var AssassinationTalents = &proto.RogueTalents{
 
 	RelentlessStrikes: 5,
 	Opportunity:       2,
+}
+
+var AssassinationRotationOptions = []*proto.Rogue_Rotation{
+	{
+		ExposeArmorFrequency:          proto.Rogue_Rotation_Never,
+		TricksOfTheTradeFrequency:     proto.Rogue_Rotation_Never,
+		AssassinationFinisherPriority: proto.Rogue_Rotation_EnvenomRupture,
+	},
+	{
+		ExposeArmorFrequency:          proto.Rogue_Rotation_Never,
+		TricksOfTheTradeFrequency:     proto.Rogue_Rotation_Once,
+		AssassinationFinisherPriority: proto.Rogue_Rotation_EnvenomRupture,
+	},
+	{
+		ExposeArmorFrequency:          proto.Rogue_Rotation_Once,
+		MinimumComboPointsExposeArmor: 3,
+		TricksOfTheTradeFrequency:     proto.Rogue_Rotation_Never,
+		AssassinationFinisherPriority: proto.Rogue_Rotation_EnvenomRupture,
+	},
+	{
+		ExposeArmorFrequency:          proto.Rogue_Rotation_Maintain,
+		TricksOfTheTradeFrequency:     proto.Rogue_Rotation_Never,
+		AssassinationFinisherPriority: proto.Rogue_Rotation_EnvenomRupture,
+	},
+	{
+		ExposeArmorFrequency:          proto.Rogue_Rotation_Never,
+		TricksOfTheTradeFrequency:     proto.Rogue_Rotation_Maintain,
+		AssassinationFinisherPriority: proto.Rogue_Rotation_EnvenomRupture,
+	},
+	{
+		ExposeArmorFrequency:          proto.Rogue_Rotation_Never,
+		TricksOfTheTradeFrequency:     proto.Rogue_Rotation_Maintain,
+		AssassinationFinisherPriority: proto.Rogue_Rotation_RuptureEnvenom,
+	},
+}
+
+var CombatRotationOptions = []*proto.Rogue_Rotation{
+	{
+		ExposeArmorFrequency:      proto.Rogue_Rotation_Never,
+		TricksOfTheTradeFrequency: proto.Rogue_Rotation_Never,
+		CombatFinisherPriority:    proto.Rogue_Rotation_RuptureEviscerate,
+	},
+	{
+		ExposeArmorFrequency:      proto.Rogue_Rotation_Never,
+		TricksOfTheTradeFrequency: proto.Rogue_Rotation_Once,
+		CombatFinisherPriority:    proto.Rogue_Rotation_RuptureEviscerate,
+	},
+	{
+		ExposeArmorFrequency:          proto.Rogue_Rotation_Once,
+		MinimumComboPointsExposeArmor: 3,
+		TricksOfTheTradeFrequency:     proto.Rogue_Rotation_Never,
+		CombatFinisherPriority:        proto.Rogue_Rotation_RuptureEviscerate,
+	},
+	{
+		ExposeArmorFrequency:      proto.Rogue_Rotation_Maintain,
+		TricksOfTheTradeFrequency: proto.Rogue_Rotation_Never,
+		CombatFinisherPriority:    proto.Rogue_Rotation_RuptureEviscerate,
+	},
+	{
+		ExposeArmorFrequency:      proto.Rogue_Rotation_Never,
+		TricksOfTheTradeFrequency: proto.Rogue_Rotation_Maintain,
+		CombatFinisherPriority:    proto.Rogue_Rotation_RuptureEviscerate,
+	},
+	{
+		ExposeArmorFrequency:      proto.Rogue_Rotation_Never,
+		TricksOfTheTradeFrequency: proto.Rogue_Rotation_Maintain,
+		CombatFinisherPriority:    proto.Rogue_Rotation_EviscerateRupture,
+	},
+}
+
+var RotationNames = []string{
+	"No Expose No Tricks Primary",
+	"No Expose One Tricks Primary",
+	"One Expose No Tricks Primary",
+	"Maintain Expose No Tricks Primary",
+	"No Expose Maintain Tricks Primary",
+	"No Expose Maintain Tricks Secondary",
+}
+
+func RotationSpecOptions(talents *proto.RogueTalents, options *proto.Rogue_Options) []core.SpecOptionsCombo {
+	specs := make([]core.SpecOptionsCombo, 0)
+	specLabel := "Assassination"
+	rotationOptions := AssassinationRotationOptions
+	if !talents.Mutilate {
+		specLabel = "Combat"
+		rotationOptions = CombatRotationOptions
+	}
+	for idx, rotation := range rotationOptions {
+		specs = append(specs, core.SpecOptionsCombo{
+			Label: specLabel + " " + RotationNames[idx],
+			SpecOptions: &proto.Player_Rogue{
+				Rogue: &proto.Rogue{
+					Talents:  talents,
+					Options:  options,
+					Rotation: rotation,
+				},
+			},
+		})
+	}
+	return specs
 }
 
 var PlayerOptionsCombatDI = &proto.Player_Rogue{

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -37,8 +37,8 @@ type Rogue struct {
 	Options  proto.Rogue_Options
 	Rotation proto.Rogue_Rotation
 
-	PriorityList    []RoguePriority
-	CurrentPriority *RoguePriority
+	PriorityItems []RoguePriorityItem
+	RotationItems []RogueRotationItem
 
 	sliceAndDiceDurations [6]time.Duration
 	exposeArmorDurations  [6]time.Duration
@@ -46,8 +46,10 @@ type Rogue struct {
 
 	initialArmorDebuffAura *core.Aura
 
+	BuilderPoints    int32
 	Builder          *core.Spell
 	Backstab         *core.Spell
+	BladeFlurry      *core.Spell
 	DeadlyPoison     *core.Spell
 	FanOfKnives      *core.Spell
 	Hemorrhage       *core.Spell
@@ -179,7 +181,7 @@ func (rogue *Rogue) Reset(sim *core.Simulation) {
 	rogue.disabledMCDs = rogue.DisableAllEnabledCooldowns(core.CooldownTypeUnknown)
 	rogue.initialArmorDebuffAura = rogue.CurrentTarget.GetActiveAuraWithTag(core.MajorArmorReductionTag)
 	rogue.LastDeadlyPoisonProcMask = core.ProcMaskEmpty
-	rogue.SetPriorityList(sim)
+	rogue.SetPriorityItems(sim)
 }
 
 func (rogue *Rogue) MeleeCritMultiplier(isMH bool, applyLethality bool) float64 {

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -37,8 +37,8 @@ type Rogue struct {
 	Options  proto.Rogue_Options
 	Rotation proto.Rogue_Rotation
 
-	PriorityItems []RoguePriorityItem
-	RotationItems []RogueRotationItem
+	priorityItems []roguePriorityItem
+	rotationItems []rogueRotationItem
 
 	sliceAndDiceDurations [6]time.Duration
 	exposeArmorDurations  [6]time.Duration
@@ -67,11 +67,11 @@ type Rogue struct {
 	Rupture      [6]*core.Spell
 	SliceAndDice [6]*core.Spell
 
-	LastDeadlyPoisonProcMask    core.ProcMask
-	DeadlyPoisonProcChanceBonus float64
-	InstantPoisonPPMM           core.PPMManager
-	DeadlyPoisonDots            []*core.Dot
-	RuptureDot                  *core.Dot
+	lastDeadlyPoisonProcMask    core.ProcMask
+	deadlyPoisonProcChanceBonus float64
+	instantPoisonPPMM           core.PPMManager
+	deadlyPoisonDots            []*core.Dot
+	ruptureDot                  *core.Dot
 
 	AdrenalineRushAura   *core.Aura
 	BladeFlurryAura      *core.Aura
@@ -164,7 +164,7 @@ func (rogue *Rogue) Initialize() {
 	rogue.DelayDPSCooldownsForArmorDebuffs()
 }
 
-func (rogue *Rogue) GetExpectedEnergyPerSecond() float64 {
+func (rogue *Rogue) getExpectedEnergyPerSecond() float64 {
 	const finishersPerSecond = 1.0 / 6
 	const averageComboPointsSpendOnFinisher = 4.0
 	bonusEnergyPerSecond := float64(rogue.Talents.CombatPotency) * 3 * 0.2 * 1.0 / (rogue.AutoAttacks.OH.SwingSpeed / 1.4)
@@ -180,8 +180,8 @@ func (rogue *Rogue) ApplyEnergyTickMultiplier(multiplier float64) {
 func (rogue *Rogue) Reset(sim *core.Simulation) {
 	rogue.disabledMCDs = rogue.DisableAllEnabledCooldowns(core.CooldownTypeUnknown)
 	rogue.initialArmorDebuffAura = rogue.CurrentTarget.GetActiveAuraWithTag(core.MajorArmorReductionTag)
-	rogue.LastDeadlyPoisonProcMask = core.ProcMaskEmpty
-	rogue.SetPriorityItems(sim)
+	rogue.lastDeadlyPoisonProcMask = core.ProcMaskEmpty
+	rogue.setPriorityItems(sim)
 }
 
 func (rogue *Rogue) MeleeCritMultiplier(isMH bool, applyLethality bool) float64 {

--- a/sim/rogue/rogue_test.go
+++ b/sim/rogue/rogue_test.go
@@ -72,6 +72,24 @@ func TestAssassination(t *testing.T) {
 	}))
 }
 
+func TestRotation(t *testing.T) {
+	specOptions := RotationSpecOptions(PlayerOptionsCombatDI.Rogue.Talents, PlayerOptionsCombatDI.Rogue.Options)
+	specOptions = append(specOptions, RotationSpecOptions(PlayerOptionsAssassinationDI.Rogue.Talents, PlayerOptionsAssassinationDI.Rogue.Options)...)
+	core.RunTestSuite(t, t.Name(), core.RotationTestSuiteGenerator(core.CharacterSuiteConfig{
+		Class:            proto.Class_ClassRogue,
+		Race:             proto.Race_RaceHuman,
+		OtherRaces:       []proto.Race{proto.Race_RaceOrc},
+		GearSet:          core.GearSetCombo{Label: "P1", GearSet: P1Gear},
+		SpecOptions:      specOptions[0],
+		OtherSpecOptions: specOptions[1:],
+		RaidBuffs:        FullRaidBuffs,
+		PartyBuffs:       FullPartyBuffs,
+		PlayerBuffs:      FullIndividualBuffs,
+		Consumes:         FullConsumes,
+		Debuffs:          FullDebuffs,
+	}))
+}
+
 type AttackType int
 
 const (

--- a/sim/rogue/rotation.go
+++ b/sim/rogue/rotation.go
@@ -2,6 +2,7 @@ package rogue
 
 import (
 	"math"
+	"sort"
 	"time"
 
 	"github.com/wowsims/wotlk/sim/core"
@@ -15,7 +16,7 @@ func (rogue *Rogue) OnEnergyGain(sim *core.Simulation) {
 	}
 	rogue.TryUseCooldowns(sim)
 	if rogue.GCD.IsReady(sim) {
-		rogue.rotation(sim)
+		rogue.simpleRotation(sim)
 	}
 }
 
@@ -24,602 +25,430 @@ func (rogue *Rogue) OnGCDReady(sim *core.Simulation) {
 		rogue.DoNothing()
 		return
 	}
-	rogue.rotation(sim)
-}
-
-func RemainingAuraDuration(sim *core.Simulation, aura *core.Aura) time.Duration {
-	if aura == nil {
-		return 0
-	}
-	return core.MaxDuration(0, aura.RemainingDuration(sim))
-}
-
-func (rogue *Rogue) ExpectedEnergyGain(sim *core.Simulation, duration time.Duration) float64 {
-	adrenalineRushDuration := time.Second * 0
-	if rogue.Talents.AdrenalineRush {
-		adrenalineRushDuration = core.MinDuration(core.MaxDuration(rogue.AdrenalineRushAura.RemainingDuration(sim), 0), duration)
-	}
-	offHandWeaponSpeed := rogue.AutoAttacks.OH.SwingSpeed
-	baseEnergyDuration := duration - adrenalineRushDuration
-	adrenalineRushEnergyPerSecond := 12.5
-	baseEnergyPerSecond := 10.0
-	guaranteedEnergy := (adrenalineRushDuration.Seconds() * adrenalineRushEnergyPerSecond) + (baseEnergyDuration.Seconds() * baseEnergyPerSecond)
-	combatPotencyEnergyPerSwing := float64(rogue.Talents.CombatPotency) * 3 * 0.2
-	expectedCombatPotencyEnergy := (duration.Seconds() / offHandWeaponSpeed) * combatPotencyEnergyPerSwing
-	return guaranteedEnergy + expectedCombatPotencyEnergy
-}
-
-func (rogue *Rogue) ExpectedComboPoints(sim *core.Simulation, duration time.Duration, builderEnergyCost float64, finisherEnergyCost float64) float64 {
-	energyGained := rogue.ExpectedEnergyGain(sim, duration)
-	availableEnergy := energyGained + rogue.CurrentEnergy() - finisherEnergyCost
-	currentComboPoints := float64(rogue.ComboPoints())
-	expectedComboPoints := currentComboPoints
-	availableDuration := duration
-	for availableDuration > 0 && ((currentComboPoints >= 4.5 && availableEnergy >= finisherEnergyCost) ||
-		(currentComboPoints < 4.5 && availableEnergy >= builderEnergyCost)) {
-		if currentComboPoints >= 4.5 {
-			currentComboPoints -= 4.4
-			availableEnergy -= finisherEnergyCost
-		} else {
-			currentComboPoints += 1
-			availableEnergy -= builderEnergyCost
-			expectedComboPoints += 1
-		}
-		availableDuration -= 1.0
-	}
-	return expectedComboPoints
-}
-
-func (rogue *Rogue) rotation(sim *core.Simulation) {
-	rogue.updatePlan(sim)
-	spell := rogue.CurrentPriority.GetSpell(sim, rogue)
-	if spell == nil && (rogue.CurrentPriority.IsBuilder || rogue.CurrentPriority.IsFinisher) {
-		panic("Builders and Finishers should always have a spell")
-	} else if spell == nil {
-		if rogue.CurrentPriority.IncrementIfNil {
-			rogue.CurrentPriority.CastCount += 1
-		}
-		rogue.CurrentPriority = rogue.CurrentPriority.Prev
-	} else {
-		castSucceeded := false
-		if rogue.CurrentPriority.IsFinisher {
-			// Pool energy?
-			if rogue.CurrentEnergy() < 100 && RemainingAuraDuration(sim, rogue.CurrentPriority.Aura) > 0 {
-				castSucceeded = false
-			} else {
-				castSucceeded = spell.Cast(sim, rogue.CurrentTarget)
-			}
-		} else {
-			castSucceeded = spell.Cast(sim, rogue.CurrentTarget)
-		}
-		if castSucceeded {
-			rogue.CurrentPriority.CastCount += 1
-			rogue.CurrentPriority = rogue.CurrentPriority.Prev
-		}
+	rogue.TryUseCooldowns(sim)
+	if rogue.IsWaitingForEnergy() {
+		rogue.DoNothing()
+		return
 	}
 	if rogue.GCD.IsReady(sim) {
-		rogue.DoNothing()
+		rogue.simpleRotation(sim)
 	}
 }
 
-type RoguePriority struct {
-	Prev                 *RoguePriority
-	CastCount            int32
-	MaxCasts             int32
-	IncrementIfNil       bool
-	ComboPointsConsumed  float64
-	Index                int
-	MinimumComboPoints   float64
-	IsBuilder            bool
-	IsFinisher           bool
-	Label                string
-	Aura                 *core.Aura
-	EnergyCost           float64
-	ComboPointsGenerated float64
-	GetSpell             func(*core.Simulation, *Rogue) *core.Spell
+type RogueRotationItem struct {
+	ExpiresAt            time.Duration
+	MinimumBuildDuration time.Duration
+	MaximumBuildDuration time.Duration
+	PrioIndex            int
 }
 
-func (rogue *Rogue) SetMultiTargetPriorityList() {
-	index := 0
-	rogue.PriorityList = make([]RoguePriority, 0)
+type RoguePriorityItem struct {
+	Aura               *core.Aura
+	CastCount          int32
+	EnergyCost         float64
+	GetSpell           func(*Rogue, int32) *core.Spell
+	MaximumComboPoints int32
+	MaxCasts           int32
+	MinimumComboPoints int32
+}
 
-	if rogue.Rotation.MultiTargetSliceFrequency != proto.Rogue_Rotation_Never {
+type ShouldCastRotationItemResult int32
 
-		// Slice And Dice
-		sliceAndDice := RoguePriority{
-			Index:              index,
-			MinimumComboPoints: 1,
-			IsBuilder:          false,
-			IsFinisher:         true,
-			Label:              "Slice and Dice",
-			Aura:               rogue.SliceAndDiceAura,
-			EnergyCost:         rogue.SliceAndDice[1].DefaultCast.Cost,
-			GetSpell: func(s *core.Simulation, r *Rogue) *core.Spell {
-				comboPoints := rogue.ComboPoints()
-				if comboPoints < 1 {
-					return nil
-				}
-				return rogue.SliceAndDice[comboPoints]
-			},
-		}
-		if rogue.Rotation.MultiTargetSliceFrequency == proto.Rogue_Rotation_Once {
-			sliceAndDice.MaxCasts = 1
-			sliceAndDice.MinimumComboPoints = core.MaxFloat(1.0, float64(rogue.Rotation.MinimumComboPointsMultiTargetSlice))
-		}
-		rogue.PriorityList = append(rogue.PriorityList, sliceAndDice)
-		index += 1
+const (
+	ShouldNotCast ShouldCastRotationItemResult = iota
+	ShouldBuild
+	ShouldCast
+	ShouldWait
+)
 
-		if rogue.CanMutilate() {
-			mutilate := RoguePriority{
-				MinimumComboPoints:   0,
-				IsBuilder:            true,
-				IsFinisher:           false,
-				Label:                "Mutilate",
-				ComboPointsGenerated: 2,
-				EnergyCost:           rogue.Mutilate.DefaultCast.Cost,
-				GetSpell: func(s *core.Simulation, r *Rogue) *core.Spell {
-					return rogue.Mutilate
-				},
+func (rogue *Rogue) EnergyToBuild(points int32) float64 {
+	costPerBuilder := rogue.Builder.DefaultCast.Cost
+	buildersNeeded := math.Ceil(float64(points) / float64(rogue.BuilderPoints))
+	return buildersNeeded * costPerBuilder
+}
+
+func (rogue *Rogue) TimeToBuild(sim *core.Simulation, points int32, builderPoints int32, eps float64, finisherCost float64) time.Duration {
+	energyNeeded := rogue.EnergyToBuild(points) + finisherCost
+	secondsNeeded := energyNeeded / eps
+	globalsNeeded := math.Ceil(float64(points)/float64(builderPoints)) + 1
+	// Return greater of the time it takes to use the globals and the time it takes to build the energy
+	return core.MaxDuration(time.Second*time.Duration(secondsNeeded), time.Second*time.Duration(globalsNeeded))
+}
+
+func (rogue *Rogue) ShouldCastNextPrioItem(sim *core.Simulation, eps float64) ShouldCastRotationItemResult {
+	if len(rogue.RotationItems) < 1 {
+		panic("Empty rotation")
+	}
+	currentEnergy := rogue.CurrentEnergy()
+	comboPoints := rogue.ComboPoints()
+	currentTime := sim.CurrentTime
+
+	// Adjusting for planning variance
+	item := rogue.RotationItems[0]
+	prio := rogue.PriorityItems[item.PrioIndex]
+	tte := item.ExpiresAt - currentTime
+
+	clippingThreshold := time.Second * 2
+
+	timeUntilNextGCD := rogue.GCD.TimeToReady(sim)
+
+	// A higher prio item will expire within the next GCD
+	if len(rogue.RotationItems) > 0 {
+		for _, nextItem := range rogue.RotationItems[1:] {
+			if nextItem.ExpiresAt-currentTime <= time.Second*1 {
+				return ShouldNotCast
 			}
-			rogue.PriorityList = append(rogue.PriorityList, mutilate)
-			index += 1
+		}
+	}
+	if tte <= timeUntilNextGCD { // Expires before next GCD
+		if comboPoints >= prio.MinimumComboPoints && currentEnergy >= prio.EnergyCost {
+			return ShouldCast
+		} else if comboPoints < prio.MinimumComboPoints && currentEnergy >= rogue.Builder.DefaultCast.Cost {
+			return ShouldBuild
 		} else {
-			sinisterStrike := RoguePriority{
-				MinimumComboPoints:   0,
-				IsBuilder:            true,
-				IsFinisher:           false,
-				Label:                "Sinister Strike",
-				ComboPointsGenerated: 1,
-				EnergyCost:           rogue.SinisterStrike.DefaultCast.Cost,
-				GetSpell: func(s *core.Simulation, r *Rogue) *core.Spell {
-					return rogue.SinisterStrike
-				},
-			}
-			rogue.PriorityList = append(rogue.PriorityList, sinisterStrike)
-			index += 1
+			return ShouldWait
 		}
-	}
-	if rogue.Talents.HungerForBlood {
-		hungerForBlood := RoguePriority{
-			IsBuilder:  false,
-			IsFinisher: false,
-			Label:      "Hunger for Blood",
-			EnergyCost: rogue.HungerForBlood.DefaultCast.Cost,
-			Aura:       rogue.HungerForBloodAura,
-			GetSpell: func(s *core.Simulation, r *Rogue) *core.Spell {
-				return rogue.HungerForBlood
-			},
-		}
-		rogue.PriorityList = append(rogue.PriorityList, hungerForBlood)
-		index += 1
-	}
-
-	// Dummy thing to enable cooldowns
-	cooldownEnabler := RoguePriority{
-		Index:          index,
-		Label:          "Enable Cooldowns",
-		MaxCasts:       1,
-		IncrementIfNil: true,
-		GetSpell: func(s *core.Simulation, r *Rogue) *core.Spell {
-			if rogue.disabledMCDs != nil {
-				rogue.EnableAllCooldowns(rogue.disabledMCDs)
-				rogue.disabledMCDs = nil
+	} else { // More than a GCD before expiration
+		if comboPoints >= prio.MaximumComboPoints { // Don't need CP
+			// Cast
+			if tte <= clippingThreshold && currentEnergy >= prio.EnergyCost {
+				return ShouldCast
 			}
-			return nil
-		},
+			// Pool energy
+			if tte <= clippingThreshold && currentEnergy < prio.EnergyCost {
+				return ShouldWait
+			}
+			// We have time to squeeze in another spell
+			if tte > item.MinimumBuildDuration {
+				// Find the first lower prio item that can be cast and use it
+				for lpi, lowerPrio := range rogue.PriorityItems[item.PrioIndex+1:] {
+					if comboPoints > lowerPrio.MinimumComboPoints && currentEnergy > lowerPrio.EnergyCost && lowerPrio.MaxCasts == 0 {
+						rogue.RotationItems = append([]RogueRotationItem{
+							{ExpiresAt: currentTime, PrioIndex: lpi + item.PrioIndex + 1},
+						}, rogue.RotationItems...)
+						return ShouldCast
+					}
+				}
+			}
+			// Overcap CP with builder
+			if rogue.TimeToBuild(sim, 1, rogue.BuilderPoints, eps, 0) <= tte && currentEnergy >= rogue.Builder.DefaultCast.Cost {
+				return ShouldBuild
+			}
+		} else if comboPoints < prio.MinimumComboPoints { // Need CP
+			if currentEnergy >= rogue.Builder.DefaultCast.Cost {
+				return ShouldBuild
+			} else {
+				return ShouldWait
+			}
+		} else { // TODO: Optionally build more CP
+			if currentEnergy >= prio.EnergyCost && tte < time.Second*1 {
+				return ShouldCast
+			} else if currentEnergy >= rogue.Builder.DefaultCast.Cost {
+				return ShouldBuild
+			} else {
+				return ShouldWait
+			}
+		}
+		return ShouldWait
 	}
-	rogue.PriorityList = append(rogue.PriorityList, cooldownEnabler)
-	index += 1
-
-	fanOfKnives := RoguePriority{
-		Label:      "Fan of Knives",
-		IsBuilder:  false,
-		IsFinisher: false,
-		EnergyCost: rogue.FanOfKnives.DefaultCast.Cost,
-		GetSpell: func(s *core.Simulation, r *Rogue) *core.Spell {
-			return rogue.FanOfKnives
-		},
-	}
-	rogue.PriorityList = append(rogue.PriorityList, fanOfKnives)
-	index += 1
 }
 
-func (rogue *Rogue) SetPriorityList(sim *core.Simulation) {
-	if rogue.CanMutilate() {
+func (rogue *Rogue) PlanRotation(sim *core.Simulation) []RogueRotationItem {
+	rotationItems := make([]RogueRotationItem, 0)
+	eps := rogue.GetExpectedEnergyPerSecond()
+	for pi, prio := range rogue.PriorityItems {
+		if prio.MaxCasts > 0 && prio.CastCount >= prio.MaxCasts {
+			continue
+		}
+		expiresAt := core.NeverExpires
+		if prio.Aura != nil {
+			expiresAt = prio.Aura.ExpiresAt()
+		} else if prio.MaxCasts == 1 {
+			expiresAt = sim.CurrentTime
+		} else {
+			expiresAt = sim.CurrentTime
+		}
+		minimumBuildDuration := rogue.TimeToBuild(sim, prio.MinimumComboPoints, rogue.BuilderPoints, eps, prio.EnergyCost)
+		maximumBuildDuration := rogue.TimeToBuild(sim, prio.MaxCasts, rogue.BuilderPoints, eps, prio.EnergyCost)
+		rotationItems = append(rotationItems, RogueRotationItem{
+			ExpiresAt:            expiresAt,
+			MaximumBuildDuration: maximumBuildDuration,
+			MinimumBuildDuration: minimumBuildDuration,
+			PrioIndex:            pi,
+		})
+	}
+
+	currentTime := sim.CurrentTime
+	comboPoints := rogue.ComboPoints()
+	currentEnergy := rogue.CurrentEnergy()
+
+	prioStack := make([]RogueRotationItem, 0)
+	for _, item := range rotationItems {
+		prio := rogue.PriorityItems[item.PrioIndex]
+		maxBuildAt := item.ExpiresAt - item.MaximumBuildDuration
+		if prio.Aura == nil {
+			timeValueOfResources := time.Duration((float64(comboPoints)*rogue.Builder.DefaultCast.Cost/float64(rogue.BuilderPoints) + currentEnergy) / eps)
+			maxBuildAt = currentTime - item.MaximumBuildDuration - timeValueOfResources
+		}
+		if currentTime < maxBuildAt {
+			// Put it on the to cast stack
+			prioStack = append(prioStack, item)
+			if prio.MinimumComboPoints > 0 {
+				comboPoints = 0
+			}
+			currentTime += item.MaximumBuildDuration
+		} else {
+			cpUsed := core.MaxInt32(0, prio.MinimumComboPoints-comboPoints)
+			energyUsed := core.MaxFloat(0, prio.EnergyCost-currentEnergy)
+			minBuildTime := rogue.TimeToBuild(sim, cpUsed, rogue.BuilderPoints, eps, energyUsed)
+			if currentTime+minBuildTime <= item.ExpiresAt {
+				prioStack = append(prioStack, item)
+				currentTime = item.ExpiresAt
+				currentEnergy = 0
+				if prio.MinimumComboPoints > 0 {
+					comboPoints = 0
+				}
+			} else if len(prioStack) < 1 || (prio.Aura != nil && !prio.Aura.IsActive()) || prio.MaxCasts == 1 {
+				// Plan to cast it as soon as possible
+				prioStack = append(prioStack, item)
+				currentTime += item.MinimumBuildDuration
+				currentEnergy = 0
+				if prio.MinimumComboPoints > 0 {
+					comboPoints = 0
+				}
+			}
+		}
+	}
+
+	// Reverse
+	sort.Slice(prioStack, func(i, j int) bool {
+		return j < i
+	})
+
+	return prioStack
+}
+
+func (rogue *Rogue) SetPriorityItems(sim *core.Simulation) {
+	rogue.Builder = rogue.SinisterStrike
+	rogue.BuilderPoints = 1
+	if rogue.Talents.Mutilate {
 		rogue.Builder = rogue.Mutilate
-	} else {
-		rogue.Builder = rogue.SinisterStrike
+		rogue.BuilderPoints = 2
 	}
-	if sim.GetNumTargets() > 3 {
-		rogue.SetMultiTargetPriorityList()
-	} else {
-		rogue.SetStandardPriorityList()
-	}
-}
+	isMultiTarget := sim.GetNumTargets() > 3
+	// Slice and Dice
+	rogue.PriorityItems = make([]RoguePriorityItem, 0)
 
-func (rogue *Rogue) SetStandardPriorityList() {
-	index := 0
-	rogue.PriorityList = make([]RoguePriority, 0)
-
-	// Slice And Dice
-	sliceAndDice := RoguePriority{
-		Index:              index,
+	sliceAndDice := RoguePriorityItem{
 		MinimumComboPoints: 1,
-		IsBuilder:          false,
-		IsFinisher:         true,
-		Label:              "Slice and Dice",
+		MaximumComboPoints: 5,
 		Aura:               rogue.SliceAndDiceAura,
 		EnergyCost:         rogue.SliceAndDice[1].DefaultCast.Cost,
-		GetSpell: func(s *core.Simulation, r *Rogue) *core.Spell {
-			comboPoints := rogue.ComboPoints()
-			if comboPoints < 1 {
-				return nil
-			}
-			return rogue.SliceAndDice[comboPoints]
+		GetSpell: func(r *Rogue, cp int32) *core.Spell {
+			return rogue.SliceAndDice[cp]
 		},
 	}
-	rogue.PriorityList = append(rogue.PriorityList, sliceAndDice)
-	index += 1
+	if isMultiTarget {
+		if rogue.Rotation.MultiTargetSliceFrequency != proto.Rogue_Rotation_Never {
+			sliceAndDice.MinimumComboPoints = rogue.Rotation.MinimumComboPointsMultiTargetSlice
+			if rogue.Rotation.MultiTargetSliceFrequency == proto.Rogue_Rotation_Once {
+				sliceAndDice.MaxCasts = 1
+			}
+			rogue.PriorityItems = append(rogue.PriorityItems, sliceAndDice)
+		}
+	} else {
+		rogue.PriorityItems = append(rogue.PriorityItems, sliceAndDice)
+	}
 
 	// Expose Armor
-	exposeArmor := RoguePriority{
-		MinimumComboPoints: 1,
-		IsBuilder:          false,
-		IsFinisher:         true,
-		Label:              "Expose Armor",
-		Aura:               rogue.ExposeArmorAura,
-		EnergyCost:         rogue.ExposeArmor[1].DefaultCast.Cost,
-		GetSpell: func(s *core.Simulation, r *Rogue) *core.Spell {
-			comboPoints := rogue.ComboPoints()
-			if comboPoints < 1 {
-				return nil
-			}
-			return rogue.ExposeArmor[comboPoints]
-		},
-	}
-	if rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Maintain {
-		exposeArmor.Index = index
-		rogue.PriorityList = append(rogue.PriorityList, exposeArmor)
-		index += 1
-	} else if rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Once {
-		exposeArmor.Index = index
-		exposeArmor.MaxCasts = 1
-		exposeArmor.MinimumComboPoints = float64(rogue.Rotation.MinimumComboPointsExposeArmor)
-		rogue.PriorityList = append(rogue.PriorityList, exposeArmor)
-		index += 1
-	}
-
-	if rogue.Talents.HungerForBlood {
-		hungerForBlood := RoguePriority{
-			IsBuilder:  false,
-			IsFinisher: false,
-			Label:      "Hunger for Blood",
-			EnergyCost: rogue.HungerForBlood.DefaultCast.Cost,
-			Aura:       rogue.HungerForBloodAura,
-			GetSpell: func(s *core.Simulation, r *Rogue) *core.Spell {
-				return rogue.HungerForBlood
-			},
+	if rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Maintain ||
+		rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Once {
+		minPoints := int32(1)
+		maxCasts := int32(0)
+		if rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Once {
+			minPoints = rogue.Rotation.MinimumComboPointsExposeArmor
+			maxCasts = 1
 		}
-		rogue.PriorityList = append(rogue.PriorityList, hungerForBlood)
-		index += 1
+		rogue.PriorityItems = append(rogue.PriorityItems, RoguePriorityItem{
+			MaxCasts:           maxCasts,
+			MaximumComboPoints: 5,
+			MinimumComboPoints: minPoints,
+			Aura:               rogue.ExposeArmorAura,
+			EnergyCost:         rogue.ExposeArmor[1].DefaultCast.Cost,
+			GetSpell: func(r *Rogue, cp int32) *core.Spell {
+				return rogue.ExposeArmor[cp]
+			},
+		})
 	}
 
-	// Dummy thing to enable cooldowns
-	cooldownEnabler := RoguePriority{
-		Index:          index,
-		Label:          "Enable Cooldowns",
-		MaxCasts:       1,
-		IncrementIfNil: true,
-		GetSpell: func(s *core.Simulation, r *Rogue) *core.Spell {
-			if rogue.disabledMCDs != nil {
-				rogue.EnableAllCooldowns(rogue.disabledMCDs)
-				rogue.disabledMCDs = nil
+	// Hunger for Blood
+	if rogue.Talents.HungerForBlood {
+		rogue.PriorityItems = append(rogue.PriorityItems, RoguePriorityItem{
+			MaximumComboPoints: 0,
+			Aura:               rogue.HungerForBloodAura,
+			EnergyCost:         rogue.HungerForBlood.DefaultCast.Cost,
+			GetSpell: func(r *Rogue, cp int32) *core.Spell {
+				return r.HungerForBlood
+			},
+		})
+	}
+
+	// Dummy priority to enable CDs
+	rogue.PriorityItems = append(rogue.PriorityItems, RoguePriorityItem{
+		MaxCasts:           1,
+		MaximumComboPoints: 0,
+		GetSpell: func(r *Rogue, cp int32) *core.Spell {
+			if r.disabledMCDs != nil {
+				r.EnableAllCooldowns(r.disabledMCDs)
+				r.disabledMCDs = nil
 			}
 			return nil
 		},
-	}
-	rogue.PriorityList = append(rogue.PriorityList, cooldownEnabler)
-	index += 1
+	})
 
-	rupture := RoguePriority{
+	// Rupture
+	rupture := RoguePriorityItem{
 		MinimumComboPoints: 3,
-		IsBuilder:          false,
-		IsFinisher:         true,
-		Label:              "Rupture",
+		MaximumComboPoints: 5,
 		Aura:               rogue.RuptureDot.Aura,
 		EnergyCost:         rogue.Rupture[1].DefaultCast.Cost,
-		GetSpell: func(s *core.Simulation, r *Rogue) *core.Spell {
-			comboPoints := rogue.ComboPoints()
-			if comboPoints < 1 {
-				return nil
-			}
-			return rogue.Rupture[comboPoints]
+		GetSpell: func(r *Rogue, cp int32) *core.Spell {
+			return rogue.Rupture[cp]
 		},
 	}
 
-	eviscerate := RoguePriority{
-		MinimumComboPoints: 3,
-		IsBuilder:          false,
-		IsFinisher:         true,
-		Label:              "Eviscerate",
+	// Eviscerate
+	eviscerate := RoguePriorityItem{
+		MinimumComboPoints: 1,
+		MaximumComboPoints: 5,
 		EnergyCost:         rogue.Eviscerate[1].DefaultCast.Cost,
-		GetSpell: func(s *core.Simulation, r *Rogue) *core.Spell {
-			comboPoints := rogue.ComboPoints()
-			if comboPoints < 1 {
-				return nil
-			}
-			return rogue.Eviscerate[comboPoints]
+		GetSpell: func(r *Rogue, cp int32) *core.Spell {
+			return rogue.Eviscerate[cp]
 		},
 	}
 
-	if rogue.Talents.MasterPoisoner > 0 || rogue.Talents.CutToTheChase > 0 {
-		envenom := RoguePriority{
-			MinimumComboPoints: 3,
-			IsBuilder:          false,
-			IsFinisher:         true,
-			Label:              "Envenom",
+	if isMultiTarget {
+		rogue.PriorityItems = append(rogue.PriorityItems, RoguePriorityItem{
+			MaximumComboPoints: 0,
+			EnergyCost:         rogue.FanOfKnives.DefaultCast.Cost,
+			GetSpell: func(r *Rogue, i int32) *core.Spell {
+				return r.FanOfKnives
+			},
+		})
+
+	} else if rogue.Talents.MasterPoisoner > 0 || rogue.Talents.CutToTheChase > 0 {
+		// Envenom
+		envenom := RoguePriorityItem{
+			MinimumComboPoints: 1,
+			MaximumComboPoints: 5,
 			Aura:               rogue.EnvenomAura,
 			EnergyCost:         rogue.Envenom[1].DefaultCast.Cost,
-			GetSpell: func(s *core.Simulation, r *Rogue) *core.Spell {
-				comboPoints := rogue.ComboPoints()
-				if comboPoints < 1 {
-					return nil
-				}
-				return rogue.Envenom[comboPoints]
+			GetSpell: func(r *Rogue, cp int32) *core.Spell {
+				return rogue.Envenom[cp]
 			},
 		}
 		switch rogue.Rotation.AssassinationFinisherPriority {
 		case proto.Rogue_Rotation_EnvenomRupture:
-			envenom.Index = index
-			envenom.MinimumComboPoints = float64(rogue.Rotation.MinimumComboPointsPrimaryFinisher)
-			rogue.PriorityList = append(rogue.PriorityList, envenom)
-			index += 1
-			rupture.Index = index
-			rupture.MinimumComboPoints = float64(rogue.Rotation.MinimumComboPointsSecondaryFinisher)
-			rogue.PriorityList = append(rogue.PriorityList, rupture)
-			index += 1
+			envenom.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
+			rogue.PriorityItems = append(rogue.PriorityItems, envenom)
+			rupture.MinimumComboPoints = rogue.Rotation.MinimumComboPointsSecondaryFinisher
+			if rupture.MinimumComboPoints > 0 && rupture.MinimumComboPoints <= 5 {
+				rogue.PriorityItems = append(rogue.PriorityItems, rupture)
+			}
 		case proto.Rogue_Rotation_RuptureEnvenom:
-			rupture.Index = index
-			rupture.MinimumComboPoints = float64(rogue.Rotation.MinimumComboPointsPrimaryFinisher)
-			rogue.PriorityList = append(rogue.PriorityList, rupture)
-			index += 1
-			envenom.Index = index
-			envenom.MinimumComboPoints = float64(rogue.Rotation.MinimumComboPointsSecondaryFinisher)
-			rogue.PriorityList = append(rogue.PriorityList, envenom)
-			index += 1
+			rupture.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
+			rogue.PriorityItems = append(rogue.PriorityItems, rupture)
+			envenom.MinimumComboPoints = rogue.Rotation.MinimumComboPointsSecondaryFinisher
+			if envenom.MinimumComboPoints > 0 && envenom.MinimumComboPoints <= 5 {
+				rogue.PriorityItems = append(rogue.PriorityItems, envenom)
+			}
 		}
 	} else {
 		switch rogue.Rotation.CombatFinisherPriority {
 		case proto.Rogue_Rotation_RuptureEviscerate:
-			rupture.Index = index
-			rupture.MinimumComboPoints = float64(rogue.Rotation.MinimumComboPointsPrimaryFinisher)
-			rogue.PriorityList = append(rogue.PriorityList, rupture)
-			index += 1
-			eviscerate.Index = index
-			eviscerate.MinimumComboPoints = float64(rogue.Rotation.MinimumComboPointsSecondaryFinisher)
-			rogue.PriorityList = append(rogue.PriorityList, eviscerate)
-			index += 1
+			rupture.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
+			rogue.PriorityItems = append(rogue.PriorityItems, rupture)
+			eviscerate.MinimumComboPoints = rogue.Rotation.MinimumComboPointsSecondaryFinisher
+			if eviscerate.MinimumComboPoints > 0 && eviscerate.MinimumComboPoints <= 5 {
+				rogue.PriorityItems = append(rogue.PriorityItems, eviscerate)
+			}
 		case proto.Rogue_Rotation_EviscerateRupture:
-			eviscerate.Index = index
-			eviscerate.MinimumComboPoints = float64(rogue.Rotation.MinimumComboPointsPrimaryFinisher)
-			rogue.PriorityList = append(rogue.PriorityList, eviscerate)
-			index += 1
-			rupture.Index = index
-			rupture.MinimumComboPoints = float64(rogue.Rotation.MinimumComboPointsSecondaryFinisher)
-			rogue.PriorityList = append(rogue.PriorityList, rupture)
-			index += 1
+			eviscerate.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
+			rogue.PriorityItems = append(rogue.PriorityItems, eviscerate)
+			rupture.MinimumComboPoints = rogue.Rotation.MinimumComboPointsSecondaryFinisher
+			if rupture.MinimumComboPoints > 0 && rupture.MinimumComboPoints <= 5 {
+				rogue.PriorityItems = append(rogue.PriorityItems, rupture)
+			}
 		}
 	}
-
-	if rogue.CanMutilate() {
-		mutilate := RoguePriority{
-			MinimumComboPoints:   0,
-			IsBuilder:            true,
-			IsFinisher:           false,
-			Label:                "Mutilate",
-			ComboPointsGenerated: 2,
-			EnergyCost:           rogue.Mutilate.DefaultCast.Cost,
-			GetSpell: func(s *core.Simulation, r *Rogue) *core.Spell {
-				return rogue.Mutilate
-			},
-		}
-		rogue.PriorityList = append(rogue.PriorityList, mutilate)
-		index += 1
-	} else {
-		sinisterStrike := RoguePriority{
-			MinimumComboPoints:   0,
-			IsBuilder:            true,
-			IsFinisher:           false,
-			Label:                "Sinister Strike",
-			ComboPointsGenerated: 1,
-			EnergyCost:           rogue.SinisterStrike.DefaultCast.Cost,
-			GetSpell: func(s *core.Simulation, r *Rogue) *core.Spell {
-				return rogue.SinisterStrike
-			},
-		}
-		rogue.PriorityList = append(rogue.PriorityList, sinisterStrike)
-		index += 1
-	}
+	rogue.RotationItems = rogue.PlanRotation(sim)
 }
 
-func (rogue *Rogue) MinimalComboPointsNeededForPlan() float64 {
-	prio := rogue.CurrentPriority
-	if prio == nil {
-		return 0
+func (rogue *Rogue) simpleRotation(sim *core.Simulation) {
+	if len(rogue.RotationItems) < 1 {
+		panic("Rotation is empty")
 	}
-	cpNeeded := prio.MinimumComboPoints
-	for prio.Prev != nil {
-		prio = prio.Prev
-		cpNeeded += prio.MinimumComboPoints
-	}
-	return cpNeeded
-}
-
-func (rogue *Rogue) IdealComboPointsNeededForPlan() float64 {
-	prio := rogue.CurrentPriority
-	if prio == nil {
-		return 0
-	}
-	cpNeeded := prio.ComboPointsConsumed
-	for prio.Prev != nil {
-		prio = prio.Prev
-		cpNeeded += prio.ComboPointsConsumed
-	}
-	return cpNeeded
-}
-
-func (rogue *Rogue) DurationOfCurrentPlan(sim *core.Simulation) time.Duration {
-	prio := rogue.CurrentPriority
-	if prio == nil {
-		return 0
-	}
-	for prio.Prev != nil {
-		prio = prio.Prev
-	}
-	return RemainingAuraDuration(sim, prio.Aura)
-}
-
-func (rogue *Rogue) DurationUntilNextExpiration(sim *core.Simulation) (bool, time.Duration) {
-	prio := rogue.CurrentPriority
-	hasExpiration := false
-	duration := time.Second * math.MaxInt32
-	for prio != nil {
-		if prio.Aura != nil {
-			hasExpiration = true
-			duration = core.MinDuration(duration, RemainingAuraDuration(sim, prio.Aura))
-		}
-		prio = prio.Prev
-	}
-	return hasExpiration, duration
-}
-
-func (rogue *Rogue) verifyPlan(sim *core.Simulation) (bool, float64) {
-	prio := rogue.CurrentPriority
-	pointsSpent := 0.0
-	error := 0.0
-	for prio != nil {
-		if prio.Aura != nil {
-			pointsNeeded := prio.ComboPointsConsumed + pointsSpent
-			neededBy := RemainingAuraDuration(sim, prio.Aura)
-			expectedPoints := rogue.ExpectedComboPoints(sim, neededBy, rogue.Builder.DefaultCast.Cost, prio.EnergyCost)
-			if expectedPoints < pointsNeeded {
-				delta := pointsNeeded - expectedPoints
-				if delta > prio.ComboPointsConsumed-prio.MinimumComboPoints {
-					return false, error
-				}
-				// We can reduce consumed points to make up the difference
-				pointsNeeded -= delta
-				error += delta
+	eps := rogue.GetExpectedEnergyPerSecond()
+	shouldCast := rogue.ShouldCastNextPrioItem(sim, eps)
+	item := rogue.RotationItems[0]
+	prio := rogue.PriorityItems[item.PrioIndex]
+	switch shouldCast {
+	case ShouldNotCast:
+		rogue.RotationItems = rogue.RotationItems[1:]
+		rogue.simpleRotation(sim)
+	case ShouldBuild:
+		spell := rogue.Builder
+		if spell == nil || spell.Cast(sim, rogue.CurrentTarget) {
+			if rogue.GCD.IsReady(sim) {
+				rogue.simpleRotation(sim)
 			}
-			pointsSpent += pointsNeeded
+		} else {
+			panic("Unexpected builder cast failure")
 		}
-		prio = prio.Prev
-	}
-	return true, error
-}
-
-func (rogue *Rogue) HasPriorityWithInactiveAura(sim *core.Simulation) bool {
-	prio := rogue.CurrentPriority
-	for prio != nil {
-		if prio.Aura != nil && !prio.Aura.IsActive() {
-			return true
+	case ShouldCast:
+		spell := prio.GetSpell(rogue, rogue.ComboPoints())
+		if spell == nil || spell.Cast(sim, rogue.CurrentTarget) {
+			rogue.PriorityItems[item.PrioIndex].CastCount += 1
+			rogue.RotationItems = rogue.PlanRotation(sim)
+			if rogue.GCD.IsReady(sim) {
+				rogue.simpleRotation(sim)
+			}
+		} else {
+			panic("Unexpected cast failure")
 		}
-		prio = prio.Prev
-	}
-	return false
-}
-
-func (rogue *Rogue) updatePlan(sim *core.Simulation) {
-	currentIndex := 0
-	builderEnergyCost := rogue.Builder.DefaultCast.Cost
-
-	// Verify current plan
-	if rogue.CurrentPriority != nil {
-		validPlan, pointDelta := rogue.verifyPlan(sim)
-		if !validPlan {
-			rogue.CurrentPriority = nil
-		} else if pointDelta > 0 {
-			if rogue.CurrentPriority.ComboPointsConsumed-pointDelta >= rogue.CurrentPriority.MinimumComboPoints {
-				rogue.CurrentPriority.ComboPointsConsumed -= pointDelta
-			} else {
-				rogue.CurrentPriority = nil
+	case ShouldWait:
+		desiredEnergy := 100.0
+		if rogue.ComboPoints() == 5 {
+			if rogue.CurrentEnergy() >= 100 {
+				panic("Rotation is capped on energy and cp")
+			}
+			desiredEnergy = prio.EnergyCost
+		} else {
+			if rogue.CurrentEnergy() < prio.EnergyCost && rogue.ComboPoints() >= prio.MinimumComboPoints {
+				desiredEnergy = prio.EnergyCost
+			} else if rogue.ComboPoints() < 5 {
+				desiredEnergy = rogue.Builder.DefaultCast.Cost
 			}
 		}
-		if rogue.CurrentPriority != nil && rogue.CurrentPriority.IsBuilder {
-			return
+		cdAvailableTime := time.Second * 10
+		if sim.CurrentTime > cdAvailableTime {
+			cdAvailableTime = core.NeverExpires
 		}
-	}
-	if rogue.CurrentPriority != nil {
-		currentIndex = rogue.CurrentPriority.Index + 1
-	}
-
-	// Add new priorities
-	freezeFinishers := false
-	for nextIndex, prio := range rogue.PriorityList[currentIndex:] {
-		prioIndex := currentIndex + nextIndex
-
-		// Filter out cast-limited priorities
-		if prio.MaxCasts > 0 && prio.CastCount >= prio.MaxCasts {
-			continue
-		}
-		if prio.IsFinisher && !freezeFinishers {
-			if rogue.HasPriorityWithInactiveAura(sim) {
-				freezeFinishers = true
-				continue
-			}
-			expectedPoints := 0.0
-			idealConsumedPoints := 0.0
-			minimalConsumedPoints := 0.0
-			energyCost := prio.EnergyCost
-			if rogue.CurrentPriority != nil {
-				minimalConsumedPoints = rogue.MinimalComboPointsNeededForPlan()
-				idealConsumedPoints = rogue.IdealComboPointsNeededForPlan()
-				expectedPoints = rogue.ExpectedComboPoints(sim, rogue.DurationOfCurrentPlan(sim), builderEnergyCost, energyCost)
-			} else {
-				expectedPoints = rogue.ExpectedComboPoints(sim, RemainingAuraDuration(sim, prio.Aura), builderEnergyCost, energyCost)
-			}
-			hasInactiveAura := prio.Aura != nil && !prio.Aura.IsActive()
-			canPrioritizeIdeal := expectedPoints >= (idealConsumedPoints+prio.MinimumComboPoints) && (prio.Aura == nil || prio.Aura.IsActive())
-			shouldPrioritize := expectedPoints >= (minimalConsumedPoints+prio.MinimumComboPoints) && hasInactiveAura
-			if rogue.CurrentPriority == nil || canPrioritizeIdeal || shouldPrioritize {
-				nextPrio := &rogue.PriorityList[prioIndex]
-				nextPrio.Prev = rogue.CurrentPriority
-				pointsToUse := 0.0
-				if canPrioritizeIdeal {
-					pointsToUse = core.MinFloat(expectedPoints-idealConsumedPoints, 5)
-				} else {
-					pointsToUse = core.MaxFloat(prio.MinimumComboPoints, float64(rogue.ComboPoints()))
-				}
-				nextPrio.ComboPointsConsumed = pointsToUse
-				if nextPrio.ComboPointsConsumed <= 0 {
-					panic("Consumed points of finishers should always be greater than 0")
-				}
-				rogue.CurrentPriority = nextPrio
-			} else {
-				freezeFinishers = true
+		nextExpiration := cdAvailableTime
+		for _, otherItem := range rogue.RotationItems {
+			if otherItem.ExpiresAt < nextExpiration {
+				nextExpiration = otherItem.ExpiresAt
 			}
 		}
-		if !prio.IsBuilder && !prio.IsFinisher && (rogue.CurrentPriority == nil || rogue.CurrentPriority.Aura.IsActive()) {
-			// Hunger for Blood
-			if prio.Aura != nil && !prio.Aura.IsActive() {
-				nextPrio := &rogue.PriorityList[prioIndex]
-				nextPrio.Prev = rogue.CurrentPriority
-				rogue.CurrentPriority = nextPrio
-			} else if prio.Aura == nil {
-				nextPrio := &rogue.PriorityList[prioIndex]
-				nextPrio.Prev = rogue.CurrentPriority
-				rogue.CurrentPriority = nextPrio
-			}
-		}
-		if prio.IsBuilder {
-			if rogue.CurrentPriority == nil || !rogue.CurrentPriority.IsFinisher {
-				continue
-			}
-			if float64(rogue.ComboPoints()) < core.MinFloat(5, rogue.CurrentPriority.ComboPointsConsumed) {
-				nextPrio := &rogue.PriorityList[prioIndex]
-				nextPrio.Prev = rogue.CurrentPriority
-				rogue.CurrentPriority = nextPrio
-			}
+		neededEnergy := desiredEnergy - rogue.CurrentEnergy()
+		energyAvailableTime := time.Second*time.Duration(neededEnergy/eps) + 1*time.Second
+		energyAt := sim.CurrentTime + energyAvailableTime
+		if energyAt < nextExpiration {
+			rogue.WaitForEnergy(sim, desiredEnergy)
+		} else if nextExpiration > sim.CurrentTime {
+			rogue.WaitUntil(sim, nextExpiration)
+		} else {
+			rogue.DoNothing()
 		}
 	}
 }

--- a/sim/rogue/rupture.go
+++ b/sim/rogue/rupture.go
@@ -38,10 +38,10 @@ func (rogue *Rogue) makeRupture(comboPoints int32) *core.Spell {
 			OutcomeApplier:   rogue.OutcomeFuncMeleeSpecialHit(),
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if spellEffect.Landed() {
-					rogue.RuptureDot.Spell = spell
-					rogue.RuptureDot.NumberOfTicks = numTicks
-					rogue.RuptureDot.RecomputeAuraDuration()
-					rogue.RuptureDot.Apply(sim)
+					rogue.ruptureDot.Spell = spell
+					rogue.ruptureDot.NumberOfTicks = numTicks
+					rogue.ruptureDot.RecomputeAuraDuration()
+					rogue.ruptureDot.Apply(sim)
 					rogue.ApplyFinisher(sim, spell)
 				} else {
 					if refundAmount > 0 {
@@ -70,7 +70,7 @@ func (rogue *Rogue) registerRupture() {
 	}
 
 	target := rogue.CurrentTarget
-	rogue.RuptureDot = core.NewDot(core.Dot{
+	rogue.ruptureDot = core.NewDot(core.Dot{
 		Spell: rogue.Rupture[0],
 		Aura: target.RegisterAura(core.Aura{
 			Label:    "Rupture-" + strconv.Itoa(int(rogue.Index)),

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -396,7 +396,7 @@ func (rogue *Rogue) registerBladeFlurryCD() {
 	})
 
 	cooldownDur := time.Minute * 2
-	bladeFlurrySpell := rogue.RegisterSpell(core.SpellConfig{
+	rogue.BladeFlurry = rogue.RegisterSpell(core.SpellConfig{
 		ActionID: BladeFlurryActionID,
 
 		ResourceType: stats.Energy,
@@ -425,7 +425,7 @@ func (rogue *Rogue) registerBladeFlurryCD() {
 	})
 
 	rogue.AddMajorCooldown(core.MajorCooldown{
-		Spell:    bladeFlurrySpell,
+		Spell:    rogue.BladeFlurry,
 		Type:     core.CooldownTypeDPS,
 		Priority: core.CooldownPriorityDefault,
 		CanActivate: func(sim *core.Simulation, character *core.Character) bool {
@@ -464,10 +464,12 @@ func (rogue *Rogue) registerAdrenalineRushCD() {
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			rogue.ResetEnergyTick(sim)
 			rogue.ApplyEnergyTickMultiplier(2.0)
+			rogue.RotationItems = rogue.PlanRotation(sim)
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			rogue.ResetEnergyTick(sim)
 			rogue.ApplyEnergyTickMultiplier(1 / 2.0)
+			rogue.RotationItems = rogue.PlanRotation(sim)
 		},
 	})
 

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -464,12 +464,12 @@ func (rogue *Rogue) registerAdrenalineRushCD() {
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			rogue.ResetEnergyTick(sim)
 			rogue.ApplyEnergyTickMultiplier(2.0)
-			rogue.RotationItems = rogue.PlanRotation(sim)
+			rogue.rotationItems = rogue.planRotation(sim)
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			rogue.ResetEnergyTick(sim)
 			rogue.ApplyEnergyTickMultiplier(1 / 2.0)
-			rogue.RotationItems = rogue.PlanRotation(sim)
+			rogue.rotationItems = rogue.planRotation(sim)
 		},
 	})
 


### PR DESCRIPTION
1. Adds a new type of test that checks cast count by action id
2. Adds a test generator for rotation tests that use the cast count as the comparison metric
3. Implements this type of test for the rogue rotation variants
4. Adds a mechanism to wait on energy in rotation code
5. Refactors the rogue rotation to be more performant by using the new wait mechanism when appropriate