### PR TITLE
Rage Generation Fixes

### DIFF
--- a/sim/core/rage.go
+++ b/sim/core/rage.go
@@ -22,7 +22,14 @@ type rageBar struct {
 	RageRefundMetrics *ResourceMetrics
 }
 
-func (unit *Unit) EnableRageBar(startingRage float64, rageMultiplier float64, onRageGain OnRageGain) {
+type RageBarOptions struct {
+	StartingRage   float64
+	RageMultiplier float64
+	MHSwingSpeed   float64
+	OHSwingSpeed   float64
+}
+
+func (unit *Unit) EnableRageBar(options RageBarOptions, onRageGain OnRageGain) {
 	rageFromDamageTakenMetrics := unit.NewRageMetrics(ActionID{OtherID: proto.OtherAction_OtherActionDamageTaken})
 
 	unit.RegisterAura(Aura{
@@ -44,16 +51,18 @@ func (unit *Unit) EnableRageBar(startingRage float64, rageMultiplier float64, on
 				return
 			}
 
-			var HitFactor float64
-
+			var hitFactor float64
+			var speed float64
 			if spellEffect.IsMH() {
-				HitFactor = 3.5
+				hitFactor = 3.5
+				speed = options.MHSwingSpeed
 			} else {
-				HitFactor = 1.75
+				hitFactor = 1.75
+				speed = options.OHSwingSpeed
 			}
 
 			if spellEffect.Outcome.Matches(OutcomeCrit) {
-				HitFactor *= 2
+				hitFactor *= 2
 			}
 
 			damage := spellEffect.Damage
@@ -62,9 +71,10 @@ func (unit *Unit) EnableRageBar(startingRage float64, rageMultiplier float64, on
 				damage = spellEffect.PreoutcomeDamage
 			}
 
-			generatedRage := MinFloat((damage*7.5/RageFactor+HitFactor)/2, damage*15/RageFactor)
-			// In practice this cap isn't reached so no need to compute it.
-			//generatedRage = MinFloat(generatedRage, damage * (15/RageFactor))
+			// generatedRage is capped for very low damage swings
+			generatedRage := MinFloat((damage*7.5/RageFactor+hitFactor*speed)/2, damage*15/RageFactor)
+
+			generatedRage *= options.RageMultiplier
 
 			if spell.ResourceMetrics == nil {
 				spell.ResourceMetrics = spell.Unit.NewRageMetrics(spell.ActionID)
@@ -84,7 +94,7 @@ func (unit *Unit) EnableRageBar(startingRage float64, rageMultiplier float64, on
 
 	unit.rageBar = rageBar{
 		unit:         unit,
-		startingRage: MaxFloat(0, MinFloat(startingRage, MaxRage)),
+		startingRage: MaxFloat(0, MinFloat(options.StartingRage, MaxRage)),
 		onRageGain:   onRageGain,
 
 		RageRefundMetrics: unit.NewRageMetrics(ActionID{OtherID: proto.OtherAction_OtherActionRefund}),

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -48,7 +48,8 @@ func NewFeralDruid(character core.Character, options proto.Player) *FeralDruid {
 
 	cat.EnableEnergyBar(100.0, cat.OnEnergyGain)
 
-	cat.EnableRageBar(0.0, 1.0, func(sim *core.Simulation) {})
+	// CHECK changing RageBarOptions affects cat dps, which sounds very fishy
+	cat.EnableRageBar(core.RageBarOptions{RageMultiplier: 1, MHSwingSpeed: 1}, func(sim *core.Simulation) {})
 
 	cat.EnableAutoAttacks(cat, core.AutoAttackOptions{
 		// Base paw weapon.

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -59,11 +59,10 @@ func (druid *Druid) PowerShiftCat(sim *core.Simulation) bool {
 
 // Handles things that function for *both* cat/bear
 func (druid *Druid) applyFeralShift(sim *core.Simulation, enter_form bool) {
-	weap := druid.GetMHWeapon()
 	pos := core.TernaryFloat64(enter_form, 1.0, -1.0)
 	fap := 0.0
-	if weap != nil {
-		dps := (((weap.WeaponDamageMax - weap.WeaponDamageMin) / 2.0) + weap.WeaponDamageMin) / weap.SwingSpeed
+	if weapon := druid.GetMHWeapon(); weapon != nil {
+		dps := (weapon.WeaponDamageMax + weapon.WeaponDamageMin) / 2.0 / weapon.SwingSpeed
 		fap = math.Floor((dps - 54.8) * 14)
 	}
 	druid.AddStatDynamic(sim, stats.AttackPower, pos*fap)

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -52,618 +52,618 @@ character_stats_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 803.81586
-  tps: 1100.5135
+  dps: 891.98384
+  tps: 1220.67547
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 798.57948
-  tps: 1092.60093
+  dps: 862.4168
+  tps: 1178.54117
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 843.91059
-  tps: 1154.78492
+  dps: 919.86249
+  tps: 1259.92021
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 803.3468
-  tps: 1107.86757
+  dps: 874.24906
+  tps: 1201.72336
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 798.57948
-  tps: 1070.86008
+  dps: 862.4168
+  tps: 1155.08943
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 802.49916
-  tps: 1101.51513
+  dps: 874.31637
+  tps: 1193.73729
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 818.61026
-  tps: 1115.90427
+  dps: 887.37111
+  tps: 1214.87913
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 845.96621
-  tps: 1157.18904
+  dps: 923.72739
+  tps: 1267.45468
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 848.13769
-  tps: 1164.48823
+  dps: 914.51511
+  tps: 1249.45184
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 840.92567
-  tps: 1147.68182
+  dps: 888.86122
+  tps: 1217.19062
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 805.14053
-  tps: 1096.07002
+  dps: 883.75213
+  tps: 1216.78951
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 803.87354
-  tps: 1098.62355
+  dps: 886.24218
+  tps: 1216.23112
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 802.00837
-  tps: 1107.40336
+  dps: 856.13277
+  tps: 1172.8858
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 800.68933
-  tps: 1103.39796
+  dps: 878.93964
+  tps: 1199.61092
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 914.73501
-  tps: 1234.02077
+  dps: 982.85137
+  tps: 1325.36986
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerGarb"
  value: {
-  dps: 693.26487
-  tps: 925.26528
+  dps: 760.61101
+  tps: 1012.91782
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 798.57948
-  tps: 1092.60093
+  dps: 862.4168
+  tps: 1178.54117
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 798.57948
-  tps: 1092.60093
+  dps: 862.4168
+  tps: 1178.54117
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 803.3468
-  tps: 1107.86757
+  dps: 874.24906
+  tps: 1201.72336
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 805.15447
-  tps: 1110.69409
+  dps: 873.77315
+  tps: 1193.68942
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 798.57948
-  tps: 1092.60093
+  dps: 862.4168
+  tps: 1178.54117
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 826.6528
-  tps: 1131.01664
+  dps: 911.50484
+  tps: 1250.316
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 821.78085
-  tps: 1123.72484
+  dps: 884.73437
+  tps: 1207.80579
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 805.3826
-  tps: 1098.7903
+  dps: 880.28642
+  tps: 1203.12695
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 798.57948
-  tps: 1092.60093
+  dps: 862.4168
+  tps: 1178.54117
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 798.57948
-  tps: 1092.60093
+  dps: 862.4168
+  tps: 1178.54117
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 833.28006
-  tps: 1139.30804
+  dps: 913.68939
+  tps: 1249.83725
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 802.00837
-  tps: 1107.40336
+  dps: 856.13277
+  tps: 1172.8858
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 1055.86574
-  tps: 1434.24139
+  dps: 1136.35762
+  tps: 1543.41071
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 741.88729
-  tps: 995.96099
+  dps: 828.63066
+  tps: 1111.07978
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 804.87019
-  tps: 1102.67935
+  dps: 867.82794
+  tps: 1186.38758
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 799.97046
-  tps: 1098.79842
+  dps: 877.35729
+  tps: 1194.5856
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 792.22772
-  tps: 1078.25949
+  dps: 860.73512
+  tps: 1179.85266
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 800.24294
-  tps: 1095.59664
+  dps: 873.23039
+  tps: 1193.26991
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 802.00837
-  tps: 1107.40336
+  dps: 856.13277
+  tps: 1172.8858
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 803.3468
-  tps: 1107.86757
+  dps: 874.24906
+  tps: 1201.72336
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 805.15447
-  tps: 1110.69409
+  dps: 873.77315
+  tps: 1193.68942
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 827.90374
-  tps: 1136.68103
+  dps: 898.07391
+  tps: 1229.3244
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 798.57948
-  tps: 1092.60093
+  dps: 862.4168
+  tps: 1178.54117
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 795.41872
-  tps: 1090.32547
+  dps: 881.29391
+  tps: 1203.26021
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 1166.17656
-  tps: 1549.19893
+  dps: 1267.78017
+  tps: 1691.64126
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveRegalia"
  value: {
-  dps: 838.11842
-  tps: 1129.88151
+  dps: 921.59045
+  tps: 1235.22895
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 802.00837
-  tps: 1107.40336
+  dps: 856.13277
+  tps: 1172.8858
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 802.00837
-  tps: 1107.40336
+  dps: 856.13277
+  tps: 1172.8858
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 1076.28176
-  tps: 1458.32859
+  dps: 1158.88676
+  tps: 1567.10551
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 766.09405
-  tps: 1030.45819
+  dps: 832.16067
+  tps: 1120.38254
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 840.92857
-  tps: 1153.59531
+  dps: 900.6703
+  tps: 1236.70876
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NightsongBattlegear"
  value: {
-  dps: 944.91083
-  tps: 1272.90223
+  dps: 1035.42436
+  tps: 1405.15401
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NightsongGarb"
  value: {
-  dps: 724.8167
-  tps: 976.21529
+  dps: 795.76666
+  tps: 1062.44217
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 802.00837
-  tps: 1107.40336
+  dps: 856.13277
+  tps: 1172.8858
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 796.78074
-  tps: 1092.1271
+  dps: 873.17949
+  tps: 1193.52074
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 795.41872
-  tps: 1090.32547
+  dps: 881.29391
+  tps: 1203.26021
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 798.57948
-  tps: 1092.60093
+  dps: 862.4168
+  tps: 1178.54117
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 798.57948
-  tps: 1092.60093
+  dps: 862.4168
+  tps: 1178.54117
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 802.00837
-  tps: 1107.40336
+  dps: 856.13277
+  tps: 1172.8858
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 870.13213
-  tps: 1180.4507
+  dps: 958.95533
+  tps: 1304.07274
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 880.31773
-  tps: 1193.95681
+  dps: 970.30156
+  tps: 1319.11784
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 811.02734
-  tps: 1111.4787
+  dps: 890.44839
+  tps: 1220.6946
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 798.57948
-  tps: 1092.60093
+  dps: 862.4168
+  tps: 1178.54117
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 802.00837
-  tps: 1107.40336
+  dps: 856.13277
+  tps: 1172.8858
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Runetotem'sBattlegear"
  value: {
-  dps: 1076.28176
-  tps: 1458.32859
+  dps: 1158.88676
+  tps: 1567.10551
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Runetotem'sRegalia"
  value: {
-  dps: 766.09405
-  tps: 1030.45819
+  dps: 832.16067
+  tps: 1120.38254
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 803.98804
-  tps: 1094.65612
+  dps: 868.62108
+  tps: 1180.87346
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 802.00837
-  tps: 1107.40336
+  dps: 856.13277
+  tps: 1172.8858
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 802.00837
-  tps: 1107.40336
+  dps: 856.13277
+  tps: 1172.8858
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 802.00837
-  tps: 1107.40336
+  dps: 856.13277
+  tps: 1172.8858
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 813.92805
-  tps: 1118.7633
+  dps: 881.58674
+  tps: 1207.33883
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-StormshroudArmor"
  value: {
-  dps: 681.18152
-  tps: 909.69427
+  dps: 752.28118
+  tps: 1012.54404
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 795.41872
-  tps: 1090.32547
+  dps: 881.29391
+  tps: 1203.26021
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 796.78074
-  tps: 1092.1271
+  dps: 873.17949
+  tps: 1193.52074
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 795.67419
-  tps: 1091.62366
+  dps: 880.66958
+  tps: 1202.22539
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartHarness"
  value: {
-  dps: 776.53454
-  tps: 1046.91089
+  dps: 854.40336
+  tps: 1146.15805
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartRegalia"
  value: {
-  dps: 656.79693
-  tps: 838.45455
+  dps: 714.06537
+  tps: 912.23379
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 804.40257
-  tps: 1102.95565
+  dps: 877.27421
+  tps: 1203.3917
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 863.32333
-  tps: 1174.0947
+  dps: 941.01566
+  tps: 1290.65138
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 849.56386
-  tps: 1165.2113
+  dps: 952.60477
+  tps: 1299.05001
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 798.57948
-  tps: 1092.60093
+  dps: 862.4168
+  tps: 1178.54117
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 798.57948
-  tps: 1092.60093
+  dps: 862.4168
+  tps: 1178.54117
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 798.57948
-  tps: 1092.60093
+  dps: 862.4168
+  tps: 1178.54117
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 798.57948
-  tps: 1092.60093
+  dps: 862.4168
+  tps: 1178.54117
  }
 }
 dps_results: {
  key: "TestFeralTank-Average-Default"
  value: {
-  dps: 1080.27228
-  tps: 1491.16109
-  dtps: 821.71321
+  dps: 1133.04744
+  tps: 1573.5224
+  dtps: 821.93088
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2453.1757
-  tps: 4465.60953
+  dps: 2487.10634
+  tps: 4519.57342
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 877.37898
-  tps: 1210.59058
+  dps: 951.97784
+  tps: 1313.624
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1030.79882
-  tps: 1441.44964
+  dps: 1071.98773
+  tps: 1520.26732
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1090.57449
-  tps: 2124.72452
+  dps: 1493.09086
+  tps: 2928.00537
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 454.40089
-  tps: 640.49236
+  dps: 534.52311
+  tps: 732.27041
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 441.6653
-  tps: 639.02933
+  dps: 512.74995
+  tps: 740.10117
  }
 }
 dps_results: {
  key: "TestFeralTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1151.4555
-  tps: 1587.45268
-  dtps: 775.09176
+  dps: 1216.71709
+  tps: 1692.57814
+  dtps: 774.51275
  }
 }

--- a/sim/druid/tank/tank.go
+++ b/sim/druid/tank/tank.go
@@ -42,7 +42,13 @@ func NewFeralTankDruid(character core.Character, options proto.Player) *FeralTan
 		Options:  *tankOptions.Options,
 	}
 
-	bear.EnableRageBar(bear.Options.StartingRage, 1, func(sim *core.Simulation) {
+	rbo := core.RageBarOptions{
+		StartingRage:   bear.Options.StartingRage,
+		RageMultiplier: 1,
+		MHSwingSpeed:   2.5,
+	}
+
+	bear.EnableRageBar(rbo, func(sim *core.Simulation) {
 		if bear.GCD.IsReady(sim) {
 			bear.TryUseCooldowns(sim)
 			if bear.GCD.IsReady(sim) {

--- a/sim/paladin/sor.go
+++ b/sim/paladin/sor.go
@@ -85,7 +85,7 @@ func (paladin *Paladin) registerSealOfRighteousnessSpellAndAura() {
 						SP: 0.044,
 					}
 
-					damage := paladin.GetMHWeapon().ToProto().WeaponSpeed * ((scaling.AP * hitEffect.MeleeAttackPower(spell.Unit)) + (scaling.SP * hitEffect.SpellPower(spell.Unit, spell)))
+					damage := paladin.GetMHWeapon().SwingSpeed * ((scaling.AP * hitEffect.MeleeAttackPower(spell.Unit)) + (scaling.SP * hitEffect.SpellPower(spell.Unit, spell)))
 					return damage
 				},
 			},

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -52,581 +52,581 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 4908.61887
-  tps: 4009.48009
+  dps: 5124.38267
+  tps: 4193.01259
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5101.64102
-  tps: 4172.74082
+  dps: 5262.17341
+  tps: 4306.08165
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5051.44515
-  tps: 4121.46426
+  dps: 5231.16354
+  tps: 4277.49985
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5090.8694
-  tps: 4161.91107
+  dps: 5300.9177
+  tps: 4340.63973
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 4876.5798
-  tps: 3983.04244
+  dps: 5187.1588
+  tps: 4242.4713
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5124.00818
-  tps: 4102.67695
+  dps: 5287.33378
+  tps: 4239.2446
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 5228.27418
-  tps: 4273.56809
+  dps: 5428.30153
+  tps: 4437.75958
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5026.78869
-  tps: 4107.58391
+  dps: 5227.24302
+  tps: 4274.67864
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5023.26645
-  tps: 4102.91096
+  dps: 5299.48398
+  tps: 4331.1874
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 4988.52539
-  tps: 4075.40743
+  dps: 5225.96616
+  tps: 4275.91606
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 4885.50008
-  tps: 3991.3918
+  dps: 5134.68189
+  tps: 4201.68844
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Defender'sCode-40257"
  value: {
-  dps: 4910.63664
-  tps: 4010.40383
+  dps: 5143.9835
+  tps: 4204.42262
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5116.58906
-  tps: 4186.26109
+  dps: 5286.08431
+  tps: 4327.03264
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 4472.41881
-  tps: 3657.72884
+  dps: 4692.30469
+  tps: 3845.51632
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5124.00818
-  tps: 4186.14557
+  dps: 5287.33378
+  tps: 4325.50443
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5124.00818
-  tps: 4186.14557
+  dps: 5287.33378
+  tps: 4325.50443
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5090.8694
-  tps: 4161.91107
+  dps: 5300.9177
+  tps: 4340.63973
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5141.94561
-  tps: 4206.89013
+  dps: 5281.49118
+  tps: 4321.22326
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5124.00818
-  tps: 4186.14557
+  dps: 5287.33378
+  tps: 4325.50443
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5060.44533
-  tps: 4130.14566
+  dps: 5269.26943
+  tps: 4308.30686
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5010.89242
-  tps: 4090.01268
+  dps: 5238.12366
+  tps: 4282.25803
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5017.17903
-  tps: 4098.07626
+  dps: 5231.56063
+  tps: 4277.71505
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5124.00818
-  tps: 4186.14557
+  dps: 5287.33378
+  tps: 4325.50443
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5124.00818
-  tps: 4186.14557
+  dps: 5287.33378
+  tps: 4325.50443
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 4977.97628
-  tps: 4068.64843
+  dps: 5258.68679
+  tps: 4296.97207
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuturesightRune-38763"
  value: {
-  dps: 4875.09546
-  tps: 3982.56468
+  dps: 5107.06435
+  tps: 4179.47135
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 4927.08476
-  tps: 4019.15122
+  dps: 5148.29855
+  tps: 4204.89907
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 4885.50008
-  tps: 3991.3918
+  dps: 5134.68189
+  tps: 4201.68844
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5090.8694
-  tps: 4161.91107
+  dps: 5300.9177
+  tps: 4340.63973
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5141.94561
-  tps: 4206.89013
+  dps: 5281.49118
+  tps: 4321.22326
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5080.03582
-  tps: 4150.91468
+  dps: 5264.37903
+  tps: 4306.8364
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5124.00818
-  tps: 4186.14557
+  dps: 5287.33378
+  tps: 4325.50443
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5135.30462
-  tps: 4197.19912
+  dps: 5285.98325
+  tps: 4323.80809
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 4913.81587
-  tps: 4014.85652
+  dps: 5112.66096
+  tps: 4182.95188
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 4885.50008
-  tps: 3991.3918
+  dps: 5134.68189
+  tps: 4201.68844
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5105.42627
-  tps: 4171.13218
+  dps: 5249.78396
+  tps: 4295.68625
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 4886.63071
-  tps: 3990.49941
+  dps: 5115.55487
+  tps: 4185.27267
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtArmor"
  value: {
-  dps: 3121.08004
-  tps: 2547.04616
+  dps: 3460.88365
+  tps: 2837.66916
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 3769.0358
-  tps: 3081.57926
+  dps: 4102.8599
+  tps: 3356.37705
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5079.51678
-  tps: 4153.82271
+  dps: 5270.58523
+  tps: 4315.42893
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5135.30462
-  tps: 4197.19912
+  dps: 5285.98325
+  tps: 4323.80809
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5124.00818
-  tps: 4186.14557
+  dps: 5287.33378
+  tps: 4325.50443
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5124.00818
-  tps: 4186.14557
+  dps: 5287.33378
+  tps: 4325.50443
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 4885.50008
-  tps: 3991.3918
+  dps: 5134.68189
+  tps: 4201.68844
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 5116.67611
-  tps: 4180.224
+  dps: 5321.95465
+  tps: 4352.3651
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 5141.96409
-  tps: 4200.45438
+  dps: 5347.37095
+  tps: 4372.69814
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5196.92675
-  tps: 4244.94502
+  dps: 5427.49143
+  tps: 4437.18644
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5124.00818
-  tps: 4186.14557
+  dps: 5287.33378
+  tps: 4325.50443
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 4913.81587
-  tps: 4014.85652
+  dps: 5112.66096
+  tps: 4182.95188
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 4923.70189
-  tps: 4022.86209
+  dps: 5114.44746
+  tps: 4183.64297
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 4885.50008
-  tps: 3991.3918
+  dps: 5134.68189
+  tps: 4201.68844
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 4528.67237
-  tps: 3703.7859
+  dps: 4820.0366
+  tps: 3939.05796
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 4875.12455
-  tps: 3982.58214
+  dps: 5107.07294
+  tps: 4179.47994
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SparkofLife-37657"
  value: {
-  dps: 5003.7613
-  tps: 4086.38382
+  dps: 5175.32724
+  tps: 4233.33603
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StormshroudArmor"
  value: {
-  dps: 3866.6583
-  tps: 3161.50917
+  dps: 4157.32223
+  tps: 3402.75679
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5135.30462
-  tps: 4197.19912
+  dps: 5285.98325
+  tps: 4323.80809
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5079.51678
-  tps: 4153.82271
+  dps: 5270.58523
+  tps: 4315.42893
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5056.15219
-  tps: 4136.5082
+  dps: 5276.84646
+  tps: 4317.18291
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheFistsofFury"
  value: {
-  dps: 2505.1755
-  tps: 2109.89321
+  dps: 2677.61988
+  tps: 2254.69478
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 2672.71673
-  tps: 2245.36168
+  dps: 2906.81952
+  tps: 2442.39933
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5115.96467
-  tps: 4184.94744
+  dps: 5291.34545
+  tps: 4329.92965
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5198.38466
-  tps: 4242.19722
+  dps: 5455.40757
+  tps: 4465.21145
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5252.32178
-  tps: 4293.83508
+  dps: 5472.48825
+  tps: 4476.08049
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5124.00818
-  tps: 4186.14557
+  dps: 5287.33378
+  tps: 4325.50443
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5124.00818
-  tps: 4186.14557
+  dps: 5287.33378
+  tps: 4325.50443
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5124.00818
-  tps: 4186.14557
+  dps: 5287.33378
+  tps: 4325.50443
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5124.00818
-  tps: 4186.14557
+  dps: 5287.33378
+  tps: 4325.50443
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 4982.25437
-  tps: 4065.2619
+  dps: 5257.66352
+  tps: 4297.37979
  }
 }
 dps_results: {
  key: "TestArms-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 5245.07863
-  tps: 4301.47211
+  dps: 5485.91208
+  tps: 4501.44325
  }
 }
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 5174.23523
-  tps: 4222.66657
+  dps: 5372.50222
+  tps: 4389.33706
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7904.36567
-  tps: 6930.48132
+  dps: 8118.35293
+  tps: 7114.87777
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5176.05234
-  tps: 4232.05009
+  dps: 5399.57421
+  tps: 4420.44629
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5116.22786
-  tps: 4204.19581
+  dps: 5360.23053
+  tps: 4401.74587
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6547.45338
-  tps: 5786.71065
+  dps: 6937.37405
+  tps: 6119.54742
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4326.78231
-  tps: 3539.28948
+  dps: 4591.68924
+  tps: 3764.59562
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4366.80001
-  tps: 3600.50268
+  dps: 4622.24856
+  tps: 3798.63138
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7852.9367
-  tps: 6882.05039
+  dps: 8219.25568
+  tps: 7192.31673
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5196.92675
-  tps: 4244.94502
+  dps: 5427.49143
+  tps: 4437.18644
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5251.20166
-  tps: 4337.66106
+  dps: 5474.60753
+  tps: 4498.26353
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6658.92249
-  tps: 5888.60971
+  dps: 7070.6404
+  tps: 6235.74211
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4335.43453
-  tps: 3546.2542
+  dps: 4625.86127
+  tps: 3791.04593
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4503.52961
-  tps: 3721.36419
+  dps: 4628.07414
+  tps: 3795.10764
  }
 }
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 4976.52395
-  tps: 4053.67766
+  dps: 5099.36563
+  tps: 4163.97851
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -52,581 +52,581 @@ character_stats_results: {
 dps_results: {
  key: "TestFury-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 3860.30081
-  tps: 2861.14519
+  dps: 3973.66634
+  tps: 2950.11608
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 3904.20185
-  tps: 2893.82739
+  dps: 4014.18508
+  tps: 2980.98076
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 3922.62952
-  tps: 2905.89936
+  dps: 4056.98976
+  tps: 3010.29394
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 3946.67228
-  tps: 2926.00485
+  dps: 4013.325
+  tps: 2979.21298
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 3808.91473
-  tps: 2818.77953
+  dps: 3955.19617
+  tps: 2935.12795
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 3929.05444
-  tps: 2853.71964
+  dps: 4037.44351
+  tps: 2938.62996
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 4032.50018
-  tps: 2988.71031
+  dps: 4154.69578
+  tps: 3084.40895
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 3950.95206
-  tps: 2925.2181
+  dps: 4048.39843
+  tps: 3004.48551
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 3938.29788
-  tps: 2916.46317
+  dps: 4107.02902
+  tps: 3045.33724
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 3890.6162
-  tps: 2883.28404
+  dps: 4004.27335
+  tps: 2971.44613
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 3785.83242
-  tps: 2806.44814
+  dps: 3943.79749
+  tps: 2927.74294
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Defender'sCode-40257"
  value: {
-  dps: 3846.231
-  tps: 2853.52933
+  dps: 3939.1837
+  tps: 2926.02429
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 3931.90833
-  tps: 2915.19328
+  dps: 4021.72471
+  tps: 2985.91543
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 3407.03872
-  tps: 2528.5436
+  dps: 3503.42075
+  tps: 2607.86293
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 3929.05444
-  tps: 2911.73678
+  dps: 4037.44351
+  tps: 2998.39477
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 3929.05444
-  tps: 2911.73678
+  dps: 4037.44351
+  tps: 2998.39477
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 3946.67228
-  tps: 2926.00485
+  dps: 4013.325
+  tps: 2979.21298
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 3930.02182
-  tps: 2913.37419
+  dps: 4078.46304
+  tps: 3027.0257
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 3929.05444
-  tps: 2911.73678
+  dps: 4037.44351
+  tps: 2998.39477
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 3945.15101
-  tps: 2922.18142
+  dps: 4076.46268
+  tps: 3024.88491
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 3914.10601
-  tps: 2899.66709
+  dps: 4030.43495
+  tps: 2991.33257
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForgeEmber-37660"
  value: {
-  dps: 3902.66765
-  tps: 2894.33817
+  dps: 4006.26483
+  tps: 2973.61539
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 3929.05444
-  tps: 2911.73678
+  dps: 4037.44351
+  tps: 2998.39477
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 3929.05444
-  tps: 2911.73678
+  dps: 4037.44351
+  tps: 2998.39477
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 3938.16534
-  tps: 2919.76288
+  dps: 4074.94059
+  tps: 3024.61957
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuturesightRune-38763"
  value: {
-  dps: 3785.83242
-  tps: 2806.44814
+  dps: 3943.79749
+  tps: 2927.74294
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 3863.06216
-  tps: 2860.76558
+  dps: 3967.41216
+  tps: 2940.92525
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 3785.83242
-  tps: 2806.44814
+  dps: 3943.79749
+  tps: 2927.74294
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 3946.67228
-  tps: 2926.00485
+  dps: 4013.325
+  tps: 2979.21298
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 3930.02182
-  tps: 2913.37419
+  dps: 4078.46304
+  tps: 3027.0257
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IncisorFragment-37723"
  value: {
-  dps: 3924.81018
-  tps: 2912.07538
+  dps: 4069.77663
+  tps: 3022.0599
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 3929.05444
-  tps: 2911.73678
+  dps: 4037.44351
+  tps: 2998.39477
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 3930.94536
-  tps: 2914.67294
+  dps: 4048.71737
+  tps: 3008.76903
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 3785.83242
-  tps: 2806.44814
+  dps: 3943.79749
+  tps: 2927.74294
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 3785.83242
-  tps: 2806.44814
+  dps: 3943.79749
+  tps: 2927.74294
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 3958.95206
-  tps: 2932.02535
+  dps: 4039.38665
+  tps: 2996.42538
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 3849.83023
-  tps: 2851.98973
+  dps: 3945.09739
+  tps: 2928.1785
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtArmor"
  value: {
-  dps: 2213.06581
-  tps: 1647.47341
+  dps: 2358.29673
+  tps: 1763.69953
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 2794.95191
-  tps: 2080.10839
+  dps: 2908.34913
+  tps: 2169.19136
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 3957.01904
-  tps: 2932.12599
+  dps: 4055.56487
+  tps: 3009.44288
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 3930.94536
-  tps: 2914.67294
+  dps: 4048.71737
+  tps: 3008.76903
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 3929.05444
-  tps: 2911.73678
+  dps: 4037.44351
+  tps: 2998.39477
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 3929.05444
-  tps: 2911.73678
+  dps: 4037.44351
+  tps: 2998.39477
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 3785.83242
-  tps: 2806.44814
+  dps: 3943.79749
+  tps: 2927.74294
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 4003.99025
-  tps: 2961.41473
+  dps: 4104.82405
+  tps: 3039.66387
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 4026.25612
-  tps: 2977.00084
+  dps: 4127.48382
+  tps: 3055.52571
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 4014.61996
-  tps: 2977.36988
+  dps: 4133.07008
+  tps: 3066.42275
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 3929.05444
-  tps: 2911.73678
+  dps: 4037.44351
+  tps: 2998.39477
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 3785.83242
-  tps: 2806.44814
+  dps: 3943.79749
+  tps: 2927.74294
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 3810.62199
-  tps: 2822.26541
+  dps: 3945.01998
+  tps: 2929.66546
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 3785.83242
-  tps: 2806.44814
+  dps: 3943.79749
+  tps: 2927.74294
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 3560.48182
-  tps: 2636.40653
+  dps: 3647.35921
+  tps: 2709.4274
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 3785.83242
-  tps: 2806.44814
+  dps: 3943.79749
+  tps: 2927.74294
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SparkofLife-37657"
  value: {
-  dps: 3854.57491
-  tps: 2856.59573
+  dps: 4010.6635
+  tps: 2976.93528
  }
 }
 dps_results: {
  key: "TestFury-AllItems-StormshroudArmor"
  value: {
-  dps: 2817.58226
-  tps: 2091.10214
+  dps: 3001.06264
+  tps: 2232.93734
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 3930.94536
-  tps: 2914.67294
+  dps: 4048.71737
+  tps: 3008.76903
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 3957.01904
-  tps: 2932.12599
+  dps: 4055.56487
+  tps: 3009.44288
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 3950.99519
-  tps: 2928.28045
+  dps: 4017.40087
+  tps: 2981.72667
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 2731.64687
-  tps: 2038.72383
+  dps: 2811.82215
+  tps: 2103.78048
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 2905.74931
-  tps: 2166.23271
+  dps: 2996.8722
+  tps: 2239.19292
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 3939.13598
-  tps: 2920.11895
+  dps: 4046.69304
+  tps: 3004.85565
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 4009.92426
-  tps: 2972.34461
+  dps: 4120.27201
+  tps: 3059.74294
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 4038.06729
-  tps: 2990.03844
+  dps: 4165.03858
+  tps: 3092.65821
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 3929.05444
-  tps: 2911.73678
+  dps: 4037.44351
+  tps: 2998.39477
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 3929.05444
-  tps: 2911.73678
+  dps: 4037.44351
+  tps: 2998.39477
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 3929.05444
-  tps: 2911.73678
+  dps: 4037.44351
+  tps: 2998.39477
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 3929.05444
-  tps: 2911.73678
+  dps: 4037.44351
+  tps: 2998.39477
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 3905.28462
-  tps: 2889.55914
+  dps: 4046.13383
+  tps: 3001.56278
  }
 }
 dps_results: {
  key: "TestFury-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 4191.90384
-  tps: 3103.11955
+  dps: 4284.40147
+  tps: 3178.55793
  }
 }
 dps_results: {
  key: "TestFury-Average-Default"
  value: {
-  dps: 3978.13236
-  tps: 2948.41338
+  dps: 4077.35052
+  tps: 3026.82678
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5401.33207
-  tps: 4382.76739
+  dps: 5479.02115
+  tps: 4428.18611
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3932.68887
-  tps: 2915.22616
+  dps: 4093.94393
+  tps: 3041.53098
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4289.59553
-  tps: 3184.09378
+  dps: 4351.59255
+  tps: 3231.02447
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4605.14599
-  tps: 3783.16222
+  dps: 4683.55129
+  tps: 3838.12594
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3281.36425
-  tps: 2437.36138
+  dps: 3387.62111
+  tps: 2523.31404
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3654.65953
-  tps: 2713.7549
+  dps: 3723.04446
+  tps: 2771.15813
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5469.44844
-  tps: 4436.60256
+  dps: 5570.98424
+  tps: 4506.62247
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4014.61996
-  tps: 2977.36988
+  dps: 4133.07008
+  tps: 3066.42275
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4472.11138
-  tps: 3318.16238
+  dps: 4569.76433
+  tps: 3391.38151
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4662.19029
-  tps: 3827.2396
+  dps: 4784.23719
+  tps: 3912.01101
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3351.66445
-  tps: 2487.9759
+  dps: 3432.20108
+  tps: 2556.60254
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3649.83624
-  tps: 2708.99333
+  dps: 3799.00185
+  tps: 2825.15167
  }
 }
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3725.87688
-  tps: 2759.12091
+  dps: 3816.84237
+  tps: 2831.41394
  }
 }

--- a/sim/warrior/dps/dps_warrior.go
+++ b/sim/warrior/dps/dps_warrior.go
@@ -52,7 +52,18 @@ func NewDpsWarrior(character core.Character, options proto.Player) *DpsWarrior {
 		Options:  *warOptions.Options,
 	}
 
-	war.EnableRageBar(warOptions.Options.StartingRage, core.TernaryFloat64(war.Talents.EndlessRage, 1.25, 1), func(sim *core.Simulation) {
+	rbo := core.RageBarOptions{
+		StartingRage:   warOptions.Options.StartingRage,
+		RageMultiplier: core.TernaryFloat64(war.Talents.EndlessRage, 1.25, 1),
+	}
+	if mh := war.GetMHWeapon(); mh != nil {
+		rbo.MHSwingSpeed = mh.SwingSpeed
+	}
+	if oh := war.GetOHWeapon(); oh != nil {
+		rbo.OHSwingSpeed = oh.SwingSpeed
+	}
+
+	war.EnableRageBar(rbo, func(sim *core.Simulation) {
 		if war.GCD.IsReady(sim) {
 			war.TryUseCooldowns(sim)
 			if war.GCD.IsReady(sim) {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -52,7 +52,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 0.68273
+  weights: 0.63055
   weights: 0
   weights: 0
   weights: 0
@@ -70,7 +70,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.13827
+  weights: 0.19031
   weights: 0
   weights: 0
   weights: 0
@@ -79,12 +79,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.0143
+  weights: 0.02855
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.18805
-  weights: -0.07263
+  weights: 0.22326
+  weights: -0.08302
   weights: 0
   weights: 0
   weights: 0
@@ -103,583 +103,583 @@ stat_weights_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 1835.43346
-  tps: 5143.56388
+  dps: 1967.76542
+  tps: 5552.64084
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1819.46846
-  tps: 5097.80307
+  dps: 1956.06996
+  tps: 5518.66522
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1902.42539
-  tps: 5306.05214
+  dps: 2061.04428
+  tps: 5793.58366
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1842.0479
-  tps: 5156.58439
+  dps: 1972.56173
+  tps: 5556.268
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1813.31689
-  tps: 5073.97016
+  dps: 1954.19235
+  tps: 5519.23315
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1828.85586
-  tps: 5026.38092
+  dps: 1959.02037
+  tps: 5428.23496
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1875.76104
-  tps: 5236.86223
+  dps: 2022.74353
+  tps: 5681.08654
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1898.4518
-  tps: 5291.94145
+  dps: 2045.94235
+  tps: 5745.59139
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1910.74369
-  tps: 5299.09646
+  dps: 2083.31079
+  tps: 5834.63236
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 1958.51476
-  tps: 5486.60402
+  dps: 2075.18277
+  tps: 5850.05254
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 1921.30606
-  tps: 5357.88061
+  dps: 2079.12376
+  tps: 5840.95667
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 1878.21803
-  tps: 5262.43297
+  dps: 2029.3893
+  tps: 5732.03081
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1849.53945
-  tps: 5175.20246
+  dps: 1982.00006
+  tps: 5594.14151
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 2072.26887
-  tps: 5750.80959
+  dps: 2187.73564
+  tps: 6099.54407
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1828.85586
-  tps: 5128.90905
+  dps: 1959.02037
+  tps: 5538.96417
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1828.85586
-  tps: 5128.90905
+  dps: 1959.02037
+  tps: 5538.96417
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1842.0479
-  tps: 5156.58439
+  dps: 1972.56173
+  tps: 5556.268
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1833.63571
-  tps: 5132.88132
+  dps: 1982.24693
+  tps: 5594.07493
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1838.48085
-  tps: 5154.85368
+  dps: 1970.08267
+  tps: 5568.78317
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1932.42513
-  tps: 5368.51937
+  dps: 2062.92006
+  tps: 5775.76066
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1875.49419
-  tps: 5228.65923
+  dps: 2044.11798
+  tps: 5750.16739
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1864.02964
-  tps: 5210.99462
+  dps: 2031.55336
+  tps: 5713.75349
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1828.85586
-  tps: 5128.90905
+  dps: 1959.02037
+  tps: 5538.96417
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1828.85586
-  tps: 5128.90905
+  dps: 1959.02037
+  tps: 5538.96417
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1910.56505
-  tps: 5355.63061
+  dps: 2034.13262
+  tps: 5737.45287
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1819.46846
-  tps: 5097.80307
+  dps: 1956.06996
+  tps: 5518.66522
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 2293.30077
-  tps: 6288.80395
+  dps: 2386.76652
+  tps: 6572.23007
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1819.46846
-  tps: 5097.80307
+  dps: 1956.06996
+  tps: 5518.66522
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1842.0479
-  tps: 5156.58439
+  dps: 1972.56173
+  tps: 5556.268
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1833.63571
-  tps: 5132.88132
+  dps: 1982.24693
+  tps: 5594.07493
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1890.94165
-  tps: 5283.12226
+  dps: 2024.87497
+  tps: 5703.09931
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1828.85586
-  tps: 5128.90905
+  dps: 1959.02037
+  tps: 5538.96417
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1834.50549
-  tps: 5143.30387
+  dps: 1971.90884
+  tps: 5562.18963
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1827.302
-  tps: 5118.91877
+  dps: 1964.89305
+  tps: 5542.44831
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1819.46846
-  tps: 5097.80307
+  dps: 1956.06996
+  tps: 5518.66522
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1914.88522
-  tps: 5349.10064
+  dps: 2071.024
+  tps: 5818.37589
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1837.61086
-  tps: 5148.78502
+  dps: 1976.03869
+  tps: 5575.72361
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 1502.75567
-  tps: 4214.16179
+  dps: 1649.26233
+  tps: 4665.17509
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 1773.16448
-  tps: 4910.54346
+  dps: 1897.27937
+  tps: 5290.36275
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1840.13022
-  tps: 5158.21817
+  dps: 1985.49919
+  tps: 5605.97493
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1834.50549
-  tps: 5143.30387
+  dps: 1971.90884
+  tps: 5562.18963
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1828.85586
-  tps: 5128.90905
+  dps: 1959.02037
+  tps: 5538.96417
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1828.85586
-  tps: 5128.90905
+  dps: 1959.02037
+  tps: 5538.96417
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1819.46846
-  tps: 5097.80307
+  dps: 1956.06996
+  tps: 5518.66522
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1903.83613
-  tps: 5272.68409
+  dps: 2042.90559
+  tps: 5698.67758
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1914.38148
-  tps: 5294.54988
+  dps: 2053.75594
+  tps: 5721.17579
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1856.42922
-  tps: 5188.13406
+  dps: 2003.98275
+  tps: 5633.22998
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1828.85586
-  tps: 5128.90905
+  dps: 1959.02037
+  tps: 5538.96417
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1819.46846
-  tps: 5097.80307
+  dps: 1956.06996
+  tps: 5518.66522
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1835.1676
-  tps: 5132.78695
+  dps: 1981.4108
+  tps: 5598.17745
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1819.46846
-  tps: 5097.80307
+  dps: 1956.06996
+  tps: 5518.66522
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 2076.30142
-  tps: 5763.64113
+  dps: 2220.9769
+  tps: 6204.90339
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1819.46846
-  tps: 5097.80307
+  dps: 1956.06996
+  tps: 5518.66522
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SparkofLife-37657"
  value: {
-  dps: 1854.90763
-  tps: 5193.31481
+  dps: 1993.19396
+  tps: 5627.31561
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormshroudArmor"
  value: {
-  dps: 1514.9561
-  tps: 4247.26216
+  dps: 1651.71601
+  tps: 4674.32773
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1834.50549
-  tps: 5143.30387
+  dps: 1971.90884
+  tps: 5562.18963
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1840.13022
-  tps: 5158.21817
+  dps: 1985.49919
+  tps: 5605.97493
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1840.53948
-  tps: 5159.16348
+  dps: 1967.73105
+  tps: 5552.08715
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 1489.02922
-  tps: 4011.40653
+  dps: 1699.70592
+  tps: 4660.59007
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1621.01508
-  tps: 4364.70921
+  dps: 1858.55489
+  tps: 5068.1836
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1843.42148
-  tps: 5165.66984
+  dps: 1976.6104
+  tps: 5570.27322
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1984.04696
-  tps: 5565.2326
+  dps: 2140.36044
+  tps: 6034.806
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2000.49453
-  tps: 5599.63288
+  dps: 2154.53644
+  tps: 6076.45688
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1828.85586
-  tps: 5128.90905
+  dps: 1959.02037
+  tps: 5538.96417
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1828.85586
-  tps: 5128.90905
+  dps: 1959.02037
+  tps: 5538.96417
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1828.85586
-  tps: 5128.90905
+  dps: 1959.02037
+  tps: 5538.96417
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1828.85586
-  tps: 5128.90905
+  dps: 1959.02037
+  tps: 5538.96417
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 2321.39572
-  tps: 6396.9676
+  dps: 2421.82902
+  tps: 6693.91682
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 2576.53238
-  tps: 7036.79903
+  dps: 2684.74037
+  tps: 7344.52721
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 2820.22902
-  tps: 7336.21909
-  dtps: 209.141
+  dps: 2847.6976
+  tps: 7416.08156
+  dtps: 207.48095
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1862.25395
-  tps: 4840.84529
+  dps: 2018.41439
+  tps: 5268.72387
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1862.25395
-  tps: 4793.27588
+  dps: 2018.41439
+  tps: 5221.15162
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2010.45562
-  tps: 5168.75926
+  dps: 2153.68927
+  tps: 5547.5615
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 862.97129
-  tps: 2320.79922
+  dps: 971.64159
+  tps: 2648.04994
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 862.97129
-  tps: 2273.20828
+  dps: 971.64159
+  tps: 2600.4463
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 772.40244
-  tps: 2053.47329
+  dps: 862.63135
+  tps: 2315.35586
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1864.1527
-  tps: 4850.40326
+  dps: 2034.00783
+  tps: 5313.57393
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1864.1527
-  tps: 4802.84202
+  dps: 2034.00783
+  tps: 5266.02314
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2003.50196
-  tps: 5149.49214
+  dps: 2143.94228
+  tps: 5522.43175
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 873.36885
-  tps: 2347.36928
+  dps: 980.02403
+  tps: 2668.87785
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 873.36885
-  tps: 2299.7788
+  dps: 980.02403
+  tps: 2621.25512
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 790.61387
-  tps: 2077.19559
+  dps: 863.89711
+  tps: 2313.77124
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2970.00933
-  tps: 7728.11943
-  dtps: 211.09852
+  dps: 2995.80135
+  tps: 7806.63581
+  dtps: 209.32273
  }
 }

--- a/sim/warrior/protection/protection_warrior.go
+++ b/sim/warrior/protection/protection_warrior.go
@@ -47,7 +47,18 @@ func NewProtectionWarrior(character core.Character, options proto.Player) *Prote
 		Options:  *warOptions.Options,
 	}
 
-	war.EnableRageBar(warOptions.Options.StartingRage, core.TernaryFloat64(war.Talents.EndlessRage, 1.25, 1), func(sim *core.Simulation) {
+	rbo := core.RageBarOptions{
+		StartingRage:   warOptions.Options.StartingRage,
+		RageMultiplier: core.TernaryFloat64(war.Talents.EndlessRage, 1.25, 1),
+	}
+	if mh := war.GetMHWeapon(); mh != nil {
+		rbo.MHSwingSpeed = mh.SwingSpeed
+	}
+	if oh := war.GetOHWeapon(); oh != nil {
+		rbo.OHSwingSpeed = oh.SwingSpeed
+	}
+
+	war.EnableRageBar(rbo, func(sim *core.Simulation) {
 		if war.GCD.IsReady(sim) {
 			war.TryUseCooldowns(sim)
 			if war.GCD.IsReady(sim) {


### PR DESCRIPTION
[core] fixed rage multiplier (warrior's EndlessRage) not being applied, and added missing swing speed in rage formula; EnableRageBar() now has an options argument, for better readability

[warrior, druid] changed EnableRageBar() calls accordingly 

[druid] added comment about cat druids' DPS tests depending on rage bar's parameterization 

[paladin] drive-by-nit