### PR TITLE
[Rogue] Fix Mutilate cost when set bonus and glyph are applied

### DIFF
--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -75,8 +75,9 @@ func (rogue *Rogue) registerMutilateSpell() {
 	ohHitSpell := rogue.newMutilateHitSpell(false)
 
 	baseCost := 60.0
+	staticModifier := 0.0
 	if rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfMutilate) {
-		baseCost -= 5
+		staticModifier = 5.0
 	}
 	refundAmount := baseCost * 0.8
 
@@ -86,7 +87,7 @@ func (rogue *Rogue) registerMutilateSpell() {
 		ProcMask:     core.ProcMaskMeleeMHSpecial,
 		Flags:        core.SpellFlagMeleeMetrics | SpellFlagBuilder,
 		ResourceType: stats.Energy,
-		BaseCost:     baseCost,
+		BaseCost:     60.0,
 
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
@@ -94,7 +95,7 @@ func (rogue *Rogue) registerMutilateSpell() {
 				GCD:  time.Second,
 			},
 			IgnoreHaste: true,
-			ModifyCast:  rogue.CastModifier,
+			ModifyCast:  rogue.makeCastModifier(staticModifier),
 		},
 
 		ThreatMultiplier: 1,

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -136,7 +136,7 @@ func (rogue *Rogue) Initialize() {
 		rogue.QuickRecoveryMetrics = rogue.NewEnergyMetrics(core.ActionID{SpellID: 31245})
 	}
 
-	rogue.CastModifier = rogue.makeCastModifier()
+	rogue.CastModifier = rogue.makeCastModifier(0)
 
 	rogue.registerBackstabSpell()
 	rogue.registerDeadlyPoisonSpell()

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -72,7 +72,7 @@ func (rogue *Rogue) makeFinishingMoveEffectApplier() func(sim *core.Simulation, 
 	}
 }
 
-func (rogue *Rogue) makeCastModifier() func(*core.Simulation, *core.Spell, *core.Cast) {
+func (rogue *Rogue) makeCastModifier(staticReduction float64) func(*core.Simulation, *core.Spell, *core.Cast) {
 	builderCostMultiplier := 1.0
 	costReduction := 40.0
 	if rogue.HasSetBonus(ItemSetBonescythe, 4) {
@@ -84,7 +84,7 @@ func (rogue *Rogue) makeCastModifier() func(*core.Simulation, *core.Spell, *core
 			costMultiplier *= builderCostMultiplier
 		}
 		cast.Cost *= costMultiplier
-		cast.Cost = math.Ceil(cast.Cost)
+		cast.Cost = math.Ceil(cast.Cost - staticReduction)
 		if rogue.VanCleefsProcAura.IsActive() {
 			cast.Cost = core.MaxFloat(0, cast.Cost-costReduction)
 			rogue.VanCleefsProcAura.Deactivate(sim)


### PR DESCRIPTION
Net effect is that Mutilate costs 52 energy in this scenario rather than 53.