### PR TITLE
Vigo/various updates

### DIFF
--- a/sim/core/dot.go
+++ b/sim/core/dot.go
@@ -184,7 +184,8 @@ func (dot *Dot) updateSnapshotEffect(sim *Simulation, target *Unit, baseEffect S
 		dot.snapshotEffect.snapshotMeleeCritRating = snapshotCrit
 		dot.snapshotEffect.snapshotSpellCritRating = snapshotSpellCrit
 	} else {
-		dot.snapshotEffect.snapshotDamageMultiplier = dot.Spell.CasterDamageMultiplier()
+		attackTable := dot.Spell.Unit.AttackTables[target.UnitIndex]
+		dot.snapshotEffect.snapshotDamageMultiplier = dot.Spell.AttackerDamageMultiplier(attackTable)
 		dot.snapshotEffect.snapshotMeleeCritRating = dot.Spell.physicalCritRating(target)
 		dot.snapshotEffect.snapshotSpellCritRating = dot.Spell.spellCritRating(target)
 	}

--- a/sim/core/flags.go
+++ b/sim/core/flags.go
@@ -195,7 +195,7 @@ const (
 	SpellFlagAgentReserved3
 	SpellFlagAgentReserved4
 
-	SpellFlagIgnoreModifiers = SpellFlagIgnoreAttackerModifiers | SpellFlagIgnoreResists | SpellFlagIgnoreTargetModifiers
+	SpellFlagIgnoreModifiers = SpellFlagIgnoreAttackerModifiers | SpellFlagIgnoreTargetModifiers
 )
 
 type SpellSchool byte

--- a/sim/core/spell.go
+++ b/sim/core/spell.go
@@ -604,10 +604,10 @@ func ApplyEffectFuncMultipleDamageCapped(baseEffects []SpellEffect, deferFinaliz
 			attackTable := spell.Unit.AttackTables[effect.Target.UnitIndex]
 			effect.Damage = effect.calculateBaseDamage(sim, spell)
 			effect.Damage *= capMultiplier
-			effect.applyAttackerModifiers(sim, spell)
+			effect.applyAttackerModifiers(spell, attackTable)
 			effect.applyResistances(sim, spell, attackTable)
-			effect.OutcomeApplier(sim, spell, effect, attackTable)
 			effect.applyTargetModifiers(spell, attackTable)
+			effect.OutcomeApplier(sim, spell, effect, attackTable)
 			if !deferFinalization {
 				effect.finalize(sim, spell)
 			}
@@ -656,13 +656,13 @@ func ApplyEffectFuncWithOutcome(baseEffects []SpellEffect, onOutcome func(*Simul
 				attackTable := spell.Unit.AttackTables[effect.Target.UnitIndex]
 				effect.Damage = effect.calculateBaseDamage(sim, spell)
 				effect.Damage *= capMultiplier
-				effect.applyAttackerModifiers(sim, spell)
+				effect.applyAttackerModifiers(spell, attackTable)
 				effect.applyResistances(sim, spell, attackTable)
+				effect.applyTargetModifiers(spell, attackTable)
 				effect.OutcomeApplier(sim, spell, effect, attackTable)
 				if i == 0 {
 					onOutcome(sim, effect.Outcome)
 				}
-				effect.applyTargetModifiers(spell, attackTable)
 				effect.finalize(sim, spell)
 			}
 		}

--- a/sim/core/spell_outcome.go
+++ b/sim/core/spell_outcome.go
@@ -11,7 +11,7 @@ import (
 type OutcomeApplier func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable)
 type NewOutcomeApplier func(sim *Simulation, result *SpellEffect, attackTable *AttackTable)
 
-func (spell *Spell) OutcomeAlwaysHit(sim *Simulation, result *SpellEffect, attackTable *AttackTable) {
+func (spell *Spell) OutcomeAlwaysHit(_ *Simulation, result *SpellEffect, _ *AttackTable) {
 	result.Outcome = OutcomeHit
 	spell.SpellMetrics[result.Target.UnitIndex].Hits++
 }
@@ -200,19 +200,19 @@ func (spell *Spell) OutcomeMeleeWhite(sim *Simulation, result *SpellEffect, atta
 	chance := 0.0
 
 	if unit.PseudoStats.InFrontOfTarget {
-		if !result.applyAttackTableMiss(spell, unit, attackTable, roll, &chance) &&
-			!result.applyAttackTableDodge(spell, unit, attackTable, roll, &chance) &&
-			!result.applyAttackTableParry(spell, unit, attackTable, roll, &chance) &&
-			!result.applyAttackTableGlance(spell, unit, attackTable, roll, &chance) &&
-			!result.applyAttackTableBlock(spell, unit, attackTable, roll, &chance) &&
-			!result.applyAttackTableCrit(spell, unit, attackTable, roll, &chance) {
+		if !result.applyAttackTableMiss(spell, attackTable, roll, &chance) &&
+			!result.applyAttackTableDodge(spell, attackTable, roll, &chance) &&
+			!result.applyAttackTableParry(spell, attackTable, roll, &chance) &&
+			!result.applyAttackTableGlance(spell, attackTable, roll, &chance) &&
+			!result.applyAttackTableBlock(spell, attackTable, roll, &chance) &&
+			!result.applyAttackTableCrit(spell, attackTable, roll, &chance) {
 			result.applyAttackTableHit(spell)
 		}
 	} else {
-		if !result.applyAttackTableMiss(spell, unit, attackTable, roll, &chance) &&
-			!result.applyAttackTableDodge(spell, unit, attackTable, roll, &chance) &&
-			!result.applyAttackTableGlance(spell, unit, attackTable, roll, &chance) &&
-			!result.applyAttackTableCrit(spell, unit, attackTable, roll, &chance) {
+		if !result.applyAttackTableMiss(spell, attackTable, roll, &chance) &&
+			!result.applyAttackTableDodge(spell, attackTable, roll, &chance) &&
+			!result.applyAttackTableGlance(spell, attackTable, roll, &chance) &&
+			!result.applyAttackTableCrit(spell, attackTable, roll, &chance) {
 			result.applyAttackTableHit(spell)
 		}
 	}
@@ -225,24 +225,22 @@ func (spell *Spell) CalcAndDealDamageMeleeWhite(sim *Simulation, target *Unit, b
 func (unit *Unit) OutcomeFuncMeleeSpecialHit() OutcomeApplier {
 	if unit.PseudoStats.InFrontOfTarget {
 		return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
-			unit := spell.Unit
 			roll := sim.RandomFloat("White Hit Table")
 			chance := 0.0
 
-			if !spellEffect.applyAttackTableMissNoDWPenalty(spell, unit, attackTable, roll, &chance) &&
-				(spell.Flags.Matches(SpellFlagCannotBeDodged) || !spellEffect.applyAttackTableDodge(spell, unit, attackTable, roll, &chance)) &&
-				!spellEffect.applyAttackTableParry(spell, unit, attackTable, roll, &chance) {
+			if !spellEffect.applyAttackTableMissNoDWPenalty(spell, attackTable, roll, &chance) &&
+				!spellEffect.applyAttackTableDodge(spell, attackTable, roll, &chance) &&
+				!spellEffect.applyAttackTableParry(spell, attackTable, roll, &chance) {
 				spellEffect.applyAttackTableHit(spell)
 			}
 		}
 	} else {
 		return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
-			unit := spell.Unit
 			roll := sim.RandomFloat("White Hit Table")
 			chance := 0.0
 
-			if !spellEffect.applyAttackTableMissNoDWPenalty(spell, unit, attackTable, roll, &chance) &&
-				(spell.Flags.Matches(SpellFlagCannotBeDodged) || !spellEffect.applyAttackTableDodge(spell, unit, attackTable, roll, &chance)) {
+			if !spellEffect.applyAttackTableMissNoDWPenalty(spell, attackTable, roll, &chance) &&
+				!spellEffect.applyAttackTableDodge(spell, attackTable, roll, &chance) {
 				spellEffect.applyAttackTableHit(spell)
 			}
 		}
@@ -252,17 +250,16 @@ func (unit *Unit) OutcomeFuncMeleeSpecialHit() OutcomeApplier {
 func (unit *Unit) OutcomeFuncMeleeSpecialHitAndCrit() OutcomeApplier {
 	if unit.PseudoStats.InFrontOfTarget {
 		return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
-			unit := spell.Unit
 			roll := sim.RandomFloat("White Hit Table")
 			chance := 0.0
 
-			if !spellEffect.applyAttackTableMissNoDWPenalty(spell, unit, attackTable, roll, &chance) &&
-				(spell.Flags.Matches(SpellFlagCannotBeDodged) || !spellEffect.applyAttackTableDodge(spell, unit, attackTable, roll, &chance)) &&
-				!spellEffect.applyAttackTableParry(spell, unit, attackTable, roll, &chance) {
+			if !spellEffect.applyAttackTableMissNoDWPenalty(spell, attackTable, roll, &chance) &&
+				!spellEffect.applyAttackTableDodge(spell, attackTable, roll, &chance) &&
+				!spellEffect.applyAttackTableParry(spell, attackTable, roll, &chance) {
 				if spellEffect.applyAttackTableCritSeparateRoll(sim, spell, attackTable) {
-					spellEffect.applyAttackTableBlock(spell, unit, attackTable, roll, &chance)
+					spellEffect.applyAttackTableBlock(spell, attackTable, roll, &chance)
 				} else {
-					if !spellEffect.applyAttackTableBlock(spell, unit, attackTable, roll, &chance) {
+					if !spellEffect.applyAttackTableBlock(spell, attackTable, roll, &chance) {
 						spellEffect.applyAttackTableHit(spell)
 					}
 				}
@@ -270,12 +267,11 @@ func (unit *Unit) OutcomeFuncMeleeSpecialHitAndCrit() OutcomeApplier {
 		}
 	} else {
 		return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
-			unit := spell.Unit
 			roll := sim.RandomFloat("White Hit Table")
 			chance := 0.0
 
-			if !spellEffect.applyAttackTableMissNoDWPenalty(spell, unit, attackTable, roll, &chance) &&
-				(spell.Flags.Matches(SpellFlagCannotBeDodged) || !spellEffect.applyAttackTableDodge(spell, unit, attackTable, roll, &chance)) &&
+			if !spellEffect.applyAttackTableMissNoDWPenalty(spell, attackTable, roll, &chance) &&
+				!spellEffect.applyAttackTableDodge(spell, attackTable, roll, &chance) &&
 				!spellEffect.applyAttackTableCritSeparateRoll(sim, spell, attackTable) {
 				spellEffect.applyAttackTableHit(spell)
 			}
@@ -283,18 +279,17 @@ func (unit *Unit) OutcomeFuncMeleeSpecialHitAndCrit() OutcomeApplier {
 	}
 }
 
-// Like OutcomeFuncMeleeSpecialHitAndCrit, but blocks prevent crits.
+// Like OutcomeFuncMeleeSpecialHitAndCrit, but blocks prevent crits (all weapon damage based attacks).
 func (unit *Unit) OutcomeFuncMeleeWeaponSpecialHitAndCrit() OutcomeApplier {
 	if unit.PseudoStats.InFrontOfTarget {
 		return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
-			unit := spell.Unit
 			roll := sim.RandomFloat("White Hit Table")
 			chance := 0.0
 
-			if !spellEffect.applyAttackTableMissNoDWPenalty(spell, unit, attackTable, roll, &chance) &&
-				(spell.Flags.Matches(SpellFlagCannotBeDodged) || !spellEffect.applyAttackTableDodge(spell, unit, attackTable, roll, &chance)) &&
-				!spellEffect.applyAttackTableParry(spell, unit, attackTable, roll, &chance) &&
-				!spellEffect.applyAttackTableBlock(spell, unit, attackTable, roll, &chance) &&
+			if !spellEffect.applyAttackTableMissNoDWPenalty(spell, attackTable, roll, &chance) &&
+				!spellEffect.applyAttackTableDodge(spell, attackTable, roll, &chance) &&
+				!spellEffect.applyAttackTableParry(spell, attackTable, roll, &chance) &&
+				!spellEffect.applyAttackTableBlock(spell, attackTable, roll, &chance) &&
 				!spellEffect.applyAttackTableCritSeparateRoll(sim, spell, attackTable) {
 				spellEffect.applyAttackTableHit(spell)
 			}
@@ -307,25 +302,23 @@ func (unit *Unit) OutcomeFuncMeleeWeaponSpecialHitAndCrit() OutcomeApplier {
 func (unit *Unit) OutcomeFuncMeleeWeaponSpecialNoCrit() OutcomeApplier {
 	if unit.PseudoStats.InFrontOfTarget {
 		return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
-			unit := spell.Unit
 			roll := sim.RandomFloat("White Hit Table")
 			chance := 0.0
 
-			if !spellEffect.applyAttackTableMissNoDWPenalty(spell, unit, attackTable, roll, &chance) &&
-				(spell.Flags.Matches(SpellFlagCannotBeDodged) || !spellEffect.applyAttackTableDodge(spell, unit, attackTable, roll, &chance)) &&
-				!spellEffect.applyAttackTableParry(spell, unit, attackTable, roll, &chance) &&
-				!spellEffect.applyAttackTableBlock(spell, unit, attackTable, roll, &chance) {
+			if !spellEffect.applyAttackTableMissNoDWPenalty(spell, attackTable, roll, &chance) &&
+				!spellEffect.applyAttackTableDodge(spell, attackTable, roll, &chance) &&
+				!spellEffect.applyAttackTableParry(spell, attackTable, roll, &chance) &&
+				!spellEffect.applyAttackTableBlock(spell, attackTable, roll, &chance) {
 				spellEffect.applyAttackTableHit(spell)
 			}
 		}
 	} else {
 		return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
-			unit := spell.Unit
 			roll := sim.RandomFloat("White Hit Table")
 			chance := 0.0
 
-			if !spellEffect.applyAttackTableMissNoDWPenalty(spell, unit, attackTable, roll, &chance) &&
-				spell.Flags.Matches(SpellFlagCannotBeDodged) || !spellEffect.applyAttackTableDodge(spell, unit, attackTable, roll, &chance) {
+			if !spellEffect.applyAttackTableMissNoDWPenalty(spell, attackTable, roll, &chance) &&
+				!spellEffect.applyAttackTableDodge(spell, attackTable, roll, &chance) {
 				spellEffect.applyAttackTableHit(spell)
 			}
 		}
@@ -334,12 +327,23 @@ func (unit *Unit) OutcomeFuncMeleeWeaponSpecialNoCrit() OutcomeApplier {
 
 func (unit *Unit) OutcomeFuncMeleeSpecialNoBlockDodgeParry() OutcomeApplier {
 	return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
-		unit := spell.Unit
 		roll := sim.RandomFloat("White Hit Table")
 		chance := 0.0
 
-		if !spellEffect.applyAttackTableMissNoDWPenalty(spell, unit, attackTable, roll, &chance) &&
+		if !spellEffect.applyAttackTableMissNoDWPenalty(spell, attackTable, roll, &chance) &&
 			!spellEffect.applyAttackTableCritSeparateRoll(sim, spell, attackTable) {
+			spellEffect.applyAttackTableHit(spell)
+		}
+	}
+}
+
+func (unit *Unit) OutcomeFuncMeleeSpecialNoBlockDodgeParryNoCrit() OutcomeApplier {
+	unit.OutcomeFuncMagicHit()
+	return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
+		roll := sim.RandomFloat("White Hit Table")
+		chance := 0.0
+
+		if !spellEffect.applyAttackTableMissNoDWPenalty(spell, attackTable, roll, &chance) {
 			spellEffect.applyAttackTableHit(spell)
 		}
 	}
@@ -361,11 +365,10 @@ func (unit *Unit) OutcomeFuncMeleeSpecialCritOnly() OutcomeApplier {
 }
 
 func (spell *Spell) OutcomeRangedHit(sim *Simulation, result *SpellEffect, attackTable *AttackTable) {
-	unit := spell.Unit
 	roll := sim.RandomFloat("White Hit Table")
 	chance := 0.0
 
-	if !result.applyAttackTableMissNoDWPenalty(spell, unit, attackTable, roll, &chance) {
+	if !result.applyAttackTableMissNoDWPenalty(spell, attackTable, roll, &chance) {
 		result.applyAttackTableHit(spell)
 	}
 }
@@ -380,22 +383,21 @@ func (unit *Unit) OutcomeFuncRangedHit() OutcomeApplier {
 }
 
 func (spell *Spell) OutcomeRangedHitAndCrit(sim *Simulation, result *SpellEffect, attackTable *AttackTable) {
-	unit := spell.Unit
 	roll := sim.RandomFloat("White Hit Table")
 	chance := 0.0
 
 	if spell.Unit.PseudoStats.InFrontOfTarget {
-		if !result.applyAttackTableMissNoDWPenalty(spell, unit, attackTable, roll, &chance) {
+		if !result.applyAttackTableMissNoDWPenalty(spell, attackTable, roll, &chance) {
 			if result.applyAttackTableCritSeparateRoll(sim, spell, attackTable) {
-				result.applyAttackTableBlock(spell, unit, attackTable, roll, &chance)
+				result.applyAttackTableBlock(spell, attackTable, roll, &chance)
 			} else {
-				if !result.applyAttackTableBlock(spell, unit, attackTable, roll, &chance) {
+				if !result.applyAttackTableBlock(spell, attackTable, roll, &chance) {
 					result.applyAttackTableHit(spell)
 				}
 			}
 		}
 	} else {
-		if !result.applyAttackTableMissNoDWPenalty(spell, unit, attackTable, roll, &chance) &&
+		if !result.applyAttackTableMissNoDWPenalty(spell, attackTable, roll, &chance) &&
 			!result.applyAttackTableCritSeparateRoll(sim, spell, attackTable) {
 			result.applyAttackTableHit(spell)
 		}
@@ -414,14 +416,13 @@ func (unit *Unit) OutcomeFuncRangedHitAndCrit() OutcomeApplier {
 func (spell *Spell) OutcomeRangedCritOnly(sim *Simulation, result *SpellEffect, attackTable *AttackTable) {
 	// Block already checks for this, but we can skip the RNG roll which is expensive.
 	if spell.Unit.PseudoStats.InFrontOfTarget {
-		unit := spell.Unit
 		roll := sim.RandomFloat("White Hit Table")
 		chance := 0.0
 
 		if result.applyAttackTableCritSeparateRoll(sim, spell, attackTable) {
-			result.applyAttackTableBlock(spell, unit, attackTable, roll, &chance)
+			result.applyAttackTableBlock(spell, attackTable, roll, &chance)
 		} else {
-			if !result.applyAttackTableBlock(spell, unit, attackTable, roll, &chance) {
+			if !result.applyAttackTableBlock(spell, attackTable, roll, &chance) {
 				result.applyAttackTableHit(spell)
 			}
 		}
@@ -438,15 +439,14 @@ func (spell *Spell) CalcAndDealDamageRangedCritOnly(sim *Simulation, target *Uni
 
 func (unit *Unit) OutcomeFuncEnemyMeleeWhite() OutcomeApplier {
 	return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
-		unit := spell.Unit
 		roll := sim.RandomFloat("Enemy White Hit Table")
 		chance := 0.0
 
-		if !spellEffect.applyEnemyAttackTableMiss(spell, unit, attackTable, roll, &chance) &&
-			!spellEffect.applyEnemyAttackTableDodge(spell, unit, attackTable, roll, &chance) &&
-			!spellEffect.applyEnemyAttackTableParry(spell, unit, attackTable, roll, &chance) &&
-			!spellEffect.applyEnemyAttackTableBlock(spell, unit, attackTable, roll, &chance) &&
-			!spellEffect.applyEnemyAttackTableCrit(spell, unit, attackTable, roll, &chance) {
+		if !spellEffect.applyEnemyAttackTableMiss(spell, attackTable, roll, &chance) &&
+			!spellEffect.applyEnemyAttackTableDodge(spell, attackTable, roll, &chance) &&
+			!spellEffect.applyEnemyAttackTableParry(spell, attackTable, roll, &chance) &&
+			!spellEffect.applyEnemyAttackTableBlock(spell, attackTable, roll, &chance) &&
+			!spellEffect.applyEnemyAttackTableCrit(spell, attackTable, roll, &chance) {
 			spellEffect.applyAttackTableHit(spell)
 		}
 	}
@@ -462,23 +462,23 @@ func (spell *Spell) fixedCritCheck(sim *Simulation, critChance float64) bool {
 	return sim.RandomFloat("Fixed Crit Roll") < critChance
 }
 
-func (spellEffect *SpellEffect) MagicCritCheck(sim *Simulation, spell *Spell, attackTable *AttackTable) bool {
-	critChance := spellEffect.SpellCritChance(spell.Unit, spell)
+func (spellEffect *SpellEffect) MagicCritCheck(sim *Simulation, spell *Spell, _ *AttackTable) bool {
+	critChance := spellEffect.SpellCritChance(spell)
 	return sim.RandomFloat("Magical Crit Roll") < critChance
 }
 
-func (spellEffect *SpellEffect) HealingCritCheck(sim *Simulation, spell *Spell, attackTable *AttackTable) bool {
-	critChance := spellEffect.HealingCritChance(spell.Unit, spell)
+func (spellEffect *SpellEffect) HealingCritCheck(sim *Simulation, spell *Spell, _ *AttackTable) bool {
+	critChance := spellEffect.HealingCritChance(spell)
 	return sim.RandomFloat("Healing Crit Roll") < critChance
 }
 
 func (spellEffect *SpellEffect) physicalCritRoll(sim *Simulation, spell *Spell, attackTable *AttackTable) bool {
-	return sim.RandomFloat("Physical Crit Roll") < spellEffect.PhysicalCritChance(spell.Unit, spell, attackTable)
+	return sim.RandomFloat("Physical Crit Roll") < spellEffect.PhysicalCritChance(spell, attackTable)
 }
 
-func (spellEffect *SpellEffect) applyAttackTableMiss(spell *Spell, unit *Unit, attackTable *AttackTable, roll float64, chance *float64) bool {
+func (spellEffect *SpellEffect) applyAttackTableMiss(spell *Spell, attackTable *AttackTable, roll float64, chance *float64) bool {
 	missChance := attackTable.BaseMissChance - spell.PhysicalHitChance(spellEffect.Target)
-	if unit.AutoAttacks.IsDualWielding && !unit.PseudoStats.DisableDWMissPenalty {
+	if spell.Unit.AutoAttacks.IsDualWielding && !spell.Unit.PseudoStats.DisableDWMissPenalty {
 		missChance += 0.19
 	}
 	*chance = MaxFloat(0, missChance)
@@ -492,7 +492,7 @@ func (spellEffect *SpellEffect) applyAttackTableMiss(spell *Spell, unit *Unit, a
 	return false
 }
 
-func (spellEffect *SpellEffect) applyAttackTableMissNoDWPenalty(spell *Spell, unit *Unit, attackTable *AttackTable, roll float64, chance *float64) bool {
+func (spellEffect *SpellEffect) applyAttackTableMissNoDWPenalty(spell *Spell, attackTable *AttackTable, roll float64, chance *float64) bool {
 	missChance := attackTable.BaseMissChance - spell.PhysicalHitChance(spellEffect.Target)
 	*chance = MaxFloat(0, missChance)
 
@@ -505,7 +505,7 @@ func (spellEffect *SpellEffect) applyAttackTableMissNoDWPenalty(spell *Spell, un
 	return false
 }
 
-func (spellEffect *SpellEffect) applyAttackTableBlock(spell *Spell, unit *Unit, attackTable *AttackTable, roll float64, chance *float64) bool {
+func (spellEffect *SpellEffect) applyAttackTableBlock(spell *Spell, attackTable *AttackTable, roll float64, chance *float64) bool {
 	*chance += attackTable.BaseBlockChance
 
 	if roll < *chance {
@@ -517,8 +517,12 @@ func (spellEffect *SpellEffect) applyAttackTableBlock(spell *Spell, unit *Unit, 
 	return false
 }
 
-func (spellEffect *SpellEffect) applyAttackTableDodge(spell *Spell, unit *Unit, attackTable *AttackTable, roll float64, chance *float64) bool {
-	*chance += MaxFloat(0, attackTable.BaseDodgeChance-spell.ExpertisePercentage()-unit.PseudoStats.DodgeReduction)
+func (spellEffect *SpellEffect) applyAttackTableDodge(spell *Spell, attackTable *AttackTable, roll float64, chance *float64) bool {
+	if spell.Flags.Matches(SpellFlagCannotBeDodged) {
+		return false
+	}
+
+	*chance += MaxFloat(0, attackTable.BaseDodgeChance-spell.ExpertisePercentage()-spell.Unit.PseudoStats.DodgeReduction)
 
 	if roll < *chance {
 		spellEffect.Outcome = OutcomeDodge
@@ -529,7 +533,7 @@ func (spellEffect *SpellEffect) applyAttackTableDodge(spell *Spell, unit *Unit, 
 	return false
 }
 
-func (spellEffect *SpellEffect) applyAttackTableParry(spell *Spell, unit *Unit, attackTable *AttackTable, roll float64, chance *float64) bool {
+func (spellEffect *SpellEffect) applyAttackTableParry(spell *Spell, attackTable *AttackTable, roll float64, chance *float64) bool {
 	*chance += MaxFloat(0, attackTable.BaseParryChance-spell.ExpertisePercentage())
 
 	if roll < *chance {
@@ -541,24 +545,24 @@ func (spellEffect *SpellEffect) applyAttackTableParry(spell *Spell, unit *Unit, 
 	return false
 }
 
-func (spellEffect *SpellEffect) applyAttackTableGlance(spell *Spell, unit *Unit, attackTable *AttackTable, roll float64, chance *float64) bool {
+func (spellEffect *SpellEffect) applyAttackTableGlance(spell *Spell, attackTable *AttackTable, roll float64, chance *float64) bool {
 	*chance += attackTable.BaseGlanceChance
 
 	if roll < *chance {
 		spellEffect.Outcome = OutcomeGlance
 		spell.SpellMetrics[spellEffect.Target.UnitIndex].Glances++
-		// TODO glancing blow damage reduction is actually a range ([65%, 85%] vs. 73)
+		// TODO glancing blow damage reduction is actually a range ([65%, 85%] vs. +3, [80%, 90%] vs. +2, [91%, 99%] vs. +1 and +0)
 		spellEffect.Damage *= attackTable.GlanceMultiplier
 		return true
 	}
 	return false
 }
 
-func (spellEffect *SpellEffect) applyAttackTableCrit(spell *Spell, unit *Unit, attackTable *AttackTable, roll float64, chance *float64) bool {
+func (spellEffect *SpellEffect) applyAttackTableCrit(spell *Spell, attackTable *AttackTable, roll float64, chance *float64) bool {
 	if spell.CritMultiplier == 0 {
 		panic("Spell " + spell.ActionID.String() + " missing CritMultiplier")
 	}
-	*chance += spellEffect.PhysicalCritChance(unit, spell, attackTable)
+	*chance += spellEffect.PhysicalCritChance(spell, attackTable)
 
 	if roll < *chance {
 		spellEffect.Outcome = OutcomeCrit
@@ -587,9 +591,9 @@ func (spellEffect *SpellEffect) applyAttackTableHit(spell *Spell) {
 	spell.SpellMetrics[spellEffect.Target.UnitIndex].Hits++
 }
 
-func (spellEffect *SpellEffect) applyEnemyAttackTableMiss(spell *Spell, unit *Unit, attackTable *AttackTable, roll float64, chance *float64) bool {
-	missChance := attackTable.BaseMissChance + unit.PseudoStats.IncreasedMissChance + spellEffect.Target.GetDiminishedMissChance()
-	if unit.AutoAttacks.IsDualWielding && !unit.PseudoStats.DisableDWMissPenalty {
+func (spellEffect *SpellEffect) applyEnemyAttackTableMiss(spell *Spell, attackTable *AttackTable, roll float64, chance *float64) bool {
+	missChance := attackTable.BaseMissChance + spell.Unit.PseudoStats.IncreasedMissChance + spellEffect.Target.GetDiminishedMissChance()
+	if spell.Unit.AutoAttacks.IsDualWielding && !spell.Unit.PseudoStats.DisableDWMissPenalty {
 		missChance += 0.19
 	}
 	*chance = MaxFloat(0, missChance)
@@ -603,7 +607,7 @@ func (spellEffect *SpellEffect) applyEnemyAttackTableMiss(spell *Spell, unit *Un
 	return false
 }
 
-func (spellEffect *SpellEffect) applyEnemyAttackTableBlock(spell *Spell, unit *Unit, attackTable *AttackTable, roll float64, chance *float64) bool {
+func (spellEffect *SpellEffect) applyEnemyAttackTableBlock(spell *Spell, attackTable *AttackTable, roll float64, chance *float64) bool {
 	if !spellEffect.Target.PseudoStats.CanBlock {
 		return false
 	}
@@ -622,11 +626,11 @@ func (spellEffect *SpellEffect) applyEnemyAttackTableBlock(spell *Spell, unit *U
 	return false
 }
 
-func (spellEffect *SpellEffect) applyEnemyAttackTableDodge(spell *Spell, unit *Unit, attackTable *AttackTable, roll float64, chance *float64) bool {
+func (spellEffect *SpellEffect) applyEnemyAttackTableDodge(spell *Spell, attackTable *AttackTable, roll float64, chance *float64) bool {
 	dodgeChance := attackTable.BaseDodgeChance +
 		spellEffect.Target.PseudoStats.BaseDodge +
 		spellEffect.Target.GetDiminishedDodgeChance() -
-		unit.PseudoStats.DodgeReduction
+		spell.Unit.PseudoStats.DodgeReduction
 	*chance += MaxFloat(0, dodgeChance)
 
 	if roll < *chance {
@@ -638,7 +642,7 @@ func (spellEffect *SpellEffect) applyEnemyAttackTableDodge(spell *Spell, unit *U
 	return false
 }
 
-func (spellEffect *SpellEffect) applyEnemyAttackTableParry(spell *Spell, unit *Unit, attackTable *AttackTable, roll float64, chance *float64) bool {
+func (spellEffect *SpellEffect) applyEnemyAttackTableParry(spell *Spell, attackTable *AttackTable, roll float64, chance *float64) bool {
 	if !spellEffect.Target.PseudoStats.CanParry {
 		return false
 	}
@@ -657,11 +661,11 @@ func (spellEffect *SpellEffect) applyEnemyAttackTableParry(spell *Spell, unit *U
 	return false
 }
 
-func (spellEffect *SpellEffect) applyEnemyAttackTableCrit(spell *Spell, unit *Unit, attackTable *AttackTable, roll float64, chance *float64) bool {
+func (spellEffect *SpellEffect) applyEnemyAttackTableCrit(spell *Spell, _ *AttackTable, roll float64, chance *float64) bool {
 	if spell.CritMultiplier == 0 {
 		panic("Spell " + spell.ActionID.String() + " missing CritMultiplier")
 	}
-	critRating := unit.stats[stats.MeleeCrit] + spell.BonusCritRating
+	critRating := spell.Unit.stats[stats.MeleeCrit] + spell.BonusCritRating
 	critChance := critRating / (CritRatingPerCritChance * 100)
 	critChance -= spellEffect.Target.stats[stats.Defense] * DefenseRatingToChanceReduction
 	critChance -= spellEffect.Target.stats[stats.Resilience] / ResilienceRatingPerCritReductionChance / 100

--- a/sim/core/stats/stats.go
+++ b/sim/core/stats/stats.go
@@ -307,7 +307,6 @@ type PseudoStats struct {
 	HolyDamageDealtMultiplier     float64
 	NatureDamageDealtMultiplier   float64
 	ShadowDamageDealtMultiplier   float64
-	DiseaseDamageDealtMultiplier  float64
 
 	// Treat melee haste as a pseudostat so that shamans, death knights, paladins, and druids can get the correct scaling
 	MeleeHasteRatingPerHastePercent float64
@@ -324,8 +323,8 @@ type PseudoStats struct {
 	ParryHaste bool
 
 	// Avoidance % not affected by Diminishing Returns
-	BaseDodge	float64
-	BaseParry	float64
+	BaseDodge float64
+	BaseParry float64
 	//BaseMiss is not needed, this is always 5%
 
 	ReducedCritTakenChance float64 // Reduces chance to be crit.
@@ -351,15 +350,15 @@ type PseudoStats struct {
 	ShadowDamageTakenMultiplier   float64
 	DiseaseDamageTakenMultiplier  float64
 
+	PeriodicPhysicalDamageTakenMultiplier float64
+	PeriodicShadowDamageTakenMultiplier   float64
+
 	ReducedPhysicalHitTakenChance float64
 	ReducedArcaneHitTakenChance   float64
 	ReducedFireHitTakenChance     float64
 	ReducedFrostHitTakenChance    float64
 	ReducedNatureHitTakenChance   float64
 	ReducedShadowHitTakenChance   float64
-
-	PeriodicPhysicalDamageTakenMultiplier float64
-	PeriodicShadowDamageTakenMultiplier   float64
 
 	HealingTakenMultiplier float64
 }
@@ -383,7 +382,6 @@ func NewPseudoStats() PseudoStats {
 		HolyDamageDealtMultiplier:     1,
 		NatureDamageDealtMultiplier:   1,
 		ShadowDamageDealtMultiplier:   1,
-		DiseaseDamageDealtMultiplier:  1,
 
 		MeleeHasteRatingPerHastePercent: 32.79,
 

--- a/sim/core/target.go
+++ b/sim/core/target.go
@@ -204,7 +204,6 @@ func (target *Target) GetMetricsProto(numIterations int32) *proto.UnitMetrics {
 }
 
 // Holds cached values for outcome/damage calculations, for a specific attacker+defender pair.
-//
 // These are updated dynamically when attacker or defender stats change.
 type AttackTable struct {
 	Attacker *Unit
@@ -228,8 +227,9 @@ type AttackTable struct {
 	PartialResistShadowThresholds Thresholds
 
 	DamageDealtMultiplier               float64
-	NatureDamageDealtMultiplier         float64
-	PeriodicShadowDamageDealtMultiplier float64
+	DamageTakenMultiplier               float64
+	NatureDamageTakenMultiplier         float64
+	PeriodicShadowDamageTakenMultiplier float64
 	HealingDealtMultiplier              float64
 }
 
@@ -239,8 +239,9 @@ func NewAttackTable(attacker *Unit, defender *Unit) *AttackTable {
 		Defender: defender,
 
 		DamageDealtMultiplier:               1,
-		NatureDamageDealtMultiplier:         1,
-		PeriodicShadowDamageDealtMultiplier: 1,
+		DamageTakenMultiplier:               1,
+		NatureDamageTakenMultiplier:         1,
+		PeriodicShadowDamageTakenMultiplier: 1,
 		HealingDealtMultiplier:              1,
 	}
 

--- a/sim/deathknight/bone_shield.go
+++ b/sim/deathknight/bone_shield.go
@@ -34,12 +34,12 @@ func (dk *Deathknight) registerBoneShieldSpell() {
 			}
 		},
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			dk.ModifyAdditiveDamageModifier(sim, 0.02)
+			dk.ModifyDamageModifier(0.02)
 
 			aura.Unit.PseudoStats.DamageTakenMultiplier *= 0.8
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			dk.ModifyAdditiveDamageModifier(sim, -0.02)
+			dk.ModifyDamageModifier(-0.02)
 
 			aura.Unit.PseudoStats.DamageTakenMultiplier /= 0.8
 		},

--- a/sim/deathknight/death_and_decay.go
+++ b/sim/deathknight/death_and_decay.go
@@ -81,7 +81,7 @@ func (dk *Deathknight) registerDeathAndDecaySpell() {
 			BaseDamage: core.BaseDamageConfig{
 				Calculator: func(sim *core.Simulation, hitEffect *core.SpellEffect, spell *core.Spell) float64 {
 					if doSnapshot {
-						dk.dndCritSnapshot = hitEffect.SpellCritChance(spell.Unit, spell)
+						dk.dndCritSnapshot = hitEffect.SpellCritChance(spell)
 						dk.dndApSnapshot = 62.0 + 0.0475*dk.getImpurityBonus(spell)
 						doSnapshot = false
 					}

--- a/sim/deathknight/death_coil.go
+++ b/sim/deathknight/death_coil.go
@@ -34,9 +34,8 @@ func (dk *Deathknight) registerDeathCoilSpell() {
 		},
 
 		BonusCritRating: dk.darkrunedBattlegearCritBonus() * core.CritRatingPerCritChance,
-		DamageMultiplier: 1 *
-			(1.0 + float64(dk.Talents.Morbidity)*0.05) *
-			core.TernaryFloat64(dk.HasMajorGlyph(proto.DeathknightMajorGlyph_GlyphOfDarkDeath), 1.15, 1.0),
+		DamageMultiplier: (1 + float64(dk.Talents.Morbidity)*0.05) +
+			core.TernaryFloat64(dk.HasMajorGlyph(proto.DeathknightMajorGlyph_GlyphOfDarkDeath), 0.15, 0.0),
 		CritMultiplier:   dk.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 1.0,
 

--- a/sim/deathknight/diseases.go
+++ b/sim/deathknight/diseases.go
@@ -314,10 +314,11 @@ func (dk *Deathknight) doWanderingPlague(sim *core.Simulation, spell *core.Spell
 		return
 	}
 
-	physCritChance := spellEffect.PhysicalCritChance(spell.Unit, spell, dk.AttackTables[spellEffect.Target.UnitIndex])
+	attackTable := dk.AttackTables[spellEffect.Target.UnitIndex]
+	physCritChance := spellEffect.PhysicalCritChance(spell, attackTable)
 	if sim.RandomFloat("Wandering Plague Roll") < physCritChance {
 		dk.LastTickTime = sim.CurrentTime
-		dk.LastDiseaseDamage = spellEffect.Damage
+		dk.LastDiseaseDamage = spellEffect.Damage / dk.WanderingPlague.TargetDamageMultiplier(attackTable, false)
 		dk.WanderingPlague.Cast(sim, spellEffect.Target)
 	}
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -45,760 +45,760 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7763.40961
-  tps: 4886.9759
-  hps: 191.42553
+  dps: 7795.92093
+  tps: 4918.3546
+  hps: 193.07215
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7461.03695
-  tps: 4766.87527
-  hps: 191.78329
+  dps: 7497.70642
+  tps: 4799.86891
+  hps: 193.39003
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7786.565
-  tps: 4911.05093
-  hps: 187.91975
+  dps: 7815.86475
+  tps: 4937.27338
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7534.11288
-  tps: 4658.82699
-  hps: 181.92153
+  dps: 7564.24808
+  tps: 4688.61305
+  hps: 183.42857
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6390.22518
-  tps: 3977.49224
-  hps: 163.83641
+  dps: 6420.66891
+  tps: 4006.0234
+  hps: 165.20496
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6181.85091
-  tps: 3919.2411
-  hps: 157.2078
+  dps: 6211.51519
+  tps: 3946.18641
+  hps: 158.5579
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6035.39607
-  tps: 3767.27163
-  hps: 155.00291
+  dps: 6059.67576
+  tps: 3788.48349
+  hps: 156.34579
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7763.40961
-  tps: 4789.23638
-  hps: 187.91975
+  dps: 7795.92093
+  tps: 4819.98751
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7868.17481
-  tps: 4984.03953
-  hps: 187.91975
+  dps: 7897.75544
+  tps: 5010.49585
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7353.46925
-  tps: 4691.39791
-  hps: 189.01805
+  dps: 7390.11518
+  tps: 4720.4868
+  hps: 190.61505
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7338.76001
-  tps: 4724.20569
-  hps: 189.95388
+  dps: 7376.52506
+  tps: 4757.84688
+  hps: 191.52817
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 7644.60486
-  tps: 4823.87176
-  hps: 192.91084
+  dps: 7683.6246
+  tps: 4858.21817
+  hps: 194.57327
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7580.81093
-  tps: 4793.69931
-  hps: 190.44129
+  dps: 7622.31869
+  tps: 4832.13389
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7133.2097
-  tps: 4557.54078
-  hps: 171.08186
+  dps: 7161.36386
+  tps: 4583.77349
+  hps: 172.53505
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 6358.40716
-  tps: 3968.18202
-  hps: 202.06455
+  dps: 6387.93063
+  tps: 3998.31489
+  hps: 203.79689
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7880.07663
-  tps: 4986.17322
-  hps: 190.44129
+  dps: 7923.75387
+  tps: 5026.59293
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7336.22545
-  tps: 4695.46525
-  hps: 192.27071
+  dps: 7372.34097
+  tps: 4723.55054
+  hps: 193.91205
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7247.89711
-  tps: 4617.2615
-  hps: 190.44129
+  dps: 7288.0614
+  tps: 4654.16839
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7787.60172
-  tps: 4912.32557
-  hps: 187.91975
+  dps: 7815.26541
+  tps: 4938.6143
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7763.40961
-  tps: 4886.9759
-  hps: 191.42553
+  dps: 7795.92093
+  tps: 4918.3546
+  hps: 193.07215
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7763.40961
-  tps: 4886.9759
-  hps: 187.91975
+  dps: 7795.92093
+  tps: 4918.3546
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7786.565
-  tps: 4911.05093
-  hps: 187.91975
+  dps: 7815.86475
+  tps: 4937.27338
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7779.80989
-  tps: 4905.7693
-  hps: 187.91975
+  dps: 7813.04543
+  tps: 4933.68914
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7763.40961
-  tps: 4886.9759
-  hps: 187.91975
+  dps: 7795.92093
+  tps: 4918.3546
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7397.2237
-  tps: 4739.00327
-  hps: 186.39578
+  dps: 7437.4374
+  tps: 4773.62944
+  hps: 187.95276
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7337.22084
-  tps: 4678.80297
-  hps: 192.91084
+  dps: 7374.28816
+  tps: 4705.94891
+  hps: 194.57327
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7323.9216
-  tps: 4663.06295
-  hps: 192.91084
+  dps: 7361.73094
+  tps: 4696.36808
+  hps: 194.57327
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7763.40961
-  tps: 4886.9759
-  hps: 187.91975
+  dps: 7795.92093
+  tps: 4918.3546
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7763.40961
-  tps: 4886.9759
-  hps: 187.91975
+  dps: 7795.92093
+  tps: 4918.3546
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7899.12624
-  tps: 5000.3895
-  hps: 190.44129
+  dps: 7942.94122
+  tps: 5040.93413
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7516.43134
-  tps: 4814.61377
-  hps: 190.44129
+  dps: 7558.5406
+  tps: 4853.30363
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7247.89711
-  tps: 4617.2615
-  hps: 190.44129
+  dps: 7288.0614
+  tps: 4654.16839
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7825.6698
-  tps: 4948.51923
-  hps: 190.44129
+  dps: 7868.98316
+  tps: 4988.59027
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7247.89711
-  tps: 4617.2615
-  hps: 190.44129
+  dps: 7288.0614
+  tps: 4654.16839
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7786.565
-  tps: 4911.05093
-  hps: 187.91975
+  dps: 7815.86475
+  tps: 4937.27338
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7779.80989
-  tps: 4905.7693
-  hps: 187.91975
+  dps: 7813.04543
+  tps: 4933.68914
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7423.88616
-  tps: 4753.50556
-  hps: 190.44129
+  dps: 7465.1543
+  tps: 4791.39225
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7763.40961
-  tps: 4886.9759
-  hps: 187.91975
+  dps: 7795.92093
+  tps: 4918.3546
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7798.64723
-  tps: 4913.16133
-  hps: 187.91975
+  dps: 7831.35832
+  tps: 4944.73373
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7247.89711
-  tps: 4617.2615
-  hps: 190.44129
+  dps: 7288.0614
+  tps: 4654.16839
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7247.89711
-  tps: 4617.2615
-  hps: 190.44129
+  dps: 7288.0614
+  tps: 4654.16839
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7489.1007
-  tps: 4733.57647
-  hps: 188.95631
+  dps: 7517.89649
+  tps: 4761.68694
+  hps: 190.59765
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7247.89711
-  tps: 4617.2615
-  hps: 190.44129
+  dps: 7288.0614
+  tps: 4654.16839
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7791.9353
-  tps: 4908.17363
-  hps: 187.91975
+  dps: 7824.60834
+  tps: 4939.70913
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7798.64723
-  tps: 4913.16133
-  hps: 187.91975
+  dps: 7831.35832
+  tps: 4944.73373
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7763.40961
-  tps: 4886.9759
-  hps: 190.76819
+  dps: 7795.92093
+  tps: 4918.3546
+  hps: 192.40916
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7763.40961
-  tps: 4886.9759
-  hps: 191.42553
+  dps: 7795.92093
+  tps: 4918.3546
+  hps: 193.07215
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7247.89711
-  tps: 4617.2615
-  hps: 190.44129
+  dps: 7288.0614
+  tps: 4654.16839
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7313.1482
-  tps: 4686.37519
-  hps: 189.55745
+  dps: 7343.50872
+  tps: 4716.33985
+  hps: 191.12795
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7324.84763
-  tps: 4695.78765
-  hps: 189.55745
+  dps: 7355.1852
+  tps: 4725.73706
+  hps: 191.12795
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7856.36248
-  tps: 4973.06264
-  hps: 187.91975
+  dps: 7889.84299
+  tps: 5001.17753
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7921.3508
-  tps: 5016.97515
-  hps: 190.44129
+  dps: 7965.32647
+  tps: 5057.66553
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7763.40961
-  tps: 4886.9759
-  hps: 187.91975
+  dps: 7795.92093
+  tps: 4918.3546
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7247.89711
-  tps: 4617.2615
-  hps: 190.44129
+  dps: 7288.0614
+  tps: 4654.16839
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7821.04626
-  tps: 4944.735
-  hps: 190.44129
+  dps: 7864.32286
+  tps: 4984.7748
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6736.31731
-  tps: 4281.43181
-  hps: 173.99359
+  dps: 6767.35596
+  tps: 4307.65716
+  hps: 175.48784
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6250.37713
-  tps: 3948.73995
-  hps: 188.16193
+  dps: 6277.62666
+  tps: 3975.25133
+  hps: 189.74241
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8052.10902
-  tps: 5247.12703
-  hps: 220.8967
+  dps: 8090.64957
+  tps: 5280.76511
+  hps: 222.78668
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6954.78409
-  tps: 4503.70185
-  hps: 235.91817
+  dps: 6986.36164
+  tps: 4534.86706
+  hps: 237.87873
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7247.89711
-  tps: 4617.2615
-  hps: 190.44129
+  dps: 7288.0614
+  tps: 4654.16839
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7247.89711
-  tps: 4617.2615
-  hps: 190.44129
+  dps: 7288.0614
+  tps: 4654.16839
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7802.1357
-  tps: 4936.51001
-  hps: 192.27071
+  dps: 7844.72833
+  tps: 4970.7386
+  hps: 193.91205
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8180.06565
-  tps: 5160.25467
-  hps: 190.44129
+  dps: 8225.50125
+  tps: 5202.29772
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7980.37447
-  tps: 5031.14353
-  hps: 190.44129
+  dps: 8024.54828
+  tps: 5072.11577
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7247.89711
-  tps: 4617.2615
-  hps: 215.75512
+  dps: 7288.0614
+  tps: 4654.16839
+  hps: 217.57788
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 7301.66798
-  tps: 4655.31432
-  hps: 187.42259
+  dps: 7334.36071
+  tps: 4686.44429
+  hps: 188.98768
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StormshroudArmor"
  value: {
-  dps: 5953.09283
-  tps: 3728.67445
-  hps: 149.54903
+  dps: 5979.89624
+  tps: 3750.67854
+  hps: 150.83835
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7798.64723
-  tps: 4913.16133
-  hps: 187.91975
+  dps: 7831.35832
+  tps: 4944.73373
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7791.9353
-  tps: 4908.17363
-  hps: 187.91975
+  dps: 7824.60834
+  tps: 4939.70913
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7780.18943
-  tps: 4899.44515
-  hps: 187.91975
+  dps: 7812.79588
+  tps: 4930.91609
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7761.25714
-  tps: 4990.21042
-  hps: 195.56109
+  dps: 7801.94893
+  tps: 5022.96496
+  hps: 197.24636
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6546.69394
-  tps: 4119.12154
-  hps: 217.46809
+  dps: 6574.82496
+  tps: 4143.77442
+  hps: 219.35959
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7818.1408
-  tps: 4941.98492
-  hps: 190.44129
+  dps: 7861.08315
+  tps: 4981.74111
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7457.81249
-  tps: 4773.97489
-  hps: 186.62973
+  dps: 7486.03951
+  tps: 4800.62491
+  hps: 188.18726
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7403.13315
-  tps: 4770.92359
-  hps: 189.40473
+  dps: 7432.52832
+  tps: 4799.1183
+  hps: 190.98875
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7763.40961
-  tps: 4886.9759
-  hps: 187.91975
+  dps: 7795.92093
+  tps: 4918.3546
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7763.40961
-  tps: 4886.9759
-  hps: 187.91975
+  dps: 7795.92093
+  tps: 4918.3546
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7763.40961
-  tps: 4886.9759
-  hps: 187.91975
+  dps: 7795.92093
+  tps: 4918.3546
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7763.40961
-  tps: 4886.9759
-  hps: 187.91975
+  dps: 7795.92093
+  tps: 4918.3546
+  hps: 189.53622
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6248.53334
-  tps: 3929.95969
-  hps: 165.20773
+  dps: 6278.15507
+  tps: 3957.58506
+  hps: 166.57987
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7946.75029
-  tps: 5035.93018
-  hps: 190.44129
+  dps: 7990.9096
+  tps: 5076.78713
+  hps: 192.05018
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 7769.62504
-  tps: 4900.90499
-  hps: 188.28856
+  dps: 7804.59979
+  tps: 4932.16799
+  hps: 189.86776
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30590.78267
-  tps: 30109.1356
-  hps: 143.6542
+  dps: 30958.90893
+  tps: 30455.57633
+  hps: 144.75277
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7271.70441
-  tps: 4703.13136
-  hps: 141.68149
+  dps: 7316.28701
+  tps: 4739.31014
+  hps: 142.86353
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10402.62461
-  tps: 5300.33041
-  hps: 135.9636
+  dps: 10438.46966
+  tps: 5339.45027
+  hps: 136.35048
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 18633.2865
-  tps: 19042.22228
-  hps: 80.6708
+  dps: 18818.57469
+  tps: 19219.9713
+  hps: 81.24106
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3596.83461
-  tps: 2552.52885
-  hps: 81.1888
+  dps: 3621.34774
+  tps: 2572.69304
+  hps: 81.84868
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4265.62391
-  tps: 2674.49894
-  hps: 76.475
+  dps: 4283.66904
+  tps: 2688.84379
+  hps: 76.65683
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30929.31494
-  tps: 30281.46147
-  hps: 140.91557
+  dps: 31289.25496
+  tps: 30623.07068
+  hps: 142.00126
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7461.04922
-  tps: 4715.49333
-  hps: 144.96462
+  dps: 7513.83385
+  tps: 4762.47844
+  hps: 146.18932
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10534.15879
-  tps: 5343.47074
-  hps: 134.18528
+  dps: 10569.54293
+  tps: 5375.68517
+  hps: 134.44066
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 18806.79005
-  tps: 19166.81414
-  hps: 81.98654
+  dps: 18997.84947
+  tps: 19348.8637
+  hps: 82.54369
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3674.12603
-  tps: 2562.94298
-  hps: 80.60503
+  dps: 3699.02432
+  tps: 2584.27606
+  hps: 81.26497
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4514.45351
-  tps: 2710.33812
-  hps: 77.0616
+  dps: 4533.48452
+  tps: 2727.73813
+  hps: 77.28088
  }
 }
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7338.26443
-  tps: 4649.24886
-  hps: 184.55661
+  dps: 7370.69937
+  tps: 4680.09617
+  hps: 186.03953
  }
 }

--- a/sim/deathknight/items.go
+++ b/sim/deathknight/items.go
@@ -328,6 +328,8 @@ func init() {
 			IcyTouchActionID,
 		}
 
+		dk := agent.(DeathKnightAgent).GetDeathKnight()
+
 		cinderProcAura := character.GetOrRegisterAura(core.Aura{
 			ActionID:  core.ActionID{SpellID: 53386},
 			Label:     "Cinderglacier",
@@ -337,10 +339,12 @@ func init() {
 				aura.SetStacks(sim, aura.MaxStacks)
 				aura.Unit.PseudoStats.ShadowDamageDealtMultiplier *= cinderBonusCoeff
 				aura.Unit.PseudoStats.FrostDamageDealtMultiplier *= cinderBonusCoeff
+				dk.modifyShadowDamageModifier(0.2)
 			},
 			OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Unit.PseudoStats.ShadowDamageDealtMultiplier /= cinderBonusCoeff
 				aura.Unit.PseudoStats.FrostDamageDealtMultiplier /= cinderBonusCoeff
+				dk.modifyShadowDamageModifier(-0.2)
 			},
 			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if !spellEffect.Outcome.Matches(core.OutcomeLanded) {

--- a/sim/deathknight/presences.go
+++ b/sim/deathknight/presences.go
@@ -88,7 +88,7 @@ func (dk *Deathknight) registerBloodPresenceAura(timer *core.Timer) {
 			aura.Unit.PseudoStats.ThreatMultiplier *= threatMultSubversion
 			aura.Unit.PseudoStats.DamageTakenMultiplier *= damageTakenMult
 
-			dk.ModifyAdditiveDamageModifier(sim, damageBonusCoeff)
+			dk.ModifyDamageModifier(damageBonusCoeff)
 			aura.Unit.EnableDynamicStatDep(sim, statDep)
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
@@ -96,7 +96,7 @@ func (dk *Deathknight) registerBloodPresenceAura(timer *core.Timer) {
 			aura.Unit.PseudoStats.ThreatMultiplier /= threatMultSubversion
 			aura.Unit.PseudoStats.DamageTakenMultiplier /= damageTakenMult
 
-			dk.ModifyAdditiveDamageModifier(sim, -damageBonusCoeff)
+			dk.ModifyDamageModifier(-damageBonusCoeff)
 			aura.Unit.DisableDynamicStatDep(sim, statDep)
 		},
 	}

--- a/sim/deathknight/talents_frost.go
+++ b/sim/deathknight/talents_frost.go
@@ -25,6 +25,7 @@ func (dk *Deathknight) ApplyFrostTalents() {
 	// Black Ice
 	dk.PseudoStats.FrostDamageDealtMultiplier *= 1.0 + 0.02*float64(dk.Talents.BlackIce)
 	dk.PseudoStats.ShadowDamageDealtMultiplier *= 1.0 + 0.02*float64(dk.Talents.BlackIce)
+	dk.modifyShadowDamageModifier(0.02 * float64(dk.Talents.BlackIce))
 
 	// Nerves Of Cold Steel
 	if dk.HasMHWeapon() && dk.HasOHWeapon() && dk.Equip[proto.ItemSlot_ItemSlotMainHand].HandType == proto.HandType_HandTypeMainHand || dk.Equip[proto.ItemSlot_ItemSlotMainHand].HandType == proto.HandType_HandTypeOneHand {

--- a/sim/deathknight/talents_unholy.go
+++ b/sim/deathknight/talents_unholy.go
@@ -79,20 +79,23 @@ func (dk *Deathknight) applyWanderingPlague() {
 		return
 	}
 
-	actionID := core.ActionID{SpellID: 49655}
-	damageMulti := []float64{0.0, 0.33, 0.66, 1.0}[dk.Talents.WanderingPlague]
+	actionID := core.ActionID{SpellID: 50526}
+
+	// this scales with damage taken modifiers, and very slightly with (shadow) damage dealt modifiers (~10%):
+	// e.g. in blood presence, a frost fever tick for 1130 hits debuffed targets for 1146 (+1.5%), and non debuffed
+	// targets for 1015 (-13%, +1.5%)
 
 	dk.WanderingPlague = dk.Unit.RegisterSpell(core.SpellConfig{
 		ActionID:    actionID,
 		SpellSchool: core.SpellSchoolShadow,
 		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       core.SpellFlagIgnoreAttackerModifiers | core.SpellFlagIgnoreTargetModifiers,
+		Flags:       core.SpellFlagNoOnCastComplete | core.SpellFlagIgnoreAttackerModifiers,
 
-		DamageMultiplier: 1,
+		DamageMultiplier: []float64{0.0, 0.33, 0.66, 1.0}[dk.Talents.WanderingPlague],
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.LastDiseaseDamage * damageMulti
+			baseDamage := dk.LastDiseaseDamage * dk.bonusCoeffs.wanderingPlagueMultiplier
 			baseDamage *= sim.Encounter.AOECapMultiplier()
 			for _, aoeTarget := range sim.Encounter.Targets {
 				spell.CalcAndDealDamageAlwaysHit(sim, &aoeTarget.Unit, baseDamage)
@@ -112,7 +115,7 @@ func (dk *Deathknight) applyNecrosis() {
 		ActionID:    core.ActionID{SpellID: 51460},
 		SpellSchool: core.SpellSchoolShadow,
 		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       core.SpellFlagIgnoreAttackerModifiers | core.SpellFlagIgnoreTargetModifiers,
+		Flags:       core.SpellFlagNoOnCastComplete | core.SpellFlagIgnoreModifiers,
 
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
@@ -178,7 +181,7 @@ func (dk *Deathknight) bloodCakedBladeHit(isMh bool) *core.Spell {
 		ActionID:    core.ActionID{SpellID: 50463}.WithTag(core.TernaryInt32(isMh, 1, 2)),
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    procMask,
-		Flags:       core.SpellFlagMeleeMetrics,
+		Flags:       core.SpellFlagNoOnCastComplete | core.SpellFlagMeleeMetrics,
 
 		DamageMultiplier: 1 *
 			core.TernaryFloat64(isMh, 1, dk.nervesOfColdSteelBonus()),
@@ -187,7 +190,7 @@ func (dk *Deathknight) bloodCakedBladeHit(isMh bool) *core.Spell {
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			BaseDamage: core.BaseDamageConfig{
 				Calculator: func(sim *core.Simulation, spellEffect *core.SpellEffect, spell *core.Spell) float64 {
-					diseaseMultiplier := (0.25 + dk.dkCountActiveDiseases(spellEffect.Target)*0.125)
+					diseaseMultiplier := 0.25 + dk.dkCountActiveDiseases(spellEffect.Target)*0.125
 					if isMh {
 						return mhBaseDamage(sim, spellEffect, spell) * diseaseMultiplier
 					} else {
@@ -249,10 +252,10 @@ func (dk *Deathknight) applyDesolation() {
 		Label:    "Desolation",
 		Duration: time.Second * 20.0,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			dk.ModifyAdditiveDamageModifier(sim, bonusDamageCoeff)
+			dk.ModifyDamageModifier(bonusDamageCoeff)
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			dk.ModifyAdditiveDamageModifier(sim, -bonusDamageCoeff)
+			dk.ModifyDamageModifier(-bonusDamageCoeff)
 		},
 	})
 }
@@ -291,7 +294,7 @@ func (dk *Deathknight) applyUnholyBlight() {
 		ActionID:    actionID,
 		SpellSchool: core.SpellSchoolShadow,
 		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       core.SpellFlagIgnoreAttackerModifiers | core.SpellFlagIgnoreTargetModifiers,
+		Flags:       core.SpellFlagNoOnCastComplete | core.SpellFlagIgnoreModifiers,
 
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,

--- a/sim/druid/demoralizing_roar.go
+++ b/sim/druid/demoralizing_roar.go
@@ -47,7 +47,7 @@ func (druid *Druid) registerDemoralizingRoarSpell() {
 	})
 }
 
-func (druid *Druid) CanDemoralizingRoar(sim *core.Simulation) bool {
+func (druid *Druid) CanDemoralizingRoar(_ *core.Simulation) bool {
 	return druid.CurrentRage() >= druid.DemoralizingRoar.DefaultCast.Cost
 }
 

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -84,24 +84,24 @@ type Druid struct {
 	Treant2  *TreantPet
 	Treant3  *TreantPet
 
-	form           DruidForm
-	disabledMCDs   []*core.MajorCooldown
-	SetBonuses     DruidTierSets
-	TalentsBonuses TalentsBonuses
+	form          DruidForm
+	disabledMCDs  []*core.MajorCooldown
+	setBonuses    druidTierSets
+	talentBonuses talentBonuses
 }
 
-type TalentsBonuses struct {
-	moonfuryMultiplier      float64
-	iffBonusCrit            float64
-	vengeanceModifier       float64
-	genesisMultiplier       float64
-	moonglowMultiplier      float64
-	naturesMajestyBonusCrit float64
-	naturesSplendorTick     int
-	starlightWrathModifier  time.Duration
+type talentBonuses struct {
+	moonfury        float64
+	vengeance       float64
+	genesis         float64
+	moonglow        float64
+	iffBonusCrit    float64
+	naturesSplendor int
+	naturesMajesty  float64
+	starlightWrath  time.Duration
 }
 
-type DruidTierSets struct {
+type druidTierSets struct {
 	balance_t6_2  bool
 	balance_t7_2  bool
 	balance_t7_4  bool
@@ -121,27 +121,26 @@ type SelfBuffs struct {
 
 // Registering non-unique Talent effects
 func (druid *Druid) RegisterTalentsBonuses() {
-	druid.TalentsBonuses = TalentsBonuses{
-		moonfuryMultiplier:      []float64{0.0, 0.03, 0.06, 0.1}[druid.Talents.Moonfury],
-		genesisMultiplier:       1 + 0.01*float64(druid.Talents.Genesis),
-		moonglowMultiplier:      1 - 0.03*float64(druid.Talents.Moonglow),
-		naturesMajestyBonusCrit: 2 * float64(druid.Talents.NaturesMajesty) * core.CritRatingPerCritChance,
-		vengeanceModifier:       0.2 * float64(druid.Talents.Vengeance),
-		naturesSplendorTick:     core.TernaryInt(druid.Talents.NaturesSplendor, 1, 0),
-		starlightWrathModifier:  time.Millisecond * 100 * time.Duration(druid.Talents.StarlightWrath),
+	druid.talentBonuses = talentBonuses{
+		moonfury:        []float64{0.0, 0.03, 0.06, 0.1}[druid.Talents.Moonfury], // additive damage bonus
+		genesis:         0.01 * float64(druid.Talents.Genesis),                   // additive damage bonus
+		moonglow:        1 - 0.03*float64(druid.Talents.Moonglow),                // cost reduction
+		naturesMajesty:  2 * float64(druid.Talents.NaturesMajesty) * core.CritRatingPerCritChance,
+		vengeance:       0.2 * float64(druid.Talents.Vengeance),
+		naturesSplendor: core.TernaryInt(druid.Talents.NaturesSplendor, 1, 0),
+		starlightWrath:  time.Millisecond * 100 * time.Duration(druid.Talents.StarlightWrath),
 	}
 }
 
 func (druid *Druid) ResetTalentsBonuses() {
-	druid.TalentsBonuses = TalentsBonuses{
-		moonfuryMultiplier:      0,
-		genesisMultiplier:       0,
-		moonglowMultiplier:      0,
-		iffBonusCrit:            0,
-		naturesMajestyBonusCrit: 0,
-		vengeanceModifier:       0,
-		naturesSplendorTick:     0,
-		starlightWrathModifier:  0,
+	druid.talentBonuses = talentBonuses{
+		moonfury:        0,
+		genesis:         0,
+		moonglow:        0,
+		naturesMajesty:  0,
+		vengeance:       0,
+		naturesSplendor: 0,
+		starlightWrath:  0,
 	}
 }
 
@@ -173,7 +172,6 @@ func (druid *Druid) AddRaidBuffs(raidBuffs *proto.RaidBuffs) {
 			raidBuffs.LeaderOfThePack = proto.TristateEffect_TristateEffectImproved
 		}
 	}
-
 }
 
 func (druid *Druid) PrimalGoreOutcomeFuncTick() core.OutcomeApplier {
@@ -188,7 +186,7 @@ func (druid *Druid) MeleeCritMultiplier() float64 {
 	// Assumes that Predatory Instincts is a primary rather than secondary modifier for now, but this needs to confirmed!
 	primaryModifier := 1.0
 	if druid.InForm(Cat | Bear) {
-		primaryModifier = 1 + ((0.1 / 3) * float64(druid.Talents.PredatoryInstincts))
+		primaryModifier = []float64{1, 1.03, 1.07, 1.10}[druid.Talents.PredatoryInstincts]
 	}
 	return druid.Character.MeleeCritMultiplier(primaryModifier, 0)
 }
@@ -209,7 +207,7 @@ func (druid *Druid) Initialize() {
 	druid.registerInnervateCD()
 
 	// Bonus sets
-	druid.SetBonuses = DruidTierSets{
+	druid.setBonuses = druidTierSets{
 		druid.HasSetBonus(ItemSetThunderheartRegalia, 2),
 		druid.HasSetBonus(ItemSetDreamwalkerGarb, 2),
 		druid.HasSetBonus(ItemSetDreamwalkerGarb, 4),
@@ -255,7 +253,7 @@ func (druid *Druid) RegisterFeralSpells(maulRageThreshold float64) {
 	druid.registerTigersFurySpell()
 }
 
-func (druid *Druid) Reset(sim *core.Simulation) {
+func (druid *Druid) Reset(_ *core.Simulation) {
 	druid.BleedsActive = 0
 	druid.form = druid.StartingForm
 	druid.disabledMCDs = []*core.MajorCooldown{}

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -45,637 +45,637 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 7457.14405
-  tps: 5694.59463
+  dps: 7124.27894
+  tps: 5435.43972
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7558.18985
-  tps: 5780.15995
+  dps: 7284.09009
+  tps: 5571.65798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7579.91242
-  tps: 5763.54214
+  dps: 7290.03727
+  tps: 5552.75017
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7577.89961
-  tps: 5777.26472
+  dps: 7261.02981
+  tps: 5553.891
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5972.96212
-  tps: 4543.57834
+  dps: 5774.82972
+  tps: 4396.5046
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7558.18985
-  tps: 5665.13622
+  dps: 7284.09009
+  tps: 5460.80129
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7749.21077
-  tps: 5922.12344
+  dps: 7417.69217
+  tps: 5670.93894
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7584.97869
-  tps: 5780.74671
+  dps: 7236.27011
+  tps: 5523.93746
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7556.95972
-  tps: 5749.49207
+  dps: 7310.93572
+  tps: 5575.89406
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 7510.21457
-  tps: 5710.85412
+  dps: 7218.03544
+  tps: 5509.24902
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7395.01647
-  tps: 5644.79911
+  dps: 7137.58613
+  tps: 5446.08062
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 7609.26596
-  tps: 5804.61398
+  dps: 7305.04359
+  tps: 5575.30674
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7487.14747
-  tps: 5690.49844
+  dps: 7178.74348
+  tps: 5480.56373
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7395.01647
-  tps: 5644.79911
+  dps: 7137.58613
+  tps: 5446.08168
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7562.00764
-  tps: 5776.68541
+  dps: 7309.40548
+  tps: 5587.75822
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 6815.90666
-  tps: 5192.31786
+  dps: 6566.93412
+  tps: 5015.64496
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreamwalkerGarb"
  value: {
-  dps: 5714.24052
-  tps: 4335.91803
+  dps: 5488.6375
+  tps: 4194.29806
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7558.18985
-  tps: 5780.15995
+  dps: 7284.09009
+  tps: 5571.65798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7558.18985
-  tps: 5780.11556
+  dps: 7284.09009
+  tps: 5571.61201
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7577.89961
-  tps: 5777.33657
+  dps: 7261.02981
+  tps: 5553.95811
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7572.22665
-  tps: 5783.5065
+  dps: 7255.63904
+  tps: 5550.22722
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7558.18985
-  tps: 5780.15995
+  dps: 7284.09009
+  tps: 5571.65798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7564.9319
-  tps: 5786.95124
+  dps: 7263.6942
+  tps: 5553.68281
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7532.65874
-  tps: 5761.67831
+  dps: 7171.74329
+  tps: 5481.91163
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7488.66658
-  tps: 5701.9127
+  dps: 7190.15606
+  tps: 5477.55321
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7558.18985
-  tps: 5780.15995
+  dps: 7284.09009
+  tps: 5571.65798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7558.18985
-  tps: 5780.15995
+  dps: 7284.09009
+  tps: 5571.65798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7615.7365
-  tps: 5798.83693
+  dps: 7330.31121
+  tps: 5580.61756
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7395.01647
-  tps: 5644.79911
+  dps: 7137.58613
+  tps: 5446.08168
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 7399.83684
-  tps: 5638.89615
+  dps: 7118.96361
+  tps: 5428.81453
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 6047.41019
-  tps: 4617.46148
+  dps: 5747.82579
+  tps: 4392.95059
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 7573.51683
-  tps: 5775.10292
+  dps: 7279.17521
+  tps: 5557.08782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 7645.51268
-  tps: 5835.54949
+  dps: 7345.04719
+  tps: 5596.26141
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 7584.24241
-  tps: 5791.1778
+  dps: 7256.06082
+  tps: 5544.94436
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 7639.2085
-  tps: 5830.7976
+  dps: 7322.46925
+  tps: 5599.44082
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 7589.34446
-  tps: 5791.34819
+  dps: 7275.77449
+  tps: 5550.87794
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7395.01647
-  tps: 5644.79911
+  dps: 7137.58613
+  tps: 5446.08168
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7577.89961
-  tps: 5777.33657
+  dps: 7261.02981
+  tps: 5553.95811
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7572.22665
-  tps: 5783.5065
+  dps: 7255.63904
+  tps: 5550.22722
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7579.89987
-  tps: 5776.16536
+  dps: 7334.43065
+  tps: 5581.20796
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7558.18985
-  tps: 5780.46413
+  dps: 7284.09009
+  tps: 5571.80792
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7623.97242
-  tps: 5819.69612
+  dps: 7284.49562
+  tps: 5571.1512
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 8170.89562
-  tps: 6168.05573
+  dps: 7867.50317
+  tps: 5949.98063
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LasherweaveRegalia"
  value: {
-  dps: 6169.68913
-  tps: 4748.48938
+  dps: 5924.37351
+  tps: 4542.15457
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7395.01647
-  tps: 5644.79911
+  dps: 7137.58613
+  tps: 5446.08168
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7395.01647
-  tps: 5644.79911
+  dps: 7137.58613
+  tps: 5446.07955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 7498.74772
-  tps: 5709.7722
+  dps: 7220.55431
+  tps: 5491.64626
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 5883.37354
-  tps: 4526.17883
+  dps: 5642.77105
+  tps: 4343.66034
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7624.77183
-  tps: 5834.66436
+  dps: 7299.04508
+  tps: 5574.29636
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NightsongBattlegear"
  value: {
-  dps: 6983.98276
-  tps: 5312.88889
+  dps: 6714.77749
+  tps: 5102.45222
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NightsongGarb"
  value: {
-  dps: 5802.97641
-  tps: 4435.58086
+  dps: 5643.87471
+  tps: 4315.91586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7395.01647
-  tps: 5644.79911
+  dps: 7137.58613
+  tps: 5446.08168
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7608.00521
-  tps: 5804.67441
+  dps: 7234.47904
+  tps: 5524.60015
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7623.97242
-  tps: 5819.69612
+  dps: 7284.49562
+  tps: 5571.1512
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7558.18985
-  tps: 5780.15995
+  dps: 7284.09009
+  tps: 5571.65798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7558.18985
-  tps: 5780.15995
+  dps: 7284.09009
+  tps: 5571.65798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7395.01647
-  tps: 5644.79911
+  dps: 7137.58613
+  tps: 5446.08168
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7395.01647
-  tps: 5644.79911
+  dps: 7137.58613
+  tps: 5446.08168
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7395.01647
-  tps: 5644.79911
+  dps: 7137.58613
+  tps: 5446.08168
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7751.38731
-  tps: 5923.60114
+  dps: 7414.63582
+  tps: 5670.9022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7558.18985
-  tps: 5779.73112
+  dps: 7284.09009
+  tps: 5571.221
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7395.01647
-  tps: 5644.79911
+  dps: 7137.58613
+  tps: 5446.08168
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Runetotem'sBattlegear"
  value: {
-  dps: 7498.74772
-  tps: 5709.7722
+  dps: 7220.55431
+  tps: 5491.64626
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Runetotem'sRegalia"
  value: {
-  dps: 5883.37354
-  tps: 4526.17883
+  dps: 5642.77105
+  tps: 4343.66034
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 7572.14945
-  tps: 5774.07385
+  dps: 7277.84134
+  tps: 5556.08693
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7395.01647
-  tps: 5644.79911
+  dps: 7137.58613
+  tps: 5446.08168
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7395.01647
-  tps: 5644.79911
+  dps: 7137.58613
+  tps: 5446.08168
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7395.01647
-  tps: 5644.79911
+  dps: 7137.58613
+  tps: 5446.08168
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 7439.86132
-  tps: 5659.42364
+  dps: 7150.15871
+  tps: 5452.12302
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StormshroudArmor"
  value: {
-  dps: 6096.68462
-  tps: 4618.05428
+  dps: 5864.46247
+  tps: 4437.59355
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7623.97242
-  tps: 5819.69612
+  dps: 7284.49562
+  tps: 5571.1512
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7608.00521
-  tps: 5804.67441
+  dps: 7234.47904
+  tps: 5524.60015
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7578.13389
-  tps: 5792.20505
+  dps: 7254.82808
+  tps: 5549.07211
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartHarness"
  value: {
-  dps: 5821.22333
-  tps: 4416.87514
+  dps: 5654.4689
+  tps: 4298.48805
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartRegalia"
  value: {
-  dps: 5124.75512
-  tps: 3903.39879
+  dps: 4990.73226
+  tps: 3800.5791
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7553.56574
-  tps: 5767.5243
+  dps: 7252.8081
+  tps: 5540.22254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7699.3313
-  tps: 5878.91838
+  dps: 7392.82437
+  tps: 5647.36419
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7693.24513
-  tps: 5870.44782
+  dps: 7408.38121
+  tps: 5656.01468
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7558.18985
-  tps: 5780.15995
+  dps: 7284.09009
+  tps: 5571.65798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7558.18985
-  tps: 5780.15995
+  dps: 7284.09009
+  tps: 5571.65798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7558.18985
-  tps: 5780.15995
+  dps: 7284.09009
+  tps: 5571.65798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7558.18985
-  tps: 5780.15995
+  dps: 7284.09009
+  tps: 5571.65798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6279.62527
-  tps: 4777.28746
+  dps: 6050.72185
+  tps: 4595.41811
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 7692.90758
-  tps: 5864.85016
+  dps: 7403.48537
+  tps: 5649.99084
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7149.92992
-  tps: 5991.39315
+  dps: 6898.88032
+  tps: 5823.77927
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7149.92992
-  tps: 5447.1107
+  dps: 6898.88032
+  tps: 5256.77751
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8043.05544
-  tps: 6144.63708
+  dps: 7632.14907
+  tps: 5826.3365
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4400.31735
-  tps: 4009.86163
+  dps: 4265.67517
+  tps: 3915.26685
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4400.31735
-  tps: 3334.05382
+  dps: 4265.67517
+  tps: 3237.27821
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4460.83624
-  tps: 3370.02714
+  dps: 4299.74677
+  tps: 3248.89343
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6507.0229
-  tps: 4953.38262
+  dps: 6263.81838
+  tps: 4761.49553
  }
 }

--- a/sim/druid/feral/presets.go
+++ b/sim/druid/feral/presets.go
@@ -21,7 +21,7 @@ var StandardTalents = &proto.DruidTalents{
 	LeaderOfThePack:         true,
 	ImprovedLeaderOfThePack: 2,
 	ProtectorOfThePack:      2,
-	PredatoryInstincts:      5,
+	PredatoryInstincts:      3,
 	KingOfTheJungle:         3,
 	Mangle:                  true,
 	RendAndTear:             5,

--- a/sim/druid/ferocious_bite.go
+++ b/sim/druid/ferocious_bite.go
@@ -11,11 +11,11 @@ import (
 func (druid *Druid) registerFerociousBiteSpell() {
 	actionID := core.ActionID{SpellID: 48577}
 	baseCost := 35.0
-	refundPercent := (0.4 * float64(druid.Talents.PrimalPrecision))
+	refundPercent := 0.4 * float64(druid.Talents.PrimalPrecision)
 	dmgPerComboPoint := 290.0 + core.TernaryFloat64(druid.Equip[items.ItemSlotRanged].ID == 25667, 14, 0)
 
 	var excessEnergy float64
-	var refundAmount float64 = 0.0
+	var refundAmount float64
 
 	biteBaseBonusCrit := core.TernaryFloat64(druid.HasT9FeralSetBonus(4), 5*core.CritRatingPerCritChance, 0.0)
 	if druid.AssumeBleedActive {

--- a/sim/druid/force_of_nature.go
+++ b/sim/druid/force_of_nature.go
@@ -83,6 +83,8 @@ func (druid *Druid) NewTreant() *TreantPet {
 	}
 	treant.AddStatDependency(stats.Strength, stats.AttackPower, 2)
 	treant.AddStatDependency(stats.Agility, stats.MeleeCrit, core.CritRatingPerCritChance/83.3)
+
+	treant.PseudoStats.DamageDealtMultiplier = 1 + 0.05*float64(druid.Talents.Brambles)
 	treant.EnableAutoAttacks(treant, core.AutoAttackOptions{
 		MainHand: core.Weapon{
 			BaseDamageMin:  252,
@@ -105,10 +107,10 @@ func (treant *TreantPet) GetPet() *core.Pet {
 func (treant *TreantPet) Initialize() {
 }
 
-func (treant *TreantPet) Reset(sim *core.Simulation) {
+func (treant *TreantPet) Reset(_ *core.Simulation) {
 }
 
-func (treant *TreantPet) OnGCDReady(sim *core.Simulation) {
+func (treant *TreantPet) OnGCDReady(_ *core.Simulation) {
 	treant.DoNothing()
 }
 

--- a/sim/druid/insect_swarm.go
+++ b/sim/druid/insect_swarm.go
@@ -29,10 +29,10 @@ func (druid *Druid) registerInsectSwarmSpell() {
 			},
 		},
 
-		DamageMultiplier: 1 *
-			druid.TalentsBonuses.genesisMultiplier *
-			(1 + core.TernaryFloat64(druid.SetBonuses.balance_t7_2, 0.1, 0) +
-				core.TernaryFloat64(druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfInsectSwarm), 0.3, 0)),
+		DamageMultiplier: 1 +
+			druid.talentBonuses.genesis +
+			core.TernaryFloat64(druid.setBonuses.balance_t7_2, 0.1, 0) +
+			core.TernaryFloat64(druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfInsectSwarm), 0.3, 0),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
@@ -60,14 +60,14 @@ func (druid *Druid) registerInsectSwarmSpell() {
 				druid.Wrath.DamageMultiplier /= 1 + 0.01*float64(druid.Talents.ImprovedInsectSwarm)
 			},
 		}),
-		NumberOfTicks: 6 + druid.TalentsBonuses.naturesSplendorTick,
+		NumberOfTicks: 6 + druid.talentBonuses.naturesSplendor,
 		TickLength:    time.Second * 2,
 		TickEffects: core.TickFuncSnapshot(target, core.SpellEffect{
 			IsPeriodic:     true,
 			BaseDamage:     core.BaseDamageConfigMagicNoRoll(215, 0.2),
 			OutcomeApplier: druid.OutcomeFuncTick(),
 			OnPeriodicDamageDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if sim.RandomFloat("Elune's Wrath proc") > (1-0.08) && druid.SetBonuses.balance_t8_4 {
+				if sim.RandomFloat("Elune's Wrath proc") > (1-0.08) && druid.setBonuses.balance_t8_4 {
 					tierProc := druid.GetOrRegisterAura(core.Aura{
 						Label:    "Elune's Wrath",
 						ActionID: core.ActionID{SpellID: 64823},

--- a/sim/druid/items.go
+++ b/sim/druid/items.go
@@ -553,7 +553,7 @@ func init() {
 }
 
 func (druid *Druid) registerLasherweaveDot() {
-	if !druid.SetBonuses.balance_t10_4 {
+	if !druid.setBonuses.balance_t10_4 {
 		return
 	}
 

--- a/sim/druid/moonfire.go
+++ b/sim/druid/moonfire.go
@@ -19,7 +19,7 @@ func (druid *Druid) registerMoonfireSpell() {
 
 	// T9-2P
 	dotOutcomeApplier := druid.OutcomeFuncTick()
-	if druid.SetBonuses.balance_t9_2 {
+	if druid.setBonuses.balance_t9_2 {
 		dotOutcomeApplier = druid.OutcomeFuncMagicHitAndCrit()
 	}
 
@@ -34,18 +34,17 @@ func (druid *Druid) registerMoonfireSpell() {
 
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
-				Cost: baseCost * druid.TalentsBonuses.moonglowMultiplier,
+				Cost: baseCost * druid.talentBonuses.moonglow,
 				GCD:  core.GCDDefault,
 			},
 		},
 
 		BonusCritRating: float64(druid.Talents.ImprovedMoonfire) * 5 * core.CritRatingPerCritChance,
-		DamageMultiplierAdditive: 1 +
+		DamageMultiplier: 1 +
 			improvedMoonfireDamageMultiplier +
-			druid.TalentsBonuses.moonfuryMultiplier -
+			druid.talentBonuses.moonfury -
 			moonfireGlyphBaseDamageMultiplier,
-		DamageMultiplier: 1,
-		CritMultiplier:   druid.SpellCritMultiplier(1, druid.TalentsBonuses.vengeanceModifier),
+		CritMultiplier:   druid.SpellCritMultiplier(1, druid.talentBonuses.vengeance),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
@@ -68,13 +67,13 @@ func (druid *Druid) registerMoonfireSpell() {
 			SpellSchool: core.SpellSchoolArcane,
 			ProcMask:    core.ProcMaskSpellDamage,
 
-			DamageMultiplierAdditive: 1 +
+			DamageMultiplier: 1 +
+				druid.talentBonuses.genesis +
 				improvedMoonfireDamageMultiplier +
-				druid.TalentsBonuses.moonfuryMultiplier +
+				druid.talentBonuses.moonfury +
 				moonfireGlyphDotDamageMultiplier,
-			DamageMultiplier: 1 *
-				druid.TalentsBonuses.genesisMultiplier,
-			CritMultiplier:   druid.SpellCritMultiplier(1, druid.TalentsBonuses.vengeanceModifier),
+
+			CritMultiplier:   druid.SpellCritMultiplier(1, druid.talentBonuses.vengeance),
 			ThreatMultiplier: 1,
 		}),
 		Aura: target.RegisterAura(core.Aura{
@@ -87,7 +86,7 @@ func (druid *Druid) registerMoonfireSpell() {
 				druid.Starfire.BonusCritRating -= core.CritRatingPerCritChance * float64(druid.Talents.ImprovedInsectSwarm)
 			},
 		}),
-		NumberOfTicks: 4 + core.TernaryInt(druid.SetBonuses.balance_t6_2, 1, 0) + druid.TalentsBonuses.naturesSplendorTick,
+		NumberOfTicks: 4 + core.TernaryInt(druid.setBonuses.balance_t6_2, 1, 0) + druid.talentBonuses.naturesSplendor,
 		TickLength:    time.Second * 3,
 		TickEffects: core.TickFuncSnapshot(target, core.SpellEffect{
 			BaseDamage:     core.BaseDamageConfigMagicNoRoll(200, 0.13),
@@ -99,8 +98,8 @@ func (druid *Druid) registerMoonfireSpell() {
 
 func (druid *Druid) maxMoonfireTicks() int {
 	base := 4
-	thunderhearthRegalia := core.TernaryInt(druid.SetBonuses.balance_t6_2, 1, 0)
-	natureSplendor := druid.TalentsBonuses.naturesSplendorTick
+	thunderhearthRegalia := core.TernaryInt(druid.setBonuses.balance_t6_2, 1, 0)
+	natureSplendor := druid.talentBonuses.naturesSplendor
 	starfireGlyph := core.TernaryInt(druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfStarfire), 3, 0)
 	return base + thunderhearthRegalia + natureSplendor + starfireGlyph
 }

--- a/sim/druid/rip.go
+++ b/sim/druid/rip.go
@@ -23,7 +23,7 @@ func (druid *Druid) registerRipSpell() {
 		ActionID:     actionID,
 		SpellSchool:  core.SpellSchoolPhysical,
 		ProcMask:     core.ProcMaskMeleeMHSpecial,
-		Flags:        core.SpellFlagMeleeMetrics | core.SpellFlagIgnoreResists,
+		Flags:        core.SpellFlagMeleeMetrics,
 		ResourceType: stats.Energy,
 		BaseCost:     baseCost,
 

--- a/sim/druid/starfall.go
+++ b/sim/druid/starfall.go
@@ -21,7 +21,7 @@ func (druid *Druid) registerStarfallSpell() {
 	tickLength := core.TernaryDuration(druid.Env.GetNumTargets() > 1, time.Millisecond*500, time.Millisecond*1000)
 
 	// Nature's Majesty
-	naturesMajestyCritBonus := druid.TalentsBonuses.naturesMajestyBonusCrit
+	naturesMajestyCritBonus := druid.talentBonuses.naturesMajesty
 
 	druid.Starfall = druid.RegisterSpell(core.SpellConfig{
 		ActionID:     core.ActionID{SpellID: 53201},
@@ -32,7 +32,7 @@ func (druid *Druid) registerStarfallSpell() {
 
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
-				Cost: baseCost * druid.TalentsBonuses.moonglowMultiplier,
+				Cost: baseCost * druid.talentBonuses.moonglow,
 				GCD:  core.GCDDefault,
 			},
 			CD: core.Cooldown{
@@ -43,7 +43,7 @@ func (druid *Druid) registerStarfallSpell() {
 
 		BonusCritRating:  naturesMajestyCritBonus,
 		DamageMultiplier: 1 * (1 + core.TernaryFloat64(druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfFocus), 0.1, 0)),
-		CritMultiplier:   druid.SpellCritMultiplier(1, druid.TalentsBonuses.vengeanceModifier),
+		CritMultiplier:   druid.SpellCritMultiplier(1, druid.talentBonuses.vengeance),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
@@ -62,7 +62,7 @@ func (druid *Druid) registerStarfallSpell() {
 		ProcMask:         core.ProcMaskSpellDamage,
 		BonusCritRating:  naturesMajestyCritBonus,
 		DamageMultiplier: 1 * (1 + core.TernaryFloat64(druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfFocus), 0.1, 0)),
-		CritMultiplier:   druid.SpellCritMultiplier(1, druid.TalentsBonuses.vengeanceModifier),
+		CritMultiplier:   druid.SpellCritMultiplier(1, druid.talentBonuses.vengeance),
 		ThreatMultiplier: 1,
 	})
 

--- a/sim/druid/starfire.go
+++ b/sim/druid/starfire.go
@@ -15,7 +15,7 @@ const IvoryMoongoddess int32 = 27518
 const ShootingStar int32 = 40321
 
 func (druid *Druid) applySwiftStarfireBonus(sim *core.Simulation, cast *core.Cast) {
-	if druid.SwiftStarfireAura.IsActive() && druid.SetBonuses.balance_pvp_4 {
+	if druid.SwiftStarfireAura.IsActive() && druid.setBonuses.balance_pvp_4 {
 		cast.CastTime -= 1500 * time.Millisecond
 		druid.SwiftStarfireAura.Deactivate(sim)
 	}
@@ -43,9 +43,9 @@ func (druid *Druid) registerStarfireSpell() {
 
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
-				Cost:     baseCost * druid.TalentsBonuses.moonglowMultiplier,
+				Cost:     baseCost * druid.talentBonuses.moonglow,
 				GCD:      core.GCDDefault,
-				CastTime: time.Millisecond*3500 - druid.TalentsBonuses.starlightWrathModifier,
+				CastTime: time.Millisecond*3500 - druid.talentBonuses.starlightWrath,
 			},
 
 			ModifyCast: func(sim *core.Simulation, spell *core.Spell, cast *core.Cast) {
@@ -60,12 +60,12 @@ func (druid *Druid) registerStarfireSpell() {
 		},
 
 		BonusCritRating: 0 +
-			druid.TalentsBonuses.naturesMajestyBonusCrit +
-			core.TernaryFloat64(druid.SetBonuses.balance_t6_2, 5*core.CritRatingPerCritChance, 0) + // T2-2P
-			core.TernaryFloat64(druid.SetBonuses.balance_t7_4, 5*core.CritRatingPerCritChance, 0), // T7-4P
-		DamageMultiplier: (1 + druid.TalentsBonuses.moonfuryMultiplier) *
-			core.TernaryFloat64(druid.SetBonuses.balance_t9_4, 1.04, 1), // T9-4P
-		CritMultiplier:   druid.SpellCritMultiplier(1, druid.TalentsBonuses.vengeanceModifier),
+			druid.talentBonuses.naturesMajesty +
+			core.TernaryFloat64(druid.setBonuses.balance_t6_2, 5*core.CritRatingPerCritChance, 0) + // T2-2P
+			core.TernaryFloat64(druid.setBonuses.balance_t7_4, 5*core.CritRatingPerCritChance, 0), // T7-4P
+		DamageMultiplier: (1 + druid.talentBonuses.moonfury) *
+			core.TernaryFloat64(druid.setBonuses.balance_t9_4, 1.04, 1), // T9-4P
+		CritMultiplier:   druid.SpellCritMultiplier(1, druid.talentBonuses.vengeance),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
@@ -76,7 +76,7 @@ func (druid *Druid) registerStarfireSpell() {
 					if druid.Talents.MoonkinForm {
 						druid.AddMana(sim, 0.02*druid.MaxMana(), manaMetrics, true)
 					}
-					if druid.SetBonuses.balance_t10_4 {
+					if druid.setBonuses.balance_t10_4 {
 						if druid.LasherweaveDot.IsActive() {
 							druid.LasherweaveDot.Refresh(sim)
 						} else {

--- a/sim/druid/talents.go
+++ b/sim/druid/talents.go
@@ -289,7 +289,7 @@ func (druid *Druid) applyOmenOfClarity() {
 				if spell == druid.Starfire || spell == druid.Wrath {
 					if sim.RandomFloat("Clearcasting") <= 1.75/(60/spell.CurCast.CastTime.Seconds()) { // 1.75 PPM emulation : https://github.com/JamminL/wotlk-classic-bugs/issues/66#issuecomment-1178282422
 						druid.ClearcastingAura.Activate(sim)
-						if druid.SetBonuses.balance_t10_2 {
+						if druid.setBonuses.balance_t10_2 {
 							lasherweave2P.Activate(sim)
 						}
 					}
@@ -321,11 +321,11 @@ func (druid *Druid) applyEclipse() {
 		Duration: time.Millisecond * 15000,
 		ActionID: core.ActionID{SpellID: 48517},
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			tierEclipseMultiplier := core.TernaryFloat64(druid.SetBonuses.balance_t8_2, 0.07, 0) // T8-2P
+			tierEclipseMultiplier := core.TernaryFloat64(druid.setBonuses.balance_t8_2, 0.07, 0) // T8-2P
 			druid.Wrath.DamageMultiplier *= 1.4 + tierEclipseMultiplier
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			tierEclipseMultiplier := core.TernaryFloat64(druid.SetBonuses.balance_t8_2, 0.07, 0) // T8-2P
+			tierEclipseMultiplier := core.TernaryFloat64(druid.setBonuses.balance_t8_2, 0.07, 0) // T8-2P
 			druid.Wrath.DamageMultiplier /= 1.4 + tierEclipseMultiplier
 		},
 	})
@@ -364,11 +364,11 @@ func (druid *Druid) applyEclipse() {
 		Duration: time.Millisecond * 15000,
 		ActionID: core.ActionID{SpellID: 48518},
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			tierEclipseBonus := core.TernaryFloat64(druid.SetBonuses.balance_t8_2, core.CritRatingPerCritChance*7, 0) // T8-2P
+			tierEclipseBonus := core.TernaryFloat64(druid.setBonuses.balance_t8_2, core.CritRatingPerCritChance*7, 0) // T8-2P
 			druid.Starfire.BonusCritRating += (core.CritRatingPerCritChance * 40) + tierEclipseBonus
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			tierEclipseBonus := core.TernaryFloat64(druid.SetBonuses.balance_t8_2, core.CritRatingPerCritChance*7, 0) // T8-2P
+			tierEclipseBonus := core.TernaryFloat64(druid.setBonuses.balance_t8_2, core.CritRatingPerCritChance*7, 0) // T8-2P
 			druid.Starfire.BonusCritRating -= (core.CritRatingPerCritChance * 40) + tierEclipseBonus
 		},
 	})

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -45,639 +45,639 @@ character_stats_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 1138.78368
-  tps: 1547.20179
+  dps: 1108.32838
+  tps: 1500.63018
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1131.14608
-  tps: 1541.69232
+  dps: 1091.42102
+  tps: 1489.04355
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1212.37839
-  tps: 1656.41323
+  dps: 1155.86407
+  tps: 1562.64549
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1126.08589
-  tps: 1545.42246
+  dps: 1101.92787
+  tps: 1488.91924
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 980.47266
-  tps: 1296.94161
+  dps: 964.4883
+  tps: 1279.673
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1131.14608
-  tps: 1511.01506
+  dps: 1091.42102
+  tps: 1459.41868
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1147.05722
-  tps: 1567.32092
+  dps: 1112.97384
+  tps: 1517.84872
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1145.61697
-  tps: 1566.89773
+  dps: 1104.97155
+  tps: 1500.31971
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1184.65424
-  tps: 1610.12196
+  dps: 1166.41841
+  tps: 1586.52489
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 1178.91391
-  tps: 1610.43269
+  dps: 1146.85166
+  tps: 1557.27075
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 1144.57752
-  tps: 1560.13592
+  dps: 1122.12316
+  tps: 1528.46454
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 1134.15987
-  tps: 1543.96414
+  dps: 1091.05115
+  tps: 1478.6796
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 1130.50825
-  tps: 1543.71045
+  dps: 1104.87197
+  tps: 1498.29864
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1134.20551
-  tps: 1544.89214
+  dps: 1110.91456
+  tps: 1514.55988
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1117.64178
-  tps: 1523.80116
+  dps: 1078.19823
+  tps: 1471.14886
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1114.85101
-  tps: 1518.64095
+  dps: 1087.14769
+  tps: 1480.23208
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 1256.38835
-  tps: 1692.11425
+  dps: 1231.42026
+  tps: 1659.8758
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerGarb"
  value: {
-  dps: 986.70428
-  tps: 1309.73959
+  dps: 953.04126
+  tps: 1263.94915
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1131.14608
-  tps: 1541.69232
+  dps: 1091.42102
+  tps: 1489.04355
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1131.14608
-  tps: 1541.69232
+  dps: 1091.42102
+  tps: 1489.04355
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1126.08589
-  tps: 1545.42246
+  dps: 1101.92787
+  tps: 1488.91924
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1125.87922
-  tps: 1537.5014
+  dps: 1097.29287
+  tps: 1494.07611
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1131.14608
-  tps: 1541.69232
+  dps: 1091.42102
+  tps: 1489.04355
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1179.35944
-  tps: 1605.70906
+  dps: 1121.16887
+  tps: 1524.27948
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1158.54301
-  tps: 1582.63615
+  dps: 1101.72151
+  tps: 1501.66376
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1122.14422
-  tps: 1530.52516
+  dps: 1098.9565
+  tps: 1491.25075
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1131.14608
-  tps: 1541.69232
+  dps: 1091.42102
+  tps: 1489.04355
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1131.14608
-  tps: 1541.69232
+  dps: 1091.42102
+  tps: 1489.04355
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1186.16263
-  tps: 1615.15907
+  dps: 1147.86524
+  tps: 1553.05002
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1117.64178
-  tps: 1523.80116
+  dps: 1078.19823
+  tps: 1471.14886
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 1447.05564
-  tps: 1963.88715
+  dps: 1401.82793
+  tps: 1903.36939
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 1048.7095
-  tps: 1408.39937
+  dps: 1007.78131
+  tps: 1341.34412
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 1115.26885
-  tps: 1513.89393
+  dps: 1098.56329
+  tps: 1492.81376
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 1142.96234
-  tps: 1558.74914
+  dps: 1091.53525
+  tps: 1484.36476
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 1108.92145
-  tps: 1509.53829
+  dps: 1081.1139
+  tps: 1468.23134
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 1133.29599
-  tps: 1540.58539
+  dps: 1094.56942
+  tps: 1488.85136
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1117.64178
-  tps: 1523.80116
+  dps: 1078.19823
+  tps: 1471.14886
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1126.08589
-  tps: 1545.42246
+  dps: 1101.92787
+  tps: 1488.91924
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1125.87922
-  tps: 1537.5014
+  dps: 1097.29287
+  tps: 1494.07611
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1162.17046
-  tps: 1586.8978
+  dps: 1134.77285
+  tps: 1544.42332
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1131.14608
-  tps: 1541.69232
+  dps: 1091.42102
+  tps: 1489.04355
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1135.18519
-  tps: 1548.97255
+  dps: 1100.12186
+  tps: 1496.1442
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 1622.12057
-  tps: 2167.4603
+  dps: 1554.60429
+  tps: 2071.28492
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveRegalia"
  value: {
-  dps: 1172.8341
-  tps: 1577.37217
+  dps: 1146.85275
+  tps: 1540.91238
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1117.64178
-  tps: 1523.80116
+  dps: 1078.19823
+  tps: 1471.14886
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1117.64178
-  tps: 1523.80116
+  dps: 1078.19823
+  tps: 1471.14886
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 1515.40961
-  tps: 2055.44453
+  dps: 1440.02152
+  tps: 1945.70754
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 1068.05803
-  tps: 1423.51216
+  dps: 1054.47987
+  tps: 1409.79374
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1182.62968
-  tps: 1615.27083
+  dps: 1136.71806
+  tps: 1543.05278
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NightsongBattlegear"
  value: {
-  dps: 1333.96356
-  tps: 1805.13956
+  dps: 1284.16605
+  tps: 1730.04278
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NightsongGarb"
  value: {
-  dps: 1020.99619
-  tps: 1357.94556
+  dps: 995.55893
+  tps: 1323.00919
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1117.64178
-  tps: 1523.80116
+  dps: 1078.19823
+  tps: 1471.14886
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1128.10823
-  tps: 1530.7805
+  dps: 1095.59645
+  tps: 1483.42517
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1135.18519
-  tps: 1548.97255
+  dps: 1100.12186
+  tps: 1496.1442
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1131.14608
-  tps: 1541.69232
+  dps: 1091.42102
+  tps: 1489.04355
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1131.14608
-  tps: 1541.69232
+  dps: 1091.42102
+  tps: 1489.04355
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1117.64178
-  tps: 1523.80116
+  dps: 1078.19823
+  tps: 1471.14886
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1117.64178
-  tps: 1523.80116
+  dps: 1078.19823
+  tps: 1471.14886
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1117.64178
-  tps: 1523.80116
+  dps: 1078.19823
+  tps: 1471.14886
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1135.74513
-  tps: 1550.79529
+  dps: 1104.78354
+  tps: 1503.00688
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1131.14608
-  tps: 1541.69232
+  dps: 1091.42102
+  tps: 1489.04355
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1117.64178
-  tps: 1523.80116
+  dps: 1078.19823
+  tps: 1471.14886
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Runetotem'sBattlegear"
  value: {
-  dps: 1515.40961
-  tps: 2055.44453
+  dps: 1440.02152
+  tps: 1945.70754
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Runetotem'sRegalia"
  value: {
-  dps: 1068.05803
-  tps: 1423.51216
+  dps: 1054.47987
+  tps: 1409.79374
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 1122.2096
-  tps: 1526.80669
+  dps: 1098.20708
+  tps: 1489.9926
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1117.64178
-  tps: 1523.80116
+  dps: 1078.19823
+  tps: 1471.14886
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1117.64178
-  tps: 1523.80116
+  dps: 1078.19823
+  tps: 1471.14886
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1117.64178
-  tps: 1523.80116
+  dps: 1078.19823
+  tps: 1471.14886
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 1137.43594
-  tps: 1546.49133
+  dps: 1092.13679
+  tps: 1483.91755
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-StormshroudArmor"
  value: {
-  dps: 981.2123
-  tps: 1305.29975
+  dps: 943.28091
+  tps: 1248.37125
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1135.18519
-  tps: 1548.97255
+  dps: 1100.12186
+  tps: 1496.1442
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1128.10823
-  tps: 1530.7805
+  dps: 1095.59645
+  tps: 1483.42517
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1138.99568
-  tps: 1550.78622
+  dps: 1089.82525
+  tps: 1476.79628
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartHarness"
  value: {
-  dps: 1102.7237
-  tps: 1462.64379
+  dps: 1060.23333
+  tps: 1407.34199
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartRegalia"
  value: {
-  dps: 935.80179
-  tps: 1192.45739
+  dps: 898.17322
+  tps: 1144.86809
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1141.25442
-  tps: 1548.50743
+  dps: 1103.20243
+  tps: 1500.89366
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1195.38215
-  tps: 1631.31644
+  dps: 1176.33634
+  tps: 1602.50249
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1236.42983
-  tps: 1695.05967
+  dps: 1183.36754
+  tps: 1611.21951
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1131.14608
-  tps: 1541.69232
+  dps: 1091.42102
+  tps: 1489.04355
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1131.14608
-  tps: 1541.69232
+  dps: 1091.42102
+  tps: 1489.04355
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1131.14608
-  tps: 1541.69232
+  dps: 1091.42102
+  tps: 1489.04355
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1131.14608
-  tps: 1541.69232
+  dps: 1091.42102
+  tps: 1489.04355
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1068.78211
-  tps: 1417.82456
+  dps: 1031.20808
+  tps: 1367.75856
  }
 }
 dps_results: {
  key: "TestFeralTank-Average-Default"
  value: {
-  dps: 1326.70734
-  tps: 1832.04825
-  dtps: 552.0513
+  dps: 1289.25509
+  tps: 1776.3737
+  dtps: 551.89462
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3025.55179
-  tps: 5295.40387
+  dps: 2938.76819
+  tps: 5169.81575
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1228.77108
-  tps: 1688.03599
+  dps: 1205.7274
+  tps: 1648.92896
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1392.09379
-  tps: 1965.87995
+  dps: 1349.9812
+  tps: 1889.11429
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1485.11862
-  tps: 2904.20136
+  dps: 1431.26744
+  tps: 2816.89586
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 537.80727
-  tps: 741.3419
+  dps: 527.56945
+  tps: 717.87481
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 521.45834
-  tps: 739.78355
+  dps: 512.17957
+  tps: 741.6888
  }
 }
 dps_results: {
  key: "TestFeralTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1445.08961
-  tps: 2010.76722
+  dps: 1397.299
+  tps: 1941.22068
   dtps: 512.98214
  }
 }

--- a/sim/druid/tank/presets.go
+++ b/sim/druid/tank/presets.go
@@ -16,7 +16,7 @@ var StandardTalents = &proto.DruidTalents{
 	SurvivalOfTheFittest:    3,
 	LeaderOfThePack:         true,
 	ImprovedLeaderOfThePack: 2,
-	PredatoryInstincts:      5,
+	PredatoryInstincts:      3,
 	Mangle:                  true,
 
 	Furor:               5,

--- a/sim/druid/wrath.go
+++ b/sim/druid/wrath.go
@@ -28,9 +28,9 @@ func (druid *Druid) registerWrathSpell() {
 
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
-				Cost:     baseCost * druid.TalentsBonuses.moonglowMultiplier,
+				Cost:     baseCost * druid.talentBonuses.moonglow,
 				GCD:      core.GCDDefault,
-				CastTime: time.Second*2 - druid.TalentsBonuses.starlightWrathModifier,
+				CastTime: time.Second*2 - druid.talentBonuses.starlightWrath,
 			},
 
 			ModifyCast: func(sim *core.Simulation, spell *core.Spell, cast *core.Cast) {
@@ -40,11 +40,11 @@ func (druid *Druid) registerWrathSpell() {
 		},
 
 		BonusCritRating: 0 +
-			druid.TalentsBonuses.naturesMajestyBonusCrit +
-			core.TernaryFloat64(druid.SetBonuses.balance_t7_4, 5*core.CritRatingPerCritChance, 0), // T7-4P
-		DamageMultiplier: (1 + druid.TalentsBonuses.moonfuryMultiplier) *
-			core.TernaryFloat64(druid.SetBonuses.balance_t9_4, 1.04, 1), // T9-4P
-		CritMultiplier:   druid.SpellCritMultiplier(1, druid.TalentsBonuses.vengeanceModifier),
+			druid.talentBonuses.naturesMajesty +
+			core.TernaryFloat64(druid.setBonuses.balance_t7_4, 5*core.CritRatingPerCritChance, 0), // T7-4P
+		DamageMultiplier: (1 + druid.talentBonuses.moonfury) *
+			core.TernaryFloat64(druid.setBonuses.balance_t9_4, 1.04, 1), // T9-4P
+		CritMultiplier:   druid.SpellCritMultiplier(1, druid.talentBonuses.vengeance),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
@@ -54,7 +54,7 @@ func (druid *Druid) registerWrathSpell() {
 				if druid.Talents.MoonkinForm {
 					druid.AddMana(sim, 0.02*druid.MaxMana(), manaMetrics, true)
 				}
-				if druid.SetBonuses.balance_t10_4 {
+				if druid.setBonuses.balance_t10_4 {
 					if druid.LasherweaveDot.IsActive() {
 						druid.LasherweaveDot.Refresh(sim)
 					} else {
@@ -62,7 +62,7 @@ func (druid *Druid) registerWrathSpell() {
 					}
 				}
 			}
-			if sim.RandomFloat("Swift Starfire proc") > 0.85 && druid.SetBonuses.balance_pvp_4 {
+			if sim.RandomFloat("Swift Starfire proc") > 0.85 && druid.setBonuses.balance_pvp_4 {
 				druid.SwiftStarfireAura.Activate(sim)
 			}
 			spell.DealDamage(sim, &result)

--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -689,43 +689,43 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6833.84243
-  tps: 6737.09615
+  dps: 6838.91441
+  tps: 6742.16813
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6833.84243
-  tps: 5738.08601
+  dps: 6838.91441
+  tps: 5743.15799
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7743.99046
-  tps: 6484.72977
+  dps: 7748.65862
+  tps: 6489.39793
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3385.16442
-  tps: 4551.13093
+  dps: 3386.73456
+  tps: 4552.70107
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3385.16442
-  tps: 3035.9162
+  dps: 3386.73456
+  tps: 3037.48633
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4116.60237
-  tps: 3667.78761
+  dps: 4118.59437
+  tps: 3669.77961
  }
 }
 dps_results: {
@@ -857,43 +857,43 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6858.95026
-  tps: 6698.8821
+  dps: 6864.06214
+  tps: 6703.99397
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6858.95026
-  tps: 5702.84649
+  dps: 6864.06214
+  tps: 5707.95836
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7838.88013
-  tps: 6505.87591
+  dps: 7843.55594
+  tps: 6510.55172
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3409.40699
-  tps: 4547.04587
+  dps: 3410.99978
+  tps: 4548.63866
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3409.40699
-  tps: 3036.62845
+  dps: 3410.99978
+  tps: 3038.22125
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4142.30027
-  tps: 3666.13136
+  dps: 4144.45342
+  tps: 3668.2845
  }
 }
 dps_results: {

--- a/sim/hunter/aimed_shot.go
+++ b/sim/hunter/aimed_shot.go
@@ -43,7 +43,7 @@ func (hunter *Hunter) registerAimedShotSpell(timer *core.Timer) {
 			.04*float64(hunter.Talents.Barrage),
 		DamageMultiplier: 1 *
 			hunter.markedForDeathMultiplier(),
-		CritMultiplier:   hunter.critMultiplier(true, true, hunter.CurrentTarget),
+		CritMultiplier:   hunter.critMultiplier(true, true),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/hunter/arcane_shot.go
+++ b/sim/hunter/arcane_shot.go
@@ -44,7 +44,7 @@ func (hunter *Hunter) registerArcaneShotSpell(timer *core.Timer) {
 			.05*float64(hunter.Talents.ImprovedArcaneShot),
 		DamageMultiplier: 1 *
 			hunter.markedForDeathMultiplier(),
-		CritMultiplier:   hunter.critMultiplier(true, true, hunter.CurrentTarget),
+		CritMultiplier:   hunter.critMultiplier(true, true),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/hunter/black_arrow.go
+++ b/sim/hunter/black_arrow.go
@@ -60,19 +60,19 @@ func (hunter *Hunter) registerBlackArrowSpell(timer *core.Timer) {
 			Label:    "BlackArrow-" + strconv.Itoa(int(hunter.Index)),
 			ActionID: actionID,
 			OnGain: func(aura *core.Aura, sim *core.Simulation) {
-				hunter.AttackTables[aura.Unit.UnitIndex].DamageDealtMultiplier *= 1.06
+				hunter.AttackTables[aura.Unit.UnitIndex].DamageTakenMultiplier *= 1.06
 			},
 			OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-				hunter.AttackTables[aura.Unit.UnitIndex].DamageDealtMultiplier /= 1.06
+				hunter.AttackTables[aura.Unit.UnitIndex].DamageTakenMultiplier /= 1.06
 			},
 		}),
 		NumberOfTicks: 5,
 		TickLength:    time.Second * 3,
 		TickEffects: core.TickFuncSnapshot(target, core.SpellEffect{
 			IsPeriodic: true,
-
+			// scales slightly better (11.5%) than the tooltip implies (10%), but isn't affected by Hunter's Mark
 			BaseDamage: core.BuildBaseDamageConfig(func(sim *core.Simulation, spellEffect *core.SpellEffect, spell *core.Spell) float64 {
-				return 553 + 0.02*spell.RangedAttackPower(spellEffect.Target)
+				return 553 + 0.023*(spell.Unit.GetStat(stats.RangedAttackPower)+spell.Unit.PseudoStats.MobTypeAttackPower)
 			}),
 			OutcomeApplier: hunter.OutcomeFuncTick(),
 		}),

--- a/sim/hunter/chimera_shot.go
+++ b/sim/hunter/chimera_shot.go
@@ -39,7 +39,7 @@ func (hunter *Hunter) registerChimeraShotSpell() {
 		},
 
 		DamageMultiplier: 1 * hunter.markedForDeathMultiplier(),
-		CritMultiplier:   hunter.critMultiplier(true, true, hunter.CurrentTarget),
+		CritMultiplier:   hunter.critMultiplier(true, true),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
@@ -76,7 +76,7 @@ func (hunter *Hunter) chimeraShotSerpentStingSpell() *core.Spell {
 		DamageMultiplier: 1 *
 			(2.0 + core.TernaryFloat64(hunter.HasMajorGlyph(proto.HunterMajorGlyph_GlyphOfSerpentSting), 0.8, 0)) *
 			hunter.markedForDeathMultiplier(),
-		CritMultiplier:   hunter.critMultiplier(true, false, hunter.CurrentTarget),
+		CritMultiplier:   hunter.critMultiplier(true, false),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/hunter/explosive_shot.go
+++ b/sim/hunter/explosive_shot.go
@@ -43,7 +43,7 @@ func (hunter *Hunter) registerExplosiveShotSpell(timer *core.Timer) {
 		DamageMultiplierAdditive: 1 +
 			.02*float64(hunter.Talents.TNT),
 		DamageMultiplier: 1,
-		CritMultiplier:   hunter.critMultiplier(true, false, hunter.CurrentTarget),
+		CritMultiplier:   hunter.critMultiplier(true, false),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/hunter/explosive_trap.go
+++ b/sim/hunter/explosive_trap.go
@@ -35,7 +35,7 @@ func (hunter *Hunter) registerExplosiveTrapSpell(timer *core.Timer) {
 
 		DamageMultiplierAdditive: 1 +
 			.02*float64(hunter.Talents.TNT),
-		CritMultiplier:   hunter.critMultiplier(false, false, hunter.CurrentTarget),
+		CritMultiplier:   hunter.critMultiplier(false, false),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
@@ -62,7 +62,7 @@ func (hunter *Hunter) registerExplosiveTrapSpell(timer *core.Timer) {
 			DamageMultiplierAdditive: 1 +
 				.10*float64(hunter.Talents.TrapMastery) +
 				.02*float64(hunter.Talents.TNT),
-			CritMultiplier:   hunter.critMultiplier(false, false, hunter.CurrentTarget),
+			CritMultiplier:   hunter.critMultiplier(false, false),
 			ThreatMultiplier: 1,
 		}),
 		Aura: hunter.RegisterAura(core.Aura{

--- a/sim/hunter/hunter.go
+++ b/sim/hunter/hunter.go
@@ -119,9 +119,9 @@ func (hunter *Hunter) AddPartyBuffs(partyBuffs *proto.PartyBuffs) {
 
 func (hunter *Hunter) Initialize() {
 	// Update auto crit multipliers now that we have the targets.
-	hunter.AutoAttacks.MHConfig.CritMultiplier = hunter.critMultiplier(false, false, hunter.CurrentTarget)
-	hunter.AutoAttacks.OHConfig.CritMultiplier = hunter.critMultiplier(false, false, hunter.CurrentTarget)
-	hunter.AutoAttacks.RangedConfig.CritMultiplier = hunter.critMultiplier(false, false, hunter.CurrentTarget)
+	hunter.AutoAttacks.MHConfig.CritMultiplier = hunter.critMultiplier(false, false)
+	hunter.AutoAttacks.OHConfig.CritMultiplier = hunter.critMultiplier(false, false)
+	hunter.AutoAttacks.RangedConfig.CritMultiplier = hunter.critMultiplier(false, false)
 
 	hunter.registerAspectOfTheDragonhawkSpell()
 	hunter.registerAspectOfTheViperSpell()

--- a/sim/hunter/kill_shot.go
+++ b/sim/hunter/kill_shot.go
@@ -35,7 +35,7 @@ func (hunter *Hunter) registerKillShotSpell() {
 			5*core.CritRatingPerCritChance*float64(hunter.Talents.SniperTraining),
 		DamageMultiplier: 1 *
 			hunter.markedForDeathMultiplier(),
-		CritMultiplier:   hunter.critMultiplier(true, true, hunter.CurrentTarget),
+		CritMultiplier:   hunter.critMultiplier(true, true),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/hunter/multi_shot.go
+++ b/sim/hunter/multi_shot.go
@@ -44,7 +44,7 @@ func (hunter *Hunter) registerMultiShotSpell(timer *core.Timer) {
 			.04*float64(hunter.Talents.Barrage),
 		DamageMultiplier: 1 *
 			hunter.markedForDeathMultiplier(),
-		CritMultiplier:   hunter.critMultiplier(true, false, hunter.CurrentTarget),
+		CritMultiplier:   hunter.critMultiplier(true, false),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/hunter/pet_abilities.go
+++ b/sim/hunter/pet_abilities.go
@@ -534,7 +534,6 @@ func (hp *HunterPet) newPoisonSpit() PetAbility {
 			ActionID:    actionID,
 			SpellSchool: core.SpellSchoolNature,
 			ProcMask:    core.ProcMaskEmpty,
-			Flags:       core.SpellFlagIgnoreResists,
 
 			Cast: core.CastConfig{
 				DefaultCast: core.Cast{
@@ -722,7 +721,6 @@ func (hp *HunterPet) newScorpidPoison() PetAbility {
 			ActionID:    actionID,
 			SpellSchool: core.SpellSchoolNature,
 			ProcMask:    core.ProcMaskEmpty,
-			Flags:       core.SpellFlagIgnoreResists,
 
 			Cast: core.CastConfig{
 				DefaultCast: core.Cast{
@@ -851,7 +849,6 @@ func (hp *HunterPet) newSporeCloud() PetAbility {
 			ActionID:    actionID,
 			SpellSchool: core.SpellSchoolNature,
 			ProcMask:    core.ProcMaskSpellDamage,
-			Flags:       core.SpellFlagIgnoreResists,
 
 			Cast: core.CastConfig{
 				DefaultCast: core.Cast{
@@ -974,7 +971,6 @@ func (hp *HunterPet) newVenomWebSpray() PetAbility {
 			ActionID:    actionID,
 			SpellSchool: core.SpellSchoolNature,
 			ProcMask:    core.ProcMaskEmpty,
-			Flags:       core.SpellFlagIgnoreResists,
 
 			Cast: core.CastConfig{
 				CD: core.Cooldown{

--- a/sim/hunter/raptor_strike.go
+++ b/sim/hunter/raptor_strike.go
@@ -31,7 +31,7 @@ func (hunter *Hunter) registerRaptorStrikeSpell() {
 
 		BonusCritRating:  float64(hunter.Talents.SavageStrikes) * 10 * core.CritRatingPerCritChance,
 		DamageMultiplier: 1,
-		CritMultiplier:   hunter.critMultiplier(false, false, hunter.CurrentTarget),
+		CritMultiplier:   hunter.critMultiplier(false, false),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{

--- a/sim/hunter/serpent_sting.go
+++ b/sim/hunter/serpent_sting.go
@@ -31,7 +31,7 @@ func (hunter *Hunter) registerSerpentStingSpell() {
 		DamageMultiplierAdditive: 1 +
 			0.1*float64(hunter.Talents.ImprovedStings) +
 			core.TernaryFloat64(hunter.HasSetBonus(ItemSetScourgestalkerBattlegear, 2), .1, 0),
-		CritMultiplier:   hunter.critMultiplier(false, false, hunter.CurrentTarget),
+		CritMultiplier:   hunter.critMultiplier(false, false),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
@@ -59,7 +59,7 @@ func (hunter *Hunter) registerSerpentStingSpell() {
 			Tag:      "SerpentSting",
 			ActionID: actionID,
 			OnGain: func(aura *core.Aura, sim *core.Simulation) {
-				hunter.AttackTables[aura.Unit.UnitIndex].DamageDealtMultiplier *= noxiousStingsMultiplier
+				hunter.AttackTables[aura.Unit.UnitIndex].DamageTakenMultiplier *= noxiousStingsMultiplier
 				// Check for 1 because this aura will always be active inside OnGain.
 				if aura.Unit.NumActiveAurasWithTag("SerpentSting") == 1 {
 					for _, otherHunter := range huntersWithGlyphOfSteadyShot {
@@ -68,7 +68,7 @@ func (hunter *Hunter) registerSerpentStingSpell() {
 				}
 			},
 			OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-				hunter.AttackTables[aura.Unit.UnitIndex].DamageDealtMultiplier /= noxiousStingsMultiplier
+				hunter.AttackTables[aura.Unit.UnitIndex].DamageTakenMultiplier /= noxiousStingsMultiplier
 				if !aura.Unit.HasActiveAuraWithTag("SerpentSting") {
 					for _, otherHunter := range huntersWithGlyphOfSteadyShot {
 						otherHunter.SteadyShot.DamageMultiplierAdditive -= .1

--- a/sim/hunter/silencing_shot.go
+++ b/sim/hunter/silencing_shot.go
@@ -34,7 +34,7 @@ func (hunter *Hunter) registerSilencingShotSpell() {
 
 		DamageMultiplier: 0.5 *
 			hunter.markedForDeathMultiplier(),
-		CritMultiplier:   hunter.critMultiplier(true, false, hunter.CurrentTarget),
+		CritMultiplier:   hunter.critMultiplier(true, false),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/hunter/steady_shot.go
+++ b/sim/hunter/steady_shot.go
@@ -73,7 +73,7 @@ func (hunter *Hunter) registerSteadyShotSpell() {
 			core.TernaryFloat64(hunter.HasSetBonus(ItemSetGronnstalker, 4), .1, 0),
 		DamageMultiplier: 1 *
 			hunter.markedForDeathMultiplier(),
-		CritMultiplier:   hunter.critMultiplier(true, true, hunter.CurrentTarget),
+		CritMultiplier:   hunter.critMultiplier(true, true),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/hunter/talents.go
+++ b/sim/hunter/talents.go
@@ -118,7 +118,7 @@ func (hunter *Hunter) ApplyTalents() {
 	hunter.registerReadinessCD()
 }
 
-func (hunter *Hunter) critMultiplier(isRanged bool, isMFDSpell bool, target *core.Unit) float64 {
+func (hunter *Hunter) critMultiplier(isRanged bool, isMFDSpell bool) float64 {
 	primaryModifier := 1.0
 	secondaryModifier := 0.0
 
@@ -262,7 +262,7 @@ func (hunter *Hunter) applyPiercingShots() {
 		ActionID:    actionID,
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskEmpty,
-		Flags:       core.SpellFlagNoOnCastComplete | core.SpellFlagIgnoreModifiers,
+		Flags:       core.SpellFlagNoOnCastComplete | core.SpellFlagIgnoreModifiers | core.SpellFlagIgnoreResists,
 
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
@@ -339,7 +339,7 @@ func (hunter *Hunter) applyWildQuiver() {
 		Flags:       core.SpellFlagNoOnCastComplete,
 
 		DamageMultiplier: 0.8,
-		CritMultiplier:   hunter.critMultiplier(false, false, hunter.CurrentTarget),
+		CritMultiplier:   hunter.critMultiplier(false, false),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/hunter/volley.go
+++ b/sim/hunter/volley.go
@@ -49,7 +49,7 @@ func (hunter *Hunter) registerVolleySpell() {
 
 		DamageMultiplier: 1 *
 			(1 + 0.04*float64(hunter.Talents.Barrage)),
-		CritMultiplier:   hunter.critMultiplier(true, false, hunter.CurrentTarget),
+		CritMultiplier:   hunter.critMultiplier(true, false),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, _ *core.Spell) {

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -45,553 +45,553 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5932.30566
-  tps: 4295.88379
+  dps: 5863.45601
+  tps: 4296.31301
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5660.94037
-  tps: 4096.45319
+  dps: 5610.525
+  tps: 4107.18887
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5990.05491
-  tps: 4337.49905
+  dps: 5920.06358
+  tps: 4336.49115
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4736.88641
-  tps: 3465.35766
+  dps: 4690.68388
+  tps: 3468.37412
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 7019.06304
-  tps: 5025.59123
+  dps: 6935.28542
+  tps: 5030.35383
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5971.26741
-  tps: 4238.605
+  dps: 5901.96182
+  tps: 4239.03008
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6143.51796
-  tps: 4425.00807
+  dps: 6079.11086
+  tps: 4430.46442
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5794.41679
-  tps: 4167.97379
+  dps: 5736.48417
+  tps: 4170.2972
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5850.04673
-  tps: 4226.72767
+  dps: 5785.64368
+  tps: 4228.21947
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 5776.35237
-  tps: 4163.06267
+  dps: 5703.90976
+  tps: 4156.54616
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 5776.35237
-  tps: 4163.06267
+  dps: 5703.90976
+  tps: 4156.54616
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 5799.38579
-  tps: 4175.6232
+  dps: 5738.88066
+  tps: 4180.05439
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5826.14645
-  tps: 4196.12131
+  dps: 5752.668
+  tps: 4197.19311
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5660.94037
-  tps: 4096.45319
+  dps: 5610.525
+  tps: 4107.18887
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5981.84013
-  tps: 4320.47279
+  dps: 5928.43819
+  tps: 4330.36554
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5932.30566
-  tps: 4295.88379
+  dps: 5863.45601
+  tps: 4296.31301
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5947.17944
-  tps: 4315.95461
+  dps: 5884.52381
+  tps: 4319.45502
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5980.38159
-  tps: 4319.78722
+  dps: 5918.39392
+  tps: 4324.97044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5978.56764
-  tps: 4318.7193
+  dps: 5913.63863
+  tps: 4320.68737
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5932.30566
-  tps: 4295.88379
+  dps: 5863.45601
+  tps: 4296.31301
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5886.2937
-  tps: 4248.41646
+  dps: 5824.12186
+  tps: 4255.12356
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6045.30489
-  tps: 4346.21038
+  dps: 5969.00939
+  tps: 4339.02321
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5963.50057
-  tps: 4285.28228
+  dps: 5887.41621
+  tps: 4282.13092
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5971.26741
-  tps: 4323.55114
+  dps: 5901.96182
+  tps: 4323.9849
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5963.47506
-  tps: 4318.01767
+  dps: 5894.26066
+  tps: 4318.45052
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FrostfireGarb"
  value: {
-  dps: 5245.92781
-  tps: 3820.86183
+  dps: 5182.62275
+  tps: 3815.99057
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5660.94037
-  tps: 4096.45319
+  dps: 5610.525
+  tps: 4107.18887
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5899.97619
-  tps: 4253.92913
+  dps: 5815.07107
+  tps: 4242.03694
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5961.81891
-  tps: 4311.44978
+  dps: 5908.5196
+  tps: 4322.69364
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5980.38159
-  tps: 4319.78722
+  dps: 5918.39392
+  tps: 4324.97044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5978.56764
-  tps: 4318.7193
+  dps: 5913.63863
+  tps: 4320.68737
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5660.94037
-  tps: 4096.45319
+  dps: 5610.525
+  tps: 4107.18887
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5947.23935
-  tps: 4297.59945
+  dps: 5873.22209
+  tps: 4296.53661
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5932.30566
-  tps: 4295.88379
+  dps: 5863.45601
+  tps: 4296.31301
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 6246.19798
-  tps: 4459.29283
+  dps: 6165.62463
+  tps: 4455.29491
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KirinTorGarb"
  value: {
-  dps: 5679.11749
-  tps: 4128.52928
+  dps: 5617.51568
+  tps: 4131.11047
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5660.94037
-  tps: 4096.45319
+  dps: 5610.525
+  tps: 4107.18887
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5867.41709
-  tps: 4214.24551
+  dps: 5780.76622
+  tps: 4205.42906
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5837.21127
-  tps: 4195.63077
+  dps: 5763.17655
+  tps: 4192.74665
  }
 }
 dps_results: {
  key: "TestFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5660.94037
-  tps: 4096.45319
+  dps: 5610.525
+  tps: 4107.18887
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5932.30566
-  tps: 4295.88379
+  dps: 5863.45601
+  tps: 4296.31301
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5932.30566
-  tps: 4295.88379
+  dps: 5863.45601
+  tps: 4296.31301
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5932.30566
-  tps: 4295.88379
+  dps: 5863.45601
+  tps: 4296.31301
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5932.30566
-  tps: 4295.88379
+  dps: 5863.45601
+  tps: 4296.31301
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5660.94037
-  tps: 4096.45319
+  dps: 5610.525
+  tps: 4107.18887
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6230.8709
-  tps: 4510.5466
+  dps: 6174.43372
+  tps: 4520.00412
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6289.03976
-  tps: 4555.15317
+  dps: 6231.95158
+  tps: 4564.58928
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6092.15044
-  tps: 4398.82299
+  dps: 6020.43447
+  tps: 4399.13169
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5932.39204
-  tps: 4296.17952
+  dps: 5882.94899
+  tps: 4307.9983
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5660.94037
-  tps: 4096.45319
+  dps: 5610.525
+  tps: 4107.18887
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5660.94037
-  tps: 4096.45319
+  dps: 5610.525
+  tps: 4107.18887
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5660.94037
-  tps: 4096.45319
+  dps: 5610.525
+  tps: 4107.18887
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5660.94037
-  tps: 4096.45319
+  dps: 5610.525
+  tps: 4107.18887
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 5745.62792
-  tps: 4157.39014
+  dps: 5672.26068
+  tps: 4153.20843
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sunstrider'sRegalia"
  value: {
-  dps: 6104.06253
-  tps: 4374.26979
+  dps: 6039.87683
+  tps: 4381.43311
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5932.30566
-  tps: 4295.88379
+  dps: 5863.45601
+  tps: 4296.31301
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5932.30566
-  tps: 4295.88379
+  dps: 5863.45601
+  tps: 4296.31301
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5932.30566
-  tps: 4295.88379
+  dps: 5863.45601
+  tps: 4296.31301
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5932.30566
-  tps: 4295.88379
+  dps: 5863.45601
+  tps: 4296.31301
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5913.74393
-  tps: 4267.65515
+  dps: 5830.41443
+  tps: 4258.12011
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5913.74393
-  tps: 4267.65515
+  dps: 5830.41443
+  tps: 4258.12011
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5971.26741
-  tps: 4323.55114
+  dps: 5901.96182
+  tps: 4323.9849
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5963.47506
-  tps: 4318.01767
+  dps: 5894.26066
+  tps: 4318.45052
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5963.47506
-  tps: 4318.01767
+  dps: 5894.26066
+  tps: 4318.45052
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5971.26741
-  tps: 4323.55114
+  dps: 5901.96182
+  tps: 4323.9849
  }
 }
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
-  dps: 6077.44553
-  tps: 4391.68546
+  dps: 6005.95009
+  tps: 4391.10376
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18336.65941
-  tps: 18842.53357
+  dps: 18177.27623
+  tps: 18840.41046
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1829.3437
-  tps: 1414.25905
+  dps: 1809.59986
+  tps: 1413.49663
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2531.02
-  tps: 1822.86858
+  dps: 2491.86147
+  tps: 1812.46791
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14255.34232
-  tps: 15389.0618
+  dps: 14150.34979
+  tps: 15385.24846
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 871.33718
-  tps: 695.30325
+  dps: 862.8674
+  tps: 693.48176
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1417.1978
-  tps: 1033.28354
+  dps: 1400.98612
+  tps: 1030.08829
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8532.29381
-  tps: 7956.79543
+  dps: 8430.00702
+  tps: 7957.46292
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6143.51796
-  tps: 4425.00807
+  dps: 6079.11086
+  tps: 4430.46442
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7459.0041
-  tps: 5295.22013
+  dps: 7376.08352
+  tps: 5302.79241
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4780.56498
-  tps: 5120.04704
+  dps: 4738.86078
+  tps: 5122.75031
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2524.74543
-  tps: 1898.5033
+  dps: 2500.24781
+  tps: 1898.10491
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3630.60116
-  tps: 2632.66353
+  dps: 3598.76822
+  tps: 2638.64394
  }
 }
 dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6143.51796
-  tps: 4425.00807
+  dps: 6079.11086
+  tps: 4430.46442
  }
 }

--- a/sim/paladin/talents.go
+++ b/sim/paladin/talents.go
@@ -18,8 +18,8 @@ func (paladin *Paladin) ApplyTalents() {
 	paladin.AddStat(stats.MeleeCrit, float64(paladin.Talents.SanctityOfBattle)*core.CritRatingPerCritChance)
 	paladin.AddStat(stats.SpellCrit, float64(paladin.Talents.SanctityOfBattle)*core.CritRatingPerCritChance)
 
-	paladin.PseudoStats.BaseParry += 0.01*float64(paladin.Talents.Deflection)
-	paladin.PseudoStats.BaseDodge += 0.01*float64(paladin.Talents.Anticipation)
+	paladin.PseudoStats.BaseParry += 0.01 * float64(paladin.Talents.Deflection)
+	paladin.PseudoStats.BaseDodge += 0.01 * float64(paladin.Talents.Anticipation)
 
 	paladin.AddStat(stats.Armor, paladin.Equip.Stats()[stats.Armor]*0.02*float64(paladin.Talents.Toughness))
 
@@ -273,10 +273,10 @@ func (paladin *Paladin) applyCrusade() {
 				for i := int32(0); i < paladin.Env.GetNumTargets(); i++ {
 					unit := paladin.Env.GetTargetUnit(i)
 					switch unit.MobType {
-						case proto.MobType_MobTypeHumanoid, proto.MobType_MobTypeDemon, proto.MobType_MobTypeUndead, proto.MobType_MobTypeElemental:
-							paladin.AttackTables[unit.UnitIndex].DamageDealtMultiplier *= 1 + (0.02 * float64(paladin.Talents.Crusade))
-						default:
-							paladin.AttackTables[unit.UnitIndex].DamageDealtMultiplier *= 1 + (0.01 * float64(paladin.Talents.Crusade))
+					case proto.MobType_MobTypeHumanoid, proto.MobType_MobTypeDemon, proto.MobType_MobTypeUndead, proto.MobType_MobTypeElemental:
+						paladin.AttackTables[unit.UnitIndex].DamageDealtMultiplier *= 1 + (0.02 * float64(paladin.Talents.Crusade))
+					default:
+						paladin.AttackTables[unit.UnitIndex].DamageDealtMultiplier *= 1 + (0.01 * float64(paladin.Talents.Crusade))
 					}
 				}
 				applied = true
@@ -491,7 +491,7 @@ func (paladin *Paladin) registerRighteousVengeanceSpell() {
 		ActionID:    dotActionID,
 		SpellSchool: core.SpellSchoolHoly,
 		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIgnoreTargetModifiers | core.SpellFlagIgnoreAttackerModifiers,
+		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIgnoreModifiers,
 
 		DamageMultiplier: 1,
 		CritMultiplier:   paladin.MeleeCritMultiplier(),

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -346,15 +346,15 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7145.33051
-  tps: 5073.18466
+  dps: 7348.27527
+  tps: 5217.27544
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7145.33051
-  tps: 5073.18466
+  dps: 7373.11107
+  tps: 5234.90886
  }
 }
 dps_results: {

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -346,15 +346,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6292.02717
-  tps: 4467.33929
+  dps: 6441.65324
+  tps: 4573.5738
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6292.02717
-  tps: 4467.33929
+  dps: 6460.68784
+  tps: 4587.08837
  }
 }
 dps_results: {

--- a/sim/rogue/backstab.go
+++ b/sim/rogue/backstab.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (rogue *Rogue) registerBackstabSpell() {
-	baseCost := 60.0
+	baseCost := 60.0 - 4.0*float64(rogue.Talents.SlaughterFromTheShadows)
 	refundAmount := baseCost * 0.8
 
 	rogue.Backstab = rogue.RegisterSpell(core.SpellConfig{
@@ -31,19 +31,19 @@ func (rogue *Rogue) registerBackstabSpell() {
 		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0) +
 			10*core.CritRatingPerCritChance*float64(rogue.Talents.PuncturingWounds),
 		// All of these use "Apply Aura: Modifies Damage/Healing Done", and stack additively (up to 142%).
-		DamageMultiplierAdditive: 1 +
+		DamageMultiplier: 1.5 * (1 +
 			0.02*float64(rogue.Talents.FindWeakness) +
 			0.1*float64(rogue.Talents.Opportunity) +
-			0.02*float64(rogue.Talents.Aggression) +
+			0.03*float64(rogue.Talents.Aggression) +
+			0.05*float64(rogue.Talents.BladeTwisting) +
 			core.TernaryFloat64(rogue.Talents.SurpriseAttacks, 0.1, 0) +
-			core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0),
-		DamageMultiplier: 1 *
-			(1.5 + 0.01*float64(rogue.Talents.SinisterCalling)),
+			core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0)) *
+			(1 + 0.02*float64(rogue.Talents.SinisterCalling)),
 		CritMultiplier:   rogue.MeleeCritMultiplier(true, true),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
-			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 170, true),
+			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 310, true),
 			OutcomeApplier: rogue.OutcomeFuncMeleeSpecialHitAndCrit(),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {

--- a/sim/rogue/hemorrhage.go
+++ b/sim/rogue/hemorrhage.go
@@ -38,10 +38,9 @@ func (rogue *Rogue) registerHemorrhageSpell() {
 		},
 	})
 
-	baseCost := 35.0
+	baseCost := 35.0 - float64(rogue.Talents.SlaughterFromTheShadows)
 	refundAmount := baseCost * 0.8
 	daggerMH := rogue.Equip[proto.ItemSlot_ItemSlotMainHand].WeaponType == proto.WeaponType_WeaponTypeDagger
-	weaponDamageBonus := core.TernaryFloat64(daggerMH, 1.6, 1.1) + float64(rogue.Talents.SinisterCalling)*0.02
 	rogue.Hemorrhage = rogue.RegisterSpell(core.SpellConfig{
 		ActionID:     actionID,
 		SpellSchool:  core.SpellSchoolPhysical,
@@ -60,9 +59,10 @@ func (rogue *Rogue) registerHemorrhageSpell() {
 		},
 
 		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0),
-		DamageMultiplier: (1 +
+		DamageMultiplier: core.TernaryFloat64(daggerMH, 1.6, 1.1) * (1 +
 			0.02*float64(rogue.Talents.FindWeakness) +
-			core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0)) * weaponDamageBonus,
+			core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0)) *
+			(1 + 0.02*float64(rogue.Talents.SinisterCalling)),
 		CritMultiplier:   rogue.MeleeCritMultiplier(true, true),
 		ThreatMultiplier: 1,
 

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -21,7 +21,6 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 
 	procMask := core.ProcMaskMeleeMHSpecial
 	effect := core.SpellEffect{
-
 		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 181, false),
 		OutcomeApplier: rogue.OutcomeFuncMeleeSpecialHitAndCrit(),
 

--- a/sim/rogue/rupture.go
+++ b/sim/rogue/rupture.go
@@ -21,7 +21,7 @@ func (rogue *Rogue) makeRupture(comboPoints int32) *core.Spell {
 		ActionID:     core.ActionID{SpellID: RuptureSpellID, Tag: comboPoints},
 		SpellSchool:  core.SpellSchoolPhysical,
 		ProcMask:     core.ProcMaskMeleeMHSpecial,
-		Flags:        core.SpellFlagMeleeMetrics | core.SpellFlagIgnoreResists | rogue.finisherFlags(),
+		Flags:        core.SpellFlagMeleeMetrics | rogue.finisherFlags(),
 		ResourceType: stats.Energy,
 		BaseCost:     baseCost,
 

--- a/sim/rogue/shiv.go
+++ b/sim/rogue/shiv.go
@@ -18,7 +18,7 @@ func (rogue *Rogue) registerShivSpell() {
 		ActionID:     core.ActionID{SpellID: 5938},
 		SpellSchool:  core.SpellSchoolPhysical,
 		ProcMask:     core.ProcMaskMeleeOHSpecial,
-		Flags:        core.SpellFlagMeleeMetrics | SpellFlagBuilder | core.SpellFlagCannotBeDodged,
+		Flags:        core.SpellFlagMeleeMetrics | SpellFlagBuilder,
 		ResourceType: stats.Energy,
 		BaseCost:     cost,
 
@@ -39,7 +39,7 @@ func (rogue *Rogue) registerShivSpell() {
 
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.OffHand, true, 0, false),
-			OutcomeApplier: rogue.OutcomeFuncMeleeSpecialHitAndCrit(),
+			OutcomeApplier: rogue.OutcomeFuncMeleeSpecialNoBlockDodgeParryNoCrit(),
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if spellEffect.Landed() {
 					rogue.AddComboPoints(sim, 1, spell.ComboPointMetrics())
@@ -48,7 +48,9 @@ func (rogue *Rogue) registerShivSpell() {
 					case proto.Rogue_Options_DeadlyPoison:
 						rogue.DeadlyPoison.Cast(sim, spellEffect.Target)
 					case proto.Rogue_Options_InstantPoison:
-						rogue.InstantPoison[2].Cast(sim, spellEffect.Target)
+						rogue.InstantPoison[ShivProc].Cast(sim, spellEffect.Target)
+					case proto.Rogue_Options_WoundPoison:
+						rogue.WoundPoison[ShivProc].Cast(sim, spellEffect.Target)
 					}
 				}
 			},

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -579,8 +579,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Thrall'sRegalia"
  value: {
-  dps: 4364.10415
-  tps: 3329.38888
+  dps: 4366.01026
+  tps: 3334.20645
  }
 }
 dps_results: {
@@ -670,8 +670,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-WorldbreakerGarb"
  value: {
-  dps: 3895.54892
-  tps: 3014.29008
+  dps: 3891.6446
+  tps: 3011.01795
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -626,8 +626,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerGarb"
  value: {
-  dps: 5719.76192
-  tps: 3229.60086
+  dps: 5718.94422
+  tps: 3229.93743
  }
 }
 dps_results: {

--- a/sim/shaman/stormstrike.go
+++ b/sim/shaman/stormstrike.go
@@ -20,10 +20,10 @@ func (shaman *Shaman) StormstrikeDebuffAura(target *core.Unit) *core.Aura {
 		Duration:  time.Second * 12,
 		MaxStacks: 4,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			shaman.AttackTables[aura.Unit.UnitIndex].NatureDamageDealtMultiplier *= core.TernaryFloat64(shaman.HasMajorGlyph(proto.ShamanMajorGlyph_GlyphOfStormstrike), 1.28, 1.2)
+			shaman.AttackTables[aura.Unit.UnitIndex].NatureDamageTakenMultiplier *= core.TernaryFloat64(shaman.HasMajorGlyph(proto.ShamanMajorGlyph_GlyphOfStormstrike), 1.28, 1.2)
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			shaman.AttackTables[aura.Unit.UnitIndex].NatureDamageDealtMultiplier /= core.TernaryFloat64(shaman.HasMajorGlyph(proto.ShamanMajorGlyph_GlyphOfStormstrike), 1.28, 1.2)
+			shaman.AttackTables[aura.Unit.UnitIndex].NatureDamageTakenMultiplier /= core.TernaryFloat64(shaman.HasMajorGlyph(proto.ShamanMajorGlyph_GlyphOfStormstrike), 1.28, 1.2)
 
 		},
 		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {

--- a/sim/warlock/TestWarlock.results
+++ b/sim/warlock/TestWarlock.results
@@ -395,43 +395,43 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Destro Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5846.50895
-  tps: 6253.57404
+  dps: 5816.3929
+  tps: 6229.41036
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Destro Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5846.50895
-  tps: 4321.73764
+  dps: 5816.3929
+  tps: 4297.57396
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Destro Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6293.11549
-  tps: 4573.64978
+  dps: 6254.4366
+  tps: 4546.94346
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Destro Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3023.69779
-  tps: 4465.96506
+  dps: 2998.4192
+  tps: 4444.9047
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Destro Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3023.69779
-  tps: 2455.61789
+  dps: 2998.4192
+  tps: 2434.55753
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Destro Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3103.52724
-  tps: 2255.97764
+  dps: 3082.835
+  tps: 2240.39995
  }
 }
 dps_results: {

--- a/sim/warlock/chaos_bolt.go
+++ b/sim/warlock/chaos_bolt.go
@@ -15,11 +15,13 @@ func (warlock *Warlock) registerChaosBoltSpell() {
 	baseCost := 0.07 * warlock.BaseMana
 	spellCoeff := 0.7142 * (1 + 0.04*float64(warlock.Talents.ShadowAndFlame))
 
+	// ChaosBolt is affected by level-based partial resists.
+	// TODO If there's bosses with elevated fire resistances, we'd need another spell flag,
+	//  or add an unlimited amount of "bonusSpellPenetration".
 	warlock.ChaosBolt = warlock.RegisterSpell(core.SpellConfig{
 		ActionID:     actionID,
 		SpellSchool:  spellSchool,
 		ProcMask:     core.ProcMaskSpellDamage,
-		Flags:        core.SpellFlagIgnoreResists,
 		ResourceType: stats.Mana,
 		BaseCost:     baseCost,
 

--- a/sim/warlock/haunt.go
+++ b/sim/warlock/haunt.go
@@ -19,10 +19,10 @@ func (warlock *Warlock) HauntDebuffAura(target *core.Unit) *core.Aura {
 		ActionID: core.ActionID{SpellID: 59164},
 		Duration: time.Second * 12,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			warlock.AttackTables[aura.Unit.UnitIndex].PeriodicShadowDamageDealtMultiplier *= shadowDotMultiplier
+			warlock.AttackTables[aura.Unit.UnitIndex].PeriodicShadowDamageTakenMultiplier *= shadowDotMultiplier
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			warlock.AttackTables[aura.Unit.UnitIndex].PeriodicShadowDamageDealtMultiplier /= shadowDotMultiplier
+			warlock.AttackTables[aura.Unit.UnitIndex].PeriodicShadowDamageTakenMultiplier /= shadowDotMultiplier
 		},
 	})
 }

--- a/sim/warlock/talents.go
+++ b/sim/warlock/talents.go
@@ -302,8 +302,8 @@ func (warlock *Warlock) ShadowEmbraceDebuffAura(target *core.Unit) *core.Aura {
 		Duration:  time.Second * 12,
 		MaxStacks: 3,
 		OnStacksChange: func(aura *core.Aura, sim *core.Simulation, oldStacks int32, newStacks int32) {
-			warlock.AttackTables[aura.Unit.UnitIndex].PeriodicShadowDamageDealtMultiplier /= 1.0 + shadowEmbraceBonus*float64(oldStacks)
-			warlock.AttackTables[aura.Unit.UnitIndex].PeriodicShadowDamageDealtMultiplier *= 1.0 + shadowEmbraceBonus*float64(newStacks)
+			warlock.AttackTables[aura.Unit.UnitIndex].PeriodicShadowDamageTakenMultiplier /= 1.0 + shadowEmbraceBonus*float64(oldStacks)
+			warlock.AttackTables[aura.Unit.UnitIndex].PeriodicShadowDamageTakenMultiplier *= 1.0 + shadowEmbraceBonus*float64(newStacks)
 		},
 	})
 }

--- a/sim/warrior/sweeping_strikes.go
+++ b/sim/warrior/sweeping_strikes.go
@@ -13,22 +13,20 @@ func (warrior *Warrior) registerSweepingStrikesCD() {
 		return
 	}
 
-	actionID := core.ActionID{SpellID: 12328}
+	actionID := core.ActionID{SpellID: 12723}
 
 	var curDmg float64
 	ssHit := warrior.RegisterSpell(core.SpellConfig{
 		ActionID:    actionID,
 		SpellSchool: core.SpellSchoolPhysical,
-		// No proc mask, so it won't proc itself.
-		ProcMask: core.ProcMaskEmpty,
-		Flags:    core.SpellFlagMeleeMetrics | core.SpellFlagNoOnCastComplete,
+		ProcMask:    core.ProcMaskEmpty, // No proc mask, so it won't proc itself.
+		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagNoOnCastComplete | core.SpellFlagIgnoreAttackerModifiers,
 
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			// Cancel out caster multiplier so it doesn't double dip.
-			spell.CalcAndDealDamageAlwaysHit(sim, target, curDmg/spell.CasterDamageMultiplier())
+			spell.CalcAndDealDamageAlwaysHit(sim, target, curDmg)
 		},
 	})
 
@@ -45,7 +43,8 @@ func (warrior *Warrior) registerSweepingStrikesCD() {
 				return
 			}
 
-			// TODO: If the triggering spell is Execute and 2nd target health > 20%, do a normalized MH hit instead.
+			// TODO: If the triggering spell is Whirlwind, or an Execute that would sweeping strike a >20% target,
+			//  do a normalized MH hit instead. This is true for Sudden Death procs as well.
 
 			// Undo armor reduction to get the raw damage value.
 			curDmg = spellEffect.Damage / warrior.AttackTables[spellEffect.Target.Index].GetArmorDamageModifier(spell)


### PR DESCRIPTION
[core] SpellFlagIgnoreModifiers no longer includes SpellFlagIgnoreResists; removed SpellFlagIgnoreResists from various spells
[core] BonusPhysicalDamageTaken is now applied before all damage taken modifiers; added TargetDamageMultiplier(), the counterpart of AttackerDamageMultiplier()
[core] simplified various OutcomeApplier factories
[core] removed unused PseudoStats.DiseaseDamageDealtMultiplier
[core] added AttackTable.DamageTakenMultiplier, and used DamageDealtMultiplier as a TargetDamageMultiplier (e.g. for dot snapshotting)
[deathknight] damage multipliers now stack multiplicatively
[deathknight] scourge strike's shadow damage and wandering plague are now properly scaling from shadow damage multipliers
[druid] the feral tests were using 5/3 predatory instincts, so most results are substantially lower
[druid] brambles now affects treant damage ;)
[druid] genesis now adds its bonus additively
[hunter] fixed black arrow scaling (2.3% instead of 2% per tick)
[mage] Ignite now has partial resists
[rogue] poisons now have ProcMaskSpellDamage; Black Magic users rejoice
[rogue] fixed Backstab and Hemorrhage damage calculations; Sinister Calling affects them both multiplicatively now
[rogue] Shiv and the poison it applies now can't crit
[warlock] Chaos Bolt now has partial resists
[warrior, rogue] Sweeping Strikes and Blade Flurry use SpellFlagIgnoreAttackerModifiers now