### PR TITLE
Add "domain=wotlk" prefix to wowhead tooltip data attribute.

### DIFF
--- a/ui/core/components/gear_picker.ts
+++ b/ui/core/components/gear_picker.ts
@@ -191,9 +191,9 @@ class ItemPicker extends Component {
 				});
 				// Make enchant text hover have a tooltip.
 				if (newItem.enchant.isSpellId) {
-					this.enchantElem.setAttribute('data-wowhead', `spell=${newItem.enchant.id}`);
+					this.enchantElem.setAttribute('data-wowhead', `domain=wotlk&spell=${newItem.enchant.id}`);
 				} else {
-					this.enchantElem.setAttribute('data-wowhead', `item=${newItem.enchant.id}`);
+					this.enchantElem.setAttribute('data-wowhead', `domain=wotlk&item=${newItem.enchant.id}`);
 				}
 			}
 

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -659,7 +659,7 @@ export class Player<SpecType extends Spec> {
     }
 
     setWowheadData(equippedItem: EquippedItem, elem: HTMLElement) {
-        let parts = [];
+        let parts = ['domain=wotlk'];
         if (equippedItem.gems.length > 0) {
             parts.push('gems=' + equippedItem.gems.map(gem => gem ? gem.id : 0).join(':'));
         }


### PR DESCRIPTION
Fixes #1002 

Tooltips for enchants were appearing as their retail version due to the omission of the domain parameter when populating the data-wowhead attribute. Given that this sim is scoped to wotlk I've added it to all tooltip attributes which should force tooltips to appear as their WOTLK version.