### PR TITLE
binary-really-gone-dodo

### DIFF
--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -385,7 +385,7 @@ func RetributionAura(character *Character, sanctifiedRetribution bool) *Aura {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *Simulation, target *Unit, spell *Spell) {
-			spell.CalcAndDealDamageMagicHitBinary(sim, target, baseDamage)
+			spell.CalcAndDealDamageMagicHit(sim, target, baseDamage)
 		},
 	})
 
@@ -418,7 +418,7 @@ func ThornsAura(character *Character, points int32) *Aura {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *Simulation, target *Unit, spell *Spell) {
-			spell.CalcAndDealDamageMagicHitBinary(sim, target, baseDamage)
+			spell.CalcAndDealDamageMagicHit(sim, target, baseDamage)
 		},
 	})
 

--- a/sim/core/spell_resistances.go
+++ b/sim/core/spell_resistances.go
@@ -12,7 +12,7 @@ func (spellEffect *SpellEffect) applyResistances(sim *Simulation, spell *Spell, 
 		return
 	}
 
-	// CHECKME spellEffect.Outcome isn't updated with resists anymore - why?
+	// TODO check why spellEffect.Outcome isn't updated with resists anymore
 	resistanceMult := spell.ResistanceMultiplier(sim, spellEffect.IsPeriodic, attackTable)
 	spellEffect.Damage *= resistanceMult
 }
@@ -63,12 +63,12 @@ func (at *AttackTable) GetArmorDamageModifier(spell *Spell) float64 {
 }
 
 func (at *AttackTable) UpdatePartialResists() {
-	at.PartialResistArcaneThresholds, at.BinaryArcaneHitChance = at.Defender.partialResistRollThresholds(SpellSchoolArcane, at.Attacker)
-	at.PartialResistHolyThresholds, at.BinaryHolyHitChance = at.Defender.partialResistRollThresholds(SpellSchoolHoly, at.Attacker)
-	at.PartialResistFireThresholds, at.BinaryFireHitChance = at.Defender.partialResistRollThresholds(SpellSchoolFire, at.Attacker)
-	at.PartialResistFrostThresholds, at.BinaryFrostHitChance = at.Defender.partialResistRollThresholds(SpellSchoolFrost, at.Attacker)
-	at.PartialResistNatureThresholds, at.BinaryNatureHitChance = at.Defender.partialResistRollThresholds(SpellSchoolNature, at.Attacker)
-	at.PartialResistShadowThresholds, at.BinaryShadowHitChance = at.Defender.partialResistRollThresholds(SpellSchoolShadow, at.Attacker)
+	at.PartialResistArcaneThresholds = at.Defender.partialResistRollThresholds(SpellSchoolArcane, at.Attacker)
+	at.PartialResistHolyThresholds = at.Defender.partialResistRollThresholds(SpellSchoolHoly, at.Attacker)
+	at.PartialResistFireThresholds = at.Defender.partialResistRollThresholds(SpellSchoolFire, at.Attacker)
+	at.PartialResistFrostThresholds = at.Defender.partialResistRollThresholds(SpellSchoolFrost, at.Attacker)
+	at.PartialResistNatureThresholds = at.Defender.partialResistRollThresholds(SpellSchoolNature, at.Attacker)
+	at.PartialResistShadowThresholds = at.Defender.partialResistRollThresholds(SpellSchoolShadow, at.Attacker)
 }
 
 func (at *AttackTable) GetPartialResistThresholds(ss SpellSchool) Thresholds {
@@ -87,24 +87,6 @@ func (at *AttackTable) GetPartialResistThresholds(ss SpellSchool) Thresholds {
 		return at.PartialResistShadowThresholds
 	}
 	return Thresholds{{cumulativeChance: 1, bracket: 0}}
-}
-
-func (at *AttackTable) GetBinaryHitChance(ss SpellSchool) float64 {
-	switch ss {
-	case SpellSchoolArcane:
-		return at.BinaryArcaneHitChance
-	case SpellSchoolHoly:
-		return at.BinaryHolyHitChance
-	case SpellSchoolFire:
-		return at.BinaryFireHitChance
-	case SpellSchoolFrost:
-		return at.BinaryFrostHitChance
-	case SpellSchoolNature:
-		return at.BinaryNatureHitChance
-	case SpellSchoolShadow:
-		return at.BinaryShadowHitChance
-	}
-	return 0
 }
 
 /*
@@ -167,7 +149,7 @@ func (x Thresholds) String() string {
 	return sb.String()
 }
 
-func (unit *Unit) partialResistRollThresholds(school SpellSchool, attacker *Unit) (Thresholds, float64) {
+func (unit *Unit) partialResistRollThresholds(school SpellSchool, attacker *Unit) Thresholds {
 	ar := unit.averageResist(school, attacker, false)
 
 	if ar <= 0.1 { // always 0%, 10%, or 20%; this covers all player vs. mob cases, in practice
@@ -175,7 +157,7 @@ func (unit *Unit) partialResistRollThresholds(school SpellSchool, attacker *Unit
 			{cumulativeChance: 1 - 7.5*ar, bracket: 0},
 			{cumulativeChance: 1 - 2.5*ar, bracket: 1},
 			{cumulativeChance: 1, bracket: 2},
-		}, 1 - ar
+		}
 	}
 
 	if ar >= 0.9 { // always 80%, 90%, or 100%; only relevant for tests ;)
@@ -183,7 +165,7 @@ func (unit *Unit) partialResistRollThresholds(school SpellSchool, attacker *Unit
 			{cumulativeChance: 1 - 7.5*(1-ar), bracket: 10},
 			{cumulativeChance: 1 - 2.5*(1-ar), bracket: 9},
 			{cumulativeChance: 1, bracket: 8},
-		}, 1 - ar
+		}
 	}
 
 	p := func(x float64) float64 {
@@ -207,5 +189,5 @@ func (unit *Unit) partialResistRollThresholds(school SpellSchool, attacker *Unit
 		thresholds[index-1].cumulativeChance = 1
 	}
 
-	return thresholds, 1 - ar
+	return thresholds
 }

--- a/sim/core/target.go
+++ b/sim/core/target.go
@@ -227,13 +227,6 @@ type AttackTable struct {
 	PartialResistNatureThresholds Thresholds
 	PartialResistShadowThresholds Thresholds
 
-	BinaryArcaneHitChance float64
-	BinaryHolyHitChance   float64
-	BinaryFireHitChance   float64
-	BinaryFrostHitChance  float64
-	BinaryNatureHitChance float64
-	BinaryShadowHitChance float64
-
 	DamageDealtMultiplier               float64
 	NatureDamageDealtMultiplier         float64
 	PeriodicShadowDamageDealtMultiplier float64

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -619,8 +619,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-Average-Default"
  value: {
-  dps: 1313.9913
-  tps: 1812.10673
+  dps: 1316.04529
+  tps: 1814.83032
   dtps: 522.98961
  }
 }
@@ -669,8 +669,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1438.59896
-  tps: 2002.31761
+  dps: 1440.58147
+  tps: 2004.94641
   dtps: 488.03992
  }
 }

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -45,456 +45,456 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 4309.64361
-  tps: 3620.75376
+  dps: 4429.83489
+  tps: 3722.05702
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 4210.15272
-  tps: 3541.24815
+  dps: 4288.05074
+  tps: 3606.66711
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 4323.7748
-  tps: 3632.3891
+  dps: 4445.33584
+  tps: 3735.50606
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 3688.57792
-  tps: 3089.85357
+  dps: 3760.03955
+  tps: 3150.28123
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 4885.14041
-  tps: 4125.01281
+  dps: 5052.81727
+  tps: 4272.99576
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 4338.65503
-  tps: 3572.8787
+  dps: 4459.71893
+  tps: 3672.8962
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 4433.06461
-  tps: 3731.03766
+  dps: 4556.81784
+  tps: 3835.66985
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 4279.06059
-  tps: 3602.82825
+  dps: 4356.17979
+  tps: 3667.26347
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 4248.91475
-  tps: 3576.9471
+  dps: 4390.25779
+  tps: 3699.00242
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 4228.54419
-  tps: 3566.10082
+  dps: 4335.18705
+  tps: 3655.52212
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 4228.54419
-  tps: 3566.10082
+  dps: 4335.18705
+  tps: 3655.52212
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 4227.11816
-  tps: 3564.12386
+  dps: 4333.85893
+  tps: 3653.61979
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 4210.15272
-  tps: 3541.24815
+  dps: 4288.05074
+  tps: 3606.66711
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 4326.3931
-  tps: 3635.27961
+  dps: 4447.48626
+  tps: 3737.41633
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 4309.64361
-  tps: 3620.75376
+  dps: 4429.83489
+  tps: 3722.05702
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 4343.42406
-  tps: 3648.9127
+  dps: 4466.71056
+  tps: 3753.22981
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 4324.28908
-  tps: 3633.38599
+  dps: 4446.63987
+  tps: 3736.73854
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 4320.94445
-  tps: 3630.47096
+  dps: 4441.43345
+  tps: 3732.12473
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 4309.64361
-  tps: 3620.75376
+  dps: 4429.83489
+  tps: 3722.05702
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 4226.44167
-  tps: 3551.29552
+  dps: 4349.03576
+  tps: 3657.73635
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 4418.39687
-  tps: 3721.85155
+  dps: 4494.86386
+  tps: 3785.91027
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 4366.47256
-  tps: 3677.57625
+  dps: 4440.15823
+  tps: 3738.80687
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 4338.65503
-  tps: 3645.29112
+  dps: 4459.71893
+  tps: 3747.33609
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 4332.85275
-  tps: 3640.38365
+  dps: 4453.74212
+  tps: 3742.28027
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FrostfireGarb"
  value: {
-  dps: 3875.28869
-  tps: 3245.25152
+  dps: 3940.14169
+  tps: 3304.03879
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 4210.15272
-  tps: 3541.24815
+  dps: 4288.05074
+  tps: 3606.66711
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 4282.02436
-  tps: 3601.54277
+  dps: 4358.47684
+  tps: 3664.23
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 4440.10998
-  tps: 3739.7173
+  dps: 4521.79324
+  tps: 3808.42911
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 4324.28908
-  tps: 3633.38599
+  dps: 4446.63987
+  tps: 3736.73854
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 4320.94445
-  tps: 3630.47096
+  dps: 4441.43345
+  tps: 3732.12473
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 4151.25733
-  tps: 3482.23488
+  dps: 4319.01662
+  tps: 3635.70484
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 4299.20951
-  tps: 3613.96586
+  dps: 4420.91034
+  tps: 3714.87792
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 4309.64361
-  tps: 3620.75376
+  dps: 4429.83489
+  tps: 3722.05702
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 4467.17643
-  tps: 3752.56528
+  dps: 4565.42078
+  tps: 3841.66217
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KirinTorGarb"
  value: {
-  dps: 4125.22754
-  tps: 3453.75564
+  dps: 4244.64407
+  tps: 3560.99603
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 4210.15272
-  tps: 3541.24815
+  dps: 4288.05074
+  tps: 3606.66711
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 4203.15348
-  tps: 3531.15841
+  dps: 4274.2085
+  tps: 3588.85641
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 4265.47223
-  tps: 3590.02594
+  dps: 4338.75636
+  tps: 3651.36383
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 4210.15272
-  tps: 3541.24815
+  dps: 4288.05074
+  tps: 3606.66711
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 4309.64361
-  tps: 3620.75376
+  dps: 4429.83489
+  tps: 3722.05702
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 4309.64361
-  tps: 3620.75376
+  dps: 4429.83489
+  tps: 3722.05702
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 4309.64361
-  tps: 3620.75376
+  dps: 4429.83489
+  tps: 3722.05702
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 4309.64361
-  tps: 3620.75376
+  dps: 4429.83489
+  tps: 3722.05702
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 4210.15272
-  tps: 3541.24815
+  dps: 4288.05074
+  tps: 3606.66711
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 4424.32285
-  tps: 3729.72488
+  dps: 4602.65125
+  tps: 3893.49224
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 4462.44845
-  tps: 3764.62797
+  dps: 4641.70189
+  tps: 3929.24484
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 4417.14818
-  tps: 3717.26852
+  dps: 4538.54178
+  tps: 3819.66698
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 4307.81451
-  tps: 3618.11393
+  dps: 4428.26807
+  tps: 3720.21967
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 4210.15272
-  tps: 3541.24815
+  dps: 4288.05074
+  tps: 3606.66711
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 4210.15272
-  tps: 3541.24815
+  dps: 4288.05074
+  tps: 3606.66711
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 4210.15272
-  tps: 3541.24815
+  dps: 4288.05074
+  tps: 3606.66711
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 4210.15272
-  tps: 3541.24815
+  dps: 4288.05074
+  tps: 3606.66711
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 4218.20089
-  tps: 3542.82833
+  dps: 4362.07308
+  tps: 3672.78688
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sunstrider'sRegalia"
  value: {
-  dps: 4467.17643
-  tps: 3755.38102
+  dps: 4565.42078
+  tps: 3846.15344
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 4309.64361
-  tps: 3620.75376
+  dps: 4429.83489
+  tps: 3722.05702
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 4309.64361
-  tps: 3620.75376
+  dps: 4429.83489
+  tps: 3722.05702
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 4309.64361
-  tps: 3620.75376
+  dps: 4429.83489
+  tps: 3722.05702
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 4285.75921
-  tps: 3597.12013
+  dps: 4465.15451
+  tps: 3753.15549
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 4285.88393
-  tps: 3600.35498
+  dps: 4432.92642
+  tps: 3726.49968
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 4285.88393
-  tps: 3600.35498
+  dps: 4432.92642
+  tps: 3726.49968
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 4338.65503
-  tps: 3645.29112
+  dps: 4459.71893
+  tps: 3747.33609
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 4332.85275
-  tps: 3640.38365
+  dps: 4453.74212
+  tps: 3742.28027
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 4332.85275
-  tps: 3640.38365
+  dps: 4453.74212
+  tps: 3742.28027
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 4338.65503
-  tps: 3645.29112
+  dps: 4459.71893
+  tps: 3747.33609
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 4379.10959
-  tps: 3677.88882
+  dps: 4544.80918
+  tps: 3826.91563
  }
 }
 dps_results: {
@@ -542,49 +542,49 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4433.06461
-  tps: 4199.76686
+  dps: 4556.81784
+  tps: 4317.16581
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4433.06461
-  tps: 3731.03766
+  dps: 4556.81784
+  tps: 3835.66985
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5604.71679
-  tps: 4543.20443
+  dps: 5752.15609
+  tps: 4672.61542
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2715.73271
-  tps: 2998.25589
+  dps: 2789.18396
+  tps: 3068.70846
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2715.73271
-  tps: 2277.05546
+  dps: 2789.18396
+  tps: 2338.15709
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3156.97675
-  tps: 2464.54807
+  dps: 3316.03838
+  tps: 2606.94928
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 4433.06461
-  tps: 3731.03766
+  dps: 4556.81784
+  tps: 3835.66985
  }
 }

--- a/sim/mage/frostbolt.go
+++ b/sim/mage/frostbolt.go
@@ -39,7 +39,7 @@ func (mage *Mage) registerFrostboltSpell() {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := sim.Roll(799, 861) + spellCoeff*spell.SpellPower()
-			spell.CalcAndDealDamageMagicHitAndCritBinary(sim, target, baseDamage)
+			spell.CalcAndDealDamageMagicHitAndCrit(sim, target, baseDamage)
 		},
 	})
 }

--- a/sim/paladin/holy_shield.go
+++ b/sim/paladin/holy_shield.go
@@ -12,9 +12,6 @@ func (paladin *Paladin) registerHolyShieldSpell() {
 	actionID := core.ActionID{SpellID: 48952}
 	numCharges := int32(8)
 
-	// Holy Shield can be both fully and partially resisted in WotLK, so it doesn't use SpellFlagBinary here,
-	//	but does use CalcAndDealDamageMagicHitBinary() below.
-	// TODO needs research ;)
 	procSpell := paladin.RegisterSpell(core.SpellConfig{
 		ActionID:    actionID.WithTag(1),
 		SpellSchool: core.SpellSchoolHoly,
@@ -30,7 +27,7 @@ func (paladin *Paladin) registerHolyShieldSpell() {
 				0.0732*spell.MeleeAttackPower() +
 				0.117*spell.SpellPower()
 
-			spell.CalcAndDealDamageMagicHitBinary(sim, target, baseDamage)
+			spell.CalcAndDealDamageMagicHit(sim, target, baseDamage)
 		},
 	})
 

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -668,8 +668,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Average-Default"
  value: {
-  dps: 2015.78153
-  tps: 4732.52326
+  dps: 2025.7904
+  tps: 4756.34442
   dtps: 64.83568
  }
 }
@@ -928,8 +928,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2127.93782
-  tps: 4977.23979
+  dps: 2137.42913
+  tps: 4999.88437
   dtps: 67.08851
  }
 }

--- a/sim/priest/Mind_Sear.go
+++ b/sim/priest/Mind_Sear.go
@@ -59,7 +59,7 @@ func (priest *Priest) newMindSearDot(numTicks int) *core.Dot {
 
 	effect := core.SpellEffect{
 		IsPeriodic:     true,
-		OutcomeApplier: priest.OutcomeFuncMagicHitBinary(),
+		OutcomeApplier: priest.OutcomeFuncMagicHit(),
 		OnPeriodicDamageDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 			if spellEffect.Landed() {
 				priest.AddShadowWeavingStack(sim)

--- a/sim/warlock/TestWarlock.results
+++ b/sim/warlock/TestWarlock.results
@@ -45,309 +45,309 @@ character_stats_results: {
 dps_results: {
  key: "TestWarlock-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 7061.16009
-  tps: 6351.11706
+  dps: 7084.43112
+  tps: 6352.63961
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6934.7879
-  tps: 6217.35939
+  dps: 6918.32136
+  tps: 6172.83203
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6951.76759
-  tps: 6234.33907
+  dps: 6948.48271
+  tps: 6205.40364
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6964.63793
-  tps: 6250.04029
+  dps: 7000.95757
+  tps: 6259.34414
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7044.01109
-  tps: 6326.58257
+  dps: 7039.50643
+  tps: 6296.42736
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 7640.2064
-  tps: 6900.06935
+  dps: 7631.68335
+  tps: 6851.89378
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-DeathbringerGarb"
  value: {
-  dps: 6543.66614
-  tps: 5858.49621
+  dps: 6586.74313
+  tps: 5875.82967
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6954.50874
-  tps: 6237.08022
+  dps: 6920.33437
+  tps: 6178.615
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6934.7879
-  tps: 6217.35939
+  dps: 6918.32136
+  tps: 6172.83203
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6964.63793
-  tps: 6250.04029
+  dps: 7000.95757
+  tps: 6259.34414
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6951.76759
-  tps: 6234.33907
+  dps: 6948.48271
+  tps: 6205.40364
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6947.31906
-  tps: 6229.89054
+  dps: 6932.8595
+  tps: 6187.37018
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6934.7879
-  tps: 6217.35939
+  dps: 6918.32136
+  tps: 6172.83203
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6964.63793
-  tps: 6250.04029
+  dps: 7000.95757
+  tps: 6259.34414
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6950.89267
-  tps: 6232.82787
+  dps: 6998.48215
+  tps: 6251.36227
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 6947.8285
-  tps: 6255.44215
+  dps: 6967.26884
+  tps: 6256.67516
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 6945.27529
-  tps: 6165.40556
+  dps: 7004.52721
+  tps: 6202.18998
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6951.76759
-  tps: 6234.33907
+  dps: 6948.48271
+  tps: 6205.40364
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6947.31906
-  tps: 6229.89054
+  dps: 6932.8595
+  tps: 6187.37018
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6933.8285
-  tps: 6221.85798
+  dps: 6968.32708
+  tps: 6222.68924
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6934.7879
-  tps: 6217.35939
+  dps: 6918.32136
+  tps: 6172.83203
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-MaleficRaiment"
  value: {
-  dps: 5171.15331
-  tps: 4554.52969
+  dps: 5214.10168
+  tps: 4570.04616
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6934.7879
-  tps: 6217.35939
+  dps: 6918.32136
+  tps: 6172.83203
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6934.7879
-  tps: 6217.35939
+  dps: 6918.32136
+  tps: 6172.83203
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-PlagueheartGarb"
  value: {
-  dps: 6166.72664
-  tps: 5511.71982
+  dps: 6213.95837
+  tps: 5531.64426
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6934.7879
-  tps: 6217.35939
+  dps: 6918.32136
+  tps: 6172.83203
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6934.7879
-  tps: 6217.35939
+  dps: 6918.32136
+  tps: 6172.83203
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7025.50323
-  tps: 6308.07471
+  dps: 7006.88708
+  tps: 6261.39775
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6933.00349
-  tps: 6223.01288
+  dps: 6935.56505
+  tps: 6187.53721
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6934.7879
-  tps: 6217.35939
+  dps: 6918.32136
+  tps: 6172.83203
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6934.7879
-  tps: 6217.35939
+  dps: 6918.32136
+  tps: 6172.83203
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6934.7879
-  tps: 6217.35939
+  dps: 6918.32136
+  tps: 6172.83203
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6934.7879
-  tps: 6217.35939
+  dps: 6918.32136
+  tps: 6172.83203
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6964.63793
-  tps: 6250.04029
+  dps: 7000.95757
+  tps: 6259.34414
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6950.89267
-  tps: 6232.82787
+  dps: 6998.48215
+  tps: 6251.36227
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6950.89267
-  tps: 6232.82787
+  dps: 6998.48215
+  tps: 6251.36227
  }
 }
 dps_results: {
  key: "TestWarlock-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6964.63793
-  tps: 6250.04029
+  dps: 7000.95757
+  tps: 6259.34414
  }
 }
 dps_results: {
  key: "TestWarlock-Average-Default"
  value: {
-  dps: 7026.61039
-  tps: 6310.99214
+  dps: 7042.35258
+  tps: 6300.55959
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6129.86966
-  tps: 7187.53845
+  dps: 6142.93038
+  tps: 7169.73753
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6129.86966
-  tps: 5436.59098
+  dps: 6142.93038
+  tps: 5420.86587
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6409.43842
-  tps: 5625.28829
+  dps: 6408.40705
+  tps: 5602.65083
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3630.44514
-  tps: 5481.52355
+  dps: 3655.09669
+  tps: 5493.82968
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3630.44514
-  tps: 3402.36278
+  dps: 3655.09669
+  tps: 3414.66891
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Affliction Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3378.81738
-  tps: 3049.73876
+  dps: 3411.19452
+  tps: 3064.11409
  }
 }
 dps_results: {
@@ -437,7 +437,7 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7009.3036
-  tps: 6326.58257
+  dps: 7004.80674
+  tps: 6296.42736
  }
 }

--- a/sim/warlock/TestWarlock.results
+++ b/sim/warlock/TestWarlock.results
@@ -45,8 +45,8 @@ character_stats_results: {
 dps_results: {
  key: "TestWarlock-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 7084.43112
-  tps: 6352.63961
+  dps: 7101.56325
+  tps: 6369.72967
  }
 }
 dps_results: {
@@ -59,8 +59,8 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6948.48271
-  tps: 6205.40364
+  dps: 6935.84464
+  tps: 6190.35532
  }
 }
 dps_results: {
@@ -73,8 +73,8 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7039.50643
-  tps: 6296.42736
+  dps: 7025.98746
+  tps: 6280.49813
  }
 }
 dps_results: {
@@ -94,8 +94,8 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6920.33437
-  tps: 6178.615
+  dps: 6936.90865
+  tps: 6191.41932
  }
 }
 dps_results: {
@@ -115,8 +115,8 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6948.48271
-  tps: 6205.40364
+  dps: 6935.84464
+  tps: 6190.35532
  }
 }
 dps_results: {
@@ -164,8 +164,8 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6948.48271
-  tps: 6205.40364
+  dps: 6935.84464
+  tps: 6190.35532
  }
 }
 dps_results: {
@@ -304,8 +304,8 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-Average-Default"
  value: {
-  dps: 7042.35258
-  tps: 6300.55959
+  dps: 7052.51393
+  tps: 6311.08561
  }
 }
 dps_results: {
@@ -437,7 +437,7 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7004.80674
-  tps: 6296.42736
+  dps: 6991.31323
+  tps: 6280.49813
  }
 }

--- a/sim/warlock/pet_abilities.go
+++ b/sim/warlock/pet_abilities.go
@@ -216,7 +216,7 @@ func (wp *WarlockPet) newShadowBite() *core.Spell {
 
 			baseDamage *= 1 + 0.15*float64(counter)
 
-			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCritBinary)
+			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
 			if impFelhunter && result.Landed() {
 				wp.AddMana(sim, wp.MaxMana()*maxManaMult, petManaMetrics, true)
 			}

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -45,7 +45,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 0.79554
+  weights: 0.79543
   weights: 0
   weights: 0
   weights: 0
@@ -56,7 +56,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.2045
+  weights: 0.20448
   weights: 0
   weights: 0
   weights: 0
@@ -65,12 +65,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.10475
+  weights: 0.10478
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.54013
-  weights: -0.12653
+  weights: 0.54019
+  weights: -0.12733
   weights: 0
   weights: 0
   weights: 0
@@ -600,8 +600,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 2813.56903
-  tps: 7411.64965
+  dps: 2814.66157
+  tps: 7413.91504
   dtps: 95.43257
  }
 }
@@ -692,8 +692,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2958.94956
-  tps: 7796.33813
+  dps: 2960.37697
+  tps: 7799.29786
   dtps: 99.39883
  }
 }


### PR DESCRIPTION
[core] remove support for binary spells. only thorns and retribution aura ignore partial resists, but they miss (logged as "resist") like regular spells, without a binary penalty

i've researched how thorns, retribution aura, and holy shield work, and they all follow the regular spell miss scheme: with 6.02% hit vs. +2 level mobs, there were no "resists" in 1,500+ retribution aura procs.