### PR TITLE
Fixed improved revenge scaling

### DIFF
--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -52,7 +52,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 0.48119
+  weights: 0.43417
   weights: 0
   weights: 0
   weights: 0
@@ -70,7 +70,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.22655
+  weights: 0.2094
   weights: 0
   weights: 0
   weights: 0
@@ -79,12 +79,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.00524
+  weights: 0.01244
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.3689
-  weights: -0.0535
+  weights: 0.37334
+  weights: -0.06186
   weights: 0
   weights: 0
   weights: 0
@@ -761,8 +761,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 2766.76311
-  tps: 7139.56979
+  dps: 2636.79584
+  tps: 6870.08268
   dtps: 298.59475
  }
 }
@@ -853,8 +853,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2912.4094
-  tps: 7507.60466
+  dps: 2774.41883
+  tps: 7221.48121
   dtps: 302.04333
  }
 }

--- a/sim/warrior/revenge.go
+++ b/sim/warrior/revenge.go
@@ -54,13 +54,13 @@ func (warrior *Warrior) registerRevengeSpell(cdTimer *core.Timer) {
 	applyEffect := core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 		ProcMask: core.ProcMaskMeleeMHSpecial,
 
-		DamageMultiplier: 1.0 + 0.3*float64(warrior.Talents.ImprovedRevenge) + 0.1*float64(warrior.Talents.UnrelentingAssault),
+		DamageMultiplier: 1.0 + 0.1*float64(warrior.Talents.UnrelentingAssault),
 		ThreatMultiplier: 1,
 		FlatThreatBonus:  121,
 
 		BaseDamage: core.BaseDamageConfig{
 			Calculator: func(sim *core.Simulation, hitEffect *core.SpellEffect, spell *core.Spell) float64 {
-				return core.DamageRoll(sim, 1636, 1998) + warrior.attackPowerMultiplier(hitEffect, spell.Unit, 0.31)
+				return core.DamageRoll(sim, 1636, 1998)*(1.0+0.3*float64(warrior.Talents.ImprovedRevenge)) + warrior.attackPowerMultiplier(hitEffect, spell.Unit, 0.31)
 			},
 			TargetSpellCoefficient: 1,
 		},


### PR DESCRIPTION
- Improved revenge 30/60 % multiplier applies only to the base damage of the skill, not to the added %AP component.
