### PR TITLE
Sparse-updates

### DIFF
--- a/sim/common/wotlk/enchant_effects.go
+++ b/sim/common/wotlk/enchant_effects.go
@@ -65,12 +65,12 @@ func init() {
 			return
 		}
 		procMask := core.GetMeleeProcMaskForHands(mh, oh)
-		ppmm := character.AutoAttacks.NewPPMManager(7.0, procMask)
+		ppmm := character.AutoAttacks.NewPPMManager(4.0, procMask)
 
 		procSpell := character.RegisterSpell(core.SpellConfig{
 			ActionID:    core.ActionID{SpellID: 44525},
 			SpellSchool: core.SpellSchoolFire,
-			ProcMask:    core.ProcMaskEmpty,
+			ProcMask:    core.ProcMaskSpellDamage,
 
 			DamageMultiplier: 1,
 			CritMultiplier:   character.DefaultSpellCritMultiplier(),
@@ -269,7 +269,7 @@ func init() {
 		w.BaseDamageMax += 15
 	})
 
-	core.NewItemEffect(54998, func(agent core.Agent) {
+	core.NewItemEffect(41091, func(agent core.Agent) {
 		character := agent.GetCharacter()
 		actionID := core.ActionID{SpellID: 54757}
 
@@ -358,7 +358,7 @@ func init() {
 		return character.RegisterSpell(core.SpellConfig{
 			ActionID:    core.ActionID{SpellID: 50401},
 			SpellSchool: core.SpellSchoolFrost,
-			ProcMask:    core.ProcMaskEmpty,
+			ProcMask:    core.ProcMaskSpellDamage,
 
 			DamageMultiplier: 1,
 			ThreatMultiplier: 1,

--- a/sim/core/target.go
+++ b/sim/core/target.go
@@ -226,8 +226,10 @@ type AttackTable struct {
 	PartialResistNatureThresholds Thresholds
 	PartialResistShadowThresholds Thresholds
 
-	DamageDealtMultiplier               float64
-	DamageTakenMultiplier               float64
+	// These damage multipliers are used if they apply to a specific attacker-defender pair only,
+	//  e.g. Stormstrike increases the caster's damage vs the debuffed mob, but noone else is affected.
+	DamageDealtMultiplier               float64 // attacker buff, used for e.g. DoT snapshotting
+	DamageTakenMultiplier               float64 // defender debuff, changing DoT ticks dynamically
 	NatureDamageTakenMultiplier         float64
 	PeriodicShadowDamageTakenMultiplier float64
 	HealingDealtMultiplier              float64

--- a/sim/hunter/talents.go
+++ b/sim/hunter/talents.go
@@ -262,7 +262,7 @@ func (hunter *Hunter) applyPiercingShots() {
 		ActionID:    actionID,
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskEmpty,
-		Flags:       core.SpellFlagNoOnCastComplete | core.SpellFlagIgnoreModifiers | core.SpellFlagIgnoreResists,
+		Flags:       core.SpellFlagNoOnCastComplete | core.SpellFlagIgnoreModifiers,
 
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -570,8 +570,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11734.59579
-  tps: 10156.49697
+  dps: 11087.28114
+  tps: 9641.0798
  }
 }
 dps_results: {
@@ -591,8 +591,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7002.26586
-  tps: 6205.40306
+  dps: 6588.32044
+  tps: 5870.84162
  }
 }
 dps_results: {
@@ -612,8 +612,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11746.89556
-  tps: 10177.35783
+  dps: 11119.56369
+  tps: 9674.5127
  }
 }
 dps_results: {
@@ -633,8 +633,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7093.60639
-  tps: 6294.38503
+  dps: 6712.50855
+  tps: 5991.12761
  }
 }
 dps_results: {

--- a/sim/warrior/sweeping_strikes.go
+++ b/sim/warrior/sweeping_strikes.go
@@ -34,9 +34,9 @@ func (warrior *Warrior) registerSweepingStrikesCD() {
 		Label:     "Sweeping Strikes",
 		ActionID:  actionID,
 		Duration:  core.NeverExpires,
-		MaxStacks: 10,
+		MaxStacks: 5,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			aura.SetStacks(sim, 10)
+			aura.SetStacks(sim, 5)
 		},
 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 			if aura.GetStacks() == 0 || spellEffect.Damage == 0 || !spell.ProcMask.Matches(core.ProcMaskMelee) {


### PR DESCRIPTION
[common] Icebreaker is now using 4 ppm, as per testing; Icebreaker and Rune of Razorice both updated to ProcMaskSpellDamage (they both proc Black Magic)
[core] sprinkled some comments
[warrior] reduced Sweeping Strike charges to 5, as per sad reality

Testing Icebreaker (using two 2.7 speed weapons):
https://classic.warcraftlogs.com/reports/vZwNHJf8c1mr9gGd

Icebreaker into Black Magic:
![Screenshot 2022-10-12 at 23 54 37](https://user-images.githubusercontent.com/9415187/195455280-d29949b0-4134-499e-b567-6a3edd09dd2f.png)

Rune of Razorice into Black Magic:
![Screenshot 2022-10-12 at 23 40 18](https://user-images.githubusercontent.com/9415187/195455307-f3cc973d-80f3-42c0-b189-977e6621fefa.png)
