### PR TITLE
Implement Avoidance Diminishing Returns

### DIFF
--- a/sim/core/avoid_dr.go
+++ b/sim/core/avoid_dr.go
@@ -22,7 +22,7 @@ const Diminish_kCm_Nondruid = (Diminish_k_Nondruid * Diminish_Cm)
 // Non-diminishing sources are added separately in spell outcome funcs
 
 
-func (unit *Unit) getDiminishedDodgeChance() (float64) {
+func (unit *Unit) GetDiminishedDodgeChance() (float64) {
 	
 	// undiminished Dodge % = D
 	// diminished Dodge % = (D * Cd)/((k*Cd) + D)
@@ -31,14 +31,14 @@ func (unit *Unit) getDiminishedDodgeChance() (float64) {
 		unit.stats[stats.Dodge]/DodgeRatingPerDodgeChance/100 +
 		unit.stats[stats.Defense]*DefenseRatingToChanceReduction
 		
-	if !unit.PseudoStats.CanParry {
-		return (dodgeChance * Diminish_Cd_Druid) / (Diminish_kCd_Druid + dodgeChance)
-	} else {
+	if unit.PseudoStats.CanParry {
 		return (dodgeChance * Diminish_Cd_Nondruid) / (Diminish_kCd_Nondruid + dodgeChance)
+	} else {
+		return (dodgeChance * Diminish_Cd_Druid) / (Diminish_kCd_Druid + dodgeChance)
 	}
 }
 
-func (unit *Unit) getDiminishedParryChance() (float64) {
+func (unit *Unit) GetDiminishedParryChance() (float64) {
 	
 	// undiminished Parry % = P
 	// diminished Parry % = (P * Cp)/((k*Cp) + P)
@@ -51,17 +51,17 @@ func (unit *Unit) getDiminishedParryChance() (float64) {
 	
 }
 
-func (unit *Unit) getDiminishedMissChance() (float64) {
+func (unit *Unit) GetDiminishedMissChance() (float64) {
 	
 	// undiminished Miss % = M
 	// diminished Miss % = (M * Cm)/((k*Cm) + M)
 
 	missChance := unit.stats[stats.Defense]*DefenseRatingToChanceReduction
 		
-	if !unit.PseudoStats.CanParry {
-		return (missChance * Diminish_Cm) / (Diminish_kCm_Druid + missChance)
-	} else {
+	if unit.PseudoStats.CanParry {
 		return (missChance * Diminish_Cm) / (Diminish_kCm_Nondruid + missChance)
+	} else {
+		return (missChance * Diminish_Cm) / (Diminish_kCm_Druid + missChance)
 	}
 }
 

--- a/sim/core/avoid_dr.go
+++ b/sim/core/avoid_dr.go
@@ -1,0 +1,67 @@
+package core
+
+import (
+	"github.com/wowsims/wotlk/sim/core/stats"
+)
+
+// Could be in constants.go, but they won't be used anywhere else
+// C values are divided by 100 so that we are working with 1% = 0.01
+const Diminish_k_Druid = 0.972
+const Diminish_k_Nondruid = 0.956
+const Diminish_Cd_Druid = 116.890707 / 100
+const Diminish_Cd_Nondruid = 88.129021 / 100
+const Diminish_Cp = 47.003525 / 100
+const Diminish_Cm = 16.000 / 100
+const Diminish_kCd_Druid = (Diminish_k_Druid * Diminish_Cd_Druid)
+const Diminish_kCd_Nondruid = (Diminish_k_Nondruid * Diminish_Cd_Nondruid)
+const Diminish_kCp = (Diminish_k_Nondruid * Diminish_Cp)
+const Diminish_kCm_Druid = (Diminish_k_Druid * Diminish_Cm)
+const Diminish_kCm_Nondruid = (Diminish_k_Nondruid * Diminish_Cm)
+
+// Diminishing Returns for tank avoidance
+// Non-diminishing sources are added separately in spell outcome funcs
+
+
+func (unit *Unit) getDiminishedDodgeChance() (float64) {
+	
+	// undiminished Dodge % = D
+	// diminished Dodge % = (D * Cd)/((k*Cd) + D)
+
+	dodgeChance := 
+		unit.stats[stats.Dodge]/DodgeRatingPerDodgeChance/100 +
+		unit.stats[stats.Defense]*DefenseRatingToChanceReduction
+		
+	if !unit.PseudoStats.CanParry {
+		return (dodgeChance * Diminish_Cd_Druid) / (Diminish_kCd_Druid + dodgeChance)
+	} else {
+		return (dodgeChance * Diminish_Cd_Nondruid) / (Diminish_kCd_Nondruid + dodgeChance)
+	}
+}
+
+func (unit *Unit) getDiminishedParryChance() (float64) {
+	
+	// undiminished Parry % = P
+	// diminished Parry % = (P * Cp)/((k*Cp) + P)
+
+	parryChance :=  
+		unit.stats[stats.Parry]/ParryRatingPerParryChance/100 +
+		unit.stats[stats.Defense]*DefenseRatingToChanceReduction
+
+	return (parryChance * Diminish_Cp) / (Diminish_kCp + parryChance)
+	
+}
+
+func (unit *Unit) getDiminishedMissChance() (float64) {
+	
+	// undiminished Miss % = M
+	// diminished Miss % = (M * Cm)/((k*Cm) + M)
+
+	missChance := unit.stats[stats.Defense]*DefenseRatingToChanceReduction
+		
+	if !unit.PseudoStats.CanParry {
+		return (missChance * Diminish_Cm) / (Diminish_kCm_Druid + missChance)
+	} else {
+		return (missChance * Diminish_Cm) / (Diminish_kCm_Nondruid + missChance)
+	}
+}
+

--- a/sim/core/spell_outcome.go
+++ b/sim/core/spell_outcome.go
@@ -588,7 +588,7 @@ func (spellEffect *SpellEffect) applyAttackTableHit(spell *Spell) {
 }
 
 func (spellEffect *SpellEffect) applyEnemyAttackTableMiss(spell *Spell, unit *Unit, attackTable *AttackTable, roll float64, chance *float64) bool {
-	missChance := attackTable.BaseMissChance + unit.PseudoStats.IncreasedMissChance + spellEffect.Target.getDiminishedMissChance()
+	missChance := attackTable.BaseMissChance + unit.PseudoStats.IncreasedMissChance + spellEffect.Target.GetDiminishedMissChance()
 	if unit.AutoAttacks.IsDualWielding && !unit.PseudoStats.DisableDWMissPenalty {
 		missChance += 0.19
 	}
@@ -625,7 +625,7 @@ func (spellEffect *SpellEffect) applyEnemyAttackTableBlock(spell *Spell, unit *U
 func (spellEffect *SpellEffect) applyEnemyAttackTableDodge(spell *Spell, unit *Unit, attackTable *AttackTable, roll float64, chance *float64) bool {
 	dodgeChance := attackTable.BaseDodgeChance +
 		spellEffect.Target.PseudoStats.BaseDodge +
-		spellEffect.Target.getDiminishedDodgeChance() -
+		spellEffect.Target.GetDiminishedDodgeChance() -
 		unit.PseudoStats.DodgeReduction
 	*chance += MaxFloat(0, dodgeChance)
 
@@ -645,7 +645,7 @@ func (spellEffect *SpellEffect) applyEnemyAttackTableParry(spell *Spell, unit *U
 
 	parryChance := attackTable.BaseParryChance +
 		spellEffect.Target.PseudoStats.BaseParry +
-		spellEffect.Target.getDiminishedParryChance()
+		spellEffect.Target.GetDiminishedParryChance()
 	*chance += MaxFloat(0, parryChance)
 
 	if roll < *chance {

--- a/sim/core/spell_outcome.go
+++ b/sim/core/spell_outcome.go
@@ -588,7 +588,7 @@ func (spellEffect *SpellEffect) applyAttackTableHit(spell *Spell) {
 }
 
 func (spellEffect *SpellEffect) applyEnemyAttackTableMiss(spell *Spell, unit *Unit, attackTable *AttackTable, roll float64, chance *float64) bool {
-	missChance := attackTable.BaseMissChance + unit.PseudoStats.IncreasedMissChance + spellEffect.Target.stats[stats.Defense]*DefenseRatingToChanceReduction
+	missChance := attackTable.BaseMissChance + unit.PseudoStats.IncreasedMissChance + spellEffect.Target.getDiminishedMissChance()
 	if unit.AutoAttacks.IsDualWielding && !unit.PseudoStats.DisableDWMissPenalty {
 		missChance += 0.19
 	}
@@ -624,8 +624,8 @@ func (spellEffect *SpellEffect) applyEnemyAttackTableBlock(spell *Spell, unit *U
 
 func (spellEffect *SpellEffect) applyEnemyAttackTableDodge(spell *Spell, unit *Unit, attackTable *AttackTable, roll float64, chance *float64) bool {
 	dodgeChance := attackTable.BaseDodgeChance +
-		spellEffect.Target.stats[stats.Dodge]/DodgeRatingPerDodgeChance/100 +
-		spellEffect.Target.stats[stats.Defense]*DefenseRatingToChanceReduction -
+		spellEffect.Target.PseudoStats.BaseDodge +
+		spellEffect.Target.getDiminishedDodgeChance() -
 		unit.PseudoStats.DodgeReduction
 	*chance += MaxFloat(0, dodgeChance)
 
@@ -644,8 +644,8 @@ func (spellEffect *SpellEffect) applyEnemyAttackTableParry(spell *Spell, unit *U
 	}
 
 	parryChance := attackTable.BaseParryChance +
-		spellEffect.Target.stats[stats.Parry]/ParryRatingPerParryChance/100 +
-		spellEffect.Target.stats[stats.Defense]*DefenseRatingToChanceReduction
+		spellEffect.Target.PseudoStats.BaseParry +
+		spellEffect.Target.getDiminishedParryChance()
 	*chance += MaxFloat(0, parryChance)
 
 	if roll < *chance {

--- a/sim/core/stats/stats.go
+++ b/sim/core/stats/stats.go
@@ -323,12 +323,17 @@ type PseudoStats struct {
 
 	ParryHaste bool
 
+	// Avoidance % not affected by Diminishing Returns
+	BaseDodge	float64
+	BaseParry	float64
+	//BaseMiss is not needed, this is always 5%
+
 	ReducedCritTakenChance float64 // Reduces chance to be crit.
 
 	BonusRangedAttackPowerTaken float64 // Hunters mark
 	BonusSpellCritRatingTaken   float64 // Imp Shadow Bolt / Imp Scorch / Winter's Chill debuff
 	BonusCritRatingTaken        float64 // Totem of Wrath / Master Poisoner / Heart of the Crusader
-	BonusMeleeHitRatingTaken    float64 //
+	BonusMeleeHitRatingTaken    float64 // Formerly Imp FF and SW Radiance; still used by Frigid Dreadplate
 	BonusSpellHitRatingTaken    float64 // Imp FF
 
 	BonusPhysicalDamageTaken float64 // Hemo, Gift of Arthas, etc

--- a/sim/core/target.go
+++ b/sim/core/target.go
@@ -261,7 +261,7 @@ func NewAttackTable(attacker *Unit, defender *Unit) *AttackTable {
 		table.BaseMissChance = UnitLevelFloat64(attacker.Level, 0.05, 0.048, 0.046, 0.044)
 		table.BaseBlockChance = UnitLevelFloat64(attacker.Level, 0.05, 0.048, 0.046, 0.044)
 		table.BaseDodgeChance = UnitLevelFloat64(attacker.Level, 0, -0.002, -0.004, -0.006)
-		table.BaseParryChance = UnitLevelFloat64(attacker.Level, 0.05, 0.048, 0.046, 0.044)
+		table.BaseParryChance = UnitLevelFloat64(attacker.Level, 0, -0.002, -0.004, -0.006)
 	}
 
 	table.UpdatePartialResists()

--- a/sim/deathknight/deathknight.go
+++ b/sim/deathknight/deathknight.go
@@ -362,6 +362,7 @@ func NewDeathknight(character core.Character, talents proto.DeathknightTalents, 
 
 	// Base dodge unaffected by Diminishing Returns
 	dk.PseudoStats.BaseDodge += 0.03664
+	dk.PseudoStats.BaseParry += 0.05
 
 	dk.PseudoStats.MeleeHasteRatingPerHastePercent /= 1.3
 

--- a/sim/deathknight/deathknight.go
+++ b/sim/deathknight/deathknight.go
@@ -358,6 +358,11 @@ func NewDeathknight(character core.Character, talents proto.DeathknightTalents, 
 	dk.AddStatDependency(stats.Strength, stats.AttackPower, 2)
 	dk.AddStatDependency(stats.Strength, stats.Parry, 0.25)
 
+	dk.PseudoStats.CanParry = true
+
+	// Base dodge unaffected by Diminishing Returns
+	dk.PseudoStats.BaseDodge += 0.03664
+
 	dk.PseudoStats.MeleeHasteRatingPerHastePercent /= 1.3
 
 	dk.Ghoul = dk.NewGhoulPet(dk.Talents.MasterOfGhouls)
@@ -444,7 +449,6 @@ func init() {
 		stats.Spirit:      61,
 		stats.AttackPower: 220,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceDwarf, Class: proto.Class_ClassDeathknight}] = stats.Stats{
 		stats.Health:      7941,
@@ -455,7 +459,6 @@ func init() {
 		stats.Spirit:      58,
 		stats.AttackPower: 220,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceGnome, Class: proto.Class_ClassDeathknight}] = stats.Stats{
 		stats.Health:      7941,
@@ -466,7 +469,6 @@ func init() {
 		stats.Spirit:      63,
 		stats.AttackPower: 220,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceHuman, Class: proto.Class_ClassDeathknight}] = stats.Stats{
 		stats.Health:      7941,
@@ -477,7 +479,6 @@ func init() {
 		stats.Spirit:      63,
 		stats.AttackPower: 220,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceNightElf, Class: proto.Class_ClassDeathknight}] = stats.Stats{
 		stats.Health:      7941,
@@ -488,7 +489,6 @@ func init() {
 		stats.Spirit:      59,
 		stats.AttackPower: 220,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceOrc, Class: proto.Class_ClassDeathknight}] = stats.Stats{
 		stats.Health:      7941,
@@ -499,7 +499,6 @@ func init() {
 		stats.Spirit:      61,
 		stats.AttackPower: 220,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceTauren, Class: proto.Class_ClassDeathknight}] = stats.Stats{
 		stats.Health:      7941,
@@ -510,7 +509,6 @@ func init() {
 		stats.Spirit:      61,
 		stats.AttackPower: 220,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceTroll, Class: proto.Class_ClassDeathknight}] = stats.Stats{
 		stats.Health:      7941,
@@ -521,7 +519,6 @@ func init() {
 		stats.Spirit:      60,
 		stats.AttackPower: 220,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceUndead, Class: proto.Class_ClassDeathknight}] = stats.Stats{
 		stats.Health:      7941,
@@ -532,7 +529,6 @@ func init() {
 		stats.Spirit:      64,
 		stats.AttackPower: 220,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceBloodElf, Class: proto.Class_ClassDeathknight}] = stats.Stats{
 		stats.Health:      7941,
@@ -543,7 +539,6 @@ func init() {
 		stats.Spirit:      57,
 		stats.AttackPower: 220,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 }
 

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -26,7 +26,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 480.61292
+  final_stats: 314.81692
   final_stats: 425.854
   final_stats: 0
   final_stats: 25128.5

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -26,7 +26,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 471.2154
+  final_stats: 305.4194
   final_stats: 423.01688
   final_stats: 0
   final_stats: 25062.5

--- a/sim/deathknight/talents_blood.go
+++ b/sim/deathknight/talents_blood.go
@@ -11,6 +11,7 @@ import (
 	"github.com/wowsims/wotlk/sim/core"
 	"github.com/wowsims/wotlk/sim/core/proto"
 	"github.com/wowsims/wotlk/sim/core/stats"
+
 )
 
 func (dk *Deathknight) ApplyBloodTalents() {
@@ -97,7 +98,7 @@ func (dk *Deathknight) applySpellDeflection() {
 
 	dk.AddDynamicDamageTakenModifier(func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 		if spell.ProcMask.Matches(core.ProcMaskSpellDamage) {
-			procChance := dk.GetStat(stats.Parry) / core.ParryRatingPerParryChance + dk.PseudoStats.BaseParry
+			procChance := dk.PseudoStats.BaseParry + dk.Unit.GetDiminishedParryChance()
 			dmgMult := 1.0 - 0.15*float64(dk.Talents.SpellDeflection)
 			if sim.RandomFloat("Spell Deflection Roll") < procChance {
 				spellEffect.Damage *= dmgMult

--- a/sim/deathknight/talents_blood.go
+++ b/sim/deathknight/talents_blood.go
@@ -97,7 +97,7 @@ func (dk *Deathknight) applySpellDeflection() {
 
 	dk.AddDynamicDamageTakenModifier(func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 		if spell.ProcMask.Matches(core.ProcMaskSpellDamage) {
-			procChance := dk.GetStat(stats.Parry) / core.ParryRatingPerParryChance
+			procChance := dk.GetStat(stats.Parry) / core.ParryRatingPerParryChance + dk.PseudoStats.BaseParry
 			dmgMult := 1.0 - 0.15*float64(dk.Talents.SpellDeflection)
 			if sim.RandomFloat("Spell Deflection Roll") < procChance {
 				spellEffect.Damage *= dmgMult

--- a/sim/deathknight/talents_unholy.go
+++ b/sim/deathknight/talents_unholy.go
@@ -14,7 +14,7 @@ import (
 
 func (dk *Deathknight) ApplyUnholyTalents() {
 	// Anticipation
-	dk.AddStat(stats.Dodge, core.DodgeRatingPerDodgeChance*1*float64(dk.Talents.Anticipation))
+	dk.PseudoStats.BaseDodge += 0.01*float64(dk.Talents.Anticipation)
 
 	// Virulence
 	dk.AddStat(stats.SpellHit, core.SpellHitRatingPerHitChance*float64(dk.Talents.Virulence))

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -26,7 +26,7 @@ character_stats_results: {
   final_stats: 572
   final_stats: 0
   final_stats: 0
-  final_stats: 821.23674
+  final_stats: 564.94074
   final_stats: 679.68094
   final_stats: 15
   final_stats: 38623.6555
@@ -612,9 +612,9 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-Average-Default"
  value: {
-  dps: 1743.00843
-  tps: 5648.06725
-  dtps: 360.29022
+  dps: 1869.25603
+  tps: 6255.45846
+  dtps: 271.44284
  }
 }
 dps_results: {
@@ -704,8 +704,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1780.06945
-  tps: 5662.71344
-  dtps: 347.77408
+  dps: 1918.079
+  tps: 6339.68553
+  dtps: 265.60917
  }
 }

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -26,7 +26,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 594.21655
+  final_stats: 341.26905
   final_stats: 0
   final_stats: 0
   final_stats: 20537.91

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -283,6 +283,9 @@ func New(char core.Character, form DruidForm, selfBuffs SelfBuffs, talents proto
 	// Druids get extra melee haste
 	druid.PseudoStats.MeleeHasteRatingPerHastePercent /= 1.3
 
+	// Base dodge is unaffected by Diminishing Returns
+	druid.PseudoStats.BaseDodge += 0.0559
+
 	if druid.Talents.ForceOfNature {
 		druid.Treant1 = druid.NewTreant()
 		druid.Treant2 = druid.NewTreant()
@@ -303,7 +306,6 @@ func init() {
 		stats.Mana:        3496,                                // 5301 mana shown on naked character
 		stats.SpellCrit:   1.85 * core.CritRatingPerCritChance, // Class-specific constant
 		stats.MeleeCrit:   7.48 * core.CritRatingPerCritChance, // 8.41% chance to crit shown on naked character screen
-		stats.Dodge:       5.59 * core.DodgeRatingPerDodgeChance,
 		stats.AttackPower: -20,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceNightElf, Class: proto.Class_ClassDruid}] = stats.Stats{
@@ -316,7 +318,6 @@ func init() {
 		stats.Mana:        3496,                                // 5361 mana shown on naked character
 		stats.SpellCrit:   1.85 * core.CritRatingPerCritChance, // Class-specific constant
 		stats.MeleeCrit:   7.48 * core.CritRatingPerCritChance, // 8.51% chance to crit shown on naked character screen
-		stats.Dodge:       5.59 * core.DodgeRatingPerDodgeChance,
 		stats.AttackPower: -20,
 	}
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -26,7 +26,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 1599.5069
+  final_stats: 1346.5594
   final_stats: 0
   final_stats: 0
   final_stats: 23928.7062

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -78,9 +78,7 @@ func (druid *Druid) applyFeralShift(sim *core.Simulation, enter_form bool) {
 		}
 	}
 	druid.AddStatDynamic(sim, stats.MeleeCrit, pos*float64(druid.Talents.SharpenedClaws)*2*core.CritRatingPerCritChance)
-	//druid.AddStatDynamic(sim, stats.Dodge, pos*core.DodgeRatingPerDodgeChance*2*float64(druid.Talents.FeralSwiftness))
-	// Unaffected by Diminishing Returns
-	druid.PseudoStats.BaseDodge += pos*0.02*float64(druid.Talents.FeralSwiftness)
+	druid.PseudoStats.BaseDodge += pos*0.02*float64(druid.Talents.FeralSwiftness) // Unaffected by Diminishing Returns
 }
 
 func (druid *Druid) registerCatFormSpell() {

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -78,7 +78,9 @@ func (druid *Druid) applyFeralShift(sim *core.Simulation, enter_form bool) {
 		}
 	}
 	druid.AddStatDynamic(sim, stats.MeleeCrit, pos*float64(druid.Talents.SharpenedClaws)*2*core.CritRatingPerCritChance)
-	druid.AddStatDynamic(sim, stats.Dodge, pos*core.DodgeRatingPerDodgeChance*2*float64(druid.Talents.FeralSwiftness))
+	//druid.AddStatDynamic(sim, stats.Dodge, pos*core.DodgeRatingPerDodgeChance*2*float64(druid.Talents.FeralSwiftness))
+	// Unaffected by Diminishing Returns
+	druid.PseudoStats.BaseDodge += pos*0.02*float64(druid.Talents.FeralSwiftness)
 }
 
 func (druid *Druid) registerCatFormSpell() {

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -26,7 +26,7 @@ character_stats_results: {
   final_stats: 108
   final_stats: 0
   final_stats: 84
-  final_stats: 1232.5128
+  final_stats: 979.5653
   final_stats: 0
   final_stats: 50
   final_stats: 23531.45
@@ -626,9 +626,9 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-Average-Default"
  value: {
-  dps: 1316.04529
-  tps: 1814.83032
-  dtps: 522.98961
+  dps: 1326.70734
+  tps: 1832.04825
+  dtps: 552.0513
  }
 }
 dps_results: {
@@ -676,8 +676,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1440.58147
-  tps: 2004.94641
-  dtps: 488.03992
+  dps: 1445.08961
+  tps: 2010.76722
+  dtps: 512.98214
  }
 }

--- a/sim/paladin/paladin.go
+++ b/sim/paladin/paladin.go
@@ -205,7 +205,11 @@ func NewPaladin(character core.Character, talents proto.PaladinTalents) *Paladin
 	// Paladins get more melee haste from haste than other classes, 25.22/1%
 	paladin.PseudoStats.MeleeHasteRatingPerHastePercent = 25.22
 
-	paladin.AddStatDependency(stats.Strength, stats.BlockValue, .5) // 50% block from str
+	// Paladins get 1 block value per 2 str
+	paladin.AddStatDependency(stats.Strength, stats.BlockValue, .5)
+
+	// Base dodge is unaffected by Diminishing Returns
+	paladin.PseudoStats.BaseDodge += 0.0327
 
 	return paladin
 }
@@ -222,7 +226,6 @@ func init() {
 		stats.Agility:     92,
 		stats.MeleeCrit:   3.27 * core.CritRatingPerCritChance,
 		stats.SpellCrit:   3.27 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.27 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceDraenei, Class: proto.Class_ClassPaladin}] = stats.Stats{
 		stats.Health:      6754,
@@ -235,7 +238,6 @@ func init() {
 		stats.Agility:     87,
 		stats.MeleeCrit:   3.27 * core.CritRatingPerCritChance,
 		stats.SpellCrit:   3.27 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.27 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceHuman, Class: proto.Class_ClassPaladin}] = stats.Stats{
 		stats.Health:      6754,
@@ -248,7 +250,6 @@ func init() {
 		stats.Agility:     90,
 		stats.MeleeCrit:   3.27 * core.CritRatingPerCritChance,
 		stats.SpellCrit:   3.27 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.27 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceDwarf, Class: proto.Class_ClassPaladin}] = stats.Stats{
 		stats.Health:      6754,
@@ -261,6 +262,5 @@ func init() {
 		stats.Agility:     86,
 		stats.MeleeCrit:   3.27 * core.CritRatingPerCritChance,
 		stats.SpellCrit:   3.27 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.27 * core.DodgeRatingPerDodgeChance,
 	}
 }

--- a/sim/paladin/paladin.go
+++ b/sim/paladin/paladin.go
@@ -210,6 +210,7 @@ func NewPaladin(character core.Character, talents proto.PaladinTalents) *Paladin
 
 	// Base dodge is unaffected by Diminishing Returns
 	paladin.PseudoStats.BaseDodge += 0.0327
+	paladin.PseudoStats.BaseParry += 0.05
 
 	return paladin
 }

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -26,8 +26,8 @@ character_stats_results: {
   final_stats: 703
   final_stats: 171
   final_stats: 2331.86704
-  final_stats: 872.13359
-  final_stats: 406.25
+  final_stats: 497.91609
+  final_stats: 180
   final_stats: 15
   final_stats: 38266.9256
   final_stats: 75
@@ -675,9 +675,9 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Average-Default"
  value: {
-  dps: 3546.67121
-  tps: 8426.48716
-  dtps: 11.56369
+  dps: 3580.15106
+  tps: 8494.12352
+  dtps: 15.26131
  }
 }
 dps_results: {
@@ -935,8 +935,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3716.34556
-  tps: 8817.89723
-  dtps: 9.44017
+  dps: 3741.04963
+  tps: 8850.18582
+  dtps: 14.43555
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -26,7 +26,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 667.92
-  final_stats: 921.1621
+  final_stats: 773.1946
   final_stats: 0
   final_stats: 0
   final_stats: 21972.5

--- a/sim/paladin/talents.go
+++ b/sim/paladin/talents.go
@@ -18,8 +18,8 @@ func (paladin *Paladin) ApplyTalents() {
 	paladin.AddStat(stats.MeleeCrit, float64(paladin.Talents.SanctityOfBattle)*core.CritRatingPerCritChance)
 	paladin.AddStat(stats.SpellCrit, float64(paladin.Talents.SanctityOfBattle)*core.CritRatingPerCritChance)
 
-	paladin.AddStat(stats.Parry, core.ParryRatingPerParryChance*1*float64(paladin.Talents.Deflection))
-	paladin.AddStat(stats.Dodge, core.DodgeRatingPerDodgeChance*1*float64(paladin.Talents.Anticipation))
+	paladin.PseudoStats.BaseParry += 0.01*float64(paladin.Talents.Deflection)
+	paladin.PseudoStats.BaseDodge += 0.01*float64(paladin.Talents.Anticipation)
 
 	paladin.AddStat(stats.Armor, paladin.Equip.Stats()[stats.Armor]*0.02*float64(paladin.Talents.Toughness))
 

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -26,7 +26,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 733.788
-  final_stats: 599.2554
+  final_stats: 433.4594
   final_stats: 0
   final_stats: 0
   final_stats: 28390.5

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -26,7 +26,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 863.28
-  final_stats: 599.2554
+  final_stats: 433.4594
   final_stats: 0
   final_stats: 0
   final_stats: 28390.5

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -26,8 +26,8 @@ character_stats_results: {
   final_stats: 670
   final_stats: 182.95
   final_stats: 1672.1068
-  final_stats: 836.14287
-  final_stats: 467.25
+  final_stats: 444.09687
+  final_stats: 241
   final_stats: 15
   final_stats: 41567.255
   final_stats: 75
@@ -45,7 +45,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 0.79543
+  weights: 0.86996
   weights: 0
   weights: 0
   weights: 0
@@ -56,7 +56,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.20448
+  weights: 0.21943
   weights: 0
   weights: 0
   weights: 0
@@ -65,12 +65,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.10478
+  weights: 0.09476
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.54019
-  weights: -0.12733
+  weights: 0.37751
+  weights: -0.0562
   weights: 0
   weights: 0
   weights: 0
@@ -607,9 +607,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 2814.66157
-  tps: 7413.91504
-  dtps: 95.43257
+  dps: 2823.39631
+  tps: 7438.94811
+  dtps: 124.87467
  }
 }
 dps_results: {
@@ -699,8 +699,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2960.37697
-  tps: 7799.29786
-  dtps: 99.39883
+  dps: 2986.88688
+  tps: 7866.13529
+  dtps: 122.46754
  }
 }

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -11,9 +11,9 @@ import (
 func (warrior *Warrior) ApplyTalents() {
 	warrior.AddStat(stats.MeleeCrit, core.CritRatingPerCritChance*1*float64(warrior.Talents.Cruelty))
 	warrior.AddStat(stats.MeleeHit, core.MeleeHitRatingPerHitChance*1*float64(warrior.Talents.Precision))
+	warrior.AddStat(stats.Armor, warrior.Equip.Stats()[stats.Armor]*0.02*float64(warrior.Talents.Toughness))
 	warrior.PseudoStats.BaseDodge += 0.01*float64(warrior.Talents.Anticipation)
 	warrior.PseudoStats.BaseParry += 0.01*float64(warrior.Talents.Deflection)
-	warrior.AddStat(stats.Armor, warrior.Equip.Stats()[stats.Armor]*0.02*float64(warrior.Talents.Toughness))
 	warrior.PseudoStats.DodgeReduction += 0.01 * float64(warrior.Talents.WeaponMastery)
 	warrior.AutoAttacks.OHConfig.DamageMultiplier *= 1 + 0.05*float64(warrior.Talents.DualWieldSpecialization)
 

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -9,10 +9,10 @@ import (
 )
 
 func (warrior *Warrior) ApplyTalents() {
-	warrior.AddStat(stats.Parry, core.ParryRatingPerParryChance*1*float64(warrior.Talents.Deflection))
 	warrior.AddStat(stats.MeleeCrit, core.CritRatingPerCritChance*1*float64(warrior.Talents.Cruelty))
 	warrior.AddStat(stats.MeleeHit, core.MeleeHitRatingPerHitChance*1*float64(warrior.Talents.Precision))
-	warrior.AddStat(stats.Dodge, core.DodgeRatingPerDodgeChance*1*float64(warrior.Talents.Anticipation))
+	warrior.PseudoStats.BaseDodge += 0.01*float64(warrior.Talents.Anticipation)
+	warrior.PseudoStats.BaseParry += 0.01*float64(warrior.Talents.Deflection)
 	warrior.AddStat(stats.Armor, warrior.Equip.Stats()[stats.Armor]*0.02*float64(warrior.Talents.Toughness))
 	warrior.PseudoStats.DodgeReduction += 0.01 * float64(warrior.Talents.WeaponMastery)
 	warrior.AutoAttacks.OHConfig.DamageMultiplier *= 1 + 0.05*float64(warrior.Talents.DualWieldSpecialization)

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -195,6 +195,9 @@ func NewWarrior(character core.Character, talents proto.WarriorTalents, inputs W
 	warrior.AddStatDependency(stats.Strength, stats.AttackPower, 2)
 	warrior.AddStatDependency(stats.Strength, stats.BlockValue, .5) // 50% block from str
 
+	// Base dodge unaffected by Diminishing Returns
+	warrior.PseudoStats.BaseDodge += 0.03664
+
 	return warrior
 }
 
@@ -249,7 +252,6 @@ func init() {
 		stats.Spirit:      61,
 		stats.AttackPower: 590,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceDwarf, Class: proto.Class_ClassWarrior}] = stats.Stats{
 		stats.Health:      9651,
@@ -260,7 +262,6 @@ func init() {
 		stats.Spirit:      58,
 		stats.AttackPower: 592,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceGnome, Class: proto.Class_ClassWarrior}] = stats.Stats{
 		stats.Health:      9581,
@@ -271,7 +272,6 @@ func init() {
 		stats.Spirit:      59,
 		stats.AttackPower: 570,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceHuman, Class: proto.Class_ClassWarrior}] = stats.Stats{
 		stats.Health:      9621,
@@ -282,7 +282,6 @@ func init() {
 		stats.Spirit:      63,
 		stats.AttackPower: 588,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceNightElf, Class: proto.Class_ClassWarrior}] = stats.Stats{
 		stats.Health:      9611,
@@ -293,7 +292,6 @@ func init() {
 		stats.Spirit:      59,
 		stats.AttackPower: 582,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceOrc, Class: proto.Class_ClassWarrior}] = stats.Stats{
 		stats.Health:      9641,
@@ -304,7 +302,6 @@ func init() {
 		stats.Spirit:      62,
 		stats.AttackPower: 594,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceTauren, Class: proto.Class_ClassWarrior}] = stats.Stats{
 		stats.Health:      10047,
@@ -315,7 +312,6 @@ func init() {
 		stats.Spirit:      61,
 		stats.AttackPower: 578,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceTroll, Class: proto.Class_ClassWarrior}] = stats.Stats{
 		stats.Health:      9631,
@@ -326,7 +322,6 @@ func init() {
 		stats.Spirit:      60,
 		stats.AttackPower: 590,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 	core.BaseStats[core.BaseStatsKey{Race: proto.Race_RaceUndead, Class: proto.Class_ClassWarrior}] = stats.Stats{
 		stats.Health:      9541,
@@ -337,7 +332,6 @@ func init() {
 		stats.Spirit:      64,
 		stats.AttackPower: 566,
 		stats.MeleeCrit:   3.188 * core.CritRatingPerCritChance,
-		stats.Dodge:       3.664 * core.DodgeRatingPerDodgeChance,
 	}
 }
 

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -197,6 +197,7 @@ func NewWarrior(character core.Character, talents proto.WarriorTalents, inputs W
 
 	// Base dodge unaffected by Diminishing Returns
 	warrior.PseudoStats.BaseDodge += 0.03664
+	warrior.PseudoStats.BaseParry += 0.05
 
 	return warrior
 }


### PR DESCRIPTION
Implement diminishing returns mechanic for avoidance (dodge/parry/miss) based on coefficients previously published by Itank; example reference here: https://github.com/Itank84/itankadin/wiki/Diminishing-Returns-on-Avoidance

- BaseDodge and BaseParry implemented as Pseudostats to handle base values and talents which are not modified by diminishing returns
- Dodge and Parry stats continue to reflect raw rating, including STR/AGI conversions as appropriate, which is true to how DR treats them as a lump sum to be diminished
- Dodge and Parry talents (Deflection, Anticipation, Feral Swiftness) moved from the latter to the former
- DK Tanks now properly have Parry enabled
- DK Spell Deflection includes Parry DR
- Moved 5% base parry from the Target AttackTable (now applies the level penalty only) to War/Pal/DK BaseParry

Did NOT touch:
- Frigid Dreadplate, which is already in the unaffected category (and possibly should not work vs bosses?)
- The left-side stats UI, which is already iffy for displaying these stats and will still need some love
- Attack table caching; this is all done live in the spell outcome calcs.