### PR TITLE
feral: default buffs / alpha tag

### DIFF
--- a/ui/core/launched_sims.ts
+++ b/ui/core/launched_sims.ts
@@ -17,7 +17,7 @@ export const simLaunchStatuses: Record<Spec, LaunchStatus> = {
 	[Spec.SpecBalanceDruid]: LaunchStatus.Alpha,
 	[Spec.SpecElementalShaman]: LaunchStatus.Alpha,
 	[Spec.SpecEnhancementShaman]: LaunchStatus.Alpha,
-	[Spec.SpecFeralDruid]: LaunchStatus.Unlaunched,
+	[Spec.SpecFeralDruid]: LaunchStatus.Alpha,
 	[Spec.SpecFeralTankDruid]: LaunchStatus.Unlaunched,
 	[Spec.SpecHunter]: LaunchStatus.Alpha,
 	[Spec.SpecMage]: LaunchStatus.Alpha,

--- a/ui/feral_druid/sim.ts
+++ b/ui/feral_druid/sim.ts
@@ -105,9 +105,11 @@ export class FeralDruidSimUI extends IndividualSimUI<Spec.SpecFeralDruid> {
 					strengthOfEarthTotem: TristateEffect.TristateEffectImproved,
 					battleShout: TristateEffect.TristateEffectImproved,
 					unleashedRage: true,
+					icyTalons: true,
+					swiftRetribution: true,
+					sanctifiedRetribution: true,
 				}),
 				partyBuffs: PartyBuffs.create({
-					braidedEterniumChain: true,
 				}),
 				individualBuffs: IndividualBuffs.create({
 					blessingOfKings: true,
@@ -121,6 +123,7 @@ export class FeralDruidSimUI extends IndividualSimUI<Spec.SpecFeralDruid> {
 					faerieFire: TristateEffect.TristateEffectImproved,
 					sunderArmor: true,
 					curseOfWeakness: TristateEffect.TristateEffectRegular,
+					heartOfTheCrusader: true,
 				}),
 			},
 


### PR DESCRIPTION
- Tweak default raid buffs a bit so cat can put its 'best paw forward' so to speak
- Tag as alpha, now within ~1% of reference sim