### PR TITLE
Engineering shared CD changes

### DIFF
--- a/sim/common/wotlk/enchant_effects.go
+++ b/sim/common/wotlk/enchant_effects.go
@@ -322,10 +322,14 @@ func init() {
 					Timer:    character.NewTimer(),
 					Duration: time.Second * 60,
 				},
-				SharedCD: core.Cooldown{
-					Timer:    character.GetOffensiveTrinketCD(),
-					Duration: time.Second * 12,
-				},
+				// Shared CD with Offensive trinkets has been removed.
+				// https://twitter.com/AggrendWoW/status/1579664462843633664
+				// Change possibly temporary, but developers have confirmed it was intended.
+
+				// SharedCD: core.Cooldown{
+				// 	Timer:    character.GetOffensiveTrinketCD(),
+				// 	Duration: time.Second * 12,
+				// },
 			},
 
 			ApplyEffects: func(sim *core.Simulation, _ *core.Unit, _ *core.Spell) {

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -297,8 +297,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7654.88139
-  tps: 4535.31735
+  dps: 7761.73661
+  tps: 4595.72263
  }
 }
 dps_results: {

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -333,9 +333,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7422.91011
-  tps: 4762.00023
-  hps: 189.09928
+  dps: 7423.88616
+  tps: 4753.50556
+  hps: 190.44129
  }
 }
 dps_results: {

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -318,8 +318,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7006.27608
-  tps: 6828.06421
+  dps: 7044.42416
+  tps: 6867.72766
  }
 }
 dps_results: {
@@ -403,7 +403,7 @@ dps_results: {
  key: "TestBalance-AllItems-OfferingofSacrifice-37638"
  value: {
   dps: 7044.42416
-  tps: 6868.53475
+  tps: 6868.34107
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -318,8 +318,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7576.17541
-  tps: 5755.5162
+  dps: 7579.89987
+  tps: 5776.16536
  }
 }
 dps_results: {

--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -73,22 +73,22 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6724.19902
-  tps: 5707.30097
+  dps: 6722.23839
+  tps: 5705.33784
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6631.71781
-  tps: 5621.98533
+  dps: 6634.06518
+  tps: 5624.33454
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 6341.40392
-  tps: 5329.48552
+  dps: 6340.4029
+  tps: 5328.48872
  }
 }
 dps_results: {
@@ -185,8 +185,8 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6721.39412
-  tps: 5698.11226
+  dps: 6718.33635
+  tps: 5695.0531
  }
 }
 dps_results: {
@@ -290,15 +290,15 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6731.81765
-  tps: 5718.68765
+  dps: 6783.4274
+  tps: 5764.54896
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6918.51511
-  tps: 5908.89464
+  dps: 6919.7539
+  tps: 5910.12511
  }
 }
 dps_results: {
@@ -332,8 +332,8 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6631.80249
-  tps: 5622.13719
+  dps: 6630.54577
+  tps: 5620.88046
  }
 }
 dps_results: {
@@ -430,15 +430,15 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6631.80249
-  tps: 5622.13719
+  dps: 6630.44596
+  tps: 5620.78065
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SparkofLife-37657"
  value: {
-  dps: 6807.28424
-  tps: 5796.38653
+  dps: 6807.25273
+  tps: 5796.35502
  }
 }
 dps_results: {
@@ -479,8 +479,8 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6761.99164
-  tps: 5742.13339
+  dps: 6763.98242
+  tps: 5744.12416
  }
 }
 dps_results: {
@@ -542,22 +542,22 @@ dps_results: {
 dps_results: {
  key: "TestHunter-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7407.96296
-  tps: 6386.20389
+  dps: 7407.8441
+  tps: 6386.08503
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 7688.93756
-  tps: 6665.57491
+  dps: 7689.30779
+  tps: 6665.94177
  }
 }
 dps_results: {
  key: "TestHunter-Average-Default"
  value: {
-  dps: 6812.57814
-  tps: 5795.60695
+  dps: 6812.77121
+  tps: 5795.79981
  }
 }
 dps_results: {

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -45,22 +45,22 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6789.66836
-  tps: 4064.95283
+  dps: 6811.2375
+  tps: 4077.85006
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6624.94617
-  tps: 3972.08839
+  dps: 6630.98627
+  tps: 3975.70389
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6825.89653
-  tps: 4085.55181
+  dps: 6829.63086
+  tps: 4087.79152
  }
 }
 dps_results: {
@@ -80,141 +80,141 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6828.80346
-  tps: 4007.54501
+  dps: 6850.49752
+  tps: 4020.25756
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6967.46855
-  tps: 4171.59512
+  dps: 6991.61679
+  tps: 4185.97369
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6701.36502
-  tps: 4017.65834
+  dps: 6707.64665
+  tps: 4021.41876
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6718.88871
-  tps: 4049.20669
+  dps: 6725.8643
+  tps: 4053.40017
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6729.99858
-  tps: 4030.76783
+  dps: 6698.16917
+  tps: 4013.31432
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6729.99858
-  tps: 4030.76783
+  dps: 6698.16917
+  tps: 4013.31432
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6742.48939
-  tps: 4036.06339
+  dps: 6754.82609
+  tps: 4042.47404
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6649.57406
-  tps: 3986.86513
+  dps: 6655.65042
+  tps: 3990.50238
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6610.67992
-  tps: 3961.56388
+  dps: 6639.73187
+  tps: 3980.60223
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6806.72777
-  tps: 4075.06435
+  dps: 6829.48575
+  tps: 4088.60876
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6789.66836
-  tps: 4064.95283
+  dps: 6811.2375
+  tps: 4077.85006
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6847.39156
-  tps: 4098.1263
+  dps: 6862.23866
+  tps: 4106.81714
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6803.7822
-  tps: 4073.38331
+  dps: 6826.12106
+  tps: 4086.67625
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6799.63426
-  tps: 4070.89454
+  dps: 6821.97312
+  tps: 4084.18749
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6789.66836
-  tps: 4064.95283
+  dps: 6811.2375
+  tps: 4077.85006
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6695.297
-  tps: 4013.79715
+  dps: 6701.57863
+  tps: 4017.55757
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6886.98827
-  tps: 4127.6812
+  dps: 6893.45183
+  tps: 4131.55078
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6845.84626
-  tps: 4103.6683
+  dps: 6852.16033
+  tps: 4107.44818
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6828.80346
-  tps: 4088.02804
+  dps: 6850.49752
+  tps: 4101.00005
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6820.97644
-  tps: 4083.413
+  dps: 6842.64552
+  tps: 4096.37005
  }
 }
 dps_results: {
@@ -227,57 +227,57 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6624.94617
-  tps: 3972.08839
+  dps: 6630.98627
+  tps: 3975.70389
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6749.32118
-  tps: 4045.31849
+  dps: 6724.07752
+  tps: 4026.83901
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6935.13549
-  tps: 4156.44602
+  dps: 6941.45734
+  tps: 4160.23057
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6803.7822
-  tps: 4073.38331
+  dps: 6826.12106
+  tps: 4086.67625
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6799.63426
-  tps: 4070.89454
+  dps: 6821.97312
+  tps: 4084.18749
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6635.46499
-  tps: 3979.41239
+  dps: 6639.73187
+  tps: 3980.60223
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6821.17824
-  tps: 4085.79385
+  dps: 6826.29073
+  tps: 4088.86874
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6789.66836
-  tps: 4064.95283
+  dps: 6811.2375
+  tps: 4077.85006
  }
 }
 dps_results: {
@@ -297,127 +297,127 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6610.67992
-  tps: 3961.56388
+  dps: 6639.73187
+  tps: 3980.60223
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6690.55711
-  tps: 4005.40637
+  dps: 6694.98917
+  tps: 4008.073
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6682.7336
-  tps: 4006.39869
+  dps: 6689.01523
+  tps: 4010.1591
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6610.67992
-  tps: 3961.56388
+  dps: 6638.13321
+  tps: 3979.64303
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6789.66836
-  tps: 4064.95283
+  dps: 6811.2375
+  tps: 4077.85006
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6789.66836
-  tps: 4064.95283
+  dps: 6811.2375
+  tps: 4077.85006
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6789.66836
-  tps: 4064.95283
+  dps: 6811.2375
+  tps: 4077.85006
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6789.66836
-  tps: 4064.95283
+  dps: 6811.2375
+  tps: 4077.85006
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6624.94617
-  tps: 3972.08839
+  dps: 6630.98627
+  tps: 3975.70389
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7046.66941
-  tps: 4300.47221
+  dps: 7052.67
+  tps: 4304.02226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7100.49985
-  tps: 4342.61483
+  dps: 7106.50845
+  tps: 4346.16301
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6952.09013
-  tps: 4162.4059
+  dps: 6975.4093
+  tps: 4176.35314
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6811.37851
-  tps: 4075.97624
+  dps: 6832.39017
+  tps: 4088.91545
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6610.67992
-  tps: 3961.56388
+  dps: 6639.73187
+  tps: 3980.60223
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6610.67992
-  tps: 3961.56388
+  dps: 6639.73187
+  tps: 3980.60223
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6624.94617
-  tps: 3972.08839
+  dps: 6630.98627
+  tps: 3975.70389
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6610.67992
-  tps: 3961.56388
+  dps: 6602.62371
+  tps: 3956.74735
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SparkofLife-37657"
  value: {
-  dps: 6749.14968
-  tps: 4040.95612
+  dps: 6726.04027
+  tps: 4029.97507
  }
 }
 dps_results: {
@@ -430,92 +430,92 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6789.66836
-  tps: 4064.95283
+  dps: 6811.2375
+  tps: 4077.85006
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6789.66836
-  tps: 4064.95283
+  dps: 6811.2375
+  tps: 4077.85006
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6789.66836
-  tps: 4064.95283
+  dps: 6811.2375
+  tps: 4077.85006
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6789.66836
-  tps: 4064.95283
+  dps: 6811.2375
+  tps: 4077.85006
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6712.38035
-  tps: 4018.88934
+  dps: 6736.34676
+  tps: 4032.8743
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6712.38035
-  tps: 4018.88934
+  dps: 6736.34676
+  tps: 4032.8743
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6828.80346
-  tps: 4088.02804
+  dps: 6850.49752
+  tps: 4101.00005
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6820.97644
-  tps: 4083.413
+  dps: 6842.64552
+  tps: 4096.37005
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6820.97644
-  tps: 4083.413
+  dps: 6842.64552
+  tps: 4096.37005
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6828.80346
-  tps: 4088.02804
+  dps: 6850.49752
+  tps: 4101.00005
  }
 }
 dps_results: {
  key: "TestArcane-Average-Default"
  value: {
-  dps: 6908.89815
-  tps: 4143.73779
+  dps: 6916.53866
+  tps: 4148.09425
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10647.48474
-  tps: 8556.70512
+  dps: 10647.65129
+  tps: 8556.80504
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1451.13921
-  tps: 905.8895
+  dps: 1453.42605
+  tps: 907.45506
  }
 }
 dps_results: {
@@ -528,15 +528,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6141.4557
-  tps: 5304.46914
+  dps: 6134.25882
+  tps: 5300.90524
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 737.00593
-  tps: 471.54982
+  dps: 742.42849
+  tps: 475.18736
  }
 }
 dps_results: {
@@ -549,15 +549,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6967.46855
-  tps: 5385.2463
+  dps: 6991.61679
+  tps: 5399.6075
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6967.46855
-  tps: 4171.59512
+  dps: 6991.61679
+  tps: 4185.97369
  }
 }
 dps_results: {
@@ -570,15 +570,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3841.59527
-  tps: 3509.08841
+  dps: 3881.6622
+  tps: 3536.66333
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3841.59527
-  tps: 2314.0169
+  dps: 3881.6622
+  tps: 2339.29939
  }
 }
 dps_results: {
@@ -591,7 +591,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6967.46855
-  tps: 4171.59512
+  dps: 6991.61679
+  tps: 4185.97369
  }
 }

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -262,8 +262,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5720.1651
-  tps: 4125.81764
+  dps: 5660.94037
+  tps: 4096.45319
  }
 }
 dps_results: {

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -45,22 +45,22 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 4429.83489
-  tps: 3722.05702
+  dps: 4429.91883
+  tps: 3722.11193
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 4288.05074
-  tps: 3606.66711
+  dps: 4288.1482
+  tps: 3606.75998
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 4445.33584
-  tps: 3735.50606
+  dps: 4445.3883
+  tps: 3735.53593
  }
 }
 dps_results: {
@@ -80,57 +80,57 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 4459.71893
-  tps: 3672.8962
+  dps: 4459.80287
+  tps: 3672.94961
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 4556.81784
-  tps: 3835.66985
+  dps: 4556.90556
+  tps: 3835.72816
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 4356.17979
-  tps: 3667.26347
+  dps: 4356.27726
+  tps: 3667.35635
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 4390.25779
-  tps: 3699.00242
+  dps: 4390.15613
+  tps: 3699.17797
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-42987"
  value: {
   dps: 4335.18705
-  tps: 3655.52212
+  tps: 3655.28418
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44253"
  value: {
   dps: 4335.18705
-  tps: 3655.52212
+  tps: 3655.28418
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44254"
  value: {
   dps: 4333.85893
-  tps: 3653.61979
+  tps: 3653.38171
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 4307.00598
-  tps: 3623.31122
+  dps: 4307.10345
+  tps: 3623.4041
  }
 }
 dps_results: {
@@ -143,78 +143,78 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 4447.48626
-  tps: 3737.41633
+  dps: 4447.57021
+  tps: 3737.47125
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 4429.83489
-  tps: 3722.05702
+  dps: 4429.91883
+  tps: 3722.11193
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 4466.71056
-  tps: 3753.22981
+  dps: 4466.65743
+  tps: 3753.16473
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 4446.63987
-  tps: 3736.73854
+  dps: 4446.72382
+  tps: 3736.79346
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 4441.43345
-  tps: 3732.12473
+  dps: 4441.5174
+  tps: 3732.17965
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 4429.83489
-  tps: 3722.05702
+  dps: 4429.91883
+  tps: 3722.11193
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 4349.03576
-  tps: 3657.73635
+  dps: 4349.42007
+  tps: 3658.21596
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 4494.86386
-  tps: 3785.91027
+  dps: 4494.96132
+  tps: 3786.00315
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 4440.15823
-  tps: 3738.80687
+  dps: 4440.2557
+  tps: 3738.89975
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 4459.71893
-  tps: 3747.33609
+  dps: 4459.80287
+  tps: 3747.391
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 4453.74212
-  tps: 3742.28027
+  dps: 4453.82607
+  tps: 3742.33519
  }
 }
 dps_results: {
@@ -227,8 +227,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 4288.05074
-  tps: 3606.66711
+  dps: 4288.1482
+  tps: 3606.75998
  }
 }
 dps_results: {
@@ -241,43 +241,43 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 4521.79324
-  tps: 3808.42911
+  dps: 4521.89071
+  tps: 3808.52199
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 4446.63987
-  tps: 3736.73854
+  dps: 4446.72382
+  tps: 3736.79346
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 4441.43345
-  tps: 3732.12473
+  dps: 4441.5174
+  tps: 3732.17965
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 4319.01662
-  tps: 3635.70484
+  dps: 4288.05074
+  tps: 3606.66711
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
   dps: 4420.91034
-  tps: 3714.87792
+  tps: 3714.88296
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 4429.83489
-  tps: 3722.05702
+  dps: 4429.91883
+  tps: 3722.11193
  }
 }
 dps_results: {
@@ -305,14 +305,14 @@ dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
   dps: 4274.2085
-  tps: 3588.85641
+  tps: 3588.9177
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 4338.75636
-  tps: 3651.36383
+  dps: 4338.85383
+  tps: 3651.45671
  }
 }
 dps_results: {
@@ -325,64 +325,64 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 4429.83489
-  tps: 3722.05702
+  dps: 4429.91883
+  tps: 3722.11193
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 4429.83489
-  tps: 3722.05702
+  dps: 4429.91883
+  tps: 3722.11193
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 4429.83489
-  tps: 3722.05702
+  dps: 4429.91883
+  tps: 3722.11193
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 4429.83489
-  tps: 3722.05702
+  dps: 4429.91883
+  tps: 3722.11193
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 4288.05074
-  tps: 3606.66711
+  dps: 4288.1482
+  tps: 3606.75998
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 4602.65125
-  tps: 3893.49224
+  dps: 4602.88639
+  tps: 3893.61487
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 4641.70189
-  tps: 3929.24484
+  dps: 4641.93702
+  tps: 3929.36747
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 4538.54178
-  tps: 3819.66698
+  dps: 4538.62951
+  tps: 3819.7253
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 4428.26807
-  tps: 3720.21967
+  dps: 4428.51357
+  tps: 3720.43732
  }
 }
 dps_results: {
@@ -402,8 +402,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 4288.05074
-  tps: 3606.66711
+  dps: 4288.1482
+  tps: 3606.75998
  }
 }
 dps_results: {
@@ -416,8 +416,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 4362.07308
-  tps: 3672.78688
+  dps: 4362.17097
+  tps: 3672.9939
  }
 }
 dps_results: {
@@ -430,78 +430,78 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 4429.83489
-  tps: 3722.05702
+  dps: 4429.91883
+  tps: 3722.11193
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 4429.83489
-  tps: 3722.05702
+  dps: 4429.91883
+  tps: 3722.11193
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 4429.83489
-  tps: 3722.05702
+  dps: 4429.91883
+  tps: 3722.11193
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 4465.15451
-  tps: 3753.15549
+  dps: 4464.86237
+  tps: 3752.8571
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 4432.92642
-  tps: 3726.49968
+  dps: 4433.07181
+  tps: 3726.62158
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 4432.92642
-  tps: 3726.49968
+  dps: 4433.07181
+  tps: 3726.62158
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 4459.71893
-  tps: 3747.33609
+  dps: 4459.80287
+  tps: 3747.391
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 4453.74212
-  tps: 3742.28027
+  dps: 4453.82607
+  tps: 3742.33519
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 4453.74212
-  tps: 3742.28027
+  dps: 4453.82607
+  tps: 3742.33519
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 4459.71893
-  tps: 3747.33609
+  dps: 4459.80287
+  tps: 3747.391
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 4544.80918
-  tps: 3826.91563
+  dps: 4544.91237
+  tps: 3826.98247
  }
 }
 dps_results: {
@@ -549,15 +549,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4556.81784
-  tps: 4317.16581
+  dps: 4556.90556
+  tps: 4316.83209
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4556.81784
-  tps: 3835.66985
+  dps: 4556.90556
+  tps: 3835.72816
  }
 }
 dps_results: {
@@ -591,7 +591,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 4556.81784
-  tps: 3835.66985
+  dps: 4556.90556
+  tps: 3835.72816
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -297,8 +297,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5913.67652
-  tps: 6012.52458
+  dps: 5855.34799
+  tps: 5953.77347
  }
 }
 dps_results: {

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -290,8 +290,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-IncisorFragment-37723"
  value: {
-  dps: 4765.32714
-  tps: 3640.74029
+  dps: 4412.35973
+  tps: 3357.74355
  }
 }
 dps_results: {

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -262,8 +262,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7335.02941
-  tps: 5207.87088
+  dps: 7323.91309
+  tps: 5199.9783
  }
 }
 dps_results: {

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -262,8 +262,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6469.36917
-  tps: 4593.25211
+  dps: 6480.9058
+  tps: 4601.44312
  }
 }
 dps_results: {

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -362,8 +362,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-IncisorFragment-37723"
  value: {
-  dps: 4025.24484
-  tps: 3085.98359
+  dps: 4024.35092
+  tps: 3091.80635
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -318,8 +318,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6641.82473
-  tps: 3736.20061
+  dps: 6635.64886
+  tps: 3726.68636
  }
 }
 dps_results: {

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -45,15 +45,15 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 8014.81543
-  tps: 6586.48776
+  dps: 8014.7826
+  tps: 6586.46149
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8233.53022
-  tps: 6766.64169
+  dps: 8233.50569
+  tps: 6766.61717
  }
 }
 dps_results: {
@@ -122,15 +122,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 8207.37827
-  tps: 6743.7647
+  dps: 8207.34544
+  tps: 6743.73844
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 8072.82731
-  tps: 6636.09181
+  dps: 8092.69515
+  tps: 6650.92382
  }
 }
 dps_results: {
@@ -143,22 +143,22 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 8114.34433
-  tps: 6672.05495
+  dps: 8114.30852
+  tps: 6672.03346
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Defender'sCode-40257"
  value: {
-  dps: 8017.99781
-  tps: 6587.14079
+  dps: 8018.03363
+  tps: 6587.16228
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8299.95152
-  tps: 6828.35607
+  dps: 8299.94095
+  tps: 6828.3455
  }
 }
 dps_results: {
@@ -206,8 +206,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 8191.07953
-  tps: 6726.30007
+  dps: 8191.06896
+  tps: 6726.2895
  }
 }
 dps_results: {
@@ -283,8 +283,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8230.64738
-  tps: 6764.2071
+  dps: 8239.14579
+  tps: 6770.97276
  }
 }
 dps_results: {
@@ -304,8 +304,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7986.69295
-  tps: 6558.95867
+  dps: 7986.72876
+  tps: 6558.98016
  }
 }
 dps_results: {
@@ -325,8 +325,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7978.54963
-  tps: 6558.93947
+  dps: 7978.50011
+  tps: 6558.90702
  }
 }
 dps_results: {
@@ -395,8 +395,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8449.25413
-  tps: 6944.75268
+  dps: 8449.24042
+  tps: 6944.74172
  }
 }
 dps_results: {
@@ -409,15 +409,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7986.7502
-  tps: 6559.01592
+  dps: 7986.78601
+  tps: 6559.03741
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 8014.13669
-  tps: 6581.06219
+  dps: 8014.22203
+  tps: 6581.11613
  }
 }
 dps_results: {
@@ -479,29 +479,29 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-TheFistsofFury"
  value: {
-  dps: 4453.86866
-  tps: 3765.80933
+  dps: 4453.846
+  tps: 3765.78667
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 4755.03581
-  tps: 4011.02339
+  dps: 4755.01445
+  tps: 4011.0063
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8316.57821
-  tps: 6841.59703
+  dps: 8316.56451
+  tps: 6841.58606
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 8506.55044
-  tps: 6996.56511
+  dps: 8506.47122
+  tps: 6996.50679
  }
 }
 dps_results: {
@@ -563,22 +563,22 @@ dps_results: {
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 8417.90079
-  tps: 6917.51034
+  dps: 8423.16113
+  tps: 6921.77814
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11644.26769
-  tps: 10084.42442
+  dps: 11734.59579
+  tps: 10156.49697
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8404.15382
-  tps: 6913.34031
+  dps: 8393.3125
+  tps: 6903.84969
  }
 }
 dps_results: {
@@ -591,8 +591,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7002.36739
-  tps: 6205.48429
+  dps: 7002.26586
+  tps: 6205.40306
  }
 }
 dps_results: {
@@ -619,8 +619,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8449.25413
-  tps: 6944.75268
+  dps: 8449.24042
+  tps: 6944.74172
  }
 }
 dps_results: {
@@ -654,7 +654,7 @@ dps_results: {
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7871.5528
-  tps: 6461.76676
+  dps: 7871.54223
+  tps: 6461.75619
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -283,8 +283,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6733.43291
-  tps: 4953.27001
+  dps: 6726.59437
+  tps: 4947.94901
  }
 }
 dps_results: {


### PR DESCRIPTION
https://twitter.com/AggrendWoW/status/1579664462843633664

https://www.bluetracker.gg/wow/topic/us-en/1323891-wrath-of-the-lich-king-classic-hotfixes-updated-october-10/

Confirmed intended removal of 12 second shared CD on `Hyperspeed Acceleration` and offensive trinkets.
In-game testing indicates `Hand-Mounted Pyro Rocket` still retains 10 second shared CD.