### PR TITLE
Partial Resists

### DIFF
--- a/sim/core/constants.go
+++ b/sim/core/constants.go
@@ -12,7 +12,6 @@ const GCDDefault = time.Millisecond * 1500
 const MeleeAttackRatingPerDamage = 14.0
 const ExpertisePerQuarterPercentReduction = 32.79 / 4 // TODO: Does it still cutoff at 1/4 percents?
 const ArmorPenPerPercentArmor = 13.99
-const ReducibleArmorConstant = 15232.5
 
 const HasteRatingPerHastePercent = 32.79
 const CritRatingPerCritChance = 45.91
@@ -30,9 +29,6 @@ const DefenseRatingToChanceReduction = (1.0 / DefenseRatingPerDefense) * MissDod
 
 const ResilienceRatingPerCritReductionChance = 82.0
 const ResilienceRatingPerCritDamageReductionPercent = 39.4231 / 2.2
-
-// With a level 80 attacker you get 32/3 bonus resist per level above attacker
-const LevelBasedNPCSpellResistancePerLevel = 32.0 / 3
 
 // TODO: Find these numbers for WOTLK
 const EnemyAutoAttackAPCoefficient = 0.000649375

--- a/sim/core/flags.go
+++ b/sim/core/flags.go
@@ -3,6 +3,8 @@ package core
 import (
 	"github.com/wowsims/wotlk/sim/core/proto"
 	"github.com/wowsims/wotlk/sim/core/stats"
+	"math/bits"
+	"strconv"
 )
 
 type ProcMask uint32
@@ -114,14 +116,20 @@ const (
 	// These bits are set by the crit and damage rolls.
 	OutcomeCrit
 	OutcomeCrush
-	OutcomePartial1_4 // 1/4 of the spell was resisted.
-	OutcomePartial2_4 // 2/4 of the spell was resisted.
-	OutcomePartial3_4 // 3/4 of the spell was resisted.
+
+	OutcomePartial1
+	OutcomePartial2
+	OutcomePartial4
+	OutcomePartial8
 )
 
 const (
-	OutcomePartial = OutcomePartial1_4 | OutcomePartial2_4 | OutcomePartial3_4
+	OutcomePartial = OutcomePartial1 | OutcomePartial2 | OutcomePartial4 | OutcomePartial8
 	OutcomeLanded  = OutcomeHit | OutcomeCrit | OutcomeCrush | OutcomeGlance | OutcomeBlock
+)
+
+var (
+	OutcomePartialOffset = bits.TrailingZeros(uint(OutcomePartial1))
 )
 
 func (ho HitOutcome) String() string {
@@ -151,15 +159,10 @@ func (ho HitOutcome) String() string {
 }
 
 func (ho HitOutcome) PartialResistString() string {
-	if ho.Matches(OutcomePartial1_4) {
-		return " (25% Resist)"
-	} else if ho.Matches(OutcomePartial2_4) {
-		return " (50% Resist)"
-	} else if ho.Matches(OutcomePartial3_4) {
-		return " (75% Resist)"
-	} else {
-		return ""
+	if x := ho >> OutcomePartialOffset; x > 0 {
+		return " (" + strconv.Itoa(10*int(x)) + "% Resist)"
 	}
+	return ""
 }
 
 // Other flags

--- a/sim/core/spell_resistances_test.go
+++ b/sim/core/spell_resistances_test.go
@@ -1,0 +1,148 @@
+package core
+
+import (
+	"github.com/wowsims/wotlk/sim/core/proto"
+	"github.com/wowsims/wotlk/sim/core/stats"
+	"math"
+	"testing"
+)
+
+func Test_PartialResistsVsPlayer(t *testing.T) {
+	attacker := &Unit{
+		Type:  EnemyUnit,
+		Level: 83,
+		stats: stats.Stats{},
+	}
+	defender := &Unit{
+		Type:  PlayerUnit,
+		Level: 80,
+		stats: stats.Stats{},
+	}
+
+	attackTable := NewAttackTable(attacker, defender)
+
+	sim := NewSim(proto.RaidSimRequest{
+		SimOptions: &proto.SimOptions{},
+		Encounter:  &proto.Encounter{},
+		Raid:       &proto.Raid{},
+	})
+
+	spell := &Spell{
+		SpellSchool: SpellSchoolFire,
+	}
+
+	for resist := 0; resist < 5_000; resist += 1 {
+		defender.stats[stats.FireResistance] = float64(resist)
+		attackTable.UpdatePartialResists()
+
+		thresholds := attackTable.GetPartialResistThresholds(SpellSchoolFire)
+
+		var chance float64
+		var resultingAr float64
+		for _, th := range thresholds {
+			chance = th.cumulativeChance - chance
+			resultingAr += chance * 0.1 * float64(th.bracket)
+			if th.cumulativeChance >= 1 {
+				break
+			}
+			chance = th.cumulativeChance
+		}
+
+		expectedAr := float64(resist) / (510 + float64(resist))
+
+		if math.Abs(resultingAr-expectedAr) > 1e-9 {
+			t.Errorf("resist = %d, thresholds = %s, resultingAr = %.2f%%, expectedAr = %.2f%%", resist, thresholds, resultingAr, expectedAr)
+			return
+		}
+
+		const n = 1_000
+
+		outcomes := make(map[HitOutcome]int, n)
+		var totalDamage float64
+		for iter := 0; iter < n; iter++ {
+			spellEffect := SpellEffect{
+				Outcome: OutcomeHit,
+				Damage:  1000,
+			}
+
+			spellEffect.applyResistances(sim, spell, attackTable)
+
+			outcomes[spellEffect.Outcome]++
+			totalDamage += spellEffect.Damage
+		}
+
+		if math.Abs(expectedAr-(1-totalDamage/float64(1000*n))) > 0.01 {
+			t.Logf("after %d iterations, resist = %d, ar = %.2f%% vs. damage lost = %.2f%%, outcomes = %v\n", n, resist, expectedAr*100, 100-100*totalDamage/float64(1000*n), outcomes)
+		}
+	}
+}
+
+func Test_PartialResistsVsBoss(t *testing.T) {
+	attacker := &Unit{
+		Type:  PlayerUnit,
+		Level: 80,
+		stats: stats.Stats{},
+	}
+	defender := &Unit{
+		Type:  EnemyUnit,
+		Level: 83,
+		stats: stats.Stats{},
+	}
+
+	attackTable := NewAttackTable(attacker, defender)
+
+	sim := NewSim(proto.RaidSimRequest{
+		SimOptions: &proto.SimOptions{},
+		Encounter:  &proto.Encounter{},
+		Raid:       &proto.Raid{},
+	})
+
+	spell := &Spell{
+		SpellSchool: SpellSchoolNature,
+	}
+
+	for resist := 0.0; resist < 50; resist += 0.01 {
+		defender.stats[stats.NatureResistance] = resist
+		attackTable.UpdatePartialResists()
+
+		thresholds := attackTable.GetPartialResistThresholds(SpellSchoolNature)
+
+		var chance float64
+		var resultingAr float64
+		for _, th := range thresholds {
+			chance = th.cumulativeChance - chance
+			resultingAr += chance * 0.1 * float64(th.bracket)
+			if th.cumulativeChance >= 1 {
+				break
+			}
+			chance = th.cumulativeChance
+		}
+
+		expectedAr := 0.06 + resist/(400+resist)
+
+		if math.Abs(resultingAr-expectedAr) > 1e-9 {
+			t.Errorf("resist = %.2f, thresholds = %s, resultingAr = %.2f%%, expectedAr = %.2f%%", resist, thresholds, resultingAr, expectedAr)
+			return
+		}
+
+		const n = 1_000
+
+		outcomes := make(map[HitOutcome]int, n)
+		var totalDamage float64
+		for iter := 0; iter < n; iter++ {
+			spellEffect := SpellEffect{
+				Outcome: OutcomeHit,
+				Damage:  1000,
+			}
+
+			spellEffect.applyResistances(sim, spell, attackTable)
+
+			outcomes[spellEffect.Outcome]++
+			totalDamage += spellEffect.Damage
+		}
+
+		if math.Abs(expectedAr-(1-totalDamage/float64(1000*n))) > 0.01 {
+			t.Logf("after %d iterations, resist = %.2f, ar = %.2f%% vs. damage lost = %.2f%%, outcomes = %v\n", n, resist, expectedAr*100, 100-100*totalDamage/float64(1000*n), outcomes)
+		}
+	}
+}

--- a/sim/core/stats/stats.go
+++ b/sim/core/stats/stats.go
@@ -335,7 +335,7 @@ type PseudoStats struct {
 
 	DamageTakenMultiplier float64 // All damage
 
-	ArmorMultiplier float64 // Major/minor/special multipicative armor modifiers
+	ArmorMultiplier float64 // Major/minor/special multiplicative armor modifiers
 
 	PhysicalDamageTakenMultiplier float64
 	ArcaneDamageTakenMultiplier   float64

--- a/sim/core/target.go
+++ b/sim/core/target.go
@@ -220,24 +220,12 @@ type AttackTable struct {
 	GlanceMultiplier float64
 	CritSuppression  float64
 
-	PartialResistArcaneRollThreshold00 float64
-	PartialResistArcaneRollThreshold25 float64
-	PartialResistArcaneRollThreshold50 float64
-	PartialResistHolyRollThreshold00   float64
-	PartialResistHolyRollThreshold25   float64
-	PartialResistHolyRollThreshold50   float64
-	PartialResistFireRollThreshold00   float64
-	PartialResistFireRollThreshold25   float64
-	PartialResistFireRollThreshold50   float64
-	PartialResistFrostRollThreshold00  float64
-	PartialResistFrostRollThreshold25  float64
-	PartialResistFrostRollThreshold50  float64
-	PartialResistNatureRollThreshold00 float64
-	PartialResistNatureRollThreshold25 float64
-	PartialResistNatureRollThreshold50 float64
-	PartialResistShadowRollThreshold00 float64
-	PartialResistShadowRollThreshold25 float64
-	PartialResistShadowRollThreshold50 float64
+	PartialResistArcaneThresholds Thresholds
+	PartialResistHolyThresholds   Thresholds
+	PartialResistFireThresholds   Thresholds
+	PartialResistFrostThresholds  Thresholds
+	PartialResistNatureThresholds Thresholds
+	PartialResistShadowThresholds Thresholds
 
 	BinaryArcaneHitChance float64
 	BinaryHolyHitChance   float64

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -45,651 +45,651 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7816.7848
-  tps: 4637.91688
+  dps: 7808.81635
+  tps: 4632.60887
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7723.25363
-  tps: 4587.88309
+  dps: 7723.37105
+  tps: 4589.2755
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7828.9525
-  tps: 4645.19
+  dps: 7821.18621
+  tps: 4640.00379
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7543.23679
-  tps: 4475.61253
+  dps: 7528.86427
+  tps: 4466.94525
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6508.76769
-  tps: 3864.36583
+  dps: 6497.693
+  tps: 3856.94825
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6390.12728
-  tps: 3800.72863
+  dps: 6375.51793
+  tps: 3793.10666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6099.33856
-  tps: 3625.56806
+  dps: 6085.70013
+  tps: 3617.99118
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7810.8815
-  tps: 4541.66044
+  dps: 7802.91968
+  tps: 4536.463
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8020.55347
-  tps: 4760.85313
+  dps: 8012.57763
+  tps: 4755.53947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7706.46222
-  tps: 4579.75485
+  dps: 7699.3734
+  tps: 4574.99881
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7722.31407
-  tps: 4589.20707
+  dps: 7714.04763
+  tps: 4583.28541
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 7905.59011
-  tps: 4693.29425
+  dps: 7898.06695
+  tps: 4688.26762
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7829.23638
-  tps: 4647.4613
+  dps: 7821.58733
+  tps: 4642.35951
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7205.11442
-  tps: 4277.49757
+  dps: 7187.08955
+  tps: 4266.68258
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 6383.85743
-  tps: 3787.05263
+  dps: 6369.9994
+  tps: 3778.93403
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7499.93322
-  tps: 4448.48581
+  dps: 7492.11591
+  tps: 4443.26719
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7623.1177
-  tps: 4529.83705
+  dps: 7615.51522
+  tps: 4524.7712
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7830.94143
-  tps: 4646.38335
+  dps: 7823.38839
+  tps: 4641.3251
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7810.8815
-  tps: 4634.34739
+  dps: 7802.91968
+  tps: 4629.04387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7810.8815
-  tps: 4634.34739
+  dps: 7802.91968
+  tps: 4629.04387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7828.9525
-  tps: 4645.19
+  dps: 7821.18621
+  tps: 4640.00379
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7824.66957
-  tps: 4642.62023
+  dps: 7816.94949
+  tps: 4637.46176
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7810.8815
-  tps: 4634.34739
+  dps: 7802.91968
+  tps: 4629.04387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7719.37099
-  tps: 4584.69675
+  dps: 7702.55137
+  tps: 4575.59279
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7691.55023
-  tps: 4570.80766
+  dps: 7684.22674
+  tps: 4565.91082
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7676.20097
-  tps: 4561.5981
+  dps: 7668.65831
+  tps: 4556.56976
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7810.8815
-  tps: 4634.34739
+  dps: 7802.91968
+  tps: 4629.04387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7810.8815
-  tps: 4634.34739
+  dps: 7802.91968
+  tps: 4629.04387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7500.57395
-  tps: 4448.87025
+  dps: 7492.75621
+  tps: 4443.65137
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7838.97628
-  tps: 4659.39333
+  dps: 7831.17766
+  tps: 4654.21032
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7603.99804
-  tps: 4518.27634
+  dps: 7596.41636
+  tps: 4513.22459
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7498.78784
-  tps: 4447.79858
+  dps: 7490.97302
+  tps: 4442.58146
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7603.99804
-  tps: 4518.27634
+  dps: 7596.41636
+  tps: 4513.22459
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7828.9525
-  tps: 4645.19
+  dps: 7821.18621
+  tps: 4640.00379
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7824.66957
-  tps: 4642.62023
+  dps: 7816.94949
+  tps: 4637.46176
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7684.70402
-  tps: 4568.37699
+  dps: 7673.73086
+  tps: 4561.75013
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7810.8815
-  tps: 4634.34739
+  dps: 7802.91968
+  tps: 4629.04387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7841.38767
-  tps: 4652.80574
+  dps: 7833.39476
+  tps: 4647.48071
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7603.99804
-  tps: 4518.27634
+  dps: 7596.41636
+  tps: 4513.22459
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7603.99804
-  tps: 4518.27634
+  dps: 7596.41636
+  tps: 4513.22459
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7740.6028
-  tps: 4593.06119
+  dps: 7731.37693
+  tps: 4587.67775
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7616.36959
-  tps: 4525.7568
+  dps: 7608.77445
+  tps: 4520.69593
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7835.57697
-  tps: 4649.28987
+  dps: 7827.58998
+  tps: 4643.96893
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7841.38767
-  tps: 4652.80574
+  dps: 7833.39476
+  tps: 4647.48071
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7810.8815
-  tps: 4634.34739
+  dps: 7802.91968
+  tps: 4629.04387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7810.8815
-  tps: 4634.34739
+  dps: 7802.91968
+  tps: 4629.04387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7603.99804
-  tps: 4518.27634
+  dps: 7596.41636
+  tps: 4513.22459
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7582.2209
-  tps: 4501.98032
+  dps: 7578.76951
+  tps: 4501.53843
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7583.41593
-  tps: 4502.69734
+  dps: 7579.97724
+  tps: 4502.26307
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8015.90283
-  tps: 4758.06757
+  dps: 8008.08766
+  tps: 4752.85024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7501.32148
-  tps: 4449.31877
+  dps: 7493.50324
+  tps: 4444.09959
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7810.8815
-  tps: 4634.34739
+  dps: 7802.91968
+  tps: 4629.04387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7603.99804
-  tps: 4518.27634
+  dps: 7596.41636
+  tps: 4513.22459
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6990.50189
-  tps: 4148.58188
+  dps: 6974.29878
+  tps: 4138.17083
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 6324.78486
-  tps: 3750.23062
+  dps: 6322.47747
+  tps: 3747.86273
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8353.56747
-  tps: 4963.72334
+  dps: 8335.4099
+  tps: 4951.9311
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6830.64344
-  tps: 4047.95107
+  dps: 6810.81857
+  tps: 4035.45745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7622.5342
-  tps: 4529.74636
+  dps: 7614.89775
+  tps: 4524.65495
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7603.99804
-  tps: 4518.27634
+  dps: 7596.41636
+  tps: 4513.22459
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7510.30879
-  tps: 4454.71115
+  dps: 7502.35724
+  tps: 4449.41199
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7903.4984
-  tps: 4686.85987
+  dps: 7895.27415
+  tps: 4681.39709
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7932.00142
-  tps: 4706.09841
+  dps: 7923.82041
+  tps: 4700.66157
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7603.99804
-  tps: 4518.27634
+  dps: 7596.41636
+  tps: 4513.22459
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 7632.31635
-  tps: 4530.73017
+  dps: 7633.56269
+  tps: 4531.01236
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StormshroudArmor"
  value: {
-  dps: 6046.80993
-  tps: 3588.54317
+  dps: 6038.74946
+  tps: 3584.73111
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7841.38767
-  tps: 4652.80574
+  dps: 7833.39476
+  tps: 4647.48071
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7835.57697
-  tps: 4649.28987
+  dps: 7827.58998
+  tps: 4643.96893
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7825.40824
-  tps: 4643.13708
+  dps: 7817.43162
+  tps: 4637.82332
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7675.69386
-  tps: 4553.94164
+  dps: 7667.0167
+  tps: 4550.42314
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6546.18349
-  tps: 3881.1705
+  dps: 6541.92539
+  tps: 3878.23066
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7806.4381
-  tps: 4626.223
+  dps: 7798.2104
+  tps: 4620.19619
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7718.78655
-  tps: 4588.22062
+  dps: 7709.35641
+  tps: 4583.37034
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7736.78891
-  tps: 4600.28774
+  dps: 7740.72918
+  tps: 4600.90604
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7810.8815
-  tps: 4634.34739
+  dps: 7802.91968
+  tps: 4629.04387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7810.8815
-  tps: 4634.34739
+  dps: 7802.91968
+  tps: 4629.04387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7810.8815
-  tps: 4634.34739
+  dps: 7802.91968
+  tps: 4629.04387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7810.8815
-  tps: 4634.34739
+  dps: 7802.91968
+  tps: 4629.04387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6398.47947
-  tps: 3799.63002
+  dps: 6381.7093
+  tps: 3788.25685
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7502.1758
-  tps: 4449.83136
+  dps: 7494.35699
+  tps: 4444.61183
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 7907.41677
-  tps: 4689.8182
+  dps: 7899.62051
+  tps: 4685.24123
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11241.41845
-  tps: 7133.8614
+  dps: 11225.19141
+  tps: 7121.19327
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5791.83161
-  tps: 3840.33641
+  dps: 5790.43911
+  tps: 3840.18846
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6674.46888
-  tps: 4130.78497
+  dps: 6636.96468
+  tps: 4104.95347
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7014.55799
-  tps: 4427.21791
+  dps: 6999.82307
+  tps: 4412.43569
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3363.04997
-  tps: 2230.61944
+  dps: 3365.37209
+  tps: 2230.7199
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3633.30051
-  tps: 2294.19064
+  dps: 3624.05217
+  tps: 2288.61033
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11237.32407
-  tps: 7110.11293
+  dps: 11218.4991
+  tps: 7104.45958
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5833.69056
-  tps: 3855.04549
+  dps: 5823.81783
+  tps: 3847.25554
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6638.05163
-  tps: 4113.69753
+  dps: 6608.70673
+  tps: 4104.45582
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7038.8244
-  tps: 4434.97399
+  dps: 7017.69369
+  tps: 4421.37153
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3363.12126
-  tps: 2224.38418
+  dps: 3356.04858
+  tps: 2221.79562
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3708.7509
-  tps: 2320.05668
+  dps: 3689.57979
+  tps: 2314.01985
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7576.42618
-  tps: 4500.23676
+  dps: 7561.52833
+  tps: 4490.51355
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -45,651 +45,651 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7778.01156
-  tps: 6011.11918
+  dps: 7773.10424
+  tps: 5982.33725
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7527.6827
-  tps: 5870.38618
+  dps: 7521.94321
+  tps: 5869.55687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7742.48631
-  tps: 6058.20266
+  dps: 7737.00574
+  tps: 6037.68389
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7527.91425
-  tps: 5867.71818
+  dps: 7517.89624
+  tps: 5841.47736
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6417.31629
-  tps: 4950.9929
+  dps: 6409.85544
+  tps: 4938.52318
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6200.48928
-  tps: 4864.90643
+  dps: 6191.34804
+  tps: 4860.5669
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5976.891
-  tps: 4689.35422
+  dps: 5965.63625
+  tps: 4680.37925
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7778.01156
-  tps: 5890.8968
+  dps: 7773.10424
+  tps: 5862.6905
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7823.08632
-  tps: 6147.24839
+  dps: 7817.4592
+  tps: 6126.16667
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7315.05785
-  tps: 5823.01644
+  dps: 7298.12069
+  tps: 5801.31331
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7414.5623
-  tps: 5859.99103
+  dps: 7398.04068
+  tps: 5821.83962
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 7616.7291
-  tps: 5954.14657
+  dps: 7599.33772
+  tps: 5946.36839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7561.68565
-  tps: 5906.15825
+  dps: 7545.59291
+  tps: 5878.17513
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7204.9559
-  tps: 5673.60288
+  dps: 7195.29509
+  tps: 5663.57568
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 6415.52828
-  tps: 4910.69969
+  dps: 6408.89233
+  tps: 4909.5982
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7782.00057
-  tps: 6146.11911
+  dps: 7765.19698
+  tps: 6116.99153
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7238.00377
-  tps: 5690.21883
+  dps: 7222.89565
+  tps: 5663.89943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7740.07043
-  tps: 6044.03858
+  dps: 7739.74099
+  tps: 6044.40222
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7778.01156
-  tps: 6011.11918
+  dps: 7773.10424
+  tps: 5982.33725
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7778.01156
-  tps: 6011.11918
+  dps: 7773.10424
+  tps: 5982.33725
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7742.48631
-  tps: 6058.20266
+  dps: 7737.00574
+  tps: 6037.68389
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7740.62222
-  tps: 6057.56443
+  dps: 7731.81623
+  tps: 6028.94951
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7778.01156
-  tps: 6011.11918
+  dps: 7773.10424
+  tps: 5982.33725
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7343.1323
-  tps: 5810.45599
+  dps: 7330.59477
+  tps: 5790.99971
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7297.47
-  tps: 5775.65547
+  dps: 7291.90429
+  tps: 5776.98193
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7280.7365
-  tps: 5766.16566
+  dps: 7264.78041
+  tps: 5759.23385
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7778.01156
-  tps: 6011.11918
+  dps: 7773.10424
+  tps: 5982.33725
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7778.01156
-  tps: 6011.11918
+  dps: 7773.10424
+  tps: 5982.33725
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7800.75458
-  tps: 6162.93376
+  dps: 7783.90575
+  tps: 6133.74216
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7422.55369
-  tps: 5933.3466
+  dps: 7406.69444
+  tps: 5905.80456
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7238.00377
-  tps: 5690.21883
+  dps: 7222.89565
+  tps: 5663.89943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7676.92455
-  tps: 6094.56654
+  dps: 7662.22844
+  tps: 6079.65719
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7203.74456
-  tps: 5690.21883
+  dps: 7188.63644
+  tps: 5663.89943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7742.48631
-  tps: 6058.20266
+  dps: 7737.00574
+  tps: 6037.68389
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7740.62222
-  tps: 6057.56443
+  dps: 7731.81623
+  tps: 6028.94951
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7341.96689
-  tps: 5850.01746
+  dps: 7326.19919
+  tps: 5839.98339
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7778.01156
-  tps: 6011.11918
+  dps: 7773.10424
+  tps: 5982.33725
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7813.17432
-  tps: 6043.40265
+  dps: 7808.2389
+  tps: 6014.4565
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7239.15683
-  tps: 5690.21883
+  dps: 7224.04872
+  tps: 5663.89943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7203.74456
-  tps: 5690.21883
+  dps: 7188.63644
+  tps: 5663.89943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7495.5598
-  tps: 5840.14118
+  dps: 7486.8577
+  tps: 5831.86245
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7241.19428
-  tps: 5690.21883
+  dps: 7226.08616
+  tps: 5663.89943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7806.47665
-  tps: 6037.25342
+  dps: 7801.54658
+  tps: 6008.33855
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7813.17432
-  tps: 6043.40265
+  dps: 7808.2389
+  tps: 6014.4565
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7778.01156
-  tps: 6011.11918
+  dps: 7773.10424
+  tps: 5982.33725
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7778.01156
-  tps: 6011.11918
+  dps: 7773.10424
+  tps: 5982.33725
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7254.4269
-  tps: 5690.21883
+  dps: 7239.31878
+  tps: 5663.89943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7361.88617
-  tps: 5734.85747
+  dps: 7339.87107
+  tps: 5712.75988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7372.77961
-  tps: 5743.60658
+  dps: 7350.74386
+  tps: 5721.49247
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7815.73601
-  tps: 6137.87244
+  dps: 7807.0381
+  tps: 6108.65493
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7822.63426
-  tps: 6182.55086
+  dps: 7805.73264
+  tps: 6153.28457
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7778.01156
-  tps: 6011.11918
+  dps: 7773.10424
+  tps: 5982.33725
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7238.00377
-  tps: 5690.21883
+  dps: 7222.89565
+  tps: 5663.89943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6772.00705
-  tps: 5350.04559
+  dps: 6758.11943
+  tps: 5328.73865
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6345.7644
-  tps: 4865.1144
+  dps: 6334.7101
+  tps: 4867.26484
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8111.86602
-  tps: 6440.82601
+  dps: 8098.60315
+  tps: 6440.23878
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7042.26862
-  tps: 5549.08627
+  dps: 7033.10117
+  tps: 5525.12738
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7238.00377
-  tps: 5690.21883
+  dps: 7222.89565
+  tps: 5663.89943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7254.4269
-  tps: 5690.21883
+  dps: 7239.31878
+  tps: 5663.89943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7776.844
-  tps: 6074.90734
+  dps: 7755.79019
+  tps: 6049.3141
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8152.63455
-  tps: 6368.56157
+  dps: 8135.16179
+  tps: 6338.2172
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7908.19131
-  tps: 6213.86072
+  dps: 7891.22723
+  tps: 6184.284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7226.65281
-  tps: 5690.21883
+  dps: 7211.54469
+  tps: 5663.89943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 7304.12645
-  tps: 5756.13925
+  dps: 7282.59845
+  tps: 5738.04069
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StormshroudArmor"
  value: {
-  dps: 5877.11038
-  tps: 4647.66641
+  dps: 5858.20746
+  tps: 4626.13669
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7813.17432
-  tps: 6043.40265
+  dps: 7808.2389
+  tps: 6014.4565
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7806.47665
-  tps: 6037.25342
+  dps: 7801.54658
+  tps: 6008.33855
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7794.75573
-  tps: 6026.49226
+  dps: 7789.83503
+  tps: 5997.63213
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7885.64665
-  tps: 6174.0217
+  dps: 7873.39343
+  tps: 6167.03651
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6594.84244
-  tps: 5021.9037
+  dps: 6582.29084
+  tps: 5003.55242
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7807.82853
-  tps: 6089.0354
+  dps: 7791.17587
+  tps: 6060.15971
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7397.40468
-  tps: 5830.30282
+  dps: 7391.25183
+  tps: 5827.22728
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7495.99338
-  tps: 5846.76241
+  dps: 7481.60909
+  tps: 5833.01349
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7778.01156
-  tps: 6011.11918
+  dps: 7773.10424
+  tps: 5982.33725
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7778.01156
-  tps: 6011.11918
+  dps: 7773.10424
+  tps: 5982.33725
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7778.01156
-  tps: 6011.11918
+  dps: 7773.10424
+  tps: 5982.33725
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7778.01156
-  tps: 6011.11918
+  dps: 7773.10424
+  tps: 5982.33725
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6253.65424
-  tps: 4894.50975
+  dps: 6235.45448
+  tps: 4870.91147
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7847.63961
-  tps: 6204.97039
+  dps: 7830.67765
+  tps: 6175.61875
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 7786.06577
-  tps: 6049.99074
+  dps: 7775.54373
+  tps: 6037.78364
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30624.20498
-  tps: 31138.32066
+  dps: 30517.46729
+  tps: 31036.63674
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7260.17115
-  tps: 5854.47959
+  dps: 7244.84541
+  tps: 5853.88402
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10532.54449
-  tps: 6420.46156
+  dps: 10534.11362
+  tps: 6370.41613
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 18691.80485
-  tps: 19802.99018
+  dps: 18622.08253
+  tps: 19738.75161
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3598.59361
-  tps: 3251.0701
+  dps: 3583.90252
+  tps: 3242.72389
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4358.68848
-  tps: 3435.75598
+  dps: 4347.37906
+  tps: 3421.01872
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30967.61885
-  tps: 31363.94483
+  dps: 30861.65365
+  tps: 31270.35525
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7406.13945
-  tps: 5860.03384
+  dps: 7389.88585
+  tps: 5831.59619
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10717.2222
-  tps: 6396.37713
+  dps: 10724.46206
+  tps: 6408.61785
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 18747.98652
-  tps: 19844.9826
+  dps: 18701.98152
+  tps: 19797.44833
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3648.44939
-  tps: 3253.95823
+  dps: 3637.52851
+  tps: 3249.83424
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4574.25476
-  tps: 3453.25788
+  dps: 4554.56823
+  tps: 3442.68921
  }
 }
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7408.36703
-  tps: 5705.79763
+  dps: 7398.748
+  tps: 5689.21063
  }
 }

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -45,630 +45,630 @@ character_stats_results: {
 dps_results: {
  key: "TestBalance-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 6777.31377
-  tps: 6598.55181
+  dps: 6766.62346
+  tps: 6587.86151
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6766.65761
-  tps: 6584.29384
+  dps: 6759.8911
+  tps: 6577.52733
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6696.24961
-  tps: 6517.48766
+  dps: 6685.56576
+  tps: 6506.80381
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6825.13333
-  tps: 6645.97256
+  dps: 6814.0427
+  tps: 6634.88192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5160.4704
-  tps: 4992.36609
+  dps: 5142.15215
+  tps: 4974.04784
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6807.06141
-  tps: 6493.49978
+  dps: 6800.24707
+  tps: 6486.82173
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7019.45371
-  tps: 6839.03946
+  dps: 7008.25436
+  tps: 6827.84011
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6736.46103
-  tps: 6557.85304
+  dps: 6719.9899
+  tps: 6541.38191
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6825.9283
-  tps: 6648.98065
+  dps: 6828.30717
+  tps: 6651.35952
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6689.23609
-  tps: 6514.63286
+  dps: 6673.01428
+  tps: 6498.41104
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6689.23609
-  tps: 6514.63286
+  dps: 6673.01428
+  tps: 6498.41104
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6734.26292
-  tps: 6558.54438
+  dps: 6717.93708
+  tps: 6542.21854
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 6904.14639
-  tps: 6723.73214
+  dps: 6893.2999
+  tps: 6712.88565
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6696.24961
-  tps: 6517.48766
+  dps: 6685.56576
+  tps: 6506.80381
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6837.83315
-  tps: 6657.01367
+  dps: 6810.12223
+  tps: 6629.30275
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 3563.5262
-  tps: 3386.5732
+  dps: 3565.34633
+  tps: 3388.39334
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DreamwalkerGarb"
  value: {
-  dps: 5644.3275
-  tps: 5485.49224
+  dps: 5623.79372
+  tps: 5464.95845
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6766.65761
-  tps: 6584.29384
+  dps: 6759.8911
+  tps: 6577.52733
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6837.32319
-  tps: 6655.6116
+  dps: 6822.61169
+  tps: 6640.90009
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6825.13333
-  tps: 6644.71908
+  dps: 6814.0427
+  tps: 6633.62844
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6814.59909
-  tps: 6632.98447
+  dps: 6784.32771
+  tps: 6602.71309
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6766.65761
-  tps: 6584.29384
+  dps: 6759.8911
+  tps: 6577.52733
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6821.82806
-  tps: 6644.81027
+  dps: 6786.08208
+  tps: 6609.06429
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6995.72893
-  tps: 6816.82119
+  dps: 6991.06985
+  tps: 6812.16211
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6903.47002
-  tps: 6725.33143
+  dps: 6897.1433
+  tps: 6719.0047
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6807.06141
-  tps: 6623.66494
+  dps: 6800.24707
+  tps: 6616.85061
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6798.98065
-  tps: 6615.79072
+  dps: 6792.17588
+  tps: 6608.98595
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6696.24961
-  tps: 6517.48766
+  dps: 6685.56576
+  tps: 6506.80381
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6800.34815
-  tps: 6619.02513
+  dps: 6789.4886
+  tps: 6608.16558
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 3894.38894
-  tps: 3724.28873
+  dps: 3873.77452
+  tps: 3703.6743
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 6626.52082
-  tps: 6456.03154
+  dps: 6608.62082
+  tps: 6438.13154
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 6904.14639
-  tps: 6723.73214
+  dps: 6893.2999
+  tps: 6712.88565
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 6904.14639
-  tps: 6723.73214
+  dps: 6893.2999
+  tps: 6712.88565
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 7111.69799
-  tps: 6936.51926
+  dps: 7077.5481
+  tps: 6902.36937
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 6922.82607
-  tps: 6741.81923
+  dps: 6892.21174
+  tps: 6711.20491
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 6904.14639
-  tps: 6723.73214
+  dps: 6893.2999
+  tps: 6712.88565
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6825.13333
-  tps: 6644.71908
+  dps: 6814.0427
+  tps: 6633.62844
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6814.59909
-  tps: 6632.98447
+  dps: 6784.32771
+  tps: 6602.71309
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6696.24961
-  tps: 6517.48766
+  dps: 6685.56576
+  tps: 6506.80381
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6796.83221
-  tps: 6622.36568
+  dps: 6782.2086
+  tps: 6607.74207
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6766.65761
-  tps: 6584.29384
+  dps: 6759.8911
+  tps: 6577.52733
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 3628.25656
-  tps: 3453.05503
+  dps: 3632.17842
+  tps: 3456.97688
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LasherweaveRegalia"
  value: {
-  dps: 7148.27229
-  tps: 6969.58517
+  dps: 7101.30221
+  tps: 6922.61508
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6696.24961
-  tps: 6517.48766
+  dps: 6685.56576
+  tps: 6506.80381
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6696.24961
-  tps: 6517.48766
+  dps: 6685.56576
+  tps: 6506.80381
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 4053.20601
-  tps: 3852.01698
+  dps: 4065.45493
+  tps: 3864.2659
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 6537.55526
-  tps: 6345.22567
+  dps: 6547.83648
+  tps: 6355.50688
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6745.43003
-  tps: 6567.36664
+  dps: 6739.64497
+  tps: 6561.58158
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NightsongBattlegear"
  value: {
-  dps: 3708.61859
-  tps: 3534.8214
+  dps: 3705.52388
+  tps: 3531.72668
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NightsongGarb"
  value: {
-  dps: 6024.77195
-  tps: 5833.98407
+  dps: 6013.3745
+  tps: 5822.58662
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6696.24961
-  tps: 6517.48766
+  dps: 6685.56576
+  tps: 6506.80381
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6766.65761
-  tps: 6584.29384
+  dps: 6759.8911
+  tps: 6577.52733
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6766.65761
-  tps: 6584.29384
+  dps: 6759.8911
+  tps: 6577.52733
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6766.65761
-  tps: 6584.29384
+  dps: 6759.8911
+  tps: 6577.52733
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6766.65761
-  tps: 6584.29384
+  dps: 6759.8911
+  tps: 6577.52733
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6696.24961
-  tps: 6517.48766
+  dps: 6685.56576
+  tps: 6506.80381
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7095.44936
-  tps: 6909.71641
+  dps: 7121.84187
+  tps: 6936.10892
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7154.67305
-  tps: 6968.19656
+  dps: 7180.73273
+  tps: 6994.25624
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6956.0542
-  tps: 6773.69042
+  dps: 6949.77096
+  tps: 6767.40719
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6766.65761
-  tps: 6584.08252
+  dps: 6759.8911
+  tps: 6577.31602
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6696.24961
-  tps: 6517.48766
+  dps: 6685.56576
+  tps: 6506.80381
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Runetotem'sBattlegear"
  value: {
-  dps: 4053.20601
-  tps: 3852.01698
+  dps: 4065.45493
+  tps: 3864.2659
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Runetotem'sRegalia"
  value: {
-  dps: 6537.55526
-  tps: 6345.22567
+  dps: 6547.83648
+  tps: 6355.50688
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 6904.14639
-  tps: 6723.73214
+  dps: 6893.2999
+  tps: 6712.88565
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6696.24961
-  tps: 6517.48766
+  dps: 6685.56576
+  tps: 6506.80381
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6696.24961
-  tps: 6517.48766
+  dps: 6685.56576
+  tps: 6506.80381
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6696.24961
-  tps: 6517.48766
+  dps: 6685.56576
+  tps: 6506.80381
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SparkofLife-37657"
  value: {
-  dps: 6793.5815
-  tps: 6615.16252
+  dps: 6770.22157
+  tps: 6591.8026
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-StormshroudArmor"
  value: {
-  dps: 4205.24964
-  tps: 4029.63622
+  dps: 4196.85932
+  tps: 4021.2459
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6766.65761
-  tps: 6584.29384
+  dps: 6759.8911
+  tps: 6577.52733
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6766.65761
-  tps: 6584.29384
+  dps: 6759.8911
+  tps: 6577.52733
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6766.65761
-  tps: 6584.29384
+  dps: 6759.8911
+  tps: 6577.52733
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartHarness"
  value: {
-  dps: 2794.12374
-  tps: 2624.55812
+  dps: 2789.77596
+  tps: 2620.21034
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartRegalia"
  value: {
-  dps: 4556.14914
-  tps: 4361.00598
+  dps: 4529.74957
+  tps: 4334.60641
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6766.65761
-  tps: 6584.29384
+  dps: 6759.8911
+  tps: 6577.52733
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6696.24961
-  tps: 6517.48766
+  dps: 6685.56576
+  tps: 6506.80381
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6696.24961
-  tps: 6517.48766
+  dps: 6685.56576
+  tps: 6506.80381
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6807.06141
-  tps: 6623.66494
+  dps: 6800.24707
+  tps: 6616.85061
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6798.98065
-  tps: 6615.79072
+  dps: 6792.17588
+  tps: 6608.98595
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6798.98065
-  tps: 6615.79072
+  dps: 6792.17588
+  tps: 6608.98595
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6807.06141
-  tps: 6623.66494
+  dps: 6800.24707
+  tps: 6616.85061
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 4098.8571
-  tps: 3921.52023
+  dps: 4092.01083
+  tps: 3914.67396
  }
 }
 dps_results: {
  key: "TestBalance-Average-Default"
  value: {
-  dps: 6931.7285
-  tps: 6746.16011
+  dps: 6916.71741
+  tps: 6731.14903
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8895.38492
-  tps: 10956.35474
+  dps: 8865.39335
+  tps: 10926.36316
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6731.37643
-  tps: 6547.78419
+  dps: 6713.53863
+  tps: 6529.9464
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7644.36089
-  tps: 7019.13793
+  dps: 7580.4874
+  tps: 6955.26443
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3388.74122
-  tps: 3729.78545
+  dps: 3382.48212
+  tps: 3723.52635
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2057.22195
-  tps: 1960.23491
+  dps: 2050.34291
+  tps: 1953.35587
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4236.24346
-  tps: 3981.32339
+  dps: 4250.55693
+  tps: 3995.63686
  }
 }
 dps_results: {
  key: "TestBalance-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6988.06404
-  tps: 6839.03946
+  dps: 6976.86469
+  tps: 6827.84011
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -59,8 +59,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7580.26593
-  tps: 5763.91702
+  dps: 7579.91242
+  tps: 5763.54214
  }
 }
 dps_results: {
@@ -101,8 +101,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7556.99433
-  tps: 5749.5373
+  dps: 7556.95972
+  tps: 5749.49207
  }
 }
 dps_results: {
@@ -192,8 +192,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7564.45098
-  tps: 5786.50774
+  dps: 7564.9319
+  tps: 5786.95124
  }
 }
 dps_results: {
@@ -521,8 +521,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-StormshroudArmor"
  value: {
-  dps: 6096.69555
-  tps: 4618.06169
+  dps: 6096.68462
+  tps: 4618.05428
  }
 }
 dps_results: {

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -59,8 +59,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1198.94281
-  tps: 1636.46154
+  dps: 1198.75987
+  tps: 1636.21896
  }
 }
 dps_results: {
@@ -101,8 +101,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1182.99922
-  tps: 1611.51216
+  dps: 1182.65487
+  tps: 1611.05555
  }
 }
 dps_results: {
@@ -199,8 +199,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1173.59741
-  tps: 1597.33089
+  dps: 1173.40768
+  tps: 1597.0793
  }
 }
 dps_results: {
@@ -521,8 +521,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-StormshroudArmor"
  value: {
-  dps: 963.7002
-  tps: 1272.89864
+  dps: 963.69469
+  tps: 1272.89147
  }
 }
 dps_results: {
@@ -619,8 +619,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-Average-Default"
  value: {
-  dps: 1318.90609
-  tps: 1820.01748
+  dps: 1316.85021
+  tps: 1817.29138
   dtps: 523.36667
  }
 }
@@ -669,8 +669,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1440.58147
-  tps: 2004.94641
+  dps: 1438.59896
+  tps: 2002.31761
   dtps: 488.03992
  }
 }

--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -45,854 +45,854 @@ character_stats_results: {
 dps_results: {
  key: "TestHunter-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 7679.02673
-  tps: 6680.17289
+  dps: 7678.23002
+  tps: 6679.37618
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 6626.24956
-  tps: 5611.45817
+  dps: 6682.89814
+  tps: 5667.99073
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6715.15911
-  tps: 5693.25019
+  dps: 6703.98234
+  tps: 5678.35773
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6742.68958
-  tps: 5721.51459
+  dps: 6788.52933
+  tps: 5767.18979
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6727.37945
-  tps: 5710.4814
+  dps: 6703.29054
+  tps: 5683.24717
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6636.09678
-  tps: 5626.3643
+  dps: 6610.29757
+  tps: 5598.07991
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 6340.38393
-  tps: 5328.46553
+  dps: 6350.14134
+  tps: 5342.55521
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5784.95349
-  tps: 4896.79054
+  dps: 5781.75981
+  tps: 4893.59687
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5540.91206
-  tps: 4667.97171
+  dps: 5545.78488
+  tps: 4672.84453
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6715.15911
-  tps: 5580.28681
+  dps: 6703.98234
+  tps: 5565.69945
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6869.52143
-  tps: 5847.61252
+  dps: 6847.90113
+  tps: 5825.4518
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 6171.86701
-  tps: 5192.46041
+  dps: 6169.85839
+  tps: 5190.45179
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6675.11477
-  tps: 5667.64357
+  dps: 6729.00449
+  tps: 5719.33918
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6711.2688
-  tps: 5703.82446
+  dps: 6762.56939
+  tps: 5752.98978
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6739.53554
-  tps: 5722.54639
+  dps: 6738.44356
+  tps: 5717.75316
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6709.65578
-  tps: 5691.8018
+  dps: 6701.00989
+  tps: 5685.606
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6632.6373
-  tps: 5622.97199
+  dps: 6631.31776
+  tps: 5621.43344
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6739.35151
-  tps: 5717.4426
+  dps: 6722.13416
+  tps: 5699.68483
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6715.15911
-  tps: 5693.25019
+  dps: 6703.98234
+  tps: 5678.35773
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6716.97741
-  tps: 5693.69556
+  dps: 6667.67021
+  tps: 5645.7915
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6735.70683
-  tps: 5713.79791
+  dps: 6715.21969
+  tps: 5692.77036
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6733.12944
-  tps: 5711.22053
+  dps: 6711.53057
+  tps: 5689.08124
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6715.15911
-  tps: 5693.25019
+  dps: 6703.98234
+  tps: 5678.35773
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6731.53271
-  tps: 5724.13426
+  dps: 6781.78548
+  tps: 5772.3121
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6658.13383
-  tps: 5650.66262
+  dps: 6713.00426
+  tps: 5703.33896
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6652.2366
-  tps: 5641.85953
+  dps: 6699.74431
+  tps: 5690.079
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6715.15911
-  tps: 5693.25019
+  dps: 6703.98234
+  tps: 5678.35773
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6715.15911
-  tps: 5693.25019
+  dps: 6703.98234
+  tps: 5678.35773
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6632.6373
-  tps: 5622.97199
+  dps: 6631.31776
+  tps: 5621.43344
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 7202.0111
-  tps: 6223.98683
+  dps: 7191.26712
+  tps: 6213.24285
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5287.88833
-  tps: 4445.92201
+  dps: 5280.763
+  tps: 4438.79668
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6576.87431
-  tps: 5567.332
+  dps: 6631.80249
+  tps: 5622.13719
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6735.70683
-  tps: 5713.79791
+  dps: 6715.21969
+  tps: 5692.77036
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6733.12944
-  tps: 5711.22053
+  dps: 6711.53057
+  tps: 5689.08124
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6721.10999
-  tps: 5707.97998
+  dps: 6732.48832
+  tps: 5719.54565
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6931.1428
-  tps: 5921.52233
+  dps: 6893.74583
+  tps: 5880.20458
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6739.49742
-  tps: 5714.97296
+  dps: 6728.2615
+  tps: 5700.01152
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6632.6373
-  tps: 5622.97199
+  dps: 6631.31776
+  tps: 5621.43344
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6586.63375
-  tps: 5578.04822
+  dps: 6603.79256
+  tps: 5592.94901
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6746.50368
-  tps: 5733.67739
+  dps: 6733.56383
+  tps: 5721.36275
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6632.6373
-  tps: 5622.97199
+  dps: 6632.52179
+  tps: 5622.63747
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6734.86155
-  tps: 5710.83529
+  dps: 6723.6369
+  tps: 5695.88699
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6739.49742
-  tps: 5714.97296
+  dps: 6728.2615
+  tps: 5700.01152
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6715.15911
-  tps: 5693.25019
+  dps: 6703.98234
+  tps: 5678.35773
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6715.15911
-  tps: 5693.25019
+  dps: 6703.98234
+  tps: 5678.35773
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6576.87431
-  tps: 5567.332
+  dps: 6631.80249
+  tps: 5622.13719
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6576.87431
-  tps: 5567.332
+  dps: 6631.80249
+  tps: 5622.13719
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6576.87431
-  tps: 5567.332
+  dps: 6631.80249
+  tps: 5622.13719
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6875.55054
-  tps: 5852.14553
+  dps: 6856.0545
+  tps: 5832.10801
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6690.26424
-  tps: 5662.87533
+  dps: 6683.35275
+  tps: 5655.19197
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6632.6373
-  tps: 5622.97199
+  dps: 6631.31776
+  tps: 5621.43344
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 6532.7486
-  tps: 5560.56333
+  dps: 6520.16163
+  tps: 5547.97635
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6632.6373
-  tps: 5622.97199
+  dps: 6631.31776
+  tps: 5621.43344
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6576.87431
-  tps: 5567.332
+  dps: 6631.80249
+  tps: 5622.13719
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6632.6373
-  tps: 5622.97199
+  dps: 6632.84268
+  tps: 5622.95836
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SparkofLife-37657"
  value: {
-  dps: 6817.96427
-  tps: 5807.06656
+  dps: 6767.68369
+  tps: 5769.49583
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StormshroudArmor"
  value: {
-  dps: 5397.1017
-  tps: 4543.33474
+  dps: 5389.95399
+  tps: 4536.18703
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6739.49742
-  tps: 5714.97296
+  dps: 6728.2615
+  tps: 5700.01152
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6734.86155
-  tps: 5710.83529
+  dps: 6723.6369
+  tps: 5695.88699
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6726.74878
-  tps: 5703.59437
+  dps: 6715.54384
+  tps: 5688.66906
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheFistsofFury"
  value: {
-  dps: 6519.36372
-  tps: 5519.88316
+  dps: 6499.77387
+  tps: 5498.79779
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6764.40871
-  tps: 5744.55045
+  dps: 6732.06644
+  tps: 5712.9347
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6577.07509
-  tps: 5567.53278
+  dps: 6631.99239
+  tps: 5622.32708
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6577.07509
-  tps: 5567.53278
+  dps: 6631.99239
+  tps: 5622.32708
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6715.15911
-  tps: 5693.25019
+  dps: 6703.98234
+  tps: 5678.35773
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6715.15911
-  tps: 5693.25019
+  dps: 6703.98234
+  tps: 5678.35773
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6715.15911
-  tps: 5693.25019
+  dps: 6703.98234
+  tps: 5678.35773
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6715.15911
-  tps: 5693.25019
+  dps: 6703.98234
+  tps: 5678.35773
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5703.38796
-  tps: 4834.53269
+  dps: 5702.68126
+  tps: 4833.82598
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 7097.5665
-  tps: 6080.1922
+  dps: 7102.40796
+  tps: 6085.03367
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7417.56997
-  tps: 6395.8109
+  dps: 7451.02518
+  tps: 6431.24393
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 7696.74613
-  tps: 6673.38347
+  dps: 7690.33083
+  tps: 6672.51166
  }
 }
 dps_results: {
  key: "TestHunter-Average-Default"
  value: {
-  dps: 6818.36521
-  tps: 5801.39402
+  dps: 6812.33276
+  tps: 5795.40569
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17417.54218
-  tps: 17336.59667
+  dps: 17382.54641
+  tps: 17301.6009
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6964.27374
-  tps: 5862.21494
+  dps: 6953.27863
+  tps: 5851.21984
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7815.50102
-  tps: 6554.69918
+  dps: 7787.68154
+  tps: 6526.8797
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10277.11259
-  tps: 11356.04894
+  dps: 10252.40573
+  tps: 11331.34209
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3439.79168
-  tps: 3089.77796
+  dps: 3439.22341
+  tps: 3089.20969
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4165.39697
-  tps: 3717.26422
+  dps: 4141.81954
+  tps: 3693.68678
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-BM-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6252.77958
-  tps: 4775.62417
+  dps: 6253.08433
+  tps: 4775.92892
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-BM-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6252.77958
-  tps: 3831.07973
+  dps: 6253.08433
+  tps: 3831.38448
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-BM-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7578.45979
-  tps: 4639.29184
+  dps: 7578.59895
+  tps: 4639.431
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-BM-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3000.50417
-  tps: 3671.08283
+  dps: 2999.64779
+  tps: 3670.22645
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-BM-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3000.50417
-  tps: 2162.80885
+  dps: 2999.64779
+  tps: 2161.95248
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-BM-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3580.58396
-  tps: 2568.00795
+  dps: 3579.79639
+  tps: 2567.22038
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6582.9209
-  tps: 6482.93556
+  dps: 6565.97503
+  tps: 6463.91257
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6582.9209
-  tps: 5616.10605
+  dps: 6565.97503
+  tps: 5598.41995
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7685.31908
-  tps: 6596.49554
+  dps: 7711.32866
+  tps: 6616.42221
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3448.03412
-  tps: 4581.82678
+  dps: 3446.86255
+  tps: 4580.65521
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3448.03412
-  tps: 3107.97944
+  dps: 3446.86255
+  tps: 3106.80787
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4225.10965
-  tps: 3769.006
+  dps: 4202.59011
+  tps: 3746.48646
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6842.51438
-  tps: 6744.94016
+  dps: 6840.15524
+  tps: 6742.58103
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6842.51438
-  tps: 5745.93002
+  dps: 6840.15524
+  tps: 5743.57089
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7760.19078
-  tps: 6499.97065
+  dps: 7752.93107
+  tps: 6492.71094
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3399.30677
-  tps: 4564.62254
+  dps: 3391.61437
+  tps: 4556.93014
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3399.30677
-  tps: 3049.40781
+  dps: 3391.61437
+  tps: 3041.71541
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4139.69943
-  tps: 3690.08989
+  dps: 4127.50109
+  tps: 3677.89155
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17499.45356
-  tps: 17352.61549
+  dps: 17463.8757
+  tps: 17317.03764
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7009.32206
-  tps: 5847.39776
+  dps: 6998.44581
+  tps: 5836.52151
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7894.3627
-  tps: 6559.80185
+  dps: 7867.83333
+  tps: 6533.27247
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10285.66582
-  tps: 11347.25119
+  dps: 10255.24045
+  tps: 11316.82582
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3464.0381
-  tps: 3089.77025
+  dps: 3455.77501
+  tps: 3081.50716
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4166.57857
-  tps: 3696.46929
+  dps: 4143.43615
+  tps: 3673.32687
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6405.98998
-  tps: 4764.35333
+  dps: 6408.66135
+  tps: 4767.0247
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6405.98998
-  tps: 3828.16665
+  dps: 6408.66135
+  tps: 3830.83802
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7733.3821
-  tps: 4602.32813
+  dps: 7744.64265
+  tps: 4613.58867
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3025.87087
-  tps: 3645.77621
+  dps: 3022.67688
+  tps: 3642.58222
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3025.87087
-  tps: 2141.46653
+  dps: 3022.67688
+  tps: 2138.27253
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3650.55539
-  tps: 2575.76847
+  dps: 3653.18675
+  tps: 2578.39983
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6608.08693
-  tps: 6455.62274
+  dps: 6568.38866
+  tps: 6398.95953
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6608.08693
-  tps: 5592.37898
+  dps: 6568.38866
+  tps: 5539.56861
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7758.22307
-  tps: 6604.44607
+  dps: 7793.69797
+  tps: 6633.61158
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3430.65313
-  tps: 4543.24591
+  dps: 3431.87478
+  tps: 4544.46756
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3430.65313
-  tps: 3067.23931
+  dps: 3431.87478
+  tps: 3068.46097
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4266.64156
-  tps: 3782.0907
+  dps: 4244.74559
+  tps: 3760.19472
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6869.31462
-  tps: 6708.4484
+  dps: 6867.8503
+  tps: 6706.98408
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6869.31462
-  tps: 5712.41279
+  dps: 6867.8503
+  tps: 5710.94847
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7849.83939
-  tps: 6516.30175
+  dps: 7841.89723
+  tps: 6508.35959
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3421.94444
-  tps: 4558.9082
+  dps: 3415.98918
+  tps: 4552.95294
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3421.94444
-  tps: 3048.49079
+  dps: 3415.98918
+  tps: 3042.53552
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4167.41447
-  tps: 3690.3343
+  dps: 4152.18142
+  tps: 3675.10126
  }
 }
 dps_results: {
  key: "TestHunter-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6779.99961
-  tps: 5828.52272
+  dps: 6833.89942
+  tps: 5876.29511
  }
 }

--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -52,43 +52,43 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 6682.89814
-  tps: 5667.99073
+  dps: 6618.2733
+  tps: 5603.48191
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6703.98234
-  tps: 5678.35773
+  dps: 6705.73621
+  tps: 5683.8273
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6788.52933
-  tps: 5767.18979
+  dps: 6730.94814
+  tps: 5709.77314
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6703.29054
-  tps: 5683.24717
+  dps: 6724.19902
+  tps: 5707.30097
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6610.29757
-  tps: 5598.07991
+  dps: 6631.71781
+  tps: 5621.98533
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 6350.14134
-  tps: 5342.55521
+  dps: 6341.40392
+  tps: 5329.48552
  }
 }
 dps_results: {
@@ -108,15 +108,15 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6703.98234
-  tps: 5565.69945
+  dps: 6705.73621
+  tps: 5571.05237
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6847.90113
-  tps: 5825.4518
+  dps: 6859.59309
+  tps: 5837.68417
  }
 }
 dps_results: {
@@ -129,120 +129,120 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6729.00449
-  tps: 5719.33918
+  dps: 6665.96826
+  tps: 5658.49706
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6762.56939
-  tps: 5752.98978
+  dps: 6708.08111
+  tps: 5700.63677
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6738.44356
-  tps: 5717.75316
+  dps: 6730.05948
+  tps: 5713.07032
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6701.00989
-  tps: 5685.606
+  dps: 6700.2963
+  tps: 5682.44232
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6631.31776
-  tps: 5621.43344
+  dps: 6631.80249
+  tps: 5622.13719
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6722.13416
-  tps: 5699.68483
+  dps: 6730.01446
+  tps: 5708.10555
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6703.98234
-  tps: 5678.35773
+  dps: 6705.73621
+  tps: 5683.8273
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6667.67021
-  tps: 5645.7915
+  dps: 6721.39412
+  tps: 5698.11226
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6715.21969
-  tps: 5692.77036
+  dps: 6726.20765
+  tps: 5704.29873
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6711.53057
-  tps: 5689.08124
+  dps: 6723.63026
+  tps: 5701.72135
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6703.98234
-  tps: 5678.35773
+  dps: 6705.73621
+  tps: 5683.8273
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6781.78548
-  tps: 5772.3121
+  dps: 6720.41063
+  tps: 5713.01219
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6713.00426
-  tps: 5703.33896
+  dps: 6648.95597
+  tps: 5641.48476
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6699.74431
-  tps: 5690.079
+  dps: 6643.07092
+  tps: 5632.69386
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6703.98234
-  tps: 5678.35773
+  dps: 6705.73621
+  tps: 5683.8273
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6703.98234
-  tps: 5678.35773
+  dps: 6705.73621
+  tps: 5683.8273
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6631.31776
-  tps: 5621.43344
+  dps: 6631.80249
+  tps: 5622.13719
  }
 }
 dps_results: {
@@ -262,141 +262,141 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6631.80249
-  tps: 5622.13719
+  dps: 6568.89209
+  tps: 5559.34978
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6715.21969
-  tps: 5692.77036
+  dps: 6726.20765
+  tps: 5704.29873
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6711.53057
-  tps: 5689.08124
+  dps: 6723.63026
+  tps: 5701.72135
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6732.48832
-  tps: 5719.54565
+  dps: 6731.81765
+  tps: 5718.68765
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6893.74583
-  tps: 5880.20458
+  dps: 6918.51511
+  tps: 5908.89464
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6728.2615
-  tps: 5700.01152
+  dps: 6730.03493
+  tps: 5705.51047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6631.31776
-  tps: 5621.43344
+  dps: 6631.80249
+  tps: 5622.13719
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6603.79256
-  tps: 5592.94901
+  dps: 6584.99041
+  tps: 5576.40487
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6733.56383
-  tps: 5721.36275
+  dps: 6747.39256
+  tps: 5734.56627
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6632.52179
-  tps: 5622.63747
+  dps: 6631.80249
+  tps: 5622.13719
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6723.6369
-  tps: 5695.88699
+  dps: 6725.4066
+  tps: 5701.38034
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6728.2615
-  tps: 5700.01152
+  dps: 6730.03493
+  tps: 5705.51047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6703.98234
-  tps: 5678.35773
+  dps: 6705.73621
+  tps: 5683.8273
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6703.98234
-  tps: 5678.35773
+  dps: 6705.73621
+  tps: 5683.8273
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6631.80249
-  tps: 5622.13719
+  dps: 6568.89209
+  tps: 5559.34978
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6631.80249
-  tps: 5622.13719
+  dps: 6568.89209
+  tps: 5559.34978
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6631.80249
-  tps: 5622.13719
+  dps: 6568.89209
+  tps: 5559.34978
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6856.0545
-  tps: 5832.10801
+  dps: 6865.60527
+  tps: 5842.20026
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6683.35275
-  tps: 5655.19197
+  dps: 6681.65568
+  tps: 5654.26678
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6631.31776
-  tps: 5621.43344
+  dps: 6631.80249
+  tps: 5622.13719
  }
 }
 dps_results: {
@@ -409,29 +409,29 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6631.31776
-  tps: 5621.43344
+  dps: 6631.80249
+  tps: 5622.13719
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShinyShardoftheGods"
+ value: {
+  dps: 6568.89209
+  tps: 5559.34978
+ }
+}
+dps_results: {
+ key: "TestHunter-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
   dps: 6631.80249
   tps: 5622.13719
  }
 }
 dps_results: {
- key: "TestHunter-AllItems-Sindragosa'sFlawlessFang-50361"
- value: {
-  dps: 6632.84268
-  tps: 5622.95836
- }
-}
-dps_results: {
  key: "TestHunter-AllItems-SparkofLife-37657"
  value: {
-  dps: 6767.68369
-  tps: 5769.49583
+  dps: 6807.28424
+  tps: 5796.38653
  }
 }
 dps_results: {
@@ -444,78 +444,78 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6728.2615
-  tps: 5700.01152
+  dps: 6730.03493
+  tps: 5705.51047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6723.6369
-  tps: 5695.88699
+  dps: 6725.4066
+  tps: 5701.38034
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6715.54384
-  tps: 5688.66906
+  dps: 6717.30703
+  tps: 5694.15262
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheFistsofFury"
  value: {
-  dps: 6499.77387
-  tps: 5498.79779
+  dps: 6524.57862
+  tps: 5525.09807
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6732.06644
-  tps: 5712.9347
+  dps: 6761.99164
+  tps: 5742.13339
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6631.99239
-  tps: 5622.32708
+  dps: 6569.1228
+  tps: 5559.58049
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6631.99239
-  tps: 5622.32708
+  dps: 6569.1228
+  tps: 5559.58049
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6703.98234
-  tps: 5678.35773
+  dps: 6705.73621
+  tps: 5683.8273
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6703.98234
-  tps: 5678.35773
+  dps: 6705.73621
+  tps: 5683.8273
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6703.98234
-  tps: 5678.35773
+  dps: 6705.73621
+  tps: 5683.8273
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6703.98234
-  tps: 5678.35773
+  dps: 6705.73621
+  tps: 5683.8273
  }
 }
 dps_results: {
@@ -535,22 +535,22 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7451.02518
-  tps: 6431.24393
+  dps: 7407.96296
+  tps: 6386.20389
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 7690.33083
-  tps: 6672.51166
+  dps: 7688.93756
+  tps: 6665.57491
  }
 }
 dps_results: {
  key: "TestHunter-Average-Default"
  value: {
-  dps: 6812.33276
-  tps: 5795.40569
+  dps: 6812.57814
+  tps: 5795.60695
  }
 }
 dps_results: {
@@ -640,22 +640,22 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6565.97503
-  tps: 6463.91257
+  dps: 6580.3614
+  tps: 6480.37606
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6565.97503
-  tps: 5598.41995
+  dps: 6580.3614
+  tps: 5613.54654
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7711.32866
-  tps: 6616.42221
+  dps: 7641.64723
+  tps: 6552.82369
  }
 }
 dps_results: {
@@ -808,22 +808,22 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6568.38866
-  tps: 6398.95953
+  dps: 6603.99883
+  tps: 6451.53463
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6568.38866
-  tps: 5539.56861
+  dps: 6603.99883
+  tps: 5588.29088
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7793.69797
-  tps: 6633.61158
+  dps: 7716.49934
+  tps: 6562.72234
  }
 }
 dps_results: {
@@ -892,7 +892,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6829.18271
-  tps: 5871.5821
+  dps: 6760.76538
+  tps: 5809.28849
  }
 }

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -45,546 +45,546 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6786.96493
-  tps: 4063.25727
+  dps: 6816.52761
+  tps: 4081.03123
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6642.43133
-  tps: 3982.94252
+  dps: 6610.67992
+  tps: 3961.57587
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6827.24221
-  tps: 4086.10566
+  dps: 6834.97819
+  tps: 4090.95759
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5755.73419
-  tps: 3457.09923
+  dps: 5754.24671
+  tps: 3454.94838
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 7884.80409
-  tps: 4730.70515
+  dps: 7840.99527
+  tps: 4704.70092
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6826.09134
-  tps: 4005.87807
+  dps: 6855.81273
+  tps: 4023.39001
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6965.07453
-  tps: 4170.10412
+  dps: 6996.98793
+  tps: 4189.20348
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6718.40377
-  tps: 4028.22993
+  dps: 6688.32803
+  tps: 4007.71354
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6732.04363
-  tps: 4056.1617
+  dps: 6752.71211
+  tps: 4066.50234
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6745.83622
-  tps: 4039.71671
+  dps: 6703.22876
+  tps: 4015.84912
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6745.83622
-  tps: 4039.71671
+  dps: 6703.22876
+  tps: 4015.84912
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6755.10388
-  tps: 4043.47052
+  dps: 6758.31042
+  tps: 4045.3453
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6639.54251
-  tps: 3978.36325
+  dps: 6610.67992
+  tps: 3961.57587
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6805.06477
-  tps: 4074.01196
+  dps: 6834.77585
+  tps: 4091.78993
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6786.96493
-  tps: 4063.25727
+  dps: 6816.52761
+  tps: 4081.03123
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6850.07773
-  tps: 4099.07167
+  dps: 6866.46545
+  tps: 4109.34344
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6801.80053
-  tps: 4072.13972
+  dps: 6831.41117
+  tps: 4089.85742
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6797.34551
-  tps: 4069.46671
+  dps: 6827.26323
+  tps: 4087.36866
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6786.96493
-  tps: 4063.25727
+  dps: 6816.52761
+  tps: 4081.03123
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6712.1442
-  tps: 4024.29053
+  dps: 6681.02789
+  tps: 4002.97467
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6904.17075
-  tps: 4138.38526
+  dps: 6873.57461
+  tps: 4117.38875
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6863.01195
-  tps: 4114.38461
+  dps: 6828.24892
+  tps: 4091.56014
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6826.09134
-  tps: 4086.32708
+  dps: 6855.81273
+  tps: 4104.19628
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6818.26606
-  tps: 4081.71312
+  dps: 6847.95571
+  tps: 4099.56327
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FrostfireGarb"
  value: {
-  dps: 6066.6181
-  tps: 3638.33504
+  dps: 6081.96666
+  tps: 3647.11539
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6642.43133
-  tps: 3982.94252
+  dps: 6610.67992
+  tps: 3961.57587
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6755.72481
-  tps: 4049.35747
+  dps: 6737.29215
+  tps: 4040.39087
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6953.30731
-  tps: 4167.72746
+  dps: 6919.99496
+  tps: 4145.39492
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6801.80053
-  tps: 4072.13972
+  dps: 6831.41117
+  tps: 4089.85742
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6797.34551
-  tps: 4069.46671
+  dps: 6827.26323
+  tps: 4087.36866
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6642.29798
-  tps: 3983.38126
+  dps: 6635.46499
+  tps: 3979.42507
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6833.79434
-  tps: 4092.66151
+  dps: 6829.28194
+  tps: 4092.21656
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6786.96493
-  tps: 4063.25727
+  dps: 6816.52761
+  tps: 4081.03123
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 6855.83108
-  tps: 4101.64582
+  dps: 6843.19985
+  tps: 4094.27705
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KirinTorGarb"
  value: {
-  dps: 6299.65235
-  tps: 3768.84777
+  dps: 6278.28406
+  tps: 3755.98595
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6639.54251
-  tps: 3978.36325
+  dps: 6610.67992
+  tps: 3961.57587
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6701.34026
-  tps: 4011.33888
+  dps: 6677.97386
+  tps: 3997.45577
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6699.39023
-  tps: 4016.78507
+  dps: 6663.79168
+  tps: 3992.8858
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6639.54251
-  tps: 3978.36325
+  dps: 6610.67992
+  tps: 3961.57587
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6786.96493
-  tps: 4063.25727
+  dps: 6816.52761
+  tps: 4081.03123
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6786.96493
-  tps: 4063.25727
+  dps: 6816.52761
+  tps: 4081.03123
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6786.96493
-  tps: 4063.25727
+  dps: 6816.52761
+  tps: 4081.03123
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6786.96493
-  tps: 4063.25727
+  dps: 6816.52761
+  tps: 4081.03123
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6642.43133
-  tps: 3982.94252
+  dps: 6610.67992
+  tps: 3961.57587
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7083.96633
-  tps: 4324.1262
+  dps: 7067.4136
+  tps: 4313.18425
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7138.22905
-  tps: 4366.64698
+  dps: 7121.3293
+  tps: 4355.38156
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6948.90656
-  tps: 4160.42225
+  dps: 6980.78044
+  tps: 4179.58293
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6826.70926
-  tps: 4084.75794
+  dps: 6820.30876
+  tps: 4083.12079
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6639.54251
-  tps: 3978.36325
+  dps: 6610.67992
+  tps: 3961.57587
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6639.54251
-  tps: 3978.36325
+  dps: 6610.67992
+  tps: 3961.57587
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6642.43133
-  tps: 3982.94252
+  dps: 6610.67992
+  tps: 3961.57587
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6639.54251
-  tps: 3978.36325
+  dps: 6610.67992
+  tps: 3961.57587
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SparkofLife-37657"
  value: {
-  dps: 6786.40097
-  tps: 4063.50503
+  dps: 6738.21928
+  tps: 4036.18508
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sunstrider'sRegalia"
  value: {
-  dps: 6761.21556
-  tps: 4045.87883
+  dps: 6749.92231
+  tps: 4039.34944
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6786.96493
-  tps: 4063.25727
+  dps: 6816.52761
+  tps: 4081.03123
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6786.96493
-  tps: 4063.25727
+  dps: 6816.52761
+  tps: 4081.03123
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6786.96493
-  tps: 4063.25727
+  dps: 6816.52761
+  tps: 4081.03123
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6786.96493
-  tps: 4063.25727
+  dps: 6816.52761
+  tps: 4081.03123
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6709.95329
-  tps: 4017.41951
+  dps: 6741.3497
+  tps: 4035.88317
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6709.95329
-  tps: 4017.41951
+  dps: 6741.3497
+  tps: 4035.88317
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6826.09134
-  tps: 4086.32708
+  dps: 6855.81273
+  tps: 4104.19628
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6818.26606
-  tps: 4081.71312
+  dps: 6847.95571
+  tps: 4099.56327
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6818.26606
-  tps: 4081.71312
+  dps: 6847.95571
+  tps: 4099.56327
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6826.09134
-  tps: 4086.32708
+  dps: 6855.81273
+  tps: 4104.19628
  }
 }
 dps_results: {
  key: "TestArcane-Average-Default"
  value: {
-  dps: 6927.0945
-  tps: 4154.51387
+  dps: 6921.3414
+  tps: 4150.95739
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10667.26631
-  tps: 8568.70089
+  dps: 10624.01981
+  tps: 8540.07326
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1454.95346
-  tps: 908.031
+  dps: 1452.52017
+  tps: 908.0207
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2365.53377
-  tps: 1400.82303
+  dps: 2377.9619
+  tps: 1408.71243
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6157.01809
-  tps: 5313.56608
+  dps: 6141.4557
+  tps: 5304.46914
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 742.03744
-  tps: 474.02203
+  dps: 737.00593
+  tps: 471.54982
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1601.25792
-  tps: 965.48273
+  dps: 1585.0723
+  tps: 956.015
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6965.07453
-  tps: 5383.7553
+  dps: 6996.98793
+  tps: 5402.97236
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6965.07453
-  tps: 4170.10412
+  dps: 6996.98793
+  tps: 4189.20348
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9086.75693
-  tps: 5374.53182
+  dps: 9061.70174
+  tps: 5357.80788
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3860.19507
-  tps: 3520.40318
+  dps: 3841.59527
+  tps: 3509.08841
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3860.19507
-  tps: 2325.33167
+  dps: 3841.59527
+  tps: 2314.0169
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5214.05112
-  tps: 3030.28517
+  dps: 5130.38868
+  tps: 2980.61225
  }
 }
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6965.07453
-  tps: 4170.10412
+  dps: 6996.98793
+  tps: 4189.20348
  }
 }

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -45,477 +45,477 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6816.52761
-  tps: 4081.03123
+  dps: 6789.66836
+  tps: 4064.95283
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6610.67992
-  tps: 3961.57587
+  dps: 6624.94617
+  tps: 3972.08839
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6834.97819
-  tps: 4090.95759
+  dps: 6825.89653
+  tps: 4085.55181
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5754.24671
-  tps: 3454.94838
+  dps: 5741.69539
+  tps: 3448.93524
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 7840.99527
-  tps: 4704.70092
+  dps: 7857.53906
+  tps: 4713.8521
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6855.81273
-  tps: 4023.39001
+  dps: 6828.80346
+  tps: 4007.54501
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6996.98793
-  tps: 4189.20348
+  dps: 6967.46855
+  tps: 4171.59512
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6688.32803
-  tps: 4007.71354
+  dps: 6701.36502
+  tps: 4017.65834
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6752.71211
-  tps: 4066.50234
+  dps: 6718.88871
+  tps: 4049.20669
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6703.22876
-  tps: 4015.84912
+  dps: 6729.99858
+  tps: 4030.76783
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6703.22876
-  tps: 4015.84912
+  dps: 6729.99858
+  tps: 4030.76783
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6758.31042
-  tps: 4045.3453
+  dps: 6742.48939
+  tps: 4036.06339
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Defender'sCode-40257"
  value: {
   dps: 6610.67992
-  tps: 3961.57587
+  tps: 3961.56388
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6834.77585
-  tps: 4091.78993
+  dps: 6806.72777
+  tps: 4075.06435
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6816.52761
-  tps: 4081.03123
+  dps: 6789.66836
+  tps: 4064.95283
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6866.46545
-  tps: 4109.34344
+  dps: 6847.39156
+  tps: 4098.1263
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6831.41117
-  tps: 4089.85742
+  dps: 6803.7822
+  tps: 4073.38331
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6827.26323
-  tps: 4087.36866
+  dps: 6799.63426
+  tps: 4070.89454
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6816.52761
-  tps: 4081.03123
+  dps: 6789.66836
+  tps: 4064.95283
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6681.02789
-  tps: 4002.97467
+  dps: 6695.297
+  tps: 4013.79715
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6873.57461
-  tps: 4117.38875
+  dps: 6886.98827
+  tps: 4127.6812
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6828.24892
-  tps: 4091.56014
+  dps: 6845.84626
+  tps: 4103.6683
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6855.81273
-  tps: 4104.19628
+  dps: 6828.80346
+  tps: 4088.02804
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6847.95571
-  tps: 4099.56327
+  dps: 6820.97644
+  tps: 4083.413
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FrostfireGarb"
  value: {
-  dps: 6081.96666
-  tps: 3647.11539
+  dps: 6052.79472
+  tps: 3629.85786
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6610.67992
-  tps: 3961.57587
+  dps: 6624.94617
+  tps: 3972.08839
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6737.29215
-  tps: 4040.39087
+  dps: 6749.32118
+  tps: 4045.31849
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6919.99496
-  tps: 4145.39492
+  dps: 6935.13549
+  tps: 4156.44602
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6831.41117
-  tps: 4089.85742
+  dps: 6803.7822
+  tps: 4073.38331
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6827.26323
-  tps: 4087.36866
+  dps: 6799.63426
+  tps: 4070.89454
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IncisorFragment-37723"
  value: {
   dps: 6635.46499
-  tps: 3979.42507
+  tps: 3979.41239
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6829.28194
-  tps: 4092.21656
+  dps: 6821.17824
+  tps: 4085.79385
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6816.52761
-  tps: 4081.03123
+  dps: 6789.66836
+  tps: 4064.95283
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 6843.19985
-  tps: 4094.27705
+  dps: 6843.48039
+  tps: 4094.44538
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KirinTorGarb"
  value: {
-  dps: 6278.28406
-  tps: 3755.98595
+  dps: 6277.66871
+  tps: 3755.61198
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Lavanthor'sTalisman-37872"
  value: {
   dps: 6610.67992
-  tps: 3961.57587
+  tps: 3961.56388
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6677.97386
-  tps: 3997.45577
+  dps: 6690.55711
+  tps: 4005.40637
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6663.79168
-  tps: 3992.8858
+  dps: 6682.7336
+  tps: 4006.39869
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-OfferingofSacrifice-37638"
  value: {
   dps: 6610.67992
-  tps: 3961.57587
+  tps: 3961.56388
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6816.52761
-  tps: 4081.03123
+  dps: 6789.66836
+  tps: 4064.95283
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6816.52761
-  tps: 4081.03123
+  dps: 6789.66836
+  tps: 4064.95283
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6816.52761
-  tps: 4081.03123
+  dps: 6789.66836
+  tps: 4064.95283
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6816.52761
-  tps: 4081.03123
+  dps: 6789.66836
+  tps: 4064.95283
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6610.67992
-  tps: 3961.57587
+  dps: 6624.94617
+  tps: 3972.08839
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7067.4136
-  tps: 4313.18425
+  dps: 7046.66941
+  tps: 4300.47221
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7121.3293
-  tps: 4355.38156
+  dps: 7100.49985
+  tps: 4342.61483
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6980.78044
-  tps: 4179.58293
+  dps: 6952.09013
+  tps: 4162.4059
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6820.30876
-  tps: 4083.12079
+  dps: 6811.37851
+  tps: 4075.97624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RuneofRepulsion-40372"
  value: {
   dps: 6610.67992
-  tps: 3961.57587
+  tps: 3961.56388
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SealofthePantheon-36993"
  value: {
   dps: 6610.67992
-  tps: 3961.57587
+  tps: 3961.56388
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6610.67992
-  tps: 3961.57587
+  dps: 6624.94617
+  tps: 3972.08839
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
   dps: 6610.67992
-  tps: 3961.57587
+  tps: 3961.56388
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SparkofLife-37657"
  value: {
-  dps: 6738.21928
-  tps: 4036.18508
+  dps: 6749.14968
+  tps: 4040.95612
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sunstrider'sRegalia"
  value: {
-  dps: 6749.92231
-  tps: 4039.34944
+  dps: 6750.20285
+  tps: 4039.51776
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6816.52761
-  tps: 4081.03123
+  dps: 6789.66836
+  tps: 4064.95283
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6816.52761
-  tps: 4081.03123
+  dps: 6789.66836
+  tps: 4064.95283
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6816.52761
-  tps: 4081.03123
+  dps: 6789.66836
+  tps: 4064.95283
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6816.52761
-  tps: 4081.03123
+  dps: 6789.66836
+  tps: 4064.95283
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6741.3497
-  tps: 4035.88317
+  dps: 6712.38035
+  tps: 4018.88934
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6741.3497
-  tps: 4035.88317
+  dps: 6712.38035
+  tps: 4018.88934
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6855.81273
-  tps: 4104.19628
+  dps: 6828.80346
+  tps: 4088.02804
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6847.95571
-  tps: 4099.56327
+  dps: 6820.97644
+  tps: 4083.413
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6847.95571
-  tps: 4099.56327
+  dps: 6820.97644
+  tps: 4083.413
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6855.81273
-  tps: 4104.19628
+  dps: 6828.80346
+  tps: 4088.02804
  }
 }
 dps_results: {
  key: "TestArcane-Average-Default"
  value: {
-  dps: 6921.3414
-  tps: 4150.95739
+  dps: 6908.89815
+  tps: 4143.73779
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10624.01981
-  tps: 8540.07326
+  dps: 10647.48474
+  tps: 8556.70512
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1452.52017
-  tps: 908.0207
+  dps: 1451.13921
+  tps: 905.8895
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2377.9619
-  tps: 1408.71243
+  dps: 2351.6054
+  tps: 1391.38955
  }
 }
 dps_results: {
@@ -542,22 +542,22 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6996.98793
-  tps: 5402.97236
+  dps: 6967.46855
+  tps: 5385.2463
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6996.98793
-  tps: 4189.20348
+  dps: 6967.46855
+  tps: 4171.59512
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9061.70174
-  tps: 5357.80788
+  dps: 9031.92391
+  tps: 5339.99191
  }
 }
 dps_results: {
@@ -584,7 +584,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6996.98793
-  tps: 4189.20348
+  dps: 6967.46855
+  tps: 4171.59512
  }
 }

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -45,546 +45,546 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5937.22194
-  tps: 4299.60523
+  dps: 5932.30566
+  tps: 4295.88379
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5683.76707
-  tps: 4112.20068
+  dps: 5660.94037
+  tps: 4096.45319
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6029.32877
-  tps: 4362.62718
+  dps: 5990.05491
+  tps: 4337.49905
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4757.12631
-  tps: 3477.25591
+  dps: 4736.88641
+  tps: 3465.35766
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 7047.54932
-  tps: 5045.94068
+  dps: 7019.06304
+  tps: 5025.59123
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5976.22305
-  tps: 4242.27979
+  dps: 5971.26741
+  tps: 4238.605
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6157.26503
-  tps: 4434.78358
+  dps: 6143.51796
+  tps: 4425.00807
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5842.24543
-  tps: 4200.05318
+  dps: 5794.41679
+  tps: 4167.97379
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5862.7431
-  tps: 4237.99775
+  dps: 5850.04673
+  tps: 4226.72767
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 5769.29246
-  tps: 4156.67507
+  dps: 5776.35237
+  tps: 4163.06267
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 5769.29246
-  tps: 4156.67507
+  dps: 5776.35237
+  tps: 4163.06267
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 5836.50046
-  tps: 4202.81487
+  dps: 5799.38579
+  tps: 4175.6232
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5683.76707
-  tps: 4112.20068
+  dps: 5660.94037
+  tps: 4096.45319
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5995.53529
-  tps: 4330.19645
+  dps: 5981.84013
+  tps: 4320.47279
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5937.22194
-  tps: 4299.60523
+  dps: 5932.30566
+  tps: 4295.88379
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5993.45785
-  tps: 4343.57087
+  dps: 5947.17944
+  tps: 4315.95461
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5993.91469
-  tps: 4329.43476
+  dps: 5980.38159
+  tps: 4319.78722
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5995.31932
-  tps: 4331.39006
+  dps: 5978.56764
+  tps: 4318.7193
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5937.22194
-  tps: 4299.60523
+  dps: 5932.30566
+  tps: 4295.88379
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5900.87451
-  tps: 4259.56193
+  dps: 5886.2937
+  tps: 4248.41646
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6058.85616
-  tps: 4356.0752
+  dps: 6045.30489
+  tps: 4346.21038
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5977.3365
-  tps: 4295.25541
+  dps: 5963.50057
+  tps: 4285.28228
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5976.22305
-  tps: 4327.30092
+  dps: 5971.26741
+  tps: 4323.55114
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5968.42283
-  tps: 4321.76178
+  dps: 5963.47506
+  tps: 4318.01767
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FrostfireGarb"
  value: {
-  dps: 5269.99501
-  tps: 3834.60861
+  dps: 5245.92781
+  tps: 3820.86183
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5683.76707
-  tps: 4112.20068
+  dps: 5660.94037
+  tps: 4096.45319
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5895.59105
-  tps: 4253.09329
+  dps: 5899.97619
+  tps: 4253.92913
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5985.6037
-  tps: 4327.83615
+  dps: 5961.81891
+  tps: 4311.44978
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5993.91469
-  tps: 4329.43476
+  dps: 5980.38159
+  tps: 4319.78722
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5995.31932
-  tps: 4331.39006
+  dps: 5978.56764
+  tps: 4318.7193
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5743.16843
-  tps: 4142.06526
+  dps: 5720.1651
+  tps: 4125.81764
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5963.80901
-  tps: 4309.66901
+  dps: 5947.23935
+  tps: 4297.59945
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5937.22194
-  tps: 4299.60523
+  dps: 5932.30566
+  tps: 4295.88379
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 6270.50022
-  tps: 4476.20253
+  dps: 6246.19798
+  tps: 4459.29283
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KirinTorGarb"
  value: {
-  dps: 5683.80406
-  tps: 4131.32997
+  dps: 5679.11749
+  tps: 4128.52928
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5683.76707
-  tps: 4112.20068
+  dps: 5660.94037
+  tps: 4096.45319
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5859.87682
-  tps: 4209.99545
+  dps: 5867.41709
+  tps: 4214.24551
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5849.82331
-  tps: 4204.74671
+  dps: 5837.21127
+  tps: 4195.63077
  }
 }
 dps_results: {
  key: "TestFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5683.76707
-  tps: 4112.20068
+  dps: 5660.94037
+  tps: 4096.45319
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5937.22194
-  tps: 4299.60523
+  dps: 5932.30566
+  tps: 4295.88379
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5937.22194
-  tps: 4299.60523
+  dps: 5932.30566
+  tps: 4295.88379
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5937.22194
-  tps: 4299.60523
+  dps: 5932.30566
+  tps: 4295.88379
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5937.22194
-  tps: 4299.60523
+  dps: 5932.30566
+  tps: 4295.88379
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5683.76707
-  tps: 4112.20068
+  dps: 5660.94037
+  tps: 4096.45319
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6258.88543
-  tps: 4527.91099
+  dps: 6230.8709
+  tps: 4510.5466
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6317.42877
-  tps: 4572.85442
+  dps: 6289.03976
+  tps: 4555.15317
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6097.28751
-  tps: 4402.67625
+  dps: 6092.15044
+  tps: 4398.82299
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5966.38345
-  tps: 4319.87416
+  dps: 5932.39204
+  tps: 4296.17952
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5683.76707
-  tps: 4112.20068
+  dps: 5660.94037
+  tps: 4096.45319
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5683.76707
-  tps: 4112.20068
+  dps: 5660.94037
+  tps: 4096.45319
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5683.76707
-  tps: 4112.20068
+  dps: 5660.94037
+  tps: 4096.45319
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5683.76707
-  tps: 4112.20068
+  dps: 5660.94037
+  tps: 4096.45319
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 5779.01286
-  tps: 4182.00123
+  dps: 5745.62792
+  tps: 4157.39014
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sunstrider'sRegalia"
  value: {
-  dps: 6134.9526
-  tps: 4394.5653
+  dps: 6104.06253
+  tps: 4374.26979
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5937.22194
-  tps: 4299.60523
+  dps: 5932.30566
+  tps: 4295.88379
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5937.22194
-  tps: 4299.60523
+  dps: 5932.30566
+  tps: 4295.88379
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5937.22194
-  tps: 4299.60523
+  dps: 5932.30566
+  tps: 4295.88379
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5937.22194
-  tps: 4299.60523
+  dps: 5932.30566
+  tps: 4295.88379
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5933.46654
-  tps: 4277.48175
+  dps: 5913.74393
+  tps: 4267.65515
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5933.46654
-  tps: 4277.48175
+  dps: 5913.74393
+  tps: 4267.65515
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5976.22305
-  tps: 4327.30092
+  dps: 5971.26741
+  tps: 4323.55114
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5968.42283
-  tps: 4321.76178
+  dps: 5963.47506
+  tps: 4318.01767
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5968.42283
-  tps: 4321.76178
+  dps: 5963.47506
+  tps: 4318.01767
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5976.22305
-  tps: 4327.30092
+  dps: 5971.26741
+  tps: 4323.55114
  }
 }
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
-  dps: 6092.08851
-  tps: 4401.98714
+  dps: 6077.44553
+  tps: 4391.68546
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18380.11409
-  tps: 18879.68223
+  dps: 18336.65941
+  tps: 18842.53357
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1832.90424
-  tps: 1418.15841
+  dps: 1829.3437
+  tps: 1414.25905
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2554.51326
-  tps: 1835.69326
+  dps: 2531.02
+  tps: 1822.86858
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14295.57439
-  tps: 15423.8241
+  dps: 14255.34232
+  tps: 15389.0618
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 873.71624
-  tps: 697.48925
+  dps: 871.33718
+  tps: 695.30325
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1422.89804
-  tps: 1037.00123
+  dps: 1417.1978
+  tps: 1033.28354
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8526.01969
-  tps: 7957.10813
+  dps: 8532.29381
+  tps: 7956.79543
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6157.26503
-  tps: 4434.78358
+  dps: 6143.51796
+  tps: 4425.00807
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7491.96829
-  tps: 5321.29444
+  dps: 7459.0041
+  tps: 5295.22013
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4809.28328
-  tps: 5139.65941
+  dps: 4780.56498
+  tps: 5120.04704
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2520.29817
-  tps: 1895.71148
+  dps: 2524.74543
+  tps: 1898.5033
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3647.53011
-  tps: 2646.89459
+  dps: 3630.60116
+  tps: 2632.66353
  }
 }
 dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6157.26503
-  tps: 4434.78358
+  dps: 6143.51796
+  tps: 4425.00807
  }
 }

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -521,22 +521,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4362.35716
-  tps: 4460.89416
+  dps: 4364.28669
+  tps: 4462.99531
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 580.96278
-  tps: 413.03697
+  dps: 582.14225
+  tps: 413.08244
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1255.21684
-  tps: 890.08769
+  dps: 1256.56324
+  tps: 891.11099
  }
 }
 dps_results: {
@@ -563,22 +563,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2703.87251
-  tps: 2991.43837
+  dps: 2713.68969
+  tps: 2996.19321
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2703.87251
-  tps: 2266.80897
+  dps: 2713.68969
+  tps: 2274.99278
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3232.6774
-  tps: 2552.35172
+  dps: 3159.23237
+  tps: 2465.58245
  }
 }
 dps_results: {

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -45,546 +45,546 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 4438.39732
-  tps: 3727.75797
+  dps: 4306.28889
+  tps: 3617.99592
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 4298.57756
-  tps: 3617.72793
+  dps: 4211.73219
+  tps: 3542.04692
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 4454.03009
-  tps: 3741.303
+  dps: 4320.28331
+  tps: 3629.50634
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 3777.22052
-  tps: 3164.43187
+  dps: 3687.53917
+  tps: 3088.98416
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 5044.52592
-  tps: 4261.2068
+  dps: 4897.27802
+  tps: 4136.41249
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 4468.33748
-  tps: 3678.52101
+  dps: 4335.28236
+  tps: 3570.16125
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 4565.57666
-  tps: 3841.5249
+  dps: 4429.42257
+  tps: 3728.0177
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 4367.3465
-  tps: 3678.87575
+  dps: 4280.99876
+  tps: 3603.95019
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 4408.08314
-  tps: 3713.03301
+  dps: 4256.40156
+  tps: 3583.82627
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 4346.01081
-  tps: 3663.28426
+  dps: 4237.46959
+  tps: 3573.81445
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 4346.01081
-  tps: 3663.28426
+  dps: 4237.46959
+  tps: 3573.81445
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 4344.6381
-  tps: 3661.34181
+  dps: 4236.01953
+  tps: 3571.81588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 4298.57756
-  tps: 3617.72793
+  dps: 4211.73219
+  tps: 3542.04692
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 4456.14429
-  tps: 3743.15968
+  dps: 4322.99204
+  tps: 3632.47654
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 4438.39732
-  tps: 3727.75797
+  dps: 4306.28889
+  tps: 3617.99592
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 4475.31065
-  tps: 3758.94224
+  dps: 4339.97753
+  tps: 3646.05865
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 4455.27458
-  tps: 3742.48189
+  dps: 4320.8113
+  tps: 3630.51387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 4450.16271
-  tps: 3737.95955
+  dps: 4317.57357
+  tps: 3627.6823
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 4438.39732
-  tps: 3727.75797
+  dps: 4306.28889
+  tps: 3617.99592
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 4356.19037
-  tps: 3661.46048
+  dps: 4234.21296
+  tps: 3558.19686
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 4506.27555
-  tps: 3797.76588
+  dps: 4419.62531
+  tps: 3722.31512
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 4451.71852
-  tps: 3750.76724
+  dps: 4367.40148
+  tps: 3677.75873
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 4468.33748
-  tps: 3753.07569
+  dps: 4335.28236
+  tps: 3642.51821
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 4462.34945
-  tps: 3748.01214
+  dps: 4329.48367
+  tps: 3637.61376
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FrostfireGarb"
  value: {
-  dps: 3940.79493
-  tps: 3304.3831
+  dps: 3870.443
+  tps: 3240.87535
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 4298.57756
-  tps: 3617.72793
+  dps: 4211.73219
+  tps: 3542.04692
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 4369.06448
-  tps: 3675.35066
+  dps: 4283.48567
+  tps: 3602.22841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 4532.9323
-  tps: 3820.06422
+  dps: 4441.74852
+  tps: 3740.54935
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 4455.27458
-  tps: 3742.48189
+  dps: 4320.8113
+  tps: 3630.51387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 4450.16271
-  tps: 3737.95955
+  dps: 4317.57357
+  tps: 3627.6823
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 4334.04174
-  tps: 3649.94675
+  dps: 4153.28936
+  tps: 3484.01167
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 4429.48837
-  tps: 3720.5914
+  dps: 4295.88985
+  tps: 3611.22524
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 4438.39732
-  tps: 3727.75797
+  dps: 4306.28889
+  tps: 3617.99592
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 4578.07453
-  tps: 3849.54768
+  dps: 4458.70123
+  tps: 3744.41385
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KirinTorGarb"
  value: {
-  dps: 4265.89891
-  tps: 3578.4594
+  dps: 4124.99495
+  tps: 3452.56908
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 4298.57756
-  tps: 3617.72793
+  dps: 4211.73219
+  tps: 3542.04692
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 4284.54533
-  tps: 3599.73143
+  dps: 4204.67506
+  tps: 3531.88494
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 4349.41469
-  tps: 3662.54088
+  dps: 4266.4382
+  tps: 3590.27437
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 4298.57756
-  tps: 3617.72793
+  dps: 4211.73219
+  tps: 3542.04692
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 4438.39732
-  tps: 3727.75797
+  dps: 4306.28889
+  tps: 3617.99592
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 4438.39732
-  tps: 3727.75797
+  dps: 4306.28889
+  tps: 3617.99592
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 4438.39732
-  tps: 3727.75797
+  dps: 4306.28889
+  tps: 3617.99592
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 4438.39732
-  tps: 3727.75797
+  dps: 4306.28889
+  tps: 3617.99592
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 4298.57756
-  tps: 3617.72793
+  dps: 4211.73219
+  tps: 3542.04692
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 4610.74896
-  tps: 3898.13536
+  dps: 4427.6327
+  tps: 3732.55596
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 4649.46648
-  tps: 3933.54046
+  dps: 4465.92304
+  tps: 3767.62159
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 4547.22409
-  tps: 3825.47582
+  dps: 4413.64063
+  tps: 3714.37313
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 4436.89715
-  tps: 3725.99557
+  dps: 4304.42634
+  tps: 3615.32798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 4298.57756
-  tps: 3617.72793
+  dps: 4211.73219
+  tps: 3542.04692
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 4298.57756
-  tps: 3617.72793
+  dps: 4211.73219
+  tps: 3542.04692
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 4298.57756
-  tps: 3617.72793
+  dps: 4211.73219
+  tps: 3542.04692
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 4298.57756
-  tps: 3617.72793
+  dps: 4211.73219
+  tps: 3542.04692
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 4370.41737
-  tps: 3680.83676
+  dps: 4216.91048
+  tps: 3541.75678
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sunstrider'sRegalia"
  value: {
-  dps: 4578.07453
-  tps: 3854.03896
+  dps: 4458.70123
+  tps: 3747.22959
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 4438.39732
-  tps: 3727.75797
+  dps: 4306.28889
+  tps: 3617.99592
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 4438.39732
-  tps: 3727.75797
+  dps: 4306.28889
+  tps: 3617.99592
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 4438.39732
-  tps: 3727.75797
+  dps: 4306.28889
+  tps: 3617.99592
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 4475.81154
-  tps: 3761.31142
+  dps: 4283.17093
+  tps: 3594.0628
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 4426.83659
-  tps: 3719.52928
+  dps: 4284.79639
+  tps: 3598.29705
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 4426.83659
-  tps: 3719.52928
+  dps: 4284.79639
+  tps: 3598.29705
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 4468.33748
-  tps: 3753.07569
+  dps: 4335.28236
+  tps: 3642.51821
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 4462.34945
-  tps: 3748.01214
+  dps: 4329.48367
+  tps: 3637.61376
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 4462.34945
-  tps: 3748.01214
+  dps: 4329.48367
+  tps: 3637.61376
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 4468.33748
-  tps: 3753.07569
+  dps: 4335.28236
+  tps: 3642.51821
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 4555.76093
-  tps: 3836.12938
+  dps: 4378.73482
+  tps: 3677.57982
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8360.6327
-  tps: 8690.11985
+  dps: 8333.69792
+  tps: 8667.48496
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1203.48128
-  tps: 888.07266
+  dps: 1201.1539
+  tps: 884.70523
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2215.9184
-  tps: 1546.24693
+  dps: 2206.49895
+  tps: 1541.3338
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4376.38412
-  tps: 4471.90604
+  dps: 4362.35716
+  tps: 4460.89416
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 583.43294
-  tps: 413.11097
+  dps: 580.96278
+  tps: 413.03697
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1267.46527
-  tps: 896.86074
+  dps: 1255.21684
+  tps: 890.08769
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4565.57666
-  tps: 4323.02086
+  dps: 4429.42257
+  tps: 4196.74691
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4565.57666
-  tps: 3841.5249
+  dps: 4429.42257
+  tps: 3728.0177
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5782.90116
-  tps: 4691.97644
+  dps: 5617.27594
+  tps: 4553.40081
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2791.38398
-  tps: 3070.83319
+  dps: 2703.87251
+  tps: 2991.43837
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2791.38398
-  tps: 2340.28183
+  dps: 2703.87251
+  tps: 2266.80897
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3342.71054
-  tps: 2630.64907
+  dps: 3232.6774
+  tps: 2552.35172
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 4565.57666
-  tps: 3841.5249
+  dps: 4429.42257
+  tps: 3728.0177
  }
 }

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -45,891 +45,891 @@ character_stats_results: {
 dps_results: {
  key: "TestProtection-AllItems-AegisBattlegear"
  value: {
-  dps: 1641.38166
-  tps: 3741.40087
+  dps: 1632.11086
+  tps: 3717.53784
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AegisPlate"
  value: {
-  dps: 1558.04385
-  tps: 3619.32185
+  dps: 1554.53129
+  tps: 3610.28051
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AshtongueTalismanofZeal-32489"
  value: {
-  dps: 1634.01815
-  tps: 3762.71175
+  dps: 1628.06943
+  tps: 3747.39974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1619.14608
-  tps: 3731.78376
+  dps: 1609.90683
+  tps: 3708.00193
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1708.15195
-  tps: 3903.58375
+  dps: 1705.24115
+  tps: 3896.09932
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1635.40673
-  tps: 3778.58619
+  dps: 1627.07819
+  tps: 3757.14852
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1599.15032
-  tps: 3688.26358
+  dps: 1595.62815
+  tps: 3679.19752
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1400.66309
-  tps: 3219.70818
+  dps: 1392.63441
+  tps: 3199.04235
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1422.10745
-  tps: 3269.51934
+  dps: 1415.0835
+  tps: 3251.4397
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1374.47333
-  tps: 3183.20145
+  dps: 1370.82512
+  tps: 3173.81095
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1620.28189
-  tps: 3660.56364
+  dps: 1611.03859
+  tps: 3637.24723
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1636.42208
-  tps: 3768.9336
+  dps: 1627.23709
+  tps: 3745.29143
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1658.78645
-  tps: 3822.82212
+  dps: 1649.49191
+  tps: 3798.89797
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1701.38249
-  tps: 3877.1839
+  dps: 1693.10887
+  tps: 3857.67046
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 1748.44414
-  tps: 4031.22949
+  dps: 1738.26677
+  tps: 4005.03296
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 1720.35107
-  tps: 3964.14287
+  dps: 1710.19833
+  tps: 3938.00972
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 1696.92979
-  tps: 3921.47807
+  dps: 1692.10536
+  tps: 3909.05999
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DeadlyGladiator'sLibramofFortitude-42852"
  value: {
-  dps: 1617.1226
-  tps: 3726.57533
+  dps: 1607.60705
+  tps: 3702.08231
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1631.47977
-  tps: 3763.53069
+  dps: 1622.11837
+  tps: 3739.43445
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1624.95487
-  tps: 3744.13376
+  dps: 1615.90349
+  tps: 3720.83549
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1619.14608
-  tps: 3731.78376
+  dps: 1609.90683
+  tps: 3708.00193
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1614.11816
-  tps: 3725.69502
+  dps: 1608.39759
+  tps: 3710.97027
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1624.18928
-  tps: 3742.32716
+  dps: 1615.06527
+  tps: 3718.84195
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1623.71711
-  tps: 3741.40035
+  dps: 1614.61509
+  tps: 3717.97176
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1631.47977
-  tps: 3763.53069
+  dps: 1622.11837
+  tps: 3739.43445
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1688.09838
-  tps: 3860.03763
+  dps: 1681.00531
+  tps: 3842.23974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1662.19625
-  tps: 3832.56002
+  dps: 1652.53947
+  tps: 3807.70347
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1651.87348
-  tps: 3808.01275
+  dps: 1642.2171
+  tps: 3783.15725
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1620.28189
-  tps: 3734.70735
+  dps: 1611.03859
+  tps: 3710.91509
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1620.05473
-  tps: 3734.12263
+  dps: 1610.81224
+  tps: 3710.33245
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FuriousGladiator'sLibramofFortitude-42853"
  value: {
-  dps: 1617.1226
-  tps: 3726.57533
+  dps: 1607.60705
+  tps: 3702.08231
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1703.32769
-  tps: 3924.33378
+  dps: 1693.64399
+  tps: 3899.40795
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1622.75007
-  tps: 3743.30338
+  dps: 1621.21866
+  tps: 3739.36153
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gladiator'sVindication"
  value: {
-  dps: 1803.03944
-  tps: 4119.28106
+  dps: 1799.6727
+  tps: 4110.61507
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HatefulGladiator'sLibramofFortitude-42851"
  value: {
-  dps: 1617.1226
-  tps: 3726.57533
+  dps: 1607.60705
+  tps: 3702.08231
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1640.44802
-  tps: 3786.61495
+  dps: 1631.05496
+  tps: 3762.43722
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1624.18928
-  tps: 3742.32716
+  dps: 1615.06527
+  tps: 3718.84195
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1623.71711
-  tps: 3741.40035
+  dps: 1614.61509
+  tps: 3717.97176
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1672.77863
-  tps: 3850.7571
+  dps: 1663.26047
+  tps: 3826.25735
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1692.57889
-  tps: 3939.41752
+  dps: 1692.29388
+  tps: 3938.6839
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1629.03701
-  tps: 3753.92171
+  dps: 1619.75327
+  tps: 3730.02537
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1656.22833
-  tps: 3827.23347
+  dps: 1646.44799
+  tps: 3802.05888
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Liadrin'sBattlegear"
  value: {
-  dps: 1777.27829
-  tps: 4036.70823
+  dps: 1773.98624
+  tps: 4028.23449
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Liadrin'sPlate"
  value: {
-  dps: 1594.31221
-  tps: 3673.99557
+  dps: 1588.00555
+  tps: 3657.76221
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofFuriousBlows-37574"
  value: {
-  dps: 1620.42505
-  tps: 3734.31383
+  dps: 1610.79572
+  tps: 3709.52796
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofReciprocation-40706"
  value: {
-  dps: 1617.1226
-  tps: 3726.57533
+  dps: 1607.60705
+  tps: 3702.08231
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofThreeTruths-50455"
  value: {
-  dps: 1617.1226
-  tps: 3726.57533
+  dps: 1607.60705
+  tps: 3702.08231
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofValiance-47661"
  value: {
-  dps: 1733.61212
-  tps: 3992.72916
+  dps: 1723.4174
+  tps: 3966.48794
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramoftheSacredShield-45145"
  value: {
-  dps: 1617.1226
-  tps: 3726.57533
+  dps: 1607.60705
+  tps: 3702.08231
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerBattlegear"
  value: {
-  dps: 1446.32305
-  tps: 3328.48828
+  dps: 1443.57339
+  tps: 3321.41065
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightswornBattlegear"
  value: {
-  dps: 2003.26145
-  tps: 4563.6976
+  dps: 1998.73332
+  tps: 4552.04219
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightswornPlate"
  value: {
-  dps: 1658.59083
-  tps: 3813.22519
+  dps: 1654.04163
+  tps: 3801.51555
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1652.94306
-  tps: 3826.66077
+  dps: 1645.65571
+  tps: 3807.90312
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1670.78071
-  tps: 3851.12705
+  dps: 1661.46819
+  tps: 3827.15661
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1631.47977
-  tps: 3763.53069
+  dps: 1622.11837
+  tps: 3739.43445
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1627.15302
-  tps: 3749.70496
+  dps: 1617.87776
+  tps: 3725.83043
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1629.03701
-  tps: 3753.92171
+  dps: 1619.75327
+  tps: 3730.02537
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1619.14608
-  tps: 3731.78376
+  dps: 1609.90683
+  tps: 3708.00193
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1619.14608
-  tps: 3731.78376
+  dps: 1609.90683
+  tps: 3708.00193
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1631.47977
-  tps: 3763.53069
+  dps: 1622.11837
+  tps: 3739.43445
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RedemptionBattlegear"
  value: {
-  dps: 1532.04379
-  tps: 3494.89951
+  dps: 1526.19085
+  tps: 3479.83405
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RedemptionPlate"
  value: {
-  dps: 1494.07505
-  tps: 3454.52261
+  dps: 1486.8533
+  tps: 3435.93384
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1633.41612
-  tps: 3768.09467
+  dps: 1628.67684
+  tps: 3755.89578
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1634.28012
-  tps: 3770.26615
+  dps: 1629.53716
+  tps: 3758.05777
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1636.29349
-  tps: 3768.74971
+  dps: 1627.10849
+  tps: 3745.10753
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RelentlessGladiator'sLibramofFortitude-42854"
  value: {
-  dps: 1617.1226
-  tps: 3726.57533
+  dps: 1607.60705
+  tps: 3702.08231
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1630.36035
-  tps: 3764.00351
+  dps: 1627.22389
+  tps: 3755.93027
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1631.47977
-  tps: 3763.53069
+  dps: 1622.11837
+  tps: 3739.43445
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SavageGladiator'sLibramofFortitude-42611"
  value: {
-  dps: 1617.1226
-  tps: 3726.57533
+  dps: 1607.60705
+  tps: 3702.08231
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1631.47977
-  tps: 3763.53069
+  dps: 1622.11837
+  tps: 3739.43445
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1631.47977
-  tps: 3763.53069
+  dps: 1622.11837
+  tps: 3739.43445
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1631.47977
-  tps: 3763.53069
+  dps: 1622.11837
+  tps: 3739.43445
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SparkofLife-37657"
  value: {
-  dps: 1677.44714
-  tps: 3876.71484
+  dps: 1670.44799
+  tps: 3858.69903
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StormshroudArmor"
  value: {
-  dps: 1307.78078
-  tps: 3018.22201
+  dps: 1304.91877
+  tps: 3010.8695
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1629.03701
-  tps: 3753.92171
+  dps: 1619.75327
+  tps: 3730.02537
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1627.15302
-  tps: 3749.70496
+  dps: 1617.87776
+  tps: 3725.83043
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1623.85605
-  tps: 3742.32565
+  dps: 1614.59561
+  tps: 3718.48928
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1622.19573
-  tps: 3740.5541
+  dps: 1613.54471
+  tps: 3718.28637
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1699.9603
-  tps: 3916.08342
+  dps: 1695.53088
+  tps: 3904.6821
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1725.93398
-  tps: 3981.82353
+  dps: 1716.06676
+  tps: 3956.4253
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1620.28189
-  tps: 3734.70735
+  dps: 1611.03859
+  tps: 3710.91509
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1620.05473
-  tps: 3734.12263
+  dps: 1610.81224
+  tps: 3710.33245
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TomeoftheLightbringer-32368"
  value: {
-  dps: 1624.70906
-  tps: 3746.10288
+  dps: 1615.27497
+  tps: 3721.81952
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1620.05473
-  tps: 3734.12263
+  dps: 1610.81224
+  tps: 3710.33245
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1620.28189
-  tps: 3734.70735
+  dps: 1611.03859
+  tps: 3710.91509
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Turalyon'sBattlegear"
  value: {
-  dps: 1777.27829
-  tps: 4036.70823
+  dps: 1773.98624
+  tps: 4028.23449
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Turalyon'sPlate"
  value: {
-  dps: 1594.31221
-  tps: 3673.99557
+  dps: 1588.00555
+  tps: 3657.76221
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1390.48843
-  tps: 3191.22451
+  dps: 1382.9892
+  tps: 3171.92148
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathfulGladiator'sLibramofFortitude-51478"
  value: {
-  dps: 1617.1226
-  tps: 3726.57533
+  dps: 1607.60705
+  tps: 3702.08231
  }
 }
 dps_results: {
  key: "TestProtection-Average-Default"
  value: {
-  dps: 2037.31201
-  tps: 4786.46983
+  dps: 2023.48125
+  tps: 4752.75756
   dtps: 65.12994
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3653.08193
-  tps: 9451.27251
+  dps: 3642.48099
+  tps: 9423.9857
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1565.30521
-  tps: 3555.84455
+  dps: 1562.93641
+  tps: 3549.74724
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOC-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2198.24882
-  tps: 5145.98741
+  dps: 2183.34817
+  tps: 5107.63314
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 926.20906
-  tps: 2245.12719
+  dps: 924.8099
+  tps: 2241.52574
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 386.61308
-  tps: 795.88831
+  dps: 386.3351
+  tps: 795.1728
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOC-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 678.86985
-  tps: 1552.43958
+  dps: 676.42463
+  tps: 1546.14561
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2926.52858
-  tps: 7582.82862
+  dps: 2919.75577
+  tps: 7565.3954
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1431.02964
-  tps: 3209.38237
+  dps: 1426.53669
+  tps: 3197.81753
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOR-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2097.77793
-  tps: 4883.40645
+  dps: 2082.38572
+  tps: 4843.78688
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 640.78098
-  tps: 1509.65529
+  dps: 638.07554
+  tps: 1502.69148
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 327.85762
-  tps: 645.61117
+  dps: 327.51975
+  tps: 644.74148
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOR-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 614.69614
-  tps: 1384.67984
+  dps: 610.93269
+  tps: 1374.99272
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3527.0228
-  tps: 9127.97367
+  dps: 3516.3527
+  tps: 9100.50882
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1747.84179
-  tps: 4023.12586
+  dps: 1744.87776
+  tps: 4015.49644
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2397.47559
-  tps: 5660.79863
+  dps: 2387.22097
+  tps: 5634.40324
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 798.12982
-  tps: 1914.32612
+  dps: 796.92018
+  tps: 1911.2125
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 472.98569
-  tps: 1020.23918
+  dps: 473.76782
+  tps: 1022.25238
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOV-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 752.64522
-  tps: 1739.40179
+  dps: 747.68124
+  tps: 1726.62451
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3671.14335
-  tps: 9464.27041
+  dps: 3671.0534
+  tps: 9464.03888
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1591.34703
-  tps: 3611.2779
+  dps: 1585.67938
+  tps: 3596.68936
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOC-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2250.97104
-  tps: 5274.01145
+  dps: 2230.79771
+  tps: 5222.08528
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 932.24056
-  tps: 2241.16618
+  dps: 930.41737
+  tps: 2236.47327
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 394.42853
-  tps: 811.95668
+  dps: 393.35171
+  tps: 809.18495
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOC-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 701.65509
-  tps: 1605.81443
+  dps: 693.24334
+  tps: 1584.16259
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2944.49682
-  tps: 7584.73132
+  dps: 2935.83914
+  tps: 7562.44644
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1447.46304
-  tps: 3244.87932
+  dps: 1445.52622
+  tps: 3239.89395
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOR-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2135.94149
-  tps: 4973.62437
+  dps: 2112.45526
+  tps: 4913.17082
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 637.5994
-  tps: 1485.01574
+  dps: 636.3507
+  tps: 1481.8016
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 331.08942
-  tps: 648.70994
+  dps: 330.94399
+  tps: 648.33559
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOR-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 628.40746
-  tps: 1413.28525
+  dps: 622.55868
+  tps: 1398.2305
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3565.83279
-  tps: 9182.30969
+  dps: 3560.9127
+  tps: 9169.64537
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1783.32469
-  tps: 4106.62582
+  dps: 1779.95841
+  tps: 4097.96102
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2410.63657
-  tps: 5696.27333
+  dps: 2411.38422
+  tps: 5698.19779
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 792.42249
-  tps: 1882.7698
+  dps: 792.50274
+  tps: 1882.97636
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 477.0059
-  tps: 1025.27036
+  dps: 477.20896
+  tps: 1025.79302
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOV-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 774.37741
-  tps: 1792.4748
+  dps: 768.34314
+  tps: 1776.94257
  }
 }
 dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2152.45978
-  tps: 5038.57328
+  dps: 2137.7374
+  tps: 5002.46391
   dtps: 67.08851
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -45,1295 +45,1295 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AegisBattlegear"
  value: {
-  dps: 5332.6172
-  tps: 5430.4759
+  dps: 5322.61014
+  tps: 5420.46884
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AegisPlate"
  value: {
-  dps: 4791.47136
-  tps: 4888.09842
+  dps: 4784.82845
+  tps: 4881.45551
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AshtongueTalismanofZeal-32489"
  value: {
-  dps: 5593.52561
-  tps: 5691.94651
+  dps: 5591.22871
+  tps: 5689.64961
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5658.97591
-  tps: 5757.40139
+  dps: 5645.51317
+  tps: 5743.93865
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5741.32537
-  tps: 5839.89067
+  dps: 5738.37693
+  tps: 5836.94223
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5663.33242
-  tps: 5762.23481
+  dps: 5659.83239
+  tps: 5758.73478
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 5577.31137
-  tps: 5674.31131
+  dps: 5569.24349
+  tps: 5666.24343
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 4745.73129
-  tps: 4842.32196
+  dps: 4731.68893
+  tps: 4828.2796
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 4593.15355
-  tps: 4689.57625
+  dps: 4581.79327
+  tps: 4678.21596
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4530.70682
-  tps: 4627.0358
+  dps: 4521.37906
+  tps: 4617.70803
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5665.79629
-  tps: 5650.90584
+  dps: 5652.28045
+  tps: 5637.66032
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 5784.09489
-  tps: 5882.52037
+  dps: 5768.71217
+  tps: 5867.13766
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5658.70575
-  tps: 5757.10827
+  dps: 5643.1634
+  tps: 5741.56592
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5699.69959
-  tps: 5798.26131
+  dps: 5688.4151
+  tps: 5786.97682
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 5639.18089
-  tps: 5737.58341
+  dps: 5626.5786
+  tps: 5724.98112
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 5569.31697
-  tps: 5667.74246
+  dps: 5554.69987
+  tps: 5653.12535
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5571.66412
-  tps: 5670.08961
+  dps: 5554.69987
+  tps: 5653.12535
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5681.73357
-  tps: 5780.15906
+  dps: 5667.1715
+  tps: 5765.59698
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5658.97591
-  tps: 5757.40139
+  dps: 5645.51317
+  tps: 5743.93865
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5659.44878
-  tps: 5758.24249
+  dps: 5647.95925
+  tps: 5746.75296
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5676.1943
-  tps: 5774.61978
+  dps: 5661.20702
+  tps: 5759.6325
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5667.1836
-  tps: 5765.60908
+  dps: 5659.58874
+  tps: 5758.01422
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5658.97591
-  tps: 5757.40139
+  dps: 5645.51317
+  tps: 5743.93865
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5726.26885
-  tps: 5824.6488
+  dps: 5706.46836
+  tps: 5804.84831
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5675.55341
-  tps: 5773.95593
+  dps: 5662.6824
+  tps: 5761.08492
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5629.26511
-  tps: 5727.66763
+  dps: 5623.07404
+  tps: 5721.47656
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5665.79629
-  tps: 5764.22177
+  dps: 5652.28045
+  tps: 5750.70593
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5664.43221
-  tps: 5762.85769
+  dps: 5650.92699
+  tps: 5749.35247
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuriousGladiator'sLibramofFortitude-42853"
  value: {
-  dps: 5800.1676
-  tps: 5898.59308
+  dps: 5784.74676
+  tps: 5883.17224
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5586.64041
-  tps: 5685.0659
+  dps: 5571.83835
+  tps: 5670.26383
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Gladiator'sVindication"
  value: {
-  dps: 5710.82275
-  tps: 5808.83373
+  dps: 5701.55792
+  tps: 5799.5689
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HatefulGladiator'sLibramofFortitude-42851"
  value: {
-  dps: 5771.05053
-  tps: 5869.47602
+  dps: 5755.7269
+  tps: 5854.15238
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5624.8771
-  tps: 5723.30258
+  dps: 5609.65725
+  tps: 5708.08273
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5676.1943
-  tps: 5774.61978
+  dps: 5661.20702
+  tps: 5759.6325
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5667.1836
-  tps: 5765.60908
+  dps: 5659.58874
+  tps: 5758.01422
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5767.34702
-  tps: 5866.19508
+  dps: 5757.59926
+  tps: 5856.44732
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5663.73266
-  tps: 5763.93153
+  dps: 5660.58364
+  tps: 5760.7825
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5687.39823
-  tps: 5785.82371
+  dps: 5673.84333
+  tps: 5772.26881
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5571.66412
-  tps: 5670.08961
+  dps: 5554.69987
+  tps: 5653.12535
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Liadrin'sBattlegear"
  value: {
-  dps: 5661.74138
-  tps: 5758.77721
+  dps: 5653.199
+  tps: 5750.23482
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Liadrin'sPlate"
  value: {
-  dps: 4895.49417
-  tps: 4991.43563
+  dps: 4891.06094
+  tps: 4987.00241
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofFuriousBlows-37574"
  value: {
-  dps: 5719.60385
-  tps: 5818.00637
+  dps: 5717.37803
+  tps: 5815.78055
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofObstruction-40707"
  value: {
-  dps: 5701.14525
-  tps: 5799.57073
+  dps: 5686.07586
+  tps: 5784.50134
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofReciprocation-40706"
  value: {
-  dps: 5701.14525
-  tps: 5799.57073
+  dps: 5686.07586
+  tps: 5784.50134
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofThreeTruths-50455"
  value: {
-  dps: 5777.69502
-  tps: 5876.12051
+  dps: 5762.35395
+  tps: 5860.77943
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofValiance-47661"
  value: {
-  dps: 6042.73895
-  tps: 6141.16443
+  dps: 6026.35863
+  tps: 6124.78411
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramoftheSacredShield-45145"
  value: {
-  dps: 5701.14525
-  tps: 5799.57073
+  dps: 5686.07586
+  tps: 5784.50134
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerBattlegear"
  value: {
-  dps: 4268.22142
-  tps: 4363.40645
+  dps: 4267.59731
+  tps: 4362.78234
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornBattlegear"
  value: {
-  dps: 6332.55741
-  tps: 6436.0375
+  dps: 6326.68144
+  tps: 6430.16153
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornPlate"
  value: {
-  dps: 5022.10222
-  tps: 5118.12548
+  dps: 5018.14939
+  tps: 5114.17264
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5569.31697
-  tps: 5667.74246
+  dps: 5554.69987
+  tps: 5653.12535
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5667.5544
-  tps: 5766.14759
+  dps: 5664.16246
+  tps: 5762.75565
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5571.66412
-  tps: 5670.08961
+  dps: 5554.69987
+  tps: 5653.12535
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5681.98446
-  tps: 5780.40994
+  dps: 5668.44711
+  tps: 5766.87259
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5687.39823
-  tps: 5785.82371
+  dps: 5673.84333
+  tps: 5772.26881
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5658.97591
-  tps: 5757.40139
+  dps: 5645.51317
+  tps: 5743.93865
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5658.97591
-  tps: 5757.40139
+  dps: 5645.51317
+  tps: 5743.93865
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5569.31697
-  tps: 5667.74246
+  dps: 5554.69987
+  tps: 5653.12535
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionBattlegear"
  value: {
-  dps: 4956.12268
-  tps: 5055.44881
+  dps: 4939.76731
+  tps: 5039.09345
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionPlate"
  value: {
-  dps: 4647.29491
-  tps: 4743.27518
+  dps: 4637.19842
+  tps: 4733.17869
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 5689.10734
-  tps: 5787.40081
+  dps: 5681.84723
+  tps: 5780.1407
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 5704.02891
-  tps: 5802.32238
+  dps: 5696.89117
+  tps: 5795.18464
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5783.66387
-  tps: 5882.08935
+  dps: 5768.30161
+  tps: 5866.72709
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessGladiator'sLibramofFortitude-42854"
  value: {
-  dps: 5819.42194
-  tps: 5917.84742
+  dps: 5803.93277
+  tps: 5902.35825
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5662.09524
-  tps: 5759.84484
+  dps: 5653.10239
+  tps: 5750.85198
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5571.66412
-  tps: 5670.08961
+  dps: 5554.69987
+  tps: 5653.12535
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SavageGladiator'sLibramofFortitude-42611"
  value: {
-  dps: 5763.13673
-  tps: 5861.56221
+  dps: 5747.84188
+  tps: 5846.26736
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5571.66412
-  tps: 5670.08961
+  dps: 5554.69987
+  tps: 5653.12535
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5569.31697
-  tps: 5667.74246
+  dps: 5554.69987
+  tps: 5653.12535
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5569.31697
-  tps: 5667.74246
+  dps: 5554.69987
+  tps: 5653.12535
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SparkofLife-37657"
  value: {
-  dps: 5625.126
-  tps: 5719.15751
+  dps: 5615.58759
+  tps: 5709.6191
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StormshroudArmor"
  value: {
-  dps: 4440.33995
-  tps: 4536.18555
+  dps: 4428.08219
+  tps: 4523.92778
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5687.39823
-  tps: 5785.82371
+  dps: 5673.84333
+  tps: 5772.26881
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5681.98446
-  tps: 5780.40994
+  dps: 5668.44711
+  tps: 5766.87259
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5672.51035
-  tps: 5770.93583
+  dps: 5659.00372
+  tps: 5757.4292
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5708.69139
-  tps: 5807.08529
+  dps: 5700.3436
+  tps: 5798.7375
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5782.06264
-  tps: 5880.6645
+  dps: 5770.76668
+  tps: 5869.36854
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5789.95759
-  tps: 5888.65377
+  dps: 5789.11036
+  tps: 5887.80654
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5665.79629
-  tps: 5764.22177
+  dps: 5652.28045
+  tps: 5750.70593
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5664.43221
-  tps: 5762.85769
+  dps: 5650.92699
+  tps: 5749.35247
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeoftheLightbringer-32368"
  value: {
-  dps: 5701.14525
-  tps: 5799.57073
+  dps: 5686.07586
+  tps: 5784.50134
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5664.43221
-  tps: 5762.85769
+  dps: 5650.92699
+  tps: 5749.35247
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5665.79629
-  tps: 5764.22177
+  dps: 5652.28045
+  tps: 5750.70593
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sBattlegear"
  value: {
-  dps: 5661.74138
-  tps: 5758.77721
+  dps: 5653.199
+  tps: 5750.23482
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sPlate"
  value: {
-  dps: 4895.49417
-  tps: 4991.43563
+  dps: 4891.06094
+  tps: 4987.00241
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 4631.67282
-  tps: 4728.91655
+  dps: 4622.66135
+  tps: 4719.90508
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathfulGladiator'sLibramofFortitude-51478"
  value: {
-  dps: 5841.42691
-  tps: 5939.85239
+  dps: 5825.85964
+  tps: 5924.28512
  }
 }
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 5732.26414
-  tps: 5830.83208
+  dps: 5725.32608
+  tps: 5823.89402
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16438.62844
-  tps: 18599.75558
+  dps: 16434.75326
+  tps: 18595.8804
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4787.05224
-  tps: 4889.262
+  dps: 4783.88938
+  tps: 4886.09914
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5416.19488
-  tps: 5523.46763
+  dps: 5407.05924
+  tps: 5514.33199
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7231.04754
-  tps: 8504.08595
+  dps: 7222.55206
+  tps: 8495.59047
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2099.16055
-  tps: 2164.65567
+  dps: 2097.13966
+  tps: 2162.63478
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2833.89124
-  tps: 2921.92255
+  dps: 2810.49584
+  tps: 2898.52715
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14137.62359
-  tps: 16298.95818
+  dps: 14154.91052
+  tps: 16316.24511
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4397.35051
-  tps: 4499.55233
+  dps: 4390.43868
+  tps: 4492.6405
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4998.45337
-  tps: 5105.70605
+  dps: 4994.10559
+  tps: 5101.35827
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6102.80681
-  tps: 7384.27731
+  dps: 6086.20194
+  tps: 7367.67244
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1869.72941
-  tps: 1935.29787
+  dps: 1866.18177
+  tps: 1931.75022
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2540.80569
-  tps: 2628.92802
+  dps: 2531.52389
+  tps: 2619.64623
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15480.99168
-  tps: 17634.73493
+  dps: 15491.19673
+  tps: 17644.93998
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5618.52688
-  tps: 5720.73665
+  dps: 5607.3973
+  tps: 5709.60707
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6147.84997
-  tps: 6255.12272
+  dps: 6144.55339
+  tps: 6251.82614
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6871.8677
-  tps: 8175.3082
+  dps: 6855.97749
+  tps: 8159.41799
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2464.09372
-  tps: 2529.55243
+  dps: 2454.92073
+  tps: 2520.37944
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3184.85141
-  tps: 3272.79169
+  dps: 3166.68601
+  tps: 3254.62629
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15153.81811
-  tps: 17314.92965
+  dps: 15175.68599
+  tps: 17336.79753
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5618.52688
-  tps: 5720.73665
+  dps: 5607.3973
+  tps: 5709.60707
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6147.84997
-  tps: 6255.12272
+  dps: 6144.55339
+  tps: 6251.82614
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6652.03816
-  tps: 7949.98616
+  dps: 6639.3734
+  tps: 7937.3214
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2464.09372
-  tps: 2529.55243
+  dps: 2454.92073
+  tps: 2520.37944
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3184.85141
-  tps: 3272.79169
+  dps: 3166.68601
+  tps: 3254.62629
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16546.34632
-  tps: 18708.016
+  dps: 16554.86083
+  tps: 18716.53051
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4793.76432
-  tps: 4895.54993
+  dps: 4790.31413
+  tps: 4892.09974
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5440.21285
-  tps: 5547.25586
+  dps: 5430.31155
+  tps: 5537.35456
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7328.35427
-  tps: 8618.82927
+  dps: 7315.00934
+  tps: 8605.48434
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2015.91841
-  tps: 2075.5571
+  dps: 2011.58394
+  tps: 2071.22263
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2840.81277
-  tps: 2929.07851
+  dps: 2817.67645
+  tps: 2905.9422
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14256.71646
-  tps: 16418.62589
+  dps: 14260.80473
+  tps: 16422.71416
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4402.82261
-  tps: 4504.60607
+  dps: 4402.2684
+  tps: 4504.05186
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5023.4824
-  tps: 5130.46938
+  dps: 5020.33398
+  tps: 5127.32096
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6232.78139
-  tps: 7523.25639
+  dps: 6217.26696
+  tps: 7507.74196
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1775.06296
-  tps: 1834.83111
+  dps: 1773.12087
+  tps: 1832.88902
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2549.55096
-  tps: 2637.91152
+  dps: 2539.88872
+  tps: 2628.24928
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15634.19983
-  tps: 17791.35722
+  dps: 15630.65497
+  tps: 17787.81235
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5647.32236
-  tps: 5749.0974
+  dps: 5632.66535
+  tps: 5734.44039
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6170.62372
-  tps: 6277.66673
+  dps: 6168.89768
+  tps: 6275.94069
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6946.68429
-  tps: 8237.15929
+  dps: 6929.03226
+  tps: 8219.50726
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2377.51253
-  tps: 2437.53635
+  dps: 2372.19521
+  tps: 2432.21902
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3192.42592
-  tps: 3280.59686
+  dps: 3174.3905
+  tps: 3262.56144
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15244.23172
-  tps: 17406.17901
+  dps: 15255.83793
+  tps: 17417.78523
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5647.32236
-  tps: 5749.0974
+  dps: 5632.66535
+  tps: 5734.44039
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6170.62372
-  tps: 6277.66673
+  dps: 6168.89768
+  tps: 6275.94069
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6746.94888
-  tps: 8037.42388
+  dps: 6724.17915
+  tps: 8014.65415
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2377.51253
-  tps: 2437.53635
+  dps: 2372.19521
+  tps: 2432.21902
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3192.42592
-  tps: 3280.59686
+  dps: 3174.3905
+  tps: 3262.56144
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16546.38134
-  tps: 18712.21139
+  dps: 16561.4527
+  tps: 18727.28275
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4825.91671
-  tps: 4928.18007
+  dps: 4813.6391
+  tps: 4915.90245
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5456.87363
-  tps: 5564.1471
+  dps: 5447.57567
+  tps: 5554.84914
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7277.27304
-  tps: 8522.33137
+  dps: 7256.85833
+  tps: 8501.91667
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2037.21282
-  tps: 2097.88052
+  dps: 2032.38209
+  tps: 2093.04979
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2855.27872
-  tps: 2943.20346
+  dps: 2831.59439
+  tps: 2919.51913
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14285.17612
-  tps: 16451.2196
+  dps: 14298.11725
+  tps: 16464.16073
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4433.17723
-  tps: 4535.44059
+  dps: 4432.54446
+  tps: 4534.80782
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5037.38582
-  tps: 5144.63891
+  dps: 5032.89365
+  tps: 5140.14674
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6131.37673
-  tps: 7376.43507
+  dps: 6116.04663
+  tps: 7361.10497
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1795.01917
-  tps: 1855.61543
+  dps: 1793.48762
+  tps: 1854.08387
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2562.81999
-  tps: 2650.83404
+  dps: 2553.51418
+  tps: 2641.52824
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15625.93604
-  tps: 17774.48085
+  dps: 15633.82014
+  tps: 17782.36495
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5683.98852
-  tps: 5786.25188
+  dps: 5673.86306
+  tps: 5776.12642
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6197.27701
-  tps: 6304.55048
+  dps: 6193.8659
+  tps: 6301.13937
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6852.93991
-  tps: 8097.99825
+  dps: 6843.46275
+  tps: 8088.52108
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2409.41128
-  tps: 2469.93386
+  dps: 2401.83508
+  tps: 2462.35766
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3210.78652
-  tps: 3298.62196
+  dps: 3192.43053
+  tps: 3280.26597
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15268.96288
-  tps: 17434.79294
+  dps: 15279.82346
+  tps: 17445.65351
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5683.98852
-  tps: 5786.25188
+  dps: 5673.86306
+  tps: 5776.12642
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6197.27701
-  tps: 6304.55048
+  dps: 6193.8659
+  tps: 6301.13937
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6645.75666
-  tps: 7890.815
+  dps: 6624.72175
+  tps: 7869.78008
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2409.41128
-  tps: 2469.93386
+  dps: 2401.83508
+  tps: 2462.35766
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3210.78652
-  tps: 3298.62196
+  dps: 3192.43053
+  tps: 3280.26597
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16541.83722
-  tps: 18707.92048
+  dps: 16544.15263
+  tps: 18710.23588
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4824.97848
-  tps: 4927.23542
+  dps: 4812.68714
+  tps: 4914.94408
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5453.86039
-  tps: 5561.12423
+  dps: 5444.57445
+  tps: 5551.83829
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7489.98196
-  tps: 8819.05363
+  dps: 7478.50991
+  tps: 8807.58157
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2108.9589
-  tps: 2172.66997
+  dps: 2101.74484
+  tps: 2165.45591
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2854.63277
-  tps: 2942.57883
+  dps: 2830.95691
+  tps: 2918.90297
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14260.97617
-  tps: 16427.0668
+  dps: 14272.20618
+  tps: 16438.29681
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4431.15815
-  tps: 4533.41508
+  dps: 4430.52993
+  tps: 4532.78686
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5036.1939
-  tps: 5143.43742
+  dps: 5031.71242
+  tps: 5138.95594
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6351.35705
-  tps: 7684.09038
+  dps: 6335.18328
+  tps: 7667.91661
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1843.93683
-  tps: 1907.12692
+  dps: 1841.97984
+  tps: 1905.16994
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2561.04735
-  tps: 2649.08306
+  dps: 2551.74672
+  tps: 2639.78243
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15620.65161
-  tps: 17776.30885
+  dps: 15642.52836
+  tps: 17798.18559
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5683.52003
-  tps: 5785.77697
+  dps: 5672.62341
+  tps: 5774.88034
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6193.61575
-  tps: 6300.87959
+  dps: 6190.21312
+  tps: 6297.47695
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7099.18696
-  tps: 8431.9203
+  dps: 7081.47834
+  tps: 8414.21167
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2481.17623
-  tps: 2545.30069
+  dps: 2476.27547
+  tps: 2540.39993
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3209.74649
-  tps: 3297.60289
+  dps: 3191.40407
+  tps: 3279.26047
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15292.10721
-  tps: 17458.10315
+  dps: 15307.29919
+  tps: 17473.29513
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5683.52003
-  tps: 5785.77697
+  dps: 5672.62341
+  tps: 5774.88034
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6193.61575
-  tps: 6300.87959
+  dps: 6190.21312
+  tps: 6297.47695
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6869.84015
-  tps: 8202.57349
+  dps: 6858.94265
+  tps: 8191.67598
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2481.17623
-  tps: 2545.30069
+  dps: 2476.27547
+  tps: 2540.39993
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3209.74649
-  tps: 3297.60289
+  dps: 3191.40407
+  tps: 3279.26047
  }
 }
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5433.21209
-  tps: 5531.66731
+  dps: 5426.2337
+  tps: 5524.68892
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -45,113 +45,113 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AegisBattlegear"
  value: {
-  dps: 5322.61014
-  tps: 5420.46884
+  dps: 5320.00736
+  tps: 5417.86606
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AegisPlate"
  value: {
-  dps: 4784.82845
-  tps: 4881.45551
+  dps: 4782.21533
+  tps: 4878.84239
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AshtongueTalismanofZeal-32489"
  value: {
-  dps: 5591.22871
-  tps: 5689.64961
+  dps: 5588.82548
+  tps: 5687.24638
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5645.51317
-  tps: 5743.93865
+  dps: 5643.15275
+  tps: 5741.57823
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5738.37693
-  tps: 5836.94223
+  dps: 5735.37793
+  tps: 5833.94322
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5659.83239
-  tps: 5758.73478
+  dps: 5657.28592
+  tps: 5756.18831
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 5569.24349
-  tps: 5666.24343
+  dps: 5566.2855
+  tps: 5663.28544
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 4731.68893
-  tps: 4828.2796
+  dps: 4729.52805
+  tps: 4826.11872
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 4581.79327
-  tps: 4678.21596
+  dps: 4579.38947
+  tps: 4675.81216
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4521.37906
-  tps: 4617.70803
+  dps: 4518.91303
+  tps: 4615.242
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5652.28045
-  tps: 5637.66032
+  dps: 5649.92003
+  tps: 5635.34711
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 5768.71217
-  tps: 5867.13766
+  dps: 5766.36709
+  tps: 5864.79257
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5643.1634
-  tps: 5741.56592
+  dps: 5640.71566
+  tps: 5739.11818
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5688.4151
-  tps: 5786.97682
+  dps: 5685.45872
+  tps: 5784.02043
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 5626.5786
-  tps: 5724.98112
+  dps: 5624.30446
+  tps: 5722.70698
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 5554.69987
-  tps: 5653.12535
+  dps: 5552.35479
+  tps: 5650.78027
  }
 }
 dps_results: {
@@ -164,148 +164,148 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5667.1715
-  tps: 5765.59698
+  dps: 5664.77625
+  tps: 5763.20173
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5645.51317
-  tps: 5743.93865
+  dps: 5643.15275
+  tps: 5741.57823
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5647.95925
-  tps: 5746.75296
+  dps: 5645.45994
+  tps: 5744.25365
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5661.20702
-  tps: 5759.6325
+  dps: 5658.86194
+  tps: 5757.28742
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5659.58874
-  tps: 5758.01422
+  dps: 5657.21737
+  tps: 5755.64285
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5645.51317
-  tps: 5743.93865
+  dps: 5643.15275
+  tps: 5741.57823
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5706.46836
-  tps: 5804.84831
+  dps: 5703.69948
+  tps: 5802.07943
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5662.6824
-  tps: 5761.08492
+  dps: 5660.24335
+  tps: 5758.64587
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5623.07404
-  tps: 5721.47656
+  dps: 5620.77129
+  tps: 5719.17381
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5652.28045
-  tps: 5750.70593
+  dps: 5649.92003
+  tps: 5748.34551
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5650.92699
-  tps: 5749.35247
+  dps: 5648.56658
+  tps: 5746.99206
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuriousGladiator'sLibramofFortitude-42853"
  value: {
-  dps: 5784.74676
-  tps: 5883.17224
+  dps: 5782.40168
+  tps: 5880.82716
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5571.83835
-  tps: 5670.26383
+  dps: 5569.49326
+  tps: 5667.91875
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Gladiator'sVindication"
  value: {
-  dps: 5701.55792
-  tps: 5799.5689
+  dps: 5698.58127
+  tps: 5796.59225
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HatefulGladiator'sLibramofFortitude-42851"
  value: {
-  dps: 5755.7269
-  tps: 5854.15238
+  dps: 5753.38182
+  tps: 5851.8073
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5609.65725
-  tps: 5708.08273
+  dps: 5607.31217
+  tps: 5705.73765
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5661.20702
-  tps: 5759.6325
+  dps: 5658.86194
+  tps: 5757.28742
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5659.58874
-  tps: 5758.01422
+  dps: 5657.21737
+  tps: 5755.64285
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5757.59926
-  tps: 5856.44732
+  dps: 5755.12099
+  tps: 5853.96904
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5660.58364
-  tps: 5760.7825
+  dps: 5658.0957
+  tps: 5758.29456
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5673.84333
-  tps: 5772.26881
+  dps: 5671.48291
+  tps: 5769.9084
  }
 }
 dps_results: {
@@ -318,92 +318,92 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-Liadrin'sBattlegear"
  value: {
-  dps: 5653.199
-  tps: 5750.23482
+  dps: 5650.73928
+  tps: 5747.7751
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Liadrin'sPlate"
  value: {
-  dps: 4891.06094
-  tps: 4987.00241
+  dps: 4888.66775
+  tps: 4984.60922
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofFuriousBlows-37574"
  value: {
-  dps: 5717.37803
-  tps: 5815.78055
+  dps: 5715.0997
+  tps: 5813.50222
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofObstruction-40707"
  value: {
-  dps: 5686.07586
-  tps: 5784.50134
+  dps: 5683.73077
+  tps: 5782.15626
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofReciprocation-40706"
  value: {
-  dps: 5686.07586
-  tps: 5784.50134
+  dps: 5683.73077
+  tps: 5782.15626
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofThreeTruths-50455"
  value: {
-  dps: 5762.35395
-  tps: 5860.77943
+  dps: 5760.00886
+  tps: 5858.43435
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofValiance-47661"
  value: {
-  dps: 6026.35863
-  tps: 6124.78411
+  dps: 6024.01355
+  tps: 6122.43903
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramoftheSacredShield-45145"
  value: {
-  dps: 5686.07586
-  tps: 5784.50134
+  dps: 5683.73077
+  tps: 5782.15626
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerBattlegear"
  value: {
-  dps: 4267.59731
-  tps: 4362.78234
+  dps: 4264.79404
+  tps: 4359.97907
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornBattlegear"
  value: {
-  dps: 6326.68144
-  tps: 6430.16153
+  dps: 6323.85402
+  tps: 6427.33411
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornPlate"
  value: {
-  dps: 5018.14939
-  tps: 5114.17264
+  dps: 5015.77467
+  tps: 5111.79792
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5554.69987
-  tps: 5653.12535
+  dps: 5552.35479
+  tps: 5650.78027
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5664.16246
-  tps: 5762.75565
+  dps: 5661.48558
+  tps: 5760.07877
  }
 }
 dps_results: {
@@ -416,85 +416,85 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5668.44711
-  tps: 5766.87259
+  dps: 5666.08669
+  tps: 5764.51218
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5673.84333
-  tps: 5772.26881
+  dps: 5671.48291
+  tps: 5769.9084
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5645.51317
-  tps: 5743.93865
+  dps: 5643.15275
+  tps: 5741.57823
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5645.51317
-  tps: 5743.93865
+  dps: 5643.15275
+  tps: 5741.57823
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5554.69987
-  tps: 5653.12535
+  dps: 5552.35479
+  tps: 5650.78027
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionBattlegear"
  value: {
-  dps: 4939.76731
-  tps: 5039.09345
+  dps: 4937.36982
+  tps: 5036.69596
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionPlate"
  value: {
-  dps: 4637.19842
-  tps: 4733.17869
+  dps: 4634.86744
+  tps: 4730.84771
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 5681.84723
-  tps: 5780.1407
+  dps: 5679.28765
+  tps: 5777.58112
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 5696.89117
-  tps: 5795.18464
+  dps: 5694.33159
+  tps: 5792.62506
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5768.30161
-  tps: 5866.72709
+  dps: 5765.95653
+  tps: 5864.38201
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessGladiator'sLibramofFortitude-42854"
  value: {
-  dps: 5803.93277
-  tps: 5902.35825
+  dps: 5801.58769
+  tps: 5900.01317
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5653.10239
-  tps: 5750.85198
+  dps: 5650.83469
+  tps: 5748.58429
  }
 }
 dps_results: {
@@ -507,8 +507,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-SavageGladiator'sLibramofFortitude-42611"
  value: {
-  dps: 5747.84188
-  tps: 5846.26736
+  dps: 5745.4968
+  tps: 5843.92228
  }
 }
 dps_results: {
@@ -521,162 +521,162 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5554.69987
-  tps: 5653.12535
+  dps: 5552.35479
+  tps: 5650.78027
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5554.69987
-  tps: 5653.12535
+  dps: 5552.35479
+  tps: 5650.78027
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SparkofLife-37657"
  value: {
-  dps: 5615.58759
-  tps: 5709.6191
+  dps: 5613.12351
+  tps: 5707.15502
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StormshroudArmor"
  value: {
-  dps: 4428.08219
-  tps: 4523.92778
+  dps: 4425.54496
+  tps: 4521.39055
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5673.84333
-  tps: 5772.26881
+  dps: 5671.48291
+  tps: 5769.9084
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5668.44711
-  tps: 5766.87259
+  dps: 5666.08669
+  tps: 5764.51218
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5659.00372
-  tps: 5757.4292
+  dps: 5656.64331
+  tps: 5755.06879
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5700.3436
-  tps: 5798.7375
+  dps: 5697.57454
+  tps: 5795.96844
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5770.76668
-  tps: 5869.36854
+  dps: 5767.87912
+  tps: 5866.48098
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5789.11036
-  tps: 5887.80654
+  dps: 5786.62826
+  tps: 5885.32444
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5652.28045
-  tps: 5750.70593
+  dps: 5649.92003
+  tps: 5748.34551
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5650.92699
-  tps: 5749.35247
+  dps: 5648.56658
+  tps: 5746.99206
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeoftheLightbringer-32368"
  value: {
-  dps: 5686.07586
-  tps: 5784.50134
+  dps: 5683.73077
+  tps: 5782.15626
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5650.92699
-  tps: 5749.35247
+  dps: 5648.56658
+  tps: 5746.99206
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5652.28045
-  tps: 5750.70593
+  dps: 5649.92003
+  tps: 5748.34551
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sBattlegear"
  value: {
-  dps: 5653.199
-  tps: 5750.23482
+  dps: 5650.73928
+  tps: 5747.7751
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sPlate"
  value: {
-  dps: 4891.06094
-  tps: 4987.00241
+  dps: 4888.66775
+  tps: 4984.60922
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 4622.66135
-  tps: 4719.90508
+  dps: 4620.18272
+  tps: 4717.42645
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathfulGladiator'sLibramofFortitude-51478"
  value: {
-  dps: 5825.85964
-  tps: 5924.28512
+  dps: 5823.51455
+  tps: 5921.94003
  }
 }
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 5725.32608
-  tps: 5823.89402
+  dps: 5722.62647
+  tps: 5821.19441
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16434.75326
-  tps: 18595.8804
+  dps: 16388.91231
+  tps: 18550.03945
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4783.88938
-  tps: 4886.09914
+  dps: 4781.39743
+  tps: 4883.6072
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5407.05924
-  tps: 5514.33199
+  dps: 5393.18073
+  tps: 5500.45348
  }
 }
 dps_results: {
@@ -703,22 +703,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14154.91052
-  tps: 16316.24511
+  dps: 14109.33571
+  tps: 16270.6703
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4390.43868
-  tps: 4492.6405
+  dps: 4387.91071
+  tps: 4490.11253
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4994.10559
-  tps: 5101.35827
+  dps: 4981.50213
+  tps: 5088.75481
  }
 }
 dps_results: {
@@ -745,22 +745,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15491.19673
-  tps: 17644.93998
+  dps: 15445.94722
+  tps: 17599.69048
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5607.3973
-  tps: 5709.60707
+  dps: 5604.88219
+  tps: 5707.09195
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6144.55339
-  tps: 6251.82614
+  dps: 6131.62538
+  tps: 6238.89813
  }
 }
 dps_results: {
@@ -787,22 +787,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15175.68599
-  tps: 17336.79753
+  dps: 15130.08328
+  tps: 17291.19482
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5607.3973
-  tps: 5709.60707
+  dps: 5604.88219
+  tps: 5707.09195
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6144.55339
-  tps: 6251.82614
+  dps: 6131.62538
+  tps: 6238.89813
  }
 }
 dps_results: {
@@ -829,22 +829,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16554.86083
-  tps: 18716.53051
+  dps: 16509.55207
+  tps: 18671.22174
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4790.31413
-  tps: 4892.09974
+  dps: 4787.63852
+  tps: 4889.42413
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5430.31155
-  tps: 5537.35456
+  dps: 5416.42093
+  tps: 5523.46394
  }
 }
 dps_results: {
@@ -871,22 +871,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14260.80473
-  tps: 16422.71416
+  dps: 14215.46163
+  tps: 16377.37105
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4402.2684
-  tps: 4504.05186
+  dps: 4399.4464
+  tps: 4501.22986
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5020.33398
-  tps: 5127.32096
+  dps: 5006.76755
+  tps: 5113.75453
  }
 }
 dps_results: {
@@ -913,22 +913,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15630.65497
-  tps: 17787.81235
+  dps: 15583.58677
+  tps: 17740.74416
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5632.66535
-  tps: 5734.44039
+  dps: 5629.96304
+  tps: 5731.73807
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6168.89768
-  tps: 6275.94069
+  dps: 6155.95728
+  tps: 6263.00029
  }
 }
 dps_results: {
@@ -955,22 +955,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15255.83793
-  tps: 17417.78523
+  dps: 15210.83836
+  tps: 17372.78566
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5632.66535
-  tps: 5734.44039
+  dps: 5629.96304
+  tps: 5731.73807
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6168.89768
-  tps: 6275.94069
+  dps: 6155.95728
+  tps: 6263.00029
  }
 }
 dps_results: {
@@ -997,22 +997,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16561.4527
-  tps: 18727.28275
+  dps: 16515.79056
+  tps: 18681.62061
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4813.6391
-  tps: 4915.90245
+  dps: 4811.09051
+  tps: 4913.35387
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5447.57567
-  tps: 5554.84914
+  dps: 5433.69716
+  tps: 5540.97063
  }
 }
 dps_results: {
@@ -1039,22 +1039,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14298.11725
-  tps: 16464.16073
+  dps: 14252.41015
+  tps: 16418.45363
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4432.54446
-  tps: 4534.80782
+  dps: 4429.91195
+  tps: 4532.17531
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5032.89365
-  tps: 5140.14674
+  dps: 5020.29019
+  tps: 5127.54328
  }
 }
 dps_results: {
@@ -1081,22 +1081,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15633.82014
-  tps: 17782.36495
+  dps: 15588.52457
+  tps: 17737.06938
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5673.86306
-  tps: 5776.12642
+  dps: 5671.19349
+  tps: 5773.45685
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6193.8659
-  tps: 6301.13937
+  dps: 6180.93789
+  tps: 6288.21136
  }
 }
 dps_results: {
@@ -1123,22 +1123,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15279.82346
-  tps: 17445.65351
+  dps: 15234.56213
+  tps: 17400.39218
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5673.86306
-  tps: 5776.12642
+  dps: 5671.19349
+  tps: 5773.45685
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6193.8659
-  tps: 6301.13937
+  dps: 6180.93789
+  tps: 6288.21136
  }
 }
 dps_results: {
@@ -1165,22 +1165,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16544.15263
-  tps: 18710.23588
+  dps: 16497.94694
+  tps: 18664.0302
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4812.68714
-  tps: 4914.94408
+  dps: 4810.13856
+  tps: 4912.39549
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5444.57445
-  tps: 5551.83829
+  dps: 5430.69594
+  tps: 5537.95978
  }
 }
 dps_results: {
@@ -1207,22 +1207,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14272.20618
-  tps: 16438.29681
+  dps: 14225.9139
+  tps: 16392.00454
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4430.52993
-  tps: 4532.78686
+  dps: 4427.89741
+  tps: 4530.15435
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5031.71242
-  tps: 5138.95594
+  dps: 5019.10896
+  tps: 5126.35248
  }
 }
 dps_results: {
@@ -1249,22 +1249,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15642.52836
-  tps: 17798.18559
+  dps: 15596.8875
+  tps: 17752.54473
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5672.62341
-  tps: 5774.88034
+  dps: 5669.95383
+  tps: 5772.21077
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6190.21312
-  tps: 6297.47695
+  dps: 6177.28511
+  tps: 6284.54894
  }
 }
 dps_results: {
@@ -1291,22 +1291,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15307.29919
-  tps: 17473.29513
+  dps: 15260.82561
+  tps: 17426.82155
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5672.62341
-  tps: 5774.88034
+  dps: 5669.95383
+  tps: 5772.21077
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6190.21312
-  tps: 6297.47695
+  dps: 6177.28511
+  tps: 6284.54894
  }
 }
 dps_results: {
@@ -1333,7 +1333,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5426.2337
-  tps: 5524.68892
+  dps: 5423.7955
+  tps: 5522.25072
  }
 }

--- a/sim/priest/healing/TestDisc.results
+++ b/sim/priest/healing/TestDisc.results
@@ -45,7 +45,7 @@ character_stats_results: {
 dps_results: {
  key: "TestDisc-AllItems-AbsolutionRegalia"
  value: {
-  dps: 96.96575
+  dps: 97.1736
   tps: 39.91741
   hps: 3691.26119
  }
@@ -53,7 +53,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-AshtongueTalismanofAcumen-32490"
  value: {
-  dps: 124.46963
+  dps: 125.11642
   tps: 55.03076
   hps: 5536.52332
  }
@@ -61,7 +61,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 123.8696
+  dps: 124.72368
   tps: 47.30354
   hps: 5438.0818
  }
@@ -69,7 +69,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 124.46963
+  dps: 125.11642
   tps: 55.03076
   hps: 5536.52332
  }
@@ -77,7 +77,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 124.84122
+  dps: 125.6953
   tps: 48.11046
   hps: 5487.29871
  }
@@ -85,7 +85,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 101.69119
+  dps: 102.464
   tps: 47.78045
   hps: 4392.03666
  }
@@ -93,7 +93,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 124.76705
+  dps: 125.62731
   tps: 47.30354
   hps: 5465.29316
  }
@@ -101,7 +101,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 124.84122
+  dps: 125.6953
   tps: 47.30354
   hps: 5457.84949
  }
@@ -109,7 +109,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 124.2357
+  dps: 124.98721
   tps: 51.84887
   hps: 5974.90263
  }
@@ -117,7 +117,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 133.19461
+  dps: 133.71382
   tps: 51.84887
   hps: 5330.7976
  }
@@ -125,7 +125,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 124.46963
+  dps: 125.11642
   tps: 55.03076
   hps: 5536.52332
  }
@@ -133,7 +133,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 126.82572
+  dps: 127.37808
   tps: 55.03076
   hps: 5590.82086
  }
@@ -141,7 +141,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 124.46963
+  dps: 125.11642
   tps: 55.03076
   hps: 5536.52332
  }
@@ -149,7 +149,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 124.46963
+  dps: 125.11642
   tps: 55.03076
   hps: 5536.52332
  }
@@ -157,7 +157,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 125.71854
+  dps: 126.42853
   tps: 55.27689
   hps: 5609.80708
  }
@@ -165,7 +165,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-Defender'sCode-40257"
  value: {
-  dps: 124.46963
+  dps: 125.11642
   tps: 55.03076
   hps: 5536.52332
  }
@@ -173,7 +173,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 124.84122
+  dps: 125.6953
   tps: 47.30354
   hps: 5462.87881
  }
@@ -181,7 +181,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 123.8696
+  dps: 124.72368
   tps: 47.30354
   hps: 5438.0818
  }
@@ -189,7 +189,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 124.76705
+  dps: 125.62731
   tps: 47.98697
   hps: 5487.73936
  }
@@ -197,7 +197,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 124.84122
+  dps: 125.6953
   tps: 47.30354
   hps: 5457.84949
  }
@@ -205,7 +205,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 124.84122
+  dps: 125.6953
   tps: 47.30354
   hps: 5456.43444
  }
@@ -213,7 +213,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 123.8696
+  dps: 124.72368
   tps: 47.30354
   hps: 5438.0818
  }
@@ -221,7 +221,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 126.82572
+  dps: 127.37808
   tps: 55.03076
   hps: 5597.29232
  }
@@ -229,7 +229,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 131.57253
+  dps: 132.1455
   tps: 55.03076
   hps: 5727.10958
  }
@@ -237,7 +237,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-ForgeEmber-37660"
  value: {
-  dps: 126.82572
+  dps: 127.37808
   tps: 55.03076
   hps: 5584.30448
  }
@@ -245,7 +245,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 124.76705
+  dps: 125.62731
   tps: 47.30354
   hps: 5465.29316
  }
@@ -253,7 +253,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 124.58756
+  dps: 125.44658
   tps: 47.30354
   hps: 5459.85089
  }
@@ -261,7 +261,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 124.46963
+  dps: 125.11642
   tps: 55.03076
   hps: 5536.52332
  }
@@ -269,7 +269,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-FuturesightRune-38763"
  value: {
-  dps: 127.6332
+  dps: 128.29781
   tps: 55.27918
   hps: 5675.41291
  }
@@ -277,7 +277,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-GarbofFaith"
  value: {
-  dps: 108.70433
+  dps: 109.33846
   tps: 45.47232
   hps: 4554.68339
  }
@@ -285,7 +285,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 130.8243
+  dps: 131.65416
   tps: 49.78644
   hps: 5833.60533
  }
@@ -293,7 +293,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 141.53673
+  dps: 142.38155
   tps: 48.57885
   hps: 5478.85853
  }
@@ -301,7 +301,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 131.92315
+  dps: 132.60858
   tps: 55.03076
   hps: 5739.10424
  }
@@ -309,7 +309,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 124.84122
+  dps: 125.6953
   tps: 47.30354
   hps: 5457.84949
  }
@@ -317,7 +317,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 124.84122
+  dps: 125.6953
   tps: 47.30354
   hps: 5456.43444
  }
@@ -325,7 +325,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-IncisorFragment-37723"
  value: {
-  dps: 124.46963
+  dps: 125.11642
   tps: 55.03076
   hps: 5536.52332
  }
@@ -333,7 +333,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 128.60633
+  dps: 129.27457
   tps: 55.03076
   hps: 5661.40132
  }
@@ -341,7 +341,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 123.8696
+  dps: 124.72368
   tps: 47.30354
   hps: 5438.0818
  }
@@ -349,7 +349,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 124.46963
+  dps: 125.11642
   tps: 55.03076
   hps: 5536.52332
  }
@@ -357,7 +357,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 125.09462
+  dps: 125.66843
   tps: 55.27843
   hps: 5658.96072
  }
@@ -365,7 +365,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 126.82572
+  dps: 127.37808
   tps: 55.03076
   hps: 5584.60517
  }
@@ -373,7 +373,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 124.46963
+  dps: 125.11642
   tps: 55.03076
   hps: 5561.86329
  }
@@ -381,7 +381,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 123.8696
+  dps: 124.72368
   tps: 47.30354
   hps: 5438.0818
  }
@@ -389,7 +389,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 123.8696
+  dps: 124.72368
   tps: 47.30354
   hps: 5438.0818
  }
@@ -397,7 +397,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 123.8696
+  dps: 124.72368
   tps: 47.30354
   hps: 5438.0818
  }
@@ -405,7 +405,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 123.8696
+  dps: 124.72368
   tps: 47.30354
   hps: 5438.0818
  }
@@ -413,7 +413,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 124.46963
+  dps: 125.11642
   tps: 55.03076
   hps: 5536.52332
  }
@@ -421,7 +421,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-RegaliaofFaith"
  value: {
-  dps: 106.95185
+  dps: 107.83293
   tps: 45.24342
   hps: 4725.70697
  }
@@ -429,7 +429,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 130.05977
+  dps: 130.73554
   tps: 55.03076
   hps: 5705.27737
  }
@@ -437,7 +437,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 130.73059
+  dps: 131.40983
   tps: 55.03076
   hps: 5725.52786
  }
@@ -445,7 +445,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 123.8696
+  dps: 124.72368
   tps: 47.30354
   hps: 5438.0818
  }
@@ -453,7 +453,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 123.8696
+  dps: 124.72368
   tps: 47.30354
   hps: 5470.4518
  }
@@ -461,7 +461,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 124.46963
+  dps: 125.11642
   tps: 55.03076
   hps: 5536.52332
  }
@@ -469,7 +469,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-SanctificationGarb"
  value: {
-  dps: 112.15649
+  dps: 112.91406
   tps: 46.25713
   hps: 4726.64652
  }
@@ -477,7 +477,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-SanctificationRegalia"
  value: {
-  dps: 114.15381
+  dps: 115.07591
   tps: 46.97653
   hps: 5080.93419
  }
@@ -485,7 +485,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 124.46963
+  dps: 125.11642
   tps: 55.03076
   hps: 5536.52332
  }
@@ -493,7 +493,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 124.46963
+  dps: 125.11642
   tps: 55.03076
   hps: 5536.52332
  }
@@ -501,7 +501,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 124.46963
+  dps: 125.11642
   tps: 55.03076
   hps: 5536.52332
  }
@@ -509,7 +509,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-SparkofLife-37657"
  value: {
-  dps: 119.88491
+  dps: 120.71159
   tps: 53.84024
   hps: 5620.01619
  }
@@ -517,7 +517,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 123.8696
+  dps: 124.72368
   tps: 47.30354
   hps: 5438.0818
  }
@@ -525,7 +525,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 123.8696
+  dps: 124.72368
   tps: 47.30354
   hps: 5438.0818
  }
@@ -533,7 +533,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 123.8696
+  dps: 124.72368
   tps: 47.30354
   hps: 5438.0818
  }
@@ -541,7 +541,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 123.8696
+  dps: 124.72368
   tps: 47.30354
   hps: 5438.0818
  }
@@ -549,7 +549,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 125.38534
+  dps: 126.00223
   tps: 55.03076
   hps: 5536.52332
  }
@@ -557,7 +557,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 125.38534
+  dps: 126.00223
   tps: 55.03076
   hps: 5536.52332
  }
@@ -565,7 +565,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 124.76705
+  dps: 125.62731
   tps: 47.30354
   hps: 5465.29316
  }
@@ -573,7 +573,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 124.58756
+  dps: 125.44658
   tps: 47.30354
   hps: 5459.85089
  }
@@ -581,7 +581,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 124.58756
+  dps: 125.44658
   tps: 47.30354
   hps: 5459.85089
  }
@@ -589,7 +589,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 124.76705
+  dps: 125.62731
   tps: 47.30354
   hps: 5465.29316
  }
@@ -597,7 +597,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-VestmentsofAbsolution"
  value: {
-  dps: 91.84528
+  dps: 92.11879
   tps: 38.50717
   hps: 3741.75763
  }
@@ -605,7 +605,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-Zabra'sRaiment"
  value: {
-  dps: 119.40906
+  dps: 120.17408
   tps: 49.33095
   hps: 5439.99205
  }
@@ -613,7 +613,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-AllItems-Zabra'sRegalia"
  value: {
-  dps: 120.78543
+  dps: 120.96437
   tps: 49.33095
   hps: 5124.87648
  }
@@ -621,7 +621,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-Average-Default"
  value: {
-  dps: 129.92258
+  dps: 129.52276
   tps: 54.88382
   hps: 5642.27251
  }
@@ -629,7 +629,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-Settings-Undead-P1-Disc-FullBuffs-LongMultiTarget"
  value: {
-  dps: 126.71789
+  dps: 127.57568
   tps: 1079.67838
   hps: 5131.21661
  }
@@ -637,7 +637,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-Settings-Undead-P1-Disc-FullBuffs-LongSingleTarget"
  value: {
-  dps: 126.71789
+  dps: 127.57568
   tps: 53.98392
   hps: 5131.21661
  }
@@ -645,7 +645,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-Settings-Undead-P1-Disc-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 633.26869
+  dps: 637.52981
   tps: 184.24697
   hps: 8207.54353
  }
@@ -653,7 +653,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-Settings-Undead-P1-Disc-NoBuffs-LongMultiTarget"
  value: {
-  dps: 56.66864
+  dps: 56.96604
   tps: 527.97948
   hps: 2738.67334
  }
@@ -661,7 +661,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-Settings-Undead-P1-Disc-NoBuffs-LongSingleTarget"
  value: {
-  dps: 56.66864
+  dps: 56.96604
   tps: 26.39897
   hps: 2738.67334
  }
@@ -669,7 +669,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-Settings-Undead-P1-Disc-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 283.34319
+  dps: 284.8302
   tps: 97.92677
   hps: 5554.24741
  }
@@ -677,7 +677,7 @@ dps_results: {
 dps_results: {
  key: "TestDisc-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 110.34454
+  dps: 110.45129
   tps: 55.03076
   hps: 5661.40132
  }

--- a/sim/priest/healing/TestHoly.results
+++ b/sim/priest/healing/TestHoly.results
@@ -45,7 +45,7 @@ character_stats_results: {
 dps_results: {
  key: "TestHoly-AllItems-AbsolutionRegalia"
  value: {
-  dps: 98.99781
+  dps: 99.29586
   tps: 35.9497
   hps: 3051.05528
  }
@@ -53,7 +53,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-AshtongueTalismanofAcumen-32490"
  value: {
-  dps: 126.62714
+  dps: 127.48575
   tps: 48.55739
   hps: 4452.77211
  }
@@ -61,7 +61,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 129.42653
+  dps: 130.41284
   tps: 42.93312
   hps: 4407.36109
  }
@@ -69,7 +69,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 126.62714
+  dps: 127.48575
   tps: 48.55739
   hps: 4452.77211
  }
@@ -77,7 +77,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 131.87535
+  dps: 132.77727
   tps: 44.00668
   hps: 4468.18893
  }
@@ -85,7 +85,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 106.31868
+  dps: 107.1302
   tps: 42.90729
   hps: 3531.96276
  }
@@ -93,7 +93,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 130.31622
+  dps: 131.30929
   tps: 42.93312
   hps: 4429.46912
  }
@@ -101,7 +101,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 129.90852
+  dps: 130.82201
   tps: 42.93312
   hps: 4420.93816
  }
@@ -109,7 +109,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 131.75366
+  dps: 132.59753
   tps: 46.79881
   hps: 4813.90159
  }
@@ -117,7 +117,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 134.8861
+  dps: 135.56775
   tps: 46.79881
   hps: 4219.62399
  }
@@ -125,7 +125,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 126.62714
+  dps: 127.48575
   tps: 48.55739
   hps: 4452.77211
  }
@@ -133,7 +133,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 128.86038
+  dps: 129.68097
   tps: 48.50813
   hps: 4488.81542
  }
@@ -141,7 +141,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 126.62714
+  dps: 127.48575
   tps: 48.55739
   hps: 4452.77211
  }
@@ -149,7 +149,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 126.62714
+  dps: 127.48575
   tps: 48.55739
   hps: 4452.77211
  }
@@ -157,7 +157,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 128.23934
+  dps: 129.31176
   tps: 48.78382
   hps: 4569.24402
  }
@@ -165,7 +165,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-Defender'sCode-40257"
  value: {
-  dps: 126.62714
+  dps: 127.48575
   tps: 48.55739
   hps: 4452.77211
  }
@@ -173,7 +173,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 129.90852
+  dps: 130.82201
   tps: 42.93312
   hps: 4423.04059
  }
@@ -181,7 +181,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 129.42653
+  dps: 130.41284
   tps: 42.93312
   hps: 4407.36109
  }
@@ -189,7 +189,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 131.37549
+  dps: 132.31907
   tps: 43.70527
   hps: 4477.81802
  }
@@ -197,7 +197,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 129.90852
+  dps: 130.82201
   tps: 42.93312
   hps: 4420.93816
  }
@@ -205,7 +205,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 129.90852
+  dps: 130.82201
   tps: 42.93312
   hps: 4418.68339
  }
@@ -213,7 +213,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 129.42653
+  dps: 130.41284
   tps: 42.93312
   hps: 4407.36109
  }
@@ -221,7 +221,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 130.77841
+  dps: 131.68853
   tps: 48.77278
   hps: 4492.12471
  }
@@ -229,7 +229,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 133.42864
+  dps: 134.27827
   tps: 48.50813
   hps: 4601.52606
  }
@@ -237,7 +237,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-ForgeEmber-37660"
  value: {
-  dps: 128.80982
+  dps: 129.5514
   tps: 48.41992
   hps: 4491.47666
  }
@@ -245,7 +245,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 130.31622
+  dps: 131.30929
   tps: 42.93312
   hps: 4429.46912
  }
@@ -253,7 +253,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 130.13829
+  dps: 131.13
   tps: 42.93312
   hps: 4425.04752
  }
@@ -261,7 +261,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 126.62714
+  dps: 127.48575
   tps: 48.55739
   hps: 4452.77211
  }
@@ -269,7 +269,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-FuturesightRune-38763"
  value: {
-  dps: 129.18714
+  dps: 130.04962
   tps: 48.64635
   hps: 4556.87946
  }
@@ -277,7 +277,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-GarbofFaith"
  value: {
-  dps: 114.32182
+  dps: 114.8725
   tps: 41.41984
   hps: 3701.51325
  }
@@ -285,7 +285,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 134.7898
+  dps: 135.75322
   tps: 44.13422
   hps: 4717.99331
  }
@@ -293,7 +293,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 144.4445
+  dps: 145.25694
   tps: 44.13422
   hps: 4274.16184
  }
@@ -301,7 +301,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 133.80975
+  dps: 134.71693
   tps: 48.55739
   hps: 4628.28973
  }
@@ -309,7 +309,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 129.90852
+  dps: 130.82201
   tps: 42.93312
   hps: 4420.93816
  }
@@ -317,7 +317,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 129.90852
+  dps: 130.82201
   tps: 42.93312
   hps: 4418.68339
  }
@@ -325,7 +325,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-IncisorFragment-37723"
  value: {
-  dps: 126.62714
+  dps: 127.48575
   tps: 48.55739
   hps: 4452.77211
  }
@@ -333,7 +333,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 130.61349
+  dps: 131.49905
   tps: 48.55739
   hps: 4554.12297
  }
@@ -341,7 +341,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 129.42653
+  dps: 130.41284
   tps: 42.93312
   hps: 4407.36109
  }
@@ -349,7 +349,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 126.62714
+  dps: 127.48575
   tps: 48.55739
   hps: 4452.77211
  }
@@ -357,7 +357,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 130.091
+  dps: 131.05059
   tps: 49.24847
   hps: 4665.47597
  }
@@ -365,7 +365,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 128.80982
+  dps: 129.5514
   tps: 48.41992
   hps: 4492.11124
  }
@@ -373,7 +373,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 125.36417
+  dps: 126.32794
   tps: 48.38095
   hps: 4448.09505
  }
@@ -381,7 +381,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 129.42653
+  dps: 130.41284
   tps: 42.93312
   hps: 4407.36109
  }
@@ -389,7 +389,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 129.42653
+  dps: 130.41284
   tps: 42.93312
   hps: 4407.36109
  }
@@ -397,7 +397,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 129.42653
+  dps: 130.41284
   tps: 42.93312
   hps: 4407.36109
  }
@@ -405,7 +405,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 129.42653
+  dps: 130.41284
   tps: 42.93312
   hps: 4407.36109
  }
@@ -413,7 +413,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 126.62714
+  dps: 127.48575
   tps: 48.55739
   hps: 4452.77211
  }
@@ -421,7 +421,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-RegaliaofFaith"
  value: {
-  dps: 111.52984
+  dps: 112.28454
   tps: 41.21983
   hps: 3890.89353
  }
@@ -429,7 +429,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 132.01409
+  dps: 132.90913
   tps: 48.55739
   hps: 4589.73274
  }
@@ -437,7 +437,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 132.66053
+  dps: 133.55994
   tps: 48.55739
   hps: 4606.16801
  }
@@ -445,7 +445,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 129.42653
+  dps: 130.41284
   tps: 42.93312
   hps: 4407.36109
  }
@@ -453,7 +453,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 131.33617
+  dps: 132.32875
   tps: 43.28021
   hps: 4462.5501
  }
@@ -461,7 +461,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 126.62714
+  dps: 127.48575
   tps: 48.55739
   hps: 4452.77211
  }
@@ -469,7 +469,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-SanctificationGarb"
  value: {
-  dps: 117.90921
+  dps: 118.68408
   tps: 42.10558
   hps: 3820.90174
  }
@@ -477,7 +477,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-SanctificationRegalia"
  value: {
-  dps: 118.37502
+  dps: 119.21396
   tps: 42.562
   hps: 4086.7364
  }
@@ -485,7 +485,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 126.62714
+  dps: 127.48575
   tps: 48.55739
   hps: 4452.77211
  }
@@ -493,7 +493,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 126.62714
+  dps: 127.48575
   tps: 48.55739
   hps: 4452.77211
  }
@@ -501,7 +501,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 126.62714
+  dps: 127.48575
   tps: 48.55739
   hps: 4452.77211
  }
@@ -509,7 +509,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-SparkofLife-37657"
  value: {
-  dps: 126.20387
+  dps: 127.10513
   tps: 48.51917
   hps: 4550.43402
  }
@@ -517,7 +517,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 129.42653
+  dps: 130.41284
   tps: 42.93312
   hps: 4407.36109
  }
@@ -525,7 +525,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 129.42653
+  dps: 130.41284
   tps: 42.93312
   hps: 4407.36109
  }
@@ -533,7 +533,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 129.42653
+  dps: 130.41284
   tps: 42.93312
   hps: 4407.36109
  }
@@ -541,7 +541,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 129.42653
+  dps: 130.41284
   tps: 42.93312
   hps: 4407.36109
  }
@@ -549,7 +549,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 128.29508
+  dps: 129.01972
   tps: 48.55739
   hps: 4452.77211
  }
@@ -557,7 +557,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 128.29508
+  dps: 129.01972
   tps: 48.55739
   hps: 4452.77211
  }
@@ -565,7 +565,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 130.31622
+  dps: 131.30929
   tps: 42.93312
   hps: 4429.46912
  }
@@ -573,7 +573,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 130.13829
+  dps: 131.13
   tps: 42.93312
   hps: 4425.04752
  }
@@ -581,7 +581,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 130.13829
+  dps: 131.13
   tps: 42.93312
   hps: 4425.04752
  }
@@ -589,7 +589,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 130.31622
+  dps: 131.30929
   tps: 42.93312
   hps: 4429.46912
  }
@@ -597,7 +597,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-VestmentsofAbsolution"
  value: {
-  dps: 97.09416
+  dps: 97.39536
   tps: 35.40217
   hps: 3114.57601
  }
@@ -605,7 +605,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-Zabra'sRaiment"
  value: {
-  dps: 124.71338
+  dps: 125.57327
   tps: 44.60932
   hps: 4324.52082
  }
@@ -613,7 +613,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-Zabra'sRegalia"
  value: {
-  dps: 125.18454
+  dps: 125.414
   tps: 44.60932
   hps: 4154.33604
  }
@@ -621,7 +621,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-Average-Default"
  value: {
-  dps: 131.64226
+  dps: 131.1779
   tps: 48.47071
   hps: 4561.24935
  }
@@ -629,7 +629,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-Settings-Undead-P1-Holy-FullBuffs-LongMultiTarget"
  value: {
-  dps: 130.44513
+  dps: 131.34695
   tps: 966.11788
   hps: 4310.56899
  }
@@ -637,7 +637,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-Settings-Undead-P1-Holy-FullBuffs-LongSingleTarget"
  value: {
-  dps: 130.44513
+  dps: 131.34695
   tps: 48.30589
   hps: 4310.56899
  }
@@ -645,7 +645,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-Settings-Undead-P1-Holy-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 647.6457
+  dps: 652.91849
   tps: 184.13932
   hps: 8852.04552
  }
@@ -653,7 +653,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-Settings-Undead-P1-Holy-NoBuffs-LongMultiTarget"
  value: {
-  dps: 58.68054
+  dps: 59.05774
   tps: 473.2568
   hps: 2225.18114
  }
@@ -661,7 +661,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-Settings-Undead-P1-Holy-NoBuffs-LongSingleTarget"
  value: {
-  dps: 58.68054
+  dps: 59.05774
   tps: 23.66284
   hps: 2225.18114
  }
@@ -669,7 +669,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-Settings-Undead-P1-Holy-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 293.40272
+  dps: 295.28871
   tps: 107.12427
   hps: 5576.41096
  }
@@ -677,7 +677,7 @@ dps_results: {
 dps_results: {
  key: "TestHoly-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 111.30317
+  dps: 111.43467
   tps: 48.55739
   hps: 4554.12297
  }

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -45,889 +45,889 @@ character_stats_results: {
 dps_results: {
  key: "TestShadow-AllItems-AbsolutionRegalia"
  value: {
-  dps: 3363.82917
-  tps: 2563.5605
+  dps: 3269.88021
+  tps: 2491.79325
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AshtongueTalismanofAcumen-32490"
  value: {
-  dps: 5103.96035
-  tps: 3896.53708
+  dps: 4975.55708
+  tps: 3799.50951
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5187.73544
-  tps: 3957.16865
+  dps: 5059.77322
+  tps: 3860.37837
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5031.95014
-  tps: 3842.03139
+  dps: 4905.37103
+  tps: 3746.33063
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5283.41236
-  tps: 4029.79826
+  dps: 5152.53187
+  tps: 3929.68021
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 3635.98012
-  tps: 2773.76948
+  dps: 3565.63131
+  tps: 2721.95271
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5222.33602
-  tps: 3904.35033
+  dps: 5093.5148
+  tps: 3808.85939
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 5304.46123
-  tps: 4047.15079
+  dps: 5171.65671
+  tps: 3946.76701
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 5218.18418
-  tps: 3982.50378
+  dps: 5041.673
+  tps: 3850.86878
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 5439.78475
-  tps: 4127.04805
+  dps: 5318.8012
+  tps: 4036.80129
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5031.95014
-  tps: 3842.03139
+  dps: 4905.37103
+  tps: 3746.33063
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5168.77506
-  tps: 3959.69163
+  dps: 5048.4806
+  tps: 3870.48886
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 4746.48031
-  tps: 3619.4263
+  dps: 4633.84097
+  tps: 3533.49951
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 4746.48031
-  tps: 3619.4263
+  dps: 4633.84097
+  tps: 3533.49951
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 4859.39084
-  tps: 3705.18509
+  dps: 4756.68676
+  tps: 3627.07698
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5031.95014
-  tps: 3842.03139
+  dps: 4905.37103
+  tps: 3746.33063
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5215.06055
-  tps: 3977.89028
+  dps: 5085.56525
+  tps: 3879.98712
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5187.73544
-  tps: 3957.16865
+  dps: 5059.77322
+  tps: 3860.37837
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5298.20656
-  tps: 4040.93475
+  dps: 5153.46268
+  tps: 3930.77203
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5210.41445
-  tps: 3974.31432
+  dps: 5080.58022
+  tps: 3876.14287
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5204.65638
-  tps: 3970.27495
+  dps: 5075.24338
+  tps: 3872.41775
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5187.73544
-  tps: 3957.16865
+  dps: 5059.77322
+  tps: 3860.37837
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5181.39895
-  tps: 3974.6955
+  dps: 5066.74291
+  tps: 3887.341
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5294.62789
-  tps: 4040.32619
+  dps: 5161.74563
+  tps: 3939.49518
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5103.99143
-  tps: 3896.50479
+  dps: 4975.08733
+  tps: 3798.73251
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5222.33602
-  tps: 3983.23219
+  dps: 5093.5148
+  tps: 3885.79211
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5215.4159
-  tps: 3978.01948
+  dps: 5086.76648
+  tps: 3880.70936
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5031.95014
-  tps: 3842.03139
+  dps: 4905.37103
+  tps: 3746.33063
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5145.30334
-  tps: 3928.49625
+  dps: 5006.48915
+  tps: 3821.59704
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GarbofFaith"
  value: {
-  dps: 4457.79847
-  tps: 3404.05073
+  dps: 4271.2377
+  tps: 3260.0667
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 5101.0794
-  tps: 3891.74588
+  dps: 4996.51402
+  tps: 3809.77633
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 5310.89693
-  tps: 4042.89491
+  dps: 5149.63044
+  tps: 3922.07435
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5210.41445
-  tps: 3974.31432
+  dps: 5080.58022
+  tps: 3876.14287
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5204.65638
-  tps: 3970.27495
+  dps: 5075.24338
+  tps: 3872.41775
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-IncisorFragment-37723"
  value: {
-  dps: 4975.50676
-  tps: 3801.29487
+  dps: 4824.11725
+  tps: 3685.25321
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5363.25026
-  tps: 4093.96073
+  dps: 5220.80026
+  tps: 3988.24011
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5187.73544
-  tps: 3957.16865
+  dps: 5059.77322
+  tps: 3860.37837
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5031.95014
-  tps: 3842.03139
+  dps: 4905.37103
+  tps: 3746.33063
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5189.62005
-  tps: 3960.56453
+  dps: 5041.85902
+  tps: 3851.31683
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5104.94466
-  tps: 3897.22924
+  dps: 4975.98598
+  tps: 3799.4619
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5031.95014
-  tps: 3842.03139
+  dps: 4905.37103
+  tps: 3746.33063
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5187.73544
-  tps: 3957.16865
+  dps: 5059.77322
+  tps: 3860.37837
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5187.73544
-  tps: 3957.16865
+  dps: 5059.77322
+  tps: 3860.37837
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5187.73544
-  tps: 3957.16865
+  dps: 5059.77322
+  tps: 3860.37837
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5187.73544
-  tps: 3957.16865
+  dps: 5059.77322
+  tps: 3860.37837
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5031.95014
-  tps: 3842.03139
+  dps: 4905.37103
+  tps: 3746.33063
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RegaliaofFaith"
  value: {
-  dps: 4337.06614
-  tps: 3311.80173
+  dps: 4196.2362
+  tps: 3202.54258
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 5250.85195
-  tps: 4011.15418
+  dps: 5114.57506
+  tps: 3904.91127
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 5277.47793
-  tps: 4031.51465
+  dps: 5140.18691
+  tps: 3924.4072
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5279.89791
-  tps: 4028.54292
+  dps: 5149.0843
+  tps: 3929.63227
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5233.57102
-  tps: 3991.43414
+  dps: 5117.23746
+  tps: 3903.10808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5031.95014
-  tps: 3842.03139
+  dps: 4905.37103
+  tps: 3746.33063
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationGarb"
  value: {
-  dps: 4656.23208
-  tps: 3563.98836
+  dps: 4564.75169
+  tps: 3494.88287
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationRegalia"
  value: {
-  dps: 4566.6567
-  tps: 3488.01329
+  dps: 4486.89421
+  tps: 3427.97993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5031.95014
-  tps: 3842.03139
+  dps: 4905.37103
+  tps: 3746.33063
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5031.95014
-  tps: 3842.03139
+  dps: 4905.37103
+  tps: 3746.33063
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5031.95014
-  tps: 3842.03139
+  dps: 4905.37103
+  tps: 3746.33063
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SparkofLife-37657"
  value: {
-  dps: 5150.59918
-  tps: 3937.33403
+  dps: 5034.42238
+  tps: 3845.90772
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5187.73544
-  tps: 3957.16865
+  dps: 5059.77322
+  tps: 3860.37837
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5187.73544
-  tps: 3957.16865
+  dps: 5059.77322
+  tps: 3860.37837
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5187.73544
-  tps: 3957.16865
+  dps: 5059.77322
+  tps: 3860.37837
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5187.73544
-  tps: 3957.16865
+  dps: 5059.77322
+  tps: 3860.37837
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5026.13896
-  tps: 3839.10928
+  dps: 4988.09422
+  tps: 3809.01767
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5026.13896
-  tps: 3839.10928
+  dps: 4988.09422
+  tps: 3809.01767
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5222.33602
-  tps: 3983.23219
+  dps: 5093.5148
+  tps: 3885.79211
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5215.4159
-  tps: 3978.01948
+  dps: 5086.76648
+  tps: 3880.70936
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5215.4159
-  tps: 3978.01948
+  dps: 5086.76648
+  tps: 3880.70936
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5222.33602
-  tps: 3983.23219
+  dps: 5093.5148
+  tps: 3885.79211
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VestmentsofAbsolution"
  value: {
-  dps: 3169.03176
-  tps: 2416.94366
+  dps: 3113.03589
+  tps: 2373.93148
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRaiment"
  value: {
-  dps: 4943.92322
-  tps: 3772.44715
+  dps: 4767.27311
+  tps: 3639.07273
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRegalia"
  value: {
-  dps: 5314.94665
-  tps: 4057.2645
+  dps: 5284.91635
+  tps: 4033.99911
  }
 }
 dps_results: {
  key: "TestShadow-Average-Default"
  value: {
-  dps: 5274.05869
-  tps: 4020.23358
+  dps: 5144.20438
+  tps: 3921.77192
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3383.22265
-  tps: 3378.87915
+  dps: 3378.61212
+  tps: 3377.31788
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3383.22265
-  tps: 2592.77017
+  dps: 3378.61212
+  tps: 2591.20891
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3592.27714
-  tps: 2874.10312
+  dps: 3577.49717
+  tps: 2862.24903
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1222.15101
-  tps: 1234.40135
+  dps: 1219.03851
+  tps: 1231.81086
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1222.15101
-  tps: 926.68368
+  dps: 1219.03851
+  tps: 924.09319
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1907.38368
-  tps: 1398.53666
+  dps: 1890.08096
+  tps: 1384.53939
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4020.01848
-  tps: 3832.09983
+  dps: 3979.4431
+  tps: 3799.79985
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4020.01848
-  tps: 3072.00492
+  dps: 3979.4431
+  tps: 3041.10711
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5641.41935
-  tps: 4454.05567
+  dps: 5569.20455
+  tps: 4398.47402
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1319.29216
-  tps: 1306.40555
+  dps: 1308.2189
+  tps: 1297.86293
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1319.29216
-  tps: 998.68789
+  dps: 1308.2189
+  tps: 990.14526
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3212.02445
-  tps: 2340.39013
+  dps: 3192.91906
+  tps: 2327.27159
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4816.517
-  tps: 4425.47443
+  dps: 4722.91751
+  tps: 4353.22779
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4816.517
-  tps: 3678.97847
+  dps: 4722.91751
+  tps: 3606.95509
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5625.49518
-  tps: 4415.8085
+  dps: 5508.49951
+  tps: 4325.64821
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1536.35116
-  tps: 1467.46451
+  dps: 1509.27351
+  tps: 1445.64709
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1536.35116
-  tps: 1159.74685
+  dps: 1509.27351
+  tps: 1137.92943
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3099.17474
-  tps: 2254.64858
+  dps: 3012.43468
+  tps: 2192.46519
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3383.28299
-  tps: 3377.14725
+  dps: 3377.93383
+  tps: 3374.12037
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3383.28299
-  tps: 2593.09594
+  dps: 3377.93383
+  tps: 2590.06906
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3590.98886
-  tps: 2873.06383
+  dps: 3576.33772
+  tps: 2861.31924
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1218.56734
-  tps: 1232.91421
+  dps: 1217.51819
+  tps: 1230.63121
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1218.56734
-  tps: 925.4578
+  dps: 1217.51819
+  tps: 923.17479
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1905.51233
-  tps: 1394.57372
+  dps: 1890.41743
+  tps: 1381.00913
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4005.60409
-  tps: 3823.26523
+  dps: 3968.47268
+  tps: 3791.80104
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4005.60409
-  tps: 3062.52185
+  dps: 3968.47268
+  tps: 3032.97215
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5630.55431
-  tps: 4444.73311
+  dps: 5550.63742
+  tps: 4384.34575
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1317.53262
-  tps: 1304.84786
+  dps: 1296.433
+  tps: 1289.78915
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1317.53262
-  tps: 997.39144
+  dps: 1296.433
+  tps: 982.33273
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3205.99693
-  tps: 2337.39443
+  dps: 3152.59855
+  tps: 2298.07151
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4811.10078
-  tps: 4420.46312
+  dps: 4682.80948
+  tps: 4322.46105
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4811.10078
-  tps: 3675.02315
+  dps: 4682.80948
+  tps: 3576.67839
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5626.87457
-  tps: 4415.99524
+  dps: 5486.37576
+  tps: 4309.61194
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1552.7655
-  tps: 1475.96887
+  dps: 1507.07344
+  tps: 1441.62058
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1552.7655
-  tps: 1168.51245
+  dps: 1507.07344
+  tps: 1134.16417
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3106.23894
-  tps: 2261.47611
+  dps: 3008.00263
+  tps: 2186.76978
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3383.28299
-  tps: 3376.18593
+  dps: 3377.93383
+  tps: 3373.15904
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3383.28299
-  tps: 2593.04787
+  dps: 3377.93383
+  tps: 2590.02099
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3590.98886
-  tps: 2872.97772
+  dps: 3576.33772
+  tps: 2861.23313
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1220.11348
-  tps: 1233.54624
+  dps: 1219.06253
+  tps: 1231.2405
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1220.11348
-  tps: 926.61232
+  dps: 1219.06253
+  tps: 924.30659
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1904.01076
-  tps: 1393.35128
+  dps: 1889.06602
+  tps: 1379.90081
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4005.15608
-  tps: 3823.05102
+  dps: 3959.08294
+  tps: 3785.10155
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4005.15608
-  tps: 3062.87617
+  dps: 3959.08294
+  tps: 3026.71508
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5630.55431
-  tps: 4444.66711
+  dps: 5550.63742
+  tps: 4384.27975
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1314.82593
-  tps: 1302.289
+  dps: 1295.30026
+  tps: 1288.34958
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1314.82593
-  tps: 995.35508
+  dps: 1295.30026
+  tps: 981.41566
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3203.41135
-  tps: 2335.29189
+  dps: 3151.81031
+  tps: 2297.33495
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4813.08599
-  tps: 4420.00294
+  dps: 4682.80948
+  tps: 4321.55847
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4813.08599
-  tps: 3676.01147
+  dps: 4682.80948
+  tps: 3576.63326
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5626.87457
-  tps: 4415.92924
+  dps: 5486.37576
+  tps: 4309.54594
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1516.55291
-  tps: 1451.52748
+  dps: 1485.64803
+  tps: 1428.22941
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1516.55291
-  tps: 1144.59356
+  dps: 1485.64803
+  tps: 1121.2955
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3105.1645
-  tps: 2260.52204
+  dps: 3006.9282
+  tps: 2185.81572
  }
 }
 dps_results: {
  key: "TestShadow-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5293.46702
-  tps: 4047.15079
+  dps: 5161.9384
+  tps: 3946.76701
  }
 }

--- a/sim/priest/smite/TestSmite.results
+++ b/sim/priest/smite/TestSmite.results
@@ -45,560 +45,560 @@ character_stats_results: {
 dps_results: {
  key: "TestSmite-AllItems-AbsolutionRegalia"
  value: {
-  dps: 2156.06633
-  tps: 1839.61503
+  dps: 2150.10037
+  tps: 1833.58661
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-AshtongueTalismanofAcumen-32490"
  value: {
-  dps: 2942.28569
-  tps: 2479.42806
+  dps: 2930.75867
+  tps: 2469.53626
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 3023.32739
-  tps: 2554.00244
+  dps: 3022.34406
+  tps: 2552.70764
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2907.31757
-  tps: 2451.23961
+  dps: 2895.7258
+  tps: 2441.34191
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 3043.821
-  tps: 2570.95006
+  dps: 3045.26375
+  tps: 2571.51387
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 2387.30573
-  tps: 2026.25334
+  dps: 2386.61618
+  tps: 2025.00889
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 3042.65214
-  tps: 2519.60769
+  dps: 3041.66223
+  tps: 2518.32923
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 3063.01477
-  tps: 2586.11425
+  dps: 3045.61409
+  tps: 2571.55568
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 3470.16793
-  tps: 2925.94785
+  dps: 3478.18242
+  tps: 2929.99098
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 3164.52988
-  tps: 2668.78161
+  dps: 3154.79994
+  tps: 2660.65146
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2905.50164
-  tps: 2447.73696
+  dps: 2904.85298
+  tps: 2446.28883
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2983.56632
-  tps: 2524.78593
+  dps: 2975.4547
+  tps: 2514.79233
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 2799.73814
-  tps: 2356.76503
+  dps: 2798.08306
+  tps: 2356.81633
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 2799.73814
-  tps: 2356.76503
+  dps: 2798.08306
+  tps: 2356.81633
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 2868.86585
-  tps: 2414.32779
+  dps: 2859.57013
+  tps: 2407.65938
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Defender'sCode-40257"
  value: {
-  dps: 2907.31757
-  tps: 2451.23961
+  dps: 2895.7258
+  tps: 2441.34191
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 3023.91269
-  tps: 2554.6107
+  dps: 3007.5387
+  tps: 2539.92912
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 3023.32739
-  tps: 2554.00244
+  dps: 3022.34406
+  tps: 2552.70764
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 3091.68889
-  tps: 2609.81776
+  dps: 3074.14987
+  tps: 2596.37363
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 3031.72322
-  tps: 2560.25393
+  dps: 3014.64322
+  tps: 2545.9645
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 3031.34996
-  tps: 2560.09825
+  dps: 3014.51391
+  tps: 2545.74372
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 3023.32739
-  tps: 2554.00244
+  dps: 3022.34406
+  tps: 2552.70764
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2974.57667
-  tps: 2514.38993
+  dps: 2967.34922
+  tps: 2509.83814
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2996.16999
-  tps: 2520.1788
+  dps: 2994.42569
+  tps: 2520.26669
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2991.43985
-  tps: 2520.858
+  dps: 2984.65898
+  tps: 2512.01641
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 3042.65214
-  tps: 2569.74344
+  dps: 3041.66223
+  tps: 2568.43889
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 3038.78719
-  tps: 2566.59524
+  dps: 3037.7986
+  tps: 2565.29264
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2907.31757
-  tps: 2451.23961
+  dps: 2895.7258
+  tps: 2441.34191
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2934.13114
-  tps: 2473.75901
+  dps: 2937.61334
+  tps: 2476.49236
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-GarbofFaith"
  value: {
-  dps: 2721.92128
-  tps: 2308.5258
+  dps: 2702.1491
+  tps: 2291.65314
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 3584.4994
-  tps: 3025.76791
+  dps: 3564.88358
+  tps: 3007.13016
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 3137.699
-  tps: 2645.05858
+  dps: 3127.02922
+  tps: 2634.8304
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 3051.34274
-  tps: 2568.13907
+  dps: 3039.21561
+  tps: 2557.78346
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 3031.72322
-  tps: 2560.25393
+  dps: 3014.64322
+  tps: 2545.9645
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 3031.34996
-  tps: 2560.09825
+  dps: 3014.51391
+  tps: 2545.74372
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2907.31757
-  tps: 2451.23961
+  dps: 2895.7258
+  tps: 2441.34191
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 3141.04718
-  tps: 2657.74221
+  dps: 3132.14977
+  tps: 2649.76985
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 3023.32739
-  tps: 2554.00244
+  dps: 3022.34406
+  tps: 2552.70764
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2907.31757
-  tps: 2451.23961
+  dps: 2895.7258
+  tps: 2441.34191
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 3097.03288
-  tps: 2612.84262
+  dps: 3083.91636
+  tps: 2602.30475
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2933.49469
-  tps: 2471.94643
+  dps: 2926.60239
+  tps: 2462.93956
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2907.31757
-  tps: 2451.23961
+  dps: 2895.7258
+  tps: 2441.34191
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 3023.32739
-  tps: 2554.00244
+  dps: 3022.34406
+  tps: 2552.70764
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 3023.32739
-  tps: 2554.00244
+  dps: 3022.34406
+  tps: 2552.70764
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 3023.32739
-  tps: 2554.00244
+  dps: 3022.34406
+  tps: 2552.70764
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 3023.32739
-  tps: 2554.00244
+  dps: 3022.34406
+  tps: 2552.70764
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2907.31757
-  tps: 2451.23961
+  dps: 2895.7258
+  tps: 2441.34191
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RegaliaofFaith"
  value: {
-  dps: 2753.50743
-  tps: 2334.98337
+  dps: 2753.55419
+  tps: 2334.67541
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 3166.88509
-  tps: 2687.22209
+  dps: 3158.39918
+  tps: 2678.6494
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 3196.82296
-  tps: 2714.66362
+  dps: 3188.1773
+  tps: 2705.9308
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 3054.18701
-  tps: 2579.48635
+  dps: 3053.2684
+  tps: 2578.25166
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 3037.39286
-  tps: 2566.9809
+  dps: 3027.53882
+  tps: 2559.12986
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2907.31757
-  tps: 2451.23961
+  dps: 2895.7258
+  tps: 2441.34191
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SanctificationGarb"
  value: {
-  dps: 2860.58048
-  tps: 2425.51369
+  dps: 2847.17396
+  tps: 2414.61508
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SanctificationRegalia"
  value: {
-  dps: 2920.4084
-  tps: 2473.53952
+  dps: 2912.30264
+  tps: 2466.57517
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2907.31757
-  tps: 2451.23961
+  dps: 2895.7258
+  tps: 2441.34191
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2907.31757
-  tps: 2451.23961
+  dps: 2895.7258
+  tps: 2441.34191
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2907.31757
-  tps: 2451.23961
+  dps: 2895.7258
+  tps: 2441.34191
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SparkofLife-37657"
  value: {
-  dps: 2923.60895
-  tps: 2463.03578
+  dps: 2918.60385
+  tps: 2460.10427
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 3023.32739
-  tps: 2554.00244
+  dps: 3022.34406
+  tps: 2552.70764
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 3023.32739
-  tps: 2554.00244
+  dps: 3022.34406
+  tps: 2552.70764
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 3023.32739
-  tps: 2554.00244
+  dps: 3022.34406
+  tps: 2552.70764
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 3023.32739
-  tps: 2554.00244
+  dps: 3022.34406
+  tps: 2552.70764
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2907.31757
-  tps: 2451.23961
+  dps: 2895.7258
+  tps: 2441.34191
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2907.31757
-  tps: 2451.23961
+  dps: 2895.7258
+  tps: 2441.34191
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 3042.65214
-  tps: 2569.74344
+  dps: 3041.66223
+  tps: 2568.43889
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 3038.78719
-  tps: 2566.59524
+  dps: 3037.7986
+  tps: 2565.29264
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 3038.78719
-  tps: 2566.59524
+  dps: 3037.7986
+  tps: 2565.29264
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 3042.65214
-  tps: 2569.74344
+  dps: 3041.66223
+  tps: 2568.43889
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-VestmentsofAbsolution"
  value: {
-  dps: 2110.13597
-  tps: 1802.90911
+  dps: 2096.69277
+  tps: 1791.79934
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Zabra'sRaiment"
  value: {
-  dps: 3203.46742
-  tps: 2707.64327
+  dps: 3193.51539
+  tps: 2699.47514
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Zabra'sRegalia"
  value: {
-  dps: 3081.7861
-  tps: 2608.62555
+  dps: 3084.03205
+  tps: 2608.93514
  }
 }
 dps_results: {
  key: "TestSmite-Average-Default"
  value: {
-  dps: 3017.99511
-  tps: 2545.85685
+  dps: 3010.56977
+  tps: 2539.6289
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2793.33487
-  tps: 3566.07176
+  dps: 2778.41469
+  tps: 3552.56653
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2793.33487
-  tps: 2369.41493
+  dps: 2778.41469
+  tps: 2355.90969
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3781.95889
-  tps: 3262.68971
+  dps: 3728.49099
+  tps: 3215.3775
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 890.58755
-  tps: 1227.83549
+  dps: 887.64435
+  tps: 1226.10905
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 890.58755
-  tps: 765.40866
+  dps: 887.64435
+  tps: 763.68222
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2326.13232
-  tps: 1855.53593
+  dps: 2310.79738
+  tps: 1845.63013
  }
 }
 dps_results: {
  key: "TestSmite-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3012.5155
-  tps: 2554.6107
+  dps: 2995.67579
+  tps: 2539.92912
  }
 }

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -45,826 +45,826 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7295.66563
-  tps: 5179.9226
+  dps: 7286.70039
+  tps: 5173.55728
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7383.84195
-  tps: 5242.52779
+  dps: 7362.7557
+  tps: 5227.55655
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7382.01371
-  tps: 5241.22973
+  dps: 7366.74457
+  tps: 5230.38865
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7362.05231
-  tps: 5227.05714
+  dps: 7340.27692
+  tps: 5211.59661
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5526.78452
-  tps: 3924.01701
+  dps: 5508.43991
+  tps: 3910.99234
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6408.25956
-  tps: 4549.86429
+  dps: 6399.15393
+  tps: 4543.39929
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7383.84195
-  tps: 5137.67723
+  dps: 7362.7557
+  tps: 5123.00542
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7481.09416
-  tps: 5311.57685
+  dps: 7458.9745
+  tps: 5295.8719
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7323.73253
-  tps: 5199.85009
+  dps: 7304.42666
+  tps: 5186.14293
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7349.52566
-  tps: 5218.16322
+  dps: 7324.62236
+  tps: 5200.48188
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 7451.90271
-  tps: 5290.85093
+  dps: 7437.64008
+  tps: 5280.72446
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7364.80321
-  tps: 5229.01028
+  dps: 7350.69459
+  tps: 5218.99316
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7157.03877
-  tps: 5081.49753
+  dps: 7145.33051
+  tps: 5073.18466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7380.2113
-  tps: 5239.95002
+  dps: 7361.80939
+  tps: 5226.88466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7383.84195
-  tps: 5242.52779
+  dps: 7362.7557
+  tps: 5227.55655
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7383.84195
-  tps: 5242.52779
+  dps: 7362.7557
+  tps: 5227.55655
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7362.05231
-  tps: 5227.05714
+  dps: 7340.27692
+  tps: 5211.59661
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7362.83689
-  tps: 5227.61419
+  dps: 7344.10433
+  tps: 5214.31408
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7383.84195
-  tps: 5242.52779
+  dps: 7362.7557
+  tps: 5227.55655
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7331.1895
-  tps: 5205.14454
+  dps: 7313.08971
+  tps: 5192.29369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7329.97451
-  tps: 5204.2819
+  dps: 7318.26902
+  tps: 5195.971
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7290.06973
-  tps: 5175.94951
+  dps: 7270.22369
+  tps: 5161.85882
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7383.84195
-  tps: 5242.52779
+  dps: 7362.7557
+  tps: 5227.55655
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7383.84195
-  tps: 5242.52779
+  dps: 7362.7557
+  tps: 5227.55655
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7432.43423
-  tps: 5277.0283
+  dps: 7420.23294
+  tps: 5268.36539
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7157.03877
-  tps: 5081.49753
+  dps: 7145.33051
+  tps: 5073.18466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7251.45489
-  tps: 5148.53297
+  dps: 7224.31369
+  tps: 5129.26272
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7157.03877
-  tps: 5081.49753
+  dps: 7145.33051
+  tps: 5073.18466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7362.05231
-  tps: 5227.05714
+  dps: 7340.27692
+  tps: 5211.59661
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7362.83689
-  tps: 5227.61419
+  dps: 7344.10433
+  tps: 5214.31408
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7346.45423
-  tps: 5215.9825
+  dps: 7335.02941
+  tps: 5207.87088
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7383.84195
-  tps: 5242.52779
+  dps: 7362.7557
+  tps: 5227.55655
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7420.57142
-  tps: 5268.60571
+  dps: 7399.38191
+  tps: 5253.56115
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7157.03877
-  tps: 5081.49753
+  dps: 7145.33051
+  tps: 5073.18466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7157.03877
-  tps: 5081.49753
+  dps: 7145.33051
+  tps: 5073.18466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7430.47346
-  tps: 5275.63616
+  dps: 7412.71944
+  tps: 5263.0308
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7157.03877
-  tps: 5081.49753
+  dps: 7145.33051
+  tps: 5073.18466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7413.57533
-  tps: 5263.63848
+  dps: 7392.40549
+  tps: 5248.6079
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7420.57142
-  tps: 5268.60571
+  dps: 7399.38191
+  tps: 5253.56115
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7383.84195
-  tps: 5242.52779
+  dps: 7362.7557
+  tps: 5227.55655
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7383.84195
-  tps: 5242.52779
+  dps: 7362.7557
+  tps: 5227.55655
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7157.03877
-  tps: 5081.49753
+  dps: 7145.33051
+  tps: 5073.18466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7157.03877
-  tps: 5081.49753
+  dps: 7145.33051
+  tps: 5073.18466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7157.03877
-  tps: 5081.49753
+  dps: 7145.33051
+  tps: 5073.18466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7477.72836
-  tps: 5309.18714
+  dps: 7461.56741
+  tps: 5297.71286
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7383.84195
-  tps: 5242.52779
+  dps: 7362.7557
+  tps: 5227.55655
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7157.03877
-  tps: 5081.49753
+  dps: 7145.33051
+  tps: 5073.18466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7157.03877
-  tps: 5081.49753
+  dps: 7145.33051
+  tps: 5073.18466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7767.15606
-  tps: 5514.6808
+  dps: 7741.17112
+  tps: 5496.2315
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7157.03877
-  tps: 5081.49753
+  dps: 7145.33051
+  tps: 5073.18466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7157.03877
-  tps: 5081.49753
+  dps: 7145.33051
+  tps: 5073.18466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 5440.17858
-  tps: 3862.52679
+  dps: 5425.30043
+  tps: 3851.9633
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 7276.57159
-  tps: 5166.36583
+  dps: 7262.22834
+  tps: 5156.18212
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StormshroudArmor"
  value: {
-  dps: 5782.80632
-  tps: 4105.79249
+  dps: 5771.49874
+  tps: 4097.7641
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7420.57142
-  tps: 5268.60571
+  dps: 7399.38191
+  tps: 5253.56115
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7413.57533
-  tps: 5263.63848
+  dps: 7392.40549
+  tps: 5248.6079
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7401.33217
-  tps: 5254.94584
+  dps: 7380.19675
+  tps: 5239.93969
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6701.89752
-  tps: 4758.34724
+  dps: 6692.67018
+  tps: 4751.79583
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheFistsofFury"
  value: {
-  dps: 6267.08258
-  tps: 4449.62863
+  dps: 6255.14018
+  tps: 4441.14953
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7423.60212
-  tps: 5270.75751
+  dps: 7404.12656
+  tps: 5256.92986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7557.40389
-  tps: 5365.75676
+  dps: 7540.83634
+  tps: 5353.9938
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7565.80937
-  tps: 5371.72465
+  dps: 7549.80219
+  tps: 5360.35956
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7383.84195
-  tps: 5242.52779
+  dps: 7362.7557
+  tps: 5227.55655
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7383.84195
-  tps: 5242.52779
+  dps: 7362.7557
+  tps: 5227.55655
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7383.84195
-  tps: 5242.52779
+  dps: 7362.7557
+  tps: 5227.55655
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7383.84195
-  tps: 5242.52779
+  dps: 7362.7557
+  tps: 5227.55655
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5845.25667
-  tps: 4150.13223
+  dps: 5836.50903
+  tps: 4143.92141
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 7127.86844
-  tps: 5060.78659
+  dps: 7111.79733
+  tps: 5049.3761
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 7440.10723
-  tps: 5282.47613
+  dps: 7428.50387
+  tps: 5274.23775
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26087.69705
-  tps: 18522.2649
+  dps: 26036.65748
+  tps: 18486.02681
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7477.72836
-  tps: 5309.18714
+  dps: 7461.56741
+  tps: 5297.71286
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8514.69124
-  tps: 6045.43078
+  dps: 8482.2793
+  tps: 6022.4183
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15277.54622
-  tps: 10847.05782
+  dps: 15246.43489
+  tps: 10824.96877
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3816.11816
-  tps: 2709.44389
+  dps: 3806.15988
+  tps: 2702.37351
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3822.88568
-  tps: 2714.24883
+  dps: 3800.62714
+  tps: 2698.44527
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15892.90994
-  tps: 11283.96606
+  dps: 15876.43622
+  tps: 11272.26972
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5347.74283
-  tps: 3796.89741
+  dps: 5342.3989
+  tps: 3793.10322
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6299.6283
-  tps: 4472.73609
+  dps: 6289.40304
+  tps: 4465.47616
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9006.59082
-  tps: 6394.67948
+  dps: 8991.97337
+  tps: 6384.30109
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2506.32658
-  tps: 1779.49187
+  dps: 2500.24968
+  tps: 1775.17727
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2598.98977
-  tps: 1845.28274
+  dps: 2583.41244
+  tps: 1834.22284
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26087.69705
-  tps: 18522.2649
+  dps: 26036.65748
+  tps: 18486.02681
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7477.72836
-  tps: 5309.18714
+  dps: 7461.56741
+  tps: 5297.71286
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8514.69124
-  tps: 6045.43078
+  dps: 8482.2793
+  tps: 6022.4183
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15277.54622
-  tps: 10847.05782
+  dps: 15246.43489
+  tps: 10824.96877
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3816.11816
-  tps: 2709.44389
+  dps: 3806.15988
+  tps: 2702.37351
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3822.88568
-  tps: 2714.24883
+  dps: 3800.62714
+  tps: 2698.44527
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20152.30381
-  tps: 14308.13571
+  dps: 20122.80816
+  tps: 14287.19379
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4888.08037
-  tps: 3470.53706
+  dps: 4880.18498
+  tps: 3464.93133
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5540.98164
-  tps: 3934.09696
+  dps: 5553.93608
+  tps: 3943.29462
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12952.02881
-  tps: 9195.94046
+  dps: 12929.97492
+  tps: 9180.28219
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2544.72811
-  tps: 1806.75696
+  dps: 2542.99194
+  tps: 1805.52428
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2605.40523
-  tps: 1849.83771
+  dps: 2593.14026
+  tps: 1841.12958
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26238.41814
-  tps: 18629.27688
+  dps: 26186.77596
+  tps: 18592.61094
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7532.10146
-  tps: 5347.79204
+  dps: 7504.70565
+  tps: 5328.34101
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8615.31042
-  tps: 6116.8704
+  dps: 8582.2455
+  tps: 6093.3943
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15303.68517
-  tps: 10865.61647
+  dps: 15273.35326
+  tps: 10844.08082
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3839.26803
-  tps: 2725.8803
+  dps: 3833.36268
+  tps: 2721.6875
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3888.78442
-  tps: 2761.03694
+  dps: 3856.86891
+  tps: 2738.37692
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15969.4521
-  tps: 11338.31099
+  dps: 15954.57947
+  tps: 11327.75143
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5371.90213
-  tps: 3814.05051
+  dps: 5362.56616
+  tps: 3807.42197
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6380.48725
-  tps: 4530.14594
+  dps: 6370.05756
+  tps: 4522.74087
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9042.42193
-  tps: 6420.11957
+  dps: 9027.66319
+  tps: 6409.64086
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2521.38176
-  tps: 1790.18105
+  dps: 2518.51605
+  tps: 1788.14639
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2644.45164
-  tps: 1877.56066
+  dps: 2627.87729
+  tps: 1865.79288
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26238.41814
-  tps: 18629.27688
+  dps: 26186.77596
+  tps: 18592.61094
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7532.10146
-  tps: 5347.79204
+  dps: 7504.70565
+  tps: 5328.34101
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8615.31042
-  tps: 6116.8704
+  dps: 8582.2455
+  tps: 6093.3943
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15303.68517
-  tps: 10865.61647
+  dps: 15273.35326
+  tps: 10844.08082
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3839.26803
-  tps: 2725.8803
+  dps: 3833.36268
+  tps: 2721.6875
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3888.78442
-  tps: 2761.03694
+  dps: 3856.86891
+  tps: 2738.37692
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20236.5348
-  tps: 14367.93971
+  dps: 20207.92608
+  tps: 14347.62752
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4924.75402
-  tps: 3496.57535
+  dps: 4914.54069
+  tps: 3489.32389
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5604.04297
-  tps: 3978.87051
+  dps: 5616.54921
+  tps: 3987.74994
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13016.45802
-  tps: 9241.68519
+  dps: 12997.07895
+  tps: 9227.92605
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2558.90621
-  tps: 1816.82341
+  dps: 2552.79599
+  tps: 1812.48515
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2645.631
-  tps: 1878.39801
+  dps: 2643.18483
+  tps: 1876.66123
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6972.18868
-  tps: 4950.25396
+  dps: 6951.10893
+  tps: 4935.28734
  }
 }

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -45,833 +45,833 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 6380.145
-  tps: 4529.90295
+  dps: 6373.27635
+  tps: 4525.02621
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6418.19613
-  tps: 4556.91926
+  dps: 6411.09797
+  tps: 4551.87956
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6500.9395
-  tps: 4615.66705
+  dps: 6493.98068
+  tps: 4610.72629
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6443.43611
-  tps: 4574.83964
+  dps: 6436.38265
+  tps: 4569.83168
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4993.99897
-  tps: 3545.73927
+  dps: 4988.73651
+  tps: 3542.00292
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BonescytheBattlegear"
  value: {
-  dps: 5760.89059
-  tps: 4090.23232
+  dps: 5755.54207
+  tps: 4086.43487
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6418.19613
-  tps: 4465.78087
+  dps: 6411.09797
+  tps: 4460.84197
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6559.69432
-  tps: 4657.38297
+  dps: 6552.64852
+  tps: 4652.38045
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6417.77171
-  tps: 4556.61791
+  dps: 6411.591
+  tps: 4552.22961
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6451.40573
-  tps: 4580.49807
+  dps: 6446.02677
+  tps: 4576.67901
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6512.03779
-  tps: 4623.54683
+  dps: 6504.93286
+  tps: 4618.50233
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6434.86635
-  tps: 4568.75511
+  dps: 6427.8476
+  tps: 4563.77179
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6298.94623
-  tps: 4472.25183
+  dps: 6292.02717
+  tps: 4467.33929
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6447.83791
-  tps: 4577.96492
+  dps: 6440.80666
+  tps: 4572.97273
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6418.19613
-  tps: 4556.91926
+  dps: 6411.09797
+  tps: 4551.87956
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6418.19613
-  tps: 4556.91926
+  dps: 6411.09797
+  tps: 4551.87956
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6443.43611
-  tps: 4574.83964
+  dps: 6436.38265
+  tps: 4569.83168
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6438.26827
-  tps: 4571.17047
+  dps: 6431.27468
+  tps: 4566.20502
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6418.19613
-  tps: 4556.91926
+  dps: 6411.09797
+  tps: 4551.87956
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6440.6102
-  tps: 4572.83324
+  dps: 6434.42616
+  tps: 4568.44257
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6395.54042
-  tps: 4540.8337
+  dps: 6389.27408
+  tps: 4536.38459
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6378.0046
-  tps: 4528.38327
+  dps: 6371.54626
+  tps: 4523.79784
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6418.19613
-  tps: 4556.91926
+  dps: 6411.09797
+  tps: 4551.87956
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6418.19613
-  tps: 4556.91926
+  dps: 6411.09797
+  tps: 4551.87956
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6544.195
-  tps: 4646.37845
+  dps: 6536.99643
+  tps: 4641.26747
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6298.94623
-  tps: 4472.25183
+  dps: 6292.02717
+  tps: 4467.33929
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Gladiator'sVestments"
  value: {
-  dps: 6498.39892
-  tps: 4613.86323
+  dps: 6493.33199
+  tps: 4610.26571
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6298.94623
-  tps: 4472.25183
+  dps: 6292.02717
+  tps: 4467.33929
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6443.43611
-  tps: 4574.83964
+  dps: 6436.38265
+  tps: 4569.83168
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6438.26827
-  tps: 4571.17047
+  dps: 6431.27468
+  tps: 4566.20502
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6479.27509
-  tps: 4600.28531
+  dps: 6469.36917
+  tps: 4593.25211
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6418.19613
-  tps: 4556.91926
+  dps: 6411.09797
+  tps: 4551.87956
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6450.55221
-  tps: 4579.89207
+  dps: 6443.41748
+  tps: 4574.82641
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6298.94623
-  tps: 4472.25183
+  dps: 6292.02717
+  tps: 4467.33929
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6298.94623
-  tps: 4472.25183
+  dps: 6292.02717
+  tps: 4467.33929
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6511.69637
-  tps: 4623.30442
+  dps: 6505.98233
+  tps: 4619.24745
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6298.94623
-  tps: 4472.25183
+  dps: 6292.02717
+  tps: 4467.33929
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6444.38915
-  tps: 4575.5163
+  dps: 6437.26138
+  tps: 4570.45558
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6450.55221
-  tps: 4579.89207
+  dps: 6443.41748
+  tps: 4574.82641
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6418.19613
-  tps: 4556.91926
+  dps: 6411.09797
+  tps: 4551.87956
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6418.19613
-  tps: 4556.91926
+  dps: 6411.09797
+  tps: 4551.87956
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6298.94623
-  tps: 4472.25183
+  dps: 6292.02717
+  tps: 4467.33929
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6298.94623
-  tps: 4472.25183
+  dps: 6292.02717
+  tps: 4467.33929
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6298.94623
-  tps: 4472.25183
+  dps: 6292.02717
+  tps: 4467.33929
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6561.26441
-  tps: 4658.49773
+  dps: 6554.10001
+  tps: 4653.41101
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6418.19613
-  tps: 4556.91926
+  dps: 6411.09797
+  tps: 4551.87956
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6298.94623
-  tps: 4472.25183
+  dps: 6292.02717
+  tps: 4467.33929
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6298.94623
-  tps: 4472.25183
+  dps: 6292.02717
+  tps: 4467.33929
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 6777.4198
-  tps: 4811.96805
+  dps: 6770.00526
+  tps: 4806.70373
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6298.94623
-  tps: 4472.25183
+  dps: 6292.02717
+  tps: 4467.33929
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6298.94623
-  tps: 4472.25183
+  dps: 6292.02717
+  tps: 4467.33929
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Slayer'sArmor"
  value: {
-  dps: 4925.42311
-  tps: 3497.05041
+  dps: 4920.05712
+  tps: 3493.24056
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SparkofLife-37657"
  value: {
-  dps: 6402.53173
-  tps: 4545.79753
+  dps: 6393.63875
+  tps: 4539.48351
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StormshroudArmor"
  value: {
-  dps: 5048.93832
-  tps: 3584.74621
+  dps: 5043.18676
+  tps: 3580.6626
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6450.55221
-  tps: 4579.89207
+  dps: 6443.41748
+  tps: 4574.82641
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6444.38915
-  tps: 4575.5163
+  dps: 6437.26138
+  tps: 4570.45558
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6433.60379
-  tps: 4567.85869
+  dps: 6426.48821
+  tps: 4562.80663
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6068.21592
-  tps: 4308.4333
+  dps: 6061.35019
+  tps: 4303.55863
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheFistsofFury"
  value: {
-  dps: 5712.75846
-  tps: 4056.05851
+  dps: 5708.2362
+  tps: 4052.8477
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5847.14178
-  tps: 4151.47066
+  dps: 5844.12279
+  tps: 4149.32718
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6503.71732
-  tps: 4617.6393
+  dps: 6495.60097
+  tps: 4611.87669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6590.75879
-  tps: 4679.43874
+  dps: 6580.66246
+  tps: 4672.27034
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6615.50929
-  tps: 4697.01159
+  dps: 6607.59851
+  tps: 4691.39494
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6418.19613
-  tps: 4556.91926
+  dps: 6411.09797
+  tps: 4551.87956
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6418.19613
-  tps: 4556.91926
+  dps: 6411.09797
+  tps: 4551.87956
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6418.19613
-  tps: 4556.91926
+  dps: 6411.09797
+  tps: 4551.87956
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6418.19613
-  tps: 4556.91926
+  dps: 6411.09797
+  tps: 4551.87956
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5287.46913
-  tps: 3754.10308
+  dps: 5279.92182
+  tps: 3748.74449
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6276.89626
-  tps: 4456.59635
+  dps: 6268.35962
+  tps: 4450.53533
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 6501.15442
-  tps: 4615.81964
+  dps: 6495.40035
+  tps: 4611.73425
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14286.30644
-  tps: 10143.27758
+  dps: 14268.59838
+  tps: 10130.70485
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5568.9307
-  tps: 3953.9408
+  dps: 5564.76062
+  tps: 3950.98004
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6755.68157
-  tps: 4796.53392
+  dps: 6744.52458
+  tps: 4788.61245
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8756.04292
-  tps: 6216.79047
+  dps: 8743.48763
+  tps: 6207.87622
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2570.91771
-  tps: 1825.35158
+  dps: 2568.65502
+  tps: 1823.74506
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2793.64612
-  tps: 1983.48875
+  dps: 2788.13375
+  tps: 1979.57497
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19498.85929
-  tps: 13844.1901
+  dps: 19467.33177
+  tps: 13821.80556
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6561.26441
-  tps: 4658.49773
+  dps: 6554.10001
+  tps: 4653.41101
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7711.13687
-  tps: 5474.90717
+  dps: 7692.31369
+  tps: 5461.54272
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12333.51693
-  tps: 8756.79702
+  dps: 12320.10796
+  tps: 8747.27665
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3221.53405
-  tps: 2287.28917
+  dps: 3219.42096
+  tps: 2285.78888
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3381.56492
-  tps: 2400.91109
+  dps: 3373.49453
+  tps: 2395.18112
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19498.85929
-  tps: 13844.1901
+  dps: 19467.33177
+  tps: 13821.80556
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6561.26441
-  tps: 4658.49773
+  dps: 6554.10001
+  tps: 4653.41101
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7711.13687
-  tps: 5474.90717
+  dps: 7692.31369
+  tps: 5461.54272
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12333.51693
-  tps: 8756.79702
+  dps: 12320.10796
+  tps: 8747.27665
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3221.53405
-  tps: 2287.28917
+  dps: 3219.42096
+  tps: 2285.78888
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3381.56492
-  tps: 2400.91109
+  dps: 3373.49453
+  tps: 2395.18112
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18219.77678
-  tps: 12936.04151
+  dps: 18197.46096
+  tps: 12920.19728
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4840.29802
-  tps: 3436.61159
+  dps: 4836.09443
+  tps: 3433.62705
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5660.83797
-  tps: 4019.19496
+  dps: 5660.21646
+  tps: 4018.75368
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11997.12388
-  tps: 8517.95796
+  dps: 11985.28312
+  tps: 8509.55102
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2395.507
-  tps: 1700.80997
+  dps: 2393.05193
+  tps: 1699.06687
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2548.49272
-  tps: 1809.42983
+  dps: 2549.27721
+  tps: 1809.98682
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14414.00131
-  tps: 10233.94093
+  dps: 14396.17276
+  tps: 10221.28266
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5614.73961
-  tps: 3986.46512
+  dps: 5610.58827
+  tps: 3983.51767
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6848.64198
-  tps: 4862.53581
+  dps: 6837.58338
+  tps: 4854.6842
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8845.06258
-  tps: 6279.99443
+  dps: 8832.39234
+  tps: 6270.99856
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2595.88631
-  tps: 1843.07928
+  dps: 2593.56199
+  tps: 1841.42901
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2837.33995
-  tps: 2014.51136
+  dps: 2831.75832
+  tps: 2010.5484
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19654.56632
-  tps: 13954.74209
+  dps: 19622.79304
+  tps: 13932.18306
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6614.14294
-  tps: 4696.04149
+  dps: 6606.9212
+  tps: 4690.91405
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7818.88528
-  tps: 5551.40855
+  dps: 7799.72723
+  tps: 5537.80633
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12444.22946
-  tps: 8835.40291
+  dps: 12430.76001
+  tps: 8825.83961
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3251.94186
-  tps: 2308.87872
+  dps: 3249.71693
+  tps: 2307.29902
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3433.18937
-  tps: 2437.56445
+  dps: 3425.14133
+  tps: 2431.85034
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19654.56632
-  tps: 13954.74209
+  dps: 19622.79304
+  tps: 13932.18306
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6614.14294
-  tps: 4696.04149
+  dps: 6606.9212
+  tps: 4690.91405
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7818.88528
-  tps: 5551.40855
+  dps: 7799.72723
+  tps: 5537.80633
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12444.22946
-  tps: 8835.40291
+  dps: 12430.76001
+  tps: 8825.83961
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3251.94186
-  tps: 2308.87872
+  dps: 3249.71693
+  tps: 2307.29902
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3433.18937
-  tps: 2437.56445
+  dps: 3425.14133
+  tps: 2431.85034
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18361.63511
-  tps: 13036.76093
+  dps: 18339.17311
+  tps: 13020.81291
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4877.76275
-  tps: 3463.21155
+  dps: 4873.5418
+  tps: 3460.21468
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5735.99334
-  tps: 4072.55527
+  dps: 5735.52703
+  tps: 4072.22419
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12102.81506
-  tps: 8592.99869
+  dps: 12090.95439
+  tps: 8584.57762
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2417.54937
-  tps: 1716.46005
+  dps: 2415.08991
+  tps: 1714.71383
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2586.51169
-  tps: 1836.4233
+  dps: 2587.42075
+  tps: 1837.06873
  }
 }
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6297.54875
-  tps: 4471.25961
+  dps: 6290.48787
+  tps: 4466.24639
  }
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -48,12 +48,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.16294
+  weights: 0.16417
   weights: 0
-  weights: 1.03882
+  weights: 1.03701
   weights: 0
-  weights: 1.64604
-  weights: 0.57235
+  weights: 1.60747
+  weights: 0.57378
   weights: 0
   weights: 0
   weights: 0
@@ -89,749 +89,749 @@ stat_weights_results: {
 dps_results: {
  key: "TestElemental-AllItems-AshtongueTalismanofVision-32491"
  value: {
-  dps: 4030.69561
-  tps: 3096.99307
+  dps: 4024.35092
+  tps: 3091.80635
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 4078.11772
-  tps: 3134.37162
+  dps: 4071.08732
+  tps: 3128.632
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 4030.69561
-  tps: 3096.99307
+  dps: 4024.35092
+  tps: 3091.80635
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 4089.95976
-  tps: 3142.90527
+  dps: 4082.37224
+  tps: 3136.59295
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 3922.63446
-  tps: 3014.38943
+  dps: 3916.4157
+  tps: 3010.64212
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 4384.2186
-  tps: 3369.85954
+  dps: 4364.95719
+  tps: 3355.02185
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 3341.90109
-  tps: 2589.40468
+  dps: 3332.88212
+  tps: 2584.17502
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 3496.84285
-  tps: 2708.42806
+  dps: 3490.59301
+  tps: 2705.76702
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 4103.46136
-  tps: 3091.04745
+  dps: 4096.39792
+  tps: 3085.39647
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 4209.37674
-  tps: 3235.70531
+  dps: 4201.5808
+  tps: 3229.18922
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 4095.31045
-  tps: 3143.40654
+  dps: 4086.81412
+  tps: 3136.38707
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 4137.23814
-  tps: 3188.47922
+  dps: 4117.73434
+  tps: 3171.97738
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 4059.60442
-  tps: 3113.77444
+  dps: 4056.29126
+  tps: 3110.73341
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 4059.60442
-  tps: 3113.77444
+  dps: 4056.29126
+  tps: 3110.73341
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 4059.60442
-  tps: 3113.77444
+  dps: 4056.29126
+  tps: 3110.73341
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Defender'sCode-40257"
  value: {
-  dps: 4030.69561
-  tps: 3096.99307
+  dps: 4024.35092
+  tps: 3091.80635
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 4090.52152
-  tps: 3143.50652
+  dps: 4083.17586
+  tps: 3137.41188
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 3213.19246
-  tps: 2484.17239
+  dps: 3205.41458
+  tps: 2475.50771
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EarthshatterGarb"
  value: {
-  dps: 3699.05996
-  tps: 2844.90627
+  dps: 3688.28716
+  tps: 2833.63198
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 4078.11772
-  tps: 3134.37162
+  dps: 4071.08732
+  tps: 3128.632
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 4108.71315
-  tps: 3156.98884
+  dps: 4101.46527
+  tps: 3151.05654
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 4089.95976
-  tps: 3143.00093
+  dps: 4082.37224
+  tps: 3136.68862
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 4087.86028
-  tps: 3141.11139
+  dps: 4080.53797
+  tps: 3135.03778
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 4078.11772
-  tps: 3134.37162
+  dps: 4071.08732
+  tps: 3128.632
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 4093.91863
-  tps: 3144.91852
+  dps: 4091.98723
+  tps: 3144.89401
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 4218.56353
-  tps: 3237.66733
+  dps: 4210.36353
+  tps: 3230.92844
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForgeEmber-37660"
  value: {
-  dps: 4175.26651
-  tps: 3206.36803
+  dps: 4167.09799
+  tps: 3199.47878
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 4103.46136
-  tps: 3153.45274
+  dps: 4096.39792
+  tps: 3147.68643
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 4098.39263
-  tps: 3149.63651
+  dps: 4091.3358
+  tps: 3143.87554
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 3518.51505
-  tps: 2705.6657
+  dps: 3515.33503
+  tps: 2702.30085
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 4635.76292
-  tps: 3515.83288
+  dps: 4629.51674
+  tps: 3511.17778
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 4030.69561
-  tps: 3096.99307
+  dps: 4024.35092
+  tps: 3091.80635
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuturesightRune-38763"
  value: {
-  dps: 4094.41772
-  tps: 3144.97107
+  dps: 4087.99083
+  tps: 3139.72214
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 3200.73312
-  tps: 2492.24641
+  dps: 3195.39755
+  tps: 2491.88441
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Gladiator'sWartide"
  value: {
-  dps: 3894.304
-  tps: 3023.82864
+  dps: 3889.19567
+  tps: 3024.62767
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 4234.19439
-  tps: 3250.04154
+  dps: 4227.58155
+  tps: 3244.65009
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 4089.95976
-  tps: 3143.00093
+  dps: 4082.37224
+  tps: 3136.68862
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 4087.86028
-  tps: 3141.11139
+  dps: 4080.53797
+  tps: 3135.03778
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IncisorFragment-37723"
  value: {
-  dps: 4034.49628
-  tps: 3091.32511
+  dps: 4025.24484
+  tps: 3085.98359
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 4083.33507
-  tps: 3145.38642
+  dps: 4076.12141
+  tps: 3139.48187
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 4078.11772
-  tps: 3134.37162
+  dps: 4071.08732
+  tps: 3128.632
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 4030.69561
-  tps: 3096.99307
+  dps: 4024.35092
+  tps: 3091.80635
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 4030.69561
-  tps: 3096.99307
+  dps: 4024.35092
+  tps: 3091.80635
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 4079.0537
-  tps: 3133.16832
+  dps: 4071.41204
+  tps: 3126.91101
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 4030.69561
-  tps: 3096.99307
+  dps: 4024.35092
+  tps: 3091.80635
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 4078.11772
-  tps: 3134.37162
+  dps: 4071.08732
+  tps: 3128.632
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 4078.11772
-  tps: 3134.37162
+  dps: 4071.08732
+  tps: 3128.632
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 4078.11772
-  tps: 3134.37162
+  dps: 4071.08732
+  tps: 3128.632
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 4078.11772
-  tps: 3134.37162
+  dps: 4071.08732
+  tps: 3128.632
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 4030.69561
-  tps: 3096.99307
+  dps: 4024.35092
+  tps: 3091.80635
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 4356.04519
-  tps: 3384.85367
+  dps: 4343.43028
+  tps: 3373.10089
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 4398.45747
-  tps: 3422.69828
+  dps: 4385.9424
+  tps: 3411.04883
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 4196.46892
-  tps: 3226.29409
+  dps: 4189.28024
+  tps: 3220.40223
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 4078.11772
-  tps: 3134.31223
+  dps: 4071.08732
+  tps: 3128.57262
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 4030.69561
-  tps: 3096.99307
+  dps: 4024.35092
+  tps: 3091.80635
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 4030.69561
-  tps: 3096.99307
+  dps: 4024.35092
+  tps: 3091.80635
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 4030.69561
-  tps: 3096.99307
+  dps: 4024.35092
+  tps: 3091.80635
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 4030.69561
-  tps: 3096.99307
+  dps: 4024.35092
+  tps: 3091.80635
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterHarness"
  value: {
-  dps: 2809.02999
-  tps: 2182.78511
+  dps: 2797.55677
+  tps: 2175.88136
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterRegalia"
  value: {
-  dps: 3310.53325
-  tps: 2548.80124
+  dps: 3298.38273
+  tps: 2539.25137
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SparkofLife-37657"
  value: {
-  dps: 4105.51074
-  tps: 3152.73172
+  dps: 4101.09873
+  tps: 3149.98498
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StormshroudArmor"
  value: {
-  dps: 3267.79474
-  tps: 2541.19663
+  dps: 3255.84627
+  tps: 2532.54139
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 4078.11772
-  tps: 3134.37162
+  dps: 4071.08732
+  tps: 3128.632
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 4078.11772
-  tps: 3134.37162
+  dps: 4071.08732
+  tps: 3128.632
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 4078.11772
-  tps: 3134.37162
+  dps: 4071.08732
+  tps: 3128.632
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheFistsofFury"
  value: {
-  dps: 3628.95579
-  tps: 2797.82205
+  dps: 3625.60824
+  tps: 2796.38036
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 3501.0082
-  tps: 2689.43536
+  dps: 3493.33567
+  tps: 2684.91843
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Thrall'sRegalia"
  value: {
-  dps: 4353.08594
-  tps: 3340.06447
+  dps: 4334.35341
+  tps: 3325.10583
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 4078.11772
-  tps: 3134.37162
+  dps: 4071.08732
+  tps: 3128.632
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TidefuryRaiment"
  value: {
-  dps: 3092.80617
-  tps: 2404.59039
+  dps: 3081.75189
+  tps: 2392.64833
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 4153.62709
-  tps: 3176.00756
+  dps: 4136.92759
+  tps: 3156.63312
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 4153.62709
-  tps: 3176.00756
+  dps: 4136.92759
+  tps: 3156.63312
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 4103.46136
-  tps: 3153.45274
+  dps: 4096.39792
+  tps: 3147.68643
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 4098.39263
-  tps: 3149.63651
+  dps: 4091.3358
+  tps: 3143.87554
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 4323.80504
-  tps: 3317.79663
+  dps: 4318.95448
+  tps: 3317.8881
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 4171.7815
-  tps: 3204.77359
+  dps: 4161.24365
+  tps: 3194.02674
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 4098.39263
-  tps: 3149.63651
+  dps: 4091.3358
+  tps: 3143.87554
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 4103.46136
-  tps: 3153.45274
+  dps: 4096.39792
+  tps: 3147.68643
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 3316.19535
-  tps: 2566.44946
+  dps: 3314.78097
+  tps: 2568.6337
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 3324.4031
-  tps: 2557.5289
+  dps: 3321.8014
+  tps: 2555.95001
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WorldbreakerGarb"
  value: {
-  dps: 3891.99734
-  tps: 3003.27292
+  dps: 3880.2012
+  tps: 2996.60438
  }
 }
 dps_results: {
  key: "TestElemental-Average-Default"
  value: {
-  dps: 4206.52991
-  tps: 3226.7886
+  dps: 4196.19201
+  tps: 3219.01628
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6456.24631
-  tps: 5954.10493
+  dps: 6432.29499
+  tps: 5934.19088
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4216.63288
-  tps: 3234.46686
+  dps: 4205.26875
+  tps: 3225.4727
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4861.9219
-  tps: 3751.94393
+  dps: 4836.64462
+  tps: 3723.76893
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2053.85763
-  tps: 1671.37279
+  dps: 2056.2444
+  tps: 1673.30171
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1778.69746
-  tps: 1389.84254
+  dps: 1777.67106
+  tps: 1392.11349
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3565.61622
-  tps: 2732.40726
+  dps: 3541.74341
+  tps: 2721.06524
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8189.85584
-  tps: 5817.61801
+  dps: 8169.93363
+  tps: 5806.21229
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4676.26407
-  tps: 3224.06329
+  dps: 4649.01622
+  tps: 3204.57455
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5987.89058
-  tps: 3681.89271
+  dps: 5931.90841
+  tps: 3636.56607
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3795.27123
-  tps: 1647.09463
+  dps: 3783.58996
+  tps: 1641.08957
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2098.12044
-  tps: 1345.84433
+  dps: 2095.36836
+  tps: 1346.7066
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4462.15863
-  tps: 2622.3
+  dps: 4428.75931
+  tps: 2601.05004
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6445.97422
-  tps: 5942.69673
+  dps: 6426.77161
+  tps: 5928.79142
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4209.37674
-  tps: 3235.70531
+  dps: 4201.5808
+  tps: 3229.18922
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4854.48289
-  tps: 3772.04902
+  dps: 4811.99328
+  tps: 3746.98562
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2056.41866
-  tps: 1673.74175
+  dps: 2055.59632
+  tps: 1674.98988
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1759.74262
-  tps: 1381.71502
+  dps: 1754.03724
+  tps: 1376.50255
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3482.4626
-  tps: 2672.42905
+  dps: 3470.08264
+  tps: 2657.57686
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8144.05247
-  tps: 5870.95122
+  dps: 8133.60898
+  tps: 5863.02685
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4642.16339
-  tps: 3214.75818
+  dps: 4622.59485
+  tps: 3204.19137
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5791.11177
-  tps: 3561.34804
+  dps: 5765.07621
+  tps: 3541.70231
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3674.47072
-  tps: 1612.63855
+  dps: 3660.95493
+  tps: 1607.82735
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2045.514
-  tps: 1312.46038
+  dps: 2046.26347
+  tps: 1315.26243
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4344.01151
-  tps: 2579.43992
+  dps: 4329.66218
+  tps: 2572.10564
  }
 }
 dps_results: {
  key: "TestElemental-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 4209.37674
-  tps: 3235.70531
+  dps: 4201.5808
+  tps: 3229.18922
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -45,749 +45,749 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-AshtongueTalismanofVision-32491"
  value: {
-  dps: 6635.79958
-  tps: 3731.89259
+  dps: 6650.02574
+  tps: 3747.34301
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6638.78078
-  tps: 3745.01885
+  dps: 6593.80689
+  tps: 3719.67087
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6794.05373
-  tps: 3833.93804
+  dps: 6681.99034
+  tps: 3762.20179
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6656.32864
-  tps: 3751.88232
+  dps: 6633.23004
+  tps: 3738.88033
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6427.06923
-  tps: 3607.95358
+  dps: 6413.57548
+  tps: 3597.66988
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 7040.86542
-  tps: 3983.95047
+  dps: 6985.75265
+  tps: 3950.51532
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5397.8294
-  tps: 3034.03459
+  dps: 5396.44634
+  tps: 3022.15365
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5340.55495
-  tps: 3006.01474
+  dps: 5276.97886
+  tps: 2958.7717
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6658.95598
-  tps: 3653.39624
+  dps: 6613.75409
+  tps: 3628.65842
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6778.05351
-  tps: 3820.74316
+  dps: 6793.91291
+  tps: 3831.00648
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6684.2258
-  tps: 3763.20635
+  dps: 6688.98546
+  tps: 3761.00742
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6802.15188
-  tps: 3842.9378
+  dps: 6755.75503
+  tps: 3812.92386
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6753.46309
-  tps: 3805.03371
+  dps: 6725.83077
+  tps: 3781.27851
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6768.15041
-  tps: 3807.50405
+  dps: 6723.00457
+  tps: 3783.15722
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6706.9396
-  tps: 3780.85385
+  dps: 6653.43432
+  tps: 3740.47592
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6581.88079
-  tps: 3707.33611
+  dps: 6560.46799
+  tps: 3697.88142
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6673.14947
-  tps: 3762.43626
+  dps: 6632.70884
+  tps: 3733.92626
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 5885.04204
-  tps: 3306.55573
+  dps: 5855.21414
+  tps: 3284.06426
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterGarb"
  value: {
-  dps: 5546.14583
-  tps: 3122.83907
+  dps: 5543.78593
+  tps: 3122.72504
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6638.78078
-  tps: 3745.01885
+  dps: 6593.80689
+  tps: 3719.67087
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6688.65377
-  tps: 3775.9336
+  dps: 6636.0475
+  tps: 3745.29058
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6631.44259
-  tps: 3736.38263
+  dps: 6645.03277
+  tps: 3745.39478
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6691.69946
-  tps: 3781.61383
+  dps: 6610.06343
+  tps: 3724.18257
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6638.78078
-  tps: 3745.01885
+  dps: 6593.80689
+  tps: 3719.67087
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6731.58232
-  tps: 3797.57717
+  dps: 6719.39837
+  tps: 3791.56606
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6798.4057
-  tps: 3836.94681
+  dps: 6739.58308
+  tps: 3801.10076
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6748.68743
-  tps: 3804.24128
+  dps: 6700.66324
+  tps: 3772.69181
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6658.95598
-  tps: 3757.65811
+  dps: 6613.75409
+  tps: 3732.15866
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6654.92094
-  tps: 3755.13026
+  dps: 6609.76465
+  tps: 3729.6611
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 6971.75792
-  tps: 3911.01612
+  dps: 6928.20978
+  tps: 3884.33079
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 6562.33114
-  tps: 3728.6783
+  dps: 6529.42886
+  tps: 3697.53986
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6739.74379
-  tps: 3788.76452
+  dps: 6732.23511
+  tps: 3789.01888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6631.31086
-  tps: 3738.23382
+  dps: 6609.73809
+  tps: 3728.69455
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 6592.81377
-  tps: 3708.9468
+  dps: 6552.31588
+  tps: 3674.6724
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sWartide"
  value: {
-  dps: 5497.88325
-  tps: 3109.0629
+  dps: 5442.89963
+  tps: 3076.19517
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6741.19219
-  tps: 3806.90816
+  dps: 6719.26219
+  tps: 3797.17976
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6631.44259
-  tps: 3736.38263
+  dps: 6645.03277
+  tps: 3745.39478
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6691.69946
-  tps: 3781.61383
+  dps: 6610.06343
+  tps: 3724.18257
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6673.30171
-  tps: 3756.96597
+  dps: 6670.21745
+  tps: 3759.34013
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6658.82292
-  tps: 3757.57026
+  dps: 6630.40255
+  tps: 3734.27347
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6664.27308
-  tps: 3759.18799
+  dps: 6613.86682
+  tps: 3729.49
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6581.88079
-  tps: 3707.33611
+  dps: 6560.46799
+  tps: 3697.88142
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6581.88079
-  tps: 3707.33611
+  dps: 6560.46799
+  tps: 3697.88142
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6581.88079
-  tps: 3707.33611
+  dps: 6560.46799
+  tps: 3697.88142
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6659.4174
-  tps: 3756.4907
+  dps: 6613.30168
+  tps: 3730.45091
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6664.27308
-  tps: 3759.18799
+  dps: 6613.86682
+  tps: 3729.49
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6638.78078
-  tps: 3745.01885
+  dps: 6593.80689
+  tps: 3719.67087
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6638.78078
-  tps: 3745.01885
+  dps: 6593.80689
+  tps: 3719.67087
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6581.88079
-  tps: 3707.33611
+  dps: 6560.46799
+  tps: 3697.88142
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6811.92842
-  tps: 3853.07902
+  dps: 6775.71331
+  tps: 3833.43771
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6839.24861
-  tps: 3871.11627
+  dps: 6803.02013
+  tps: 3851.47118
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6833.87598
-  tps: 3861.64986
+  dps: 6737.11228
+  tps: 3800.30823
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6638.69617
-  tps: 3748.93617
+  dps: 6584.23232
+  tps: 3711.20524
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6581.88079
-  tps: 3707.33611
+  dps: 6560.46799
+  tps: 3697.88142
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6581.88079
-  tps: 3707.33611
+  dps: 6560.46799
+  tps: 3697.88142
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6581.88079
-  tps: 3707.33611
+  dps: 6560.46799
+  tps: 3697.88142
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6581.88079
-  tps: 3707.33611
+  dps: 6560.46799
+  tps: 3697.88142
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterHarness"
  value: {
-  dps: 4782.05044
-  tps: 2668.83059
+  dps: 4768.33767
+  tps: 2661.76829
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterRegalia"
  value: {
-  dps: 4728.09257
-  tps: 2655.02097
+  dps: 4709.65622
+  tps: 2647.73917
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SparkofLife-37657"
  value: {
-  dps: 6670.19918
-  tps: 3763.84644
+  dps: 6674.33407
+  tps: 3763.62973
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StormshroudArmor"
  value: {
-  dps: 5059.64911
-  tps: 2836.32549
+  dps: 5026.4167
+  tps: 2814.15237
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6664.27308
-  tps: 3759.18799
+  dps: 6613.86682
+  tps: 3729.49
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6659.4174
-  tps: 3756.4907
+  dps: 6613.30168
+  tps: 3730.45091
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6650.91997
-  tps: 3751.76581
+  dps: 6605.85734
+  tps: 3726.34504
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheFistsofFury"
  value: {
-  dps: 5300.17752
-  tps: 2914.64409
+  dps: 5263.40507
+  tps: 2893.89139
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 6744.9311
-  tps: 3817.99976
+  dps: 6710.96359
+  tps: 3797.25447
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sRegalia"
  value: {
-  dps: 6318.54093
-  tps: 3591.20721
+  dps: 6226.30774
+  tps: 3538.64372
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6704.79129
-  tps: 3782.88646
+  dps: 6677.33304
+  tps: 3765.29252
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TidefuryRaiment"
  value: {
-  dps: 4756.10011
-  tps: 2671.38771
+  dps: 4744.91185
+  tps: 2658.93283
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6779.21647
-  tps: 3825.8891
+  dps: 6768.26054
+  tps: 3821.56233
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6787.22662
-  tps: 3830.46654
+  dps: 6777.06578
+  tps: 3825.81491
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6658.95598
-  tps: 3757.65811
+  dps: 6613.75409
+  tps: 3732.15866
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6654.92094
-  tps: 3755.13026
+  dps: 6609.76465
+  tps: 3729.6611
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 6943.60319
-  tps: 3926.04164
+  dps: 6905.36611
+  tps: 3893.68551
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 7016.32259
-  tps: 3945.7302
+  dps: 6975.22805
+  tps: 3924.56978
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheElementalPlane-40708"
  value: {
-  dps: 6776.80997
-  tps: 3818.03373
+  dps: 6744.23023
+  tps: 3802.97437
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6654.92094
-  tps: 3755.13026
+  dps: 6609.76465
+  tps: 3729.6611
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6658.95598
-  tps: 3757.65811
+  dps: 6613.75409
+  tps: 3732.15866
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5314.59072
-  tps: 2977.37534
+  dps: 5327.79679
+  tps: 2989.02211
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 6259.19566
-  tps: 3538.86899
+  dps: 6202.48766
+  tps: 3502.86032
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerGarb"
  value: {
-  dps: 5750.62915
-  tps: 3249.88777
+  dps: 5712.5801
+  tps: 3226.82698
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 6832.0256
-  tps: 3857.92691
+  dps: 6803.05894
+  tps: 3838.57967
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17897.73077
-  tps: 10535.85675
+  dps: 17837.29691
+  tps: 10548.57796
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6780.41057
-  tps: 3806.99307
+  dps: 6779.04821
+  tps: 3814.23862
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7909.34585
-  tps: 4149.58637
+  dps: 7920.33067
+  tps: 4164.73846
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8557.73983
-  tps: 5012.64347
+  dps: 9013.80721
+  tps: 5344.52216
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2918.87606
-  tps: 1646.06201
+  dps: 3005.58471
+  tps: 1689.77565
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4878.38364
-  tps: 2610.38136
+  dps: 4888.97748
+  tps: 2629.90402
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18393.68888
-  tps: 10274.43009
+  dps: 18357.28964
+  tps: 10257.37533
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6532.88982
-  tps: 3390.68688
+  dps: 6522.45411
+  tps: 3382.22973
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhFireElemental-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8035.17202
-  tps: 3695.11488
+  dps: 8052.66569
+  tps: 3706.05295
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhFireElemental-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12804.24673
-  tps: 7679.95391
+  dps: 12786.06068
+  tps: 7672.34774
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhFireElemental-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3467.46512
-  tps: 1859.13743
+  dps: 3463.48051
+  tps: 1855.41968
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhFireElemental-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5087.23893
-  tps: 2298.9637
+  dps: 5063.53655
+  tps: 2287.63772
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17866.5073
-  tps: 10522.19415
+  dps: 17773.02597
+  tps: 10371.77887
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6833.87598
-  tps: 3861.64986
+  dps: 6737.11228
+  tps: 3800.30823
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8036.34139
-  tps: 4262.18839
+  dps: 7957.69601
+  tps: 4215.53841
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8628.06119
-  tps: 5100.43435
+  dps: 8454.82574
+  tps: 4950.37758
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2935.61594
-  tps: 1661.8708
+  dps: 2782.59763
+  tps: 1565.30528
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4913.04768
-  tps: 2652.33565
+  dps: 4916.55352
+  tps: 2658.18774
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18045.72129
-  tps: 10195.1632
+  dps: 17985.3355
+  tps: 10162.90728
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6459.63732
-  tps: 3380.97824
+  dps: 6453.2257
+  tps: 3377.67814
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhFireElemental-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7907.182
-  tps: 3739.1107
+  dps: 7904.82765
+  tps: 3741.02864
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhFireElemental-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12778.5793
-  tps: 7802.71427
+  dps: 12749.52919
+  tps: 7787.51079
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhFireElemental-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3509.25164
-  tps: 1909.23484
+  dps: 3505.98624
+  tps: 1906.04371
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhFireElemental-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4990.61548
-  tps: 2320.23133
+  dps: 4971.82167
+  tps: 2302.84365
  }
 }
 dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6486.12949
-  tps: 3638.00833
+  dps: 6456.08645
+  tps: 3623.07676
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -612,8 +612,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 6803.05894
-  tps: 3838.57967
+  dps: 6803.0576
+  tps: 3838.57873
  }
 }
 dps_results: {

--- a/sim/warlock/TestWarlock.results
+++ b/sim/warlock/TestWarlock.results
@@ -45,399 +45,399 @@ character_stats_results: {
 dps_results: {
  key: "TestWarlock-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 7188.18248
-  tps: 6454.259
+  dps: 7080.61143
+  tps: 6366.48928
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7056.02764
-  tps: 6311.61976
+  dps: 6966.35655
+  tps: 6250.80188
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7073.20743
-  tps: 6328.79955
+  dps: 6983.68982
+  tps: 6268.13516
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7065.80277
-  tps: 6315.2612
+  dps: 7005.9745
+  tps: 6285.16306
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7165.66642
-  tps: 6421.25854
+  dps: 7076.21368
+  tps: 6360.65902
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 7744.48809
-  tps: 6963.56346
+  dps: 7672.42502
+  tps: 6926.22342
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-DeathbringerGarb"
  value: {
-  dps: 6662.83328
-  tps: 5949.28023
+  dps: 6553.66336
+  tps: 5870.82785
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7078.08343
-  tps: 6333.67555
+  dps: 6986.21725
+  tps: 6270.66258
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7056.02764
-  tps: 6311.61976
+  dps: 6966.35655
+  tps: 6250.80188
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7065.80277
-  tps: 6315.2612
+  dps: 7005.9745
+  tps: 6285.16306
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7073.20743
-  tps: 6328.79955
+  dps: 6983.68982
+  tps: 6268.13516
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7071.21035
-  tps: 6326.80246
+  dps: 6978.77511
+  tps: 6263.22045
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7056.02764
-  tps: 6311.61976
+  dps: 6966.35655
+  tps: 6250.80188
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7065.80277
-  tps: 6315.2612
+  dps: 7005.9745
+  tps: 6285.16306
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7060.87204
-  tps: 6306.23271
+  dps: 7001.77197
+  tps: 6285.49392
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 7043.12719
-  tps: 6330.73445
+  dps: 6953.90421
+  tps: 6267.03903
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 7115.03706
-  tps: 6309.82689
+  dps: 6986.67633
+  tps: 6206.1342
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7073.20743
-  tps: 6328.79955
+  dps: 6983.68982
+  tps: 6268.13516
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7071.21035
-  tps: 6326.80246
+  dps: 6978.77511
+  tps: 6263.22045
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7021.27908
-  tps: 6275.18689
+  dps: 6937.46378
+  tps: 6217.78644
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7056.02764
-  tps: 6311.61976
+  dps: 6966.35655
+  tps: 6250.80188
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-MaleficRaiment"
  value: {
-  dps: 5280.07102
-  tps: 4635.3377
+  dps: 5180.46928
+  tps: 4565.74872
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7056.02764
-  tps: 6311.61976
+  dps: 6966.35655
+  tps: 6250.80188
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7056.02764
-  tps: 6311.61976
+  dps: 6966.35655
+  tps: 6250.80188
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-PlagueheartGarb"
  value: {
-  dps: 6273.3332
-  tps: 5592.92727
+  dps: 6227.72172
+  tps: 5572.07695
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7056.02764
-  tps: 6311.61976
+  dps: 6966.35655
+  tps: 6250.80188
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7056.02764
-  tps: 6311.61976
+  dps: 6966.35655
+  tps: 6250.80188
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7146.94045
-  tps: 6402.53257
+  dps: 7057.32041
+  tps: 6341.76575
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6998.01358
-  tps: 6254.85124
+  dps: 6970.00974
+  tps: 6255.39116
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7056.02764
-  tps: 6311.61976
+  dps: 6966.35655
+  tps: 6250.80188
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7056.02764
-  tps: 6311.61976
+  dps: 6966.35655
+  tps: 6250.80188
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7056.02764
-  tps: 6311.61976
+  dps: 6966.35655
+  tps: 6250.80188
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7056.02764
-  tps: 6311.61976
+  dps: 6966.35655
+  tps: 6250.80188
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7065.80277
-  tps: 6315.2612
+  dps: 7005.9745
+  tps: 6285.16306
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7060.87204
-  tps: 6306.23271
+  dps: 7001.77197
+  tps: 6285.49392
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7060.87204
-  tps: 6306.23271
+  dps: 7001.77197
+  tps: 6285.49392
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7065.80277
-  tps: 6315.2612
+  dps: 7005.9745
+  tps: 6285.16306
  }
 }
 dps_results: {
  key: "TestWarlock-Average-Default"
  value: {
-  dps: 7133.88383
-  tps: 6390.97773
+  dps: 7067.25377
+  tps: 6351.52905
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6223.289
-  tps: 7249.03988
+  dps: 6129.71337
+  tps: 7177.89525
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6223.289
-  tps: 5495.73029
+  dps: 6129.71337
+  tps: 5428.49951
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6529.10315
-  tps: 5720.45522
+  dps: 6453.59129
+  tps: 5668.34273
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3699.93402
-  tps: 5545.03831
+  dps: 3657.49688
+  tps: 5524.01249
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3699.93402
-  tps: 3460.373
+  dps: 3657.49688
+  tps: 3429.44879
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3447.53471
-  tps: 3097.12661
+  dps: 3399.63684
+  tps: 3073.00875
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Demonology Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10094.71091
-  tps: 11085.95723
+  dps: 10065.72576
+  tps: 11056.97209
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Demonology Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6470.92289
-  tps: 5493.82927
+  dps: 6436.50329
+  tps: 5459.40966
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Demonology Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7423.71633
-  tps: 6259.59749
+  dps: 7384.63261
+  tps: 6220.51377
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Demonology Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7036.79208
-  tps: 9128.2199
+  dps: 7040.29215
+  tps: 9131.71997
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Demonology Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3789.98168
-  tps: 3516.77408
+  dps: 3784.24647
+  tps: 3511.03887
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Demonology Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3811.1528
-  tps: 3447.88161
+  dps: 3776.59002
+  tps: 3413.31883
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Destro Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5827.48133
-  tps: 6237.74092
+  dps: 5816.8445
+  tps: 6230.30041
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Destro Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5827.48133
-  tps: 4311.38333
+  dps: 5816.8445
+  tps: 4303.94282
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Destro Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6340.59068
-  tps: 4611.98134
+  dps: 6293.11549
+  tps: 4573.64978
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Destro Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3019.23738
-  tps: 4441.18173
+  dps: 3011.00711
+  tps: 4434.17036
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Destro Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3019.23738
-  tps: 2446.96517
+  dps: 3011.00711
+  tps: 2439.95379
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Destro Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3117.04964
-  tps: 2265.08778
+  dps: 3103.52724
+  tps: 2255.97764
  }
 }
 dps_results: {
  key: "TestWarlock-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7130.9532
-  tps: 6421.25854
+  dps: 7041.50957
+  tps: 6360.65902
  }
 }

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -45,36 +45,36 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 7957.61368
-  tps: 6556.52524
+  dps: 7928.49282
+  tps: 6530.54736
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8236.97541
-  tps: 6792.68022
+  dps: 8161.07606
+  tps: 6719.50585
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8104.20528
-  tps: 6667.40407
+  dps: 8088.75295
+  tps: 6653.11097
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8245.46408
-  tps: 6797.40606
+  dps: 8214.27034
+  tps: 6774.79946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 8122.91995
-  tps: 6689.81076
+  dps: 8147.22423
+  tps: 6710.86533
  }
 }
 dps_results: {
@@ -101,57 +101,57 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8162.92527
-  tps: 6593.85125
+  dps: 8196.69614
+  tps: 6623.1359
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8357.19623
-  tps: 6892.01412
+  dps: 8397.66781
+  tps: 6919.30004
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 8108.80337
-  tps: 6678.04261
+  dps: 8113.70425
+  tps: 6683.91299
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 8132.43374
-  tps: 6697.40353
+  dps: 8112.74344
+  tps: 6676.26781
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 8076.75624
-  tps: 6649.64683
+  dps: 8062.7648
+  tps: 6641.65286
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7976.79532
-  tps: 6566.63262
+  dps: 7879.25789
+  tps: 6488.33869
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7925.54386
-  tps: 6517.70293
+  dps: 7945.26954
+  tps: 6543.76308
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8285.16258
-  tps: 6833.97114
+  dps: 8213.96071
+  tps: 6774.35656
  }
 }
 dps_results: {
@@ -164,85 +164,85 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8162.92527
-  tps: 6728.15486
+  dps: 8196.69614
+  tps: 6758.03369
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8162.92527
-  tps: 6728.15486
+  dps: 8196.69614
+  tps: 6758.03369
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8245.46408
-  tps: 6797.40606
+  dps: 8214.27034
+  tps: 6774.79946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8177.21178
-  tps: 6739.96772
+  dps: 8244.02144
+  tps: 6795.00216
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8162.92527
-  tps: 6728.15486
+  dps: 8196.69614
+  tps: 6758.03369
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 8134.47037
-  tps: 6699.02268
+  dps: 8146.28834
+  tps: 6711.04416
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 8102.1054
-  tps: 6674.13953
+  dps: 8038.11399
+  tps: 6623.31053
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForgeEmber-37660"
  value: {
-  dps: 8036.5654
-  tps: 6616.94091
+  dps: 8047.56085
+  tps: 6628.62751
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8162.92527
-  tps: 6728.15486
+  dps: 8196.69614
+  tps: 6758.03369
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8162.92527
-  tps: 6728.15486
+  dps: 8196.69614
+  tps: 6758.03369
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8168.93459
-  tps: 6723.22104
+  dps: 8113.69906
+  tps: 6681.30684
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7955.91955
-  tps: 6550.2128
+  dps: 7986.40057
+  tps: 6581.56276
  }
 }
 dps_results: {
@@ -255,71 +255,71 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7976.79532
-  tps: 6566.63262
+  dps: 7879.25789
+  tps: 6488.33869
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8245.46408
-  tps: 6797.40606
+  dps: 8214.27034
+  tps: 6774.79946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8177.21178
-  tps: 6739.96772
+  dps: 8244.02144
+  tps: 6795.00216
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8091.77212
-  tps: 6658.428
+  dps: 8181.00948
+  tps: 6735.85154
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8162.92527
-  tps: 6728.15486
+  dps: 8196.69614
+  tps: 6758.03369
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8215.0364
-  tps: 6772.81802
+  dps: 8237.32328
+  tps: 6794.29602
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7976.79532
-  tps: 6566.63262
+  dps: 7899.77484
+  tps: 6503.57956
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7976.79532
-  tps: 6566.63262
+  dps: 7879.25789
+  tps: 6488.33869
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8152.90087
-  tps: 6720.88788
+  dps: 8179.73937
+  tps: 6737.61761
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7935.64104
-  tps: 6532.12881
+  dps: 7944.40277
+  tps: 6541.04741
  }
 }
 dps_results: {
@@ -339,85 +339,85 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8209.38077
-  tps: 6763.28094
+  dps: 8178.47118
+  tps: 6741.12274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8215.0364
-  tps: 6772.81802
+  dps: 8237.32328
+  tps: 6794.29602
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8162.92527
-  tps: 6728.15486
+  dps: 8196.69614
+  tps: 6758.03369
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8162.92527
-  tps: 6728.15486
+  dps: 8196.69614
+  tps: 6758.03369
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7976.79532
-  tps: 6566.63262
+  dps: 7879.25789
+  tps: 6488.33869
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7976.79532
-  tps: 6566.63262
+  dps: 7879.25789
+  tps: 6488.33869
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7976.79532
-  tps: 6566.63262
+  dps: 7879.25789
+  tps: 6488.33869
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8366.54181
-  tps: 6895.86576
+  dps: 8346.2574
+  tps: 6878.59432
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8162.92527
-  tps: 6728.15486
+  dps: 8196.69614
+  tps: 6758.03369
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7976.79532
-  tps: 6566.63262
+  dps: 7899.77484
+  tps: 6503.57956
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7919.11196
-  tps: 6514.21033
+  dps: 7961.73424
+  tps: 6559.89996
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7976.79532
-  tps: 6566.63262
+  dps: 7879.25789
+  tps: 6488.33869
  }
 }
 dps_results: {
@@ -430,15 +430,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7955.91955
-  tps: 6550.2128
+  dps: 7986.40057
+  tps: 6581.56276
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SparkofLife-37657"
  value: {
-  dps: 8007.14725
-  tps: 6595.52673
+  dps: 7985.44345
+  tps: 6577.43596
  }
 }
 dps_results: {
@@ -451,85 +451,85 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8215.0364
-  tps: 6772.81802
+  dps: 8237.32328
+  tps: 6794.29602
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8209.38077
-  tps: 6763.28094
+  dps: 8178.47118
+  tps: 6741.12274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8202.84851
-  tps: 6759.95732
+  dps: 8180.40616
+  tps: 6741.65578
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheFistsofFury"
  value: {
-  dps: 4418.61351
-  tps: 3741.07456
+  dps: 4399.66446
+  tps: 3724.13648
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 4697.2208
-  tps: 3963.67543
+  dps: 4709.48069
+  tps: 3975.28883
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8278.69576
-  tps: 6823.58041
+  dps: 8260.62412
+  tps: 6808.886
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 8397.25524
-  tps: 6919.00382
+  dps: 8362.11594
+  tps: 6889.42423
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8478.16534
-  tps: 6985.92055
+  dps: 8421.93251
+  tps: 6933.45701
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8162.92527
-  tps: 6728.15486
+  dps: 8196.69614
+  tps: 6758.03369
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8162.92527
-  tps: 6728.15486
+  dps: 8196.69614
+  tps: 6758.03369
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8162.92527
-  tps: 6728.15486
+  dps: 8196.69614
+  tps: 6758.03369
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8162.92527
-  tps: 6728.15486
+  dps: 8196.69614
+  tps: 6758.03369
  }
 }
 dps_results: {
@@ -556,15 +556,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 8343.31723
-  tps: 6866.51726
+  dps: 8341.69825
+  tps: 6865.98477
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11547.26345
-  tps: 10016.70024
+  dps: 11538.98739
+  tps: 10010.0794
  }
 }
 dps_results: {
@@ -605,22 +605,22 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11740.4922
-  tps: 10181.28183
+  dps: 11672.20463
+  tps: 10114.25896
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8366.54181
-  tps: 6895.86576
+  dps: 8346.2574
+  tps: 6878.59432
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9043.47203
-  tps: 7481.25396
+  dps: 8907.22542
+  tps: 7374.22653
  }
 }
 dps_results: {
@@ -647,7 +647,7 @@ dps_results: {
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7758.14118
-  tps: 6376.89234
+  dps: 7784.46245
+  tps: 6399.09448
  }
 }

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -45,36 +45,36 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 8011.71312
-  tps: 6600.34963
+  dps: 7971.53464
+  tps: 6566.9595
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8209.30823
-  tps: 6764.90462
+  dps: 8177.83129
+  tps: 6736.34316
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8080.5764
-  tps: 6651.55572
+  dps: 8167.33547
+  tps: 6722.19018
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8219.2451
-  tps: 6776.67651
+  dps: 8203.41129
+  tps: 6759.57625
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 8124.73074
-  tps: 6692.99596
+  dps: 8108.79246
+  tps: 6678.06512
  }
 }
 dps_results: {
@@ -101,57 +101,57 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8201.32821
-  tps: 6619.71588
+  dps: 8184.30351
+  tps: 6607.47
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8426.30734
-  tps: 6943.27693
+  dps: 8418.41767
+  tps: 6934.36719
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 8050.03535
-  tps: 6630.27319
+  dps: 8129.30295
+  tps: 6692.73912
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 8120.78233
-  tps: 6685.13277
+  dps: 8170.22031
+  tps: 6725.58722
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 8035.16973
-  tps: 6622.91819
+  dps: 8001.65134
+  tps: 6589.62163
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7991.92293
-  tps: 6584.55652
+  dps: 7965.54619
+  tps: 6558.44172
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7973.00362
-  tps: 6564.10031
+  dps: 7934.39205
+  tps: 6532.1231
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8217.13429
-  tps: 6776.69052
+  dps: 8240.99871
+  tps: 6797.10433
  }
 }
 dps_results: {
@@ -164,85 +164,85 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8201.32821
-  tps: 6754.54874
+  dps: 8184.30351
+  tps: 6742.04987
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8201.32821
-  tps: 6754.54874
+  dps: 8184.30351
+  tps: 6742.04987
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8219.2451
-  tps: 6776.67651
+  dps: 8203.41129
+  tps: 6759.57625
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8226.72637
-  tps: 6782.06037
+  dps: 8218.69031
+  tps: 6776.30516
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8201.32821
-  tps: 6754.54874
+  dps: 8184.30351
+  tps: 6742.04987
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 8134.45947
-  tps: 6698.90452
+  dps: 8122.87711
+  tps: 6689.16988
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 8077.38064
-  tps: 6654.80225
+  dps: 8063.93538
+  tps: 6645.42104
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForgeEmber-37660"
  value: {
-  dps: 8086.4404
-  tps: 6657.83575
+  dps: 8003.72228
+  tps: 6592.94782
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8201.32821
-  tps: 6754.54874
+  dps: 8184.30351
+  tps: 6742.04987
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8201.32821
-  tps: 6754.54874
+  dps: 8184.30351
+  tps: 6742.04987
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8129.18753
-  tps: 6692.79314
+  dps: 8120.38097
+  tps: 6682.50799
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7981.70506
-  tps: 6574.1161
+  dps: 7919.35255
+  tps: 6520.84413
  }
 }
 dps_results: {
@@ -255,71 +255,71 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7991.92293
-  tps: 6584.55652
+  dps: 7965.54619
+  tps: 6558.44172
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8219.2451
-  tps: 6776.67651
+  dps: 8203.41129
+  tps: 6759.57625
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8226.72637
-  tps: 6782.06037
+  dps: 8218.69031
+  tps: 6776.30516
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8088.10261
-  tps: 6660.29864
+  dps: 8139.31305
+  tps: 6698.3216
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8201.32821
-  tps: 6754.54874
+  dps: 8184.30351
+  tps: 6742.04987
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8173.62279
-  tps: 6736.0252
+  dps: 8238.31468
+  tps: 6793.5303
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7938.1367
-  tps: 6533.45569
+  dps: 7965.51038
+  tps: 6558.42023
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7991.92293
-  tps: 6584.55652
+  dps: 7965.54619
+  tps: 6558.44172
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8120.16388
-  tps: 6688.09249
+  dps: 8187.68398
+  tps: 6749.03021
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7991.64495
-  tps: 6577.9506
+  dps: 7958.58246
+  tps: 6549.74791
  }
 }
 dps_results: {
@@ -339,85 +339,85 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8217.86512
-  tps: 6773.95982
+  dps: 8240.86902
+  tps: 6792.23269
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8173.62279
-  tps: 6736.0252
+  dps: 8238.31468
+  tps: 6793.5303
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8201.32821
-  tps: 6754.54874
+  dps: 8184.30351
+  tps: 6742.04987
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8201.32821
-  tps: 6754.54874
+  dps: 8184.30351
+  tps: 6742.04987
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7991.92293
-  tps: 6584.55652
+  dps: 7965.54619
+  tps: 6558.44172
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7991.92293
-  tps: 6584.55652
+  dps: 7965.54619
+  tps: 6558.44172
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7991.92293
-  tps: 6584.55652
+  dps: 7965.54619
+  tps: 6558.44172
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8383.94391
-  tps: 6908.67602
+  dps: 8368.20621
+  tps: 6892.04435
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8201.32821
-  tps: 6754.54874
+  dps: 8184.30351
+  tps: 6742.04987
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7938.1367
-  tps: 6533.45569
+  dps: 7965.51038
+  tps: 6558.42023
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7953.25393
-  tps: 6548.47776
+  dps: 7902.33862
+  tps: 6506.02631
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7991.92293
-  tps: 6584.55652
+  dps: 7965.54619
+  tps: 6558.44172
  }
 }
 dps_results: {
@@ -430,106 +430,106 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7981.70506
-  tps: 6574.1161
+  dps: 7919.35255
+  tps: 6520.84413
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SparkofLife-37657"
  value: {
-  dps: 8051.83069
-  tps: 6634.83967
+  dps: 8041.12918
+  tps: 6624.74621
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StormshroudArmor"
  value: {
-  dps: 6581.64109
-  tps: 5427.39979
+  dps: 6581.63799
+  tps: 5427.39731
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8173.62279
-  tps: 6736.0252
+  dps: 8238.31468
+  tps: 6793.5303
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8217.86512
-  tps: 6773.95982
+  dps: 8240.86902
+  tps: 6792.23269
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8221.29141
-  tps: 6775.71829
+  dps: 8213.1969
+  tps: 6770.36726
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheFistsofFury"
  value: {
-  dps: 4370.69497
-  tps: 3697.18875
+  dps: 4420.0496
+  tps: 3741.55462
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 4701.12952
-  tps: 3970.0141
+  dps: 4689.36579
+  tps: 3957.97162
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8219.63934
-  tps: 6774.1437
+  dps: 8273.65557
+  tps: 6822.3763
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 8424.4769
-  tps: 6943.49006
+  dps: 8405.11092
+  tps: 6923.29929
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8451.54989
-  tps: 6965.60473
+  dps: 8470.58661
+  tps: 6979.90332
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8201.32821
-  tps: 6754.54874
+  dps: 8184.30351
+  tps: 6742.04987
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8201.32821
-  tps: 6754.54874
+  dps: 8184.30351
+  tps: 6742.04987
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8201.32821
-  tps: 6754.54874
+  dps: 8184.30351
+  tps: 6742.04987
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8201.32821
-  tps: 6754.54874
+  dps: 8184.30351
+  tps: 6742.04987
  }
 }
 dps_results: {
@@ -556,15 +556,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 8340.63321
-  tps: 6865.82098
+  dps: 8338.64464
+  tps: 6863.20322
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11654.35012
-  tps: 10106.27548
+  dps: 11675.15693
+  tps: 10123.36444
  }
 }
 dps_results: {
@@ -605,22 +605,22 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11798.44385
-  tps: 10224.29266
+  dps: 11768.82355
+  tps: 10202.83779
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8383.94391
-  tps: 6908.67602
+  dps: 8368.20621
+  tps: 6892.04435
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8989.10065
-  tps: 7436.45834
+  dps: 8994.0707
+  tps: 7454.57648
  }
 }
 dps_results: {
@@ -647,7 +647,7 @@ dps_results: {
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7793.4642
-  tps: 6402.44902
+  dps: 7762.36005
+  tps: 6383.2752
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -45,36 +45,36 @@ character_stats_results: {
 dps_results: {
  key: "TestFury-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 6583.82483
-  tps: 4843.96524
+  dps: 6619.86353
+  tps: 4872.98723
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6658.34561
-  tps: 4900.13262
+  dps: 6673.28749
+  tps: 4909.48664
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6684.61067
-  tps: 4916.54572
+  dps: 6746.85097
+  tps: 4961.00669
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6675.52759
-  tps: 4916.04942
+  dps: 6697.38076
+  tps: 4923.26787
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6466.25885
-  tps: 4757.3555
+  dps: 6539.73755
+  tps: 4810.36996
  }
 }
 dps_results: {
@@ -101,57 +101,57 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6632.71238
-  tps: 4782.49985
+  dps: 6687.29236
+  tps: 4822.07513
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6819.9343
-  tps: 5017.33669
+  dps: 6805.66742
+  tps: 5004.90237
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6706.39322
-  tps: 4933.09959
+  dps: 6690.38418
+  tps: 4919.95702
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6740.80394
-  tps: 4955.44136
+  dps: 6766.0117
+  tps: 4974.28238
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6696.89797
-  tps: 4927.73345
+  dps: 6662.53191
+  tps: 4900.1555
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6521.47363
-  tps: 4804.27378
+  dps: 6566.16088
+  tps: 4833.72444
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6552.06403
-  tps: 4822.09557
+  dps: 6577.75227
+  tps: 4839.11273
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6649.57383
-  tps: 4893.01044
+  dps: 6689.93063
+  tps: 4921.31371
  }
 }
 dps_results: {
@@ -164,85 +164,85 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6632.71238
-  tps: 4879.88653
+  dps: 6687.29236
+  tps: 4920.27325
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6632.71238
-  tps: 4879.88653
+  dps: 6687.29236
+  tps: 4920.27325
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6675.52759
-  tps: 4916.04942
+  dps: 6697.38076
+  tps: 4923.26787
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6668.30546
-  tps: 4907.976
+  dps: 6693.17531
+  tps: 4923.87177
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6632.71238
-  tps: 4879.88653
+  dps: 6687.29236
+  tps: 4920.27325
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6750.165
-  tps: 4964.42058
+  dps: 6754.42625
+  tps: 4965.52364
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6686.81757
-  tps: 4914.67198
+  dps: 6673.62065
+  tps: 4906.34543
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6623.62257
-  tps: 4874.92303
+  dps: 6627.94226
+  tps: 4877.62934
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6632.71238
-  tps: 4879.88653
+  dps: 6687.29236
+  tps: 4920.27325
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6632.71238
-  tps: 4879.88653
+  dps: 6687.29236
+  tps: 4920.27325
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6710.37551
-  tps: 4936.52174
+  dps: 6688.59618
+  tps: 4919.6021
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6521.47363
-  tps: 4804.27378
+  dps: 6564.35342
+  tps: 4828.82987
  }
 }
 dps_results: {
@@ -255,71 +255,71 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6521.47363
-  tps: 4804.27378
+  dps: 6566.16088
+  tps: 4833.72444
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6675.52759
-  tps: 4916.04942
+  dps: 6697.38076
+  tps: 4923.26787
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6668.30546
-  tps: 4907.976
+  dps: 6693.17531
+  tps: 4923.87177
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6730.52993
-  tps: 4949.15637
+  dps: 6736.30757
+  tps: 4954.04858
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6632.71238
-  tps: 4879.88653
+  dps: 6687.29236
+  tps: 4920.27325
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6738.62995
-  tps: 4953.21092
+  dps: 6719.72238
+  tps: 4943.29823
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6521.47363
-  tps: 4804.27378
+  dps: 6566.16088
+  tps: 4833.72444
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6521.47363
-  tps: 4804.27378
+  dps: 6566.16088
+  tps: 4833.72444
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6752.969
-  tps: 4964.00937
+  dps: 6802.12311
+  tps: 5001.94085
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6531.67195
-  tps: 4807.07829
+  dps: 6523.61221
+  tps: 4798.04614
  }
 }
 dps_results: {
@@ -339,85 +339,85 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6643.19669
-  tps: 4888.19859
+  dps: 6703.90198
+  tps: 4932.50765
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6738.62995
-  tps: 4953.21092
+  dps: 6719.72238
+  tps: 4943.29823
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6632.71238
-  tps: 4879.88653
+  dps: 6687.29236
+  tps: 4920.27325
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6632.71238
-  tps: 4879.88653
+  dps: 6687.29236
+  tps: 4920.27325
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6521.47363
-  tps: 4804.27378
+  dps: 6566.16088
+  tps: 4833.72444
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6521.47363
-  tps: 4804.27378
+  dps: 6566.16088
+  tps: 4833.72444
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6521.47363
-  tps: 4804.27378
+  dps: 6566.16088
+  tps: 4833.72444
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6848.33176
-  tps: 5038.07812
+  dps: 6830.9284
+  tps: 5024.48176
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6632.71238
-  tps: 4879.88653
+  dps: 6687.29236
+  tps: 4920.27325
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6521.47363
-  tps: 4804.27378
+  dps: 6566.16088
+  tps: 4833.72444
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6505.24286
-  tps: 4788.08495
+  dps: 6562.57352
+  tps: 4829.21427
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6521.47363
-  tps: 4804.27378
+  dps: 6566.16088
+  tps: 4833.72444
  }
 }
 dps_results: {
@@ -430,106 +430,106 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6521.47363
-  tps: 4804.27378
+  dps: 6564.35342
+  tps: 4828.82987
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SparkofLife-37657"
  value: {
-  dps: 6640.02182
-  tps: 4885.26171
+  dps: 6653.96055
+  tps: 4896.24804
  }
 }
 dps_results: {
  key: "TestFury-AllItems-StormshroudArmor"
  value: {
-  dps: 5097.20124
-  tps: 3765.05582
+  dps: 5097.19471
+  tps: 3765.05124
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6738.62995
-  tps: 4953.21092
+  dps: 6719.72238
+  tps: 4943.29823
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6643.19669
-  tps: 4888.19859
+  dps: 6703.90198
+  tps: 4932.50765
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6631.01584
-  tps: 4880.23236
+  dps: 6683.24873
+  tps: 4917.43397
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 4819.1123
-  tps: 3574.86551
+  dps: 4836.24713
+  tps: 3587.51336
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5035.82437
-  tps: 3728.88145
+  dps: 5034.52118
+  tps: 3727.32662
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6733.97628
-  tps: 4955.56041
+  dps: 6748.73501
+  tps: 4965.00073
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6809.44239
-  tps: 5005.39316
+  dps: 6830.17564
+  tps: 5023.45248
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6889.40134
-  tps: 5065.39995
+  dps: 6832.28901
+  tps: 5022.49492
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6632.71238
-  tps: 4879.88653
+  dps: 6687.29236
+  tps: 4920.27325
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6632.71238
-  tps: 4879.88653
+  dps: 6687.29236
+  tps: 4920.27325
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6632.71238
-  tps: 4879.88653
+  dps: 6687.29236
+  tps: 4920.27325
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6632.71238
-  tps: 4879.88653
+  dps: 6687.29236
+  tps: 4920.27325
  }
 }
 dps_results: {
@@ -556,8 +556,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-Average-Default"
  value: {
-  dps: 6756.42954
-  tps: 4970.78694
+  dps: 6760.11053
+  tps: 4973.72827
  }
 }
 dps_results: {
@@ -605,22 +605,22 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8477.60965
-  tps: 6640.15518
+  dps: 8490.98209
+  tps: 6655.37401
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6848.33176
-  tps: 5038.07812
+  dps: 6830.9284
+  tps: 5024.48176
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8067.877
-  tps: 5924.35339
+  dps: 8175.68946
+  tps: 6001.42518
  }
 }
 dps_results: {
@@ -647,7 +647,7 @@ dps_results: {
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6258.02579
-  tps: 4605.74563
+  dps: 6278.206
+  tps: 4617.63232
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -45,36 +45,36 @@ character_stats_results: {
 dps_results: {
  key: "TestFury-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 6604.83087
-  tps: 4859.94999
+  dps: 6597.06131
+  tps: 4856.56732
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6644.50942
-  tps: 4887.88518
+  dps: 6692.44708
+  tps: 4922.70953
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6710.26676
-  tps: 4935.71661
+  dps: 6697.8135
+  tps: 4928.39709
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6675.71678
-  tps: 4907.72556
+  dps: 6730.38993
+  tps: 4955.13789
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6545.53163
-  tps: 4812.29122
+  dps: 6537.97092
+  tps: 4810.887
  }
 }
 dps_results: {
@@ -101,57 +101,57 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6629.50122
-  tps: 4778.15315
+  dps: 6678.51393
+  tps: 4815.74763
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6822.33129
-  tps: 5019.3307
+  dps: 6841.13408
+  tps: 5031.37738
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6698.03101
-  tps: 4923.74755
+  dps: 6706.15015
+  tps: 4930.37613
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6764.80924
-  tps: 4974.71483
+  dps: 6714.27697
+  tps: 4935.8948
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6655.68448
-  tps: 4898.78016
+  dps: 6678.38651
+  tps: 4909.75838
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6539.52427
-  tps: 4814.72609
+  dps: 6587.0207
+  tps: 4849.38942
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6537.93585
-  tps: 4815.7901
+  dps: 6572.97583
+  tps: 4836.07205
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6747.11075
-  tps: 4963.07676
+  dps: 6736.13055
+  tps: 4956.85309
  }
 }
 dps_results: {
@@ -164,85 +164,85 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6629.50122
-  tps: 4875.44227
+  dps: 6678.51393
+  tps: 4913.80387
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6629.50122
-  tps: 4875.44227
+  dps: 6678.51393
+  tps: 4913.80387
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6675.71678
-  tps: 4907.72556
+  dps: 6730.38993
+  tps: 4955.13789
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6671.86701
-  tps: 4907.63677
+  dps: 6673.22657
+  tps: 4908.00401
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6629.50122
-  tps: 4875.44227
+  dps: 6678.51393
+  tps: 4913.80387
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6758.94009
-  tps: 4969.00185
+  dps: 6763.91815
+  tps: 4972.06885
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6633.19227
-  tps: 4880.56853
+  dps: 6666.70138
+  tps: 4902.44532
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6685.93638
-  tps: 4919.96196
+  dps: 6692.83607
+  tps: 4922.59715
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6629.50122
-  tps: 4875.44227
+  dps: 6678.51393
+  tps: 4913.80387
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6629.50122
-  tps: 4875.44227
+  dps: 6678.51393
+  tps: 4913.80387
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6718.34934
-  tps: 4942.14953
+  dps: 6733.35238
+  tps: 4950.29228
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6612.07782
-  tps: 4862.49979
+  dps: 6587.0207
+  tps: 4849.38942
  }
 }
 dps_results: {
@@ -255,71 +255,71 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6539.52427
-  tps: 4814.72609
+  dps: 6587.0207
+  tps: 4849.38942
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6675.71678
-  tps: 4907.72556
+  dps: 6730.38993
+  tps: 4955.13789
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6671.86701
-  tps: 4907.63677
+  dps: 6673.22657
+  tps: 4908.00401
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6736.7345
-  tps: 4957.2805
+  dps: 6733.43291
+  tps: 4953.27001
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6629.50122
-  tps: 4875.44227
+  dps: 6678.51393
+  tps: 4913.80387
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6659.87559
-  tps: 4900.06025
+  dps: 6738.85725
+  tps: 4955.05108
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6539.52427
-  tps: 4814.72609
+  dps: 6587.0207
+  tps: 4849.38942
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6539.52427
-  tps: 4814.72609
+  dps: 6587.0207
+  tps: 4849.38942
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6838.37365
-  tps: 5027.89696
+  dps: 6743.25441
+  tps: 4958.90301
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6522.30623
-  tps: 4803.16196
+  dps: 6569.56697
+  tps: 4833.52473
  }
 }
 dps_results: {
@@ -339,85 +339,85 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6658.52959
-  tps: 4897.63164
+  dps: 6695.14579
+  tps: 4927.98495
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6659.87559
-  tps: 4900.06025
+  dps: 6738.85725
+  tps: 4955.05108
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6629.50122
-  tps: 4875.44227
+  dps: 6678.51393
+  tps: 4913.80387
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6629.50122
-  tps: 4875.44227
+  dps: 6678.51393
+  tps: 4913.80387
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6539.52427
-  tps: 4814.72609
+  dps: 6587.0207
+  tps: 4849.38942
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6539.52427
-  tps: 4814.72609
+  dps: 6587.0207
+  tps: 4849.38942
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6539.52427
-  tps: 4814.72609
+  dps: 6587.0207
+  tps: 4849.38942
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6883.29276
-  tps: 5061.65133
+  dps: 6878.3672
+  tps: 5059.48278
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6629.50122
-  tps: 4875.44227
+  dps: 6678.51393
+  tps: 4913.80387
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6539.52427
-  tps: 4814.72609
+  dps: 6587.0207
+  tps: 4849.38942
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6585.29899
-  tps: 4846.0435
+  dps: 6571.89697
+  tps: 4837.71682
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6539.52427
-  tps: 4814.72609
+  dps: 6587.0207
+  tps: 4849.38942
  }
 }
 dps_results: {
@@ -430,15 +430,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6612.07782
-  tps: 4862.49979
+  dps: 6587.0207
+  tps: 4849.38942
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SparkofLife-37657"
  value: {
-  dps: 6657.73121
-  tps: 4899.93721
+  dps: 6637.36406
+  tps: 4881.95491
  }
 }
 dps_results: {
@@ -451,85 +451,85 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6659.87559
-  tps: 4900.06025
+  dps: 6738.85725
+  tps: 4955.05108
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6658.52959
-  tps: 4897.63164
+  dps: 6695.14579
+  tps: 4927.98495
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6675.21892
-  tps: 4910.90613
+  dps: 6698.84664
+  tps: 4931.19316
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 4764.90131
-  tps: 3537.75392
+  dps: 4791.44109
+  tps: 3556.81133
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5029.00432
-  tps: 3722.73004
+  dps: 5024.80773
+  tps: 3723.90741
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6740.66444
-  tps: 4961.01178
+  dps: 6776.88631
+  tps: 4990.72363
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6868.19977
-  tps: 5051.24854
+  dps: 6845.13397
+  tps: 5036.76536
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6884.68533
-  tps: 5062.44089
+  dps: 6916.08452
+  tps: 5087.4999
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6629.50122
-  tps: 4875.44227
+  dps: 6678.51393
+  tps: 4913.80387
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6629.50122
-  tps: 4875.44227
+  dps: 6678.51393
+  tps: 4913.80387
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6629.50122
-  tps: 4875.44227
+  dps: 6678.51393
+  tps: 4913.80387
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6629.50122
-  tps: 4875.44227
+  dps: 6678.51393
+  tps: 4913.80387
  }
 }
 dps_results: {
@@ -556,8 +556,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-Average-Default"
  value: {
-  dps: 6769.06431
-  tps: 4980.9343
+  dps: 6766.66256
+  tps: 4979.18968
  }
 }
 dps_results: {
@@ -605,22 +605,22 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8494.76067
-  tps: 6669.99446
+  dps: 8539.64096
+  tps: 6698.91371
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6883.29276
-  tps: 5061.65133
+  dps: 6878.3672
+  tps: 5059.48278
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8076.17285
-  tps: 5923.94393
+  dps: 8189.28317
+  tps: 6016.90751
  }
 }
 dps_results: {
@@ -647,7 +647,7 @@ dps_results: {
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6335.17079
-  tps: 4664.03623
+  dps: 6296.1205
+  tps: 4634.94815
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -45,7 +45,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 0.79114
+  weights: 0.7912
   weights: 0
   weights: 0
   weights: 0
@@ -56,7 +56,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.25069
+  weights: 0.25075
   weights: 0
   weights: 0
   weights: 0
@@ -65,12 +65,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.0451
+  weights: 0.04504
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.5234
-  weights: 0.15868
+  weights: 0.52334
+  weights: 0.15951
   weights: 0
   weights: 0
   weights: 0
@@ -103,8 +103,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1970.80937
-  tps: 5718.55477
+  dps: 1970.96638
+  tps: 5718.88033
  }
 }
 dps_results: {
@@ -166,8 +166,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2005.36866
-  tps: 5789.87304
+  dps: 2005.34251
+  tps: 5789.81883
  }
 }
 dps_results: {
@@ -243,8 +243,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2000.19053
-  tps: 5781.47781
+  dps: 2000.33496
+  tps: 5781.77728
  }
 }
 dps_results: {
@@ -488,8 +488,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormshroudArmor"
  value: {
-  dps: 1556.04394
-  tps: 4596.30546
+  dps: 1556.04347
+  tps: 4596.30447
  }
 }
 dps_results: {
@@ -516,8 +516,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 1450.74461
-  tps: 4225.09699
+  dps: 1450.65229
+  tps: 4224.90556
  }
 }
 dps_results: {
@@ -600,8 +600,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 2819.69746
-  tps: 7424.52929
+  dps: 2818.60122
+  tps: 7422.25625
   dtps: 95.64931
  }
 }
@@ -692,8 +692,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2960.37697
-  tps: 7799.29786
+  dps: 2958.94956
+  tps: 7796.33813
   dtps: 99.39883
  }
 }


### PR DESCRIPTION
[core] updated partial resist mechanics for WotLK (using 10% brackets instead of 25% etc.)

[core] drive-by: GetArmorDamageModifier() was using a level-ignorant constant for reducible armor ("arpen cap")

This has slightly lowered DPS for all casters or caster items, so I guess the effective partial resist percentage was too low before (should be 6%, but was 5.78%)