### PR TITLE
Threat of Thassarian

### DIFF
--- a/sim/deathknight/blood_strike.go
+++ b/sim/deathknight/blood_strike.go
@@ -10,7 +10,7 @@ var BloodStrikeActionID = core.ActionID{SpellID: 49930}
 func (dk *Deathknight) newBloodStrikeSpell(isMH bool, onhit func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect)) *RuneSpell {
 	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 764.0, 1.0, 0.4, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 764.0, dk.nervesOfColdSteelBonus(), 0.4, true)
+		weaponBaseDamage = dk.offhandDamageCalculator(764.0, 0.4)
 	}
 
 	diseaseMulti := dk.dkDiseaseMultiplier(0.125)
@@ -40,7 +40,7 @@ func (dk *Deathknight) newBloodStrikeSpell(isMH bool, onhit func(sim *core.Simul
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(effect),
 	}
 	rs := &RuneSpell{}
-	if isMH { // offhand doesnt need GCD
+	if isMH { // offhand doesn't need GCD
 		conf.ResourceType = stats.RunicPower
 		conf.BaseCost = float64(core.NewRuneCost(10, 1, 0, 0, 0))
 		conf.Cast = core.CastConfig{
@@ -73,9 +73,7 @@ func (dk *Deathknight) newBloodStrikeSpell(isMH bool, onhit func(sim *core.Simul
 
 func (dk *Deathknight) registerBloodStrikeSpell() {
 	dk.BloodStrikeMhHit = dk.newBloodStrikeSpell(true, func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-		if dk.Talents.ThreatOfThassarian > 0 && dk.GetOHWeapon() != nil && dk.threatOfThassarianWillProc(sim) {
-			dk.BloodStrikeOhHit.Cast(sim, spellEffect.Target)
-		}
+		dk.threatOfThassarianProc(sim, spellEffect, dk.BloodStrikeOhHit)
 		dk.LastOutcome = spellEffect.Outcome
 
 		if spellEffect.Outcome.Matches(core.OutcomeLanded) {

--- a/sim/deathknight/death_strike.go
+++ b/sim/deathknight/death_strike.go
@@ -13,7 +13,7 @@ func (dk *Deathknight) newDeathStrikeSpell(isMH bool, onhit func(sim *core.Simul
 	bonusBaseDamage := dk.sigilOfAwarenessBonus(dk.DeathStrike)
 	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 297.0+bonusBaseDamage, 1.0, 0.75, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 297.0+bonusBaseDamage, dk.nervesOfColdSteelBonus(), 0.75, true)
+		weaponBaseDamage = dk.offhandDamageCalculator(297.0+bonusBaseDamage, 0.75)
 	}
 
 	hasGlyph := dk.HasMajorGlyph(proto.DeathknightMajorGlyph_GlyphOfDeathStrike)
@@ -92,7 +92,7 @@ func (dk *Deathknight) registerDeathStrikeSpell() {
 			dk.DeathStrikeHeals = append(dk.DeathStrikeHeals, healingAmount)
 		}
 
-		dk.threatOfThassarianProc(sim, spellEffect, dk.DeathStrikeMhHit, dk.DeathStrikeOhHit)
+		dk.threatOfThassarianProc(sim, spellEffect, dk.DeathStrikeOhHit)
 	})
 	dk.DeathStrike = dk.DeathStrikeMhHit
 }

--- a/sim/deathknight/deathknight.go
+++ b/sim/deathknight/deathknight.go
@@ -265,6 +265,13 @@ func (dk *Deathknight) Initialize() {
 	dk.registerDeathPactSpell()
 }
 
+func (dk *Deathknight) offhandDamageCalculator(flatBonus float64, baseMultiplier float64) core.BaseDamageCalculator {
+	return func(sim *core.Simulation, hitEffect *core.SpellEffect, spell *core.Spell) float64 {
+		nwd := spell.Unit.AutoAttacks.OH.CalculateNormalizedWeaponDamage(sim, hitEffect.MeleeAttackPower(spell.Unit))
+		return (nwd + flatBonus) * baseMultiplier * 0.5 * dk.nervesOfColdSteelBonus()
+	}
+}
+
 func (dk *Deathknight) ResetBonusCoeffs() {
 	dk.bonusCoeffs = DeathknightCoeffs{
 		glacierRotBonusCoeff:      1.0,

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -52,623 +52,623 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7745.91854
-  tps: 4595.45403
+  dps: 7486.04293
+  tps: 4439.52866
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7750.36356
-  tps: 4607.10715
+  dps: 7481.23537
+  tps: 4445.63023
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7768.68313
-  tps: 4609.0876
+  dps: 7508.07045
+  tps: 4452.71999
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7544.27632
-  tps: 4468.8442
+  dps: 7283.45949
+  tps: 4312.3541
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7740.08221
-  tps: 4500.0885
+  dps: 7480.2066
+  tps: 4347.28164
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7957.55998
-  tps: 4722.91574
+  dps: 7689.03074
+  tps: 4561.7982
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7645.05395
-  tps: 4542.70556
+  dps: 7372.8851
+  tps: 4379.40425
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7740.86194
-  tps: 4603.35406
+  dps: 7467.2342
+  tps: 4439.17742
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 7832.31244
-  tps: 4649.20034
+  dps: 7561.63626
+  tps: 4486.79463
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7765.64342
-  tps: 4609.18005
+  dps: 7497.28423
+  tps: 4448.16454
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7278.42841
-  tps: 4318.22876
+  dps: 7018.21145
+  tps: 4162.09858
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 6400.50193
-  tps: 3793.35154
+  dps: 6168.94053
+  tps: 3654.4147
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7589.27137
-  tps: 4501.94698
+  dps: 7388.89784
+  tps: 4381.72286
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7564.33099
-  tps: 4494.3528
+  dps: 7295.97179
+  tps: 4333.33729
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7770.62212
-  tps: 4610.25099
+  dps: 7510.00945
+  tps: 4453.88339
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7740.08221
-  tps: 4591.92704
+  dps: 7480.2066
+  tps: 4436.00167
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7740.08221
-  tps: 4591.92704
+  dps: 7480.2066
+  tps: 4436.00167
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7768.68313
-  tps: 4609.0876
+  dps: 7508.07045
+  tps: 4452.71999
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7762.01305
-  tps: 4605.08555
+  dps: 7501.5608
+  tps: 4448.81419
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7740.08221
-  tps: 4591.92704
+  dps: 7480.2066
+  tps: 4436.00167
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7789.71164
-  tps: 4627.62945
+  dps: 7513.47127
+  tps: 4461.88523
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7627.13106
-  tps: 4532.75906
+  dps: 7355.83316
+  tps: 4369.98032
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7611.23518
-  tps: 4523.32249
+  dps: 7340.559
+  tps: 4360.91678
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7740.08221
-  tps: 4591.92704
+  dps: 7480.2066
+  tps: 4436.00167
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7740.08221
-  tps: 4591.92704
+  dps: 7480.2066
+  tps: 4436.00167
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7589.95155
-  tps: 4502.35509
+  dps: 7389.57803
+  tps: 4382.13098
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7778.20158
-  tps: 4622.74645
+  dps: 7509.84239
+  tps: 4461.73094
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7545.41111
-  tps: 4482.91986
+  dps: 7277.05192
+  tps: 4321.90434
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7588.04259
-  tps: 4501.20971
+  dps: 7387.66907
+  tps: 4380.9856
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7545.41111
-  tps: 4482.91986
+  dps: 7277.05192
+  tps: 4321.90434
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7768.68313
-  tps: 4609.0876
+  dps: 7508.07045
+  tps: 4452.71999
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7762.01305
-  tps: 4605.08555
+  dps: 7501.5608
+  tps: 4448.81419
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7671.85774
-  tps: 4561.07024
+  dps: 7402.84218
+  tps: 4399.66091
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7740.08221
-  tps: 4591.92704
+  dps: 7480.2066
+  tps: 4436.00167
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7770.27693
-  tps: 4610.18547
+  dps: 7510.40132
+  tps: 4454.2601
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7545.41111
-  tps: 4482.91986
+  dps: 7277.05192
+  tps: 4321.90434
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7545.41111
-  tps: 4482.91986
+  dps: 7277.05192
+  tps: 4321.90434
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7761.99819
-  tps: 4609.99692
+  dps: 7491.43275
+  tps: 4447.65766
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7557.65338
-  tps: 4490.31765
+  dps: 7289.29419
+  tps: 4329.30213
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7764.52555
-  tps: 4606.70767
+  dps: 7504.64994
+  tps: 4450.78231
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7770.27693
-  tps: 4610.18547
+  dps: 7510.40132
+  tps: 4454.2601
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7740.08221
-  tps: 4591.92704
+  dps: 7480.2066
+  tps: 4436.00167
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7740.08221
-  tps: 4591.92704
+  dps: 7480.2066
+  tps: 4436.00167
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7545.41111
-  tps: 4482.91986
+  dps: 7277.05192
+  tps: 4321.90434
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7897.44237
-  tps: 4688.492
+  dps: 7631.08341
+  tps: 4528.67662
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7935.61798
-  tps: 4711.39737
+  dps: 7669.25902
+  tps: 4551.58199
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7950.38075
-  tps: 4718.61261
+  dps: 7682.02156
+  tps: 4557.59709
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7590.74511
-  tps: 4502.83122
+  dps: 7390.37158
+  tps: 4382.60711
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7740.08221
-  tps: 4591.92704
+  dps: 7480.2066
+  tps: 4436.00167
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7545.41111
-  tps: 4482.91986
+  dps: 7277.05192
+  tps: 4321.90434
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6976.17428
-  tps: 4138.00664
+  dps: 6720.03286
+  tps: 3984.32179
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 6343.45833
-  tps: 3763.82651
+  dps: 6110.54609
+  tps: 3624.07916
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8364.1228
-  tps: 4967.41794
+  dps: 8073.80603
+  tps: 4793.22788
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6858.34459
-  tps: 4072.63595
+  dps: 6628.81582
+  tps: 3934.91869
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7564.04861
-  tps: 4494.40937
+  dps: 7295.68942
+  tps: 4333.39386
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7545.41111
-  tps: 4482.91986
+  dps: 7277.05192
+  tps: 4321.90434
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7596.78693
-  tps: 4506.45632
+  dps: 7396.14619
+  tps: 4386.07187
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7984.35917
-  tps: 4736.1243
+  dps: 7783.98565
+  tps: 4615.90018
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 8016.45205
-  tps: 4756.71473
+  dps: 7816.07852
+  tps: 4636.49062
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7545.41111
-  tps: 4482.91986
+  dps: 7277.05192
+  tps: 4321.90434
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 7626.58448
-  tps: 4526.13707
+  dps: 7357.32134
+  tps: 4364.57919
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StormshroudArmor"
  value: {
-  dps: 6118.63455
-  tps: 3630.39313
+  dps: 5873.63729
+  tps: 3483.39478
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7770.27693
-  tps: 4610.18547
+  dps: 7510.40132
+  tps: 4454.2601
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7764.52555
-  tps: 4606.70767
+  dps: 7504.64994
+  tps: 4450.78231
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7754.46065
-  tps: 4600.62153
+  dps: 7494.58504
+  tps: 4444.69616
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7673.29223
-  tps: 4547.68201
+  dps: 7420.38718
+  tps: 4395.93898
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6521.94644
-  tps: 3866.72536
+  dps: 6289.32012
+  tps: 3727.14957
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7842.6843
-  tps: 4649.68417
+  dps: 7576.85913
+  tps: 4490.18907
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7811.02004
-  tps: 4639.792
+  dps: 7536.87454
+  tps: 4475.3047
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7773.54507
-  tps: 4618.92994
+  dps: 7505.3562
+  tps: 4458.01662
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7740.08221
-  tps: 4591.92704
+  dps: 7480.2066
+  tps: 4436.00167
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7740.08221
-  tps: 4591.92704
+  dps: 7480.2066
+  tps: 4436.00167
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7740.08221
-  tps: 4591.92704
+  dps: 7480.2066
+  tps: 4436.00167
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7740.08221
-  tps: 4591.92704
+  dps: 7480.2066
+  tps: 4436.00167
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7591.65202
-  tps: 4503.37537
+  dps: 7391.2785
+  tps: 4383.15126
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 7924.0114
-  tps: 4699.52973
+  dps: 7655.29919
+  tps: 4538.30241
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11079.88612
-  tps: 6989.24731
+  dps: 10913.79071
+  tps: 6889.59007
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5799.60897
-  tps: 3831.58254
+  dps: 5630.18777
+  tps: 3729.92982
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6581.86946
-  tps: 4092.27982
+  dps: 6420.02369
+  tps: 3995.17236
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7076.51579
-  tps: 4469.07944
+  dps: 6944.44892
+  tps: 4389.83931
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3418.47563
-  tps: 2274.24403
+  dps: 3287.99295
+  tps: 2195.95442
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3667.38033
-  tps: 2333.05558
+  dps: 3541.7325
+  tps: 2257.66689
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11362.33316
-  tps: 7172.09779
+  dps: 11188.89467
+  tps: 7068.0347
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5858.83947
-  tps: 3855.25196
+  dps: 5690.41678
+  tps: 3754.19835
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6560.94892
-  tps: 4055.23007
+  dps: 6400.97237
+  tps: 3959.24414
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7099.85783
-  tps: 4464.18635
+  dps: 6969.23855
+  tps: 4385.81478
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3385.4259
-  tps: 2247.36789
+  dps: 3256.6348
+  tps: 2170.09323
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3673.43017
-  tps: 2325.71112
+  dps: 3548.42041
+  tps: 2250.70526
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7613.33801
-  tps: 4520.9984
+  dps: 7332.27231
+  tps: 4352.35898
  }
 }

--- a/sim/deathknight/frost_strike.go
+++ b/sim/deathknight/frost_strike.go
@@ -12,7 +12,7 @@ func (dk *Deathknight) newFrostStrikeHitSpell(isMH bool, onhit func(sim *core.Si
 	baseDamage := 250.0 + dk.sigilOfTheVengefulHeartFrostStrike()
 	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, baseDamage, 1.0, 0.55, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, baseDamage, dk.nervesOfColdSteelBonus(), 0.55, true)
+		weaponBaseDamage = dk.offhandDamageCalculator(baseDamage, 0.55)
 	}
 
 	effect := core.SpellEffect{
@@ -74,7 +74,7 @@ func (dk *Deathknight) newFrostStrikeHitSpell(isMH bool, onhit func(sim *core.Si
 func (dk *Deathknight) registerFrostStrikeSpell() {
 	dk.FrostStrikeMhHit = dk.newFrostStrikeHitSpell(true, func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 		dk.LastOutcome = spellEffect.Outcome
-		dk.threatOfThassarianProc(sim, spellEffect, dk.FrostStrikeMhHit, dk.FrostStrikeOhHit)
+		dk.threatOfThassarianProc(sim, spellEffect, dk.FrostStrikeOhHit)
 
 		// KM Consume after OH
 		if spellEffect.Landed() && dk.KillingMachineAura.IsActive() {

--- a/sim/deathknight/obliterate.go
+++ b/sim/deathknight/obliterate.go
@@ -13,7 +13,7 @@ func (dk *Deathknight) newObliterateHitSpell(isMH bool, onhit func(sim *core.Sim
 	bonusBaseDamage := dk.sigilOfAwarenessBonus(dk.Obliterate)
 	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 584.0+bonusBaseDamage, 1.0, 0.8, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 584.0+bonusBaseDamage, dk.nervesOfColdSteelBonus(), 0.8, true)
+		weaponBaseDamage = dk.offhandDamageCalculator(584.0+bonusBaseDamage, 0.8)
 	}
 
 	diseaseMulti := dk.dkDiseaseMultiplier(0.125)
@@ -85,7 +85,7 @@ func (dk *Deathknight) registerObliterateSpell() {
 
 	dk.ObliterateMhHit = dk.newObliterateHitSpell(true, func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 		dk.LastOutcome = spellEffect.Outcome
-		dk.threatOfThassarianProc(sim, spellEffect, dk.ObliterateMhHit, dk.ObliterateOhHit)
+		dk.threatOfThassarianProc(sim, spellEffect, dk.ObliterateOhHit)
 
 		if sim.RandomFloat("Annihilation") < diseaseConsumptionChance {
 			dk.FrostFeverDisease[spellEffect.Target.Index].Deactivate(sim)

--- a/sim/deathknight/plague_strike.go
+++ b/sim/deathknight/plague_strike.go
@@ -11,7 +11,7 @@ var PlagueStrikeActionID = core.ActionID{SpellID: 49921}
 func (dk *Deathknight) newPlagueStrikeSpell(isMH bool, onhit func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect)) *RuneSpell {
 	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 378.0, 1.0, 0.5, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 378.0, dk.nervesOfColdSteelBonus(), 0.5, true)
+		weaponBaseDamage = dk.offhandDamageCalculator(378.0, 0.5)
 	}
 
 	outbreakBonus := 1.0 + 0.1*float64(dk.Talents.Outbreak)
@@ -71,9 +71,7 @@ func (dk *Deathknight) newPlagueStrikeSpell(isMH bool, onhit func(sim *core.Simu
 
 func (dk *Deathknight) registerPlagueStrikeSpell() {
 	dk.PlagueStrikeMhHit = dk.newPlagueStrikeSpell(true, func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-		if dk.Talents.ThreatOfThassarian > 0 && dk.GetOHWeapon() != nil && dk.threatOfThassarianWillProc(sim) {
-			dk.PlagueStrikeOhHit.Cast(sim, spellEffect.Target)
-		}
+		dk.threatOfThassarianProc(sim, spellEffect, dk.PlagueStrikeOhHit)
 		dk.LastOutcome = spellEffect.Outcome
 		if spellEffect.Landed() {
 			dk.BloodPlagueExtended[spellEffect.Target.Index] = 0

--- a/sim/deathknight/talents_frost.go
+++ b/sim/deathknight/talents_frost.go
@@ -197,7 +197,7 @@ func (dk *Deathknight) applyIcyTalons() {
 	icyTalonsCoeff := 1.0 + 0.04*float64(dk.Talents.IcyTalons)
 
 	dk.IcyTalonsAura = dk.RegisterAura(core.Aura{
-		ActionID: core.ActionID{SpellID: 50887}, // This probably doesnt need to be in metrics.
+		ActionID: core.ActionID{SpellID: 50887}, // This probably doesn't need to be in metrics.
 		Label:    "Icy Talons",
 		Duration: time.Second * 20.0,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
@@ -217,10 +217,6 @@ func (dk *Deathknight) applyThreatOfThassarian() {
 	dk.bonusCoeffs.threatOfThassarianChance = []float64{0.0, 0.3, 0.6, 1.0}[dk.Talents.ThreatOfThassarian]
 }
 
-func (dk *Deathknight) threatOfThassarianWillProc(sim *core.Simulation) bool {
-	return sim.RandomFloat("Threat of Thassarian") <= dk.bonusCoeffs.threatOfThassarianChance
-}
-
 func (dk *Deathknight) threatOfThassarianProcMasks(isMH bool, effect *core.SpellEffect, isGuileOfGorefiendStrike bool, isMightOfMograineStrike bool, wrapper func(outcomeApplier core.OutcomeApplier) core.OutcomeApplier) {
 	critMultiplier := dk.critMultiplier()
 	if isGuileOfGorefiendStrike || isMightOfMograineStrike {
@@ -236,8 +232,19 @@ func (dk *Deathknight) threatOfThassarianProcMasks(isMH bool, effect *core.Spell
 	}
 }
 
-func (dk *Deathknight) threatOfThassarianProc(sim *core.Simulation, spellEffect *core.SpellEffect, mhSpell *RuneSpell, ohSpell *RuneSpell) {
-	if dk.Talents.ThreatOfThassarian > 0 && dk.GetOHWeapon() != nil && dk.threatOfThassarianWillProc(sim) {
+func (dk *Deathknight) threatOfThassarianProc(sim *core.Simulation, spellEffect *core.SpellEffect, ohSpell *RuneSpell) {
+	if dk.threatOfThassarianWillProc(sim) && dk.GetOHWeapon() != nil {
 		ohSpell.Cast(sim, spellEffect.Target)
+	}
+}
+
+func (dk *Deathknight) threatOfThassarianWillProc(sim *core.Simulation) bool {
+	switch dk.Talents.ThreatOfThassarian {
+	case 0:
+		return false
+	case 3:
+		return true
+	default:
+		return sim.RandomFloat("Threat of Thassarian") < dk.bonusCoeffs.threatOfThassarianChance
 	}
 }


### PR DESCRIPTION
[deathknight] fixed all offhand strikes triggered by Threat of Thassarian to use the correct damage formula, reducing the impact of the "flatModifier" by up to 50%, plus minor refactoring

This was tested on the current PTR, with a level 70 toon. ToT essentially adds an OH swing that's dealing 50% (or 62.5%, with Nerves of Cold Steel) damage, after all other multipliers.

E.g. an Obliterate OH swing is currently calculated to deal

(NWD * 0.5 * 1.25 + 584) * 0.8

damage, but should only deal

(NWD * 0.5 * 1.25 + 584 * 0.5 * 1.25) * 0.8

damage (~175 less).