### PR TITLE
feral rotation updates

### DIFF
--- a/sim/common/tbc/melee_trinkets.go
+++ b/sim/common/tbc/melee_trinkets.go
@@ -186,7 +186,7 @@ func init() {
 
 		character.AddMajorCooldown(core.MajorCooldown{
 			Spell: spell,
-			Type:  core.CooldownTypeDPS | core.CooldownTypeUsableShapeShifted,
+			Type:  core.CooldownTypeDPS,
 		})
 	})
 

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -562,7 +562,7 @@ func registerBloodlustCD(agent Agent) {
 	character.AddMajorCooldown(MajorCooldown{
 		Spell:    spell,
 		Priority: CooldownPriorityBloodlust,
-		Type:     CooldownTypeDPS | CooldownTypeUsableShapeShifted,
+		Type:     CooldownTypeDPS,
 		ShouldActivate: func(sim *Simulation, character *Character) bool {
 			// Haste portion doesn't stack with Power Infusion, so prefer to wait.
 			return !character.HasActiveAuraWithTag(PowerInfusionAuraTag)
@@ -626,7 +626,7 @@ func registerPowerInfusionCD(agent Agent, numPowerInfusions int32) {
 			CooldownPriority: CooldownPriorityDefault,
 			AuraDuration:     PowerInfusionDuration,
 			AuraCD:           PowerInfusionCD,
-			Type:             CooldownTypeDPS | CooldownTypeUsableShapeShifted,
+			Type:             CooldownTypeDPS,
 
 			ShouldActivate: func(sim *Simulation, character *Character) bool {
 				// Haste portion doesn't stack with Bloodlust, so prefer to wait.
@@ -685,7 +685,7 @@ func registerTricksOfTheTradeCD(agent Agent, numTricksOfTheTrades int32) {
 			CooldownPriority: CooldownPriorityDefault,
 			AuraDuration:     TricksOfTheTradeDuration,
 			AuraCD:           TricksOfTheTradeCD,
-			Type:             CooldownTypeDPS | CooldownTypeUsableShapeShifted,
+			Type:             CooldownTypeDPS,
 
 			ShouldActivate: func(sim *Simulation, character *Character) bool {
 				return true
@@ -732,7 +732,7 @@ func registerUnholyFrenzyCD(agent Agent, numUnholyFrenzy int32) {
 			CooldownPriority: CooldownPriorityDefault,
 			AuraDuration:     UnholyFrenzyDuration,
 			AuraCD:           UnholyFrenzyCD,
-			Type:             CooldownTypeDPS | CooldownTypeUsableShapeShifted,
+			Type:             CooldownTypeDPS,
 
 			ShouldActivate: func(sim *Simulation, character *Character) bool {
 				return true
@@ -873,7 +873,7 @@ func registerInnervateCD(agent Agent, numInnervates int32) {
 			CooldownPriority: CooldownPriorityDefault,
 			AuraDuration:     InnervateDuration,
 			AuraCD:           InnervateCD,
-			Type:             CooldownTypeMana | CooldownTypeUsableShapeShifted,
+			Type:             CooldownTypeMana,
 			ShouldActivate: func(sim *Simulation, character *Character) bool {
 				// Only cast innervate when very low on mana, to make sure all other mana CDs are prioritized.
 				if character.CurrentMana() > innervateThreshold {
@@ -963,7 +963,7 @@ func registerManaTideTotemCD(agent Agent, numManaTideTotems int32) {
 			CooldownPriority: CooldownPriorityDefault,
 			AuraDuration:     ManaTideTotemDuration,
 			AuraCD:           ManaTideTotemCD,
-			Type:             CooldownTypeMana | CooldownTypeUsableShapeShifted,
+			Type:             CooldownTypeMana,
 			ShouldActivate: func(sim *Simulation, character *Character) bool {
 				// A normal resto shaman would wait to use MTT.
 				if sim.CurrentTime < initialDelay {

--- a/sim/core/major_cooldown.go
+++ b/sim/core/major_cooldown.go
@@ -22,7 +22,6 @@ const (
 	CooldownTypeMana    CooldownType = 1 << iota
 	CooldownTypeDPS
 	CooldownTypeSurvival
-	CooldownTypeUsableShapeShifted
 )
 
 func (ct CooldownType) Matches(other CooldownType) bool {
@@ -452,7 +451,7 @@ func (mcdm *majorCooldownManager) sort() {
 func RegisterTemporaryStatsOnUseCD(character *Character, auraLabel string, tempStats stats.Stats, duration time.Duration, config SpellConfig) {
 	aura := character.NewTemporaryStatsAura(auraLabel, config.ActionID, tempStats, duration)
 
-	cdType := CooldownTypeUsableShapeShifted
+	cdType := CooldownTypeUnknown
 	if tempStats.DotProduct(stats.Stats{stats.Armor: 1, stats.Block: 1, stats.BlockValue: 1, stats.Dodge: 1, stats.Parry: 1, stats.Health: 1}).Equals(stats.Stats{}) {
 		cdType |= CooldownTypeDPS
 	} else {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -52,78 +52,78 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 570.58611
-  tps: 405.11614
+  dps: 571.10236
+  tps: 405.48268
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 624.95452
-  tps: 443.71771
+  dps: 625.48832
+  tps: 444.09671
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 584.4253
-  tps: 414.94196
+  dps: 585.45078
+  tps: 415.67005
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 585.29038
-  tps: 415.55617
+  dps: 585.80663
+  tps: 415.92271
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 621.43705
-  tps: 441.2203
+  dps: 621.9533
+  tps: 441.58684
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 613.16081
-  tps: 435.34417
+  dps: 613.74922
+  tps: 435.76194
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 609.8591
-  tps: 432.99996
+  dps: 610.43736
+  tps: 433.41053
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 591.80623
-  tps: 420.18242
+  dps: 592.37434
+  tps: 420.58578
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 583.76778
-  tps: 414.47513
+  dps: 584.30767
+  tps: 414.85844
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 580.79912
-  tps: 412.36738
+  dps: 581.33984
+  tps: 412.75129
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 570.58611
-  tps: 405.11614
+  dps: 571.10236
+  tps: 405.48268
  }
 }
 dps_results: {
@@ -136,197 +136,197 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-DreamwalkerGarb"
  value: {
-  dps: 520.44503
-  tps: 369.51597
+  dps: 521.08777
+  tps: 369.97232
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 583.3266
-  tps: 414.16189
+  dps: 583.84285
+  tps: 414.52843
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 582.09749
-  tps: 413.28922
+  dps: 582.61374
+  tps: 413.65576
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 579.72758
-  tps: 411.60658
+  dps: 580.24383
+  tps: 411.97312
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 601.64351
-  tps: 427.1669
+  dps: 602.18078
+  tps: 427.54835
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 570.58611
-  tps: 405.11614
+  dps: 571.10236
+  tps: 405.48268
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 838.26222
-  tps: 595.16618
+  dps: 857.0113
+  tps: 608.47802
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 555.05049
-  tps: 394.08585
+  dps: 569.63801
+  tps: 404.44298
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 583.76778
-  tps: 414.47513
+  dps: 584.30767
+  tps: 414.85844
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdolofTerror-33509"
  value: {
-  dps: 583.76778
-  tps: 414.47513
+  dps: 584.30767
+  tps: 414.85844
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 583.76778
-  tps: 414.47513
+  dps: 584.30767
+  tps: 414.85844
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 583.76778
-  tps: 414.47513
+  dps: 584.30767
+  tps: 414.85844
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdolofthePlainstalker-37573"
  value: {
-  dps: 583.76778
-  tps: 414.47513
+  dps: 584.30767
+  tps: 414.85844
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 588.77485
-  tps: 418.03014
+  dps: 589.31473
+  tps: 418.41346
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 583.76778
-  tps: 414.47513
+  dps: 584.30767
+  tps: 414.85844
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheWastes-38295"
  value: {
-  dps: 596.7188
-  tps: 423.67035
+  dps: 597.27137
+  tps: 424.06267
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 583.76778
-  tps: 414.47513
+  dps: 584.30767
+  tps: 414.85844
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 570.58611
-  tps: 405.11614
+  dps: 571.10236
+  tps: 405.48268
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 594.59811
-  tps: 422.16466
+  dps: 595.15417
+  tps: 422.55946
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 574.34165
-  tps: 407.78257
+  dps: 574.8579
+  tps: 408.14911
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 897.58612
-  tps: 637.28615
+  dps: 899.9826
+  tps: 638.98764
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LasherweaveRegalia"
  value: {
-  dps: 622.93651
-  tps: 442.28492
+  dps: 624.05078
+  tps: 443.07605
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 570.58611
-  tps: 405.11614
+  dps: 571.10236
+  tps: 405.48268
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LivingRootoftheWildheart-30664"
  value: {
-  dps: 576.41051
-  tps: 409.25146
+  dps: 576.92676
+  tps: 409.618
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 570.58611
-  tps: 405.11614
+  dps: 571.10236
+  tps: 405.48268
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 811.37561
-  tps: 576.07668
+  dps: 812.36745
+  tps: 576.78089
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 568.85801
-  tps: 403.88919
+  dps: 579.23909
+  tps: 411.25976
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MalorneHarness"
  value: {
-  dps: 573.63801
-  tps: 407.28299
+  dps: 589.22026
+  tps: 418.34638
  }
 }
 dps_results: {
@@ -339,15 +339,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 498.39128
-  tps: 353.85781
+  dps: 512.73976
+  tps: 364.04523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 600.27944
-  tps: 426.1984
+  dps: 600.79566
+  tps: 426.56492
  }
 }
 dps_results: {
@@ -360,29 +360,29 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-NightsongGarb"
  value: {
-  dps: 540.4663
-  tps: 383.73107
+  dps: 542.07205
+  tps: 384.87116
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NordrassilHarness"
  value: {
-  dps: 578.26578
-  tps: 410.5687
+  dps: 579.32018
+  tps: 411.31733
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NordrassilRegalia"
  value: {
-  dps: 506.44894
-  tps: 359.57875
+  dps: 506.90459
+  tps: 359.90226
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 570.58611
-  tps: 405.11614
+  dps: 571.10236
+  tps: 405.48268
  }
 }
 dps_results: {
@@ -395,85 +395,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 570.58611
-  tps: 405.11614
+  dps: 571.10236
+  tps: 405.48268
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 693.3664
-  tps: 492.29014
+  dps: 693.88264
+  tps: 492.65668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 708.6967
-  tps: 503.17465
+  dps: 709.21294
+  tps: 503.54119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 570.58611
-  tps: 405.11614
+  dps: 571.10236
+  tps: 405.48268
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Runetotem'sBattlegear"
  value: {
-  dps: 811.37561
-  tps: 576.07668
+  dps: 812.36745
+  tps: 576.78089
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Runetotem'sRegalia"
  value: {
-  dps: 568.85801
-  tps: 403.88919
+  dps: 579.23909
+  tps: 411.25976
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 583.76778
-  tps: 414.47513
+  dps: 584.30767
+  tps: 414.85844
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 570.58611
-  tps: 405.11614
+  dps: 571.10236
+  tps: 405.48268
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 575.40254
-  tps: 408.5358
+  dps: 575.91879
+  tps: 408.90234
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 570.58611
-  tps: 405.11614
+  dps: 571.10236
+  tps: 405.48268
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 570.58611
-  tps: 405.11614
+  dps: 571.10236
+  tps: 405.48268
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 587.10973
-  tps: 416.84791
+  dps: 587.41295
+  tps: 417.0632
  }
 }
 dps_results: {
@@ -493,8 +493,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 520.32359
-  tps: 369.42975
+  dps: 520.9374
+  tps: 369.86555
  }
 }
 dps_results: {
@@ -514,8 +514,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartRegalia"
  value: {
-  dps: 493.43005
-  tps: 350.33534
+  dps: 493.89421
+  tps: 350.66489
  }
 }
 dps_results: {
@@ -528,8 +528,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 601.36997
-  tps: 426.97268
+  dps: 633.92088
+  tps: 450.08382
  }
 }
 dps_results: {
@@ -542,64 +542,64 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-WindhawkArmor"
  value: {
-  dps: 539.76689
-  tps: 383.23449
+  dps: 540.27076
+  tps: 383.59224
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofSpellfire"
  value: {
-  dps: 540.36049
-  tps: 383.65595
+  dps: 540.86441
+  tps: 384.01373
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 583.60273
-  tps: 414.35794
+  dps: 584.94539
+  tps: 415.31122
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 583.79887
-  tps: 414.4972
+  dps: 584.33875
+  tps: 414.88052
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 583.79887
-  tps: 414.4972
+  dps: 584.33875
+  tps: 414.88052
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 710.93813
-  tps: 504.76607
+  dps: 716.43033
+  tps: 508.66554
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 254.47844
-  tps: 180.96085
+  dps: 262.33348
+  tps: 186.53793
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 254.47844
-  tps: 180.96085
+  dps: 262.33348
+  tps: 186.53793
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 263.18439
-  tps: 188.26672
+  dps: 266.90808
+  tps: 190.91053
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -52,560 +52,560 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 543.81447
-  tps: 386.10827
+  dps: 570.58611
+  tps: 405.11614
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 597.02958
-  tps: 423.891
+  dps: 624.95452
+  tps: 443.71771
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 548.20539
-  tps: 389.22583
+  dps: 584.4253
+  tps: 414.94196
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 557.78303
-  tps: 396.02595
+  dps: 585.29038
+  tps: 415.55617
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 594.25527
-  tps: 421.92124
+  dps: 621.43705
+  tps: 441.2203
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 584.74508
-  tps: 415.169
+  dps: 613.16081
+  tps: 435.34417
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 582.74511
-  tps: 413.74903
+  dps: 609.8591
+  tps: 432.99996
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 564.38667
-  tps: 400.71453
+  dps: 591.80623
+  tps: 420.18242
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 550.65908
-  tps: 390.96794
+  dps: 583.76778
+  tps: 414.47513
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 553.63462
-  tps: 393.08058
+  dps: 580.79912
+  tps: 412.36738
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 543.81447
-  tps: 386.10827
+  dps: 570.58611
+  tps: 405.11614
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 640.41821
-  tps: 454.69693
+  dps: 678.42671
+  tps: 481.68296
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreamwalkerGarb"
  value: {
-  dps: 489.66679
-  tps: 347.66342
+  dps: 520.44503
+  tps: 369.51597
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 556.05739
-  tps: 394.80075
+  dps: 583.3266
+  tps: 414.16189
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 554.91572
-  tps: 393.99016
+  dps: 582.09749
+  tps: 413.28922
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 552.63118
-  tps: 392.36814
+  dps: 579.72758
+  tps: 411.60658
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 573.42517
-  tps: 407.13187
+  dps: 601.64351
+  tps: 427.1669
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 543.81447
-  tps: 386.10827
+  dps: 570.58611
+  tps: 405.11614
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 791.22793
-  tps: 561.77183
+  dps: 838.26222
+  tps: 595.16618
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 521.99321
-  tps: 370.61518
+  dps: 555.05049
+  tps: 394.08585
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 550.65908
-  tps: 390.96794
+  dps: 583.76778
+  tps: 414.47513
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdolofTerror-33509"
  value: {
-  dps: 550.65908
-  tps: 390.96794
+  dps: 583.76778
+  tps: 414.47513
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 550.65908
-  tps: 390.96794
+  dps: 583.76778
+  tps: 414.47513
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 550.65908
-  tps: 390.96794
+  dps: 583.76778
+  tps: 414.47513
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdolofthePlainstalker-37573"
  value: {
-  dps: 550.65908
-  tps: 390.96794
+  dps: 583.76778
+  tps: 414.47513
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 555.53484
-  tps: 394.42973
+  dps: 588.77485
+  tps: 418.03014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 550.65908
-  tps: 390.96794
+  dps: 583.76778
+  tps: 414.47513
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheWastes-38295"
  value: {
-  dps: 562.8651
-  tps: 399.63422
+  dps: 596.7188
+  tps: 423.67035
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 550.65908
-  tps: 390.96794
+  dps: 583.76778
+  tps: 414.47513
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 543.81447
-  tps: 386.10827
+  dps: 570.58611
+  tps: 405.11614
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 557.94784
-  tps: 396.14297
+  dps: 594.59811
+  tps: 422.16466
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 547.56989
-  tps: 388.77462
+  dps: 574.34165
+  tps: 407.78257
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 866.78354
-  tps: 615.41632
+  dps: 897.58612
+  tps: 637.28615
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LasherweaveRegalia"
  value: {
-  dps: 586.68119
-  tps: 416.54364
+  dps: 622.93651
+  tps: 442.28492
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 543.81447
-  tps: 386.10827
+  dps: 570.58611
+  tps: 405.11614
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LivingRootoftheWildheart-30664"
  value: {
-  dps: 549.19199
-  tps: 389.92631
+  dps: 576.41051
+  tps: 409.25146
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 543.81447
-  tps: 386.10827
+  dps: 570.58611
+  tps: 405.11614
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 765.34712
-  tps: 543.39646
+  dps: 811.37561
+  tps: 576.07668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 534.42111
-  tps: 379.43899
+  dps: 568.85801
+  tps: 403.88919
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MalorneHarness"
  value: {
-  dps: 540.2697
-  tps: 383.59149
+  dps: 573.63801
+  tps: 407.28299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MalorneRegalia"
  value: {
-  dps: 471.28616
-  tps: 334.61318
+  dps: 498.99697
+  tps: 354.28785
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 468.51024
-  tps: 332.64227
+  dps: 498.39128
+  tps: 353.85781
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 572.98885
-  tps: 406.82208
+  dps: 600.27944
+  tps: 426.1984
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NightsongBattlegear"
  value: {
-  dps: 686.64958
-  tps: 487.5212
+  dps: 722.25648
+  tps: 512.8021
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NightsongGarb"
  value: {
-  dps: 509.29073
-  tps: 361.59642
+  dps: 540.4663
+  tps: 383.73107
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NordrassilHarness"
  value: {
-  dps: 544.63426
-  tps: 386.69033
+  dps: 578.26578
+  tps: 410.5687
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NordrassilRegalia"
  value: {
-  dps: 477.10604
-  tps: 338.74529
+  dps: 506.44894
+  tps: 359.57875
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 543.81447
-  tps: 386.10827
+  dps: 570.58611
+  tps: 405.11614
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PrimalIntent"
  value: {
-  dps: 551.61131
-  tps: 391.64403
+  dps: 579.39342
+  tps: 411.36933
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 543.81447
-  tps: 386.10827
+  dps: 570.58611
+  tps: 405.11614
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 663.53247
-  tps: 471.10805
+  dps: 693.3664
+  tps: 492.29014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 678.48041
-  tps: 481.72109
+  dps: 708.6967
+  tps: 503.17465
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 543.81447
-  tps: 386.10827
+  dps: 570.58611
+  tps: 405.11614
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Runetotem'sBattlegear"
  value: {
-  dps: 765.34712
-  tps: 543.39646
+  dps: 811.37561
+  tps: 576.07668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Runetotem'sRegalia"
  value: {
-  dps: 534.42111
-  tps: 379.43899
+  dps: 568.85801
+  tps: 403.88919
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 550.65908
-  tps: 390.96794
+  dps: 583.76778
+  tps: 414.47513
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 543.81447
-  tps: 386.10827
+  dps: 570.58611
+  tps: 405.11614
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 548.5485
-  tps: 389.46944
+  dps: 575.40254
+  tps: 408.5358
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 543.81447
-  tps: 386.10827
+  dps: 570.58611
+  tps: 405.11614
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 543.81447
-  tps: 386.10827
+  dps: 570.58611
+  tps: 405.11614
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 559.23686
-  tps: 397.05817
+  dps: 587.10973
+  tps: 416.84791
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 528.14227
-  tps: 374.98102
+  dps: 559.1771
+  tps: 397.01574
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StormshroudArmor"
  value: {
-  dps: 475.29784
-  tps: 336.80011
+  dps: 502.65147
+  tps: 356.1629
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 489.61847
-  tps: 347.62912
+  dps: 520.32359
+  tps: 369.42975
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheTwinStars"
  value: {
-  dps: 532.08035
-  tps: 377.77705
+  dps: 562.89547
+  tps: 399.65578
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartHarness"
  value: {
-  dps: 567.06877
-  tps: 402.61882
+  dps: 601.60024
+  tps: 427.13617
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartRegalia"
  value: {
-  dps: 463.98149
-  tps: 329.42685
+  dps: 493.43005
+  tps: 350.33534
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 569.13903
-  tps: 404.08871
+  dps: 597.63021
+  tps: 424.31745
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 573.9804
-  tps: 407.52609
+  dps: 601.36997
+  tps: 426.97268
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WastewalkerArmor"
  value: {
-  dps: 519.46785
-  tps: 368.82217
+  dps: 550.35394
+  tps: 390.7513
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WindhawkArmor"
  value: {
-  dps: 508.60974
-  tps: 361.11291
+  dps: 539.76689
+  tps: 383.23449
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofSpellfire"
  value: {
-  dps: 509.11919
-  tps: 361.47462
+  dps: 540.36049
+  tps: 383.65595
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 550.8426
-  tps: 391.09825
+  dps: 583.60273
+  tps: 414.35794
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 550.69016
-  tps: 390.99001
+  dps: 583.79887
+  tps: 414.4972
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 550.69016
-  tps: 390.99001
+  dps: 583.79887
+  tps: 414.4972
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 574.8273
-  tps: 408.12738
+  dps: 710.93813
+  tps: 504.76607
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 260.15648
-  tps: 184.99226
+  dps: 254.47844
+  tps: 180.96085
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 260.15648
-  tps: 184.99226
+  dps: 254.47844
+  tps: 180.96085
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 266.90808
-  tps: 190.91053
+  dps: 263.18439
+  tps: 188.26672
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 481.8474
-  tps: 342.11165
+  dps: 510.29651
+  tps: 362.31052
  }
 }

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -49,11 +49,7 @@ func NewFeralDruid(character core.Character, options proto.Player) *FeralDruid {
 	// Prevents Windfury from applying.
 	cat.HasMHWeaponImbue = true
 
-	cat.EnableEnergyBar(100.0, func(sim *core.Simulation) {
-		if cat.InForm(druid.Cat) {
-			cat.doTigersFury(sim)
-		}
-	})
+	cat.EnableEnergyBar(100.0, cat.OnEnergyGain)
 
 	cat.EnableAutoAttacks(cat, core.AutoAttackOptions{
 		// Base paw weapon.

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -10,7 +10,15 @@ import (
 	"github.com/wowsims/wotlk/sim/druid"
 )
 
+func (cat *FeralDruid) OnEnergyGain(sim *core.Simulation) {
+	cat.TryUseCooldowns(sim)
+	if cat.InForm(druid.Cat) {
+		cat.doTigersFury(sim)
+	}
+}
+
 func (cat *FeralDruid) OnGCDReady(sim *core.Simulation) {
+	cat.TryUseCooldowns(sim)
 	cat.doRotation(sim)
 }
 

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -94,9 +94,9 @@ func (cat *FeralDruid) clipRoar(sim *core.Simulation) bool {
 	maxRipDur := time.Duration(float64(cat.maxRipTicks) * float64(cat.RipDot.TickLength))
 
 	ripDur := cat.RipDot.Aura.StartedAt() + maxRipDur - sim.CurrentTime
-	roarDur := cat.SavageRoarAura.ExpiresAt() - sim.CurrentTime
+	roarDur := cat.SavageRoarAura.RemainingDuration(sim)
 	availableTime := ripDur - roarDur
-	expectedEnergyGain := 10.0 * float64(availableTime/time.Second)
+	expectedEnergyGain := 10.0 * (float64(availableTime) / float64(time.Second))
 
 	if cat.tfExpectedBefore(sim, cat.RipDot.ExpiresAt()) {
 		expectedEnergyGain += 60.0
@@ -118,13 +118,13 @@ func (cat *FeralDruid) clipRoar(sim *core.Simulation) bool {
 	// Now calculate the effective Energy cost for building back 5 CPs once
 	// Roar expires and casting Rip
 	ripCost := core.TernaryFloat64(cat.berserkExpectedAt(sim, cat.RipDot.ExpiresAt()), 15.0, 30.0)
-	cpPerBuilder := 1 + cat.GetStat(stats.MeleeCrit)
+	cpPerBuilder := 1 + ((cat.GetStat(stats.MeleeCrit) / core.CritRatingPerCritChance) / 100)
 	costPerBuilder := (42. + 42. + 35.) / 3. * (1 + 0.2*cat.missChance)
 	ripRefreshCost := 5./cpPerBuilder*costPerBuilder + ripCost
 
 	// If the cost is less than the expected Energy gain in the available
 	// time, then there's no reason to clip Roar.
-	if availableEnergy >= ripRefreshCost {
+	if ripRefreshCost <= availableEnergy {
 		return false
 	}
 
@@ -149,12 +149,16 @@ func (cat *FeralDruid) doOnAutoAttack(sim *core.Simulation, spell *core.Spell) {
 
 func (cat *FeralDruid) doTigersFury(sim *core.Simulation) {
 	// Handle tigers fury
-	leewayTime := core.MaxFloat(float64(cat.GCD.TimeToReady(sim)/time.Second), float64(cat.latency/time.Second))
+	gcdTimeToRdy := float64(cat.GCD.TimeToReady(sim))
+	leewayTime := core.MaxFloat(float64(gcdTimeToRdy/float64(time.Second)), float64(cat.latency)/float64(time.Second))
 	tfEnergyThresh := 40.0 - 10.0*(leewayTime+core.TernaryFloat64(cat.ClearcastingAura.IsActive(), 1.0, 0))
 	tfNow := (cat.CurrentEnergy() < tfEnergyThresh) && cat.TigersFury.IsReady(sim) && !cat.BerserkAura.IsActive()
 
 	if tfNow {
 		cat.TigersFury.Cast(sim, nil)
+		// Kick gcd loop, also need to account for any gcd 'left'
+		// otherwise it breaks gcd logic
+		cat.WaitUntil(sim, sim.CurrentTime+time.Duration(leewayTime*float64(time.Second)))
 	}
 }
 
@@ -231,11 +235,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) {
 		return pendingActions[i].refreshTime < pendingActions[j].refreshTime
 	})
 
-	if !cat.SavageRoarAura.IsActive() && curEnergy >= 25 {
-		endThresh = time.Second * 10
-	}
-
-	latencySecs := cat.latency / time.Second
+	latencySecs := float64(cat.latency) / float64(time.Second)
 	// Allow for bearweaving if the next pending action is >= 4.5s away
 	furorCap := core.MinFloat(20.0*float64(cat.Talents.Furor), 85)
 	weaveEnergy := furorCap - 30 - 20*float64(latencySecs)
@@ -262,9 +262,9 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) {
 	previousTime := sim.CurrentTime
 
 	for _, s := range pendingActions {
-		delta_t := s.refreshTime - previousTime
-		if float64(delta_t/time.Second) < s.cost/10.0 {
-			floatingEnergy += s.cost - 10.0*float64(delta_t/time.Second)
+		delta_t := float64(s.refreshTime - previousTime)
+		if delta_t/float64(time.Second) < s.cost/10.0 {
+			floatingEnergy += s.cost - 10.0*(delta_t/float64(time.Second))
 			previousTime = s.refreshTime
 		} else {
 			previousTime += time.Duration((s.cost / 10.0) * float64(time.Second))
@@ -383,7 +383,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) {
 		nextAction = core.MinDuration(nextAction, pendingActions[0].refreshTime)
 	}
 
-	nextAction += latencySecs
+	nextAction += time.Duration(latencySecs * float64(time.Second))
 
 	// TODO: This probably shouldnt happen
 	if nextAction <= sim.CurrentTime {

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -262,12 +262,12 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) {
 	previousTime := sim.CurrentTime
 
 	for _, s := range pendingActions {
-		delta_t := float64(s.refreshTime - previousTime)
-		if delta_t/float64(time.Second) < s.cost/10.0 {
-			floatingEnergy += s.cost - 10.0*(delta_t/float64(time.Second))
+		delta_t := float64((s.refreshTime - previousTime) / core.EnergyTickDuration)
+		if delta_t < s.cost {
+			floatingEnergy += s.cost - delta_t
 			previousTime = s.refreshTime
 		} else {
-			previousTime += time.Duration((s.cost / 10.0) * float64(time.Second))
+			previousTime += time.Duration(s.cost * float64(core.EnergyTickDuration))
 		}
 	}
 

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -52,744 +52,744 @@ character_stats_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 744.86691
-  tps: 991.70669
+  dps: 766.97136
+  tps: 1013.53017
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 694.44737
-  tps: 921.50394
+  dps: 733.60673
+  tps: 979.98202
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 774.26403
-  tps: 1026.78748
+  dps: 800.63643
+  tps: 1061.54635
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 706.1511
-  tps: 933.13155
+  dps: 729.59598
+  tps: 966.63542
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 694.44737
-  tps: 903.17062
+  dps: 733.60673
+  tps: 960.48571
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Braxley'sBackyardMoonshine-35937"
  value: {
-  dps: 715.39163
-  tps: 946.4345
+  dps: 747.62925
+  tps: 990.1231
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 724.90114
-  tps: 962.04623
+  dps: 748.74389
+  tps: 994.12631
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 731.76435
-  tps: 972.93127
+  dps: 769.68625
+  tps: 1026.69767
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 765.14713
-  tps: 1018.29432
+  dps: 802.47569
+  tps: 1064.73723
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 761.65333
-  tps: 1014.47745
+  dps: 783.47513
+  tps: 1041.06365
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 730.57079
-  tps: 966.51773
+  dps: 764.29074
+  tps: 1017.23341
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 722.80752
-  tps: 958.7984
+  dps: 762.52115
+  tps: 1005.90025
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 737.2101
-  tps: 978.06572
+  dps: 752.16189
+  tps: 999.61884
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 723.84997
-  tps: 956.72058
+  dps: 747.36692
+  tps: 994.74323
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 706.316
-  tps: 941.53654
+  dps: 748.93823
+  tps: 997.44491
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 710.14868
-  tps: 940.63242
+  dps: 732.25974
+  tps: 970.93629
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 855.51233
-  tps: 1120.76994
+  dps: 879.14605
+  tps: 1147.14099
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerGarb"
  value: {
-  dps: 651.95629
-  tps: 842.0589
+  dps: 673.76638
+  tps: 875.38215
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 694.44737
-  tps: 921.50394
+  dps: 733.60673
+  tps: 979.98202
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 694.44737
-  tps: 921.50394
+  dps: 733.60673
+  tps: 979.98202
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 706.1511
-  tps: 933.13155
+  dps: 729.59598
+  tps: 966.63542
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 710.85857
-  tps: 946.01656
+  dps: 737.29818
+  tps: 980.23644
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 694.44737
-  tps: 921.50394
+  dps: 733.60673
+  tps: 979.98202
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 763.26118
-  tps: 1008.17316
+  dps: 775.92021
+  tps: 1033.9533
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 737.05109
-  tps: 978.10831
+  dps: 766.32314
+  tps: 1017.63996
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 736.16765
-  tps: 978.1107
+  dps: 771.92557
+  tps: 1021.94996
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 694.44737
-  tps: 921.50394
+  dps: 733.60673
+  tps: 979.98202
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 694.44737
-  tps: 921.50394
+  dps: 733.60673
+  tps: 979.98202
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 756.4321
-  tps: 1004.51252
+  dps: 787.42981
+  tps: 1039.5556
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 706.316
-  tps: 941.53654
+  dps: 748.93823
+  tps: 997.44491
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 972.13327
-  tps: 1285.11066
+  dps: 1012.46673
+  tps: 1335.16905
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 704.02398
-  tps: 918.8342
+  dps: 729.53588
+  tps: 957.90162
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 714.42958
-  tps: 945.4537
+  dps: 746.83573
+  tps: 990.22083
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdolofTerror-33509"
  value: {
-  dps: 725.37101
-  tps: 961.90141
+  dps: 748.76979
+  tps: 992.42231
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 754.66358
-  tps: 1001.459
+  dps: 777.39401
+  tps: 1041.12778
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 705.10172
-  tps: 939.92642
+  dps: 747.35721
+  tps: 995.34849
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdolofthePlainstalker-37573"
  value: {
-  dps: 717.11496
-  tps: 948.60591
+  dps: 744.43781
+  tps: 986.92586
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 706.41809
-  tps: 936.73647
+  dps: 755.31818
+  tps: 1008.51027
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 705.10172
-  tps: 939.92642
+  dps: 747.35721
+  tps: 995.34849
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheWastes-38295"
  value: {
-  dps: 722.04805
-  tps: 963.24946
+  dps: 766.70589
+  tps: 1013.64787
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 730.39943
-  tps: 966.40023
+  dps: 761.01805
+  tps: 1008.33939
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 706.316
-  tps: 941.53654
+  dps: 748.93823
+  tps: 997.44491
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 706.1511
-  tps: 933.13155
+  dps: 729.59598
+  tps: 966.63542
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 710.85857
-  tps: 946.01656
+  dps: 737.29818
+  tps: 980.23644
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 736.13227
-  tps: 971.89439
+  dps: 782.54996
+  tps: 1037.43831
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InfusedColdstoneRune-35935"
  value: {
-  dps: 710.92542
-  tps: 941.07325
+  dps: 762.49286
+  tps: 1017.04484
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 694.44737
-  tps: 921.50394
+  dps: 733.60673
+  tps: 979.98202
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 700.7622
-  tps: 928.41885
+  dps: 739.79304
+  tps: 984.04229
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 1081.30058
-  tps: 1384.93273
+  dps: 1123.41864
+  tps: 1448.66749
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveRegalia"
  value: {
-  dps: 785.8056
-  tps: 1028.06132
+  dps: 815.2458
+  tps: 1066.32075
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 706.316
-  tps: 941.53654
+  dps: 748.93823
+  tps: 997.44491
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LivingRootoftheWildheart-30664"
  value: {
-  dps: 706.316
-  tps: 941.53654
+  dps: 748.93823
+  tps: 997.44491
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 706.316
-  tps: 941.53654
+  dps: 748.93823
+  tps: 997.44491
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 976.38705
-  tps: 1273.6129
+  dps: 1043.23164
+  tps: 1368.44695
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 712.50208
-  tps: 931.33894
+  dps: 735.02697
+  tps: 957.47687
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MalorneHarness"
  value: {
-  dps: 680.69595
-  tps: 887.03299
+  dps: 718.97932
+  tps: 933.59912
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MalorneRegalia"
  value: {
-  dps: 629.76141
-  tps: 816.97618
+  dps: 641.44657
+  tps: 834.45577
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 618.00795
-  tps: 805.89903
+  dps: 639.30003
+  tps: 826.00426
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 762.16861
-  tps: 1007.22613
+  dps: 777.45949
+  tps: 1040.26995
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NightsongBattlegear"
  value: {
-  dps: 877.50143
-  tps: 1149.64693
+  dps: 915.15214
+  tps: 1198.24754
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NightsongGarb"
  value: {
-  dps: 674.87984
-  tps: 880.35521
+  dps: 707.00718
+  tps: 927.09536
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NordrassilHarness"
  value: {
-  dps: 721.45053
-  tps: 919.90738
+  dps: 758.20699
+  tps: 968.83783
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NordrassilRegalia"
  value: {
-  dps: 625.75825
-  tps: 812.16502
+  dps: 657.55878
+  tps: 859.97044
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 706.316
-  tps: 941.53654
+  dps: 748.93823
+  tps: 997.44491
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 707.36539
-  tps: 936.68544
+  dps: 733.74193
+  tps: 976.07495
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 700.7622
-  tps: 928.41885
+  dps: 739.79304
+  tps: 984.04229
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 694.44737
-  tps: 921.50394
+  dps: 733.60673
+  tps: 979.98202
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 694.44737
-  tps: 921.50394
+  dps: 733.60673
+  tps: 979.98202
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PrimalIntent"
  value: {
-  dps: 717.67309
-  tps: 949.42638
+  dps: 749.89186
+  tps: 989.38688
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 706.316
-  tps: 941.53654
+  dps: 748.93823
+  tps: 997.44491
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 804.15663
-  tps: 1059.902
+  dps: 831.48848
+  tps: 1100.11225
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 814.57431
-  tps: 1073.71586
+  dps: 842.07714
+  tps: 1114.15282
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 709.36618
-  tps: 940.83357
+  dps: 748.61489
+  tps: 996.51502
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 694.44737
-  tps: 921.50394
+  dps: 733.60673
+  tps: 979.98202
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 706.316
-  tps: 941.53654
+  dps: 748.93823
+  tps: 997.44491
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Runetotem'sBattlegear"
  value: {
-  dps: 976.38705
-  tps: 1273.6129
+  dps: 1043.23164
+  tps: 1368.44695
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Runetotem'sRegalia"
  value: {
-  dps: 712.50208
-  tps: 931.33894
+  dps: 735.02697
+  tps: 957.47687
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 726.8146
-  tps: 961.74406
+  dps: 752.16519
+  tps: 992.79874
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 706.316
-  tps: 941.53654
+  dps: 748.93823
+  tps: 997.44491
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Serrah'sStar-37559"
  value: {
-  dps: 713.78391
-  tps: 946.62662
+  dps: 755.28048
+  tps: 1004.74726
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 706.316
-  tps: 941.53654
+  dps: 748.93823
+  tps: 997.44491
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 706.316
-  tps: 941.53654
+  dps: 748.93823
+  tps: 997.44491
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 726.09087
-  tps: 959.86892
+  dps: 755.13535
+  tps: 1005.55405
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 667.5689
-  tps: 885.80277
+  dps: 693.36144
+  tps: 919.41217
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-StormshroudArmor"
  value: {
-  dps: 652.27087
-  tps: 846.38154
+  dps: 673.23217
+  tps: 872.44313
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 656.93566
-  tps: 872.62597
+  dps: 683.77746
+  tps: 905.44349
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 700.7622
-  tps: 928.41885
+  dps: 739.79304
+  tps: 984.04229
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 707.36539
-  tps: 936.68544
+  dps: 733.74193
+  tps: 976.07495
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 712.93257
-  tps: 950.74242
+  dps: 735.79407
+  tps: 982.58613
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TheTwinStars"
  value: {
-  dps: 694.00526
-  tps: 922.84373
+  dps: 731.00617
+  tps: 968.44544
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartHarness"
  value: {
-  dps: 754.83636
-  tps: 1026.90989
+  dps: 770.68881
+  tps: 1049.71529
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartRegalia"
  value: {
-  dps: 634.79472
-  tps: 819.03815
+  dps: 662.44219
+  tps: 856.77596
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 710.18584
-  tps: 946.05227
+  dps: 729.56576
+  tps: 970.38755
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 772.79016
-  tps: 1027.32961
+  dps: 793.61414
+  tps: 1051.01392
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 773.59013
-  tps: 1025.478
+  dps: 804.57033
+  tps: 1064.21266
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 694.44737
-  tps: 921.50394
+  dps: 733.60673
+  tps: 979.98202
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 694.44737
-  tps: 921.50394
+  dps: 733.60673
+  tps: 979.98202
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 694.44737
-  tps: 921.50394
+  dps: 733.60673
+  tps: 979.98202
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 694.44737
-  tps: 921.50394
+  dps: 733.60673
+  tps: 979.98202
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WastewalkerArmor"
  value: {
-  dps: 673.2851
-  tps: 879.31059
+  dps: 687.69164
+  tps: 892.80578
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WindhawkArmor"
  value: {
-  dps: 683.30924
-  tps: 903.36149
+  dps: 704.35301
+  tps: 936.22087
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WrathofSpellfire"
  value: {
-  dps: 680.87569
-  tps: 882.24294
+  dps: 706.31355
+  tps: 919.17807
  }
 }
 dps_results: {
  key: "TestFeralTank-Average-Default"
  value: {
-  dps: 972.70322
-  tps: 1326.42929
-  dtps: 956.06303
+  dps: 996.27722
+  tps: 1361.88131
+  dtps: 956.94821
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2172.1474
-  tps: 3830.05249
+  dps: 2269.62651
+  tps: 3999.0799
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 809.15975
-  tps: 1081.74515
+  dps: 836.16954
+  tps: 1116.96794
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 838.61072
-  tps: 1154.05562
+  dps: 962.50804
+  tps: 1317.3015
  }
 }
 dps_results: {
@@ -816,8 +816,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1098.15936
-  tps: 1493.9786
-  dtps: 889.86559
+  dps: 1117.09966
+  tps: 1526.96308
+  dtps: 889.91678
  }
 }

--- a/ui/index.html
+++ b/ui/index.html
@@ -112,186 +112,150 @@
         </div>
         <hr style="width: 50%">
         <div class="dropdown-panel sim-title-dropdown within-raid-sim-hide">
-            <div class="sim-title-option dropdown-option" style="flex-basis:100%; justify-content: center; background-color: rgba(0, 0, 0, 0.5);">
-                <a href="/wotlk/raid/" class="">
+            <a href="/wotlk/raid/" class="sim-title-dropdown-option-container" style="flex-basis:100%; color:white">
+                <div class="sim-title-option dropdown-option" style="background-color: rgba(0, 0, 0, 0.5); justify-content: center;">
                     <img src="/wotlk/assets/img/raid_icon.png" class="sim-title-icon">
-                </a>
-                <a href="/wotlk/raid/" class="sim-title-dropdown-option-container" style="color: white;">
                     <div class="sim-title-label-container">
                         <span class="sim-title-spec-label sim-title-label">RAID</span>
                     </div>
-                </a>
-            </div>
-            <div class="sim-title-option dropdown-option">
-                <a href="/wotlk/balance_druid/" class="">
+                </div>
+            </a>
+            <a href="/wotlk/balance_druid/" class="sim-title-dropdown-option-container" style="color: rgb(255, 125, 10);">
+                <div class="sim-title-option dropdown-option">
                     <img src="/wotlk/assets/img/balance_druid_icon.png" class="sim-title-icon">
-                </a>
-                <a href="/wotlk/balance_druid/" class="sim-title-dropdown-option-container" style="color: rgb(255, 125, 10);">
                     <div class="sim-title-label-container">
                         <span class="sim-title-spec-label sim-title-label">BALANCE DRUID</span>
                     </div>
-                </a>
-            </div>
-            <div class="sim-title-option dropdown-option">
-                <a href="/wotlk/feral_druid/" class="">
+                </div>
+            </a>
+            <a href="/wotlk/feral_druid/" class="sim-title-dropdown-option-container" style="color: rgb(255, 125, 10);">
+                <div class="sim-title-option dropdown-option">
                     <img src="/wotlk/assets/img/feral_druid_icon.png" class="sim-title-icon">
-                </a>
-                <a href="/wotlk/feral_druid/" class="sim-title-dropdown-option-container" style="color: rgb(255, 125, 10);">
                     <div class="sim-title-label-container">
                         <span class="sim-title-spec-label sim-title-label">FERAL DRUID</span>
                     </div>
-                </a>
-            </div>
-            <div class="sim-title-option dropdown-option">
-                <a href="/wotlk/feral_tank_druid/" class="">
+                </div>
+            </a>
+            <a href="/wotlk/feral_tank_druid/" class="sim-title-dropdown-option-container" style="color: rgb(255, 125, 10);">
+                <div class="sim-title-option dropdown-option">
                     <img src="/wotlk/assets/img/feral_druid_tank_icon.png" class="sim-title-icon">
-                </a>
-                <a href="/wotlk/feral_tank_druid/" class="sim-title-dropdown-option-container" style="color: rgb(255, 125, 10);">
                     <div class="sim-title-label-container">
                         <span class="sim-title-spec-label sim-title-label">FERAL TANK DRUID</span>
                     </div>
-                </a>
-            </div>
-            <div class="sim-title-option dropdown-option">
-                <a href="/wotlk/hunter/" class="">
+                </div>
+            </a>
+            <a href="/wotlk/hunter/" class="sim-title-dropdown-option-container" style="color: rgb(171, 212, 115);">
+                <div class="sim-title-option dropdown-option">
                     <img src="/wotlk/assets/img/hunter_icon.png" class="sim-title-icon">
-                </a>
-                <a href="/wotlk/hunter/" class="sim-title-dropdown-option-container" style="color: rgb(171, 212, 115);">
                     <div class="sim-title-label-container">
                         <span class="sim-title-spec-label sim-title-label">HUNTER</span>
                     </div>
-                </a>
-            </div>
-            <div class="sim-title-option dropdown-option">
-                <a href="/wotlk/mage/" class="">
+                </div>
+            </a>
+            <a href="/wotlk/mage/" class="sim-title-dropdown-option-container" style="color: rgb(105, 204, 240);">
+                <div class="sim-title-option dropdown-option">
                     <img src="/wotlk/assets/img/mage_icon.png" class="sim-title-icon">
-                </a>
-                <a href="/wotlk/mage/" class="sim-title-dropdown-option-container" style="color: rgb(105, 204, 240);">
                     <div class="sim-title-label-container">
                         <span class="sim-title-spec-label sim-title-label">MAGE</span>
                     </div>
-                </a>
-            </div>
-            <div class="sim-title-option dropdown-option">
-                <a href="/wotlk/retribution_paladin/" class="">
+                </div>
+            </a>
+            <a href="/wotlk/retribution_paladin/" class="sim-title-dropdown-option-container" style="color: rgb(245, 140, 186);">
+                <div class="sim-title-option dropdown-option">
                     <img src="/wotlk/assets/img/retribution_icon.png" class="sim-title-icon">
-                </a>
-                <a href="/wotlk/retribution_paladin/" class="sim-title-dropdown-option-container" style="color: rgb(245, 140, 186);">
                     <div class="sim-title-label-container">
                         <span class="sim-title-spec-label sim-title-label">RETRIBUTION PALADIN</span>
                     </div>
-                </a>
-            </div>
-            <div class="sim-title-option dropdown-option">
-                <a href="/wotlk/protection_paladin/" class="">
+                </div>
+            </a>
+            <a href="/wotlk/protection_paladin/" class="sim-title-dropdown-option-container" style="color: rgb(245, 140, 186);">
+                <div class="sim-title-option dropdown-option">
                     <img src="/wotlk/assets/img/protection_paladin_icon.png" class="sim-title-icon">
-                </a>
-                <a href="/wotlk/protection_paladin/" class="sim-title-dropdown-option-container" style="color: rgb(245, 140, 186);">
                     <div class="sim-title-label-container">
                         <span class="sim-title-spec-label sim-title-label">PROTECTION PALADIN</span>
                     </div>
-                </a>
-            </div>
-            <div class="sim-title-option dropdown-option">
-                <a href="/wotlk/shadow_priest/" class="">
+                </div>
+            </a>
+            <a href="/wotlk/shadow_priest/" class="sim-title-dropdown-option-container" style="color: rgb(255, 255, 255);">
+                <div class="sim-title-option dropdown-option">
                     <img src="/wotlk/assets/img/shadow_priest_icon.png" class="sim-title-icon">
-                </a>
-                <a href="/wotlk/shadow_priest/" class="sim-title-dropdown-option-container" style="color: rgb(255, 255, 255);">
                     <div class="sim-title-label-container">
                         <span class="sim-title-spec-label sim-title-label">SHADOW PRIEST</span>
                     </div>
-                </a>
-            </div>
-            <div class="sim-title-option dropdown-option">
-                <a href="/wotlk/smite_priest/" class="">
+                </div>
+            </a>
+            <a href="/wotlk/smite_priest/" class="sim-title-dropdown-option-container" style="color: rgb(255, 255, 255);">
+                <div class="sim-title-option dropdown-option">
                     <img src="/wotlk/assets/img/smite_priest_icon.png" class="sim-title-icon">
-                </a>
-                <a href="/wotlk/smite_priest/" class="sim-title-dropdown-option-container" style="color: rgb(255, 255, 255);">
                     <div class="sim-title-label-container">
                         <span class="sim-title-spec-label sim-title-label">SMITE PRIEST</span>
                     </div>
-                </a>
-            </div>
-            <div class="sim-title-option dropdown-option">
-                <a href="/wotlk/rogue/" class="">
+                </div>
+            </a>
+            <a href="/wotlk/rogue/" class="sim-title-dropdown-option-container" style="color: rgb(255, 245, 105);">
+                <div class="sim-title-option dropdown-option">
                     <img src="/wotlk/assets/img/rogue_icon.png" class="sim-title-icon">
-                </a>
-                <a href="/wotlk/rogue/" class="sim-title-dropdown-option-container" style="color: rgb(255, 245, 105);">
                     <div class="sim-title-label-container">
                         <span class="sim-title-spec-label sim-title-label">ROGUE</span>
                     </div>
-                </a>
-            </div>
-            <div class="sim-title-option dropdown-option">
-                <a href="/wotlk/elemental_shaman/" class="">
+                </div>
+            </a>
+            <a href="/wotlk/elemental_shaman/" class="sim-title-dropdown-option-container" style="color: rgb(36, 89, 255);">
+                <div class="sim-title-option dropdown-option">
                     <img src="/wotlk/assets/img/elemental_shaman_icon.png" class="sim-title-icon">
-                </a>
-                <a href="/wotlk/elemental_shaman/" class="sim-title-dropdown-option-container" style="color: rgb(36, 89, 255);">
                     <div class="sim-title-label-container">
                         <span class="sim-title-spec-label sim-title-label">ELEMENTAL SHAMAN</span>
                     </div>
-                </a>
-            </div>
-            <div class="sim-title-option dropdown-option">
-                <a href="/wotlk/enhancement_shaman/" class="">
+                </div>
+            </a>
+            <a href="/wotlk/enhancement_shaman/" class="sim-title-dropdown-option-container" style="color: rgb(36, 89, 255);">
+                <div class="sim-title-option dropdown-option">
                     <img src="/wotlk/assets/img/enhancement_shaman_icon.png" class="sim-title-icon">
-                </a>
-                <a href="/wotlk/enhancement_shaman/" class="sim-title-dropdown-option-container" style="color: rgb(36, 89, 255);">
                     <div class="sim-title-label-container">
                         <span class="sim-title-spec-label sim-title-label">ENHANCEMENT SHAMAN</span>
                     </div>
-                </a>
-            </div>
-            <div class="sim-title-option dropdown-option">
-                <a href="/wotlk/warlock/" class="">
+                </div>
+            </a>
+            <a href="/wotlk/warlock/" class="sim-title-dropdown-option-container" style="color: rgb(148, 130, 201);">
+                <div class="sim-title-option dropdown-option">
                     <img src="/wotlk/assets/img/warlock_icon.png" class="sim-title-icon">
-                </a>
-                <a href="/wotlk/warlock/" class="sim-title-dropdown-option-container" style="color: rgb(148, 130, 201);">
                     <div class="sim-title-label-container">
                         <span class="sim-title-spec-label sim-title-label">WARLOCK</span>
                     </div>
-                </a>
-            </div>
-            <div class="sim-title-option dropdown-option">
-                <a href="/wotlk/warrior/" class="">
+                </div>
+            </a>
+            <a href="/wotlk/warrior/" class="sim-title-dropdown-option-container" style="color: rgb(199, 156, 110);">
+                <div class="sim-title-option dropdown-option">
                     <img src="/wotlk/assets/img/warrior_icon.png" class="sim-title-icon">
-                </a>
-                <a href="/wotlk/warrior/" class="sim-title-dropdown-option-container" style="color: rgb(199, 156, 110);">
                     <div class="sim-title-label-container">
                         <span class="sim-title-spec-label sim-title-label">WARRIOR</span>
                     </div>
-                </a>
-            </div>
-            <div class="sim-title-option dropdown-option">
-                <a href="/wotlk/protection_warrior/" class="">
+                </div>
+            </a>
+            <a href="/wotlk/protection_warrior/" class="sim-title-dropdown-option-container" style="color: rgb(199, 156, 110);">
+                <div class="sim-title-option dropdown-option">
                     <img src="/wotlk/assets/img/protection_warrior_icon.png" class="sim-title-icon">
-                </a>
-                <a href="/wotlk/protection_warrior/" class="sim-title-dropdown-option-container" style="color: rgb(199, 156, 110);">
                     <div class="sim-title-label-container">
                         <span class="sim-title-spec-label sim-title-label">PROTECTION WARRIOR</span>
                     </div>
-                </a>
-            </div>
-            <div class="sim-title-option dropdown-option">
-                <a href="/wotlk/deathknight/" class="">
+                </div>
+            </a>
+            <a href="/wotlk/deathknight/" class="sim-title-dropdown-option-container" style="color: rgb(194, 46, 70);">
+                <div class="sim-title-option dropdown-option">
                     <img src="/wotlk/assets/img/death_knight_icon.png" class="sim-title-icon">
-                </a>
-                <a href="/wotlk/deathknight/" class="sim-title-dropdown-option-container" style="color: rgb(194, 46, 70);">
                     <div class="sim-title-label-container">
                         <span class="sim-title-spec-label sim-title-label">DEATH KNIGHT</span>
                     </div>
-                </a>
-            </div>
-            <div class="sim-title-option dropdown-option">
-                <a href="/wotlk/tank_deathknight/" class="">
+                </div>
+            </a>
+            <a href="/wotlk/tank_deathknight/" class="sim-title-dropdown-option-container" style="color: rgb(194, 46, 70);">
+                <div class="sim-title-option dropdown-option">
                     <img src="/wotlk/assets/img/death_knight_icon.png" class="sim-title-icon">
-                </a>
-                <a href="/wotlk/tank_deathknight/" class="sim-title-dropdown-option-container" style="color: rgb(194, 46, 70);">
                     <div class="sim-title-label-container">
                         <span class="sim-title-spec-label sim-title-label">DEATH KNIGHT TANK</span>
                     </div>
-                </a>
-            </div>
+                </div>
+            </a>
         </div>
     </div>
 </body>


### PR DESCRIPTION
Fix feral 'mono-cat' rotation to actually keep up rip better (85% -> 94%), and actually use other cooldowns/potions