### PR TITLE
Fire Ele fix for raid sim

### DIFF
--- a/sim/shaman/fire_elemental_spells.go
+++ b/sim/shaman/fire_elemental_spells.go
@@ -1,6 +1,7 @@
 package shaman
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/wowsims/wotlk/sim/core"
@@ -97,7 +98,7 @@ func (fireElemental *FireElemental) registerFireShieldAura() {
 	fireShieldDot := core.NewDot(core.Dot{
 		Spell: spell,
 		Aura: target.RegisterAura(core.Aura{
-			Label:    "Fire Shield",
+			Label:    "FireShield-" + strconv.Itoa(int(fireElemental.Index)),
 			ActionID: actionID,
 		}),
 		NumberOfTicks: 40,


### PR DESCRIPTION
fixes the issue with fireshield, and applying multiple fireshield dots to a target crashing the raid sim.