### PR TITLE
Minor warrior updates

### DIFF
--- a/sim/warrior/bloodthirst.go
+++ b/sim/warrior/bloodthirst.go
@@ -34,7 +34,7 @@ func (warrior *Warrior) registerBloodthirstSpell(cdTimer *core.Timer) {
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			ProcMask: core.ProcMaskMeleeMHSpecial,
 
-			DamageMultiplier: 1 * core.TernaryFloat64(warrior.HasSetBonus(ItemSetOnslaughtBattlegear, 4), 1.05, 1) * (1 + 0.02*float64(warrior.Talents.UnendingFury)),
+			DamageMultiplier: 1 + 0.02*float64(warrior.Talents.UnendingFury) + core.TernaryFloat64(warrior.HasSetBonus(ItemSetOnslaughtBattlegear, 4), 0.05, 0),
 			BonusCritRating:  core.TernaryFloat64(warrior.HasSetBonus(ItemSetSiegebreakerBattlegear, 4), 10, 0) * core.CritRatingPerCritChance,
 			ThreatMultiplier: 1,
 			DynamicThreatMultiplier: func(spellEffect *core.SpellEffect, spell *core.Spell) float64 {
@@ -50,7 +50,7 @@ func (warrior *Warrior) registerBloodthirstSpell(cdTimer *core.Timer) {
 				},
 				TargetSpellCoefficient: 1,
 			},
-			OutcomeApplier: warrior.OutcomeFuncMeleeSpecialHitAndCrit(warrior.critMultiplier(true)),
+			OutcomeApplier: warrior.OutcomeFuncMeleeSpecialHitAndCrit(warrior.critMultiplier(mh)),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if !spellEffect.Landed() {

--- a/sim/warrior/concussion_blow.go
+++ b/sim/warrior/concussion_blow.go
@@ -47,7 +47,7 @@ func (warrior *Warrior) registerConcussionBlowSpell() {
 				},
 				TargetSpellCoefficient: 1,
 			},
-			OutcomeApplier: warrior.OutcomeFuncMeleeSpecialHitAndCrit(warrior.critMultiplier(true)),
+			OutcomeApplier: warrior.OutcomeFuncMeleeSpecialHitAndCrit(warrior.critMultiplier(mh)),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if !spellEffect.Landed() {

--- a/sim/warrior/devastate.go
+++ b/sim/warrior/devastate.go
@@ -46,10 +46,10 @@ func (warrior *Warrior) registerDevastateSpell() {
 	flatThreatBonus := core.TernaryFloat64(hasGlyph, 630, 315)
 	dynaThreatBonus := core.TernaryFloat64(hasGlyph, 0.1, 0.05)
 
-	normalBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 0, 1.2, 1.0, true)
+	normalBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 0, 1.2, 1.0, false)
 
 	warrior.Devastate = warrior.RegisterSpell(core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: 30022},
+		ActionID:    core.ActionID{SpellID: 47498},
 		SpellSchool: core.SpellSchoolPhysical,
 		Flags:       core.SpellFlagMeleeMetrics,
 
@@ -88,7 +88,7 @@ func (warrior *Warrior) registerDevastateSpell() {
 				},
 				TargetSpellCoefficient: 0,
 			},
-			OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(true)),
+			OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(mh)),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if spellEffect.Landed() {

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -52,581 +52,581 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 3378.79412
-  tps: 2958.15579
+  dps: 4753.5376
+  tps: 3886.05185
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 3494.70179
-  tps: 3063.70224
+  dps: 4962.69743
+  tps: 4054.68484
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 3511.1563
-  tps: 3068.36878
+  dps: 4923.37866
+  tps: 4021.90695
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 3525.24936
-  tps: 3087.54278
+  dps: 4955.58161
+  tps: 4055.13606
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 3378.68565
-  tps: 2952.23081
+  dps: 4780.94223
+  tps: 3900.7748
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 3501.71013
-  tps: 3005.90426
+  dps: 4959.3694
+  tps: 3975.9479
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 3584.58499
-  tps: 3140.11989
+  dps: 4998.35715
+  tps: 4084.53139
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 3493.50264
-  tps: 3056.66294
+  dps: 4924.51902
+  tps: 4017.14232
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 3525.89193
-  tps: 3079.49025
+  dps: 4912.35649
+  tps: 4008.50978
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 3460.92881
-  tps: 3028.67494
+  dps: 4846.93501
+  tps: 3957.5187
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 3378.79412
-  tps: 2958.15579
+  dps: 4736.11662
+  tps: 3867.98815
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Defender'sCode-40257"
  value: {
-  dps: 3395.14006
-  tps: 2971.01235
+  dps: 4808.01308
+  tps: 3925.01516
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 3514.14527
-  tps: 3076.9072
+  dps: 4972.43703
+  tps: 4062.86652
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 3101.50903
-  tps: 2721.28612
+  dps: 4358.68236
+  tps: 3567.79237
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 3501.71013
-  tps: 3067.02234
+  dps: 4959.3694
+  tps: 4056.82853
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 3501.71013
-  tps: 3067.02234
+  dps: 4959.3694
+  tps: 4056.82853
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 3525.24936
-  tps: 3087.54278
+  dps: 4955.58161
+  tps: 4055.13606
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 3515.70531
-  tps: 3078.47938
+  dps: 4924.44595
+  tps: 4028.09003
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 3501.71013
-  tps: 3067.02234
+  dps: 4959.3694
+  tps: 4056.82853
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 3537.17248
-  tps: 3091.67232
+  dps: 4917.98221
+  tps: 4012.08456
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 3479.99977
-  tps: 3045.10855
+  dps: 4879.32683
+  tps: 3983.38761
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForgeEmber-37660"
  value: {
-  dps: 3464.04469
-  tps: 3029.78743
+  dps: 4893.10507
+  tps: 3998.58041
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 3501.71013
-  tps: 3067.02234
+  dps: 4959.3694
+  tps: 4056.82853
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 3501.71013
-  tps: 3067.02234
+  dps: 4959.3694
+  tps: 4056.82853
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 3481.68324
-  tps: 3046.11159
+  dps: 4905.85707
+  tps: 4002.44718
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuturesightRune-38763"
  value: {
-  dps: 3378.79412
-  tps: 2958.15579
+  dps: 4733.82052
+  tps: 3867.5002
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 3336.45209
-  tps: 2916.28522
+  dps: 4782.63218
+  tps: 3898.6856
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 3378.79412
-  tps: 2958.15579
+  dps: 4736.11662
+  tps: 3867.98815
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 3525.24936
-  tps: 3087.54278
+  dps: 4955.58161
+  tps: 4055.13606
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 3515.70531
-  tps: 3078.47938
+  dps: 4924.44595
+  tps: 4028.09003
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IncisorFragment-37723"
  value: {
-  dps: 3496.34922
-  tps: 3059.73154
+  dps: 4896.36127
+  tps: 3996.01668
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 3501.71013
-  tps: 3067.02234
+  dps: 4959.3694
+  tps: 4056.82853
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 3492.19517
-  tps: 3058.93381
+  dps: 4926.65544
+  tps: 4031.7039
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 3378.79412
-  tps: 2958.15579
+  dps: 4733.82052
+  tps: 3867.5002
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 3378.79412
-  tps: 2958.15579
+  dps: 4736.11662
+  tps: 3867.98815
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 3539.57644
-  tps: 3093.3277
+  dps: 4921.03349
+  tps: 4016.20237
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 3408.143
-  tps: 2981.17236
+  dps: 4787.00312
+  tps: 3907.27655
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtArmor"
  value: {
-  dps: 2256.39946
-  tps: 1978.09618
+  dps: 3113.79047
+  tps: 2546.64651
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 2641.74738
-  tps: 2316.13694
+  dps: 3684.16968
+  tps: 3011.06625
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 3490.24122
-  tps: 3057.22829
+  dps: 4947.85654
+  tps: 4045.35823
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 3492.19517
-  tps: 3058.93381
+  dps: 4926.65544
+  tps: 4031.7039
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 3501.71013
-  tps: 3067.02234
+  dps: 4959.3694
+  tps: 4056.82853
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 3501.71013
-  tps: 3067.02234
+  dps: 4959.3694
+  tps: 4056.82853
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 3378.79412
-  tps: 2958.15579
+  dps: 4736.11662
+  tps: 3867.98815
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 3544.05026
-  tps: 3090.1697
+  dps: 4931.0898
+  tps: 4024.67523
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 3565.99993
-  tps: 3107.72944
+  dps: 4956.17055
+  tps: 4044.73983
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 3575.76516
-  tps: 3130.86604
+  dps: 5063.24057
+  tps: 4140.19938
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 3501.71013
-  tps: 3067.02234
+  dps: 4959.3694
+  tps: 4056.82853
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 3378.79412
-  tps: 2958.15579
+  dps: 4733.82052
+  tps: 3867.5002
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 3433.65173
-  tps: 3003.50173
+  dps: 4778.76391
+  tps: 3901.52951
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 3378.79412
-  tps: 2958.15579
+  dps: 4736.11662
+  tps: 3867.98815
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 3167.61794
-  tps: 2775.98263
+  dps: 4455.62584
+  tps: 3638.74537
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 3378.79412
-  tps: 2958.15579
+  dps: 4734.13257
+  tps: 3867.75159
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SparkofLife-37657"
  value: {
-  dps: 3430.12383
-  tps: 2997.23897
+  dps: 4837.25301
+  tps: 3950.38929
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StormshroudArmor"
  value: {
-  dps: 2728.24846
-  tps: 2387.15376
+  dps: 3735.5219
+  tps: 3051.20022
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 3492.19517
-  tps: 3058.93381
+  dps: 4926.65544
+  tps: 4031.7039
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 3490.24122
-  tps: 3057.22829
+  dps: 4947.85654
+  tps: 4045.35823
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 3485.48077
-  tps: 3051.82028
+  dps: 4937.42551
+  tps: 4038.47363
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheFistsofFury"
  value: {
-  dps: 2061.80658
-  tps: 1859.92518
+  dps: 2498.81084
+  tps: 2102.80163
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 2210.24792
-  tps: 1991.35133
+  dps: 2660.59999
+  tps: 2233.65133
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 3517.8383
-  tps: 3080.2291
+  dps: 4964.85829
+  tps: 4061.15547
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 3670.30751
-  tps: 3207.53902
+  dps: 5086.66472
+  tps: 4161.38556
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 3667.82791
-  tps: 3206.3249
+  dps: 5082.22138
+  tps: 4154.34507
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 3501.71013
-  tps: 3067.02234
+  dps: 4959.3694
+  tps: 4056.82853
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 3501.71013
-  tps: 3067.02234
+  dps: 4959.3694
+  tps: 4056.82853
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 3501.71013
-  tps: 3067.02234
+  dps: 4959.3694
+  tps: 4056.82853
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 3501.71013
-  tps: 3067.02234
+  dps: 4959.3694
+  tps: 4056.82853
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 3492.21726
-  tps: 3054.43349
+  dps: 4839.8638
+  tps: 3953.52929
  }
 }
 dps_results: {
  key: "TestArms-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 3659.12569
-  tps: 3212.24483
+  dps: 5140.80359
+  tps: 4211.76407
  }
 }
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 3588.79895
-  tps: 3141.01374
+  dps: 5026.51921
+  tps: 4102.10156
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5323.60326
-  tps: 5031.89193
+  dps: 7643.84564
+  tps: 6711.75772
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3564.87807
-  tps: 3118.92473
+  dps: 5005.02844
+  tps: 4092.46488
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3793.90635
-  tps: 3345.1191
+  dps: 5008.14579
+  tps: 4126.88508
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4570.64738
-  tps: 4353.80514
+  dps: 6462.22408
+  tps: 5709.59745
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3011.20924
-  tps: 2639.1018
+  dps: 4199.99313
+  tps: 3435.36088
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3237.16273
-  tps: 2853.39067
+  dps: 4260.04579
+  tps: 3508.75057
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5368.79518
-  tps: 5076.9212
+  dps: 7713.69368
+  tps: 6774.62392
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3575.76516
-  tps: 3130.86604
+  dps: 5063.24057
+  tps: 4140.19938
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3869.40585
-  tps: 3414.56699
+  dps: 5080.12589
+  tps: 4188.44295
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4591.41195
-  tps: 4372.56538
+  dps: 6539.22122
+  tps: 5784.40739
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3051.06155
-  tps: 2672.65844
+  dps: 4265.41238
+  tps: 3488.60523
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3279.82857
-  tps: 2898.36348
+  dps: 4369.83548
+  tps: 3608.05124
  }
 }
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3357.27912
-  tps: 2936.86634
+  dps: 4797.21035
+  tps: 3910.27658
  }
 }

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -129,8 +129,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Defender'sCode-40257"
  value: {
-  dps: 4911.06896
-  tps: 4006.78438
+  dps: 4910.63664
+  tps: 4010.40383
  }
 }
 dps_results: {
@@ -227,8 +227,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-FuturesightRune-38763"
  value: {
-  dps: 4885.50008
-  tps: 3991.3918
+  dps: 4875.09546
+  tps: 3982.56468
  }
 }
 dps_results: {
@@ -262,8 +262,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5053.01091
-  tps: 4128.21232
+  dps: 5080.03582
+  tps: 4150.91468
  }
 }
 dps_results: {
@@ -283,8 +283,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 4885.50008
-  tps: 3991.3918
+  dps: 4913.81587
+  tps: 4014.85652
  }
 }
 dps_results: {
@@ -304,8 +304,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 4897.00264
-  tps: 3998.73667
+  dps: 4886.63071
+  tps: 3990.49941
  }
 }
 dps_results: {
@@ -388,15 +388,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 4885.50008
-  tps: 3991.3918
+  dps: 4913.81587
+  tps: 4014.85652
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 4862.11249
-  tps: 3971.10311
+  dps: 4923.70189
+  tps: 4022.86209
  }
 }
 dps_results: {
@@ -416,8 +416,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 4885.50008
-  tps: 3991.3918
+  dps: 4875.12455
+  tps: 3982.58214
  }
 }
 dps_results: {

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -52,581 +52,581 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 4753.5376
-  tps: 3886.05185
+  dps: 4908.61887
+  tps: 4009.48009
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 4962.69743
-  tps: 4054.68484
+  dps: 5101.64102
+  tps: 4172.74082
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 4923.37866
-  tps: 4021.90695
+  dps: 5051.44515
+  tps: 4121.46426
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 4955.58161
-  tps: 4055.13606
+  dps: 5090.8694
+  tps: 4161.91107
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 4780.94223
-  tps: 3900.7748
+  dps: 4876.5798
+  tps: 3983.04244
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 4959.3694
-  tps: 3975.9479
+  dps: 5124.00818
+  tps: 4102.67695
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 4998.35715
-  tps: 4084.53139
+  dps: 5228.27418
+  tps: 4273.56809
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 4924.51902
-  tps: 4017.14232
+  dps: 5026.78869
+  tps: 4107.58391
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 4912.35649
-  tps: 4008.50978
+  dps: 5023.26645
+  tps: 4102.91096
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 4846.93501
-  tps: 3957.5187
+  dps: 4988.52539
+  tps: 4075.40743
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 4736.11662
-  tps: 3867.98815
+  dps: 4885.50008
+  tps: 3991.3918
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Defender'sCode-40257"
  value: {
-  dps: 4808.01308
-  tps: 3925.01516
+  dps: 4911.06896
+  tps: 4006.78438
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 4972.43703
-  tps: 4062.86652
+  dps: 5116.58906
+  tps: 4186.26109
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 4358.68236
-  tps: 3567.79237
+  dps: 4472.41881
+  tps: 3657.72884
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 4959.3694
-  tps: 4056.82853
+  dps: 5124.00818
+  tps: 4186.14557
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 4959.3694
-  tps: 4056.82853
+  dps: 5124.00818
+  tps: 4186.14557
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 4955.58161
-  tps: 4055.13606
+  dps: 5090.8694
+  tps: 4161.91107
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 4924.44595
-  tps: 4028.09003
+  dps: 5141.94561
+  tps: 4206.89013
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 4959.3694
-  tps: 4056.82853
+  dps: 5124.00818
+  tps: 4186.14557
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 4917.98221
-  tps: 4012.08456
+  dps: 5060.44533
+  tps: 4130.14566
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 4879.32683
-  tps: 3983.38761
+  dps: 5010.89242
+  tps: 4090.01268
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForgeEmber-37660"
  value: {
-  dps: 4893.10507
-  tps: 3998.58041
+  dps: 5017.17903
+  tps: 4098.07626
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 4959.3694
-  tps: 4056.82853
+  dps: 5124.00818
+  tps: 4186.14557
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 4959.3694
-  tps: 4056.82853
+  dps: 5124.00818
+  tps: 4186.14557
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 4905.85707
-  tps: 4002.44718
+  dps: 4977.97628
+  tps: 4068.64843
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuturesightRune-38763"
  value: {
-  dps: 4733.82052
-  tps: 3867.5002
+  dps: 4885.50008
+  tps: 3991.3918
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 4782.63218
-  tps: 3898.6856
+  dps: 4927.08476
+  tps: 4019.15122
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 4736.11662
-  tps: 3867.98815
+  dps: 4885.50008
+  tps: 3991.3918
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 4955.58161
-  tps: 4055.13606
+  dps: 5090.8694
+  tps: 4161.91107
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 4924.44595
-  tps: 4028.09003
+  dps: 5141.94561
+  tps: 4206.89013
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IncisorFragment-37723"
  value: {
-  dps: 4896.36127
-  tps: 3996.01668
+  dps: 5053.01091
+  tps: 4128.21232
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 4959.3694
-  tps: 4056.82853
+  dps: 5124.00818
+  tps: 4186.14557
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 4926.65544
-  tps: 4031.7039
+  dps: 5135.30462
+  tps: 4197.19912
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 4733.82052
-  tps: 3867.5002
+  dps: 4885.50008
+  tps: 3991.3918
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 4736.11662
-  tps: 3867.98815
+  dps: 4885.50008
+  tps: 3991.3918
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 4921.03349
-  tps: 4016.20237
+  dps: 5105.42627
+  tps: 4171.13218
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 4787.00312
-  tps: 3907.27655
+  dps: 4897.00264
+  tps: 3998.73667
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtArmor"
  value: {
-  dps: 3113.79047
-  tps: 2546.64651
+  dps: 3121.08004
+  tps: 2547.04616
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 3684.16968
-  tps: 3011.06625
+  dps: 3769.0358
+  tps: 3081.57926
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 4947.85654
-  tps: 4045.35823
+  dps: 5079.51678
+  tps: 4153.82271
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 4926.65544
-  tps: 4031.7039
+  dps: 5135.30462
+  tps: 4197.19912
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 4959.3694
-  tps: 4056.82853
+  dps: 5124.00818
+  tps: 4186.14557
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 4959.3694
-  tps: 4056.82853
+  dps: 5124.00818
+  tps: 4186.14557
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 4736.11662
-  tps: 3867.98815
+  dps: 4885.50008
+  tps: 3991.3918
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 4931.0898
-  tps: 4024.67523
+  dps: 5116.67611
+  tps: 4180.224
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 4956.17055
-  tps: 4044.73983
+  dps: 5141.96409
+  tps: 4200.45438
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5063.24057
-  tps: 4140.19938
+  dps: 5196.92675
+  tps: 4244.94502
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 4959.3694
-  tps: 4056.82853
+  dps: 5124.00818
+  tps: 4186.14557
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 4733.82052
-  tps: 3867.5002
+  dps: 4885.50008
+  tps: 3991.3918
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 4778.76391
-  tps: 3901.52951
+  dps: 4862.11249
+  tps: 3971.10311
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 4736.11662
-  tps: 3867.98815
+  dps: 4885.50008
+  tps: 3991.3918
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 4455.62584
-  tps: 3638.74537
+  dps: 4528.67237
+  tps: 3703.7859
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 4734.13257
-  tps: 3867.75159
+  dps: 4885.50008
+  tps: 3991.3918
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SparkofLife-37657"
  value: {
-  dps: 4837.25301
-  tps: 3950.38929
+  dps: 5003.7613
+  tps: 4086.38382
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StormshroudArmor"
  value: {
-  dps: 3735.5219
-  tps: 3051.20022
+  dps: 3866.6583
+  tps: 3161.50917
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 4926.65544
-  tps: 4031.7039
+  dps: 5135.30462
+  tps: 4197.19912
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 4947.85654
-  tps: 4045.35823
+  dps: 5079.51678
+  tps: 4153.82271
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 4937.42551
-  tps: 4038.47363
+  dps: 5056.15219
+  tps: 4136.5082
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheFistsofFury"
  value: {
-  dps: 2498.81084
-  tps: 2102.80163
+  dps: 2505.1755
+  tps: 2109.89321
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 2660.59999
-  tps: 2233.65133
+  dps: 2672.71673
+  tps: 2245.36168
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 4964.85829
-  tps: 4061.15547
+  dps: 5115.96467
+  tps: 4184.94744
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5086.66472
-  tps: 4161.38556
+  dps: 5198.38466
+  tps: 4242.19722
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5082.22138
-  tps: 4154.34507
+  dps: 5252.32178
+  tps: 4293.83508
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 4959.3694
-  tps: 4056.82853
+  dps: 5124.00818
+  tps: 4186.14557
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 4959.3694
-  tps: 4056.82853
+  dps: 5124.00818
+  tps: 4186.14557
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 4959.3694
-  tps: 4056.82853
+  dps: 5124.00818
+  tps: 4186.14557
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 4959.3694
-  tps: 4056.82853
+  dps: 5124.00818
+  tps: 4186.14557
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 4839.8638
-  tps: 3953.52929
+  dps: 4982.25437
+  tps: 4065.2619
  }
 }
 dps_results: {
  key: "TestArms-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 5140.80359
-  tps: 4211.76407
+  dps: 5245.07863
+  tps: 4301.47211
  }
 }
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 5026.51921
-  tps: 4102.10156
+  dps: 5174.23523
+  tps: 4222.66657
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7643.84564
-  tps: 6711.75772
+  dps: 7904.36567
+  tps: 6930.48132
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5005.02844
-  tps: 4092.46488
+  dps: 5176.05234
+  tps: 4232.05009
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5008.14579
-  tps: 4126.88508
+  dps: 5116.22786
+  tps: 4204.19581
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6462.22408
-  tps: 5709.59745
+  dps: 6547.45338
+  tps: 5786.71065
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4199.99313
-  tps: 3435.36088
+  dps: 4326.78231
+  tps: 3539.28948
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4260.04579
-  tps: 3508.75057
+  dps: 4366.80001
+  tps: 3600.50268
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7713.69368
-  tps: 6774.62392
+  dps: 7852.9367
+  tps: 6882.05039
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5063.24057
-  tps: 4140.19938
+  dps: 5196.92675
+  tps: 4244.94502
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5080.12589
-  tps: 4188.44295
+  dps: 5251.20166
+  tps: 4337.66106
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6539.22122
-  tps: 5784.40739
+  dps: 6658.92249
+  tps: 5888.60971
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4265.41238
-  tps: 3488.60523
+  dps: 4335.43453
+  tps: 3546.2542
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4369.83548
-  tps: 3608.05124
+  dps: 4503.52961
+  tps: 3721.36419
  }
 }
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 4797.21035
-  tps: 3910.27658
+  dps: 4976.52395
+  tps: 4053.67766
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -52,581 +52,581 @@ character_stats_results: {
 dps_results: {
  key: "TestFury-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 3830.35285
-  tps: 2834.50494
+  dps: 3860.30081
+  tps: 2861.14519
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 3874.79885
-  tps: 2867.64623
+  dps: 3904.20185
+  tps: 2893.82739
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 3892.13805
-  tps: 2878.77133
+  dps: 3922.62952
+  tps: 2905.89936
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 3916.78395
-  tps: 2899.39182
+  dps: 3946.67228
+  tps: 2926.00485
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 3778.78904
-  tps: 2791.98706
+  dps: 3808.91473
+  tps: 2818.77953
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 3899.85733
-  tps: 2828.22469
+  dps: 3929.05444
+  tps: 2853.71964
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 4000.92434
-  tps: 2960.62316
+  dps: 4032.50018
+  tps: 2988.71031
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 3921.56453
-  tps: 2899.04744
+  dps: 3950.95206
+  tps: 2925.2181
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 3907.47853
-  tps: 2889.04672
+  dps: 3938.29788
+  tps: 2916.46317
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 3860.61391
-  tps: 2856.56597
+  dps: 3890.6162
+  tps: 2883.28404
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 3755.30926
-  tps: 2779.30351
+  dps: 3785.83242
+  tps: 2806.44814
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Defender'sCode-40257"
  value: {
-  dps: 3815.49103
-  tps: 2826.18922
+  dps: 3846.231
+  tps: 2853.52933
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 3901.49688
-  tps: 2888.12087
+  dps: 3931.90833
+  tps: 2915.19328
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 3380.24816
-  tps: 2504.70297
+  dps: 3407.03872
+  tps: 2528.5436
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 3899.85733
-  tps: 2885.72152
+  dps: 3929.05444
+  tps: 2911.73678
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 3899.85733
-  tps: 2885.72152
+  dps: 3929.05444
+  tps: 2911.73678
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 3916.78395
-  tps: 2899.39182
+  dps: 3946.67228
+  tps: 2926.00485
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 3899.59857
-  tps: 2886.2948
+  dps: 3930.02182
+  tps: 2913.37419
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 3899.85733
-  tps: 2885.72152
+  dps: 3929.05444
+  tps: 2911.73678
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 3915.2483
-  tps: 2895.5604
+  dps: 3945.15101
+  tps: 2922.18142
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 3883.80684
-  tps: 2872.70179
+  dps: 3914.10601
+  tps: 2899.66709
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForgeEmber-37660"
  value: {
-  dps: 3872.37082
-  tps: 2867.39824
+  dps: 3902.66765
+  tps: 2894.33817
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 3899.85733
-  tps: 2885.72152
+  dps: 3929.05444
+  tps: 2911.73678
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 3899.85733
-  tps: 2885.72152
+  dps: 3929.05444
+  tps: 2911.73678
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 3907.4169
-  tps: 2892.40916
+  dps: 3938.16534
+  tps: 2919.76288
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuturesightRune-38763"
  value: {
-  dps: 3755.30926
-  tps: 2779.30351
+  dps: 3785.83242
+  tps: 2806.44814
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 3828.74174
-  tps: 2830.73522
+  dps: 3863.06216
+  tps: 2860.76558
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 3755.30926
-  tps: 2779.30351
+  dps: 3785.83242
+  tps: 2806.44814
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 3916.78395
-  tps: 2899.39182
+  dps: 3946.67228
+  tps: 2926.00485
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 3899.59857
-  tps: 2886.2948
+  dps: 3930.02182
+  tps: 2913.37419
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IncisorFragment-37723"
  value: {
-  dps: 3893.04793
-  tps: 2883.80847
+  dps: 3924.81018
+  tps: 2912.07538
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 3899.85733
-  tps: 2885.72152
+  dps: 3929.05444
+  tps: 2911.73678
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 3900.97998
-  tps: 2887.99294
+  dps: 3930.94536
+  tps: 2914.67294
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 3755.30926
-  tps: 2779.30351
+  dps: 3785.83242
+  tps: 2806.44814
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 3755.30926
-  tps: 2779.30351
+  dps: 3785.83242
+  tps: 2806.44814
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 3928.62187
-  tps: 2905.03818
+  dps: 3958.95206
+  tps: 2932.02535
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 3820.93722
-  tps: 2826.25713
+  dps: 3849.83023
+  tps: 2851.98973
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtArmor"
  value: {
-  dps: 2190.76708
-  tps: 1627.96202
+  dps: 2213.06581
+  tps: 1647.47341
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 2771.66073
-  tps: 2059.29256
+  dps: 2794.95191
+  tps: 2080.10839
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 3928.25035
-  tps: 2906.48684
+  dps: 3957.01904
+  tps: 2932.12599
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 3900.97998
-  tps: 2887.99294
+  dps: 3930.94536
+  tps: 2914.67294
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 3899.85733
-  tps: 2885.72152
+  dps: 3929.05444
+  tps: 2911.73678
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 3899.85733
-  tps: 2885.72152
+  dps: 3929.05444
+  tps: 2911.73678
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 3755.30926
-  tps: 2779.30351
+  dps: 3785.83242
+  tps: 2806.44814
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 3974.53539
-  tps: 2935.2109
+  dps: 4003.99025
+  tps: 2961.41473
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 3996.80127
-  tps: 2950.79701
+  dps: 4026.25612
+  tps: 2977.00084
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 3984.20271
-  tps: 2950.27938
+  dps: 4014.61996
+  tps: 2977.36988
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 3899.85733
-  tps: 2885.72152
+  dps: 3929.05444
+  tps: 2911.73678
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 3755.30926
-  tps: 2779.30351
+  dps: 3785.83242
+  tps: 2806.44814
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 3781.2383
-  tps: 2796.11642
+  dps: 3810.62199
+  tps: 2822.26541
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 3755.30926
-  tps: 2779.30351
+  dps: 3785.83242
+  tps: 2806.44814
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 3530.60405
-  tps: 2610.26347
+  dps: 3560.48182
+  tps: 2636.40653
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 3755.30926
-  tps: 2779.30351
+  dps: 3785.83242
+  tps: 2806.44814
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SparkofLife-37657"
  value: {
-  dps: 3824.53967
-  tps: 2829.87218
+  dps: 3854.57491
+  tps: 2856.59573
  }
 }
 dps_results: {
  key: "TestFury-AllItems-StormshroudArmor"
  value: {
-  dps: 2792.45534
-  tps: 2069.11609
+  dps: 2817.58226
+  tps: 2091.10214
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 3900.97998
-  tps: 2887.99294
+  dps: 3930.94536
+  tps: 2914.67294
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 3928.25035
-  tps: 2906.48684
+  dps: 3957.01904
+  tps: 2932.12599
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 3921.30963
-  tps: 2901.85079
+  dps: 3950.99519
+  tps: 2928.28045
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 2714.33107
-  tps: 2023.29803
+  dps: 2731.64687
+  tps: 2038.72383
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 2887.17593
-  tps: 2149.66907
+  dps: 2905.74931
+  tps: 2166.23271
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 3909.13433
-  tps: 2893.41649
+  dps: 3939.13598
+  tps: 2920.11895
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 3978.7326
-  tps: 2944.58833
+  dps: 4009.92426
+  tps: 2972.34461
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 4008.5905
-  tps: 2963.77393
+  dps: 4038.06729
+  tps: 2990.03844
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 3899.85733
-  tps: 2885.72152
+  dps: 3929.05444
+  tps: 2911.73678
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 3899.85733
-  tps: 2885.72152
+  dps: 3929.05444
+  tps: 2911.73678
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 3899.85733
-  tps: 2885.72152
+  dps: 3929.05444
+  tps: 2911.73678
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 3899.85733
-  tps: 2885.72152
+  dps: 3929.05444
+  tps: 2911.73678
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 3871.31845
-  tps: 2859.83875
+  dps: 3905.28462
+  tps: 2889.55914
  }
 }
 dps_results: {
  key: "TestFury-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 4155.22623
-  tps: 3071.02665
+  dps: 4191.90384
+  tps: 3103.11955
  }
 }
 dps_results: {
  key: "TestFury-Average-Default"
  value: {
-  dps: 3947.40132
-  tps: 2921.05617
+  dps: 3978.13236
+  tps: 2948.41338
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5275.91601
-  tps: 4272.41687
+  dps: 5401.33207
+  tps: 4382.76739
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3902.64485
-  tps: 2888.48428
+  dps: 3932.68887
+  tps: 2915.22616
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4253.28799
-  tps: 3151.81255
+  dps: 4289.59553
+  tps: 3184.09378
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4493.61731
-  tps: 3685.04367
+  dps: 4605.14599
+  tps: 3783.16222
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3255.90512
-  tps: 2414.722
+  dps: 3281.36425
+  tps: 2437.36138
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3624.13668
-  tps: 2686.64923
+  dps: 3654.65953
+  tps: 2713.7549
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5339.7151
-  tps: 4322.46039
+  dps: 5469.44844
+  tps: 4436.60256
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3984.20271
-  tps: 2950.27938
+  dps: 4014.61996
+  tps: 2977.36988
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4434.60061
-  tps: 3284.86754
+  dps: 4472.11138
+  tps: 3318.16238
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4548.75206
-  tps: 3727.46177
+  dps: 4662.19029
+  tps: 3827.2396
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3326.3263
-  tps: 2465.4382
+  dps: 3351.66445
+  tps: 2487.9759
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3620.50168
-  tps: 2682.95263
+  dps: 3649.83624
+  tps: 2708.99333
  }
 }
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3698.98625
-  tps: 2735.17425
+  dps: 3725.87688
+  tps: 2759.12091
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -52,581 +52,581 @@ character_stats_results: {
 dps_results: {
  key: "TestFury-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 2644.85402
-  tps: 2259.14894
+  dps: 3830.35285
+  tps: 2834.50494
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 2725.42639
-  tps: 2325.54465
+  dps: 3874.79885
+  tps: 2867.64623
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2740.65576
-  tps: 2335.96851
+  dps: 3892.13805
+  tps: 2878.77133
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 2743.1001
-  tps: 2342.20232
+  dps: 3916.78395
+  tps: 2899.39182
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 2633.71044
-  tps: 2248.68094
+  dps: 3778.78904
+  tps: 2791.98706
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2701.72081
-  tps: 2261.35106
+  dps: 3899.85733
+  tps: 2828.22469
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2754.48813
-  tps: 2352.19353
+  dps: 4000.92434
+  tps: 2960.62316
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2759.19958
-  tps: 2353.57137
+  dps: 3921.56453
+  tps: 2899.04744
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2792.58198
-  tps: 2381.34367
+  dps: 3907.47853
+  tps: 2889.04672
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 2717.93038
-  tps: 2318.40633
+  dps: 3860.61391
+  tps: 2856.56597
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 2644.85402
-  tps: 2259.14894
+  dps: 3755.30926
+  tps: 2779.30351
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Defender'sCode-40257"
  value: {
-  dps: 2675.03025
-  tps: 2284.77871
+  dps: 3815.49103
+  tps: 2826.18922
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2747.53612
-  tps: 2345.07176
+  dps: 3901.49688
+  tps: 2888.12087
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 2351.73582
-  tps: 2015.81701
+  dps: 3380.24816
+  tps: 2504.70297
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 2701.72081
-  tps: 2307.29348
+  dps: 3899.85733
+  tps: 2885.72152
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2701.72081
-  tps: 2307.29348
+  dps: 3899.85733
+  tps: 2885.72152
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 2743.1001
-  tps: 2342.20232
+  dps: 3916.78395
+  tps: 2899.39182
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2737.03295
-  tps: 2335.98199
+  dps: 3899.59857
+  tps: 2886.2948
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 2701.72081
-  tps: 2307.29348
+  dps: 3899.85733
+  tps: 2885.72152
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2794.07975
-  tps: 2380.43545
+  dps: 3915.2483
+  tps: 2895.5604
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2727.22379
-  tps: 2326.74688
+  dps: 3883.80684
+  tps: 2872.70179
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2716.86751
-  tps: 2317.52145
+  dps: 3872.37082
+  tps: 2867.39824
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2701.72081
-  tps: 2307.29348
+  dps: 3899.85733
+  tps: 2885.72152
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2701.72081
-  tps: 2307.29348
+  dps: 3899.85733
+  tps: 2885.72152
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2729.82788
-  tps: 2329.52862
+  dps: 3907.4169
+  tps: 2892.40916
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2644.85402
-  tps: 2259.14894
+  dps: 3755.30926
+  tps: 2779.30351
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 2602.42156
-  tps: 2216.96633
+  dps: 3828.74174
+  tps: 2830.73522
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 2644.85402
-  tps: 2259.14894
+  dps: 3755.30926
+  tps: 2779.30351
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 2743.1001
-  tps: 2342.20232
+  dps: 3916.78395
+  tps: 2899.39182
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2737.03295
-  tps: 2335.98199
+  dps: 3899.59857
+  tps: 2886.2948
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2752.2989
-  tps: 2351.71328
+  dps: 3893.04793
+  tps: 2883.80847
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 2701.72081
-  tps: 2307.29348
+  dps: 3899.85733
+  tps: 2885.72152
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2707.63145
-  tps: 2312.30548
+  dps: 3900.97998
+  tps: 2887.99294
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2644.85402
-  tps: 2259.14894
+  dps: 3755.30926
+  tps: 2779.30351
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 2644.85402
-  tps: 2259.14894
+  dps: 3755.30926
+  tps: 2779.30351
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2839.30062
-  tps: 2421.61204
+  dps: 3928.62187
+  tps: 2905.03818
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2641.83767
-  tps: 2257.18386
+  dps: 3820.93722
+  tps: 2826.25713
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtArmor"
  value: {
-  dps: 1622.33632
-  tps: 1396.27539
+  dps: 2190.76708
+  tps: 1627.96202
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 1937.13656
-  tps: 1662.13985
+  dps: 2771.66073
+  tps: 2059.29256
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 2714.37765
-  tps: 2317.16733
+  dps: 3928.25035
+  tps: 2906.48684
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2707.63145
-  tps: 2312.30548
+  dps: 3900.97998
+  tps: 2887.99294
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 2701.72081
-  tps: 2307.29348
+  dps: 3899.85733
+  tps: 2885.72152
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 2701.72081
-  tps: 2307.29348
+  dps: 3899.85733
+  tps: 2885.72152
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2644.85402
-  tps: 2259.14894
+  dps: 3755.30926
+  tps: 2779.30351
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 2814.15445
-  tps: 2394.46458
+  dps: 3974.53539
+  tps: 2935.2109
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 2833.10784
-  tps: 2409.6091
+  dps: 3996.80127
+  tps: 2950.79701
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2757.85043
-  tps: 2355.4972
+  dps: 3984.20271
+  tps: 2950.27938
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2701.72081
-  tps: 2307.29348
+  dps: 3899.85733
+  tps: 2885.72152
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2644.85402
-  tps: 2259.14894
+  dps: 3755.30926
+  tps: 2779.30351
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2688.08153
-  tps: 2296.75027
+  dps: 3781.2383
+  tps: 2796.11642
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2644.85402
-  tps: 2259.14894
+  dps: 3755.30926
+  tps: 2779.30351
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 2383.33543
-  tps: 2036.49955
+  dps: 3530.60405
+  tps: 2610.26347
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2644.85402
-  tps: 2259.14894
+  dps: 3755.30926
+  tps: 2779.30351
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SparkofLife-37657"
  value: {
-  dps: 2708.74944
-  tps: 2311.47691
+  dps: 3824.53967
+  tps: 2829.87218
  }
 }
 dps_results: {
  key: "TestFury-AllItems-StormshroudArmor"
  value: {
-  dps: 2012.86368
-  tps: 1722.2467
+  dps: 2792.45534
+  tps: 2069.11609
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2707.63145
-  tps: 2312.30548
+  dps: 3900.97998
+  tps: 2887.99294
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 2714.37765
-  tps: 2317.16733
+  dps: 3928.25035
+  tps: 2906.48684
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2721.13549
-  tps: 2323.87001
+  dps: 3921.30963
+  tps: 2901.85079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 1971.83091
-  tps: 1728.048
+  dps: 2714.33107
+  tps: 2023.29803
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 2073.1698
-  tps: 1811.26717
+  dps: 2887.17593
+  tps: 2149.66907
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 2770.64597
-  tps: 2367.24598
+  dps: 3909.13433
+  tps: 2893.41649
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2771.15362
-  tps: 2363.51385
+  dps: 3978.7326
+  tps: 2944.58833
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2840.70947
-  tps: 2423.91407
+  dps: 4008.5905
+  tps: 2963.77393
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2701.72081
-  tps: 2307.29348
+  dps: 3899.85733
+  tps: 2885.72152
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2701.72081
-  tps: 2307.29348
+  dps: 3899.85733
+  tps: 2885.72152
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2701.72081
-  tps: 2307.29348
+  dps: 3899.85733
+  tps: 2885.72152
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2701.72081
-  tps: 2307.29348
+  dps: 3899.85733
+  tps: 2885.72152
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 2679.07073
-  tps: 2283.41075
+  dps: 3871.31845
+  tps: 2859.83875
  }
 }
 dps_results: {
  key: "TestFury-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 2835.32076
-  tps: 2417.63537
+  dps: 4155.22623
+  tps: 3071.02665
  }
 }
 dps_results: {
  key: "TestFury-Average-Default"
  value: {
-  dps: 2787.56136
-  tps: 2379.84912
+  dps: 3947.40132
+  tps: 2921.05617
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2745.67813
-  tps: 2534.74488
+  dps: 5275.91601
+  tps: 4272.41687
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2745.67813
-  tps: 2345.5817
+  dps: 3902.64485
+  tps: 2888.48428
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3070.98514
-  tps: 2616.52644
+  dps: 4253.28799
+  tps: 3151.81255
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2162.31611
-  tps: 2065.82382
+  dps: 4493.61731
+  tps: 3685.04367
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2162.31611
-  tps: 1859.13704
+  dps: 3255.90512
+  tps: 2414.722
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2495.21133
-  tps: 2133.87054
+  dps: 3624.13668
+  tps: 2686.64923
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2757.85043
-  tps: 2550.18157
+  dps: 5339.7151
+  tps: 4322.46039
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2757.85043
-  tps: 2355.4972
+  dps: 3984.20271
+  tps: 2950.27938
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3025.97984
-  tps: 2573.21085
+  dps: 4434.60061
+  tps: 3284.86754
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2200.18063
-  tps: 2097.13083
+  dps: 4548.75206
+  tps: 3727.46177
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2200.18063
-  tps: 1888.31647
+  dps: 3326.3263
+  tps: 2465.4382
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2471.18675
-  tps: 2110.09039
+  dps: 3620.50168
+  tps: 2682.95263
  }
 }
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2585.68947
-  tps: 2208.49224
+  dps: 3698.98625
+  tps: 2735.17425
  }
 }

--- a/sim/warrior/dps/presets.go
+++ b/sim/warrior/dps/presets.go
@@ -17,7 +17,7 @@ var PlayerOptionsFury = &proto.Player_Warrior{
 	Warrior: &proto.Warrior{
 		Talents:  FuryTalents,
 		Options:  warriorOptions,
-		Rotation: warriorRotation,
+		Rotation: furyRotation,
 	},
 }
 
@@ -30,11 +30,11 @@ var ArmsTalents = &proto.WarriorTalents{
 	Impale:                        2,
 	DeepWounds:                    3,
 	TwoHandedWeaponSpecialization: 3,
+	TasteForBlood:                 3,
 	PoleaxeSpecialization:         5,
-	TasteForBlood:                 0,
-	MaceSpecialization:            0,
-	SwordSpecialization:           0,
-	WeaponMastery:                 0,
+	SweepingStrikes:               true,
+	WeaponMastery:                 2,
+	MortalStrike:                  true,
 	StrengthOfArms:                2,
 	ImprovedSlam:                  2,
 	ImprovedMortalStrike:          3,
@@ -45,12 +45,12 @@ var ArmsTalents = &proto.WarriorTalents{
 	WreckingCrew:                  5,
 	Bladestorm:                    true,
 
-	Cruelty:           5,
 	ArmoredToTheTeeth: 3,
+	Cruelty:           5,
 
 	ImprovedBloodrage:   2,
-	Incite:              3,
 	ImprovedThunderClap: 3,
+	Incite:              3,
 }
 
 var FuryTalents = &proto.WarriorTalents{
@@ -63,21 +63,23 @@ var FuryTalents = &proto.WarriorTalents{
 	DeepWounds:                    3,
 	TwoHandedWeaponSpecialization: 3,
 
-	Cruelty:                 5,
 	ArmoredToTheTeeth:       3,
+	Cruelty:                 5,
 	UnbridledWrath:          2,
 	ImprovedCleave:          3,
 	PiercingHowl:            true,
 	CommandingPresence:      1,
 	DualWieldSpecialization: 5,
-	Enrage:                  4,
+	ImprovedExecute:         2,
 	Precision:               3,
 	DeathWish:               true,
 	ImprovedBerserkerRage:   1,
 	Flurry:                  5,
 	IntensifyRage:           3,
+	Bloodthirst:             true,
 	ImprovedWhirlwind:       2,
 	ImprovedBerserkerStance: 5,
+	Rampage:                 true,
 	Bloodsurge:              3,
 	UnendingFury:            5,
 	TitansGrip:              true,
@@ -103,8 +105,8 @@ var armsRotation = &proto.Warrior_Rotation{
 	StanceOption: proto.Warrior_Rotation_DefaultStance,
 }
 
-var warriorRotation = &proto.Warrior_Rotation{
-	UseRend:   true,
+var furyRotation = &proto.Warrior_Rotation{
+	UseRend:   false,
 	UseCleave: false,
 
 	HsRageThreshold:        60,
@@ -120,7 +122,7 @@ var warriorRotation = &proto.Warrior_Rotation{
 	MaintainDemoShout:   false,
 	MaintainThunderClap: false,
 
-	StanceOption: proto.Warrior_Rotation_DefaultStance,
+	StanceOption: proto.Warrior_Rotation_BerserkerStance,
 }
 
 var warriorOptions = &proto.Warrior_Options{

--- a/sim/warrior/execute.go
+++ b/sim/warrior/execute.go
@@ -55,7 +55,7 @@ func (warrior *Warrior) registerExecuteSpell() {
 				},
 				TargetSpellCoefficient: 1,
 			},
-			OutcomeApplier: warrior.OutcomeFuncMeleeSpecialHitAndCrit(warrior.critMultiplier(true)),
+			OutcomeApplier: warrior.OutcomeFuncMeleeSpecialHitAndCrit(warrior.critMultiplier(mh)),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if !spellEffect.Landed() {

--- a/sim/warrior/heroic_strike_cleave.go
+++ b/sim/warrior/heroic_strike_cleave.go
@@ -49,7 +49,7 @@ func (warrior *Warrior) registerHeroicStrikeSpell() {
 			BonusCritRating:  (float64(warrior.Talents.Incite)*5 + core.TernaryFloat64(warrior.HasSetBonus(ItemSetWrynnsBattlegear, 4), 5, 0)) * core.CritRatingPerCritChance,
 
 			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 495, 1, 1, true),
-			OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(true)),
+			OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(mh)),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if sim.CurrentTime < warrior.disableHsCleaveUntil {
@@ -79,7 +79,7 @@ func (warrior *Warrior) registerCleaveSpell() {
 		BonusCritRating:  float64(warrior.Talents.Incite) * 5 * core.CritRatingPerCritChance,
 
 		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, flatDamageBonus, 1, 1, true),
-		OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(true)),
+		OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(mh)),
 	}
 
 	targets := core.TernaryInt32(warrior.HasMajorGlyph(proto.WarriorMajorGlyph_GlyphOfCleaving), 3, 2)

--- a/sim/warrior/mortal_strike.go
+++ b/sim/warrior/mortal_strike.go
@@ -13,7 +13,7 @@ func (warrior *Warrior) registerMortalStrikeSpell(cdTimer *core.Timer) {
 	refundAmount := cost * 0.8
 
 	warrior.MortalStrike = warrior.RegisterSpell(core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: 71552},
+		ActionID:    core.ActionID{SpellID: 47486},
 		SpellSchool: core.SpellSchoolPhysical,
 		Flags:       core.SpellFlagMeleeMetrics,
 
@@ -35,10 +35,10 @@ func (warrior *Warrior) registerMortalStrikeSpell(cdTimer *core.Timer) {
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			ProcMask: core.ProcMaskMeleeMHSpecial,
 
-			DamageMultiplier: 1 *
-				(1 + 0.01*float64(warrior.Talents.ImprovedMortalStrike)) *
-				core.TernaryFloat64(warrior.HasMajorGlyph(proto.WarriorMajorGlyph_GlyphOfMortalStrike), 1.1, 1) *
-				core.TernaryFloat64(warrior.HasSetBonus(ItemSetOnslaughtBattlegear, 4), 1.05, 1),
+			DamageMultiplier: 1 +
+				[]float64{0, 0.03, 0.06, 0.1}[warrior.Talents.ImprovedMortalStrike] +
+				core.TernaryFloat64(warrior.HasMajorGlyph(proto.WarriorMajorGlyph_GlyphOfMortalStrike), 0.1, 0) +
+				core.TernaryFloat64(warrior.HasSetBonus(ItemSetOnslaughtBattlegear, 4), 0.05, 0),
 			BonusCritRating:  core.TernaryFloat64(warrior.HasSetBonus(ItemSetSiegebreakerBattlegear, 4), 10, 0) * core.CritRatingPerCritChance,
 			ThreatMultiplier: 1,
 			DynamicThreatMultiplier: func(spellEffect *core.SpellEffect, spell *core.Spell) float64 {
@@ -48,8 +48,8 @@ func (warrior *Warrior) registerMortalStrikeSpell(cdTimer *core.Timer) {
 				return 1.0
 			},
 
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 80, 1, 1, true),
-			OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(true)),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 380, 1, 1, true),
+			OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(mh)),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if !spellEffect.Landed() {

--- a/sim/warrior/overpower.go
+++ b/sim/warrior/overpower.go
@@ -32,12 +32,12 @@ func (warrior *Warrior) registerOverpowerSpell(cdTimer *core.Timer) {
 	damageEffect := core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 		ProcMask: core.ProcMaskMeleeMHSpecial,
 
-		DamageMultiplier: 1 + float64(warrior.Talents.UnrelentingAssault)*0.1,
+		DamageMultiplier: 1 + 0.1*float64(warrior.Talents.UnrelentingAssault),
 		ThreatMultiplier: 0.75,
 		BonusCritRating:  25 * core.CritRatingPerCritChance * float64(warrior.Talents.ImprovedOverpower),
 
-		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 35, 1, 1, true),
-		OutcomeApplier: warrior.OutcomeFuncMeleeSpecialNoBlockDodgeParry(warrior.critMultiplier(true)),
+		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 0, 1, 1, true),
+		OutcomeApplier: warrior.OutcomeFuncMeleeSpecialNoBlockDodgeParry(warrior.critMultiplier(mh)),
 
 		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 			if !spellEffect.Landed() {
@@ -52,7 +52,7 @@ func (warrior *Warrior) registerOverpowerSpell(cdTimer *core.Timer) {
 		cooldownDur -= time.Second * 4
 	}
 	warrior.Overpower = warrior.RegisterSpell(core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: 11585},
+		ActionID:    core.ActionID{SpellID: 7384},
 		SpellSchool: core.SpellSchoolPhysical,
 		Flags:       core.SpellFlagMeleeMetrics,
 

--- a/sim/warrior/rend.go
+++ b/sim/warrior/rend.go
@@ -61,7 +61,7 @@ func (warrior *Warrior) registerRendSpell() {
 		TickLength:    time.Second * 3,
 		TickEffects: core.TickFuncApplyEffectsToUnit(target, core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			ProcMask: core.ProcMaskPeriodicDamage,
-			// 135% damage multiplier is applied at the begining of the fight and removed when target is at 75% health
+			// 135% damage multiplier is applied at the beginning of the fight and removed when target is at 75% health
 			DamageMultiplier: (1 + 0.1*float64(warrior.Talents.ImprovedRend)) * 1.35,
 			ThreatMultiplier: 1,
 			IsPeriodic:       true,

--- a/sim/warrior/revenge.go
+++ b/sim/warrior/revenge.go
@@ -64,7 +64,7 @@ func (warrior *Warrior) registerRevengeSpell(cdTimer *core.Timer) {
 			},
 			TargetSpellCoefficient: 1,
 		},
-		OutcomeApplier: warrior.OutcomeFuncMeleeSpecialHitAndCrit(warrior.critMultiplier(true)),
+		OutcomeApplier: warrior.OutcomeFuncMeleeSpecialHitAndCrit(warrior.critMultiplier(mh)),
 
 		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 			if !spellEffect.Landed() {

--- a/sim/warrior/shield_slam.go
+++ b/sim/warrior/shield_slam.go
@@ -62,7 +62,7 @@ func (warrior *Warrior) registerShieldSlamSpell() {
 			ProcMask: core.ProcMaskMeleeMHSpecial, // TODO: Is this right?
 
 			BonusCritRating:  5 * core.CritRatingPerCritChance * float64(warrior.Talents.CriticalBlock),
-			DamageMultiplier: core.TernaryFloat64(warrior.HasSetBonus(ItemSetOnslaughtArmor, 4), 1.1, 1) * (1.0 + 0.05*float64(warrior.Talents.GagOrder)),
+			DamageMultiplier: (1.0 + 0.05*float64(warrior.Talents.GagOrder)) * core.TernaryFloat64(warrior.HasSetBonus(ItemSetOnslaughtArmor, 4), 1.1, 1), // TODO: GagOrder might apply differently
 			ThreatMultiplier: 1.3,
 			FlatThreatBonus:  770,
 
@@ -74,7 +74,7 @@ func (warrior *Warrior) registerShieldSlamSpell() {
 				},
 				TargetSpellCoefficient: 1,
 			},
-			OutcomeApplier: warrior.OutcomeFuncMeleeSpecialHitAndCrit(warrior.critMultiplier(true)),
+			OutcomeApplier: warrior.OutcomeFuncMeleeSpecialHitAndCrit(warrior.critMultiplier(mh)),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if !spellEffect.Landed() {

--- a/sim/warrior/shockwave.go
+++ b/sim/warrior/shockwave.go
@@ -44,7 +44,7 @@ func (warrior *Warrior) registerShockwaveSpell() {
 				},
 				TargetSpellCoefficient: 1,
 			},
-			OutcomeApplier: warrior.OutcomeFuncMeleeSpecialHitAndCrit(warrior.critMultiplier(true)),
+			OutcomeApplier: warrior.OutcomeFuncMeleeSpecialHitAndCrit(warrior.critMultiplier(none)),
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if !spellEffect.Landed() {
 					warrior.AddRage(sim, refundAmount, warrior.RageRefundMetrics)

--- a/sim/warrior/slam.go
+++ b/sim/warrior/slam.go
@@ -29,15 +29,14 @@ func (warrior *Warrior) registerSlamSpell() {
 		},
 
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
-			ProcMask: core.ProcMaskMeleeMHSpecial,
-
-			DamageMultiplier: 1 * (1 + 0.02*float64(warrior.Talents.UnendingFury)) * core.TernaryFloat64(warrior.HasSetBonus(ItemSetDreadnaughtBattlegear, 2), 1.1, 1),
+			ProcMask:         core.ProcMaskMeleeMHSpecial,
+			DamageMultiplier: 1 + 0.02*float64(warrior.Talents.UnendingFury) + core.TernaryFloat64(warrior.HasSetBonus(ItemSetDreadnaughtBattlegear, 2), 0.1, 0),
 			ThreatMultiplier: 1,
 			BonusCritRating:  core.TernaryFloat64(warrior.HasSetBonus(ItemSetWrynnsBattlegear, 4), 5, 0) * core.CritRatingPerCritChance,
 			FlatThreatBonus:  140,
 
 			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 250, 1, 1, true),
-			OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(true)),
+			OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(mh)),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if !spellEffect.Landed() {

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -742,25 +742,25 @@ func (warrior *Warrior) RegisterBladestormCD() {
 		},
 	})
 
+	dm := 1 + 0.1*float64(warrior.Talents.ImprovedWhirlwind) + 0.02*float64(warrior.Talents.UnendingFury)
+
 	baseEffectMH := core.SpellEffect{
 		ProcMask: core.ProcMaskMeleeMHSpecial,
 
-		DamageMultiplier: 1 + 0.02*float64(warrior.Talents.UnendingFury),
+		DamageMultiplier: dm,
 		ThreatMultiplier: 1.25,
 
 		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 0, 1, 1, true),
-		OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(true)),
+		OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(mh)),
 	}
 	baseEffectOH := core.SpellEffect{
 		ProcMask: core.ProcMaskMeleeOHSpecial,
 
-		DamageMultiplier: 1 *
-			(1 + 0.02*float64(warrior.Talents.UnendingFury)) *
-			(1 + 0.1*float64(warrior.Talents.ImprovedWhirlwind)),
+		DamageMultiplier: dm,
 		ThreatMultiplier: 1.25,
 
-		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, 1+0.05*float64(warrior.Talents.DualWieldSpecialization), 1, true),
-		OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(true)),
+		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, 1, 1+0.05*float64(warrior.Talents.DualWieldSpecialization), true),
+		OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(oh)),
 	}
 
 	numHits := core.MinInt32(4, warrior.Env.GetNumTargets())

--- a/sim/warrior/thunder_clap.go
+++ b/sim/warrior/thunder_clap.go
@@ -1,6 +1,7 @@
 package warrior
 
 import (
+	"github.com/wowsims/wotlk/sim/core/proto"
 	"time"
 
 	"github.com/wowsims/wotlk/sim/core"
@@ -9,12 +10,13 @@ import (
 
 func (warrior *Warrior) registerThunderClapSpell() {
 	cost := 20.0 - float64(warrior.Talents.FocusedRage) - []float64{0, 1, 2, 4}[warrior.Talents.ImprovedThunderClap]
+	cost -= core.TernaryFloat64(warrior.HasMajorGlyph(proto.WarriorMajorGlyph_GlyphOfResonatingPower), 5, 0)
 	impTCDamageMult := []float64{1.0, 1.1, 1.2, 1.3}[warrior.Talents.ImprovedThunderClap]
 
 	warrior.ThunderClapAura = core.ThunderClapAura(warrior.CurrentTarget, warrior.Talents.ImprovedThunderClap)
 
 	baseEffect := core.SpellEffect{
-		ProcMask:         core.ProcMaskSpellDamage,
+		ProcMask:         core.ProcMaskRangedSpecial,
 		DamageMultiplier: impTCDamageMult,
 		ThreatMultiplier: 1.85,
 		BonusCritRating:  float64(warrior.Talents.Incite) * 5 * core.CritRatingPerCritChance,
@@ -24,7 +26,7 @@ func (warrior *Warrior) registerThunderClapSpell() {
 			},
 			TargetSpellCoefficient: 1,
 		},
-		OutcomeApplier: warrior.OutcomeFuncRangedHitAndCrit(warrior.critMultiplier(true)),
+		OutcomeApplier: warrior.OutcomeFuncRangedHitAndCrit(warrior.critMultiplier(none)),
 		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 			if spellEffect.Landed() {
 				core.ThunderClapAura(spellEffect.Target, warrior.Talents.ImprovedThunderClap).Activate(sim)

--- a/sim/warrior/whirlwind.go
+++ b/sim/warrior/whirlwind.go
@@ -12,25 +12,25 @@ func (warrior *Warrior) registerWhirlwindSpell() {
 	cost := 25.0 - float64(warrior.Talents.FocusedRage)
 	cd := core.TernaryDuration(warrior.HasMajorGlyph(proto.WarriorMajorGlyph_GlyphOfWhirlwind), time.Second*8, time.Second*10)
 
+	dm := 1 + 0.02*float64(warrior.Talents.UnendingFury) + 0.1*float64(warrior.Talents.ImprovedWhirlwind)
+
 	baseEffectMH := core.SpellEffect{
 		ProcMask: core.ProcMaskMeleeMHSpecial,
 
-		DamageMultiplier: 1 + 0.02*float64(warrior.Talents.UnendingFury),
+		DamageMultiplier: dm,
 		ThreatMultiplier: 1.25,
 
 		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 0, 1, 1, true),
-		OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(true)),
+		OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(mh)),
 	}
 	baseEffectOH := core.SpellEffect{
 		ProcMask: core.ProcMaskMeleeOHSpecial,
 
-		DamageMultiplier: 1 *
-			(1 + 0.02*float64(warrior.Talents.UnendingFury)) *
-			(1 + 0.1*float64(warrior.Talents.ImprovedWhirlwind)),
+		DamageMultiplier: dm,
 		ThreatMultiplier: 1.25,
 
-		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, 1+0.05*float64(warrior.Talents.DualWieldSpecialization), 1, true),
-		OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(true)),
+		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, 1, 1+0.05*float64(warrior.Talents.DualWieldSpecialization), true),
+		OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(oh)),
 	}
 
 	numHits := core.MinInt32(4, warrior.Env.GetNumTargets())


### PR DESCRIPTION
- update test presets so that core abilities are actually used (MS for arms, WW and BT for fury)

- fixed PoleaxeSpecialization to apply as a primary ("crit multiplier"), not a secondary ("crit damage bonus") crit modifier (i.e. auto/impale crits are now 210% / 243%, up from 205% / 235%)
- fixed PoleaxeSpecialization to correctly work with offhand abilities (for WW and Bladestorm), or abilities non affected by weapon type (Thunder Clap, and presumably Shockwave)
- fixed Improved Whirlwind not applying to main hand, and Dual Wield Specialization not applying to bonus damage (very minor)
- fixed Improved Mortal Strike to apply 3% / 6% / 10% instead of only 1% / 2% / 3%, and fixed Mortal Strike's "flatDamage" from 80 to 380
- fixed Overpower's "flatDamage" from 35 to 0
- fixed Devastate to not use bonus damage (very minor)
- fixed a few SpellIDs, and changed some damage multipliers from multiplicative to additive stacking (when using the same "Apply Aura" category, e.g. Improved Whirlwind and Unending Fury)