### PR TITLE
core: add 'CurrentPowerBar' concept

### DIFF
--- a/sim/common/tbc/melee_items.go
+++ b/sim/common/tbc/melee_items.go
@@ -628,11 +628,13 @@ func init() {
 		const procChance = 2.7 / 60.0
 		actionID := core.ActionID{ItemID: 29996}
 
-		var resourceMetrics *core.ResourceMetrics
+		var resourceMetricsRage *core.ResourceMetrics
+		var resourceMetricsEnergy *core.ResourceMetrics
 		if character.HasRageBar() {
-			resourceMetrics = character.NewRageMetrics(actionID)
-		} else if character.HasEnergyBar() {
-			resourceMetrics = character.NewEnergyMetrics(actionID)
+			resourceMetricsRage = character.NewRageMetrics(actionID)
+		}
+		if character.HasEnergyBar() {
+			resourceMetricsEnergy = character.NewEnergyMetrics(actionID)
 		}
 
 		character.GetOrRegisterAura(core.Aura{
@@ -646,16 +648,17 @@ func init() {
 					return
 				}
 
-				if spell.Unit.HasRageBar() {
+				cpb := spell.Unit.GetCurrentPowerBar()
+				if cpb == core.RageBar {
 					if sim.RandomFloat("Rod of the Sun King") > procChance {
 						return
 					}
-					spell.Unit.AddRage(sim, 5, resourceMetrics)
-				} else if spell.Unit.HasEnergyBar() {
+					spell.Unit.AddRage(sim, 5, resourceMetricsRage)
+				} else if cpb == core.EnergyBar {
 					if sim.RandomFloat("Rod of the Sun King") > procChance {
 						return
 					}
-					spell.Unit.AddEnergy(sim, 10, resourceMetrics)
+					spell.Unit.AddEnergy(sim, 10, resourceMetricsEnergy)
 				}
 			},
 		})

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -790,13 +790,14 @@ func registerRevitalizeHotCD(agent Agent, label string, hotID ActionID, ticks in
 				NumTicks: ticks,
 				OnAction: func(s *Simulation) {
 					if s.RandomFloat("Revitalize Proc") < 0.15 {
-						if aura.Unit.HasManaBar() {
+						cpb := aura.Unit.GetCurrentPowerBar()
+						if cpb == ManaBar {
 							aura.Unit.AddMana(s, aura.Unit.MaxMana()*0.01, manaMetrics, true)
-						} else if aura.Unit.HasEnergyBar() {
+						} else if cpb == EnergyBar {
 							aura.Unit.AddEnergy(s, 8, energyMetrics)
-						} else if aura.Unit.HasRageBar() {
+						} else if cpb == RageBar {
 							aura.Unit.AddRage(s, 4, rageMetrics)
-						} else if aura.Unit.HasRunicPowerBar() {
+						} else if cpb == RunicPower {
 							aura.Unit.AddRunicPower(s, 16, rpMetrics)
 						}
 					}

--- a/sim/core/energy.go
+++ b/sim/core/energy.go
@@ -34,6 +34,7 @@ type energyBar struct {
 }
 
 func (unit *Unit) EnableEnergyBar(maxEnergy float64, onEnergyGain OnEnergyGain) {
+	unit.SetCurrentPowerBar(EnergyBar)
 
 	unit.energyBar = energyBar{
 		unit:      unit,

--- a/sim/core/mana.go
+++ b/sim/core/mana.go
@@ -35,6 +35,7 @@ type manaBar struct {
 // It will then enable mana gain metrics for reporting.
 func (character *Character) EnableManaBar() {
 	character.EnableManaBarWithModifier(1.0)
+	character.Unit.SetCurrentPowerBar(ManaBar)
 }
 
 func (character *Character) EnableManaBarWithModifier(modifier float64) {

--- a/sim/core/rage.go
+++ b/sim/core/rage.go
@@ -32,6 +32,7 @@ type RageBarOptions struct {
 func (unit *Unit) EnableRageBar(options RageBarOptions, onRageGain OnRageGain) {
 	rageFromDamageTakenMetrics := unit.NewRageMetrics(ActionID{OtherID: proto.OtherAction_OtherActionDamageTaken})
 
+	unit.SetCurrentPowerBar(RageBar)
 	unit.RegisterAura(Aura{
 		Label:    "RageBar",
 		Duration: NeverExpires,

--- a/sim/core/runic_power.go
+++ b/sim/core/runic_power.go
@@ -119,6 +119,7 @@ func (unit *Unit) EnableRunicPowerBar(currentRunicPower float64, maxRunicPower f
 	onUnholyRuneGain OnRune,
 	onDeathRuneGain OnRune,
 	onRunicPowerGain OnRunicPowerGain) {
+	unit.SetCurrentPowerBar(RunicPower)
 	unit.RunicPowerBar = RunicPowerBar{
 		unit: unit,
 

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -15,6 +15,15 @@ const (
 	PetUnit
 )
 
+type PowerBarType int
+
+const (
+	ManaBar PowerBarType = iota
+	EnergyBar
+	RageBar
+	RunicPower
+)
+
 type DynamicDamageTakenModifier func(sim *Simulation, spellEffect *SpellEffect)
 
 // Unit is an abstraction of a Character/Boss/Pet/etc, containing functionality
@@ -78,6 +87,7 @@ type Unit struct {
 
 	PseudoStats stats.PseudoStats
 
+	currentPowerBar PowerBarType
 	healthBar
 	manaBar
 	rageBar
@@ -376,6 +386,14 @@ func (unit *Unit) MultiplyAttackSpeed(sim *Simulation, amount float64) {
 	unit.PseudoStats.MeleeSpeedMultiplier *= amount
 	unit.PseudoStats.RangedSpeedMultiplier *= amount
 	unit.AutoAttacks.UpdateSwingTime(sim)
+}
+
+func (unit *Unit) SetCurrentPowerBar(bar PowerBarType) {
+	unit.currentPowerBar = bar
+}
+
+func (unit *Unit) GetCurrentPowerBar() PowerBarType {
+	return unit.currentPowerBar
 }
 
 func (unit *Unit) finalize() {

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -39,6 +39,7 @@ func (druid *Druid) ClearForm(sim *core.Simulation) {
 		druid.BearFormAura.Deactivate(sim)
 	}
 	druid.form = Humanoid
+	druid.SetCurrentPowerBar(core.ManaBar)
 }
 
 func (druid *Druid) PowerShiftCat(sim *core.Simulation) bool {
@@ -98,6 +99,7 @@ func (druid *Druid) registerCatFormSpell() {
 				druid.ClearForm(sim)
 			}
 			druid.form = Cat
+			druid.SetCurrentPowerBar(core.EnergyBar)
 			druid.manageCooldownsEnabled(sim)
 			druid.PseudoStats.SpiritRegenMultiplier *= AnimalSpiritRegenSuppression
 			druid.UpdateManaRegenRates()
@@ -217,6 +219,7 @@ func (druid *Druid) registerBearFormSpell() {
 			}
 			druid.form = Bear
 
+			druid.SetCurrentPowerBar(core.RageBar)
 			druid.applyFeralShift(sim, true)
 			druid.AddStatDynamic(sim, stats.AttackPower, 3*float64(core.CharacterLevel))
 			druid.EnableDynamicStatDep(sim, stamdep)

--- a/ui/feral_druid/sim.ts
+++ b/ui/feral_druid/sim.ts
@@ -34,7 +34,6 @@ export class FeralDruidSimUI extends IndividualSimUI<Spec.SpecFeralDruid> {
 			// List any known bugs / issues here and they'll be shown on the site.
 			knownIssues: [
 				"Stats display only humanoid form",
-				"Revitalize doesn't work",
 				"ilotp mana regen not implemented"
 			],
 			warnings: [


### PR DESCRIPTION
 - used to correctly handle revitalize and others to correct give rage/energy based on current power bar

Signed-off-by: jarves <jarveson@gmail.com>