### PR TITLE
Move weapon multiplier out of base weapon damage func

### DIFF
--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -229,14 +229,14 @@ func (unit *Unit) EnableAutoAttacks(agent Agent, options AutoAttackOptions) {
 			ProcMask:         ProcMaskMeleeMHAuto,
 			DamageMultiplier: 1,
 			ThreatMultiplier: 1,
-			BaseDamage:       BaseDamageConfigMeleeWeapon(MainHand, false, 0, 1, true),
+			BaseDamage:       BaseDamageConfigMeleeWeapon(MainHand, false, 0, true),
 			OutcomeApplier:   unit.OutcomeFuncMeleeWhite(options.MainHand.CritMultiplier),
 		}
 		unit.AutoAttacks.OHEffect = SpellEffect{
 			ProcMask:         ProcMaskMeleeOHAuto,
 			DamageMultiplier: 1,
 			ThreatMultiplier: 1,
-			BaseDamage:       BaseDamageConfigMeleeWeapon(OffHand, false, 0, 1, true),
+			BaseDamage:       BaseDamageConfigMeleeWeapon(OffHand, false, 0, true),
 			OutcomeApplier:   unit.OutcomeFuncMeleeWhite(options.OffHand.CritMultiplier),
 		}
 		unit.AutoAttacks.RangedEffect = SpellEffect{

--- a/sim/core/spell_damage.go
+++ b/sim/core/spell_damage.go
@@ -156,7 +156,7 @@ type Hand bool
 const MainHand Hand = true
 const OffHand Hand = false
 
-func BaseDamageFuncMeleeWeapon(hand Hand, normalized bool, flatBonus float64, weaponMultiplier float64, includeBonusWeaponDamage bool) BaseDamageCalculator {
+func BaseDamageFuncMeleeWeapon(hand Hand, normalized bool, flatBonus float64, includeBonusWeaponDamage bool) BaseDamageCalculator {
 	// Bonus weapon damage applies after OH penalty: https://www.youtube.com/watch?v=bwCIU87hqTs
 	if normalized {
 		if hand == MainHand {
@@ -166,7 +166,7 @@ func BaseDamageFuncMeleeWeapon(hand Hand, normalized bool, flatBonus float64, we
 				if includeBonusWeaponDamage {
 					damage += hitEffect.BonusWeaponDamage(spell.Unit)
 				}
-				return damage * weaponMultiplier
+				return damage
 			}
 		} else {
 			return func(sim *Simulation, hitEffect *SpellEffect, spell *Spell) float64 {
@@ -175,7 +175,7 @@ func BaseDamageFuncMeleeWeapon(hand Hand, normalized bool, flatBonus float64, we
 				if includeBonusWeaponDamage {
 					damage += hitEffect.BonusWeaponDamage(spell.Unit)
 				}
-				return damage * weaponMultiplier
+				return damage
 			}
 		}
 	} else {
@@ -186,7 +186,7 @@ func BaseDamageFuncMeleeWeapon(hand Hand, normalized bool, flatBonus float64, we
 				if includeBonusWeaponDamage {
 					damage += hitEffect.BonusWeaponDamage(spell.Unit)
 				}
-				return damage * weaponMultiplier
+				return damage
 			}
 		} else {
 			return func(sim *Simulation, hitEffect *SpellEffect, spell *Spell) float64 {
@@ -195,13 +195,13 @@ func BaseDamageFuncMeleeWeapon(hand Hand, normalized bool, flatBonus float64, we
 				if includeBonusWeaponDamage {
 					damage += hitEffect.BonusWeaponDamage(spell.Unit)
 				}
-				return damage * weaponMultiplier
+				return damage
 			}
 		}
 	}
 }
-func BaseDamageConfigMeleeWeapon(hand Hand, normalized bool, flatBonus float64, weaponMultiplier float64, includeBonusWeaponDamage bool) BaseDamageConfig {
-	calculator := BaseDamageFuncMeleeWeapon(hand, normalized, flatBonus, weaponMultiplier, includeBonusWeaponDamage)
+func BaseDamageConfigMeleeWeapon(hand Hand, normalized bool, flatBonus float64, includeBonusWeaponDamage bool) BaseDamageConfig {
+	calculator := BaseDamageFuncMeleeWeapon(hand, normalized, flatBonus, includeBonusWeaponDamage)
 	if includeBonusWeaponDamage {
 		return BuildBaseDamageConfig(calculator, 1)
 	} else {

--- a/sim/core/spell_damage.go
+++ b/sim/core/spell_damage.go
@@ -171,7 +171,7 @@ func BaseDamageFuncMeleeWeapon(hand Hand, normalized bool, flatBonus float64, in
 		} else {
 			return func(sim *Simulation, hitEffect *SpellEffect, spell *Spell) float64 {
 				damage := spell.Unit.AutoAttacks.OH.CalculateNormalizedWeaponDamage(sim, hitEffect.MeleeAttackPower(spell.Unit))
-				damage = (damage + flatBonus) * 0.5
+				damage = damage*0.5 + flatBonus
 				if includeBonusWeaponDamage {
 					damage += hitEffect.BonusWeaponDamage(spell.Unit)
 				}
@@ -191,7 +191,7 @@ func BaseDamageFuncMeleeWeapon(hand Hand, normalized bool, flatBonus float64, in
 		} else {
 			return func(sim *Simulation, hitEffect *SpellEffect, spell *Spell) float64 {
 				damage := spell.Unit.AutoAttacks.OH.CalculateWeaponDamage(sim, hitEffect.MeleeAttackPower(spell.Unit))
-				damage = (damage + flatBonus) * 0.5
+				damage = damage*0.5 + flatBonus
 				if includeBonusWeaponDamage {
 					damage += hitEffect.BonusWeaponDamage(spell.Unit)
 				}

--- a/sim/deathknight/blood_strike.go
+++ b/sim/deathknight/blood_strike.go
@@ -10,7 +10,7 @@ var BloodStrikeActionID = core.ActionID{SpellID: 49930}
 func (dk *Deathknight) newBloodStrikeSpell(isMH bool, onhit func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect)) *RuneSpell {
 	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 764.0, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 764.0, true)
+		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 764.0*0.5, true)
 	}
 
 	diseaseMulti := dk.dkDiseaseMultiplier(0.125)

--- a/sim/deathknight/blood_strike.go
+++ b/sim/deathknight/blood_strike.go
@@ -8,16 +8,20 @@ import (
 var BloodStrikeActionID = core.ActionID{SpellID: 49930}
 
 func (dk *Deathknight) newBloodStrikeSpell(isMH bool, onhit func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect)) *RuneSpell {
-	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 764.0, 0.4, true)
+	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 764.0, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 764.0, dk.nervesOfColdSteelBonus()*0.4, true)
+		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 764.0, true)
 	}
 
 	diseaseMulti := dk.dkDiseaseMultiplier(0.125)
+	weaponMulti := 0.4
+	if !isMH {
+		weaponMulti = 0.4 * dk.nervesOfColdSteelBonus()
+	}
 
 	effect := core.SpellEffect{
 		BonusCritRating:  (dk.subversionCritBonus() + dk.annihilationCritBonus()) * core.CritRatingPerCritChance,
-		DamageMultiplier: dk.bloodOfTheNorthCoeff() * dk.thassariansPlateDamageBonus() * dk.bloodyStrikesBonus(dk.BloodStrike),
+		DamageMultiplier: weaponMulti * dk.bloodOfTheNorthCoeff() * dk.thassariansPlateDamageBonus() * dk.bloodyStrikesBonus(dk.BloodStrike),
 		ThreatMultiplier: 1,
 
 		BaseDamage: core.BaseDamageConfig{

--- a/sim/deathknight/death_strike.go
+++ b/sim/deathknight/death_strike.go
@@ -13,7 +13,7 @@ func (dk *Deathknight) newDeathStrikeSpell(isMH bool, onhit func(sim *core.Simul
 	bonusBaseDamage := dk.sigilOfAwarenessBonus()
 	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 297.0+bonusBaseDamage, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 297.0+bonusBaseDamage, true)
+		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, (297.0+bonusBaseDamage)*0.5, true)
 	}
 
 	hasGlyph := dk.HasMajorGlyph(proto.DeathknightMajorGlyph_GlyphOfDeathStrike)

--- a/sim/deathknight/death_strike.go
+++ b/sim/deathknight/death_strike.go
@@ -11,16 +11,20 @@ var DeathStrikeActionID = core.ActionID{SpellID: 49924}
 
 func (dk *Deathknight) newDeathStrikeSpell(isMH bool, onhit func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect)) *RuneSpell {
 	bonusBaseDamage := dk.sigilOfAwarenessBonus()
-	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 297.0+bonusBaseDamage, 0.75, true)
+	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 297.0+bonusBaseDamage, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 297.0+bonusBaseDamage, dk.nervesOfColdSteelBonus()*0.75, true)
+		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 297.0+bonusBaseDamage, true)
 	}
 
 	hasGlyph := dk.HasMajorGlyph(proto.DeathknightMajorGlyph_GlyphOfDeathStrike)
+	weaponMulti := 0.75
+	if !isMH {
+		weaponMulti = 0.75 * dk.nervesOfColdSteelBonus()
+	}
 
 	effect := core.SpellEffect{
 		BonusCritRating:  (dk.annihilationCritBonus() + dk.improvedDeathStrikeCritBonus()) * core.CritRatingPerCritChance,
-		DamageMultiplier: 1.0 + 0.15*float64(dk.Talents.ImprovedDeathStrike),
+		DamageMultiplier: weaponMulti * (1.0 + 0.15*float64(dk.Talents.ImprovedDeathStrike)),
 		ThreatMultiplier: 1,
 
 		BaseDamage: core.BaseDamageConfig{
@@ -99,9 +103,10 @@ func (dk *Deathknight) registerDeathStrikeSpell() {
 
 func (dk *Deathknight) registerDrwDeathStrikeSpell() {
 	bonusBaseDamage := dk.sigilOfAwarenessBonus()
-	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 297.0+bonusBaseDamage, 0.75, true)
+	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 297.0+bonusBaseDamage, true)
 
 	hasGlyph := dk.HasMajorGlyph(proto.DeathknightMajorGlyph_GlyphOfDeathStrike)
+	weaponMulti := 0.75
 
 	dk.RuneWeapon.DeathStrike = dk.RuneWeapon.RegisterSpell(core.SpellConfig{
 		ActionID:    DeathStrikeActionID.WithTag(1),
@@ -110,7 +115,7 @@ func (dk *Deathknight) registerDrwDeathStrikeSpell() {
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			ProcMask:         core.ProcMaskMeleeSpecial,
 			BonusCritRating:  (dk.annihilationCritBonus() + dk.improvedDeathStrikeCritBonus()) * core.CritRatingPerCritChance,
-			DamageMultiplier: dk.improvedDeathStrikeDamageBonus(),
+			DamageMultiplier: weaponMulti * dk.improvedDeathStrikeDamageBonus(),
 			ThreatMultiplier: 1,
 			OutcomeApplier:   dk.RuneWeapon.OutcomeFuncMeleeWeaponSpecialHitAndCrit(dk.RuneWeapon.MeleeCritMultiplier(1.0, 0.0)),
 			BaseDamage: core.BaseDamageConfig{

--- a/sim/deathknight/frost_strike.go
+++ b/sim/deathknight/frost_strike.go
@@ -12,7 +12,7 @@ func (dk *Deathknight) newFrostStrikeHitSpell(isMH bool, onhit func(sim *core.Si
 	baseDamage := 250.0 + dk.sigilOfTheVengefulHeartFrostStrike()
 	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, baseDamage, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, baseDamage, true)
+		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, baseDamage*0.5, true)
 	}
 
 	weaponMulti := 0.55

--- a/sim/deathknight/frost_strike.go
+++ b/sim/deathknight/frost_strike.go
@@ -10,14 +10,19 @@ var FrostStrikeActionID = core.ActionID{SpellID: 55268}
 
 func (dk *Deathknight) newFrostStrikeHitSpell(isMH bool, onhit func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect)) *RuneSpell {
 	baseDamage := 250.0 + dk.sigilOfTheVengefulHeartFrostStrike()
-	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, baseDamage, 0.55, true)
+	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, baseDamage, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, baseDamage, dk.nervesOfColdSteelBonus()*0.55, true)
+		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, baseDamage, true)
+	}
+
+	weaponMulti := 0.55
+	if !isMH {
+		weaponMulti = 0.55 * dk.nervesOfColdSteelBonus()
 	}
 
 	effect := core.SpellEffect{
 		BonusCritRating:  (dk.annihilationCritBonus() + dk.darkrunedBattlegearCritBonus()) * core.CritRatingPerCritChance,
-		DamageMultiplier: dk.bloodOfTheNorthCoeff(),
+		DamageMultiplier: weaponMulti * dk.bloodOfTheNorthCoeff(),
 		ThreatMultiplier: 1,
 
 		BaseDamage: core.BaseDamageConfig{

--- a/sim/deathknight/ghoul_pet_abilities.go
+++ b/sim/deathknight/ghoul_pet_abilities.go
@@ -68,9 +68,9 @@ func (ghoulPet *GhoulPet) newClaw() PetAbility {
 
 			ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 				ProcMask:         core.ProcMaskMeleeMHSpecial,
-				DamageMultiplier: 1,
+				DamageMultiplier: 1.5,
 				ThreatMultiplier: 1,
-				BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 0, 1.5, true),
+				BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 0, true),
 				OutcomeApplier:   ghoulPet.OutcomeFuncMeleeSpecialHitAndCrit(2),
 			}),
 		}),

--- a/sim/deathknight/heart_strike.go
+++ b/sim/deathknight/heart_strike.go
@@ -8,12 +8,16 @@ import (
 var HeartStrikeActionID = core.ActionID{SpellID: 55050}
 
 func (dk *Deathknight) newHeartStrikeSpell(isMainTarget bool, isDrw bool, onhit func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect)) *RuneSpell {
-	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 250.0, 0.5, true)
+	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 250.0, true)
 	if !isMainTarget {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 250.0, 0.25, true)
+		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 250.0, true)
 	}
 
 	diseaseMulti := dk.dkDiseaseMultiplier(0.1)
+	weaponMulti := 0.5
+	if !isMainTarget {
+		weaponMulti = 0.25
+	}
 
 	outcomeApplier := dk.OutcomeFuncMeleeSpecialHitAndCrit(dk.critMultiplierGoGandMoM())
 	if isDrw {
@@ -24,7 +28,7 @@ func (dk *Deathknight) newHeartStrikeSpell(isMainTarget bool, isDrw bool, onhit 
 	effect := core.SpellEffect{
 		ProcMask:         core.ProcMaskMeleeSpecial,
 		BonusCritRating:  (dk.subversionCritBonus() + dk.annihilationCritBonus()) * core.CritRatingPerCritChance,
-		DamageMultiplier: dk.thassariansPlateDamageBonus() * dk.scourgelordsBattlegearDamageBonus(dk.HeartStrike) * dk.bloodyStrikesBonus(dk.HeartStrike),
+		DamageMultiplier: weaponMulti * dk.thassariansPlateDamageBonus() * dk.scourgelordsBattlegearDamageBonus(dk.HeartStrike) * dk.bloodyStrikesBonus(dk.HeartStrike),
 		ThreatMultiplier: 1,
 		OutcomeApplier:   outcomeApplier,
 		BaseDamage: core.BaseDamageConfig{

--- a/sim/deathknight/obliterate.go
+++ b/sim/deathknight/obliterate.go
@@ -11,16 +11,20 @@ var ObliterateActionID = core.ActionID{SpellID: 51425}
 
 func (dk *Deathknight) newObliterateHitSpell(isMH bool, onhit func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect)) *RuneSpell {
 	bonusBaseDamage := dk.sigilOfAwarenessBonus()
-	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 584.0+bonusBaseDamage, 0.8, true)
+	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 584.0+bonusBaseDamage, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 584.0+bonusBaseDamage, dk.nervesOfColdSteelBonus()*0.8, true)
+		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 584.0+bonusBaseDamage, true)
 	}
 
 	diseaseMulti := dk.dkDiseaseMultiplier(0.125)
+	weaponMulti := 0.8
+	if !isMH {
+		weaponMulti = 0.8 * dk.nervesOfColdSteelBonus()
+	}
 
 	effect := core.SpellEffect{
 		BonusCritRating:  (dk.rimeCritBonus() + dk.subversionCritBonus() + dk.annihilationCritBonus() + dk.scourgeborneBattlegearCritBonus()) * core.CritRatingPerCritChance,
-		DamageMultiplier: core.TernaryFloat64(dk.HasMajorGlyph(proto.DeathknightMajorGlyph_GlyphOfObliterate), 1.25, 1.0) * dk.scourgelordsBattlegearDamageBonus(dk.Obliterate),
+		DamageMultiplier: weaponMulti * core.TernaryFloat64(dk.HasMajorGlyph(proto.DeathknightMajorGlyph_GlyphOfObliterate), 1.25, 1.0) * dk.scourgelordsBattlegearDamageBonus(dk.Obliterate),
 		ThreatMultiplier: 1,
 
 		BaseDamage: core.BaseDamageConfig{

--- a/sim/deathknight/obliterate.go
+++ b/sim/deathknight/obliterate.go
@@ -13,7 +13,7 @@ func (dk *Deathknight) newObliterateHitSpell(isMH bool, onhit func(sim *core.Sim
 	bonusBaseDamage := dk.sigilOfAwarenessBonus()
 	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 584.0+bonusBaseDamage, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 584.0+bonusBaseDamage, true)
+		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, (584.0+bonusBaseDamage)*0.5, true)
 	}
 
 	diseaseMulti := dk.dkDiseaseMultiplier(0.125)

--- a/sim/deathknight/plague_strike.go
+++ b/sim/deathknight/plague_strike.go
@@ -9,17 +9,22 @@ import (
 var PlagueStrikeActionID = core.ActionID{SpellID: 49921}
 
 func (dk *Deathknight) newPlagueStrikeSpell(isMH bool, onhit func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect)) *RuneSpell {
-	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 378.0, 0.5, true)
+	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 378.0, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 378.0, dk.nervesOfColdSteelBonus()*0.5, true)
+		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 378.0, true)
 	}
 
 	outbreakBonus := 1.0 + 0.1*float64(dk.Talents.Outbreak)
 	glyphDmgBonus := core.TernaryFloat64(dk.HasMajorGlyph(proto.DeathknightMajorGlyph_GlyphOfPlagueStrike), 1.2, 1.0)
 
+	weaponMulti := 0.5
+	if !isMH {
+		weaponMulti = 0.5 * dk.nervesOfColdSteelBonus()
+	}
+
 	effect := core.SpellEffect{
 		BonusCritRating:  (dk.annihilationCritBonus() + dk.scourgebornePlateCritBonus() + dk.viciousStrikesCritChanceBonus()) * core.CritRatingPerCritChance,
-		DamageMultiplier: outbreakBonus,
+		DamageMultiplier: weaponMulti * outbreakBonus,
 		ThreatMultiplier: 1,
 
 		BaseDamage: core.BaseDamageConfig{
@@ -90,7 +95,8 @@ func (dk *Deathknight) registerPlagueStrikeSpell() {
 	dk.PlagueStrike = dk.PlagueStrikeMhHit
 }
 func (dk *Deathknight) registerDrwPlagueStrikeSpell() {
-	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 378.0, 0.5, true)
+	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 378.0, true)
+	weaponMulti := 0.5
 	outbreakBonus := 1.0 + 0.1*float64(dk.Talents.Outbreak)
 
 	dk.RuneWeapon.PlagueStrike = dk.RuneWeapon.RegisterSpell(core.SpellConfig{
@@ -100,7 +106,7 @@ func (dk *Deathknight) registerDrwPlagueStrikeSpell() {
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			ProcMask:         core.ProcMaskMeleeMHSpecial,
 			BonusCritRating:  (dk.annihilationCritBonus() + dk.scourgebornePlateCritBonus() + dk.viciousStrikesCritChanceBonus()) * core.CritRatingPerCritChance,
-			DamageMultiplier: outbreakBonus,
+			DamageMultiplier: weaponMulti * outbreakBonus,
 			ThreatMultiplier: 1,
 			OutcomeApplier:   dk.RuneWeapon.OutcomeFuncMeleeWeaponSpecialHitAndCrit(dk.RuneWeapon.MeleeCritMultiplier(1.0, 0.0)),
 			BaseDamage: core.BaseDamageConfig{

--- a/sim/deathknight/plague_strike.go
+++ b/sim/deathknight/plague_strike.go
@@ -11,7 +11,7 @@ var PlagueStrikeActionID = core.ActionID{SpellID: 49921}
 func (dk *Deathknight) newPlagueStrikeSpell(isMH bool, onhit func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect)) *RuneSpell {
 	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 378.0, true)
 	if !isMH {
-		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 378.0, true)
+		weaponBaseDamage = core.BaseDamageFuncMeleeWeapon(core.OffHand, true, 378.0*0.5, true)
 	}
 
 	outbreakBonus := 1.0 + 0.1*float64(dk.Talents.Outbreak)

--- a/sim/deathknight/rune_strike.go
+++ b/sim/deathknight/rune_strike.go
@@ -13,6 +13,8 @@ func (dk *Deathknight) registerRuneStrikeSpell() {
 
 	runeStrikeGlyphCritBonus := core.TernaryFloat64(dk.HasMajorGlyph(proto.DeathknightMajorGlyph_GlyphOfRuneStrike), 10.0, 0.0)
 
+	weaponMulti := 1.5
+
 	baseCost := float64(core.NewRuneCost(20, 0, 0, 0, 0))
 	rs := &RuneSpell{}
 	dk.RuneStrike = dk.RegisterSpell(rs, core.SpellConfig{
@@ -33,14 +35,14 @@ func (dk *Deathknight) registerRuneStrikeSpell() {
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			ProcMask: core.ProcMaskMeleeMHAuto | core.ProcMaskMeleeMHSpecial,
 
-			DamageMultiplier: dk.darkrunedPlateRuneStrikeDamageBonus(),
+			DamageMultiplier: weaponMulti * dk.darkrunedPlateRuneStrikeDamageBonus(),
 			ThreatMultiplier: 1.75,
 			BonusCritRating:  (dk.annihilationCritBonus() + runeStrikeGlyphCritBonus) * core.CritRatingPerCritChance,
 
 			BaseDamage: core.BaseDamageConfig{
 				Calculator: func(sim *core.Simulation, hitEffect *core.SpellEffect, spell *core.Spell) float64 {
 					bonusDmg := 0.15 * hitEffect.MeleeAttackPower(spell.Unit)
-					weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, false, bonusDmg, 1.5, true)
+					weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, false, bonusDmg, true)
 
 					return weaponBaseDamage(sim, hitEffect, spell) *
 						dk.RoRTSBonus(hitEffect.Target)

--- a/sim/deathknight/scourge_strike.go
+++ b/sim/deathknight/scourge_strike.go
@@ -40,7 +40,8 @@ func (dk *Deathknight) registerScourgeStrikeSpell() {
 
 	shadowDamageSpell := dk.registerScourgeStrikeShadowDamageSpell()
 	bonusBaseDamage := dk.sigilOfAwarenessBonus() + dk.sigilOfArthriticBindingBonus()
-	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 800.0+bonusBaseDamage, 0.7, true)
+	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 800.0+bonusBaseDamage, true)
+	weaponMulti := 0.7
 	outbreakBonus := []float64{1.0, 1.07, 1.13, 1.2}[dk.Talents.Outbreak]
 	rpGain := 15.0 + 2.5*float64(dk.Talents.Dirge) + dk.scourgeborneBattlegearRunicPowerBonus()
 	hasGlyph := dk.HasMajorGlyph(proto.DeathknightMajorGlyph_GlyphOfScourgeStrike)
@@ -67,7 +68,7 @@ func (dk *Deathknight) registerScourgeStrikeSpell() {
 		ApplyEffects: dk.withRuneRefund(rs, core.SpellEffect{
 			ProcMask:         core.ProcMaskMeleeMHSpecial,
 			BonusCritRating:  (dk.subversionCritBonus() + dk.viciousStrikesCritChanceBonus() + dk.scourgeborneBattlegearCritBonus()) * core.CritRatingPerCritChance,
-			DamageMultiplier: outbreakBonus * dk.scourgelordsBattlegearDamageBonus(dk.ScourgeStrike),
+			DamageMultiplier: weaponMulti * outbreakBonus * dk.scourgelordsBattlegearDamageBonus(dk.ScourgeStrike),
 			ThreatMultiplier: 1,
 
 			BaseDamage: core.BaseDamageConfig{

--- a/sim/deathknight/talents_frost.go
+++ b/sim/deathknight/talents_frost.go
@@ -29,7 +29,7 @@ func (dk *Deathknight) ApplyFrostTalents() {
 	// Nerves Of Cold Steel
 	if dk.HasMHWeapon() && dk.HasOHWeapon() && dk.Equip[proto.ItemSlot_ItemSlotMainHand].HandType == proto.HandType_HandTypeMainHand || dk.Equip[proto.ItemSlot_ItemSlotMainHand].HandType == proto.HandType_HandTypeOneHand {
 		dk.AddStat(stats.MeleeHit, core.MeleeHitRatingPerHitChance*float64(dk.Talents.NervesOfColdSteel))
-		dk.AutoAttacks.OHEffect.BaseDamage.Calculator = core.BaseDamageFuncMeleeWeapon(core.OffHand, false, 0, dk.nervesOfColdSteelBonus(), true)
+		dk.AutoAttacks.OHEffect.DamageMultiplier = dk.nervesOfColdSteelBonus()
 	}
 
 	// Icy Talons

--- a/sim/deathknight/talents_unholy.go
+++ b/sim/deathknight/talents_unholy.go
@@ -179,8 +179,13 @@ func (dk *Deathknight) applyBloodCakedBlade() {
 }
 
 func (dk *Deathknight) bloodCakedBladeHit(isMh bool) *core.Spell {
-	mhBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, false, 0, 1.0, true)
-	ohBaseDamage := core.BaseDamageFuncMeleeWeapon(core.OffHand, false, 0, dk.nervesOfColdSteelBonus(), true)
+	mhBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, false, 0, true)
+	ohBaseDamage := core.BaseDamageFuncMeleeWeapon(core.OffHand, false, 0, true)
+
+	weaponMulti := 1.0
+	if !isMh {
+		weaponMulti = dk.nervesOfColdSteelBonus()
+	}
 
 	procMask := core.ProcMaskMeleeOHSpecial
 	if isMh {
@@ -195,7 +200,7 @@ func (dk *Deathknight) bloodCakedBladeHit(isMh bool) *core.Spell {
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			ProcMask: procMask,
 
-			DamageMultiplier: 1,
+			DamageMultiplier: weaponMulti,
 			ThreatMultiplier: 1,
 
 			BaseDamage: core.BaseDamageConfig{

--- a/sim/druid/mangle.go
+++ b/sim/druid/mangle.go
@@ -44,11 +44,11 @@ func (druid *Druid) registerMangleBearSpell() {
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			ProcMask: core.ProcMaskMeleeMHSpecial,
 
-			DamageMultiplier: 1 + 0.1*float64(druid.Talents.SavageFury) + glyphBonus,
+			DamageMultiplier: (1 + 0.1*float64(druid.Talents.SavageFury) + glyphBonus) * 1.15,
 			ThreatMultiplier: (1.5 / 1.15) *
 				core.TernaryFloat64(druid.InForm(Bear) && druid.HasSetBonus(ItemSetThunderheartHarness, 2), 1.15, 1),
 
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 299/1.15, 1.15, true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 299/1.15, true),
 			OutcomeApplier: druid.OutcomeFuncMeleeSpecialHitAndCrit(druid.MeleeCritMultiplier()),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
@@ -97,10 +97,10 @@ func (druid *Druid) registerMangleCatSpell() {
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			ProcMask: core.ProcMaskMeleeMHSpecial,
 
-			DamageMultiplier: 1 + 0.1*float64(druid.Talents.SavageFury) + glyphBonus,
+			DamageMultiplier: (1 + 0.1*float64(druid.Talents.SavageFury) + glyphBonus) * 2.0,
 			ThreatMultiplier: 1,
 
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 566/2.0, 2.0, true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 566/2.0, true),
 			OutcomeApplier: druid.OutcomeFuncMeleeSpecialHitAndCrit(druid.MeleeCritMultiplier()),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {

--- a/sim/druid/maul.go
+++ b/sim/druid/maul.go
@@ -26,7 +26,7 @@ func (druid *Druid) registerMaulSpell(rageThreshold float64) {
 		FlatThreatBonus:  344,
 
 		BaseDamage: core.WrapBaseDamageConfig(
-			core.BaseDamageConfigMeleeWeapon(core.MainHand, false, baseDamage, 1, true),
+			core.BaseDamageConfigMeleeWeapon(core.MainHand, false, baseDamage, true),
 			func(oldCalculator core.BaseDamageCalculator) core.BaseDamageCalculator {
 				return func(sim *core.Simulation, spellEffect *core.SpellEffect, spell *core.Spell) float64 {
 					normalDamage := oldCalculator(sim, spellEffect, spell)

--- a/sim/druid/shred.go
+++ b/sim/druid/shred.go
@@ -39,11 +39,11 @@ func (druid *Druid) registerShredSpell() {
 
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			ProcMask:         core.ProcMaskMeleeMHSpecial,
-			DamageMultiplier: 1,
+			DamageMultiplier: 2.25,
 			ThreatMultiplier: 1,
 
 			BaseDamage: core.WrapBaseDamageConfig(
-				core.BaseDamageConfigMeleeWeapon(core.MainHand, false, flatDamageBonus/2.25, 2.25, true),
+				core.BaseDamageConfigMeleeWeapon(core.MainHand, false, flatDamageBonus/2.25, true),
 				func(oldCalculator core.BaseDamageCalculator) core.BaseDamageCalculator {
 					return func(sim *core.Simulation, spellEffect *core.SpellEffect, spell *core.Spell) float64 {
 						normalDamage := oldCalculator(sim, spellEffect, spell)

--- a/sim/druid/swipe.go
+++ b/sim/druid/swipe.go
@@ -59,13 +59,14 @@ func (druid *Druid) registerSwipeBearSpell() {
 func (druid *Druid) registerSwipeCatSpell() {
 	cost := 50.0 - float64(druid.Talents.Ferocity)
 
-	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 0.0, 2.5, false)
+	weaponBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 0.0, false)
+	weaponMulti := 2.5
 	fidm := 1.0 + 0.1*float64(druid.Talents.FeralInstinct)
 
 	baseEffect := core.SpellEffect{
 		ProcMask: core.ProcMaskMeleeMHSpecial,
 
-		DamageMultiplier: fidm,
+		DamageMultiplier: fidm * weaponMulti,
 		ThreatMultiplier: 1,
 
 		BaseDamage: core.BaseDamageConfig{

--- a/sim/hunter/raptor_strike.go
+++ b/sim/hunter/raptor_strike.go
@@ -36,7 +36,7 @@ func (hunter *Hunter) registerRaptorStrikeSpell() {
 			DamageMultiplier: 1,
 			ThreatMultiplier: 1,
 
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 335, 1, true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 335, true),
 			OutcomeApplier: hunter.OutcomeFuncMeleeSpecialHitAndCrit(hunter.critMultiplier(false, false, hunter.CurrentTarget)),
 		}),
 	})

--- a/sim/paladin/crusader_strike.go
+++ b/sim/paladin/crusader_strike.go
@@ -41,7 +41,8 @@ func (paladin *Paladin) registerCrusaderStrikeSpell() {
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			ProcMask: core.ProcMaskMeleeMHSpecial,
 
-			DamageMultiplier: baseMultiplier,
+			DamageMultiplier: baseMultiplier *
+				(0.75), // base multiplier's .75, can be improved by sanctity (15%), taow (10%) & pvp gloves (5%), stacking additively,
 			ThreatMultiplier: 1,
 			BonusCritRating:  core.TernaryFloat64(paladin.HasSetBonus(ItemSetAegisBattlegear, 4), 10, 0) * core.CritRatingPerCritChance,
 
@@ -50,7 +51,6 @@ func (paladin *Paladin) registerCrusaderStrikeSpell() {
 				true, // cs is subject to normalisation
 				core.TernaryFloat64(paladin.Equip[proto.ItemSlot_ItemSlotRanged].ID == 31033, 36, 0)+ // Libram of Righteous Power
 					core.TernaryFloat64(paladin.Equip[proto.ItemSlot_ItemSlotRanged].ID == 40191, 79, 0), // Libram of Radiance
-				(0.75), // base multiplier's .75, can be improved by sanctity (15%), taow (10%) & pvp gloves (5%), stacking additively
 				true,
 			),
 			OutcomeApplier: paladin.OutcomeFuncMeleeSpecialHitAndCrit(paladin.MeleeCritMultiplier()),

--- a/sim/paladin/divine_storm.go
+++ b/sim/paladin/divine_storm.go
@@ -20,7 +20,8 @@ func (paladin *Paladin) registerDivineStormSpell() {
 	baseEffectMH := core.SpellEffect{ // wait how will this work, something like whirlwind
 		ProcMask: core.ProcMaskMeleeMHSpecial,
 
-		DamageMultiplier: baseMultiplier,
+		DamageMultiplier: baseMultiplier *
+			(1.1), // base 1.1 multiplier, can be further improved by 10% via taow for a grand total of 1.21. NOTE: Unlike cs, ds tooltip IS NOT updated to reflect this.
 		ThreatMultiplier: 1,
 		BonusCritRating:  core.TernaryFloat64(paladin.HasSetBonus(ItemSetAegisBattlegear, 4), 10, 0) * core.CritRatingPerCritChance,
 
@@ -30,7 +31,6 @@ func (paladin *Paladin) registerDivineStormSpell() {
 			core.TernaryFloat64(paladin.Equip[proto.ItemSlot_ItemSlotRanged].ID == 45510, 235, 0)+ // Libram of Discord
 				core.TernaryFloat64(paladin.Equip[proto.ItemSlot_ItemSlotRanged].ID == 38362, 81, 0), // Venture Co. Libram of Retribution
 			// (much akin to what stuff like hs or ms have intrinsically)
-			(1.1), // base 1.1 multiplier, can be further improved by 10% via taow for a grand total of 1.21. NOTE: Unlike cs, ds tooltip IS NOT updated to reflect this.
 			true,
 		),
 		OutcomeApplier: paladin.OutcomeFuncMeleeSpecialHitAndCrit(paladin.MeleeCritMultiplier()),

--- a/sim/paladin/soc.go
+++ b/sim/paladin/soc.go
@@ -41,8 +41,9 @@ func (paladin *Paladin) registerSealOfCommandSpellAndAura() {
 		SpellSchool: core.SpellSchoolHoly,
 		Flags:       core.SpellFlagMeleeMetrics | SpellFlagSecondaryJudgement,
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
-			ProcMask:         core.ProcMaskMeleeOrRangedSpecial,
-			DamageMultiplier: judgementMultiplier,
+			ProcMask: core.ProcMaskMeleeOrRangedSpecial,
+			DamageMultiplier: judgementMultiplier *
+				(0.19),
 			ThreatMultiplier: 1,
 
 			BonusCritRating: (6 * float64(paladin.Talents.Fanaticism) * core.CritRatingPerCritChance) +
@@ -51,7 +52,6 @@ func (paladin *Paladin) registerSealOfCommandSpellAndAura() {
 				core.MainHand,
 				false,
 				0,
-				(0.19),
 				true,
 			), func(oldCalculator core.BaseDamageCalculator) core.BaseDamageCalculator {
 				return func(sim *core.Simulation, hitEffect *core.SpellEffect, spell *core.Spell) float64 {
@@ -67,14 +67,14 @@ func (paladin *Paladin) registerSealOfCommandSpellAndAura() {
 	})
 
 	baseEffect := core.SpellEffect{
-		ProcMask:         core.ProcMaskEmpty,
-		DamageMultiplier: baseMultiplier,
+		ProcMask: core.ProcMaskEmpty,
+		DamageMultiplier: baseMultiplier *
+			(0.36),
 		ThreatMultiplier: 1,
 		BaseDamage: core.BaseDamageConfigMeleeWeapon(
 			core.MainHand,
 			false,
 			0,
-			(0.36),
 			true,
 		),
 		OutcomeApplier: paladin.OutcomeFuncMeleeSpecialHitAndCrit(paladin.MeleeCritMultiplier()),

--- a/sim/paladin/sov.go
+++ b/sim/paladin/sov.go
@@ -116,12 +116,12 @@ func (paladin *Paladin) registerSealOfVengeanceSpellAndAura() {
 		Flags:       core.SpellFlagMeleeMetrics,
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			ProcMask:         core.ProcMaskEmpty,
-			DamageMultiplier: baseMultiplier,
+			DamageMultiplier: baseMultiplier * damagePerStack,
 			ThreatMultiplier: 1,
 			BaseDamage: core.BaseDamageConfig{
 				Calculator: func(sim *core.Simulation, hitEffect *core.SpellEffect, spell *core.Spell) float64 {
 					dot := paladin.SealOfVengeanceDots[hitEffect.Target.Index]
-					return core.MultiplyByStacks(core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 0, damagePerStack, false), dot.Aura).Calculator(sim, hitEffect, spell)
+					return core.MultiplyByStacks(core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 0, false), dot.Aura).Calculator(sim, hitEffect, spell)
 				},
 			},
 			OutcomeApplier: paladin.OutcomeFuncMeleeSpecialCritOnly(paladin.MeleeCritMultiplier()), // can't miss if melee swing landed, but can crit

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -52,812 +52,812 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7125.84957
-  tps: 5059.35319
+  dps: 7179.55411
+  tps: 5097.48342
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7135.14799
-  tps: 5065.95507
+  dps: 7186.32552
+  tps: 5102.29112
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7206.6514
-  tps: 5116.72249
+  dps: 7258.24175
+  tps: 5153.35164
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7162.13665
-  tps: 5085.11702
+  dps: 7214.16976
+  tps: 5122.06053
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6225.35189
-  tps: 4419.99984
+  dps: 6273.21436
+  tps: 4453.9822
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7135.14799
-  tps: 4964.63597
+  dps: 7186.32552
+  tps: 5000.2453
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7276.89724
-  tps: 5166.59704
+  dps: 7330.31206
+  tps: 5204.52156
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7109.53264
-  tps: 5047.76817
+  dps: 7162.8277
+  tps: 5085.60766
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7140.33986
-  tps: 5069.6413
+  dps: 7193.51766
+  tps: 5107.39754
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 7231.00807
-  tps: 5134.01573
+  dps: 7282.94836
+  tps: 5170.89333
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7144.17643
-  tps: 5072.36527
+  dps: 7196.11672
+  tps: 5109.24287
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6989.87703
-  tps: 4962.81269
+  dps: 7041.46738
+  tps: 4999.44184
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7177.90562
-  tps: 5096.31299
+  dps: 7230.82861
+  tps: 5133.88832
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7135.14799
-  tps: 5065.95507
+  dps: 7186.32552
+  tps: 5102.29112
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7135.14799
-  tps: 5065.95507
+  dps: 7186.32552
+  tps: 5102.29112
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7162.13665
-  tps: 5085.11702
+  dps: 7214.16976
+  tps: 5122.06053
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7167.84438
-  tps: 5089.16951
+  dps: 7220.53019
+  tps: 5126.57643
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7135.14799
-  tps: 5065.95507
+  dps: 7186.32552
+  tps: 5102.29112
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7125.81456
-  tps: 5059.32834
+  dps: 7178.38781
+  tps: 5096.65535
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7102.77925
-  tps: 5042.97327
+  dps: 7155.78613
+  tps: 5080.60815
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7079.44035
-  tps: 5026.40265
+  dps: 7132.03563
+  tps: 5063.7453
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7135.14799
-  tps: 5065.95507
+  dps: 7186.32552
+  tps: 5102.29112
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7135.14799
-  tps: 5065.95507
+  dps: 7186.32552
+  tps: 5102.29112
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7265.85719
-  tps: 5158.75861
+  dps: 7317.44754
+  tps: 5195.38776
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6989.87703
-  tps: 4962.81269
+  dps: 7041.46738
+  tps: 4999.44184
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7064.25212
-  tps: 5015.61901
+  dps: 7115.16104
+  tps: 5051.76434
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6989.87703
-  tps: 4962.81269
+  dps: 7041.46738
+  tps: 4999.44184
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7162.13665
-  tps: 5085.11702
+  dps: 7214.16976
+  tps: 5122.06053
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7167.84438
-  tps: 5089.16951
+  dps: 7220.53019
+  tps: 5126.57643
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7172.78142
-  tps: 5092.67481
+  dps: 7225.46251
+  tps: 5130.07838
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7135.14799
-  tps: 5065.95507
+  dps: 7186.32552
+  tps: 5102.29112
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7171.59168
-  tps: 5091.83009
+  dps: 7222.76921
+  tps: 5128.16614
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6989.87703
-  tps: 4962.81269
+  dps: 7041.46738
+  tps: 4999.44184
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6989.87703
-  tps: 4962.81269
+  dps: 7041.46738
+  tps: 4999.44184
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7212.76631
-  tps: 5121.06408
+  dps: 7265.71727
+  tps: 5158.65926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6989.87703
-  tps: 4962.81269
+  dps: 7041.46738
+  tps: 4999.44184
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7164.65002
-  tps: 5086.90151
+  dps: 7215.82756
+  tps: 5123.23757
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7171.59168
-  tps: 5091.83009
+  dps: 7222.76921
+  tps: 5128.16614
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7135.14799
-  tps: 5065.95507
+  dps: 7186.32552
+  tps: 5102.29112
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7135.14799
-  tps: 5065.95507
+  dps: 7186.32552
+  tps: 5102.29112
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6989.87703
-  tps: 4962.81269
+  dps: 7041.46738
+  tps: 4999.44184
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6989.87703
-  tps: 4962.81269
+  dps: 7041.46738
+  tps: 4999.44184
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6989.87703
-  tps: 4962.81269
+  dps: 7041.46738
+  tps: 4999.44184
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7325.10211
-  tps: 5200.8225
+  dps: 7378.86717
+  tps: 5238.99569
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7135.14799
-  tps: 5065.95507
+  dps: 7186.32552
+  tps: 5102.29112
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6989.87703
-  tps: 4962.81269
+  dps: 7041.46738
+  tps: 4999.44184
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6989.87703
-  tps: 4962.81269
+  dps: 7041.46738
+  tps: 4999.44184
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7559.2548
-  tps: 5367.07091
+  dps: 7616.46148
+  tps: 5407.68765
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6989.87703
-  tps: 4962.81269
+  dps: 7041.46738
+  tps: 4999.44184
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6989.87703
-  tps: 4962.81269
+  dps: 7041.46738
+  tps: 4999.44184
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 5277.88765
-  tps: 3747.30023
+  dps: 5320.00633
+  tps: 3777.2045
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 7102.08317
-  tps: 5042.47905
+  dps: 7153.40875
+  tps: 5078.92021
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StormshroudArmor"
  value: {
-  dps: 5593.74974
-  tps: 3968.95528
+  dps: 5643.67346
+  tps: 4004.40112
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7171.59168
-  tps: 5091.83009
+  dps: 7222.76921
+  tps: 5128.16614
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7164.65002
-  tps: 5086.90151
+  dps: 7215.82756
+  tps: 5123.23757
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7152.50212
-  tps: 5078.27651
+  dps: 7203.67966
+  tps: 5114.61256
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6518.75971
-  tps: 4628.31939
+  dps: 6566.03944
+  tps: 4661.888
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheFistsofFury"
  value: {
-  dps: 6050.53449
-  tps: 4295.87949
+  dps: 6102.14543
+  tps: 4332.52326
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7199.49036
-  tps: 5111.63815
+  dps: 7251.96433
+  tps: 5148.89467
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7345.30127
-  tps: 5215.1639
+  dps: 7398.17016
+  tps: 5252.70082
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7366.47905
-  tps: 5230.20013
+  dps: 7419.15581
+  tps: 5267.60062
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7135.14799
-  tps: 5065.95507
+  dps: 7186.32552
+  tps: 5102.29112
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7135.14799
-  tps: 5065.95507
+  dps: 7186.32552
+  tps: 5102.29112
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7135.14799
-  tps: 5065.95507
+  dps: 7186.32552
+  tps: 5102.29112
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7135.14799
-  tps: 5065.95507
+  dps: 7186.32552
+  tps: 5102.29112
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6910.37181
-  tps: 4906.36399
+  dps: 6963.28344
+  tps: 4943.93124
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 7243.63952
-  tps: 5142.98406
+  dps: 7296.65715
+  tps: 5180.62658
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26065.319
-  tps: 18506.37649
+  dps: 26067.00569
+  tps: 18507.57404
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7325.10211
-  tps: 5200.8225
+  dps: 7378.86717
+  tps: 5238.99569
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8280.46792
-  tps: 5879.13222
+  dps: 8341.97129
+  tps: 5922.79962
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15276.06015
-  tps: 10846.00271
+  dps: 15277.54622
+  tps: 10847.05782
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3705.25653
-  tps: 2630.73214
+  dps: 3743.65213
+  tps: 2657.99301
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3689.71871
-  tps: 2619.70029
+  dps: 3733.16769
+  tps: 2650.54906
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15870.72186
-  tps: 11268.21252
+  dps: 15872.25513
+  tps: 11269.30115
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4494.269
-  tps: 3190.93099
+  dps: 4538.88797
+  tps: 3222.61046
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5325.98792
-  tps: 3781.45143
+  dps: 5376.31274
+  tps: 3817.18204
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9005.33529
-  tps: 6393.78806
+  dps: 9006.59082
+  tps: 6394.67948
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2126.47455
-  tps: 1509.79693
+  dps: 2157.23231
+  tps: 1531.63494
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2190.99455
-  tps: 1555.60613
+  dps: 2225.45413
+  tps: 1580.07243
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26065.319
-  tps: 18506.37649
+  dps: 26067.00569
+  tps: 18507.57404
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7325.10211
-  tps: 5200.8225
+  dps: 7378.86717
+  tps: 5238.99569
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8280.46792
-  tps: 5879.13222
+  dps: 8341.97129
+  tps: 5922.79962
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15276.06015
-  tps: 10846.00271
+  dps: 15277.54622
+  tps: 10847.05782
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3705.25653
-  tps: 2630.73214
+  dps: 3743.65213
+  tps: 2657.99301
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3689.71871
-  tps: 2619.70029
+  dps: 3733.16769
+  tps: 2650.54906
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20129.96483
-  tps: 14292.27503
+  dps: 20131.64263
+  tps: 14293.46627
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4725.1286
-  tps: 3354.84131
+  dps: 4779.03701
+  tps: 3393.11628
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5356.56196
-  tps: 3803.15899
+  dps: 5418.11795
+  tps: 3846.86374
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12950.66682
-  tps: 9194.97344
+  dps: 12952.02881
+  tps: 9195.94046
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2429.58335
-  tps: 1725.00418
+  dps: 2467.78067
+  tps: 1752.12428
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2466.57551
-  tps: 1751.26861
+  dps: 2510.06158
+  tps: 1782.14372
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26216.02168
-  tps: 18613.37539
+  dps: 26217.71688
+  tps: 18614.57899
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7355.41613
-  tps: 5222.34545
+  dps: 7409.14435
+  tps: 5260.49249
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8379.34814
-  tps: 5949.33718
+  dps: 8440.85151
+  tps: 5993.00457
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15302.15043
-  tps: 10864.52681
+  dps: 15303.68517
+  tps: 10865.61647
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3729.17402
-  tps: 2647.71355
+  dps: 3767.93617
+  tps: 2675.23468
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3747.12966
-  tps: 2660.46206
+  dps: 3790.87945
+  tps: 2691.52441
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15947.28992
-  tps: 11322.57585
+  dps: 15948.84943
+  tps: 11323.68309
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4511.74785
-  tps: 3203.34097
+  dps: 4556.36682
+  tps: 3235.02044
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5389.98442
-  tps: 3826.88894
+  dps: 5440.30924
+  tps: 3862.61956
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9041.06798
-  tps: 6419.15827
+  dps: 9042.42193
+  tps: 6420.11957
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2140.21882
-  tps: 1519.55536
+  dps: 2170.88612
+  tps: 1541.32914
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2224.64154
-  tps: 1579.49549
+  dps: 2259.10111
+  tps: 1603.96179
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26216.02168
-  tps: 18613.37539
+  dps: 26217.71688
+  tps: 18614.57899
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7355.41613
-  tps: 5222.34545
+  dps: 7409.14435
+  tps: 5260.49249
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8379.34814
-  tps: 5949.33718
+  dps: 8440.85151
+  tps: 5993.00457
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15302.15043
-  tps: 10864.52681
+  dps: 15303.68517
+  tps: 10865.61647
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3729.17402
-  tps: 2647.71355
+  dps: 3767.93617
+  tps: 2675.23468
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3747.12966
-  tps: 2660.46206
+  dps: 3790.87945
+  tps: 2691.52441
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20214.28442
-  tps: 14352.14194
+  dps: 20215.98849
+  tps: 14353.35183
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4749.60119
-  tps: 3372.21684
+  dps: 4803.48648
+  tps: 3410.4754
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5419.08343
-  tps: 3847.54923
+  dps: 5480.63941
+  tps: 3891.25398
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13015.05579
-  tps: 9240.68961
+  dps: 13016.45802
+  tps: 9241.68519
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2449.0615
-  tps: 1738.83367
+  dps: 2488.18842
+  tps: 1766.61378
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2520.52965
-  tps: 1789.57605
+  dps: 2564.20764
+  tps: 1820.58743
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6778.29406
-  tps: 4812.58878
+  dps: 6826.77123
+  tps: 4847.00757
  }
 }

--- a/sim/rogue/backstab.go
+++ b/sim/rogue/backstab.go
@@ -33,15 +33,15 @@ func (rogue *Rogue) registerBackstabSpell() {
 			BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0) +
 				10*core.CritRatingPerCritChance*float64(rogue.Talents.PuncturingWounds),
 			// All of these use "Apply Aura: Modifies Damage/Healing Done", and stack additively (up to 142%).
-			DamageMultiplier: 1 +
+			DamageMultiplier: (1 +
 				0.02*float64(rogue.Talents.FindWeakness) +
 				0.1*float64(rogue.Talents.Opportunity) +
 				0.02*float64(rogue.Talents.Aggression) +
 				core.TernaryFloat64(rogue.Talents.SurpriseAttacks, 0.1, 0) +
-				core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0),
+				core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0)) * (1.5 + 0.01*float64(rogue.Talents.SinisterCalling)),
 			ThreatMultiplier: 1,
 
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 170, 1.5+0.01*float64(rogue.Talents.SinisterCalling), true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 170, true),
 			OutcomeApplier: rogue.OutcomeFuncMeleeSpecialHitAndCrit(rogue.MeleeCritMultiplier(true, true)),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {

--- a/sim/rogue/fan_of_knives.go
+++ b/sim/rogue/fan_of_knives.go
@@ -13,22 +13,23 @@ const FanOfKnivesSpellID int32 = 51723
 func (rogue *Rogue) makeFanOfKnivesWeaponHitEffect(isMH bool) core.SpellEffect {
 	var procMask core.ProcMask
 	var baseDamageConfig core.BaseDamageConfig
+	weaponMultiplier := 0.0
 	if isMH {
-		weaponMultiplier := core.TernaryFloat64(rogue.Equip[proto.ItemSlot_ItemSlotMainHand].WeaponType == proto.WeaponType_WeaponTypeDagger, 1.05, 0.7)
+		weaponMultiplier = core.TernaryFloat64(rogue.Equip[proto.ItemSlot_ItemSlotMainHand].WeaponType == proto.WeaponType_WeaponTypeDagger, 1.05, 0.7)
 		procMask = core.ProcMaskMeleeMHSpecial
-		baseDamageConfig = core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 0, weaponMultiplier, false)
+		baseDamageConfig = core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 0, false)
 
 	} else {
-		weaponMultiplier := core.TernaryFloat64(rogue.Equip[proto.ItemSlot_ItemSlotOffHand].WeaponType == proto.WeaponType_WeaponTypeDagger, 1.05, 0.7)
+		weaponMultiplier = core.TernaryFloat64(rogue.Equip[proto.ItemSlot_ItemSlotOffHand].WeaponType == proto.WeaponType_WeaponTypeDagger, 1.05, 0.7)
 		weaponMultiplier += 0.1 * float64(rogue.Talents.DualWieldSpecialization)
 		procMask = core.ProcMaskMeleeOHSpecial
-		baseDamageConfig = core.BaseDamageConfigMeleeWeapon(core.OffHand, false, 0, weaponMultiplier, false)
+		baseDamageConfig = core.BaseDamageConfigMeleeWeapon(core.OffHand, false, 0, false)
 	}
 	return core.SpellEffect{
 		ProcMask: procMask,
-		DamageMultiplier: 1 +
+		DamageMultiplier: (1 +
 			0.02*float64(rogue.Talents.FindWeakness) +
-			core.TernaryFloat64(rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfFanOfKnives), 0.2, 0.0),
+			core.TernaryFloat64(rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfFanOfKnives), 0.2, 0.0)) * weaponMultiplier,
 		ThreatMultiplier: 1,
 		BaseDamage:       baseDamageConfig,
 		OutcomeApplier:   rogue.OutcomeFuncMeleeSpecialHitAndCrit(rogue.MeleeCritMultiplier(isMH, false)),

--- a/sim/rogue/hemorrhage.go
+++ b/sim/rogue/hemorrhage.go
@@ -62,12 +62,12 @@ func (rogue *Rogue) registerHemorrhageSpell() {
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			ProcMask:        core.ProcMaskMeleeMHSpecial,
 			BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0),
-			DamageMultiplier: 1 +
+			DamageMultiplier: (1 +
 				0.02*float64(rogue.Talents.FindWeakness) +
-				core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0),
+				core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0)) * weaponDamageBonus,
 			ThreatMultiplier: 1,
 			BaseDamage: core.BaseDamageConfigMeleeWeapon(
-				core.MainHand, true, 0, weaponDamageBonus, true),
+				core.MainHand, true, 0, true),
 			OutcomeApplier: rogue.OutcomeFuncMeleeSpecialHitAndCrit(rogue.MeleeCritMultiplier(true, true)),
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if spellEffect.Landed() {

--- a/sim/rogue/killing_spree.go
+++ b/sim/rogue/killing_spree.go
@@ -23,10 +23,10 @@ func (rogue *Rogue) makeKillingSpreedWeaponSwingEffect(isMh bool) core.SpellEffe
 	}
 	return core.SpellEffect{
 		ProcMask: procMask,
-		DamageMultiplier: 1 +
-			0.02*float64(rogue.Talents.FindWeakness),
+		DamageMultiplier: (1 +
+			0.02*float64(rogue.Talents.FindWeakness)) * baseMultiplier,
 		ThreatMultiplier: 1,
-		BaseDamage:       core.BaseDamageConfigMeleeWeapon(hand, true, 0, baseMultiplier, true),
+		BaseDamage:       core.BaseDamageConfigMeleeWeapon(hand, true, 0, true),
 		OutcomeApplier:   rogue.OutcomeFuncMeleeWeaponSpecialHitAndCrit(rogue.MeleeCritMultiplier(isMh, false)),
 	}
 }

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -30,7 +30,7 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 			core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0),
 		ThreatMultiplier: 1,
 
-		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 181, 1, false),
+		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 181, false),
 		OutcomeApplier: rogue.OutcomeFuncMeleeSpecialHitAndCrit(rogue.MeleeCritMultiplier(isMH, true)),
 
 		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
@@ -43,7 +43,8 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 	}
 	if !isMH {
 		effect.ProcMask = core.ProcMaskMeleeOHSpecial
-		effect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 181, 1+0.1*float64(rogue.Talents.DualWieldSpecialization), false)
+		effect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 181, false)
+		effect.DamageMultiplier *= (1 + 0.1*float64(rogue.Talents.DualWieldSpecialization))
 	}
 
 	effect.BaseDamage = core.WrapBaseDamageConfig(effect.BaseDamage, func(oldCalculator core.BaseDamageCalculator) core.BaseDamageCalculator {

--- a/sim/rogue/shiv.go
+++ b/sim/rogue/shiv.go
@@ -33,11 +33,11 @@ func (rogue *Rogue) registerShivSpell() {
 
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			ProcMask: core.ProcMaskMeleeOHSpecial,
-			DamageMultiplier: 1 +
+			DamageMultiplier: (1 +
 				0.02*float64(rogue.Talents.FindWeakness) +
-				core.TernaryFloat64(rogue.Talents.SurpriseAttacks, 0.1, 0),
+				core.TernaryFloat64(rogue.Talents.SurpriseAttacks, 0.1, 0)) * (1 + 0.1*float64(rogue.Talents.DualWieldSpecialization)),
 			ThreatMultiplier: 1,
-			BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, 1+0.1*float64(rogue.Talents.DualWieldSpecialization), false),
+			BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, false),
 			OutcomeApplier:   rogue.OutcomeFuncMeleeSpecialHitAndCrit(rogue.MeleeCritMultiplier(false, true)),
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if spellEffect.Landed() {

--- a/sim/rogue/sinister_strike.go
+++ b/sim/rogue/sinister_strike.go
@@ -45,7 +45,7 @@ func (rogue *Rogue) registerSinisterStrikeSpell() {
 			ThreatMultiplier: 1,
 			BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0) +
 				[]float64{0, 2, 4, 6}[rogue.Talents.TurnTheTables]*core.CritRatingPerCritChance,
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 180, 1, true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 180, true),
 			OutcomeApplier: rogue.OutcomeFuncMeleeSpecialHitAndCrit(rogue.MeleeCritMultiplier(true, true)),
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if spellEffect.Landed() {

--- a/sim/shaman/lavalash.go
+++ b/sim/shaman/lavalash.go
@@ -67,7 +67,7 @@ func (shaman *Shaman) newLavaLashSpell() *core.Spell {
 				core.TernaryFloat64(shaman.HasSetBonus(ItemSetWorldbreakerBattlegear, 2), 1.2, 1),
 			ThreatMultiplier: 1 - (0.1/3)*float64(shaman.Talents.ElementalPrecision),
 
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.OffHand, false, flatDamageBonus, 1, true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.OffHand, false, flatDamageBonus, true),
 			OutcomeApplier: shaman.OutcomeFuncMeleeSpecialHitAndCrit(shaman.ElementalCritMultiplier(0)),
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if !spellEffect.Landed() { //TODO: verify that it actually needs to hit

--- a/sim/shaman/stormstrike.go
+++ b/sim/shaman/stormstrike.go
@@ -55,10 +55,10 @@ func (shaman *Shaman) newStormstrikeHitSpell(isMH bool) *core.Spell {
 
 	if isMH {
 		effect.ProcMask = core.ProcMaskMeleeMHSpecial
-		effect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.MainHand, false, flatDamageBonus, 1, true)
+		effect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.MainHand, false, flatDamageBonus, true)
 	} else {
 		effect.ProcMask = core.ProcMaskMeleeOHSpecial
-		effect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.OffHand, false, flatDamageBonus, 1, true)
+		effect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.OffHand, false, flatDamageBonus, true)
 	}
 
 	return shaman.RegisterSpell(core.SpellConfig{

--- a/sim/shaman/weapon_imbues.go
+++ b/sim/shaman/weapon_imbues.go
@@ -31,12 +31,13 @@ func (shaman *Shaman) newWindfuryImbueSpell(isMH bool) *core.Spell {
 	}
 
 	weaponDamageMultiplier := 1 + math.Round(float64(shaman.Talents.ElementalWeapons)*13.33)/100
+	baseEffect.DamageMultiplier *= weaponDamageMultiplier
 	if isMH {
 		actionID.Tag = 1
-		baseEffect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 0, weaponDamageMultiplier, true)
+		baseEffect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 0, true)
 	} else {
 		actionID.Tag = 2
-		baseEffect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.OffHand, false, 0, weaponDamageMultiplier, true)
+		baseEffect.BaseDamage = core.BaseDamageConfigMeleeWeapon(core.OffHand, false, 0, true)
 
 		// For whatever reason, OH penalty does not apply to the bonus AP from WF OH
 		// hits. Implement this by doubling the AP bonus we provide.

--- a/sim/warlock/pet_abilities.go
+++ b/sim/warlock/pet_abilities.go
@@ -93,7 +93,7 @@ func (wp *WarlockPet) newCleave() *core.Spell {
 		ProcMask:         core.ProcMaskMeleeMHSpecial,
 		DamageMultiplier: 1.0,
 		ThreatMultiplier: 1,
-		BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 124, 1.0, true),
+		BaseDamage:       core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 124, true),
 		OutcomeApplier:   wp.OutcomeFuncMeleeSpecialHitAndCrit(2),
 	}
 

--- a/sim/warrior/devastate.go
+++ b/sim/warrior/devastate.go
@@ -46,7 +46,8 @@ func (warrior *Warrior) registerDevastateSpell() {
 	flatThreatBonus := core.TernaryFloat64(hasGlyph, 630, 315)
 	dynaThreatBonus := core.TernaryFloat64(hasGlyph, 0.1, 0.05)
 
-	normalBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 0, 1.2, false)
+	normalBaseDamage := core.BaseDamageFuncMeleeWeapon(core.MainHand, true, 0, false)
+	weaponMulti := 1.2
 
 	warrior.Devastate = warrior.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 47498},
@@ -68,7 +69,7 @@ func (warrior *Warrior) registerDevastateSpell() {
 			ProcMask: core.ProcMaskMeleeMHSpecial,
 
 			BonusCritRating:  5 * core.CritRatingPerCritChance * float64(warrior.Talents.SwordAndBoard),
-			DamageMultiplier: 1,
+			DamageMultiplier: weaponMulti,
 			ThreatMultiplier: 1,
 			FlatThreatBonus:  flatThreatBonus,
 			DynamicThreatBonus: func(spellEffect *core.SpellEffect, spell *core.Spell) float64 {

--- a/sim/warrior/heroic_strike_cleave.go
+++ b/sim/warrior/heroic_strike_cleave.go
@@ -48,7 +48,7 @@ func (warrior *Warrior) registerHeroicStrikeSpell() {
 			FlatThreatBonus:  259,
 			BonusCritRating:  (float64(warrior.Talents.Incite)*5 + core.TernaryFloat64(warrior.HasSetBonus(ItemSetWrynnsBattlegear, 4), 5, 0)) * core.CritRatingPerCritChance,
 
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 495, 1, true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 495, true),
 			OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(mh)),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
@@ -78,7 +78,7 @@ func (warrior *Warrior) registerCleaveSpell() {
 		FlatThreatBonus:  225,
 		BonusCritRating:  float64(warrior.Talents.Incite) * 5 * core.CritRatingPerCritChance,
 
-		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, flatDamageBonus, 1, true),
+		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, flatDamageBonus, true),
 		OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(mh)),
 	}
 

--- a/sim/warrior/mortal_strike.go
+++ b/sim/warrior/mortal_strike.go
@@ -48,7 +48,7 @@ func (warrior *Warrior) registerMortalStrikeSpell(cdTimer *core.Timer) {
 				return 1.0
 			},
 
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 380, 1, true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 380, true),
 			OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(mh)),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {

--- a/sim/warrior/overpower.go
+++ b/sim/warrior/overpower.go
@@ -36,7 +36,7 @@ func (warrior *Warrior) registerOverpowerSpell(cdTimer *core.Timer) {
 		ThreatMultiplier: 0.75,
 		BonusCritRating:  25 * core.CritRatingPerCritChance * float64(warrior.Talents.ImprovedOverpower),
 
-		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 0, 1, true),
+		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 0, true),
 		OutcomeApplier: warrior.OutcomeFuncMeleeSpecialNoBlockDodgeParry(warrior.critMultiplier(mh)),
 
 		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -52,7 +52,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 0.63055
+  weights: 0.63217
   weights: 0
   weights: 0
   weights: 0
@@ -70,7 +70,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.19031
+  weights: 0.19013
   weights: 0
   weights: 0
   weights: 0
@@ -79,12 +79,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.02855
+  weights: 0.03115
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.22326
-  weights: -0.08302
+  weights: 0.22155
+  weights: -0.08912
   weights: 0
   weights: 0
   weights: 0
@@ -103,583 +103,583 @@ stat_weights_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 1967.76542
-  tps: 5552.64084
+  dps: 2045.77921
+  tps: 5714.40245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1956.06996
-  tps: 5518.66522
+  dps: 2033.50529
+  tps: 5679.22739
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2061.04428
-  tps: 5793.58366
+  dps: 2140.34034
+  tps: 5958.00405
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1972.56173
-  tps: 5556.268
+  dps: 2050.83993
+  tps: 5718.57785
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1954.19235
-  tps: 5519.23315
+  dps: 2031.3691
+  tps: 5679.25913
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1959.02037
-  tps: 5428.23496
+  dps: 2035.34973
+  tps: 5583.33852
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2022.74353
-  tps: 5681.08654
+  dps: 2102.70037
+  tps: 5846.87705
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2045.94235
-  tps: 5745.59139
+  dps: 2126.30209
+  tps: 5912.2173
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2083.31079
-  tps: 5834.63236
+  dps: 2163.99132
+  tps: 6001.92342
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 2075.18277
-  tps: 5850.05254
+  dps: 2153.99491
+  tps: 6013.46951
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 2079.12376
-  tps: 5840.95667
+  dps: 2158.99962
+  tps: 6006.57927
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 2029.3893
-  tps: 5732.03081
+  dps: 2107.5431
+  tps: 5894.08271
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1982.00006
-  tps: 5594.14151
+  dps: 2060.88019
+  tps: 5757.69946
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 2187.73564
-  tps: 6099.54407
+  dps: 2275.98654
+  tps: 6282.5323
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1959.02037
-  tps: 5538.96417
+  dps: 2035.34973
+  tps: 5697.23311
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1959.02037
-  tps: 5538.96417
+  dps: 2035.34973
+  tps: 5697.23311
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1972.56173
-  tps: 5556.268
+  dps: 2050.83993
+  tps: 5718.57785
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1982.24693
-  tps: 5594.07493
+  dps: 2059.80242
+  tps: 5754.88624
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1970.08267
-  tps: 5568.78317
+  dps: 2046.41204
+  tps: 5727.05211
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2062.92006
-  tps: 5775.76066
+  dps: 2142.20018
+  tps: 5940.14798
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2044.11798
-  tps: 5750.16739
+  dps: 2125.06206
+  tps: 5918.00493
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2031.55336
-  tps: 5713.75349
+  dps: 2111.13693
+  tps: 5878.77002
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1959.02037
-  tps: 5538.96417
+  dps: 2035.34973
+  tps: 5697.23311
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1959.02037
-  tps: 5538.96417
+  dps: 2035.34973
+  tps: 5697.23311
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2034.13262
-  tps: 5737.45287
+  dps: 2112.90094
+  tps: 5900.77898
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1956.06996
-  tps: 5518.66522
+  dps: 2033.50529
+  tps: 5679.22739
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 2386.76652
-  tps: 6572.23007
+  dps: 2471.67184
+  tps: 6748.28125
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1956.06996
-  tps: 5518.66522
+  dps: 2033.50529
+  tps: 5679.22739
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1972.56173
-  tps: 5556.268
+  dps: 2050.83993
+  tps: 5718.57785
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1982.24693
-  tps: 5594.07493
+  dps: 2059.80242
+  tps: 5754.88624
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2024.87497
-  tps: 5703.09931
+  dps: 2104.1502
+  tps: 5867.47651
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1959.02037
-  tps: 5538.96417
+  dps: 2035.34973
+  tps: 5697.23311
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1971.90884
-  tps: 5562.18963
+  dps: 2049.51658
+  tps: 5723.10929
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1964.89305
-  tps: 5542.44831
+  dps: 2042.32838
+  tps: 5703.01048
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1956.06996
-  tps: 5518.66522
+  dps: 2033.50529
+  tps: 5679.22739
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2071.024
-  tps: 5818.37589
+  dps: 2151.7346
+  tps: 5985.72932
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1976.03869
-  tps: 5575.72361
+  dps: 2054.59736
+  tps: 5738.615
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 1649.26233
-  tps: 4665.17509
+  dps: 1717.56968
+  tps: 4806.81038
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 1897.27937
-  tps: 5290.36275
+  dps: 1977.0825
+  tps: 5455.83454
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1985.49919
-  tps: 5605.97493
+  dps: 2064.05086
+  tps: 5768.85182
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1971.90884
-  tps: 5562.18963
+  dps: 2049.51658
+  tps: 5723.10929
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1959.02037
-  tps: 5538.96417
+  dps: 2035.34973
+  tps: 5697.23311
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1959.02037
-  tps: 5538.96417
+  dps: 2035.34973
+  tps: 5697.23311
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1956.06996
-  tps: 5518.66522
+  dps: 2033.50529
+  tps: 5679.22739
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1956.06996
-  tps: 5518.66522
+  dps: 2033.50529
+  tps: 5679.22739
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1956.06996
-  tps: 5518.66522
+  dps: 2033.50529
+  tps: 5679.22739
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2003.98275
-  tps: 5633.22998
+  dps: 2083.26966
+  tps: 5797.63138
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1959.02037
-  tps: 5538.96417
+  dps: 2035.34973
+  tps: 5697.23311
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1956.06996
-  tps: 5518.66522
+  dps: 2033.50529
+  tps: 5679.22739
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1981.4108
-  tps: 5598.17745
+  dps: 2059.64992
+  tps: 5760.40628
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1956.06996
-  tps: 5518.66522
+  dps: 2033.50529
+  tps: 5679.22739
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 2220.9769
-  tps: 6204.90339
+  dps: 2308.53683
+  tps: 6386.45891
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1956.06996
-  tps: 5518.66522
+  dps: 2033.50529
+  tps: 5679.22739
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SparkofLife-37657"
  value: {
-  dps: 1993.19396
-  tps: 5627.31561
+  dps: 2071.80342
+  tps: 5790.31234
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormshroudArmor"
  value: {
-  dps: 1651.71601
-  tps: 4674.32773
+  dps: 1722.42095
+  tps: 4820.93441
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1971.90884
-  tps: 5562.18963
+  dps: 2049.51658
+  tps: 5723.10929
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1985.49919
-  tps: 5605.97493
+  dps: 2064.05086
+  tps: 5768.85182
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1967.73105
-  tps: 5552.08715
+  dps: 2046.48842
+  tps: 5715.39056
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 1699.70592
-  tps: 4660.59007
+  dps: 1799.1679
+  tps: 4866.82448
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1858.55489
-  tps: 5068.1836
+  dps: 1962.93706
+  tps: 5284.62004
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1976.6104
-  tps: 5570.27322
+  dps: 2055.46946
+  tps: 5733.78749
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2140.36044
-  tps: 6034.806
+  dps: 2223.57767
+  tps: 6207.35693
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2154.53644
-  tps: 6076.45688
+  dps: 2238.40321
+  tps: 6250.35461
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1959.02037
-  tps: 5538.96417
+  dps: 2035.34973
+  tps: 5697.23311
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1959.02037
-  tps: 5538.96417
+  dps: 2035.34973
+  tps: 5697.23311
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1959.02037
-  tps: 5538.96417
+  dps: 2035.34973
+  tps: 5697.23311
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1959.02037
-  tps: 5538.96417
+  dps: 2035.34973
+  tps: 5697.23311
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 2421.82902
-  tps: 6693.91682
+  dps: 2512.5504
+  tps: 6882.0276
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 2684.74037
-  tps: 7344.52721
+  dps: 2781.61557
+  tps: 7545.39794
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 2847.6976
-  tps: 7416.08156
+  dps: 2911.43644
+  tps: 7548.24405
   dtps: 207.48095
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2018.41439
-  tps: 5268.72387
+  dps: 2099.79017
+  tps: 5437.45654
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2018.41439
-  tps: 5221.15162
+  dps: 2099.79017
+  tps: 5389.88428
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2153.68927
-  tps: 5547.5615
+  dps: 2232.82724
+  tps: 5711.65407
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 971.64159
-  tps: 2648.04994
+  dps: 1015.07385
+  tps: 2738.10672
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 971.64159
-  tps: 2600.4463
+  dps: 1015.07385
+  tps: 2690.50308
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 862.63135
-  tps: 2315.35586
+  dps: 895.72602
+  tps: 2383.97767
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2034.00783
-  tps: 5313.57393
+  dps: 2114.44524
+  tps: 5480.36089
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2034.00783
-  tps: 5266.02314
+  dps: 2114.44524
+  tps: 5432.81011
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2143.94228
-  tps: 5522.43175
+  dps: 2222.32931
+  tps: 5684.96726
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 980.02403
-  tps: 2668.87785
+  dps: 1023.91148
+  tps: 2759.87848
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 980.02403
-  tps: 2621.25512
+  dps: 1023.91148
+  tps: 2712.25575
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 863.89711
-  tps: 2313.77124
+  dps: 897.62955
+  tps: 2383.71545
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2995.80135
-  tps: 7806.63581
+  dps: 3062.72698
+  tps: 7945.40611
   dtps: 209.32273
  }
 }

--- a/sim/warrior/slam.go
+++ b/sim/warrior/slam.go
@@ -35,7 +35,7 @@ func (warrior *Warrior) registerSlamSpell() {
 			BonusCritRating:  core.TernaryFloat64(warrior.HasSetBonus(ItemSetWrynnsBattlegear, 4), 5, 0) * core.CritRatingPerCritChance,
 			FlatThreatBonus:  140,
 
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 250, 1, true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, false, 250, true),
 			OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(mh)),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -750,16 +750,16 @@ func (warrior *Warrior) RegisterBladestormCD() {
 		DamageMultiplier: dm,
 		ThreatMultiplier: 1.25,
 
-		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 0, 1, true),
+		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 0, true),
 		OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(mh)),
 	}
 	baseEffectOH := core.SpellEffect{
 		ProcMask: core.ProcMaskMeleeOHSpecial,
 
-		DamageMultiplier: dm,
+		DamageMultiplier: dm * (1 + 0.05*float64(warrior.Talents.DualWieldSpecialization)),
 		ThreatMultiplier: 1.25,
 
-		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, 1+0.05*float64(warrior.Talents.DualWieldSpecialization), true),
+		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, true),
 		OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(oh)),
 	}
 

--- a/sim/warrior/whirlwind.go
+++ b/sim/warrior/whirlwind.go
@@ -20,16 +20,16 @@ func (warrior *Warrior) registerWhirlwindSpell() {
 		DamageMultiplier: dm,
 		ThreatMultiplier: 1.25,
 
-		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 0, 1, true),
+		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 0, true),
 		OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(mh)),
 	}
 	baseEffectOH := core.SpellEffect{
 		ProcMask: core.ProcMaskMeleeOHSpecial,
 
-		DamageMultiplier: dm,
+		DamageMultiplier: dm * (1 + 0.05*float64(warrior.Talents.DualWieldSpecialization)),
 		ThreatMultiplier: 1.25,
 
-		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, 1+0.05*float64(warrior.Talents.DualWieldSpecialization), true),
+		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, true),
 		OutcomeApplier: warrior.OutcomeFuncMeleeWeaponSpecialHitAndCrit(warrior.critMultiplier(oh)),
 	}
 


### PR DESCRIPTION
Moved weapon multiplier to SpellEffect.DamageMultiplier to optimise run speed
also fixed oh penalty to not apply to flat damage (except for dk where it is done manually)