### PR TITLE
[Debuffs] Activate expose armor 3 seconds into the fight (rather than…

### DIFF
--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -178,7 +178,7 @@ func AcidSpitPeriodicActionOptions(aura *Aura) PeriodicActionOptions {
 
 func ExposeArmorPeriodicActonOptions(aura *Aura) PeriodicActionOptions {
 	return PeriodicActionOptions{
-		Period:   time.Second * 10,
+		Period:   time.Second * 3,
 		NumTicks: 1,
 		OnAction: func(sim *Simulation) {
 			aura.Activate(sim)


### PR DESCRIPTION
… 10)


This is more representative of how expose will be maintained by rogues in Wotlk (especially those using the glyphed version)