### PR TITLE
Testing stability

### DIFF
--- a/sim/core/major_cooldown.go
+++ b/sim/core/major_cooldown.go
@@ -392,13 +392,13 @@ func (mcdm *majorCooldownManager) TryUseCooldowns(sim *Simulation) {
 
 // sortOne will take the given mcd and attempt to sort it towards the back.
 // If it finds a linked CD (like trinkets that share offensive CD) it will sort them backwards first.
-//  If while sorting it finds something further back with lower CD than the previous one (for example, after activating cold snap)
-//  it will mark that the whole slice needs to be re-sorted "mcdm.fullSort" and returns immediately.
+//	If while sorting it finds something further back with lower CD than the previous one (for example, after activating cold snap)
+//	it will mark that the whole slice needs to be re-sorted "mcdm.fullSort" and returns immediately.
 func (mcdm *majorCooldownManager) sortOne(mcd *MajorCooldown, curIdx int) bool {
 	newReadyAt := mcd.ReadyAt()
 	var lastReadAt time.Duration
 	for sortIdx := curIdx + 1; sortIdx < len(mcdm.majorCooldowns); sortIdx++ {
-		if mcdm.majorCooldowns[sortIdx].Spell.SharedCD.Timer == mcd.Spell.SharedCD.Timer {
+		if mcd.Spell.SharedCD.Timer != nil && mcdm.majorCooldowns[sortIdx].Spell.SharedCD.Timer == mcd.Spell.SharedCD.Timer {
 			mcdm.sortOne(mcdm.majorCooldowns[sortIdx], sortIdx)
 			if mcdm.fullSort {
 				return true
@@ -438,7 +438,7 @@ func (mcdm *majorCooldownManager) UpdateMajorCooldowns() {
 }
 
 func (mcdm *majorCooldownManager) sort() {
-	sort.Slice(mcdm.majorCooldowns, func(i, j int) bool {
+	sort.SliceStable(mcdm.majorCooldowns, func(i, j int) bool {
 		// Since we're just comparing and don't actually care about the remaining CD, ok to use 0 instead of sim.CurrentTime.
 		cdA := mcdm.majorCooldowns[i].ReadyAt()
 		cdB := mcdm.majorCooldowns[j].ReadyAt()

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -45,646 +45,646 @@ character_stats_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1480.09805
-  tps: 4523.03836
+  dps: 1479.78346
+  tps: 4501.9521
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1556.68497
-  tps: 4716.49412
+  dps: 1557.91536
+  tps: 4707.46776
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1481.7402
-  tps: 4523.66536
+  dps: 1480.4678
+  tps: 4500.61584
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1450.60623
-  tps: 4419.02152
+  dps: 1455.11582
+  tps: 4441.51472
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1348.83475
-  tps: 4123.56003
+  dps: 1373.13859
+  tps: 4181.19184
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1317.99947
-  tps: 4024.42639
+  dps: 1320.86056
+  tps: 4018.29923
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1232.46207
-  tps: 3775.80244
+  dps: 1227.57069
+  tps: 3754.07289
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1477.46863
-  tps: 4424.5121
+  dps: 1477.15488
+  tps: 4403.87156
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1493.88547
-  tps: 4561.72582
+  dps: 1492.32187
+  tps: 4538.14492
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1499.28276
-  tps: 4581.08705
+  dps: 1496.57122
+  tps: 4552.32154
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1562.76707
-  tps: 4720.62562
+  dps: 1559.24694
+  tps: 4697.76357
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 1577.63847
-  tps: 4833.62825
+  dps: 1576.18751
+  tps: 4804.26099
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 1544.96573
-  tps: 4723.5097
+  dps: 1543.31864
+  tps: 4694.27128
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 1532.34691
-  tps: 4695.50177
+  dps: 1530.82859
+  tps: 4666.54546
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 1628.58579
-  tps: 4945.05408
+  dps: 1622.72724
+  tps: 4942.29912
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedPlate"
  value: {
-  dps: 1450.20319
-  tps: 4451.0049
+  dps: 1455.65387
+  tps: 4429.98046
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 1494.12804
-  tps: 4563.62878
+  dps: 1493.78657
+  tps: 4542.12154
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1491.25031
-  tps: 4556.73833
+  dps: 1489.64089
+  tps: 4532.7252
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1488.48457
-  tps: 4549.28821
+  dps: 1488.16732
+  tps: 4528.12385
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1482.00422
-  tps: 4524.2128
+  dps: 1480.7354
+  tps: 4501.17071
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1477.46863
-  tps: 4514.80826
+  dps: 1477.15488
+  tps: 4493.74649
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1477.46863
-  tps: 4514.80826
+  dps: 1477.15488
+  tps: 4493.74649
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1481.7402
-  tps: 4523.66536
+  dps: 1480.4678
+  tps: 4500.61584
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1480.95223
-  tps: 4522.03151
+  dps: 1479.55322
+  tps: 4498.71945
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1477.46863
-  tps: 4514.80826
+  dps: 1477.15488
+  tps: 4493.74649
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1540.56823
-  tps: 4651.29787
+  dps: 1543.12064
+  tps: 4679.37679
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1496.61669
-  tps: 4575.72589
+  dps: 1494.34985
+  tps: 4550.21741
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1491.90443
-  tps: 4560.86077
+  dps: 1491.3239
+  tps: 4538.68396
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1477.46863
-  tps: 4514.80826
+  dps: 1477.15488
+  tps: 4493.74649
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1477.46863
-  tps: 4514.80826
+  dps: 1477.15488
+  tps: 4493.74649
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 1497.39131
-  tps: 4572.69501
+  dps: 1497.03641
+  tps: 4551.08688
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1539.25097
-  tps: 4704.33159
+  dps: 1539.08118
+  tps: 4683.23172
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1480.09805
-  tps: 4523.03836
+  dps: 1479.78346
+  tps: 4501.9521
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 1488.17539
-  tps: 4544.46394
+  dps: 1488.04746
+  tps: 4524.45828
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1480.09805
-  tps: 4523.03836
+  dps: 1479.78346
+  tps: 4501.9521
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1481.7402
-  tps: 4523.66536
+  dps: 1480.4678
+  tps: 4500.61584
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1480.95223
-  tps: 4522.03151
+  dps: 1479.55322
+  tps: 4498.71945
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1524.98052
-  tps: 4647.09493
+  dps: 1524.51211
+  tps: 4625.43589
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1477.46863
-  tps: 4514.80826
+  dps: 1477.15488
+  tps: 4493.74649
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1485.79348
-  tps: 4540.8651
+  dps: 1485.47709
+  tps: 4519.7258
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1480.09805
-  tps: 4523.03836
+  dps: 1479.78346
+  tps: 4501.9521
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1480.09805
-  tps: 4523.03836
+  dps: 1479.78346
+  tps: 4501.9521
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1513.5501
-  tps: 4580.5136
+  dps: 1510.48731
+  tps: 4578.32305
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1489.86411
-  tps: 4539.51095
+  dps: 1496.18722
+  tps: 4554.01751
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1484.2078
-  tps: 4535.90189
+  dps: 1483.8919
+  tps: 4514.77736
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1485.79348
-  tps: 4540.8651
+  dps: 1485.47709
+  tps: 4519.7258
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1477.46863
-  tps: 4514.80826
+  dps: 1477.15488
+  tps: 4493.74649
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1477.46863
-  tps: 4514.80826
+  dps: 1477.15488
+  tps: 4493.74649
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1480.09805
-  tps: 4523.03836
+  dps: 1479.78346
+  tps: 4501.9521
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1495.48847
-  tps: 4544.95541
+  dps: 1495.57688
+  tps: 4541.24971
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1496.32009
-  tps: 4546.67977
+  dps: 1496.32563
+  tps: 4542.80224
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1493.46223
-  tps: 4561.28181
+  dps: 1491.76286
+  tps: 4537.4159
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 1501.19845
-  tps: 4583.27228
+  dps: 1500.82789
+  tps: 4561.54645
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1477.46863
-  tps: 4514.80826
+  dps: 1477.15488
+  tps: 4493.74649
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1480.09805
-  tps: 4523.03836
+  dps: 1479.78346
+  tps: 4501.9521
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 1487.00214
-  tps: 4541.50172
+  dps: 1486.85763
+  tps: 4521.38317
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 1552.27232
-  tps: 4747.72984
+  dps: 1543.12842
+  tps: 4727.81124
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgebornePlate"
  value: {
-  dps: 1412.25275
-  tps: 4339.15905
+  dps: 1432.05448
+  tps: 4374.16805
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 1775.99782
-  tps: 5408.87025
+  dps: 1776.99823
+  tps: 5429.60485
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 1571.6544
-  tps: 4796.58862
+  dps: 1571.46811
+  tps: 4806.0072
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1487.28442
-  tps: 4547.11272
+  dps: 1486.58336
+  tps: 4524.99022
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1480.09805
-  tps: 4523.03836
+  dps: 1479.78346
+  tps: 4501.9521
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 1479.08576
-  tps: 4520.93938
+  dps: 1480.11815
+  tps: 4505.45302
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 1492.88478
-  tps: 4563.99607
+  dps: 1492.84828
+  tps: 4543.54337
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 1485.58498
-  tps: 4542.2856
+  dps: 1485.15521
+  tps: 4520.72357
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1480.09805
-  tps: 4523.03836
+  dps: 1479.78346
+  tps: 4501.9521
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 1482.9152
-  tps: 4514.9252
+  dps: 1490.62458
+  tps: 4507.7674
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-StormshroudArmor"
  value: {
-  dps: 1217.75056
-  tps: 3725.37415
+  dps: 1226.98489
+  tps: 3753.3382
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1485.79348
-  tps: 4540.8651
+  dps: 1485.47709
+  tps: 4519.7258
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1484.2078
-  tps: 4535.90189
+  dps: 1483.8919
+  tps: 4514.77736
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1481.43284
-  tps: 4527.21628
+  dps: 1481.11783
+  tps: 4506.11759
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 1722.19313
-  tps: 5208.8504
+  dps: 1737.84372
+  tps: 5231.42507
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sPlate"
  value: {
-  dps: 1479.56313
-  tps: 4535.53763
+  dps: 1481.92702
+  tps: 4539.81714
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1481.78062
-  tps: 4527.57461
+  dps: 1491.94313
+  tps: 4523.90188
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1539.83783
-  tps: 4654.13159
+  dps: 1543.00743
+  tps: 4654.37607
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1542.45763
-  tps: 4658.82182
+  dps: 1567.62548
+  tps: 4709.98891
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1477.46863
-  tps: 4514.80826
+  dps: 1477.15488
+  tps: 4493.74649
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1477.46863
-  tps: 4514.80826
+  dps: 1477.15488
+  tps: 4493.74649
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1477.46863
-  tps: 4514.80826
+  dps: 1477.15488
+  tps: 4493.74649
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1477.46863
-  tps: 4514.80826
+  dps: 1477.15488
+  tps: 4493.74649
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1319.45095
-  tps: 4008.78878
+  dps: 1304.97224
+  tps: 3972.23189
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 1505.54947
-  tps: 4595.36058
+  dps: 1505.16102
+  tps: 4573.50024
  }
 }
 dps_results: {
  key: "TestBloodTank-Average-Default"
  value: {
-  dps: 1862.64404
-  tps: 6255.45846
-  dtps: 271.44284
+  dps: 1876.65563
+  tps: 6256.04864
+  dtps: 272.55767
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5136.72741
-  tps: 12169.06317
+  dps: 5312.54436
+  tps: 12421.6383
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1480.80988
-  tps: 4582.96934
+  dps: 1535.40987
+  tps: 4594.47978
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1680.80123
-  tps: 5645.82972
+  dps: 1754.43559
+  tps: 5616.29537
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3639.42372
-  tps: 8454.93073
+  dps: 3652.57273
+  tps: 8400.45411
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 819.74866
-  tps: 2600.53992
+  dps: 865.35314
+  tps: 2615.50185
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 886.28092
-  tps: 3149.09332
+  dps: 1007.18165
+  tps: 3115.62767
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5297.4157
-  tps: 12424.49007
+  dps: 5360.85999
+  tps: 12538.79953
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1549.48944
-  tps: 4663.23389
+  dps: 1550.66186
+  tps: 4643.40428
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1799.03594
-  tps: 5767.87128
+  dps: 1783.96527
+  tps: 5728.42269
  }
 }
 dps_results: {
@@ -711,8 +711,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1911.21632
-  tps: 6339.68553
-  dtps: 265.60917
+  dps: 1919.35482
+  tps: 6288.24752
+  dtps: 267.19236
  }
 }

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -403,7 +403,7 @@ dps_results: {
  key: "TestBalance-AllItems-OfferingofSacrifice-37638"
  value: {
   dps: 7044.42416
-  tps: 6868.34107
+  tps: 6868.53475
  }
 }
 dps_results: {
@@ -515,7 +515,7 @@ dps_results: {
  key: "TestBalance-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
   dps: 7044.42416
-  tps: 6864.9375
+  tps: 6864.83082
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -626,8 +626,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 7403.48537
-  tps: 5649.99084
+  dps: 7403.48379
+  tps: 5649.98973
  }
 }
 dps_results: {

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -282,7 +282,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) {
 		pendingActions = append(pendingActions, pendingAction{cat.SavageRoarAura.ExpiresAt(), roarCost})
 	}
 
-	sort.Slice(pendingActions, func(i, j int) bool {
+	sort.SliceStable(pendingActions, func(i, j int) bool {
 		return pendingActions[i].refreshTime < pendingActions[j].refreshTime
 	})
 

--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -45,519 +45,519 @@ character_stats_results: {
 dps_results: {
  key: "TestHunter-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 7485.22033
-  tps: 6488.40811
+  dps: 7500.71223
+  tps: 6509.37366
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 6618.2733
-  tps: 5603.48191
+  dps: 6654.9264
+  tps: 5642.61912
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6705.73621
-  tps: 5683.8273
+  dps: 6746.38261
+  tps: 5721.28485
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6730.94814
-  tps: 5709.77314
+  dps: 6763.84919
+  tps: 5745.03312
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6722.23839
-  tps: 5705.33784
+  dps: 6746.40446
+  tps: 5721.61144
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6634.06518
-  tps: 5624.33454
+  dps: 6585.92769
+  tps: 5575.18038
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 6340.4029
-  tps: 5328.48872
+  dps: 6315.65506
+  tps: 5294.33374
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5781.75981
-  tps: 4893.59687
+  dps: 5771.39548
+  tps: 4890.15636
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5545.78488
-  tps: 4672.84453
+  dps: 5533.60371
+  tps: 4662.79123
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6705.73621
-  tps: 5571.05237
+  dps: 6746.38261
+  tps: 5607.76569
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6859.59309
-  tps: 5837.68417
+  dps: 6897.15324
+  tps: 5872.05547
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 6169.85839
-  tps: 5190.45179
+  dps: 6149.54649
+  tps: 5173.58437
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6665.96826
-  tps: 5658.49706
+  dps: 6726.2777
+  tps: 5716.87086
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6708.08111
-  tps: 5700.63677
+  dps: 6751.77163
+  tps: 5741.69194
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6730.05948
-  tps: 5713.07032
+  dps: 6755.49885
+  tps: 5739.15136
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6700.2963
-  tps: 5682.44232
+  dps: 6737.93858
+  tps: 5718.1725
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6678.10806
-  tps: 5670.5178
+  dps: 6697.49574
+  tps: 5688.08891
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6631.80249
-  tps: 5622.13719
+  dps: 6604.89634
+  tps: 5597.84677
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6730.01446
-  tps: 5708.10555
+  dps: 6766.64796
+  tps: 5741.5502
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6705.73621
-  tps: 5683.8273
+  dps: 6746.38261
+  tps: 5721.28485
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6718.33635
-  tps: 5695.0531
+  dps: 6687.99245
+  tps: 5671.62006
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6726.20765
-  tps: 5704.29873
+  dps: 6762.30477
+  tps: 5737.207
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6723.63026
-  tps: 5701.72135
+  dps: 6760.80201
+  tps: 5735.70424
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6705.73621
-  tps: 5683.8273
+  dps: 6746.38261
+  tps: 5721.28485
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6720.41063
-  tps: 5713.01219
+  dps: 6771.79998
+  tps: 5762.32873
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6648.95597
-  tps: 5641.48476
+  dps: 6708.14978
+  tps: 5698.74295
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6643.07092
-  tps: 5632.69386
+  dps: 6691.33013
+  tps: 5681.32659
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6705.73621
-  tps: 5683.8273
+  dps: 6746.38261
+  tps: 5721.28485
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6705.73621
-  tps: 5683.8273
+  dps: 6746.38261
+  tps: 5721.28485
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6631.80249
-  tps: 5622.13719
+  dps: 6604.89634
+  tps: 5597.84677
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 7017.35358
-  tps: 6053.95939
+  dps: 7065.82973
+  tps: 6097.57557
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5280.763
-  tps: 4438.79668
+  dps: 5280.05509
+  tps: 4440.36751
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6568.89209
-  tps: 5559.34978
+  dps: 6604.89634
+  tps: 5597.84677
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6726.20765
-  tps: 5704.29873
+  dps: 6762.30477
+  tps: 5737.207
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6723.63026
-  tps: 5701.72135
+  dps: 6760.80201
+  tps: 5735.70424
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6783.4274
-  tps: 5764.54896
+  dps: 6756.88428
+  tps: 5740.64997
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6919.7539
-  tps: 5910.12511
+  dps: 6906.03055
+  tps: 5889.43297
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6730.03493
-  tps: 5705.51047
+  dps: 6770.83491
+  tps: 5743.11454
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6631.80249
-  tps: 5622.13719
+  dps: 6604.89634
+  tps: 5597.84677
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6584.99041
-  tps: 5576.40487
+  dps: 6592.0999
+  tps: 5578.78124
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6747.39256
-  tps: 5734.56627
+  dps: 6735.60724
+  tps: 5725.32778
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6630.54577
-  tps: 5620.88046
+  dps: 6604.89634
+  tps: 5597.84677
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6725.4066
-  tps: 5701.38034
+  dps: 6766.17733
+  tps: 5738.9565
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6730.03493
-  tps: 5705.51047
+  dps: 6770.83491
+  tps: 5743.11454
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6705.73621
-  tps: 5683.8273
+  dps: 6746.38261
+  tps: 5721.28485
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6705.73621
-  tps: 5683.8273
+  dps: 6746.38261
+  tps: 5721.28485
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6568.89209
-  tps: 5559.34978
+  dps: 6604.89634
+  tps: 5597.84677
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6568.89209
-  tps: 5559.34978
+  dps: 6604.89634
+  tps: 5597.84677
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6568.89209
-  tps: 5559.34978
+  dps: 6604.89634
+  tps: 5597.84677
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6865.60527
-  tps: 5842.20026
+  dps: 6908.48055
+  tps: 5881.88265
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6681.65568
-  tps: 5654.26678
+  dps: 6749.19129
+  tps: 5733.02772
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6631.80249
-  tps: 5622.13719
+  dps: 6604.89634
+  tps: 5597.84677
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 6520.16163
-  tps: 5547.97635
+  dps: 6471.1819
+  tps: 5502.76406
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6631.80249
-  tps: 5622.13719
+  dps: 6604.89634
+  tps: 5597.84677
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6568.89209
-  tps: 5559.34978
+  dps: 6604.89634
+  tps: 5597.84677
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6630.44596
-  tps: 5620.78065
+  dps: 6604.89634
+  tps: 5597.84677
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SparkofLife-37657"
  value: {
-  dps: 6807.25273
-  tps: 5796.35502
+  dps: 6759.76273
+  tps: 5745.85109
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StormshroudArmor"
  value: {
-  dps: 5389.95399
-  tps: 4536.18703
+  dps: 5399.17399
+  tps: 4540.88839
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6730.03493
-  tps: 5705.51047
+  dps: 6770.83491
+  tps: 5743.11454
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6725.4066
-  tps: 5701.38034
+  dps: 6766.17733
+  tps: 5738.9565
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6717.30703
-  tps: 5694.15262
+  dps: 6758.02657
+  tps: 5731.67994
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheFistsofFury"
  value: {
-  dps: 6524.57862
-  tps: 5525.09807
+  dps: 6504.93735
+  tps: 5498.82903
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6763.98242
-  tps: 5744.12416
+  dps: 6700.32973
+  tps: 5678.66735
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6569.1228
-  tps: 5559.58049
+  dps: 6605.10799
+  tps: 5598.05841
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6569.1228
-  tps: 5559.58049
+  dps: 6605.10799
+  tps: 5598.05841
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6705.73621
-  tps: 5683.8273
+  dps: 6746.38261
+  tps: 5721.28485
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6705.73621
-  tps: 5683.8273
+  dps: 6746.38261
+  tps: 5721.28485
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6705.73621
-  tps: 5683.8273
+  dps: 6746.38261
+  tps: 5721.28485
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6705.73621
-  tps: 5683.8273
+  dps: 6746.38261
+  tps: 5721.28485
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5702.68126
-  tps: 4833.82598
+  dps: 5700.62596
+  tps: 4820.17181
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 6925.20605
-  tps: 5917.3482
+  dps: 6886.4568
+  tps: 5870.86156
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7309.72142
-  tps: 6293.19759
+  dps: 7359.78843
+  tps: 6341.32734
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 7554.22365
-  tps: 6537.97319
+  dps: 7570.81095
+  tps: 6555.88204
  }
 }
 dps_results: {
  key: "TestHunter-Average-Default"
  value: {
-  dps: 6812.77121
-  tps: 5795.79981
+  dps: 6803.62443
+  tps: 5784.05916
  }
 }
 dps_results: {
@@ -605,64 +605,64 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-BM-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6253.08433
-  tps: 4775.92892
+  dps: 6238.70884
+  tps: 4737.43558
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-BM-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6253.08433
-  tps: 3831.38448
+  dps: 6238.70884
+  tps: 3806.348
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-BM-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7578.59895
-  tps: 4639.431
+  tps: 4638.4095
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-BM-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2999.64779
-  tps: 3670.22645
+  dps: 3014.21007
+  tps: 3677.87417
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-BM-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2999.64779
-  tps: 2161.95248
+  dps: 3014.21007
+  tps: 2171.00249
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-BM-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3579.79639
-  tps: 2567.22038
+  dps: 3544.25409
+  tps: 2522.01763
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6580.3614
-  tps: 6480.37606
+  dps: 6587.33867
+  tps: 6485.84583
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6580.3614
-  tps: 5613.54654
+  dps: 6587.33867
+  tps: 5617.2746
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7641.64723
-  tps: 6552.82369
+  dps: 7757.25792
+  tps: 6655.2283
  }
 }
 dps_results: {
@@ -773,64 +773,64 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6408.66135
-  tps: 4767.0247
+  dps: 6404.75749
+  tps: 4780.08601
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6408.66135
-  tps: 3830.83802
+  dps: 6404.75749
+  tps: 3845.28443
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7744.64265
-  tps: 4613.58867
+  tps: 4612.53922
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3022.67688
-  tps: 3642.58222
+  dps: 3044.38759
+  tps: 3659.71321
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3022.67688
-  tps: 2138.27253
+  dps: 3044.38759
+  tps: 2155.38573
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3653.18675
-  tps: 2578.39983
+  dps: 3624.80815
+  tps: 2536.01217
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6603.99883
-  tps: 6451.53463
+  dps: 6588.69835
+  tps: 6446.14155
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6603.99883
-  tps: 5588.29088
+  dps: 6588.69835
+  tps: 5575.75518
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7716.49934
-  tps: 6562.72234
+  dps: 7792.33649
+  tps: 6613.678
  }
 }
 dps_results: {
@@ -899,7 +899,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6760.76538
-  tps: 5809.28849
+  dps: 6820.19668
+  tps: 5862.32033
  }
 }

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -45,553 +45,553 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6811.2375
-  tps: 4077.85006
+  dps: 6821.02533
+  tps: 4083.73111
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6630.98627
-  tps: 3975.70389
+  dps: 6642.60209
+  tps: 3982.32692
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6829.63086
-  tps: 4087.79152
+  dps: 6843.09752
+  tps: 4095.64561
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5741.69539
-  tps: 3448.93524
+  dps: 5740.76346
+  tps: 3447.44462
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 7635.745
-  tps: 4581.14208
+  dps: 7652.32889
+  tps: 4592.16493
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6850.49752
-  tps: 4020.25756
+  dps: 6860.33459
+  tps: 4026.0501
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6991.61679
-  tps: 4185.97369
+  dps: 7001.56128
+  tps: 4191.94873
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6707.64665
-  tps: 4021.41876
+  dps: 6718.56223
+  tps: 4027.6951
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6725.8643
-  tps: 4053.40017
+  dps: 6759.49568
+  tps: 4070.72985
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6698.16917
-  tps: 4013.31432
+  dps: 6704.50474
+  tps: 4016.8502
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6698.16917
-  tps: 4013.31432
+  dps: 6704.50474
+  tps: 4016.8502
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6754.82609
-  tps: 4042.47404
+  dps: 6759.77165
+  tps: 4043.76005
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6655.65042
-  tps: 3990.50238
+  dps: 6666.23805
+  tps: 3996.50849
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6639.73187
-  tps: 3980.60223
+  dps: 6642.60209
+  tps: 3982.32692
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6829.48575
-  tps: 4088.60876
+  dps: 6839.27358
+  tps: 4094.48981
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6811.2375
-  tps: 4077.85006
+  dps: 6821.02533
+  tps: 4083.73111
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6862.23866
-  tps: 4106.81714
+  dps: 6877.30218
+  tps: 4115.65576
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6826.12106
-  tps: 4086.67625
+  dps: 6835.90889
+  tps: 4092.5573
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6821.97312
-  tps: 4084.18749
+  dps: 6831.76095
+  tps: 4090.06853
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6811.2375
-  tps: 4077.85006
+  dps: 6821.02533
+  tps: 4083.73111
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6701.57863
-  tps: 4017.55757
+  dps: 6712.37177
+  tps: 4023.8339
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6893.45183
-  tps: 4131.55078
+  dps: 6904.58041
+  tps: 4137.94782
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6852.16033
-  tps: 4107.44818
+  dps: 6862.87095
+  tps: 4113.60155
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6850.49752
-  tps: 4101.00005
+  dps: 6860.33459
+  tps: 4106.91064
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6842.64552
-  tps: 4096.37005
+  dps: 6852.47274
+  tps: 4102.27473
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FrostfireGarb"
  value: {
-  dps: 6052.79472
-  tps: 3629.85786
+  dps: 6076.79277
+  tps: 3644.1157
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6630.98627
-  tps: 3975.70389
+  dps: 6642.60209
+  tps: 3982.32692
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6724.07752
-  tps: 4026.83901
+  dps: 6726.33954
+  tps: 4032.39317
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6941.45734
-  tps: 4160.23057
+  dps: 6953.36261
+  tps: 4167.01597
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6826.12106
-  tps: 4086.67625
+  dps: 6835.90889
+  tps: 4092.5573
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6821.97312
-  tps: 4084.18749
+  dps: 6831.76095
+  tps: 4090.06853
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6639.73187
-  tps: 3980.60223
+  dps: 6642.60209
+  tps: 3982.32692
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6826.29073
-  tps: 4088.86874
+  dps: 6824.57091
+  tps: 4090.32857
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6811.2375
-  tps: 4077.85006
+  dps: 6821.02533
+  tps: 4083.73111
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 6694.6161
-  tps: 4004.44142
+  dps: 6687.7828
+  tps: 4000.645
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KirinTorGarb"
  value: {
-  dps: 6277.66871
-  tps: 3755.61198
+  dps: 6302.36283
+  tps: 3769.76798
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6639.73187
-  tps: 3980.60223
+  dps: 6642.60209
+  tps: 3982.32692
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6694.98917
-  tps: 4008.073
+  dps: 6705.78581
+  tps: 4014.57239
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6689.01523
-  tps: 4010.1591
+  dps: 6698.78854
+  tps: 4015.75008
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6638.13321
-  tps: 3979.64303
+  dps: 6642.60209
+  tps: 3982.32692
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6811.2375
-  tps: 4077.85006
+  dps: 6821.02533
+  tps: 4083.73111
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6811.2375
-  tps: 4077.85006
+  dps: 6821.02533
+  tps: 4083.73111
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6811.2375
-  tps: 4077.85006
+  dps: 6821.02533
+  tps: 4083.73111
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6811.2375
-  tps: 4077.85006
+  dps: 6821.02533
+  tps: 4083.73111
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6630.98627
-  tps: 3975.70389
+  dps: 6642.60209
+  tps: 3982.32692
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7052.67
-  tps: 4304.02226
+  dps: 7071.68205
+  tps: 4319.55101
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7106.50845
-  tps: 4346.16301
+  dps: 7125.40059
+  tps: 4361.55239
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6975.4093
-  tps: 4176.35314
+  dps: 6985.35379
+  tps: 4182.32818
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6832.39017
-  tps: 4088.91545
+  dps: 6827.06926
+  tps: 4087.19645
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6639.73187
-  tps: 3980.60223
+  dps: 6642.60209
+  tps: 3982.32692
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6639.73187
-  tps: 3980.60223
+  dps: 6642.60209
+  tps: 3982.32692
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6630.98627
-  tps: 3975.70389
+  dps: 6642.60209
+  tps: 3982.32692
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6602.62371
-  tps: 3956.74735
+  dps: 6642.60209
+  tps: 3982.32692
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SparkofLife-37657"
  value: {
-  dps: 6726.04027
-  tps: 4029.97507
+  dps: 6751.18388
+  tps: 4044.99292
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sunstrider'sRegalia"
  value: {
-  dps: 6598.19197
-  tps: 3947.44306
+  dps: 6595.60424
+  tps: 3946.14544
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6811.2375
-  tps: 4077.85006
+  dps: 6821.02533
+  tps: 4083.73111
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6811.2375
-  tps: 4077.85006
+  dps: 6821.02533
+  tps: 4083.73111
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6811.2375
-  tps: 4077.85006
+  dps: 6821.02533
+  tps: 4083.73111
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6811.2375
-  tps: 4077.85006
+  dps: 6821.02533
+  tps: 4083.73111
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6736.34676
-  tps: 4032.8743
+  dps: 6746.42043
+  tps: 4038.92685
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6736.34676
-  tps: 4032.8743
+  dps: 6746.42043
+  tps: 4038.92685
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6850.49752
-  tps: 4101.00005
+  dps: 6860.33459
+  tps: 4106.91064
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6842.64552
-  tps: 4096.37005
+  dps: 6852.47274
+  tps: 4102.27473
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6842.64552
-  tps: 4096.37005
+  dps: 6852.47274
+  tps: 4102.27473
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6850.49752
-  tps: 4101.00005
+  dps: 6860.33459
+  tps: 4106.91064
  }
 }
 dps_results: {
  key: "TestArcane-Average-Default"
  value: {
-  dps: 6916.53866
-  tps: 4148.09425
+  dps: 6928.31327
+  tps: 4155.29024
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10647.65129
-  tps: 8556.80504
+  dps: 10630.57539
+  tps: 8527.49947
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1453.42605
-  tps: 907.45506
+  dps: 1458.8149
+  tps: 913.04524
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2351.6054
-  tps: 1391.38955
+  dps: 2377.9619
+  tps: 1407.17597
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6134.25882
-  tps: 5300.90524
+  dps: 6212.65255
+  tps: 5343.60468
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 742.42849
-  tps: 475.18736
+  dps: 751.03149
+  tps: 481.61993
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1585.0723
-  tps: 956.015
+  dps: 1584.98185
+  tps: 956.75769
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6991.61679
-  tps: 5399.6075
+  dps: 7001.56128
+  tps: 5405.74121
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6991.61679
-  tps: 4185.97369
+  dps: 7001.56128
+  tps: 4191.94873
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9031.92391
-  tps: 5339.99191
+  dps: 9061.70174
+  tps: 5357.79934
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3881.6622
-  tps: 3536.66333
+  dps: 3895.51752
+  tps: 3544.86148
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3881.6622
-  tps: 2339.29939
+  dps: 3895.51752
+  tps: 2348.10343
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5130.38868
-  tps: 2980.61225
+  dps: 5126.38815
+  tps: 2979.6995
  }
 }
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6991.61679
-  tps: 4185.97369
+  dps: 7001.56128
+  tps: 4191.94873
  }
 }

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -514,8 +514,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1809.59986
-  tps: 1413.49663
+  dps: 1806.71665
+  tps: 1409.87446
  }
 }
 dps_results: {

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -101,8 +101,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 4390.15613
-  tps: 3699.17797
+  dps: 4390.19406
+  tps: 3699.04916
  }
 }
 dps_results: {
@@ -185,8 +185,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 4349.42007
-  tps: 3658.21596
+  dps: 4349.51168
+  tps: 3658.13715
  }
 }
 dps_results: {
@@ -318,8 +318,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 4288.05074
-  tps: 3606.66711
+  dps: 4288.1482
+  tps: 3606.75998
  }
 }
 dps_results: {
@@ -500,8 +500,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 4544.91237
-  tps: 3826.98247
+  dps: 4544.91734
+  tps: 3826.9784
  }
 }
 dps_results: {
@@ -528,22 +528,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4364.28669
-  tps: 4462.99531
+  dps: 4362.35716
+  tps: 4460.89416
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 582.14225
-  tps: 413.08244
+  dps: 580.96278
+  tps: 413.03697
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1256.56324
-  tps: 891.11099
+  dps: 1255.21684
+  tps: 890.08769
  }
 }
 dps_results: {
@@ -570,22 +570,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2789.18396
-  tps: 3068.70846
+  dps: 2753.40583
+  tps: 3038.41429
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2789.18396
-  tps: 2338.15709
+  dps: 2753.40583
+  tps: 2311.55151
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3316.03838
-  tps: 2606.94928
+  dps: 3316.79954
+  tps: 2625.65882
  }
 }
 dps_results: {

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -164,8 +164,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5707.7822
-  tps: 5806.20768
+  dps: 5705.37155
+  tps: 5803.79703
  }
 }
 dps_results: {
@@ -318,8 +318,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5707.7822
-  tps: 5806.20768
+  dps: 5705.37155
+  tps: 5803.79703
  }
 }
 dps_results: {
@@ -416,8 +416,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5707.7822
-  tps: 5806.20768
+  dps: 5705.37155
+  tps: 5803.79703
  }
 }
 dps_results: {
@@ -507,8 +507,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5707.7822
-  tps: 5806.20768
+  dps: 5705.37155
+  tps: 5803.79703
  }
 }
 dps_results: {
@@ -521,8 +521,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5707.7822
-  tps: 5806.20768
+  dps: 5705.37155
+  tps: 5803.79703
  }
 }
 dps_results: {

--- a/sim/rogue/TestRotation.results
+++ b/sim/rogue/TestRotation.results
@@ -39,19 +39,19 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 37.3
+   value: 37.1
   }
   casts: {
    key: "spell_id:48665"
-   value: 37.3
+   value: 37.1
   }
   casts: {
    key: "spell_id:48666"
-   value: 37.3
+   value: 37.1
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0.2
+   value: 0.1
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -95,7 +95,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:51662"
-   value: 6.3
+   value: 6.2
   }
   casts: {
    key: "spell_id:51723"
@@ -115,11 +115,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 155.7
+   value: 156.3
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 297.9
+   value: 299
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -127,7 +127,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 302.9
+   value: 304
   }
   casts: {
    key: "spell_id:57975"
@@ -143,19 +143,19 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:1"
-   value: 38.6
+   value: 38.5
   }
   casts: {
    key: "spell_id:57993 tag:2"
-   value: 3.1
+   value: 3
   }
   casts: {
    key: "spell_id:57993 tag:3"
-   value: 17.1
+   value: 17.3
   }
   casts: {
    key: "spell_id:57993 tag:4"
-   value: 0.3
+   value: 0.2
   }
   casts: {
    key: "spell_id:57993 tag:5"
@@ -183,23 +183,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:4"
-   value: 0.1
+   value: 0
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 0.6
+   value: 0.5
   }
   casts: {
    key: "spell_id:8647 tag:1"
-   value: 7
+   value: 7.3
   }
   casts: {
    key: "spell_id:8647 tag:2"
-   value: 2
+   value: 2.2
   }
   casts: {
    key: "spell_id:8647 tag:3"
-   value: 10.2
+   value: 9.9
   }
   casts: {
    key: "spell_id:8647 tag:4"
@@ -690,7 +690,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0.1
+   value: 0.2
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -754,11 +754,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 166.1
+   value: 166.7
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 310.1
+   value: 309.3
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -766,7 +766,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 315.1
+   value: 314.3
   }
   casts: {
    key: "spell_id:57975"
@@ -782,15 +782,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:1"
-   value: 44.6
+   value: 44.7
   }
   casts: {
    key: "spell_id:57993 tag:2"
-   value: 4.9
+   value: 5.3
   }
   casts: {
    key: "spell_id:57993 tag:3"
-   value: 27.1
+   value: 26.7
   }
   casts: {
    key: "spell_id:57993 tag:4"
@@ -798,7 +798,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:5"
-   value: 0
+   value: 0.1
   }
   casts: {
    key: "spell_id:58426"
@@ -818,7 +818,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 0.9
+   value: 0.8
   }
   casts: {
    key: "spell_id:6774 tag:4"
@@ -1104,15 +1104,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 35
+   value: 35.1
   }
   casts: {
    key: "spell_id:48665"
-   value: 35
+   value: 35.1
   }
   casts: {
    key: "spell_id:48666"
-   value: 35
+   value: 35.1
   }
   casts: {
    key: "spell_id:48668 tag:1"
@@ -1180,11 +1180,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 165.7
+   value: 166.3
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 309.1
+   value: 309
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -1192,7 +1192,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 314.2
+   value: 314
   }
   casts: {
    key: "spell_id:57975"
@@ -1208,7 +1208,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:1"
-   value: 44.4
+   value: 44.1
   }
   casts: {
    key: "spell_id:57993 tag:2"
@@ -1216,11 +1216,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:3"
-   value: 26.7
+   value: 26.8
   }
   casts: {
    key: "spell_id:57993 tag:4"
-   value: 1.1
+   value: 1.2
   }
   casts: {
    key: "spell_id:57993 tag:5"
@@ -1240,11 +1240,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 0.1
+   value: 0.2
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 0.9
+   value: 0.8
   }
   casts: {
    key: "spell_id:6774 tag:4"
@@ -1264,7 +1264,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:8647 tag:3"
-   value: 0.4
+   value: 0.5
   }
   casts: {
    key: "spell_id:8647 tag:4"
@@ -1272,7 +1272,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:8647 tag:5"
-   value: 0.1
+   value: 0
   }
  }
 }

--- a/sim/rogue/rotation.go
+++ b/sim/rogue/rotation.go
@@ -2,7 +2,6 @@ package rogue
 
 import (
 	"math"
-	"sort"
 	"time"
 
 	"github.com/wowsims/wotlk/sim/core"
@@ -230,9 +229,9 @@ func (rogue *Rogue) planRotation(sim *core.Simulation) []rogueRotationItem {
 	}
 
 	// Reverse
-	sort.Slice(prioStack, func(i, j int) bool {
-		return j < i
-	})
+	for i, j := 0, len(prioStack)-1; i < j; i, j = i+1, j-1 {
+		prioStack[i], prioStack[j] = prioStack[j], prioStack[i]
+	}
 
 	return prioStack
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -747,64 +747,64 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2071.23258
-  tps: 1686.19832
+  dps: 2073.68045
+  tps: 1687.36613
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1734.56279
-  tps: 1356.15818
+  dps: 1755.20035
+  tps: 1377.87567
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3564.31529
-  tps: 2726.59953
+  dps: 3562.89015
+  tps: 2729.03295
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8241.80428
-  tps: 5861.9468
+  dps: 8282.08529
+  tps: 5843.59474
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4671.7897
-  tps: 3222.523
+  dps: 4688.99832
+  tps: 3217.88123
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5994.35507
-  tps: 3709.62992
+  dps: 6027.3068
+  tps: 3653.49161
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3790.5235
-  tps: 1649.22872
+  dps: 3850.45938
+  tps: 1648.75024
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2066.59618
-  tps: 1324.35578
+  dps: 2085.24251
+  tps: 1319.17192
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4392.51255
-  tps: 2584.6411
+  dps: 4493.00398
+  tps: 2621.49903
  }
 }
 dps_results: {
@@ -852,43 +852,43 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8002.43412
-  tps: 5744.33769
+  dps: 8128.18155
+  tps: 5849.9576
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4645.93459
-  tps: 3226.04221
+  dps: 4617.97998
+  tps: 3202.80252
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5809.64493
-  tps: 3588.55855
+  dps: 5695.47431
+  tps: 3495.87855
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3632.07341
-  tps: 1584.69836
+  dps: 3655.14072
+  tps: 1609.24864
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2027.3376
-  tps: 1304.36482
+  dps: 2019.56248
+  tps: 1292.2771
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4383.03989
-  tps: 2637.25303
+  dps: 4314.70828
+  tps: 2547.26
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -675,8 +675,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 6800.20612
-  tps: 3836.48191
+  dps: 6800.21702
+  tps: 3836.48914
  }
 }
 dps_results: {

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -45,554 +45,554 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 8014.7826
-  tps: 6586.46149
+  dps: 8044.51785
+  tps: 6612.86671
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8233.50569
-  tps: 6766.61717
+  dps: 8258.78545
+  tps: 6795.96199
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8153.71219
-  tps: 6697.30558
+  dps: 8159.64403
+  tps: 6697.18805
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8266.80076
-  tps: 6806.75745
+  dps: 8272.2939
+  tps: 6805.65539
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 8132.18329
-  tps: 6682.22941
+  dps: 8186.39815
+  tps: 6733.37736
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6934.40746
-  tps: 5697.22314
+  dps: 6999.42513
+  tps: 5752.17408
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6969.48703
-  tps: 5722.84815
+  dps: 6971.52269
+  tps: 5730.04254
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6609.25004
-  tps: 5438.76366
+  dps: 6669.83277
+  tps: 5484.79153
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8279.07293
-  tps: 6675.33671
+  dps: 8231.94144
+  tps: 6637.18909
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8414.41768
-  tps: 6918.66323
+  dps: 8451.90764
+  tps: 6955.21455
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 8204.56309
-  tps: 6745.7896
+  dps: 8189.28274
+  tps: 6737.20163
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 8207.34544
-  tps: 6743.73844
+  dps: 8194.85154
+  tps: 6735.47535
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 8092.69515
-  tps: 6650.92382
+  dps: 8146.10007
+  tps: 6695.64695
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 8042.14357
-  tps: 6609.74781
+  dps: 7977.34784
+  tps: 6552.82521
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 8114.30852
-  tps: 6672.03346
+  dps: 8111.5796
+  tps: 6666.39625
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Defender'sCode-40257"
  value: {
-  dps: 8018.03363
-  tps: 6587.16228
+  dps: 8004.46615
+  tps: 6580.21291
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8299.94095
-  tps: 6828.3455
+  dps: 8268.3589
+  tps: 6804.80248
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 7406.33706
-  tps: 6097.64346
+  dps: 7426.36401
+  tps: 6112.96455
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8279.07293
-  tps: 6811.29371
+  dps: 8231.94144
+  tps: 6772.36886
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8279.07293
-  tps: 6811.29371
+  dps: 8231.94144
+  tps: 6772.36886
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8266.80076
-  tps: 6806.75745
+  dps: 8272.2939
+  tps: 6805.65539
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8220.10078
-  tps: 6759.56809
+  dps: 8303.49932
+  tps: 6835.53581
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8279.07293
-  tps: 6811.29371
+  dps: 8231.94144
+  tps: 6772.36886
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 8191.06896
-  tps: 6726.2895
+  dps: 8239.81992
+  tps: 6776.73925
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 8169.15394
-  tps: 6715.8416
+  dps: 8125.90413
+  tps: 6681.95849
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForgeEmber-37660"
  value: {
-  dps: 8116.6858
-  tps: 6667.66147
+  dps: 8182.67469
+  tps: 6727.3469
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8279.07293
-  tps: 6811.29371
+  dps: 8231.94144
+  tps: 6772.36886
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8279.07293
-  tps: 6811.29371
+  dps: 8231.94144
+  tps: 6772.36886
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8210.78226
-  tps: 6741.16087
+  dps: 8257.28205
+  tps: 6787.15333
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7976.28912
-  tps: 6555.14992
+  dps: 7977.34784
+  tps: 6552.82521
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 7887.3676
-  tps: 6463.62296
+  dps: 7832.795
+  tps: 6424.54624
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 8042.14357
-  tps: 6609.74781
+  dps: 7977.34784
+  tps: 6552.82521
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8266.80076
-  tps: 6806.75745
+  dps: 8272.2939
+  tps: 6805.65539
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8220.10078
-  tps: 6759.56809
+  dps: 8303.49932
+  tps: 6835.53581
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8239.14579
-  tps: 6770.97276
+  dps: 8246.77631
+  tps: 6773.52037
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8279.07293
-  tps: 6811.29371
+  dps: 8231.94144
+  tps: 6772.36886
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8309.9612
-  tps: 6836.8074
+  dps: 8320.39649
+  tps: 6847.06664
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7986.72876
-  tps: 6558.98016
+  dps: 7977.34784
+  tps: 6552.82521
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 8042.14357
-  tps: 6609.74781
+  dps: 7977.34784
+  tps: 6552.82521
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8266.54623
-  tps: 6797.14861
+  dps: 8219.40258
+  tps: 6757.83311
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7978.50011
-  tps: 6558.90702
+  dps: 7985.47725
+  tps: 6561.48525
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtArmor"
  value: {
-  dps: 5684.55392
-  tps: 4669.73987
+  dps: 5615.84622
+  tps: 4616.79348
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 6547.40926
-  tps: 5375.41829
+  dps: 6568.29514
+  tps: 5388.60933
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8329.2191
-  tps: 6851.95889
+  dps: 8302.80076
+  tps: 6830.30294
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8309.9612
-  tps: 6836.8074
+  dps: 8320.39649
+  tps: 6847.06664
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8279.07293
-  tps: 6811.29371
+  dps: 8231.94144
+  tps: 6772.36886
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8279.07293
-  tps: 6811.29371
+  dps: 8231.94144
+  tps: 6772.36886
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 8042.14357
-  tps: 6609.74781
+  dps: 7977.34784
+  tps: 6552.82521
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 8042.14357
-  tps: 6609.74781
+  dps: 7977.34784
+  tps: 6552.82521
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 8042.14357
-  tps: 6609.74781
+  dps: 7977.34784
+  tps: 6552.82521
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8449.24042
-  tps: 6944.74172
+  dps: 8494.2969
+  tps: 6989.37843
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8279.07293
-  tps: 6811.29371
+  dps: 8231.94144
+  tps: 6772.36886
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7986.78601
-  tps: 6559.03741
+  dps: 7977.34784
+  tps: 6552.82521
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 8014.22203
-  tps: 6581.11613
+  dps: 8014.16001
+  tps: 6583.40947
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 8042.14357
-  tps: 6609.74781
+  dps: 7977.34784
+  tps: 6552.82521
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 7702.84844
-  tps: 6334.89499
+  dps: 7707.43871
+  tps: 6340.51483
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7976.28912
-  tps: 6555.14992
+  dps: 7977.34784
+  tps: 6552.82521
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SparkofLife-37657"
  value: {
-  dps: 8154.34938
-  tps: 6707.96185
+  dps: 8077.45101
+  tps: 6642.6813
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StormshroudArmor"
  value: {
-  dps: 6624.67093
-  tps: 5446.5598
+  dps: 6623.23453
+  tps: 5444.73419
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8309.9612
-  tps: 6836.8074
+  dps: 8320.39649
+  tps: 6847.06664
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8329.2191
-  tps: 6851.95889
+  dps: 8302.80076
+  tps: 6830.30294
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8302.80731
-  tps: 6829.03285
+  dps: 8325.45821
+  tps: 6850.33686
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheFistsofFury"
  value: {
-  dps: 4453.846
-  tps: 3765.78667
+  dps: 4487.00546
+  tps: 3791.95422
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 4755.01445
-  tps: 4011.0063
+  dps: 4807.08276
+  tps: 4051.82335
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8316.56451
-  tps: 6841.58606
+  dps: 8298.44727
+  tps: 6827.20358
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 8506.47122
-  tps: 6996.50679
+  dps: 8479.1618
+  tps: 6970.37816
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8555.62892
-  tps: 7037.96789
+  dps: 8532.34971
+  tps: 7016.72092
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8279.07293
-  tps: 6811.29371
+  dps: 8231.94144
+  tps: 6772.36886
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8279.07293
-  tps: 6811.29371
+  dps: 8231.94144
+  tps: 6772.36886
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8279.07293
-  tps: 6811.29371
+  dps: 8231.94144
+  tps: 6772.36886
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8279.07293
-  tps: 6811.29371
+  dps: 8231.94144
+  tps: 6772.36886
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 7006.29159
-  tps: 5756.60006
+  dps: 6986.43834
+  tps: 5742.23064
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 8076.74315
-  tps: 6638.98641
+  dps: 8108.89353
+  tps: 6664.80421
  }
 }
 dps_results: {
  key: "TestArms-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 8405.91284
-  tps: 6931.25168
+  dps: 8439.80646
+  tps: 6961.54298
  }
 }
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 8423.16113
-  tps: 6921.77814
+  dps: 8423.74244
+  tps: 6921.48159
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11087.28114
-  tps: 9641.0798
+  dps: 11090.19264
+  tps: 9648.45824
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8393.3125
-  tps: 6903.84969
+  dps: 8449.52642
+  tps: 6954.2865
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9038.36729
-  tps: 7474.07712
+  dps: 8903.1805
+  tps: 7361.31038
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6588.32044
-  tps: 5870.84162
+  dps: 6602.40387
+  tps: 5892.24245
  }
 }
 dps_results: {
@@ -612,49 +612,49 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11119.56369
-  tps: 9674.5127
+  dps: 11119.09693
+  tps: 9668.76562
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8449.24042
-  tps: 6944.74172
+  dps: 8494.2969
+  tps: 6989.37843
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8998.45812
-  tps: 7442.85827
+  dps: 9048.96525
+  tps: 7477.41816
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6712.50855
-  tps: 5991.12761
+  dps: 6644.44307
+  tps: 5933.67449
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4653.24855
-  tps: 3838.23229
+  dps: 4683.13883
+  tps: 3865.76867
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4843.75615
-  tps: 4017.00817
+  dps: 4703.11415
+  tps: 3902.48722
  }
 }
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7871.54223
-  tps: 6461.75619
+  dps: 7895.15073
+  tps: 6476.15676
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -52,8 +52,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6715.57814
-  tps: 4946.24133
+  dps: 6701.32894
+  tps: 4935.43911
  }
 }
 dps_results: {
@@ -80,22 +80,22 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 5475.52751
-  tps: 4040.59193
+  dps: 5420.03223
+  tps: 4000.31977
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5486.27239
-  tps: 4046.85468
+  dps: 5446.97591
+  tps: 4022.02975
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5197.85844
-  tps: 3839.41545
+  dps: 5215.90923
+  tps: 3853.48131
  }
 }
 dps_results: {
@@ -164,8 +164,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 5932.48384
-  tps: 4378.36279
+  dps: 5959.50987
+  tps: 4392.36846
  }
 }
 dps_results: {
@@ -192,8 +192,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6747.23954
-  tps: 4965.47162
+  dps: 6745.99805
+  tps: 4965.36904
  }
 }
 dps_results: {
@@ -255,8 +255,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 6401.90477
-  tps: 4712.64737
+  dps: 6435.72311
+  tps: 4739.3568
  }
 }
 dps_results: {
@@ -276,8 +276,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6747.23954
-  tps: 4965.47162
+  dps: 6745.99805
+  tps: 4965.36904
  }
 }
 dps_results: {
@@ -318,8 +318,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6862.13906
-  tps: 5049.42983
+  dps: 6858.18225
+  tps: 5045.16785
  }
 }
 dps_results: {
@@ -332,15 +332,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-OnslaughtArmor"
  value: {
-  dps: 4147.85204
-  tps: 3073.53938
+  dps: 4167.72259
+  tps: 3089.78983
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 4973.71227
-  tps: 3676.65961
+  dps: 4991.18564
+  tps: 3690.34821
  }
 }
 dps_results: {
@@ -430,8 +430,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 6240.35952
-  tps: 4599.74781
+  dps: 6223.98676
+  tps: 4585.43166
  }
 }
 dps_results: {
@@ -451,8 +451,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-StormshroudArmor"
  value: {
-  dps: 5108.30385
-  tps: 3774.22229
+  dps: 5101.05813
+  tps: 3768.67964
  }
 }
 dps_results: {
@@ -542,50 +542,50 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5464.19781
-  tps: 4033.63975
+  dps: 5448.2137
+  tps: 4020.10766
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 6660.12906
-  tps: 4899.22633
+  dps: 6622.23712
+  tps: 4872.35012
  }
 }
 dps_results: {
  key: "TestFury-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 7035.62799
-  tps: 5174.51211
+  dps: 7091.52215
+  tps: 5215.89406
  }
 }
 dps_results: {
  key: "TestFury-Average-Default"
  value: {
-  dps: 6828.54195
-  tps: 5027.09378
+  dps: 6831.45783
+  tps: 5029.06853
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8837.48528
-  tps: 6964.42967
+  dps: 8846.66331
+  tps: 6972.83926
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6821.59942
-  tps: 5020.57967
+  dps: 6809.25487
+  tps: 5010.5639
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7958.98158
-  tps: 5851.61966
+  dps: 8048.53095
+  tps: 5917.13334
  }
 }
 dps_results: {
@@ -626,35 +626,35 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8187.27008
-  tps: 6013.17461
+  dps: 8112.68467
+  tps: 5957.1463
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5058.37285
-  tps: 4166.47668
+  dps: 5093.6002
+  tps: 4191.42445
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3507.58442
-  tps: 2610.98204
+  dps: 3488.31294
+  tps: 2597.0434
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3841.78479
-  tps: 2861.32266
+  dps: 3856.78678
+  tps: 2877.43882
  }
 }
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6327.74368
-  tps: 4658.74341
+  dps: 6334.14654
+  tps: 4667.65436
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -45,7 +45,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 0.86996
+  weights: 0.62992
   weights: 0
   weights: 0
   weights: 0
@@ -56,7 +56,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.21943
+  weights: 0.18186
   weights: 0
   weights: 0
   weights: 0
@@ -65,12 +65,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.09476
+  weights: -0.06217
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.37751
-  weights: -0.0562
+  weights: 0.37404
+  weights: -0.07311
   weights: 0
   weights: 0
   weights: 0
@@ -89,435 +89,435 @@ stat_weights_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 1898.77265
-  tps: 5553.13955
+  dps: 1894.83697
+  tps: 5540.33798
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1870.57373
-  tps: 5477.58198
+  dps: 1879.1792
+  tps: 5498.64034
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1965.73982
-  tps: 5706.66923
+  dps: 1969.94729
+  tps: 5721.94291
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1909.45748
-  tps: 5582.21768
+  dps: 1901.01853
+  tps: 5553.91458
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1859.59142
-  tps: 5434.00909
+  dps: 1860.0319
+  tps: 5426.31489
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1678.9213
-  tps: 4941.73214
+  dps: 1682.54247
+  tps: 4956.10889
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1662.39594
-  tps: 4872.86871
+  dps: 1677.85734
+  tps: 4904.31598
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1563.17474
-  tps: 4617.74954
+  dps: 1564.35992
+  tps: 4623.71675
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1871.38391
-  tps: 5369.16288
+  dps: 1879.89425
+  tps: 5390.80542
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1921.46537
-  tps: 5598.30218
+  dps: 1918.94815
+  tps: 5589.9405
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1950.25137
-  tps: 5673.5721
+  dps: 1945.91403
+  tps: 5664.37731
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1982.13142
-  tps: 5727.60496
+  dps: 1992.971
+  tps: 5765.28105
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 2020.31469
-  tps: 5894.51915
+  dps: 2000.38259
+  tps: 5830.0197
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 2010.26685
-  tps: 5843.92846
+  dps: 2000.70806
+  tps: 5819.69657
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 1934.18238
-  tps: 5651.66461
+  dps: 1944.20566
+  tps: 5676.13779
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1927.79542
-  tps: 5611.81381
+  dps: 1934.68662
+  tps: 5635.05403
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1898.07271
-  tps: 5543.63605
+  dps: 1903.79567
+  tps: 5553.03829
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 2049.9149
-  tps: 5925.20731
+  dps: 2042.37912
+  tps: 5908.52116
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1871.38391
-  tps: 5478.68656
+  dps: 1879.89425
+  tps: 5500.77077
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1871.38391
-  tps: 5478.68656
+  dps: 1879.89425
+  tps: 5500.77077
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1909.45748
-  tps: 5582.21768
+  dps: 1901.01853
+  tps: 5553.91458
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1897.04446
-  tps: 5541.35707
+  dps: 1881.26618
+  tps: 5498.51534
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1891.86016
-  tps: 5533.88132
+  dps: 1899.87859
+  tps: 5554.63956
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1986.78575
-  tps: 5744.8787
+  dps: 1987.2406
+  tps: 5743.59683
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1938.59003
-  tps: 5637.85512
+  dps: 1949.94694
+  tps: 5676.31751
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1927.31656
-  tps: 5610.76296
+  dps: 1930.84673
+  tps: 5625.45144
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1871.38391
-  tps: 5478.68656
+  dps: 1879.89425
+  tps: 5500.77077
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1871.38391
-  tps: 5478.68656
+  dps: 1879.89425
+  tps: 5500.77077
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1948.36867
-  tps: 5696.45744
+  dps: 1955.69316
+  tps: 5718.67617
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1870.57373
-  tps: 5477.58198
+  dps: 1879.1792
+  tps: 5498.64034
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 2207.64029
-  tps: 6281.60925
+  dps: 2219.25804
+  tps: 6306.39199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1870.57373
-  tps: 5477.58198
+  dps: 1879.1792
+  tps: 5498.64034
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1909.45748
-  tps: 5582.21768
+  dps: 1901.01853
+  tps: 5553.91458
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1897.04446
-  tps: 5541.35707
+  dps: 1881.26618
+  tps: 5498.51534
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1937.74003
-  tps: 5652.33034
+  dps: 1946.36951
+  tps: 5678.18908
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1871.38391
-  tps: 5478.68656
+  dps: 1879.89425
+  tps: 5500.77077
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1896.22874
-  tps: 5547.53628
+  dps: 1893.33539
+  tps: 5533.90941
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1921.57127
-  tps: 5615.0484
+  dps: 1930.28957
+  tps: 5636.4109
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1870.57373
-  tps: 5477.58198
+  dps: 1879.1792
+  tps: 5498.64034
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1967.92926
-  tps: 5727.30122
+  dps: 1956.62105
+  tps: 5692.47047
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1874.96782
-  tps: 5480.10771
+  dps: 1888.28025
+  tps: 5528.10071
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 1567.87142
-  tps: 4625.37451
+  dps: 1570.56662
+  tps: 4626.26717
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 1750.24657
-  tps: 5075.00219
+  dps: 1750.39832
+  tps: 5061.72865
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1886.38955
-  tps: 5518.3605
+  dps: 1883.38165
+  tps: 5506.96551
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1896.22874
-  tps: 5547.53628
+  dps: 1893.33539
+  tps: 5533.90941
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1871.38391
-  tps: 5478.68656
+  dps: 1879.89425
+  tps: 5500.77077
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1871.38391
-  tps: 5478.68656
+  dps: 1879.89425
+  tps: 5500.77077
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1870.57373
-  tps: 5477.58198
+  dps: 1879.1792
+  tps: 5498.64034
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1870.57373
-  tps: 5477.58198
+  dps: 1879.1792
+  tps: 5498.64034
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1870.57373
-  tps: 5477.58198
+  dps: 1879.1792
+  tps: 5498.64034
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1922.21106
-  tps: 5595.00292
+  dps: 1934.12236
+  tps: 5629.55929
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1871.38391
-  tps: 5478.68656
+  dps: 1879.89425
+  tps: 5500.77077
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1870.57373
-  tps: 5477.58198
+  dps: 1879.1792
+  tps: 5498.64034
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1887.50545
-  tps: 5525.8793
+  dps: 1874.46037
+  tps: 5490.80322
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1870.57373
-  tps: 5477.58198
+  dps: 1879.1792
+  tps: 5498.64034
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 2099.24547
-  tps: 6071.8845
+  dps: 2095.78697
+  tps: 6055.09651
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1870.57373
-  tps: 5477.58198
+  dps: 1879.1792
+  tps: 5498.64034
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SparkofLife-37657"
  value: {
-  dps: 1924.14659
-  tps: 5624.90286
+  dps: 1918.03895
+  tps: 5607.27893
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormshroudArmor"
  value: {
-  dps: 1543.99159
-  tps: 4568.40275
+  dps: 1549.52784
+  tps: 4581.08334
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1896.22874
-  tps: 5547.53628
+  dps: 1893.33539
+  tps: 5533.90941
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1886.38955
-  tps: 5518.3605
+  dps: 1883.38165
+  tps: 5506.96551
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1887.86217
-  tps: 5527.79637
+  dps: 1888.53572
+  tps: 5530.66978
  }
 }
 dps_results: {
@@ -537,170 +537,170 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1890.70883
-  tps: 5528.29956
+  dps: 1885.43181
+  tps: 5511.6036
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2024.41079
-  tps: 5907.59243
+  dps: 2001.40559
+  tps: 5850.72942
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2023.79731
-  tps: 5906.75165
+  dps: 2031.42368
+  tps: 5927.68638
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1871.38391
-  tps: 5478.68656
+  dps: 1879.89425
+  tps: 5500.77077
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1871.38391
-  tps: 5478.68656
+  dps: 1879.89425
+  tps: 5500.77077
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1871.38391
-  tps: 5478.68656
+  dps: 1879.89425
+  tps: 5500.77077
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1871.38391
-  tps: 5478.68656
+  dps: 1879.89425
+  tps: 5500.77077
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1685.69296
-  tps: 4936.64092
+  dps: 1678.74486
+  tps: 4915.98849
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 2226.07784
-  tps: 6369.90631
+  dps: 2238.47289
+  tps: 6398.50647
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 2442.62511
-  tps: 6899.25577
+  dps: 2451.6361
+  tps: 6932.19633
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 2823.39631
-  tps: 7438.94811
-  dtps: 124.87467
+  dps: 2821.29298
+  tps: 7434.15922
+  dtps: 125.82077
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1925.45638
-  tps: 5194.50497
+  dps: 1919.47526
+  tps: 5179.88814
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1925.45638
-  tps: 5146.93147
+  dps: 1919.47526
+  tps: 5132.33115
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2093.47651
-  tps: 5539.22483
+  dps: 2045.22867
+  tps: 5417.55816
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1026.31104
-  tps: 2772.23286
+  dps: 1021.20745
+  tps: 2753.27577
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1026.31104
-  tps: 2724.67202
+  dps: 1021.20745
+  tps: 2705.71758
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 908.07598
-  tps: 2421.23716
+  dps: 890.05683
+  tps: 2372.68953
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1940.26656
-  tps: 5235.86608
+  dps: 1929.84328
+  tps: 5212.05316
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1940.26656
-  tps: 5188.31419
+  dps: 1929.84328
+  tps: 5164.48507
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2096.55236
-  tps: 5550.84518
+  dps: 2081.39967
+  tps: 5516.80172
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1036.66725
-  tps: 2799.79992
+  dps: 1022.46665
+  tps: 2765.13955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1036.66725
-  tps: 2752.24181
+  dps: 1022.46665
+  tps: 2717.55836
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 924.91201
-  tps: 2464.80895
+  dps: 903.1648
+  tps: 2405.0954
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2986.88688
-  tps: 7866.13529
-  dtps: 122.46754
+  dps: 2986.14098
+  tps: 7863.541
+  dtps: 121.89261
  }
 }


### PR DESCRIPTION
[core] major cooldowns were (sometimes) sorted with sort.Slice(), so go versions >= 1.18.7 (with a different implementation) had different test results

[core] majorCooldownManager.sortOne() wasn't nil-checking SharedCDs, and treated all spells without SharedCDs as sharing a CD

[druid] another instance of sort.Slice() with potential for instability 

[rogue] hand-written reverse

[many] hence, test results changed all over