### PR TITLE
Damage intake improvements

### DIFF
--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -95,7 +95,9 @@ func (weapon Weapon) GetSpellSchool() SpellSchool {
 }
 
 func (weapon Weapon) EnemyWeaponDamage(sim *Simulation, attackPower float64) float64 {
-	rand := 1 + 0.5*sim.RandomFloat("Enemy Weapon Damage")
+	// Maximum damage range is 135% of minimum damage; AP contribution is % of minimum damage roll
+	// TODO: Scrape more logs to determine this value, it was 133% in classic but seems to be slightly higher?
+	rand := 1 + 0.35*sim.RandomFloat("Enemy Weapon Damage")
 	return weapon.BaseDamageMin * (rand + attackPower*EnemyAutoAttackAPCoefficient)
 }
 

--- a/sim/core/constants.go
+++ b/sim/core/constants.go
@@ -24,7 +24,7 @@ const DefenseRatingPerDefense = 4.92
 const DodgeRatingPerDodgeChance = 45.25
 const ParryRatingPerParryChance = 45.25
 const BlockRatingPerBlockChance = 16.39
-const MissDodgeParryBlockCritChancePerDefense = 0.0325 // TODO: verify this.
+const MissDodgeParryBlockCritChancePerDefense = 0.04
 
 const DefenseRatingToChanceReduction = (1.0 / DefenseRatingPerDefense) * MissDodgeParryBlockCritChancePerDefense / 100
 

--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -845,7 +845,7 @@ func ScreechAura(target *Unit) *Aura {
 const AtkSpeedReductionAuraTag = "AtkSpdReduction"
 
 func ThunderClapAura(target *Unit, points int32) *Aura {
-	speedMultiplier := []float64{0.9, 0.86, 0.83, 0.8}[points]
+	speedMultiplier := []float64{1.1, 1.14, 1.17, 1.2}[points]
 	inverseMult := 1 / speedMultiplier
 
 	return target.GetOrRegisterAura(Aura{
@@ -853,18 +853,18 @@ func ThunderClapAura(target *Unit, points int32) *Aura {
 		Tag:      AtkSpeedReductionAuraTag,
 		ActionID: ActionID{SpellID: 47502},
 		Duration: time.Second * 30,
-		Priority: inverseMult,
+		Priority: speedMultiplier,
 		OnGain: func(aura *Aura, sim *Simulation) {
-			aura.Unit.MultiplyAttackSpeed(sim, speedMultiplier)
+			aura.Unit.MultiplyAttackSpeed(sim, inverseMult)
 		},
 		OnExpire: func(aura *Aura, sim *Simulation) {
-			aura.Unit.MultiplyAttackSpeed(sim, inverseMult)
+			aura.Unit.MultiplyAttackSpeed(sim, speedMultiplier)
 		},
 	})
 }
 
 func InfectedWoundsAura(target *Unit, points int32) *Aura {
-	speedMultiplier := []float64{1.0, 0.94, 0.86, 0.80}[points]
+	speedMultiplier := []float64{1.0, 1.06, 1.14, 1.20}[points]
 	inverseMult := 1 / speedMultiplier
 
 	return target.GetOrRegisterAura(Aura{
@@ -872,12 +872,12 @@ func InfectedWoundsAura(target *Unit, points int32) *Aura {
 		Tag:      AtkSpeedReductionAuraTag,
 		ActionID: ActionID{SpellID: 48485},
 		Duration: time.Second * 12,
-		Priority: inverseMult,
+		Priority: speedMultiplier,
 		OnGain: func(aura *Aura, sim *Simulation) {
-			aura.Unit.MultiplyAttackSpeed(sim, speedMultiplier)
+			aura.Unit.MultiplyAttackSpeed(sim, inverseMult)
 		},
 		OnExpire: func(aura *Aura, sim *Simulation) {
-			aura.Unit.MultiplyAttackSpeed(sim, inverseMult)
+			aura.Unit.MultiplyAttackSpeed(sim, speedMultiplier)
 		},
 	})
 }
@@ -885,7 +885,7 @@ func InfectedWoundsAura(target *Unit, points int32) *Aura {
 // Note: Paladin code might apply this as part of their judgement auras instead
 // of using another separate aura.
 func JudgementsOfTheJustAura(target *Unit, points int32) *Aura {
-	speedMultiplier := 1.0 - 0.1*float64(points)
+	speedMultiplier := 1.0 + 0.1*float64(points)
 	inverseMult := 1 / speedMultiplier
 
 	return target.GetOrRegisterAura(Aura{
@@ -893,18 +893,18 @@ func JudgementsOfTheJustAura(target *Unit, points int32) *Aura {
 		Tag:      AtkSpeedReductionAuraTag,
 		ActionID: ActionID{SpellID: 53696},
 		Duration: time.Second * 30,
-		Priority: inverseMult,
+		Priority: speedMultiplier,
 		OnGain: func(aura *Aura, sim *Simulation) {
-			aura.Unit.MultiplyAttackSpeed(sim, speedMultiplier)
+			aura.Unit.MultiplyAttackSpeed(sim, inverseMult)
 		},
 		OnExpire: func(aura *Aura, sim *Simulation) {
-			aura.Unit.MultiplyAttackSpeed(sim, inverseMult)
+			aura.Unit.MultiplyAttackSpeed(sim, speedMultiplier)
 		},
 	})
 }
 
 func FrostFeverAura(target *Unit, impIcyTouch int32) *Aura {
-	speedMultiplier := 0.86 - 0.02*float64(impIcyTouch)
+	speedMultiplier := 1.14 + 0.02*float64(impIcyTouch)
 
 	inverseMult := 1 / speedMultiplier
 	return target.GetOrRegisterAura(Aura{
@@ -912,12 +912,12 @@ func FrostFeverAura(target *Unit, impIcyTouch int32) *Aura {
 		Tag:      AtkSpeedReductionAuraTag,
 		ActionID: ActionID{SpellID: 55095},
 		Duration: time.Second * 15,
-		Priority: inverseMult,
+		Priority: speedMultiplier,
 		OnGain: func(aura *Aura, sim *Simulation) {
-			aura.Unit.MultiplyAttackSpeed(sim, speedMultiplier)
+			aura.Unit.MultiplyAttackSpeed(sim, inverseMult)
 		},
 		OnExpire: func(aura *Aura, sim *Simulation) {
-			aura.Unit.MultiplyAttackSpeed(sim, inverseMult)
+			aura.Unit.MultiplyAttackSpeed(sim, speedMultiplier)
 		},
 	})
 }

--- a/sim/core/target.go
+++ b/sim/core/target.go
@@ -137,9 +137,8 @@ func NewTarget(options proto.Target, targetIndex int32) *Target {
 	}
 
 	if target.Level == defaultRaidBossLevel && options.SuppressDodge {
-		// Sunwell boss Dodge Suppression. -20% dodge and -5% miss chance.
+		// ICC boss Dodge Suppression. -20% dodge only.
 		target.PseudoStats.DodgeReduction += 0.2
-		target.PseudoStats.IncreasedMissChance -= 0.05
 	}
 
 	target.PseudoStats.CanBlock = true
@@ -253,7 +252,7 @@ func NewAttackTable(attacker *Unit, defender *Unit) *AttackTable {
 	}
 
 	if defender.Type == EnemyUnit {
-		// Assumes attacker (the Player) is level 70.
+		// Assumes attacker (the Player) is level 80.
 		table.BaseSpellMissChance = UnitLevelFloat64(defender.Level, 0.04, 0.05, 0.06, 0.17)
 		table.BaseMissChance = UnitLevelFloat64(defender.Level, 0.05, 0.055, 0.06, 0.08)
 		table.BaseBlockChance = 0.05
@@ -264,7 +263,7 @@ func NewAttackTable(attacker *Unit, defender *Unit) *AttackTable {
 		table.GlanceMultiplier = UnitLevelFloat64(defender.Level, 0.95, 0.95, 0.85, 0.75)
 		table.CritSuppression = UnitLevelFloat64(defender.Level, 0, 0.01, 0.02, 0.048)
 	} else {
-		// Assumes defender (the Player) is level 70.
+		// Assumes defender (the Player) is level 80.
 		table.BaseSpellMissChance = 0.05
 		table.BaseMissChance = UnitLevelFloat64(attacker.Level, 0.05, 0.048, 0.046, 0.044)
 		table.BaseBlockChance = UnitLevelFloat64(attacker.Level, 0.05, 0.048, 0.046, 0.044)

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -619,9 +619,9 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-Average-Default"
  value: {
-  dps: 1323.73595
-  tps: 1827.68205
-  dtps: 537.78976
+  dps: 1318.90609
+  tps: 1820.01748
+  dtps: 523.36667
  }
 }
 dps_results: {
@@ -669,8 +669,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1425.13223
-  tps: 1979.90617
-  dtps: 500.58089
+  dps: 1440.58147
+  tps: 2004.94641
+  dtps: 488.03992
  }
 }

--- a/sim/encounters/naxxrammas/kelthuzad25_ai.go
+++ b/sim/encounters/naxxrammas/kelthuzad25_ai.go
@@ -23,8 +23,8 @@ func addKelThuzad25(bossPrefix string) {
 			}.ToFloatArray(),
 
 			SpellSchool:      proto.SpellSchool_SpellSchoolPhysical,
-			SwingSpeed:       2.5,
-			MinBaseDamage:    14135,
+			SwingSpeed:       2.3,
+			MinBaseDamage:    28767,
 			SuppressDodge:    false,
 			ParryHaste:       false,
 			DualWield:        false,

--- a/sim/encounters/naxxrammas/loatheb25_ai.go
+++ b/sim/encounters/naxxrammas/loatheb25_ai.go
@@ -23,8 +23,8 @@ func addLoatheb25(bossPrefix string) {
 			}.ToFloatArray(),
 
 			SpellSchool:      proto.SpellSchool_SpellSchoolPhysical,
-			SwingSpeed:       1.5,
-			MinBaseDamage:    14135,
+			SwingSpeed:       1.2,
+			MinBaseDamage:    6727,
 			SuppressDodge:    false,
 			ParryHaste:       false,
 			DualWield:        false,

--- a/sim/encounters/naxxrammas/patchwerk25_ai.go
+++ b/sim/encounters/naxxrammas/patchwerk25_ai.go
@@ -25,11 +25,11 @@ func addPatchwerk25(bossPrefix string) {
 			}.ToFloatArray(),
 
 			SpellSchool:      proto.SpellSchool_SpellSchoolPhysical,
-			SwingSpeed:       1.6,
-			MinBaseDamage:    14135,
+			SwingSpeed:       0.75,
+			MinBaseDamage:    38068,
 			SuppressDodge:    false,
 			ParryHaste:       false,
-			DualWield:        true,
+			DualWield:        false,
 			DualWieldPenalty: false,
 		},
 		AI: NewPatchwerk25AI(),
@@ -59,6 +59,7 @@ func (ai *Patchwerk25AI) Initialize(target *core.Target) {
 	ai.registerFrenzySpell(target)
 }
 
+
 func (ai *Patchwerk25AI) registerHatefulStrikeSpell(target *core.Target) {
 	actionID := core.ActionID{SpellID: 59192}
 
@@ -71,7 +72,7 @@ func (ai *Patchwerk25AI) registerHatefulStrikeSpell(target *core.Target) {
 		Cast: core.CastConfig{
 			CD: core.Cooldown{
 				Timer:    target.NewTimer(),
-				Duration: time.Second * 3,
+				Duration: time.Millisecond * 1200,
 			},
 		},
 
@@ -123,7 +124,9 @@ func (ai *Patchwerk25AI) DoAction(sim *core.Simulation) {
 	if ai.Frenzy.IsReady(sim) && sim.GetRemainingDurationPercent() < 0.05 {
 		ai.Frenzy.Cast(sim, ai.Target.CurrentTarget)
 	}
-
+	
+	// TODO: Only enable Hateful Strike in solo sim if you are assigned OT instead of MT
+	// TODO: Actual targeting logic for Hateful Strike in raidsim
 	if ai.HatefulStrike.IsReady(sim) {
 		ai.HatefulStrike.Cast(sim, ai.Target.CurrentTarget)
 	}

--- a/sim/encounters/naxxrammas/thaddius25_ai.go
+++ b/sim/encounters/naxxrammas/thaddius25_ai.go
@@ -23,8 +23,8 @@ func addThaddius25(bossPrefix string) {
 			}.ToFloatArray(),
 
 			SpellSchool:      proto.SpellSchool_SpellSchoolPhysical,
-			SwingSpeed:       2.0,
-			MinBaseDamage:    14135,
+			SwingSpeed:       1.25,
+			MinBaseDamage:    25315,
 			SuppressDodge:    false,
 			ParryHaste:       false,
 			DualWield:        false,

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -668,9 +668,9 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Average-Default"
  value: {
-  dps: 2019.06495
-  tps: 4734.59835
-  dtps: 112.33398
+  dps: 2037.31201
+  tps: 4786.46983
+  dtps: 65.12994
  }
 }
 dps_results: {
@@ -928,8 +928,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2134.11995
-  tps: 4984.56756
-  dtps: 117.4614
+  dps: 2152.45978
+  tps: 5038.57328
+  dtps: 67.08851
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -45,7 +45,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 0.71044
+  weights: 0.79114
   weights: 0
   weights: 0
   weights: 0
@@ -56,7 +56,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.29792
+  weights: 0.25069
   weights: 0
   weights: 0
   weights: 0
@@ -65,12 +65,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.05253
+  weights: 0.0451
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.35331
-  weights: 0.02787
+  weights: 0.5234
+  weights: 0.15868
   weights: 0
   weights: 0
   weights: 0
@@ -600,9 +600,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 2803.52826
-  tps: 7392.9856
-  dtps: 124.28564
+  dps: 2819.69746
+  tps: 7424.52929
+  dtps: 95.64931
  }
 }
 dps_results: {
@@ -692,8 +692,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2944.93883
-  tps: 7780.00793
-  dtps: 129.44816
+  dps: 2960.37697
+  tps: 7799.29786
+  dtps: 99.39883
  }
 }

--- a/ui/core/components/encounter_picker.ts
+++ b/ui/core/components/encounter_picker.ts
@@ -316,6 +316,7 @@ class TargetPicker extends Component {
 		new NumberPicker(section3, modTarget, {
 			label: 'Swing Speed',
 			labelTooltip: 'Time in seconds between auto attacks. Set to 0 to disable auto attacks.',
+			float: true,
 			changedEvent: (target: Target) => target.propChangeEmitter,
 			getValue: (target: Target) => target.getSwingSpeed(),
 			setValue: (eventID: EventID, target: Target, newValue: number) => {
@@ -378,8 +379,8 @@ class TargetPicker extends Component {
 			},
 		});
 		new BooleanPicker(section3, modTarget, {
-			label: 'Sunwell Radiance',
-			labelTooltip: 'Reduces the chance for this enemy\'s attacks to be dodged by 20% and be missed by 5%. All Sunwell Plateau bosses have this.',
+			label: 'Chill of the Throne',
+			labelTooltip: 'Reduces the chance for this enemy\'s attacks to be dodged by 20%. Active in Icecrown Citadel.',
 			changedEvent: (target: Target) => target.changeEmitter,
 			getValue: (target: Target) => target.getSuppressDodge(),
 			setValue: (eventID: EventID, target: Target, newValue: boolean) => {

--- a/ui/core/talents/paladin.ts
+++ b/ui/core/talents/paladin.ts
@@ -487,7 +487,7 @@ export const paladinTalentsConfig: TalentsConfig<PaladinTalents> = newTalentsCon
 				},
 				prereqLocation: {
 					rowIdx: 8,
-					colIdx: 2,
+					colIdx: 1,
 				},
 				spellIds: [53709],
 				maxPoints: 3,

--- a/ui/protection_warrior/sim.ts
+++ b/ui/protection_warrior/sim.ts
@@ -133,7 +133,7 @@ export class ProtectionWarriorSimUI extends IndividualSimUI<Spec.SpecProtectionW
 				debuffs: Debuffs.create({
 					sunderArmor: true,
 					mangle: true,
-					curseOfWeakness: TristateEffect.TristateEffectRegular,
+					vindication: true,
 					faerieFire: TristateEffect.TristateEffectImproved,
 					insectSwarm: true,
 					bloodFrenzy: true,


### PR DESCRIPTION
Fixes:
- Swingspeed UI on encounter picker no longer rounds to integer
- Defense constant to 0.04
- CoW no longer a default AP debuff for PWar due to issue #1160 
- Inverted logic of Thunderclap type debuffs to properly increase time between attacks by 20% instead of applying -20% haste (which was 25% time between attacks)

Updates:
- Sunwell Radiance changed to Chill of the Throne
- Enemy swing damage range adjusted from 50% to 35% to closer match log observations
- Naxx25 presets updated based on log scraping, see notes here:
https://docs.google.com/spreadsheets/d/1kAr14X9R3wcCSM7Mm1D7e1j2PyF4Yd-20bIJiwKa568/edit?usp=sharing

Known Issues:
- Fixing the defense constant further exacerbates missing Avoidance DR, looks this was a minor fudge factor