### PR TITLE
binaries-gone-dodo

### DIFF
--- a/sim/common/wotlk/enchant_effects.go
+++ b/sim/common/wotlk/enchant_effects.go
@@ -117,7 +117,6 @@ func init() {
 			ActionID:    actionID,
 			SpellSchool: core.SpellSchoolPhysical,
 			ProcMask:    core.ProcMaskEmpty,
-			Flags:       core.SpellFlagBinary,
 
 			DamageMultiplier: 1,
 			CritMultiplier:   character.DefaultMeleeCritMultiplier(),
@@ -137,7 +136,7 @@ func init() {
 				aura.Activate(sim)
 			},
 			OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if spellEffect.Landed() && spell.SpellSchool == core.SpellSchoolPhysical {
+				if spellEffect.Landed() && spell.ProcMask.Matches(core.ProcMaskMelee) {
 					procSpell.Cast(sim, spell.Unit)
 				}
 			},

--- a/sim/core/spell_outcome.go
+++ b/sim/core/spell_outcome.go
@@ -228,8 +228,8 @@ func (spell *Spell) OutcomeMagicHitBinary(sim *Simulation, result *SpellEffect, 
 		spell.SpellMetrics[result.Target.UnitIndex].Misses++
 	}
 }
-func (spell *Spell) CalcAndDealDamageMagicHitBinary(sim *Simulation, target *Unit, baseHealing float64) {
-	result := spell.CalcDamage(sim, target, baseHealing, spell.OutcomeMagicHitBinary)
+func (spell *Spell) CalcAndDealDamageMagicHitBinary(sim *Simulation, target *Unit, baseDamage float64) {
+	result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicHitBinary)
 	spell.DealDamage(sim, &result)
 }
 func (unit *Unit) OutcomeFuncMagicHitBinary() OutcomeApplier {
@@ -501,6 +501,10 @@ func (spell *Spell) MagicHitCheck(sim *Simulation, attackTable *AttackTable) boo
 	missChance := attackTable.BaseSpellMissChance - spell.SpellHitChance(attackTable.Defender)
 	return sim.RandomFloat("Magical Hit Roll") > missChance
 }
+
+// TODO if a binary spell misses, it's logged as "resist" (similar to "dodge", "miss", etc.), so it's treated
+//  as just another HitOutcome.
+// TODO research the few remaining binary spells (Thorns, Retribution Aura, and Holy Shield).
 func (spell *Spell) MagicHitCheckBinary(sim *Simulation, attackTable *AttackTable) bool {
 	baseHitChance := (1 - attackTable.BaseSpellMissChance) * attackTable.GetBinaryHitChance(spell.SpellSchool)
 	missChance := 1 - baseHitChance - spell.SpellHitChance(attackTable.Defender)

--- a/sim/paladin/holy_shield.go
+++ b/sim/paladin/holy_shield.go
@@ -12,11 +12,13 @@ func (paladin *Paladin) registerHolyShieldSpell() {
 	actionID := core.ActionID{SpellID: 48952}
 	numCharges := int32(8)
 
+	// Holy Shield can be both fully and partially resisted in WotLK, so it doesn't use SpellFlagBinary here,
+	//	but does use CalcAndDealDamageMagicHitBinary() below.
+	// TODO needs research ;)
 	procSpell := paladin.RegisterSpell(core.SpellConfig{
 		ActionID:    actionID.WithTag(1),
 		SpellSchool: core.SpellSchoolHoly,
 		ProcMask:    core.ProcMaskEmpty,
-		Flags:       core.SpellFlagBinary,
 
 		// DamageMultiplier: 1 + 0.1*float64(paladin.Talents.ImprovedHolyShield),
 		DamageMultiplier: 1,

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -668,8 +668,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Average-Default"
  value: {
-  dps: 2022.79921
-  tps: 4750.58678
+  dps: 2015.78153
+  tps: 4732.52326
   dtps: 64.83568
  }
 }
@@ -928,8 +928,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2137.7374
-  tps: 5002.46391
+  dps: 2127.93782
+  tps: 4977.23979
   dtps: 67.08851
  }
 }

--- a/sim/priest/Mind_Sear.go
+++ b/sim/priest/Mind_Sear.go
@@ -9,6 +9,8 @@ import (
 	"github.com/wowsims/wotlk/sim/core/stats"
 )
 
+// TODO see Mind Flay: Mind Sear (53023) now "periodically triggers" Mind Sear (53022).
+//  Since Mind Flay no longer is a binary spell, Mind Sear likely isn't, either.
 func (priest *Priest) MindSearActionID(numTicks int) core.ActionID {
 	return core.ActionID{SpellID: 53023, Tag: int32(numTicks)}
 }
@@ -18,7 +20,7 @@ func (priest *Priest) newMindSearSpell(numTicks int) *core.Spell {
 	channelTime := time.Second * time.Duration(numTicks)
 
 	effect := core.SpellEffect{
-		OutcomeApplier: priest.OutcomeFuncMagicHitBinary(),
+		OutcomeApplier: priest.OutcomeFuncMagicHit(),
 		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 			if !spellEffect.Landed() {
 				return
@@ -31,7 +33,7 @@ func (priest *Priest) newMindSearSpell(numTicks int) *core.Spell {
 		ActionID:     priest.MindSearActionID(numTicks),
 		SpellSchool:  core.SpellSchoolShadow,
 		ProcMask:     core.ProcMaskEmpty,
-		Flags:        core.SpellFlagBinary | core.SpellFlagChanneled,
+		Flags:        core.SpellFlagChanneled,
 		ResourceType: stats.Mana,
 		BaseCost:     baseCost,
 

--- a/sim/priest/mind_flay.go
+++ b/sim/priest/mind_flay.go
@@ -9,6 +9,8 @@ import (
 	"github.com/wowsims/wotlk/sim/core/stats"
 )
 
+// TODO Mind Flay (48156) now "periodically triggers" Mind Flay (58381), probably to allow haste to work.
+//  The first never deals damage, so the latter should probably be used as ActionID here.
 func (priest *Priest) MindFlayActionID(numTicks int) core.ActionID {
 	return core.ActionID{SpellID: 48156, Tag: int32(numTicks)}
 }
@@ -22,7 +24,7 @@ func (priest *Priest) newMindFlaySpell(numTicks int) *core.Spell {
 	}
 
 	effect := core.SpellEffect{
-		OutcomeApplier: priest.OutcomeFuncMagicHitBinary(),
+		OutcomeApplier: priest.OutcomeFuncMagicHit(),
 		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 			if !spellEffect.Landed() {
 				return
@@ -42,7 +44,7 @@ func (priest *Priest) newMindFlaySpell(numTicks int) *core.Spell {
 		ActionID:     priest.MindFlayActionID(numTicks),
 		SpellSchool:  core.SpellSchoolShadow,
 		ProcMask:     core.ProcMaskEmpty,
-		Flags:        core.SpellFlagBinary | core.SpellFlagChanneled,
+		Flags:        core.SpellFlagChanneled,
 		ResourceType: stats.Mana,
 		BaseCost:     baseCost,
 

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -45,505 +45,505 @@ character_stats_results: {
 dps_results: {
  key: "TestShadow-AllItems-AbsolutionRegalia"
  value: {
-  dps: 3269.88021
-  tps: 2491.79325
+  dps: 3265.76243
+  tps: 2489.14418
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AshtongueTalismanofAcumen-32490"
  value: {
-  dps: 4975.55708
-  tps: 3799.50951
+  dps: 4943.17874
+  tps: 3774.32853
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5059.77322
-  tps: 3860.37837
+  dps: 5024.03924
+  tps: 3832.71204
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 4905.37103
-  tps: 3746.33063
+  dps: 4873.41853
+  tps: 3721.5541
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5152.53187
-  tps: 3929.68021
+  dps: 5111.54956
+  tps: 3898.91783
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 3565.63131
-  tps: 2721.95271
+  dps: 3534.38199
+  tps: 2697.78069
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5093.5148
-  tps: 3808.85939
+  dps: 5057.54584
+  tps: 3781.56802
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 5171.65671
-  tps: 3946.76701
+  dps: 5137.18131
+  tps: 3920.02364
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 5041.673
-  tps: 3850.86878
+  dps: 5060.34183
+  tps: 3862.46593
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 5318.8012
-  tps: 4036.80129
+  dps: 5264.33212
+  tps: 3995.69354
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 4905.37103
-  tps: 3746.33063
+  dps: 4873.41853
+  tps: 3721.5541
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5048.4806
-  tps: 3870.48886
+  dps: 5006.74862
+  tps: 3837.33713
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 4633.84097
-  tps: 3533.49951
+  dps: 4603.14882
+  tps: 3509.465
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 4633.84097
-  tps: 3533.49951
+  dps: 4603.14882
+  tps: 3509.465
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 4756.68676
-  tps: 3627.07698
+  dps: 4710.85969
+  tps: 3593.37345
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Defender'sCode-40257"
  value: {
-  dps: 4905.37103
-  tps: 3746.33063
+  dps: 4873.41853
+  tps: 3721.5541
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5085.56525
-  tps: 3879.98712
+  dps: 5050.41657
+  tps: 3852.76156
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5059.77322
-  tps: 3860.37837
+  dps: 5024.03924
+  tps: 3832.71204
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5153.46268
-  tps: 3930.77203
+  dps: 5127.88383
+  tps: 3911.68
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5080.58022
-  tps: 3876.14287
+  dps: 5045.98146
+  tps: 3849.3527
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5075.24338
-  tps: 3872.41775
+  dps: 5040.61477
+  tps: 3845.57468
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5059.77322
-  tps: 3860.37837
+  dps: 5024.03924
+  tps: 3832.71204
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5066.74291
-  tps: 3887.341
+  dps: 5022.40125
+  tps: 3854.31469
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5161.74563
-  tps: 3939.49518
+  dps: 5127.96756
+  tps: 3913.58525
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForgeEmber-37660"
  value: {
-  dps: 4975.08733
-  tps: 3798.73251
+  dps: 4943.8171
+  tps: 3774.70679
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5093.5148
-  tps: 3885.79211
+  dps: 5057.54584
+  tps: 3857.94412
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5086.76648
-  tps: 3880.70936
+  dps: 5050.84452
+  tps: 3852.8977
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 4905.37103
-  tps: 3746.33063
+  dps: 4873.41853
+  tps: 3721.5541
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5006.48915
-  tps: 3821.59704
+  dps: 4983.20805
+  tps: 3804.19997
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GarbofFaith"
  value: {
-  dps: 4271.2377
-  tps: 3260.0667
+  dps: 4324.45042
+  tps: 3303.60071
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 4996.51402
-  tps: 3809.77633
+  dps: 4953.32882
+  tps: 3776.58289
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 5149.63044
-  tps: 3922.07435
+  dps: 5149.24629
+  tps: 3921.54348
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5080.58022
-  tps: 3876.14287
+  dps: 5045.98146
+  tps: 3849.3527
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5075.24338
-  tps: 3872.41775
+  dps: 5040.61477
+  tps: 3845.57468
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-IncisorFragment-37723"
  value: {
-  dps: 4824.11725
-  tps: 3685.25321
+  dps: 4819.24823
+  tps: 3681.3106
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5220.80026
-  tps: 3988.24011
+  dps: 5188.69874
+  tps: 3962.19175
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5059.77322
-  tps: 3860.37837
+  dps: 5024.03924
+  tps: 3832.71204
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 4905.37103
-  tps: 3746.33063
+  dps: 4873.41853
+  tps: 3721.5541
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5041.85902
-  tps: 3851.31683
+  dps: 5025.80841
+  tps: 3837.85354
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 4975.98598
-  tps: 3799.4619
+  dps: 4944.67306
+  tps: 3775.35732
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 4905.37103
-  tps: 3746.33063
+  dps: 4873.41853
+  tps: 3721.5541
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5059.77322
-  tps: 3860.37837
+  dps: 5024.03924
+  tps: 3832.71204
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5059.77322
-  tps: 3860.37837
+  dps: 5024.03924
+  tps: 3832.71204
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5059.77322
-  tps: 3860.37837
+  dps: 5024.03924
+  tps: 3832.71204
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5059.77322
-  tps: 3860.37837
+  dps: 5024.03924
+  tps: 3832.71204
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 4905.37103
-  tps: 3746.33063
+  dps: 4873.41853
+  tps: 3721.5541
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RegaliaofFaith"
  value: {
-  dps: 4196.2362
-  tps: 3202.54258
+  dps: 4202.02974
+  tps: 3210.38392
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 5114.57506
-  tps: 3904.91127
+  dps: 5089.22019
+  tps: 3887.19091
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 5140.18691
-  tps: 3924.4072
+  dps: 5115.06308
+  tps: 3906.95279
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5149.0843
-  tps: 3929.63227
+  dps: 5113.40953
+  tps: 3901.96191
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5117.23746
-  tps: 3903.10808
+  dps: 5066.97839
+  tps: 3865.19736
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 4905.37103
-  tps: 3746.33063
+  dps: 4873.41853
+  tps: 3721.5541
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationGarb"
  value: {
-  dps: 4564.75169
-  tps: 3494.88287
+  dps: 4523.75938
+  tps: 3464.79266
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationRegalia"
  value: {
-  dps: 4486.89421
-  tps: 3427.97993
+  dps: 4429.2072
+  tps: 3383.5519
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 4905.37103
-  tps: 3746.33063
+  dps: 4873.41853
+  tps: 3721.5541
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 4905.37103
-  tps: 3746.33063
+  dps: 4873.41853
+  tps: 3721.5541
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 4905.37103
-  tps: 3746.33063
+  dps: 4873.41853
+  tps: 3721.5541
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SparkofLife-37657"
  value: {
-  dps: 5034.42238
-  tps: 3845.90772
+  dps: 4993.36435
+  tps: 3817.49123
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5059.77322
-  tps: 3860.37837
+  dps: 5024.03924
+  tps: 3832.71204
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5059.77322
-  tps: 3860.37837
+  dps: 5024.03924
+  tps: 3832.71204
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5059.77322
-  tps: 3860.37837
+  dps: 5024.03924
+  tps: 3832.71204
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5059.77322
-  tps: 3860.37837
+  dps: 5024.03924
+  tps: 3832.71204
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 4988.09422
-  tps: 3809.01767
+  dps: 4869.06244
+  tps: 3718.69425
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 4988.09422
-  tps: 3809.01767
+  dps: 4869.06244
+  tps: 3718.69425
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5093.5148
-  tps: 3885.79211
+  dps: 5057.54584
+  tps: 3857.94412
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5086.76648
-  tps: 3880.70936
+  dps: 5050.84452
+  tps: 3852.8977
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5086.76648
-  tps: 3880.70936
+  dps: 5050.84452
+  tps: 3852.8977
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5093.5148
-  tps: 3885.79211
+  dps: 5057.54584
+  tps: 3857.94412
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VestmentsofAbsolution"
  value: {
-  dps: 3113.03589
-  tps: 2373.93148
+  dps: 3083.13532
+  tps: 2351.82577
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRaiment"
  value: {
-  dps: 4767.27311
-  tps: 3639.07273
+  dps: 4795.79645
+  tps: 3658.88461
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRegalia"
  value: {
-  dps: 5284.91635
-  tps: 4033.99911
+  dps: 5142.91561
+  tps: 3927.52338
  }
 }
 dps_results: {
  key: "TestShadow-Average-Default"
  value: {
-  dps: 5144.20438
-  tps: 3921.77192
+  dps: 5111.64307
+  tps: 3896.78301
  }
 }
 dps_results: {
@@ -591,85 +591,85 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3979.4431
-  tps: 3799.79985
+  dps: 3949.52229
+  tps: 3778.16335
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3979.4431
-  tps: 3041.10711
+  dps: 3949.52229
+  tps: 3018.06845
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5569.20455
-  tps: 4398.47402
+  dps: 5509.29665
+  tps: 4352.87551
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1308.2189
-  tps: 1297.86293
+  dps: 1302.29768
+  tps: 1293.54871
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1308.2189
-  tps: 990.14526
+  dps: 1302.29768
+  tps: 985.83104
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3192.91906
-  tps: 2327.27159
+  dps: 3136.07682
+  tps: 2285.25614
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4722.91751
-  tps: 4353.22779
+  dps: 4670.21859
+  tps: 4313.81941
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4722.91751
-  tps: 3606.95509
+  dps: 4670.21859
+  tps: 3567.32345
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5508.49951
-  tps: 4325.64821
+  dps: 5447.2953
+  tps: 4279.27501
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1509.27351
-  tps: 1445.64709
+  dps: 1498.51629
+  tps: 1438.49426
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1509.27351
-  tps: 1137.92943
+  dps: 1498.51629
+  tps: 1130.7766
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3012.43468
-  tps: 2192.46519
+  dps: 3003.63165
+  tps: 2183.27767
  }
 }
 dps_results: {
@@ -717,85 +717,85 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3968.47268
-  tps: 3791.80104
+  dps: 3939.51827
+  tps: 3772.36768
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3968.47268
-  tps: 3032.97215
+  dps: 3939.51827
+  tps: 3011.62431
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5550.63742
-  tps: 4384.34575
+  dps: 5499.85507
+  tps: 4344.20304
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1296.433
-  tps: 1289.78915
+  dps: 1301.41865
+  tps: 1292.79043
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1296.433
-  tps: 982.33273
+  dps: 1301.41865
+  tps: 985.33402
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3152.59855
-  tps: 2298.07151
+  dps: 3137.93817
+  tps: 2287.40253
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4682.80948
-  tps: 4322.46105
+  dps: 4665.2166
+  tps: 4309.34782
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4682.80948
-  tps: 3576.67839
+  dps: 4665.2166
+  tps: 3563.90785
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5486.37576
-  tps: 4309.61194
+  dps: 5451.08382
+  tps: 4281.40796
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1507.07344
-  tps: 1441.62058
+  dps: 1511.8786
+  tps: 1445.52412
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1507.07344
-  tps: 1134.16417
+  dps: 1511.8786
+  tps: 1138.0677
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3008.00263
-  tps: 2186.76978
+  dps: 3005.05614
+  tps: 2185.82625
  }
 }
 dps_results: {
@@ -843,91 +843,91 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3959.08294
-  tps: 3785.10155
+  dps: 3939.97219
+  tps: 3772.27965
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3959.08294
-  tps: 3026.71508
+  dps: 3939.97219
+  tps: 3012.1048
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5550.63742
-  tps: 4384.27975
+  dps: 5499.85507
+  tps: 4344.13704
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1295.30026
-  tps: 1288.34958
+  dps: 1298.91812
+  tps: 1290.36048
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1295.30026
-  tps: 981.41566
+  dps: 1298.91812
+  tps: 983.42656
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3151.81031
-  tps: 2297.33495
+  dps: 3135.35259
+  tps: 2285.29999
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4682.80948
-  tps: 4321.55847
+  dps: 4668.02622
+  tps: 4309.02619
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4682.80948
-  tps: 3576.63326
+  dps: 4668.02622
+  tps: 3565.03473
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5486.37576
-  tps: 4309.54594
+  dps: 5451.08382
+  tps: 4281.34196
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1485.64803
-  tps: 1428.22941
+  dps: 1481.66102
+  tps: 1425.78341
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1485.64803
-  tps: 1121.2955
+  dps: 1481.66102
+  tps: 1118.84949
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3006.9282
-  tps: 2185.81572
+  dps: 3004.08916
+  tps: 2184.95384
  }
 }
 dps_results: {
  key: "TestShadow-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5161.9384
-  tps: 3946.76701
+  dps: 5126.61349
+  tps: 3920.02364
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -45,617 +45,617 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-AshtongueTalismanofVision-32491"
  value: {
-  dps: 6650.02574
-  tps: 3747.34301
+  dps: 6597.14368
+  tps: 3707.02537
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6593.80689
-  tps: 3719.67087
+  dps: 6603.18058
+  tps: 3721.96024
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6681.99034
-  tps: 3762.20179
+  dps: 6761.24602
+  tps: 3813.57442
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6633.23004
-  tps: 3738.88033
+  dps: 6615.9477
+  tps: 3724.96523
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6413.57548
-  tps: 3597.66988
+  dps: 6389.27758
+  tps: 3581.7811
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 6985.75265
-  tps: 3950.51532
+  dps: 7019.67698
+  tps: 3971.3538
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5396.44634
-  tps: 3022.15365
+  dps: 5362.93966
+  tps: 3011.22983
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5276.97886
-  tps: 2958.7717
+  dps: 5314.36122
+  tps: 2987.81254
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6613.75409
-  tps: 3628.65842
+  dps: 6623.18939
+  tps: 3630.88999
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6793.91291
-  tps: 3831.00648
+  dps: 6741.76707
+  tps: 3797.25694
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6688.98546
-  tps: 3761.00742
+  dps: 6639.22622
+  tps: 3733.67003
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6755.75503
-  tps: 3812.92386
+  dps: 6767.28106
+  tps: 3821.23958
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6725.83077
-  tps: 3781.27851
+  dps: 6725.29884
+  tps: 3784.6856
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6723.00457
-  tps: 3783.15722
+  dps: 6726.19667
+  tps: 3781.53096
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6653.43432
-  tps: 3740.47592
+  dps: 6671.41551
+  tps: 3755.02991
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6560.46799
-  tps: 3697.88142
+  dps: 6540.47231
+  tps: 3680.8966
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6632.70884
-  tps: 3733.92626
+  dps: 6640.3114
+  tps: 3742.2363
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 5855.21414
-  tps: 3284.06426
+  dps: 5855.62939
+  tps: 3288.36213
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterGarb"
  value: {
-  dps: 5543.78593
-  tps: 3122.72504
+  dps: 5524.8146
+  tps: 3108.72708
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6593.80689
-  tps: 3719.67087
+  dps: 6603.18058
+  tps: 3721.96024
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6636.0475
-  tps: 3745.29058
+  dps: 6655.88559
+  tps: 3755.80058
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6645.03277
-  tps: 3745.39478
+  dps: 6596.35407
+  tps: 3713.66751
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6610.06343
-  tps: 3724.18257
+  dps: 6657.28309
+  tps: 3759.79771
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6593.80689
-  tps: 3719.67087
+  dps: 6603.18058
+  tps: 3721.96024
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6719.39837
-  tps: 3791.56606
+  dps: 6692.83953
+  tps: 3771.79389
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6739.58308
-  tps: 3801.10076
+  dps: 6762.07702
+  tps: 3814.1353
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6700.66324
-  tps: 3772.69181
+  dps: 6702.80124
+  tps: 3774.48163
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6613.75409
-  tps: 3732.15866
+  dps: 6623.18939
+  tps: 3734.48992
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6609.76465
-  tps: 3729.6611
+  dps: 6619.18763
+  tps: 3731.98398
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 6928.20978
-  tps: 3884.33079
+  dps: 6932.79342
+  tps: 3884.98261
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 6529.42886
-  tps: 3697.53986
+  dps: 6519.56683
+  tps: 3697.58848
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6732.23511
-  tps: 3789.01888
+  dps: 6700.72626
+  tps: 3763.66553
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6609.73809
-  tps: 3728.69455
+  dps: 6589.41405
+  tps: 3711.47552
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 6552.31588
-  tps: 3674.6724
+  dps: 6557.70494
+  tps: 3686.19565
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sWartide"
  value: {
-  dps: 5442.89963
-  tps: 3076.19517
+  dps: 5464.3466
+  tps: 3083.78233
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6719.26219
-  tps: 3797.17976
+  dps: 6698.21143
+  tps: 3779.44239
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6645.03277
-  tps: 3745.39478
+  dps: 6596.35407
+  tps: 3713.66751
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6610.06343
-  tps: 3724.18257
+  dps: 6657.28309
+  tps: 3759.79771
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6670.21745
-  tps: 3759.34013
+  dps: 6641.82473
+  tps: 3736.20061
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6630.40255
-  tps: 3734.27347
+  dps: 6632.89628
+  tps: 3742.70262
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6613.86682
-  tps: 3729.49
+  dps: 6628.58261
+  tps: 3736.07001
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6560.46799
-  tps: 3697.88142
+  dps: 6540.47231
+  tps: 3680.8966
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6560.46799
-  tps: 3697.88142
+  dps: 6540.47231
+  tps: 3680.8966
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6560.46799
-  tps: 3697.88142
+  dps: 6540.47231
+  tps: 3680.8966
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6613.30168
-  tps: 3730.45091
+  dps: 6623.74413
+  tps: 3733.38403
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6613.86682
-  tps: 3729.49
+  dps: 6628.58261
+  tps: 3736.07001
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6593.80689
-  tps: 3719.67087
+  dps: 6603.18058
+  tps: 3721.96024
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6593.80689
-  tps: 3719.67087
+  dps: 6603.18058
+  tps: 3721.96024
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6560.46799
-  tps: 3697.88142
+  dps: 6540.47231
+  tps: 3680.8966
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6775.71331
-  tps: 3833.43771
+  dps: 6776.24134
+  tps: 3827.62701
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6803.02013
-  tps: 3851.47118
+  dps: 6803.48188
+  tps: 3845.60733
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6737.11228
-  tps: 3800.30823
+  dps: 6795.9367
+  tps: 3837.73819
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6584.23232
-  tps: 3711.20524
+  dps: 6597.4559
+  tps: 3722.3511
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6560.46799
-  tps: 3697.88142
+  dps: 6540.47231
+  tps: 3680.8966
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6560.46799
-  tps: 3697.88142
+  dps: 6540.47231
+  tps: 3680.8966
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6560.46799
-  tps: 3697.88142
+  dps: 6540.47231
+  tps: 3680.8966
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6560.46799
-  tps: 3697.88142
+  dps: 6540.47231
+  tps: 3680.8966
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterHarness"
  value: {
-  dps: 4768.33767
-  tps: 2661.76829
+  dps: 4761.30429
+  tps: 2654.8831
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterRegalia"
  value: {
-  dps: 4709.65622
-  tps: 2647.73917
+  dps: 4701.67278
+  tps: 2637.56967
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SparkofLife-37657"
  value: {
-  dps: 6674.33407
-  tps: 3763.62973
+  dps: 6636.70401
+  tps: 3742.5207
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StormshroudArmor"
  value: {
-  dps: 5026.4167
-  tps: 2814.15237
+  dps: 5026.85256
+  tps: 2815.60389
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6613.86682
-  tps: 3729.49
+  dps: 6628.58261
+  tps: 3736.07001
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6613.30168
-  tps: 3730.45091
+  dps: 6623.74413
+  tps: 3733.38403
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6605.85734
-  tps: 3726.34504
+  dps: 6615.27678
+  tps: 3728.67893
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheFistsofFury"
  value: {
-  dps: 5263.40507
-  tps: 2893.89139
+  dps: 5278.12141
+  tps: 2902.35901
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 6710.96359
-  tps: 3797.25447
+  dps: 6694.05154
+  tps: 3782.53226
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sRegalia"
  value: {
-  dps: 6226.30774
-  tps: 3538.64372
+  dps: 6288.24483
+  tps: 3574.50033
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6677.33304
-  tps: 3765.29252
+  dps: 6667.33368
+  tps: 3759.24823
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TidefuryRaiment"
  value: {
-  dps: 4744.91185
-  tps: 2658.93283
+  dps: 4716.84031
+  tps: 2644.38883
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6768.26054
-  tps: 3821.56233
+  dps: 6744.48468
+  tps: 3801.15207
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6777.06578
-  tps: 3825.81491
+  dps: 6767.28537
+  tps: 3817.18619
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6613.75409
-  tps: 3732.15866
+  dps: 6623.18939
+  tps: 3734.48992
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6609.76465
-  tps: 3729.6611
+  dps: 6619.18763
+  tps: 3731.98398
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 6905.36611
-  tps: 3893.68551
+  dps: 6922.06591
+  tps: 3912.71493
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 6975.22805
-  tps: 3924.56978
+  dps: 6976.48288
+  tps: 3920.90538
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheElementalPlane-40708"
  value: {
-  dps: 6744.23023
-  tps: 3802.97437
+  dps: 6739.9379
+  tps: 3793.80157
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6609.76465
-  tps: 3729.6611
+  dps: 6619.18763
+  tps: 3731.98398
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6613.75409
-  tps: 3732.15866
+  dps: 6623.18939
+  tps: 3734.48992
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5327.79679
-  tps: 2989.02211
+  dps: 5291.30986
+  tps: 2962.33087
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 6202.48766
-  tps: 3502.86032
+  dps: 6219.42454
+  tps: 3510.8921
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerGarb"
  value: {
-  dps: 5712.5801
-  tps: 3226.82698
+  dps: 5719.76192
+  tps: 3229.60086
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 6803.0576
-  tps: 3838.57873
+  dps: 6800.20612
+  tps: 3836.48191
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17837.29691
-  tps: 10548.57796
+  dps: 17832.98185
+  tps: 10501.57254
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6779.04821
-  tps: 3814.23862
+  dps: 6747.65061
+  tps: 3786.73681
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7920.33067
-  tps: 4164.73846
+  dps: 7876.13735
+  tps: 4132.07676
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9013.80721
-  tps: 5344.52216
+  dps: 8531.19828
+  tps: 4997.20223
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3005.58471
-  tps: 1689.77565
+  dps: 2908.50003
+  tps: 1638.48894
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4888.97748
-  tps: 2629.90402
+  dps: 4857.3058
+  tps: 2597.25538
  }
 }
 dps_results: {
@@ -703,43 +703,43 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17773.02597
-  tps: 10371.77887
+  dps: 17795.9533
+  tps: 10476.59566
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6737.11228
-  tps: 3800.30823
+  dps: 6795.9367
+  tps: 3837.73819
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7957.69601
-  tps: 4215.53841
+  dps: 8007.63636
+  tps: 4241.21046
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8454.82574
-  tps: 4950.37758
+  dps: 8600.41007
+  tps: 5084.40697
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2782.59763
-  tps: 1565.30528
+  dps: 2926.89672
+  tps: 1655.72844
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4916.55352
-  tps: 2658.18774
+  dps: 4890.69026
+  tps: 2636.12939
  }
 }
 dps_results: {
@@ -787,7 +787,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6481.06459
-  tps: 3640.17102
+  dps: 6412.55614
+  tps: 3592.99138
  }
 }

--- a/sim/shaman/shocks.go
+++ b/sim/shaman/shocks.go
@@ -55,10 +55,9 @@ func (shaman *Shaman) newShockSpellConfig(spellID int32, spellSchool core.SpellS
 
 func (shaman *Shaman) registerEarthShockSpell(shockTimer *core.Timer) {
 	config := shaman.newShockSpellConfig(49231, core.SpellSchoolNature, baseMana*0.18, shockTimer)
-	config.Flags |= core.SpellFlagBinary
 	config.ApplyEffects = func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 		baseDamage := sim.Roll(854, 900) + 0.386*spell.SpellPower()
-		spell.CalcAndDealDamageMagicHitAndCritBinary(sim, target, baseDamage)
+		spell.CalcAndDealDamageMagicHitAndCrit(sim, target, baseDamage)
 	}
 
 	shaman.EarthShock = shaman.RegisterSpell(config)
@@ -123,13 +122,12 @@ func (shaman *Shaman) registerFlameShockSpell(shockTimer *core.Timer) {
 
 func (shaman *Shaman) registerFrostShockSpell(shockTimer *core.Timer) {
 	config := shaman.newShockSpellConfig(49236, core.SpellSchoolFrost, baseMana*0.18, shockTimer)
-	config.Flags |= core.SpellFlagBinary
 	config.Cast.CD.Duration -= time.Duration(shaman.Talents.BoomingEchoes) * time.Second
 	config.DamageMultiplier *= 1 + 0.1*float64(shaman.Talents.BoomingEchoes)
 	config.ThreatMultiplier *= 2
 	config.ApplyEffects = func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 		baseDamage := sim.Roll(812, 858) + 0.386*spell.SpellPower()
-		spell.CalcAndDealDamageMagicHitAndCritBinary(sim, target, baseDamage)
+		spell.CalcAndDealDamageMagicHitAndCrit(sim, target, baseDamage)
 	}
 
 	shaman.FrostShock = shaman.RegisterSpell(config)

--- a/sim/warlock/TestWarlock.results
+++ b/sim/warlock/TestWarlock.results
@@ -45,309 +45,309 @@ character_stats_results: {
 dps_results: {
  key: "TestWarlock-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 7095.20562
-  tps: 6389.33883
+  dps: 7061.16009
+  tps: 6351.11706
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6973.84989
-  tps: 6257.53183
+  dps: 6934.7879
+  tps: 6217.35939
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6994.06586
-  tps: 6277.7478
+  dps: 6951.76759
+  tps: 6234.33907
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7041.07443
-  tps: 6324.60445
+  dps: 6964.63793
+  tps: 6250.04029
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7086.67828
-  tps: 6370.36022
+  dps: 7044.01109
+  tps: 6326.58257
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 7672.42502
-  tps: 6926.22342
+  dps: 7640.2064
+  tps: 6900.06935
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-DeathbringerGarb"
  value: {
-  dps: 6553.66336
-  tps: 5870.82785
+  dps: 6543.66614
+  tps: 5858.49621
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6995.98913
-  tps: 6279.67108
+  dps: 6954.50874
+  tps: 6237.08022
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6973.84989
-  tps: 6257.53183
+  dps: 6934.7879
+  tps: 6217.35939
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7041.07443
-  tps: 6324.60445
+  dps: 6964.63793
+  tps: 6250.04029
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6994.06586
-  tps: 6277.7478
+  dps: 6951.76759
+  tps: 6234.33907
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6990.93027
-  tps: 6274.61221
+  dps: 6947.31906
+  tps: 6229.89054
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6973.84989
-  tps: 6257.53183
+  dps: 6934.7879
+  tps: 6217.35939
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7041.07443
-  tps: 6324.60445
+  dps: 6964.63793
+  tps: 6250.04029
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7018.09584
-  tps: 6298.82572
+  dps: 6950.89267
+  tps: 6232.82787
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 6953.90421
-  tps: 6267.03903
+  dps: 6947.8285
+  tps: 6255.44215
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 6986.67633
-  tps: 6206.1342
+  dps: 6945.27529
+  tps: 6165.40556
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6994.06586
-  tps: 6277.7478
+  dps: 6951.76759
+  tps: 6234.33907
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6990.93027
-  tps: 6274.61221
+  dps: 6947.31906
+  tps: 6229.89054
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6966.55339
-  tps: 6245.9009
+  dps: 6933.8285
+  tps: 6221.85798
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6973.84989
-  tps: 6257.53183
+  dps: 6934.7879
+  tps: 6217.35939
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-MaleficRaiment"
  value: {
-  dps: 5180.46928
-  tps: 4565.74872
+  dps: 5171.15331
+  tps: 4554.52969
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6973.84989
-  tps: 6257.53183
+  dps: 6934.7879
+  tps: 6217.35939
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6973.84989
-  tps: 6257.53183
+  dps: 6934.7879
+  tps: 6217.35939
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-PlagueheartGarb"
  value: {
-  dps: 6205.57185
-  tps: 5547.16924
+  dps: 6166.72664
+  tps: 5511.71982
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6973.84989
-  tps: 6257.53183
+  dps: 6934.7879
+  tps: 6217.35939
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6973.84989
-  tps: 6257.53183
+  dps: 6934.7879
+  tps: 6217.35939
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7064.64287
-  tps: 6348.32482
+  dps: 7025.50323
+  tps: 6308.07471
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6936.06245
-  tps: 6218.77425
+  dps: 6933.00349
+  tps: 6223.01288
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6973.84989
-  tps: 6257.53183
+  dps: 6934.7879
+  tps: 6217.35939
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6973.84989
-  tps: 6257.53183
+  dps: 6934.7879
+  tps: 6217.35939
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6973.84989
-  tps: 6257.53183
+  dps: 6934.7879
+  tps: 6217.35939
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6973.84989
-  tps: 6257.53183
+  dps: 6934.7879
+  tps: 6217.35939
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7041.07443
-  tps: 6324.60445
+  dps: 6964.63793
+  tps: 6250.04029
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7018.09584
-  tps: 6298.82572
+  dps: 6950.89267
+  tps: 6232.82787
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7018.09584
-  tps: 6298.82572
+  dps: 6950.89267
+  tps: 6232.82787
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7041.07443
-  tps: 6324.60445
+  dps: 6964.63793
+  tps: 6250.04029
  }
 }
 dps_results: {
  key: "TestWarlock-Average-Default"
  value: {
-  dps: 7067.90158
-  tps: 6351.5339
+  dps: 7026.61039
+  tps: 6310.99214
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6146.53363
-  tps: 7214.40047
+  dps: 6129.86966
+  tps: 7187.53845
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6146.53363
-  tps: 5449.00493
+  dps: 6129.86966
+  tps: 5436.59098
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6453.59129
-  tps: 5668.34273
+  dps: 6409.43842
+  tps: 5625.28829
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3659.15811
-  tps: 5536.35273
+  dps: 3630.44514
+  tps: 5481.52355
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3659.15811
-  tps: 3432.24964
+  dps: 3630.44514
+  tps: 3402.36278
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3399.63684
-  tps: 3073.14
+  dps: 3378.81738
+  tps: 3049.73876
  }
 }
 dps_results: {
@@ -437,7 +437,7 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7051.94591
-  tps: 6370.36022
+  dps: 7009.3036
+  tps: 6326.58257
  }
 }

--- a/sim/warlock/drain_soul.go
+++ b/sim/warlock/drain_soul.go
@@ -28,7 +28,7 @@ func (warlock *Warlock) registerDrainSoulSpell() {
 		ActionID:     actionID,
 		SpellSchool:  spellSchool,
 		ProcMask:     core.ProcMaskEmpty,
-		Flags:        core.SpellFlagBinary | core.SpellFlagChanneled,
+		Flags:        core.SpellFlagChanneled,
 		ResourceType: stats.Mana,
 		BaseCost:     baseCost,
 
@@ -46,7 +46,7 @@ func (warlock *Warlock) registerDrainSoulSpell() {
 		ThreatMultiplier: 1 - 0.1*float64(warlock.Talents.ImprovedDrainSoul),
 
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
-			OutcomeApplier: warlock.OutcomeFuncMagicHitBinary(),
+			OutcomeApplier: warlock.OutcomeFuncMagicHit(),
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if !spellEffect.Landed() {
 					return

--- a/sim/warrior/thunder_clap.go
+++ b/sim/warrior/thunder_clap.go
@@ -24,7 +24,7 @@ func (warrior *Warrior) registerThunderClapSpell() {
 		ActionID:    core.ActionID{SpellID: 47502},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskRangedSpecial,
-		Flags:       core.SpellFlagBinary | core.SpellFlagIncludeTargetBonusDamage,
+		Flags:       core.SpellFlagIncludeTargetBonusDamage,
 
 		ResourceType: stats.Rage,
 		BaseCost:     cost,


### PR DESCRIPTION
[shaman] earth shock and frost shock are no longer binary
[priest] mind sear and mind flay are no longer binary 
[warlock] drain soul is lo longer binary
[paladin] holy shield can both be fully and partially resisted

apart from thorns, retribution aura, and - to some degree - holy shield, no spells are binary anymore.

the following "log shots" are all from very recent (post-pre-patch) logs, against brutallus:

earth and frost shock
![Screenshot 2022-09-29 at 22 47 25](https://user-images.githubusercontent.com/9415187/193158336-8cc50f53-9a8b-425b-9bb5-998b2378342e.png)

![Screenshot 2022-09-29 at 23 53 53](https://user-images.githubusercontent.com/9415187/193158503-647b195f-1d19-4931-b9e2-53fb28d7bbce.png)

mind flay, i'm pretty sure mind sear will behave likewise
![Screenshot 2022-09-29 at 22 43 39](https://user-images.githubusercontent.com/9415187/193158736-d7787d6a-7846-41a7-b6ab-294d6ddb1d33.png)

drain soul
![Screenshot 2022-09-30 at 00 42 40](https://user-images.githubusercontent.com/9415187/193158808-3320cc34-bf0e-4d61-8172-2c1de2e224d4.png)

holy shield, behaving wildly
![Screenshot 2022-09-29 at 22 51 37](https://user-images.githubusercontent.com/9415187/193158908-b1fd58d8-5c39-45f3-96d5-07a3df49151f.png)

and finally, thorns and retribution aura, without partial resists at all
![Screenshot 2022-09-29 at 22 50 38](https://user-images.githubusercontent.com/9415187/193158981-1ce4d34d-5acf-445e-a428-60342809ac83.png)

![Screenshot 2022-09-29 at 22 50 55](https://user-images.githubusercontent.com/9415187/193158998-cc85c172-e146-401e-ac19-378ba0ac22cc.png)
