### PR TITLE
Fix missing Spell multipliers

### DIFF
--- a/sim/encounters/naxxrammas/patchwerk10_ai.go
+++ b/sim/encounters/naxxrammas/patchwerk10_ai.go
@@ -76,6 +76,7 @@ func (ai *Patchwerk10AI) registerHatefulStrikeSpell(target *core.Target) {
 		},
 
 		DamageMultiplier: 1,
+		CritMultiplier:   1,
 
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			BaseDamage:     core.BaseDamageConfigRoll(27750, 32250),

--- a/sim/encounters/naxxrammas/patchwerk25_ai.go
+++ b/sim/encounters/naxxrammas/patchwerk25_ai.go
@@ -76,6 +76,7 @@ func (ai *Patchwerk25AI) registerHatefulStrikeSpell(target *core.Target) {
 		},
 
 		DamageMultiplier: 1,
+		CritMultiplier:   1,
 
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			BaseDamage:     core.BaseDamageConfigRoll(79000, 81000),

--- a/sim/paladin/talents.go
+++ b/sim/paladin/talents.go
@@ -198,6 +198,8 @@ func (paladin *Paladin) applyReckoning() {
 				SpellSchool:  core.SpellSchoolPhysical,
 				ProcMask:     core.ProcMaskMeleeMH,
 				Flags:        core.SpellFlagMeleeMetrics,
+				CritMultiplier:   paladin.MeleeCritMultiplier(),
+				DamageMultiplier:	1,
 				ApplyEffects: core.ApplyEffectFuncDirectDamage(paladin.AutoAttacks.MHEffect),
 			})
 		},


### PR DESCRIPTION
Reckoning procs were missing damage multiplier and new Spell CritMultiplier
Patchwerk's Hateful Strike was missing the new Spell CritMultiplier