### PR TITLE
enchant: fix/nerf mongoose

### DIFF
--- a/sim/common/tbc/enchant_effects.go
+++ b/sim/common/tbc/enchant_effects.go
@@ -86,10 +86,10 @@ func init() {
 			return
 		}
 		procMask := core.GetMeleeProcMaskForHands(mh, oh)
-		ppmm := character.AutoAttacks.NewPPMManager(1.0, procMask)
+		ppmm := character.AutoAttacks.NewPPMManager(0.73, procMask)
 
-		mhAura := character.NewTemporaryStatsAura("Lightning Speed MH", core.ActionID{SpellID: 28093, Tag: 1}, stats.Stats{stats.MeleeHaste: 30.0}, time.Second*15)
-		ohAura := character.NewTemporaryStatsAura("Lightning Speed OH", core.ActionID{SpellID: 28093, Tag: 2}, stats.Stats{stats.MeleeHaste: 30.0}, time.Second*15)
+		mhAura := character.NewTemporaryStatsAura("Lightning Speed MH", core.ActionID{SpellID: 28093, Tag: 1}, stats.Stats{stats.MeleeHaste: 30.0, stats.Agility: 120}, time.Second*15)
+		ohAura := character.NewTemporaryStatsAura("Lightning Speed OH", core.ActionID{SpellID: 28093, Tag: 2}, stats.Stats{stats.MeleeHaste: 30.0, stats.Agility: 120}, time.Second*15)
 
 		character.GetOrRegisterAura(core.Aura{
 			Label:    "Mongoose Enchant",

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -52,681 +52,681 @@ character_stats_results: {
 dps_results: {
  key: "TestProtection-AllItems-AegisBattlegear"
  value: {
-  dps: 1311.70159
-  tps: 2978.21768
+  dps: 1304.78473
+  tps: 2953.1626
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AshtongueTalismanofZeal-32489"
  value: {
-  dps: 1104.78165
-  tps: 2515.13828
+  dps: 1114.668
+  tps: 2540.41991
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1096.05676
-  tps: 2499.09047
+  dps: 1103.79158
+  tps: 2519.02262
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1175.54848
-  tps: 2649.6858
+  dps: 1184.47425
+  tps: 2670.75494
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1103.0622
-  tps: 2513.77147
+  dps: 1119.97417
+  tps: 2556.53961
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1095.2127
-  tps: 2497.49759
+  dps: 1102.05948
+  tps: 2515.54851
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1076.3109
-  tps: 2451.66391
+  dps: 1074.67881
+  tps: 2446.04149
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1081.50887
-  tps: 2473.86257
+  dps: 1089.44264
+  tps: 2491.25189
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1033.80111
-  tps: 2367.93143
+  dps: 1043.96269
+  tps: 2396.30199
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1097.06883
-  tps: 2452.11545
+  dps: 1104.80405
+  tps: 2471.65072
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1107.50625
-  tps: 2523.51936
+  dps: 1114.40941
+  tps: 2541.51639
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1118.8233
-  tps: 2549.8302
+  dps: 1127.66291
+  tps: 2571.73255
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1163.95892
-  tps: 2610.20323
+  dps: 1170.5539
+  tps: 2631.41393
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 1200.37274
-  tps: 2737.85528
+  dps: 1207.89469
+  tps: 2757.1781
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 1171.76199
-  tps: 2670.4966
+  dps: 1179.97115
+  tps: 2691.1253
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 1153.96313
-  tps: 2634.13232
+  dps: 1170.87345
+  tps: 2672.89162
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DeadlyGladiator'sLibramofFortitude-42852"
  value: {
-  dps: 1090.44468
-  tps: 2484.64498
+  dps: 1097.40403
+  tps: 2502.58106
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1101.32458
-  tps: 2512.64985
+  dps: 1109.3773
+  tps: 2533.40026
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1100.82702
-  tps: 2509.36875
+  dps: 1107.69366
+  tps: 2527.60027
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1096.05676
-  tps: 2499.09047
+  dps: 1103.79158
+  tps: 2519.02262
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1107.05113
-  tps: 2530.05141
+  dps: 1116.11191
+  tps: 2547.19063
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1100.23196
-  tps: 2508.22994
+  dps: 1106.50683
+  tps: 2524.66597
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1099.47984
-  tps: 2506.43149
+  dps: 1105.91267
+  tps: 2523.39892
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1101.32458
-  tps: 2512.64985
+  dps: 1109.3773
+  tps: 2533.40026
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1148.4588
-  tps: 2592.77642
+  dps: 1155.92561
+  tps: 2609.44479
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1121.60475
-  tps: 2557.64104
+  dps: 1130.2157
+  tps: 2579.37003
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1114.57159
-  tps: 2540.07105
+  dps: 1122.6377
+  tps: 2561.08269
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1097.06883
-  tps: 2501.69555
+  dps: 1104.80405
+  tps: 2521.6287
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1096.86642
-  tps: 2501.17453
+  dps: 1104.60156
+  tps: 2521.10748
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FuriousGladiator'sLibramofFortitude-42853"
  value: {
-  dps: 1090.44468
-  tps: 2484.64498
+  dps: 1097.40403
+  tps: 2502.58106
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1164.11959
-  tps: 2652.97203
+  dps: 1172.07824
+  tps: 2673.46695
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1110.55713
-  tps: 2536.45145
+  dps: 1118.95508
+  tps: 2555.57549
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gladiator'sVindication"
  value: {
-  dps: 1424.31096
-  tps: 3227.90536
+  dps: 1424.1704
+  tps: 3227.3061
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HatefulGladiator'sLibramofFortitude-42851"
  value: {
-  dps: 1090.44468
-  tps: 2484.64498
+  dps: 1097.40403
+  tps: 2502.58106
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1109.36038
-  tps: 2533.33399
+  dps: 1117.39885
+  tps: 2554.04772
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1100.23196
-  tps: 2508.22994
+  dps: 1106.50683
+  tps: 2524.66597
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1099.47984
-  tps: 2506.43149
+  dps: 1105.91267
+  tps: 2523.39892
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1136.8004
-  tps: 2587.98345
+  dps: 1144.97371
+  tps: 2608.87432
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1163.99183
-  tps: 2683.44709
+  dps: 1177.45726
+  tps: 2727.73472
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1104.73558
-  tps: 2518.48318
+  dps: 1112.46827
+  tps: 2538.40318
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1113.89383
-  tps: 2545.00309
+  dps: 1123.0444
+  tps: 2568.57936
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Liadrin'sBattlegear"
  value: {
-  dps: 1423.99923
-  tps: 3220.1184
+  dps: 1437.18835
+  tps: 3250.07367
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofFuriousBlows-37574"
  value: {
-  dps: 1091.14442
-  tps: 2486.30924
+  dps: 1098.48013
+  tps: 2505.06724
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofReciprocation-40706"
  value: {
-  dps: 1090.44468
-  tps: 2484.64498
+  dps: 1097.40403
+  tps: 2502.58106
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofThreeTruths-50455"
  value: {
-  dps: 1090.44468
-  tps: 2484.64498
+  dps: 1097.40403
+  tps: 2502.58106
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofValiance-47661"
  value: {
-  dps: 1186.13583
-  tps: 2701.14429
+  dps: 1193.31189
+  tps: 2719.6172
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerBattlegear"
  value: {
-  dps: 1218.01713
-  tps: 2789.60349
+  dps: 1214.55202
+  tps: 2781.81177
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightswornBattlegear"
  value: {
-  dps: 1605.63075
-  tps: 3634.12482
+  dps: 1615.58862
+  tps: 3652.21095
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1119.09072
-  tps: 2560.73993
+  dps: 1128.45204
+  tps: 2583.24089
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1137.6473
-  tps: 2586.28375
+  dps: 1161.58367
+  tps: 2643.8174
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1101.32458
-  tps: 2512.64985
+  dps: 1109.3773
+  tps: 2533.40026
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1103.08247
-  tps: 2514.78933
+  dps: 1110.81557
+  tps: 2534.71165
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1104.73558
-  tps: 2518.48318
+  dps: 1112.46827
+  tps: 2538.40318
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1096.05676
-  tps: 2499.09047
+  dps: 1103.79158
+  tps: 2519.02262
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1096.05676
-  tps: 2499.09047
+  dps: 1103.79158
+  tps: 2519.02262
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1101.32458
-  tps: 2512.64985
+  dps: 1109.3773
+  tps: 2533.40026
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RedemptionBattlegear"
  value: {
-  dps: 1196.9561
-  tps: 2709.05154
+  dps: 1206.91016
+  tps: 2735.12223
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1107.39701
-  tps: 2528.28028
+  dps: 1115.45209
+  tps: 2549.03676
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1108.1257
-  tps: 2530.15594
+  dps: 1116.18106
+  tps: 2550.91314
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1107.16391
-  tps: 2522.63818
+  dps: 1114.40941
+  tps: 2541.51639
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RelentlessGladiator'sLibramofFortitude-42854"
  value: {
-  dps: 1090.44468
-  tps: 2484.64498
+  dps: 1097.40403
+  tps: 2502.58106
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1113.57445
-  tps: 2550.65838
+  dps: 1115.02793
+  tps: 2544.42305
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1101.32458
-  tps: 2512.64985
+  dps: 1109.3773
+  tps: 2533.40026
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SavageGladiator'sLibramofFortitude-42611"
  value: {
-  dps: 1090.44468
-  tps: 2484.64498
+  dps: 1097.40403
+  tps: 2502.58106
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1101.32458
-  tps: 2512.64985
+  dps: 1109.3773
+  tps: 2533.40026
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1101.32458
-  tps: 2512.64985
+  dps: 1109.3773
+  tps: 2533.40026
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1101.32458
-  tps: 2512.64985
+  dps: 1109.3773
+  tps: 2533.40026
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SparkofLife-37657"
  value: {
-  dps: 1194.3445
-  tps: 2744.21138
+  dps: 1190.64758
+  tps: 2734.05856
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StormshroudArmor"
  value: {
-  dps: 976.58025
-  tps: 2222.07551
+  dps: 981.818
+  tps: 2239.68306
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1104.73558
-  tps: 2518.48318
+  dps: 1112.46827
+  tps: 2538.40318
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1103.08247
-  tps: 2514.78933
+  dps: 1110.81557
+  tps: 2534.71165
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1100.18953
-  tps: 2508.32509
+  dps: 1107.92334
+  tps: 2528.25146
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1110.52205
-  tps: 2531.69444
+  dps: 1118.46386
+  tps: 2547.08384
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1161.02941
-  tps: 2643.59293
+  dps: 1186.00239
+  tps: 2699.07396
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1180.1883
-  tps: 2689.75613
+  dps: 1186.84629
+  tps: 2709.59416
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1097.06883
-  tps: 2501.69555
+  dps: 1104.80405
+  tps: 2521.6287
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1096.86642
-  tps: 2501.17453
+  dps: 1104.60156
+  tps: 2521.10748
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TomeoftheLightbringer-32368"
  value: {
-  dps: 1096.19372
-  tps: 2499.44301
+  dps: 1103.73082
+  tps: 2518.8662
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1096.86642
-  tps: 2501.17453
+  dps: 1104.60156
+  tps: 2521.10748
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1097.06883
-  tps: 2501.69555
+  dps: 1104.80405
+  tps: 2521.6287
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Turalyon'sBattlegear"
  value: {
-  dps: 1423.99923
-  tps: 3220.1184
+  dps: 1437.18835
+  tps: 3250.07367
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1064.90114
-  tps: 2427.43774
+  dps: 1070.33349
+  tps: 2433.4074
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathfulGladiator'sLibramofFortitude-51478"
  value: {
-  dps: 1090.44468
-  tps: 2484.64498
+  dps: 1097.40403
+  tps: 2502.58106
  }
 }
 dps_results: {
  key: "TestProtection-Average-Default"
  value: {
-  dps: 1421.04122
-  tps: 3351.20947
-  dtps: 349.63632
+  dps: 1427.86875
+  tps: 3367.40719
+  dtps: 342.47039
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2221.09188
-  tps: 5779.09454
+  dps: 2245.49044
+  tps: 5843.14684
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1248.40839
-  tps: 2836.41491
+  dps: 1241.90743
+  tps: 2818.3232
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1882.30624
-  tps: 4418.86053
+  dps: 1892.5465
+  tps: 4435.84703
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 634.21677
-  tps: 1540.36408
+  dps: 635.16794
+  tps: 1543.51562
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 347.82418
-  tps: 747.9256
+  dps: 349.89816
+  tps: 752.51813
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 582.31553
-  tps: 1350.54727
+  dps: 583.58584
+  tps: 1353.81706
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2245.88617
-  tps: 5799.62644
+  dps: 2269.12915
+  tps: 5855.78784
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1254.25658
-  tps: 2846.60136
+  dps: 1259.76882
+  tps: 2856.90924
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1891.34488
-  tps: 4432.02189
+  dps: 1905.50722
+  tps: 4464.12344
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin-NoBuffs-LongMultiTarget"
  value: {
-  dps: 641.33666
-  tps: 1543.70572
+  dps: 642.86269
+  tps: 1548.35005
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin-NoBuffs-LongSingleTarget"
  value: {
-  dps: 352.15402
-  tps: 755.15975
+  dps: 352.32297
+  tps: 755.27923
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 571.16897
-  tps: 1327.64368
+  dps: 571.81635
+  tps: 1329.31003
  }
 }
 dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1523.87937
-  tps: 3555.52894
-  dtps: 340.22809
+  dps: 1542.57052
+  tps: 3602.48085
+  dtps: 335.05669
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -52,7 +52,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 0.7985
+  weights: 0.67887
   weights: 0
   weights: 0
   weights: 0
@@ -70,7 +70,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.13083
+  weights: 0.10429
   weights: 0
   weights: 0
   weights: 0
@@ -79,12 +79,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.04047
+  weights: 0.00172
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.36666
-  weights: -0.03713
+  weights: 0.41333
+  weights: 0.0486
   weights: 0
   weights: 0
   weights: 0
@@ -103,428 +103,428 @@ stat_weights_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 2091.82871
-  tps: 5843.50555
+  dps: 2108.09538
+  tps: 5886.33539
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 2074.33441
-  tps: 5807.32462
+  dps: 2107.792
+  tps: 5884.69185
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2147.36337
-  tps: 5979.99367
+  dps: 2176.58317
+  tps: 6053.59744
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 2077.94771
-  tps: 5813.64603
+  dps: 2107.58253
+  tps: 5882.80104
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 2045.86667
-  tps: 5719.80915
+  dps: 2092.44756
+  tps: 5837.89552
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1879.65474
-  tps: 5266.92904
+  dps: 1918.3372
+  tps: 5367.01964
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1860.11968
-  tps: 5196.8957
+  dps: 1878.01975
+  tps: 5237.57757
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1756.11869
-  tps: 4911.04048
+  dps: 1771.48092
+  tps: 4960.75152
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2053.42375
-  tps: 5632.97581
+  dps: 2085.07297
+  tps: 5708.78478
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2112.70801
-  tps: 5896.00714
+  dps: 2135.42038
+  tps: 5941.27499
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2145.62404
-  tps: 5971.84044
+  dps: 2170.10395
+  tps: 6037.32017
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2162.66949
-  tps: 5998.88994
+  dps: 2188.71235
+  tps: 6070.19616
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 2199.03779
-  tps: 6151.56468
+  dps: 2219.12968
+  tps: 6193.71793
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 2205.76465
-  tps: 6155.32286
+  dps: 2231.19086
+  tps: 6214.25823
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 2130.65586
-  tps: 5957.35263
+  dps: 2154.74203
+  tps: 6024.81526
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2080.8148
-  tps: 5815.95412
+  dps: 2098.73342
+  tps: 5849.99866
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 2294.05684
-  tps: 6352.45567
+  dps: 2312.14685
+  tps: 6393.53277
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 2053.42375
-  tps: 5747.88343
+  dps: 2085.07297
+  tps: 5825.2395
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2053.42375
-  tps: 5747.88343
+  dps: 2085.07297
+  tps: 5825.2395
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 2077.94771
-  tps: 5813.64603
+  dps: 2107.58253
+  tps: 5882.80104
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2077.58339
-  tps: 5805.14627
+  dps: 2100.08657
+  tps: 5857.31401
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 2071.40908
-  tps: 5796.36381
+  dps: 2102.98803
+  tps: 5873.53044
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2170.20789
-  tps: 6024.43172
+  dps: 2192.12005
+  tps: 6075.30643
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2122.87286
-  tps: 5915.25652
+  dps: 2171.87139
+  tps: 6049.08216
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2122.97484
-  tps: 5923.00817
+  dps: 2131.09925
+  tps: 5937.69198
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2053.42375
-  tps: 5747.88343
+  dps: 2085.07297
+  tps: 5825.2395
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2053.42375
-  tps: 5747.88343
+  dps: 2085.07297
+  tps: 5825.2395
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2134.26642
-  tps: 5974.39429
+  dps: 2169.0311
+  tps: 6061.29672
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2074.33441
-  tps: 5807.32462
+  dps: 2107.792
+  tps: 5884.69185
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 2535.79236
-  tps: 6938.84664
+  dps: 2524.52976
+  tps: 6893.89633
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 2074.33441
-  tps: 5807.32462
+  dps: 2107.792
+  tps: 5884.69185
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 2077.94771
-  tps: 5813.64603
+  dps: 2107.58253
+  tps: 5882.80104
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2077.58339
-  tps: 5805.14627
+  dps: 2100.08657
+  tps: 5857.31401
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2139.1776
-  tps: 5969.00238
+  dps: 2154.91979
+  tps: 6002.69876
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 2053.42375
-  tps: 5747.88343
+  dps: 2085.07297
+  tps: 5825.2395
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2089.4568
-  tps: 5843.41861
+  dps: 2114.18605
+  tps: 5897.72534
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2124.12199
-  tps: 5941.52951
+  dps: 2156.12698
+  tps: 6014.98119
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 2074.33441
-  tps: 5807.32462
+  dps: 2107.792
+  tps: 5884.69185
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2155.50753
-  tps: 6008.9943
+  dps: 2194.33756
+  tps: 6107.37283
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2073.58763
-  tps: 5803.71811
+  dps: 2113.4805
+  tps: 5909.94904
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 1734.64942
-  tps: 4857.11634
+  dps: 1756.20227
+  tps: 4908.06168
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 1964.41314
-  tps: 5429.94546
+  dps: 2004.16552
+  tps: 5529.43601
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 2079.26498
-  tps: 5816.4146
+  dps: 2099.2777
+  tps: 5865.38051
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2089.4568
-  tps: 5843.41861
+  dps: 2114.18605
+  tps: 5897.72534
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 2053.42375
-  tps: 5747.88343
+  dps: 2085.07297
+  tps: 5825.2395
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 2053.42375
-  tps: 5747.88343
+  dps: 2085.07297
+  tps: 5825.2395
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2074.33441
-  tps: 5807.32462
+  dps: 2107.792
+  tps: 5884.69185
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 2074.33441
-  tps: 5807.32462
+  dps: 2107.792
+  tps: 5884.69185
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 2074.33441
-  tps: 5807.32462
+  dps: 2107.792
+  tps: 5884.69185
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2119.78275
-  tps: 5908.50685
+  dps: 2137.50618
+  tps: 5954.69231
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2053.42375
-  tps: 5747.88343
+  dps: 2085.07297
+  tps: 5825.2395
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2074.33441
-  tps: 5807.32462
+  dps: 2107.792
+  tps: 5884.69185
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2072.89811
-  tps: 5800.15143
+  dps: 2111.88753
+  tps: 5897.71719
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2074.33441
-  tps: 5807.32462
+  dps: 2107.792
+  tps: 5884.69185
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 2340.10637
-  tps: 6471.75379
+  dps: 2377.69172
+  tps: 6569.10236
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2074.33441
-  tps: 5807.32462
+  dps: 2107.792
+  tps: 5884.69185
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SparkofLife-37657"
  value: {
-  dps: 2103.61067
-  tps: 5886.77983
+  dps: 2113.0704
+  tps: 5909.7071
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormshroudArmor"
  value: {
-  dps: 1733.40923
-  tps: 4858.77422
+  dps: 1749.73506
+  tps: 4887.70889
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2089.4568
-  tps: 5843.41861
+  dps: 2114.18605
+  tps: 5897.72534
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 2079.26498
-  tps: 5816.4146
+  dps: 2099.2777
+  tps: 5865.38051
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2063.02364
-  tps: 5783.90632
+  dps: 2108.56155
+  tps: 5881.80784
  }
 }
 dps_results: {
@@ -544,170 +544,170 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 2094.85044
-  tps: 5862.64752
+  dps: 2116.77349
+  tps: 5908.76281
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2254.9277
-  tps: 6310.5266
+  dps: 2300.15896
+  tps: 6425.13391
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2277.4336
-  tps: 6368.72959
+  dps: 2273.29336
+  tps: 6353.19124
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2053.42375
-  tps: 5747.88343
+  dps: 2085.07297
+  tps: 5825.2395
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2053.42375
-  tps: 5747.88343
+  dps: 2085.07297
+  tps: 5825.2395
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2053.42375
-  tps: 5747.88343
+  dps: 2085.07297
+  tps: 5825.2395
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2053.42375
-  tps: 5747.88343
+  dps: 2085.07297
+  tps: 5825.2395
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1858.51734
-  tps: 5190.55265
+  dps: 1899.63575
+  tps: 5290.93782
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 2540.26838
-  tps: 6972.53394
+  dps: 2589.58641
+  tps: 7090.8418
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 2806.60332
-  tps: 7634.83956
+  dps: 2854.18439
+  tps: 7741.86356
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 2958.48042
-  tps: 7693.13086
-  dtps: 215.47243
+  dps: 2984.71757
+  tps: 7750.96721
+  dtps: 210.04643
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2120.36359
-  tps: 5515.89857
+  dps: 2157.07914
+  tps: 5603.15285
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2120.36359
-  tps: 5468.36302
+  dps: 2157.07914
+  tps: 5555.60738
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2249.91351
-  tps: 5766.52879
+  dps: 2244.09344
+  tps: 5751.08289
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1015.26035
-  tps: 2745.79974
+  dps: 1026.31104
+  tps: 2772.23286
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1015.26035
-  tps: 2698.23249
+  dps: 1026.31104
+  tps: 2724.67202
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 900.62233
-  tps: 2404.39327
+  dps: 908.07598
+  tps: 2421.23716
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2116.86641
-  tps: 5503.57366
+  dps: 2156.40667
+  tps: 5601.72098
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2116.86641
-  tps: 5456.03485
+  dps: 2156.40667
+  tps: 5554.16052
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2232.29067
-  tps: 5734.44494
+  dps: 2272.25124
+  tps: 5821.69618
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1024.51243
-  tps: 2762.2591
+  dps: 1036.66725
+  tps: 2799.79992
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1024.51243
-  tps: 2714.67638
+  dps: 1036.66725
+  tps: 2752.24181
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 913.7615
-  tps: 2433.80587
+  dps: 924.91201
+  tps: 2464.80895
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3098.54563
-  tps: 8067.99501
-  dtps: 218.15347
+  dps: 3129.39074
+  tps: 8133.89159
+  dtps: 211.52243
  }
 }


### PR DESCRIPTION
 - was missing agi proc from last commit
 - mongoose proc nerfed to 0.73 in wotlk, confirmed from druid/shaman discord testing

Signed-off-by: jarves <jarveson@gmail.com>