### PR TITLE
fix Tiger Fury being active while Berserk

### DIFF
--- a/sim/druid/berserk.go
+++ b/sim/druid/berserk.go
@@ -23,6 +23,7 @@ func (druid *Druid) registerBerserkCD() {
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			if druid.InForm(Cat) {
 				druid.PseudoStats.CostMultiplier /= 2.0
+				druid.TigersFuryAura.Deactivate(sim)
 			}
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {


### PR DESCRIPTION
This fix should prevent TF overlapping with Berserk.

<img width="330" alt="image" src="https://user-images.githubusercontent.com/24717126/192272784-60e42b32-e4a3-4738-8835-4b926bda925c.png">

```

[3.04] [Player (#1)] Gained 60.0 Energy from Tiger's Fury. (21.0 --> 81.0)
[3.04] [Player (#1)] Aura gained: Tiger's Fury.
[3.04] [Player (#1)] Pausing GCD for 959.567574ms due to rotation / CDs.
[3.14] [Player (#1)] Gained 1.0 Energy from Energy Tick. (81.0 --> 82.0)
[3.24] [Player (#1)] Gained 1.0 Energy from Energy Tick. (82.0 --> 83.0)
[3.34] [Player (#1)] Gained 1.0 Energy from Energy Tick. (83.0 --> 84.0)
[3.44] [Player (#1)] Gained 1.0 Energy from Energy Tick. (84.0 --> 85.0)
[3.54] [Player (#1)] Gained 1.0 Energy from Energy Tick. (85.0 --> 86.0)
[3.54] [Player (#1)] Casting Attack (Main Hand) (Cast time = 0.00s, Cost = 0.0).
[3.54] [Player (#1)] [Target 1] {OtherID: 3, Tag: 1} [DEBUG] MAP: 17719.8, RAP: 5475.8, SP: 280.0, BaseDamage:1403.9, AfterAttackerMods:2115.5, AfterResistances:2072.7, AfterTargetMods:2163.9, AfterOutcome:1622.9
[3.54] [Player (#1)] Attack (Main Hand) Glance Target 1 for 1622.91. (1152.27 Threat)
[3.54] [Player (#1)] Gained 0.0 Rage from Attack (Main Hand). (100.0 --> 100.0)
[3.54] [Player (#1)] Gained 0.0 Mana from Judgement of Wisdom. (8996.1 --> 8996.1)
[3.64] [Player (#1)] Gained 1.0 Energy from Energy Tick. (86.0 --> 87.0)
[3.74] [Player (#1)] Gained 1.0 Energy from Energy Tick. (87.0 --> 88.0)
[3.84] [Player (#1)] Gained 1.0 Energy from Energy Tick. (88.0 --> 89.0)
[3.94] [Player (#1)] Gained 1.0 Energy from Energy Tick. (89.0 --> 90.0)
[4.00] [Player (#1)] Gained 0.0 Mana from Mana Tick (Not Casting). (8996.1 --> 8996.1)
[4.00] [Player (#1)] Casting Berserk (Cast time = 0.00s, Cost = 0.0).
[4.00] [Player (#1)] Aura gained: Berserk.
[4.04] [Player (#1)] Gained 1.0 Energy from Energy Tick. (90.0 --> 91.0)
[4.14] [Player (#1)] Gained 1.0 Energy from Energy Tick. (91.0 --> 92.0)
```
