### PR TITLE
feral: rotation prepop tweak

### DIFF
--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -654,22 +654,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4448.92779
-  tps: 4066.29748
+  dps: 4400.31735
+  tps: 4009.86163
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4448.92779
-  tps: 3387.72981
+  dps: 4400.31735
+  tps: 3334.05382
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4468.2671
-  tps: 3377.8366
+  dps: 4460.83624
+  tps: 3370.02714
  }
 }
 dps_results: {

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -243,7 +243,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) {
 
 	ripNow := (curCp >= rotation.MinCombosForRip) && !cat.RipDot.IsActive() && (simTimeRemain >= endThresh) && !isClearcast
 	biteAtEnd := (curCp >= rotation.MinCombosForBite) && ((simTimeRemain < endThresh) || (cat.RipDot.IsActive() && (simTimeRemain-cat.RipDot.RemainingDuration(sim) < endThresh)))
-	mangleNow := !ripNow && !cat.MangleAura.IsActive() && !isClearcast
+	mangleNow := !ripNow && !cat.MangleAura.IsActive()
 
 	biteBeforeRip := (curCp >= rotation.MinCombosForBite) && cat.RipDot.IsActive() && cat.SavageRoarAura.IsActive() && rotation.UseBite && cat.canBite(sim)
 	biteNow := (biteBeforeRip || biteAtEnd) && !isClearcast

--- a/sim/druid/talents.go
+++ b/sim/druid/talents.go
@@ -405,6 +405,7 @@ func (druid *Druid) applyImprovedLotp() {
 	}
 
 	manaMetrics := druid.NewManaMetrics(core.ActionID{SpellID: 34300})
+	manaRestore := float64(druid.Talents.ImprovedLeaderOfThePack) * 0.04
 
 	icd := core.Cooldown{
 		Timer:    druid.NewTimer(),
@@ -428,7 +429,7 @@ func (druid *Druid) applyImprovedLotp() {
 				return
 			}
 			icd.Use(sim)
-			druid.AddMana(sim, druid.MaxMana()*0.08, manaMetrics, false)
+			druid.AddMana(sim, druid.MaxMana()*manaRestore, manaMetrics, false)
 		},
 	})
 }

--- a/ui/feral_druid/presets.ts
+++ b/ui/feral_druid/presets.ts
@@ -57,7 +57,7 @@ export const DefaultRotation = FeralDruidRotation.create({
 
 export const DefaultOptions = FeralDruidOptions.create({
 	latencyMs: 100,
-	prepopOoc: false,
+	prepopOoc: true,
 	assumeBleedActive: false,
 });
 


### PR DESCRIPTION
 - allow spending mangle on clearcasts, mainly for when pre-popping ooc