### PR TITLE
mage: fix arcane blast mana cost

### DIFF
--- a/sim/mage/arcane_blast.go
+++ b/sim/mage/arcane_blast.go
@@ -45,11 +45,7 @@ func (mage *Mage) registerArcaneBlastSpell() {
 			},
 			ModifyCast: func(sim *core.Simulation, spell *core.Spell, cast *core.Cast) {
 				cast.Cost = ArcaneBlastBaseManaCost*totalDiscount*
-					(1+1.75*float64(mage.ArcaneBlastAura.GetStacks())) +
-					.01*float64(mage.Talents.Precision)*ArcaneBlastBaseManaCost
-				//This is really hacky. In essence for only arcane blast we need precision to apply to the
-				//original base cost of the spell instead of as a cost multiplier, so add extra mana cost equal
-				//to the mana saved from having precision as a cost multiplier.
+					(1+1.75*float64(mage.ArcaneBlastAura.GetStacks()))
 			},
 			AfterCast: func(sim *core.Simulation, spell *core.Spell) {
 				if mage.ArcaneBlastAura.GetStacks() >= 4 {


### PR DESCRIPTION
The current calculation does not match observed mana cost on live. With no T5 set and both precision and arcane focus talents 3/3, the observed mana costs are 147 / 404 / 662 / 919 / 1176.