### PR TITLE
(Mostly) rogue stuff

### DIFF
--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -159,6 +159,17 @@ func (sim *Simulation) Roll(min float64, max float64) float64 {
 	return min + (max-min)*sim.RandomFloat("Damage Roll")
 }
 
+func (sim *Simulation) Proc(p float64, label string) bool {
+	switch {
+	case p >= 1:
+		return true
+	case p <= 0:
+		return false
+	default:
+		return sim.RandomFloat(label) < p
+	}
+}
+
 func (sim *Simulation) Reset() {
 	sim.reset()
 }

--- a/sim/deathknight/anti_magic_shell.go
+++ b/sim/deathknight/anti_magic_shell.go
@@ -1,18 +1,18 @@
 package deathknight
 
 import (
+	"github.com/wowsims/wotlk/sim/core/proto"
 	"time"
 
 	"github.com/wowsims/wotlk/sim/core"
-	"github.com/wowsims/wotlk/sim/core/proto"
 	"github.com/wowsims/wotlk/sim/core/stats"
 )
 
 func (dk *Deathknight) registerAntiMagicShellSpell() {
 	actionID := core.ActionID{SpellID: 48707}
 	cdTimer := dk.NewTimer()
-	cd := time.Second*45 - time.Second*time.Duration(core.TernaryInt32(dk.HasMajorGlyph(proto.DeathknightMajorGlyph_GlyphOfAntiMagicShell), 2, 0))
-
+	cd := time.Second * 45
+	
 	baseCost := float64(core.NewRuneCost(20.0, 0, 0, 0, 0))
 	rs := &RuneSpell{}
 	dk.AntiMagicShell = dk.RegisterSpell(rs, core.SpellConfig{
@@ -47,7 +47,7 @@ func (dk *Deathknight) registerAntiMagicShellSpell() {
 	dk.AntiMagicShellAura = dk.RegisterAura(core.Aura{
 		Label:    "Anti-Magic Shell",
 		ActionID: actionID,
-		Duration: time.Second * 5,
+		Duration: time.Second*5 + core.TernaryDuration(dk.HasMajorGlyph(proto.DeathknightMajorGlyph_GlyphOfAntiMagicShell), 2*time.Second, 0),
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			if dk.Inputs.IsDps {
 				target := aura.Unit.CurrentTarget

--- a/sim/deathknight/runespell.go
+++ b/sim/deathknight/runespell.go
@@ -31,14 +31,11 @@ type RuneSpell struct {
 func (rs *RuneSpell) OnOutcome(sim *core.Simulation, outcome core.HitOutcome) {
 	cost := core.RuneCost(rs.Spell.CurCast.Cost) // cost was already optimized in RuneSpell.Cast
 	if cost == 0 {
-		return // it was free this time. we dont care
+		return // it was free this time. we don't care
 	}
 	if outcome.Matches(core.OutcomeLanded) {
 		slot1, slot2, slot3 := rs.Spell.Unit.SpendRuneCost(sim, rs.Spell, cost)
-		if rs.DeathConvertChance == 0 {
-			return
-		}
-		if rs.DeathConvertChance < 1 && sim.RandomFloat("Blood of The North / Reaping / DRM") > rs.DeathConvertChance {
+		if !sim.Proc(rs.DeathConvertChance, "Blood of The North / Reaping / DRM") {
 			return
 		}
 		if (rs.ConvertType&RuneTypeBlood != 0 && (slot1 == 0 || slot1 == 1)) ||
@@ -57,7 +54,7 @@ func (rs *RuneSpell) OnOutcome(sim *core.Simulation, outcome core.HitOutcome) {
 			rs.dk.ConvertToDeath(sim, slot3, true, core.NeverExpires)
 		}
 	}
-	// misses just dont get spent as a way to avoid having to cancel regeneration PAs
+	// misses just don't get spent as a way to avoid having to cancel regeneration PAs
 }
 
 func (rs *RuneSpell) DoCost(sim *core.Simulation) {
@@ -101,7 +98,8 @@ func (rs *RuneSpell) Cast(sim *core.Simulation, target *core.Unit) bool {
 }
 
 // RegisterSpell will connect the underlying spell to the given RuneSpell.
-//  If no RuneSpell is provided, it will be constructed here.
+//
+//	If no RuneSpell is provided, it will be constructed here.
 func (dk *Deathknight) RegisterSpell(rs *RuneSpell, spellConfig core.SpellConfig, canCast func(sim *core.Simulation) bool, onCast func(sim *core.Simulation)) *RuneSpell {
 	if rs == nil {
 		rs = &RuneSpell{}

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -202,7 +202,6 @@ func (druid *Druid) PowerShiftBear(sim *core.Simulation) {
 func (druid *Druid) registerBearFormSpell() {
 	actionID := core.ActionID{SpellID: 9634}
 	baseCost := druid.BaseMana * 0.35
-	furorProcChance := 0.2 * float64(druid.Talents.Furor)
 
 	stamdep := druid.NewDynamicMultiplyStat(stats.Stamina, 1.25)
 	bearHotw := druid.NewDynamicMultiplyStat(stats.Stamina, 1.0+0.02*float64(druid.Talents.HeartOfTheWild))
@@ -229,7 +228,7 @@ func (druid *Druid) registerBearFormSpell() {
 
 			druid.PseudoStats.ThreatMultiplier *= 1.3
 			druid.PseudoStats.DamageDealtMultiplier *= 1.0 + 0.02*float64(druid.Talents.MasterShapeshifter)
-			druid.PseudoStats.DamageTakenMultiplier *= (1.0 - potpdtm)
+			druid.PseudoStats.DamageTakenMultiplier *= 1.0 - potpdtm
 
 			druid.manageCooldownsEnabled(sim)
 			druid.PseudoStats.SpiritRegenMultiplier *= AnimalSpiritRegenSuppression
@@ -261,7 +260,7 @@ func (druid *Druid) registerBearFormSpell() {
 
 			druid.PseudoStats.ThreatMultiplier /= 1.3
 			druid.PseudoStats.DamageDealtMultiplier /= 1.0 + 0.02*float64(druid.Talents.MasterShapeshifter)
-			druid.PseudoStats.DamageTakenMultiplier /= (1.0 - potpdtm)
+			druid.PseudoStats.DamageTakenMultiplier /= 1.0 - potpdtm
 
 			druid.AutoAttacks.CancelAutoSwing(sim)
 			druid.manageCooldownsEnabled(sim)
@@ -273,6 +272,8 @@ func (druid *Druid) registerBearFormSpell() {
 	})
 
 	rageMetrics := druid.NewRageMetrics(actionID)
+
+	furorProcChance := []float64{0, 0.2, 0.4, 0.6, 0.8, 1}[druid.Talents.Furor]
 
 	druid.BearForm = druid.RegisterSpell(core.SpellConfig{
 		ActionID: actionID,
@@ -290,9 +291,9 @@ func (druid *Druid) registerBearFormSpell() {
 		},
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
-			rageDelta := 0.0 - druid.CurrentRage()
-			if furorProcChance >= 0.9 || (furorProcChance > 0 && sim.RandomFloat("Furor") < furorProcChance) {
-				rageDelta += 10.0
+			rageDelta := 0 - druid.CurrentRage()
+			if sim.Proc(furorProcChance, "Furor") {
+				rageDelta += 10
 			}
 			if rageDelta > 0 {
 				druid.AddRage(sim, rageDelta, rageMetrics)

--- a/sim/druid/talents.go
+++ b/sim/druid/talents.go
@@ -180,7 +180,7 @@ func (druid *Druid) applyPrimalFury() {
 		return
 	}
 
-	procChance := 0.5 * float64(druid.Talents.PrimalFury)
+	procChance := []float64{0, 0.5, 1}[druid.Talents.PrimalFury]
 	actionID := core.ActionID{SpellID: 37117}
 	rageMetrics := druid.NewRageMetrics(actionID)
 	cpMetrics := druid.NewComboPointMetrics(actionID)
@@ -194,14 +194,14 @@ func (druid *Druid) applyPrimalFury() {
 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 			if druid.InForm(Bear) {
 				if spellEffect.Outcome.Matches(core.OutcomeCrit) {
-					if procChance >= 0.9 || sim.RandomFloat("Primal Fury") < procChance {
+					if sim.Proc(procChance, "Primal Fury") {
 						druid.AddRage(sim, 5, rageMetrics)
 					}
 				}
 			} else if druid.InForm(Cat) {
 				if druid.IsMangle(spell) || spell == druid.Shred || spell == druid.Rake {
 					if spellEffect.Outcome.Matches(core.OutcomeCrit) {
-						if procChance >= 0.9 || sim.RandomFloat("Primal Fury") < procChance {
+						if sim.Proc(procChance, "Primal Fury") {
 							druid.AddComboPoints(sim, 1, cpMetrics)
 						}
 					}

--- a/sim/encounters/default_ai.go
+++ b/sim/encounters/default_ai.go
@@ -57,7 +57,7 @@ func (ai *DefaultAI) DoAction(sim *core.Simulation) {
 			continue
 		}
 
-		if ability.ChanceToUse == 1 || sim.RandomFloat("TargetAbility") < ability.ChanceToUse {
+		if sim.Proc(ability.ChanceToUse, "TargetAbility") {
 			ability.Spell.Cast(sim, ai.Target.CurrentTarget)
 			return
 		}

--- a/sim/hunter/talents.go
+++ b/sim/hunter/talents.go
@@ -187,7 +187,7 @@ func (hunter *Hunter) applyInvigoration() {
 				return
 			}
 
-			if procChance == 1 || sim.RandomFloat("Invigoration") < procChance {
+			if sim.Proc(procChance, "Invigoration") {
 				hunter.AddMana(sim, 0.01*hunter.MaxMana(), manaMetrics, false)
 			}
 		},
@@ -404,7 +404,7 @@ func (hunter *Hunter) applyFrenzy() {
 			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
-			if procChance == 1 || sim.RandomFloat("Frenzy") < procChance {
+			if sim.Proc(procChance, "Frenzy") {
 				procAura.Activate(sim)
 			}
 		},
@@ -629,7 +629,7 @@ func (hunter *Hunter) applyThrillOfTheHunt() {
 				return
 			}
 
-			if procChance == 1 || sim.RandomFloat("ThrillOfTheHunt") < procChance {
+			if sim.Proc(procChance, "ThrillOfTheHunt") {
 				hunter.AddMana(sim, spell.CurCast.Cost*0.4, manaMetrics, false)
 			}
 		},
@@ -675,7 +675,7 @@ func (hunter *Hunter) applyExposeWeakness() {
 				return
 			}
 
-			if procChance == 1 || sim.RandomFloat("ExposeWeakness") < procChance {
+			if sim.Proc(procChance, "ExposeWeakness") {
 				procAura.Activate(sim)
 			}
 		},
@@ -688,7 +688,7 @@ func (hunter *Hunter) applyExposeWeakness() {
 				return
 			}
 
-			if procChance == 1 || sim.RandomFloat("ExposeWeakness") < procChance {
+			if sim.Proc(procChance, "ExposeWeakness") {
 				procAura.Activate(sim)
 			}
 		},

--- a/sim/mage/scorch.go
+++ b/sim/mage/scorch.go
@@ -49,7 +49,7 @@ func (mage *Mage) registerScorchSpell() {
 			baseDamage := sim.Roll(382, 451) + (1.5/3.5)*spell.SpellPower()
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
 			if hasImpScorch && result.Landed() {
-				if procChance == 1.0 || sim.RandomFloat("Improved Scorch") <= procChance {
+				if sim.Proc(procChance, "Improved Scorch") {
 					mage.ScorchAura.Activate(sim)
 				}
 			}

--- a/sim/mage/talents.go
+++ b/sim/mage/talents.go
@@ -102,7 +102,7 @@ func (mage *Mage) applyHotStreak() {
 				return
 			} else {
 				if heatingUp {
-					if procChance == 1 || sim.RandomFloat("Hot Streak") < procChance {
+					if sim.Proc(procChance, "Hot Streak") {
 						mage.HotStreakAura.Activate(sim)
 						heatingUp = false
 					}

--- a/sim/mage/winters_chill.go
+++ b/sim/mage/winters_chill.go
@@ -43,7 +43,7 @@ func (mage *Mage) applyWintersChill() {
 		return
 	}
 
-	procChance := float64(mage.Talents.WintersChill) / 3
+	procChance := []float64{0, 0.33, 0.66, 1}[mage.Talents.WintersChill]
 
 	mage.RegisterAura(core.Aura{
 		Label:    "Winters Chill Talent",
@@ -57,7 +57,7 @@ func (mage *Mage) applyWintersChill() {
 			}
 
 			if spell.SpellSchool == core.SpellSchoolFrost && spell != mage.WintersChill {
-				if procChance == 1.0 || sim.RandomFloat("Winters Chill") < procChance {
+				if sim.Proc(procChance, "Winters Chill") {
 					mage.WintersChill.Cast(sim, spellEffect.Target)
 				}
 			}

--- a/sim/priest/talents.go
+++ b/sim/priest/talents.go
@@ -151,7 +151,7 @@ func (priest *Priest) applyGrace() {
 		},
 		OnHealDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 			if spell == priest.FlashHeal || spell == priest.GreaterHeal || spell == priest.PenanceHeal {
-				if procChance == 1 || sim.RandomFloat("Grace") < procChance {
+				if sim.Proc(procChance, "Grace") {
 					aura := auras[spellEffect.Target.UnitIndex]
 					aura.Activate(sim)
 					aura.AddStack(sim)

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -45,833 +45,833 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7286.70039
-  tps: 5173.55728
+  dps: 7171.59249
+  tps: 5091.83067
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7362.7557
-  tps: 5227.55655
+  dps: 7190.17421
+  tps: 5105.02369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7366.74457
-  tps: 5230.38865
+  dps: 7267.89886
+  tps: 5160.20819
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7340.27692
-  tps: 5211.59661
+  dps: 7217.46622
+  tps: 5124.40101
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5508.43991
-  tps: 3910.99234
+  dps: 5422.66343
+  tps: 3850.09104
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6399.15393
-  tps: 4543.39929
+  dps: 6293.42933
+  tps: 4468.33483
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7362.7557
-  tps: 5123.00542
+  dps: 7190.17421
+  tps: 5002.92321
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7458.9745
-  tps: 5295.8719
+  dps: 7333.6426
+  tps: 5206.88625
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7304.42666
-  tps: 5186.14293
+  dps: 7179.76252
+  tps: 5097.63139
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7324.62236
-  tps: 5200.48188
+  dps: 7189.10733
+  tps: 5104.26621
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 7437.64008
-  tps: 5280.72446
+  dps: 7289.70485
+  tps: 5175.69044
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7350.69459
-  tps: 5218.99316
+  dps: 7203.17314
+  tps: 5114.25293
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7310.93763
-  tps: 5190.76571
+  dps: 7136.82861
+  tps: 5067.14832
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7145.33051
-  tps: 5073.18466
+  dps: 7047.80114
+  tps: 5003.93881
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7361.80939
-  tps: 5226.88466
+  dps: 7219.16531
+  tps: 5125.60737
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7362.7557
-  tps: 5227.55655
+  dps: 7190.17421
+  tps: 5105.02369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7362.7557
-  tps: 5227.55655
+  dps: 7190.17421
+  tps: 5105.02369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7340.27692
-  tps: 5211.59661
+  dps: 7217.46622
+  tps: 5124.40101
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7344.10433
-  tps: 5214.31408
+  dps: 7212.2193
+  tps: 5120.67571
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7362.7557
-  tps: 5227.55655
+  dps: 7190.17421
+  tps: 5105.02369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7313.08971
-  tps: 5192.29369
+  dps: 7137.2466
+  tps: 5067.44509
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7318.26902
-  tps: 5195.971
+  dps: 7141.74777
+  tps: 5070.64091
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7270.22369
-  tps: 5161.85882
+  dps: 7124.93011
+  tps: 5058.70038
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7362.7557
-  tps: 5227.55655
+  dps: 7190.17421
+  tps: 5105.02369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7362.7557
-  tps: 5227.55655
+  dps: 7190.17421
+  tps: 5105.02369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7420.23294
-  tps: 5268.36539
+  dps: 7323.12646
+  tps: 5199.41978
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7145.33051
-  tps: 5073.18466
+  dps: 7047.80114
+  tps: 5003.93881
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7131.58856
-  tps: 5063.42788
+  dps: 7042.12094
+  tps: 4999.90587
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7145.33051
-  tps: 5073.18466
+  dps: 7047.80114
+  tps: 5003.93881
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7340.27692
-  tps: 5211.59661
+  dps: 7217.46622
+  tps: 5124.40101
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7344.10433
-  tps: 5214.31408
+  dps: 7212.2193
+  tps: 5120.67571
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7323.91309
-  tps: 5199.9783
+  dps: 7226.1439
+  tps: 5130.56217
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7362.7557
-  tps: 5227.55655
+  dps: 7190.17421
+  tps: 5105.02369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7399.38191
-  tps: 5253.56115
+  dps: 7226.52115
+  tps: 5130.83001
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7145.33051
-  tps: 5073.18466
+  dps: 7047.80114
+  tps: 5003.93881
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7145.33051
-  tps: 5073.18466
+  dps: 7047.80114
+  tps: 5003.93881
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7412.71944
-  tps: 5263.0308
+  dps: 7261.66937
+  tps: 5155.78525
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7145.33051
-  tps: 5073.18466
+  dps: 7047.80114
+  tps: 5003.93881
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7392.40549
-  tps: 5248.6079
+  dps: 7219.59792
+  tps: 5125.91452
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7399.38191
-  tps: 5253.56115
+  dps: 7226.52115
+  tps: 5130.83001
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7362.7557
-  tps: 5227.55655
+  dps: 7190.17421
+  tps: 5105.02369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7362.7557
-  tps: 5227.55655
+  dps: 7190.17421
+  tps: 5105.02369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7145.33051
-  tps: 5073.18466
+  dps: 7047.80114
+  tps: 5003.93881
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7348.27527
-  tps: 5217.27544
+  dps: 7246.36834
+  tps: 5144.92152
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7373.11107
-  tps: 5234.90886
+  dps: 7271.63662
+  tps: 5162.862
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7461.56741
-  tps: 5297.71286
+  dps: 7343.91287
+  tps: 5214.17814
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7362.7557
-  tps: 5227.55655
+  dps: 7190.17421
+  tps: 5105.02369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7145.33051
-  tps: 5073.18466
+  dps: 7047.80114
+  tps: 5003.93881
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7145.33051
-  tps: 5073.18466
+  dps: 7047.80114
+  tps: 5003.93881
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7577.38087
-  tps: 5379.94041
+  dps: 7506.99462
+  tps: 5329.96618
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7145.33051
-  tps: 5073.18466
+  dps: 7047.80114
+  tps: 5003.93881
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7145.33051
-  tps: 5073.18466
+  dps: 7047.80114
+  tps: 5003.93881
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 5425.30043
-  tps: 3851.9633
+  dps: 5375.68579
+  tps: 3816.73691
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 7262.22834
-  tps: 5156.18212
+  dps: 7095.32193
+  tps: 5037.67857
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StormshroudArmor"
  value: {
-  dps: 5771.49874
-  tps: 4097.7641
+  dps: 5693.47989
+  tps: 4042.37072
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7399.38191
-  tps: 5253.56115
+  dps: 7226.52115
+  tps: 5130.83001
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7392.40549
-  tps: 5248.6079
+  dps: 7219.59792
+  tps: 5125.91452
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7380.19675
-  tps: 5239.93969
+  dps: 7207.48227
+  tps: 5117.31241
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6692.67018
-  tps: 4751.79583
+  dps: 6606.62253
+  tps: 4690.702
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheFistsofFury"
  value: {
-  dps: 6255.14018
-  tps: 4441.14953
+  dps: 6125.85766
+  tps: 4349.35894
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7404.12656
-  tps: 5256.92986
+  dps: 7238.21896
+  tps: 5139.13546
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7540.83634
-  tps: 5353.9938
+  dps: 7377.3882
+  tps: 5237.94563
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7549.80219
-  tps: 5360.35956
+  dps: 7398.43781
+  tps: 5252.89085
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7362.7557
-  tps: 5227.55655
+  dps: 7190.17421
+  tps: 5105.02369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7362.7557
-  tps: 5227.55655
+  dps: 7190.17421
+  tps: 5105.02369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7362.7557
-  tps: 5227.55655
+  dps: 7190.17421
+  tps: 5105.02369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7362.7557
-  tps: 5227.55655
+  dps: 7190.17421
+  tps: 5105.02369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5836.50903
-  tps: 4143.92141
+  dps: 5783.26597
+  tps: 4106.11884
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6881.39336
-  tps: 4885.78929
+  dps: 6737.17227
+  tps: 4783.39231
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 7428.50387
-  tps: 5274.23775
+  dps: 7294.81078
+  tps: 5179.31566
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26036.65748
-  tps: 18486.02681
+  dps: 25755.20766
+  tps: 18286.19744
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7461.56741
-  tps: 5297.71286
+  dps: 7343.91287
+  tps: 5214.17814
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8482.2793
-  tps: 6022.4183
+  dps: 8467.87171
+  tps: 6012.18891
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15246.43489
-  tps: 10824.96877
+  dps: 15083.14159
+  tps: 10709.03053
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3806.15988
-  tps: 2702.37351
+  dps: 3741.02616
+  tps: 2656.12857
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3800.62714
-  tps: 2698.44527
+  dps: 3748.05164
+  tps: 2661.11666
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15876.43622
-  tps: 11272.26972
+  dps: 15750.98141
+  tps: 11183.1968
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5342.3989
-  tps: 3793.10322
+  dps: 5739.2089
+  tps: 4074.83832
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6289.40304
-  tps: 4465.47616
+  dps: 6876.41851
+  tps: 4882.25715
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8991.97337
-  tps: 6384.30109
+  dps: 8956.49983
+  tps: 6359.11488
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2500.24968
-  tps: 1775.17727
+  dps: 2687.72276
+  tps: 1908.28316
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2583.41244
-  tps: 1834.22284
+  dps: 2746.10014
+  tps: 1949.7311
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26036.65748
-  tps: 18486.02681
+  dps: 25755.20766
+  tps: 18286.19744
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7461.56741
-  tps: 5297.71286
+  dps: 7343.91287
+  tps: 5214.17814
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8482.2793
-  tps: 6022.4183
+  dps: 8467.87171
+  tps: 6012.18891
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15246.43489
-  tps: 10824.96877
+  dps: 15083.14159
+  tps: 10709.03053
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3806.15988
-  tps: 2702.37351
+  dps: 3741.02616
+  tps: 2656.12857
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3800.62714
-  tps: 2698.44527
+  dps: 3748.05164
+  tps: 2661.11666
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20122.80816
-  tps: 14287.19379
+  dps: 20038.72317
+  tps: 14227.49345
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4880.18498
-  tps: 3464.93133
+  dps: 4768.21598
+  tps: 3385.43335
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5553.93608
-  tps: 3943.29462
+  dps: 5489.91066
+  tps: 3897.83657
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12929.97492
-  tps: 9180.28219
+  dps: 12920.34393
+  tps: 9173.44419
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2542.99194
-  tps: 1805.52428
+  dps: 2469.56277
+  tps: 1753.38957
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2593.14026
-  tps: 1841.12958
+  dps: 2536.49459
+  tps: 1800.91116
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26186.77596
-  tps: 18592.61094
+  dps: 25870.45726
+  tps: 18368.02465
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7504.70565
-  tps: 5328.34101
+  dps: 7390.06147
+  tps: 5246.94364
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8582.2455
-  tps: 6093.3943
+  dps: 8569.05907
+  tps: 6084.03194
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15273.35326
-  tps: 10844.08082
+  dps: 15219.17605
+  tps: 10805.61499
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3833.36268
-  tps: 2721.6875
+  dps: 3752.65647
+  tps: 2664.38609
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3856.86891
-  tps: 2738.37692
+  dps: 3782.11978
+  tps: 2685.30505
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15954.57947
-  tps: 11327.75143
+  dps: 15834.73221
+  tps: 11242.65987
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5362.56616
-  tps: 3807.42197
+  dps: 5787.54161
+  tps: 4109.15454
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6370.05756
-  tps: 4522.74087
+  dps: 6962.61354
+  tps: 4943.45561
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9027.66319
-  tps: 6409.64086
+  dps: 9011.91479
+  tps: 6398.4595
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2518.51605
-  tps: 1788.14639
+  dps: 2702.50714
+  tps: 1918.78007
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2627.87729
-  tps: 1865.79288
+  dps: 2784.78799
+  tps: 1977.19947
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26186.77596
-  tps: 18592.61094
+  dps: 25870.45726
+  tps: 18368.02465
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7504.70565
-  tps: 5328.34101
+  dps: 7390.06147
+  tps: 5246.94364
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8582.2455
-  tps: 6093.3943
+  dps: 8569.05907
+  tps: 6084.03194
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15273.35326
-  tps: 10844.08082
+  dps: 15219.17605
+  tps: 10805.61499
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3833.36268
-  tps: 2721.6875
+  dps: 3752.65647
+  tps: 2664.38609
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3856.86891
-  tps: 2738.37692
+  dps: 3782.11978
+  tps: 2685.30505
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20207.92608
-  tps: 14347.62752
+  dps: 20116.05977
+  tps: 14282.40244
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4914.54069
-  tps: 3489.32389
+  dps: 4793.58123
+  tps: 3403.44267
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5616.54921
-  tps: 3987.74994
+  dps: 5554.04209
+  tps: 3943.36988
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12997.07895
-  tps: 9227.92605
+  dps: 13037.67021
+  tps: 9256.74585
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2552.79599
-  tps: 1812.48515
+  dps: 2467.09764
+  tps: 1751.63932
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2643.18483
-  tps: 1876.66123
+  dps: 2560.34208
+  tps: 1817.84288
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6926.50542
-  tps: 4917.81885
+  dps: 6876.31758
+  tps: 4882.18548
  }
 }

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -45,840 +45,840 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 6373.27635
-  tps: 4525.02621
+  dps: 6371.53182
+  tps: 4523.78759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6411.09797
-  tps: 4551.87956
+  dps: 6411.89228
+  tps: 4552.44352
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6493.98068
-  tps: 4610.72629
+  dps: 6493.02899
+  tps: 4610.05058
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6436.38265
-  tps: 4569.83168
+  dps: 6436.8908
+  tps: 4570.19247
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4988.73651
-  tps: 3542.00292
+  dps: 4979.19746
+  tps: 3535.2302
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BonescytheBattlegear"
  value: {
-  dps: 5755.54207
-  tps: 4086.43487
+  dps: 5759.44355
+  tps: 4089.20492
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6411.09797
-  tps: 4460.84197
+  dps: 6411.89228
+  tps: 4461.39465
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6552.64852
-  tps: 4652.38045
+  dps: 6553.33547
+  tps: 4652.86818
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6411.591
-  tps: 4552.22961
+  dps: 6412.95801
+  tps: 4553.20019
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6446.02677
-  tps: 4576.67901
+  dps: 6447.48878
+  tps: 4577.71704
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6504.93286
-  tps: 4618.50233
+  dps: 6508.80865
+  tps: 4621.25414
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6427.8476
-  tps: 4563.77179
+  dps: 6431.65479
+  tps: 4566.4749
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6390.98412
-  tps: 4537.59872
+  dps: 6389.95107
+  tps: 4536.86526
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6292.02717
-  tps: 4467.33929
+  dps: 6292.58318
+  tps: 4467.73406
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6440.80666
-  tps: 4572.97273
+  dps: 6440.95811
+  tps: 4573.08026
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6411.09797
-  tps: 4551.87956
+  dps: 6411.89228
+  tps: 4552.44352
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6411.09797
-  tps: 4551.87956
+  dps: 6411.89228
+  tps: 4552.44352
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6436.38265
-  tps: 4569.83168
+  dps: 6436.8908
+  tps: 4570.19247
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6431.27468
-  tps: 4566.20502
+  dps: 6431.42682
+  tps: 4566.31304
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6411.09797
-  tps: 4551.87956
+  dps: 6411.89228
+  tps: 4552.44352
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6434.42616
-  tps: 4568.44257
+  dps: 6436.35217
+  tps: 4569.81004
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6389.27408
-  tps: 4536.38459
+  dps: 6392.69066
+  tps: 4538.81037
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6371.54626
-  tps: 4523.79784
+  dps: 6375.26254
+  tps: 4526.4364
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6411.09797
-  tps: 4551.87956
+  dps: 6411.89228
+  tps: 4552.44352
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6411.09797
-  tps: 4551.87956
+  dps: 6411.89228
+  tps: 4552.44352
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6536.99643
-  tps: 4641.26747
+  dps: 6537.64679
+  tps: 4641.72922
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6292.02717
-  tps: 4467.33929
+  dps: 6292.58318
+  tps: 4467.73406
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Gladiator'sVestments"
  value: {
-  dps: 6359.19468
-  tps: 4515.02822
+  dps: 6363.7697
+  tps: 4518.27649
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6292.02717
-  tps: 4467.33929
+  dps: 6292.58318
+  tps: 4467.73406
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6436.38265
-  tps: 4569.83168
+  dps: 6436.8908
+  tps: 4570.19247
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6431.27468
-  tps: 4566.20502
+  dps: 6431.42682
+  tps: 4566.31304
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6480.9058
-  tps: 4601.44312
+  dps: 6481.39514
+  tps: 4601.79055
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6411.09797
-  tps: 4551.87956
+  dps: 6411.89228
+  tps: 4552.44352
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6443.41748
-  tps: 4574.82641
+  dps: 6444.23749
+  tps: 4575.40862
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6292.02717
-  tps: 4467.33929
+  dps: 6292.58318
+  tps: 4467.73406
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6292.02717
-  tps: 4467.33929
+  dps: 6292.58318
+  tps: 4467.73406
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6505.98233
-  tps: 4619.24745
+  dps: 6511.62909
+  tps: 4623.25665
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6292.02717
-  tps: 4467.33929
+  dps: 6292.58318
+  tps: 4467.73406
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6437.26138
-  tps: 4570.45558
+  dps: 6438.0765
+  tps: 4571.03431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6443.41748
-  tps: 4574.82641
+  dps: 6444.23749
+  tps: 4575.40862
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6411.09797
-  tps: 4551.87956
+  dps: 6411.89228
+  tps: 4552.44352
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6411.09797
-  tps: 4551.87956
+  dps: 6411.89228
+  tps: 4552.44352
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6292.02717
-  tps: 4467.33929
+  dps: 6292.58318
+  tps: 4467.73406
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6441.65324
-  tps: 4573.5738
+  dps: 6443.76828
+  tps: 4575.07548
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6460.68784
-  tps: 4587.08837
+  dps: 6462.96988
+  tps: 4588.70861
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6554.10001
-  tps: 4653.41101
+  dps: 6555.62021
+  tps: 4654.49035
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6411.09797
-  tps: 4551.87956
+  dps: 6411.89228
+  tps: 4552.44352
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6292.02717
-  tps: 4467.33929
+  dps: 6292.58318
+  tps: 4467.73406
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6292.02717
-  tps: 4467.33929
+  dps: 6292.58318
+  tps: 4467.73406
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 6584.58051
-  tps: 4675.05216
+  dps: 6594.40941
+  tps: 4682.03068
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6292.02717
-  tps: 4467.33929
+  dps: 6292.58318
+  tps: 4467.73406
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6292.02717
-  tps: 4467.33929
+  dps: 6292.58318
+  tps: 4467.73406
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Slayer'sArmor"
  value: {
-  dps: 4920.05712
-  tps: 3493.24056
+  dps: 4887.18671
+  tps: 3469.90256
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SparkofLife-37657"
  value: {
-  dps: 6393.63875
-  tps: 4539.48351
+  dps: 6392.06273
+  tps: 4538.36454
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StormshroudArmor"
  value: {
-  dps: 5043.18676
-  tps: 3580.6626
+  dps: 5059.12384
+  tps: 3591.97793
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6443.41748
-  tps: 4574.82641
+  dps: 6444.23749
+  tps: 4575.40862
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6437.26138
-  tps: 4570.45558
+  dps: 6438.0765
+  tps: 4571.03431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6426.48821
-  tps: 4562.80663
+  dps: 6427.29476
+  tps: 4563.37928
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6061.35019
-  tps: 4303.55863
+  dps: 6054.52288
+  tps: 4298.71125
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheFistsofFury"
  value: {
-  dps: 5708.2362
-  tps: 4052.8477
+  dps: 5713.6337
+  tps: 4056.67993
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5844.12279
-  tps: 4149.32718
+  dps: 5852.43272
+  tps: 4155.22723
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6495.60097
-  tps: 4611.87669
+  dps: 6492.89641
+  tps: 4609.95645
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6580.66246
-  tps: 4672.27034
+  dps: 6573.71224
+  tps: 4667.33569
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6607.59851
-  tps: 4691.39494
+  dps: 6606.87218
+  tps: 4690.87925
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6411.09797
-  tps: 4551.87956
+  dps: 6411.89228
+  tps: 4552.44352
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6411.09797
-  tps: 4551.87956
+  dps: 6411.89228
+  tps: 4552.44352
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6411.09797
-  tps: 4551.87956
+  dps: 6411.89228
+  tps: 4552.44352
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6411.09797
-  tps: 4551.87956
+  dps: 6411.89228
+  tps: 4552.44352
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5279.92182
-  tps: 3748.74449
+  dps: 5300.73331
+  tps: 3763.52065
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6084.03941
-  tps: 4319.66798
+  dps: 6086.11073
+  tps: 4321.13862
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 6495.40035
-  tps: 4611.73425
+  dps: 6487.31651
+  tps: 4605.99472
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14268.59838
-  tps: 10130.70485
+  dps: 14213.43845
+  tps: 10091.5413
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5564.76062
-  tps: 3950.98004
+  dps: 5562.67448
+  tps: 3949.49888
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6744.52458
-  tps: 4788.61245
+  dps: 6746.25116
+  tps: 4789.83833
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8743.48763
-  tps: 6207.87622
+  dps: 8692.83698
+  tps: 6171.91426
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2568.65502
-  tps: 1823.74506
+  dps: 2567.07714
+  tps: 1822.62477
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2788.13375
-  tps: 1979.57497
+  dps: 2784.78918
+  tps: 1977.20032
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19467.33177
-  tps: 13821.80556
+  dps: 19381.64754
+  tps: 13760.96975
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6554.10001
-  tps: 4653.41101
+  dps: 6555.62021
+  tps: 4654.49035
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7692.31369
-  tps: 5461.54272
+  dps: 7678.35108
+  tps: 5451.62927
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12320.10796
-  tps: 8747.27665
+  dps: 12282.69932
+  tps: 8720.71652
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3219.42096
-  tps: 2285.78888
+  dps: 3217.28306
+  tps: 2284.27097
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3373.49453
-  tps: 2395.18112
+  dps: 3393.34455
+  tps: 2409.27463
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19467.33177
-  tps: 13821.80556
+  dps: 19381.64754
+  tps: 13760.96975
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6554.10001
-  tps: 4653.41101
+  dps: 6555.62021
+  tps: 4654.49035
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7692.31369
-  tps: 5461.54272
+  dps: 7678.35108
+  tps: 5451.62927
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12320.10796
-  tps: 8747.27665
+  dps: 12282.69932
+  tps: 8720.71652
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3219.42096
-  tps: 2285.78888
+  dps: 3217.28306
+  tps: 2284.27097
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3373.49453
-  tps: 2395.18112
+  dps: 3393.34455
+  tps: 2409.27463
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18197.46096
-  tps: 12920.19728
+  dps: 18112.18624
+  tps: 12859.65223
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4836.09443
-  tps: 3433.62705
+  dps: 4840.50732
+  tps: 3436.7602
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5660.21646
-  tps: 4018.75368
+  dps: 5657.76857
+  tps: 4017.01568
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11985.28312
-  tps: 8509.55102
+  dps: 11948.95336
+  tps: 8483.75688
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2393.05193
-  tps: 1699.06687
+  dps: 2391.34779
+  tps: 1697.85693
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2549.27721
-  tps: 1809.98682
+  dps: 2561.51782
+  tps: 1818.67766
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14396.17276
-  tps: 10221.28266
+  dps: 14339.94287
+  tps: 10181.35944
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5610.58827
-  tps: 3983.51767
+  dps: 5607.67846
+  tps: 3981.4517
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6837.58338
-  tps: 4854.6842
+  dps: 6839.00077
+  tps: 4855.69055
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8832.39234
-  tps: 6270.99856
+  dps: 8780.71022
+  tps: 6234.30425
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2593.56199
-  tps: 1841.42901
+  dps: 2591.92821
+  tps: 1840.26903
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2831.75832
-  tps: 2010.5484
+  dps: 2827.94155
+  tps: 2007.8385
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19622.79304
-  tps: 13932.18306
+  dps: 19533.11385
+  tps: 13868.51083
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6606.9212
-  tps: 4690.91405
+  dps: 6607.65051
+  tps: 4691.43186
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7799.72723
-  tps: 5537.80633
+  dps: 7784.00686
+  tps: 5526.64487
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12430.76001
-  tps: 8825.83961
+  dps: 12392.93167
+  tps: 8798.98149
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3249.71693
-  tps: 2307.29902
+  dps: 3247.36159
+  tps: 2305.62673
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3425.14133
-  tps: 2431.85034
+  dps: 3445.703
+  tps: 2446.44913
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19622.79304
-  tps: 13932.18306
+  dps: 19533.11385
+  tps: 13868.51083
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6606.9212
-  tps: 4690.91405
+  dps: 6607.65051
+  tps: 4691.43186
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7799.72723
-  tps: 5537.80633
+  dps: 7784.00686
+  tps: 5526.64487
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12430.76001
-  tps: 8825.83961
+  dps: 12392.93167
+  tps: 8798.98149
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3249.71693
-  tps: 2307.29902
+  dps: 3247.36159
+  tps: 2305.62673
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3425.14133
-  tps: 2431.85034
+  dps: 3445.703
+  tps: 2446.44913
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18339.17311
-  tps: 13020.81291
+  dps: 18252.24907
+  tps: 12959.09684
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4873.5418
-  tps: 3460.21468
+  dps: 4877.60835
+  tps: 3463.10193
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5735.52703
-  tps: 4072.22419
+  dps: 5733.01389
+  tps: 4070.43987
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12090.95439
-  tps: 8584.57762
+  dps: 12053.88339
+  tps: 8558.25721
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2415.08991
-  tps: 1714.71383
+  dps: 2413.01542
+  tps: 1713.24095
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2587.42075
-  tps: 1837.06873
+  dps: 2599.42623
+  tps: 1845.59262
  }
 }
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6288.33364
-  tps: 4464.71689
+  dps: 6259.2635
+  tps: 4444.07708
  }
 }

--- a/sim/rogue/TestRotation.results
+++ b/sim/rogue/TestRotation.results
@@ -39,15 +39,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 37.1
+   value: 37.2
   }
   casts: {
    key: "spell_id:48665"
-   value: 37.1
+   value: 37.2
   }
   casts: {
    key: "spell_id:48666"
-   value: 37.1
+   value: 37.2
   }
   casts: {
    key: "spell_id:48668 tag:1"
@@ -95,7 +95,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:51662"
-   value: 6.2
+   value: 6
   }
   casts: {
    key: "spell_id:51723"
@@ -115,11 +115,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 156.3
+   value: 155.5
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 299
+   value: 298.7
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -127,7 +127,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 304
+   value: 303.7
   }
   casts: {
    key: "spell_id:57975"
@@ -143,7 +143,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:1"
-   value: 38.5
+   value: 39.1
   }
   casts: {
    key: "spell_id:57993 tag:2"
@@ -151,7 +151,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:3"
-   value: 17.3
+   value: 17.5
   }
   casts: {
    key: "spell_id:57993 tag:4"
@@ -171,7 +171,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:1"
-   value: 0.1
+   value: 0
   }
   casts: {
    key: "spell_id:6774 tag:2"
@@ -179,7 +179,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 0.9
+   value: 0.8
   }
   casts: {
    key: "spell_id:6774 tag:4"
@@ -187,23 +187,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 0.5
+   value: 0.4
   }
   casts: {
    key: "spell_id:8647 tag:1"
-   value: 7.3
+   value: 6.7
   }
   casts: {
    key: "spell_id:8647 tag:2"
-   value: 2.2
+   value: 2.1
   }
   casts: {
    key: "spell_id:8647 tag:3"
-   value: 9.9
+   value: 10.1
   }
   casts: {
    key: "spell_id:8647 tag:4"
-   value: 1.7
+   value: 1.9
   }
   casts: {
    key: "spell_id:8647 tag:5"
@@ -252,19 +252,19 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 33.2
+   value: 33
   }
   casts: {
    key: "spell_id:48665"
-   value: 33.2
+   value: 33
   }
   casts: {
    key: "spell_id:48666"
-   value: 33.2
+   value: 33
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0.1
+   value: 0.2
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -324,15 +324,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57934 tag:1"
-   value: 8.3
+   value: 10
   }
   casts: {
    key: "spell_id:57968"
-   value: 164.8
+   value: 164.6
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 304.5
+   value: 303.2
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -340,7 +340,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 309.5
+   value: 308.2
   }
   casts: {
    key: "spell_id:57975"
@@ -356,23 +356,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:1"
-   value: 44
+   value: 43.5
   }
   casts: {
    key: "spell_id:57993 tag:2"
-   value: 4.9
+   value: 5
   }
   casts: {
    key: "spell_id:57993 tag:3"
-   value: 26
+   value: 25.9
   }
   casts: {
    key: "spell_id:57993 tag:4"
-   value: 1
+   value: 0.9
   }
   casts: {
    key: "spell_id:57993 tag:5"
-   value: 0.1
+   value: 0
   }
   casts: {
    key: "spell_id:58426"
@@ -392,7 +392,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 0.9
+   value: 0.8
   }
   casts: {
    key: "spell_id:6774 tag:4"
@@ -437,11 +437,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 421.8
+   value: 421.6
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 328.2
+   value: 328.1
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -465,15 +465,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 62.3
+   value: 62
   }
   casts: {
    key: "spell_id:48665"
-   value: 62.3
+   value: 62
   }
   casts: {
    key: "spell_id:48666"
-   value: 62.3
+   value: 62
   }
   casts: {
    key: "spell_id:48668 tag:1"
@@ -493,7 +493,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:5"
-   value: 6.7
+   value: 6.4
   }
   casts: {
    key: "spell_id:48672"
@@ -501,11 +501,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 1.2
+   value: 1.1
   }
   casts: {
    key: "spell_id:48672 tag:2"
-   value: 0.9
+   value: 0.7
   }
   casts: {
    key: "spell_id:48672 tag:3"
@@ -513,15 +513,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:4"
-   value: 6.1
+   value: 6
   }
   casts: {
    key: "spell_id:48672 tag:5"
-   value: 12.1
+   value: 12.2
   }
   casts: {
    key: "spell_id:51662"
-   value: 5.5
+   value: 5.6
   }
   casts: {
    key: "spell_id:51723"
@@ -537,15 +537,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57934 tag:1"
-   value: 8.3
+   value: 10
   }
   casts: {
    key: "spell_id:57968"
-   value: 134.4
+   value: 133.8
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 257.7
+   value: 257.4
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -553,7 +553,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 262.7
+   value: 262.4
   }
   casts: {
    key: "spell_id:57975"
@@ -601,11 +601,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 0.9
+   value: 1.1
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 5.4
+   value: 5.3
   }
   casts: {
    key: "spell_id:6774 tag:4"
@@ -613,7 +613,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 1.1
+   value: 1.2
   }
   casts: {
    key: "spell_id:8647 tag:1"
@@ -690,7 +690,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0.2
+   value: 0.1
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -734,7 +734,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:51662"
-   value: 5.5
+   value: 5.6
   }
   casts: {
    key: "spell_id:51723"
@@ -754,11 +754,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 166.7
+   value: 167.1
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 309.3
+   value: 309.6
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -766,7 +766,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 314.3
+   value: 314.6
   }
   casts: {
    key: "spell_id:57975"
@@ -782,11 +782,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:1"
-   value: 44.7
+   value: 44.6
   }
   casts: {
    key: "spell_id:57993 tag:2"
-   value: 5.3
+   value: 5.2
   }
   casts: {
    key: "spell_id:57993 tag:3"
@@ -814,11 +814,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 0.2
+   value: 0.1
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 0.8
+   value: 0.9
   }
   casts: {
    key: "spell_id:6774 tag:4"
@@ -891,19 +891,19 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 33.2
+   value: 33
   }
   casts: {
    key: "spell_id:48665"
-   value: 33.2
+   value: 33
   }
   casts: {
    key: "spell_id:48666"
-   value: 33.2
+   value: 33
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0.1
+   value: 0.2
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -963,15 +963,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57934 tag:1"
-   value: 8.3
+   value: 10
   }
   casts: {
    key: "spell_id:57968"
-   value: 164.8
+   value: 164.6
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 304.5
+   value: 303.2
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -979,7 +979,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 309.5
+   value: 308.2
   }
   casts: {
    key: "spell_id:57975"
@@ -995,23 +995,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:1"
-   value: 44
+   value: 43.5
   }
   casts: {
    key: "spell_id:57993 tag:2"
-   value: 4.9
+   value: 5
   }
   casts: {
    key: "spell_id:57993 tag:3"
-   value: 26
+   value: 25.9
   }
   casts: {
    key: "spell_id:57993 tag:4"
-   value: 1
+   value: 0.9
   }
   casts: {
    key: "spell_id:57993 tag:5"
-   value: 0.1
+   value: 0
   }
   casts: {
    key: "spell_id:58426"
@@ -1031,7 +1031,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 0.9
+   value: 0.8
   }
   casts: {
    key: "spell_id:6774 tag:4"
@@ -1104,15 +1104,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 35.1
+   value: 34.9
   }
   casts: {
    key: "spell_id:48665"
-   value: 35.1
+   value: 34.9
   }
   casts: {
    key: "spell_id:48666"
-   value: 35.1
+   value: 34.9
   }
   casts: {
    key: "spell_id:48668 tag:1"
@@ -1180,11 +1180,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 166.3
+   value: 165.5
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 309
+   value: 309.3
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -1192,7 +1192,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 314
+   value: 314.3
   }
   casts: {
    key: "spell_id:57975"
@@ -1208,15 +1208,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:1"
-   value: 44.1
+   value: 44.4
   }
   casts: {
    key: "spell_id:57993 tag:2"
-   value: 4.8
+   value: 5.2
   }
   casts: {
    key: "spell_id:57993 tag:3"
-   value: 26.8
+   value: 26.2
   }
   casts: {
    key: "spell_id:57993 tag:4"
@@ -1224,7 +1224,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:5"
-   value: 0.1
+   value: 0
   }
   casts: {
    key: "spell_id:58426"
@@ -1405,7 +1405,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 113.8
+   value: 113.9
   }
   casts: {
    key: "spell_id:57968 tag:1"
@@ -1490,11 +1490,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 480.1
+   value: 480.4
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 373.6
+   value: 373.8
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -1518,7 +1518,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48638"
-   value: 96.3
+   value: 95.6
   }
   casts: {
    key: "spell_id:48664"
@@ -1534,7 +1534,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 1.1
+   value: 1.2
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -1558,23 +1558,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 7.1
+   value: 7.8
   }
   casts: {
    key: "spell_id:48672 tag:2"
-   value: 3.6
+   value: 3.5
   }
   casts: {
    key: "spell_id:48672 tag:3"
-   value: 5.1
+   value: 5.2
   }
   casts: {
    key: "spell_id:48672 tag:4"
-   value: 4.9
+   value: 4.6
   }
   casts: {
    key: "spell_id:48672 tag:5"
-   value: 4.9
+   value: 4.8
   }
   casts: {
    key: "spell_id:51690"
@@ -1602,15 +1602,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57934 tag:1"
-   value: 8.4
+   value: 10
   }
   casts: {
    key: "spell_id:57968"
-   value: 113.6
+   value: 113.4
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 227.9
+   value: 228.2
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -1618,7 +1618,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 233
+   value: 233.2
   }
   casts: {
    key: "spell_id:57975"
@@ -1638,7 +1638,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:1"
-   value: 4.8
+   value: 4.3
   }
   casts: {
    key: "spell_id:6774 tag:2"
@@ -1646,15 +1646,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 3.1
+   value: 3.2
   }
   casts: {
    key: "spell_id:6774 tag:4"
-   value: 3
+   value: 2.9
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 1.3
+   value: 1.4
   }
   casts: {
    key: "spell_id:8647 tag:1"
@@ -1691,11 +1691,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 474.4
+   value: 474
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 369.2
+   value: 368.7
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -1719,7 +1719,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48638"
-   value: 40.9
+   value: 40.7
   }
   casts: {
    key: "spell_id:48664"
@@ -1735,7 +1735,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 77.5
+   value: 77.1
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -1803,7 +1803,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57934 tag:1"
-   value: 8.6
+   value: 10
   }
   casts: {
    key: "spell_id:57968"
@@ -1811,7 +1811,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 223.7
+   value: 223.5
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -1819,7 +1819,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 228.7
+   value: 228.6
   }
   casts: {
    key: "spell_id:57975"
@@ -1839,7 +1839,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:1"
-   value: 21.5
+   value: 21.4
   }
   casts: {
    key: "spell_id:6774 tag:2"
@@ -2093,11 +2093,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 480.1
+   value: 480.4
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 373.6
+   value: 373.8
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -2121,7 +2121,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48638"
-   value: 96.3
+   value: 95.6
   }
   casts: {
    key: "spell_id:48664"
@@ -2137,7 +2137,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 1.1
+   value: 1.2
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -2161,23 +2161,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 7.1
+   value: 7.8
   }
   casts: {
    key: "spell_id:48672 tag:2"
-   value: 3.6
+   value: 3.5
   }
   casts: {
    key: "spell_id:48672 tag:3"
-   value: 5.1
+   value: 5.2
   }
   casts: {
    key: "spell_id:48672 tag:4"
-   value: 4.9
+   value: 4.6
   }
   casts: {
    key: "spell_id:48672 tag:5"
-   value: 4.9
+   value: 4.8
   }
   casts: {
    key: "spell_id:51690"
@@ -2205,15 +2205,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57934 tag:1"
-   value: 8.4
+   value: 10
   }
   casts: {
    key: "spell_id:57968"
-   value: 113.6
+   value: 113.4
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 227.9
+   value: 228.2
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -2221,7 +2221,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 233
+   value: 233.2
   }
   casts: {
    key: "spell_id:57975"
@@ -2241,7 +2241,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:1"
-   value: 4.8
+   value: 4.3
   }
   casts: {
    key: "spell_id:6774 tag:2"
@@ -2249,15 +2249,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 3.1
+   value: 3.2
   }
   casts: {
    key: "spell_id:6774 tag:4"
-   value: 3
+   value: 2.9
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 1.3
+   value: 1.4
   }
   casts: {
    key: "spell_id:8647 tag:1"

--- a/sim/rogue/backstab.go
+++ b/sim/rogue/backstab.go
@@ -44,7 +44,7 @@ func (rogue *Rogue) registerBackstabSpell() {
 
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 310, true),
-			OutcomeApplier: rogue.OutcomeFuncMeleeSpecialHitAndCrit(),
+			OutcomeApplier: rogue.OutcomeFuncMeleeWeaponSpecialHitAndCrit(),
 
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if spellEffect.Landed() {

--- a/sim/rogue/eviscerate.go
+++ b/sim/rogue/eviscerate.go
@@ -10,7 +10,9 @@ import (
 
 func (rogue *Rogue) makeEviscerate(comboPoints int32) *core.Spell {
 	baseDamage := 127.0 + 370*float64(comboPoints)
-	apRatio := 0.05 * float64(comboPoints)
+	// tooltip implies 3..7% AP scaling, but testing show it's fixed at 7% (3.4.0.46158)
+	apRatio := 0.07 * float64(comboPoints)
+
 	cost := 35.0
 	refundAmount := 0.4 * float64(rogue.Talents.QuickRecovery)
 

--- a/sim/rogue/fan_of_knives.go
+++ b/sim/rogue/fan_of_knives.go
@@ -33,7 +33,7 @@ func (rogue *Rogue) makeFanOfKnivesWeaponHitSpell(isMH bool) (*core.Spell, core.
 
 	effect := core.SpellEffect{
 		BaseDamage:     baseDamageConfig,
-		OutcomeApplier: rogue.OutcomeFuncMeleeSpecialHitAndCrit(),
+		OutcomeApplier: rogue.OutcomeFuncMeleeWeaponSpecialHitAndCrit(),
 	}
 
 	spell := rogue.RegisterSpell(core.SpellConfig{

--- a/sim/rogue/hemorrhage.go
+++ b/sim/rogue/hemorrhage.go
@@ -69,7 +69,7 @@ func (rogue *Rogue) registerHemorrhageSpell() {
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			BaseDamage: core.BaseDamageConfigMeleeWeapon(
 				core.MainHand, true, 0, true),
-			OutcomeApplier: rogue.OutcomeFuncMeleeSpecialHitAndCrit(),
+			OutcomeApplier: rogue.OutcomeFuncMeleeWeaponSpecialHitAndCrit(),
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if spellEffect.Landed() {
 					rogue.AddComboPoints(sim, 1, spell.ComboPointMetrics())

--- a/sim/rogue/items.go
+++ b/sim/rogue/items.go
@@ -208,8 +208,8 @@ func init() {
 				numPoints = rogue.ComboPoints()
 
 				if spell.SameActionIgnoreTag(rogue.SliceAndDice[1].ActionID) {
-					// SND won't call OnSpellHit so we have to add the effect now.
-					if numPoints == 5 || sim.RandomFloat("AshtongueTalismanOfLethality") < 0.2*float64(numPoints) {
+					// SND won't call OnSpellHit, so we have to add the effect now.
+					if p := 0.2 * float64(numPoints); sim.Proc(p, "AshtongueTalismanOfLethality") {
 						procAura.Activate(sim)
 					}
 				}
@@ -219,7 +219,7 @@ func init() {
 					return
 				}
 
-				if numPoints == 5 || sim.RandomFloat("AshtongueTalismanOfLethality") < 0.2*float64(numPoints) {
+				if p := 0.2 * float64(numPoints); sim.Proc(p, "AshtongueTalismanOfLethality") {
 					procAura.Activate(sim)
 				}
 			},

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -22,7 +22,7 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 	procMask := core.ProcMaskMeleeMHSpecial
 	effect := core.SpellEffect{
 		BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 181, false),
-		OutcomeApplier: rogue.OutcomeFuncMeleeSpecialHitAndCrit(),
+		OutcomeApplier: rogue.OutcomeFuncMeleeSpecialCritOnly(), // Crit/Hit, should include Block
 
 		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 			if isMH {
@@ -100,7 +100,7 @@ func (rogue *Rogue) registerMutilateSpell() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
-			OutcomeApplier: rogue.OutcomeFuncMeleeSpecialHit(),
+			OutcomeApplier: rogue.OutcomeFuncMeleeSpecialHit(), // Miss/Dodge/Parry/Hit
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if !spellEffect.Landed() {
 					rogue.AddEnergy(sim, refundAmount, rogue.EnergyRefundMetrics)

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -69,8 +69,9 @@ type Rogue struct {
 
 	lastDeadlyPoisonProcMask    core.ProcMask
 	deadlyPoisonProcChanceBonus float64
-	instantPoisonPPMM           core.PPMManager
 	deadlyPoisonDots            []*core.Dot
+	instantPoisonPPMM           core.PPMManager
+	woundPoisonPPMM             core.PPMManager
 	ruptureDot                  *core.Dot
 
 	AdrenalineRushAura   *core.Aura
@@ -244,8 +245,8 @@ func NewRogue(character core.Character, options proto.Player) *Rogue {
 
 func (rogue *Rogue) ApplyCutToTheChase(sim *core.Simulation) {
 	if rogue.Talents.CutToTheChase > 0 && rogue.SliceAndDiceAura.IsActive() {
-		chanceToRefresh := float64(rogue.Talents.CutToTheChase) * 0.2
-		if chanceToRefresh == 1 || sim.RandomFloat("Cut to the Chase") < chanceToRefresh {
+		procChance := float64(rogue.Talents.CutToTheChase) * 0.2
+		if sim.Proc(procChance, "Cut to the Chase") {
 			rogue.SliceAndDiceAura.Duration = rogue.sliceAndDiceDurations[5]
 			rogue.SliceAndDiceAura.Activate(sim)
 		}

--- a/sim/rogue/rupture.go
+++ b/sim/rogue/rupture.go
@@ -14,7 +14,7 @@ const RuptureSpellID = 48672
 
 func (rogue *Rogue) makeRupture(comboPoints int32) *core.Spell {
 	refundAmount := 0.4 * float64(rogue.Talents.QuickRecovery)
-	numTicks := int(comboPoints) + 3 + core.TernaryInt(rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfRupture), 2, 0)
+	numTicks := comboPoints + 3 + core.TernaryInt32(rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfRupture), 2, 0)
 	baseCost := RuptureEnergyCost
 
 	return rogue.RegisterSpell(core.SpellConfig{
@@ -48,7 +48,7 @@ func (rogue *Rogue) makeRupture(comboPoints int32) *core.Spell {
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if spellEffect.Landed() {
 					rogue.ruptureDot.Spell = spell
-					rogue.ruptureDot.NumberOfTicks = numTicks
+					rogue.ruptureDot.NumberOfTicks = int(numTicks)
 					rogue.ruptureDot.RecomputeAuraDuration()
 					rogue.ruptureDot.Apply(sim)
 					rogue.ApplyFinisher(sim, spell)
@@ -93,7 +93,7 @@ func (rogue *Rogue) registerRupture() {
 				comboPoints := rogue.ComboPoints()
 				return 127 +
 					18*float64(comboPoints) +
-					[]float64{0.0, 0.015, 0.024, 0.03, 0.034286, 0.0375}[comboPoints]*spell.MeleeAttackPower()
+					[]float64{0, 0.06 / 4, 0.12 / 5, 0.18 / 6, 0.24 / 7, 0.30 / 8}[comboPoints]*spell.MeleeAttackPower()
 			}),
 			OutcomeApplier: rogue.OutcomeFuncTickHitAndCrit(),
 		}),

--- a/sim/rogue/sinister_strike.go
+++ b/sim/rogue/sinister_strike.go
@@ -47,7 +47,7 @@ func (rogue *Rogue) registerSinisterStrikeSpell() {
 
 		ApplyEffects: core.ApplyEffectFuncDirectDamage(core.SpellEffect{
 			BaseDamage:     core.BaseDamageConfigMeleeWeapon(core.MainHand, true, 180, true),
-			OutcomeApplier: rogue.OutcomeFuncMeleeSpecialHitAndCrit(),
+			OutcomeApplier: rogue.OutcomeFuncMeleeWeaponSpecialHitAndCrit(),
 			OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 				if spellEffect.Landed() {
 					points := int32(1)

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -54,18 +54,17 @@ func getRelentlessStrikesSpellID(talentPoints int32) int32 {
 }
 
 func (rogue *Rogue) makeFinishingMoveEffectApplier() func(sim *core.Simulation, numPoints int32) {
-	ruthlessnessChance := 0.2 * float64(rogue.Talents.Ruthlessness)
 	ruthlessnessMetrics := rogue.NewComboPointMetrics(core.ActionID{SpellID: 14161})
-
-	relentlessStrikes := rogue.Talents.RelentlessStrikes
 	relentlessStrikesMetrics := rogue.NewEnergyMetrics(core.ActionID{SpellID: getRelentlessStrikesSpellID(rogue.Talents.RelentlessStrikes)})
 
 	return func(sim *core.Simulation, numPoints int32) {
-		if ruthlessnessChance > 0 && sim.RandomFloat("Ruthlessness") < ruthlessnessChance {
-			rogue.AddComboPoints(sim, 1, ruthlessnessMetrics)
+		if t := rogue.Talents.Ruthlessness; t > 0 {
+			if sim.RandomFloat("Ruthlessness") < 0.2*float64(t) {
+				rogue.AddComboPoints(sim, 1, ruthlessnessMetrics)
+			}
 		}
-		if relentlessStrikes > 0 {
-			if sim.RandomFloat("RelentlessStrikes") < 0.04*float64(relentlessStrikes)*float64(numPoints) {
+		if t := rogue.Talents.RelentlessStrikes; t > 0 {
+			if sim.RandomFloat("RelentlessStrikes") < 0.04*float64(t*numPoints) {
 				rogue.AddEnergy(sim, 25, relentlessStrikesMetrics)
 			}
 		}
@@ -227,7 +226,7 @@ func (rogue *Rogue) applySealFate() {
 				return
 			}
 
-			if procChance == 1 || sim.RandomFloat("Seal Fate") < procChance {
+			if sim.Proc(procChance, "Seal Fate") {
 				rogue.AddComboPoints(sim, 1, cpMetrics)
 			}
 		},
@@ -323,7 +322,7 @@ func (rogue *Rogue) applyFocusedAttacks() {
 		return
 	}
 
-	procChance := float64(rogue.Talents.FocusedAttacks) / 3.0
+	procChance := []float64{0, 0.33, 0.66, 1}[rogue.Talents.FocusedAttacks]
 	energyMetrics := rogue.NewEnergyMetrics(core.ActionID{SpellID: 51637})
 
 	rogue.RegisterAura(core.Aura{
@@ -340,7 +339,7 @@ func (rogue *Rogue) applyFocusedAttacks() {
 			if spell.ProcMask.Matches(core.ProcMaskMeleeOH) && spell.IsSpellAction(FanOfKnivesSpellID) {
 				return
 			}
-			if procChance == 1 || sim.RandomFloat("Focused Attacks") <= procChance {
+			if sim.Proc(procChance, "Focused Attacks") {
 				rogue.AddEnergy(sim, 2, energyMetrics)
 			}
 		},

--- a/sim/rogue/tricks_of_the_trade.go
+++ b/sim/rogue/tricks_of_the_trade.go
@@ -13,12 +13,14 @@ var TricksOfTheTradeActionID = core.ActionID{SpellID: 57934}
 func (rogue *Rogue) registerTricksOfTheTradeSpell() {
 	hasShadowblades := rogue.HasSetBonus(ItemSetShadowblades, 2)
 	energyMetrics := rogue.NewEnergyMetrics(TricksOfTheTradeActionID)
-	energyCost := 15.0
+	energyCost := 15 - 5*float64(rogue.Talents.FilthyTricks)
+
 	auraDuration := time.Second * 6
-	spellTag := int32(0)
 	if rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfTricksOfTheTrade) {
 		auraDuration += time.Second * 4
 	}
+
+	var spellTag int32
 	if rogue.Options.TricksOfTheTradeTarget != nil {
 		target := rogue.Env.Raid.GetPlayerFromRaidTarget(*rogue.Options.TricksOfTheTradeTarget).GetCharacter()
 		rogue.TricksOfTheTradeAura = core.TricksOfTheTradeAura(target, spellTag)
@@ -42,7 +44,7 @@ func (rogue *Rogue) registerTricksOfTheTradeSpell() {
 			IgnoreHaste: true,
 			CD: core.Cooldown{
 				Timer:    rogue.NewTimer(),
-				Duration: time.Second*30 + auraDuration,
+				Duration: time.Second * time.Duration(30-5*rogue.Talents.FilthyTricks),
 			},
 			ModifyCast: func(sim *core.Simulation, spell *core.Spell, cast *core.Cast) {
 				if hasShadowblades {

--- a/sim/warlock/TestWarlock.results
+++ b/sim/warlock/TestWarlock.results
@@ -45,8 +45,8 @@ character_stats_results: {
 dps_results: {
  key: "TestWarlock-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 7101.56325
-  tps: 6369.72967
+  dps: 7084.43112
+  tps: 6352.63961
  }
 }
 dps_results: {
@@ -59,8 +59,8 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6935.84464
-  tps: 6190.35532
+  dps: 6948.48271
+  tps: 6205.40364
  }
 }
 dps_results: {
@@ -73,8 +73,8 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7025.98746
-  tps: 6280.49813
+  dps: 7039.50643
+  tps: 6296.42736
  }
 }
 dps_results: {
@@ -94,8 +94,8 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6936.90865
-  tps: 6191.41932
+  dps: 6920.33437
+  tps: 6178.615
  }
 }
 dps_results: {
@@ -115,8 +115,8 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6935.84464
-  tps: 6190.35532
+  dps: 6948.48271
+  tps: 6205.40364
  }
 }
 dps_results: {
@@ -164,8 +164,8 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6935.84464
-  tps: 6190.35532
+  dps: 6948.48271
+  tps: 6205.40364
  }
 }
 dps_results: {
@@ -304,8 +304,8 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-Average-Default"
  value: {
-  dps: 7052.51393
-  tps: 6311.08561
+  dps: 7042.35258
+  tps: 6300.55959
  }
 }
 dps_results: {
@@ -437,7 +437,7 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6991.31323
-  tps: 6280.49813
+  dps: 7004.80674
+  tps: 6296.42736
  }
 }

--- a/sim/warlock/shadowbolt.go
+++ b/sim/warlock/shadowbolt.go
@@ -53,7 +53,7 @@ func (warlock *Warlock) registerShadowBoltSpell() {
 			spell.WaitTravelTime(sim, func(sim *core.Simulation) {
 				if result.Landed() {
 					// ISB debuff
-					if ISBProcChance > 0 && (ISBProcChance == 1 || sim.RandomFloat("ISB") <= ISBProcChance) {
+					if sim.Proc(ISBProcChance, "ISB") {
 						// TODO precalculate aura
 						core.ShadowMasteryAura(target).Activate(sim) // calls refresh if already active.
 					}

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -587,7 +587,7 @@ func (warrior *Warrior) applySuddenDeath() {
 		Label:    "Sudden Death Proc",
 		ActionID: core.ActionID{SpellID: 29724},
 		Duration: time.Second * 10,
-		// 2 stacks to accomodate T10 4 pc
+		// 2 stacks to accommodate T10 4 pc
 		MaxStacks: 2,
 	})
 	warrior.RegisterAura(core.Aura{
@@ -647,7 +647,7 @@ func (warrior *Warrior) applyShieldSpecialization() {
 		},
 		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 			if spellEffect.Outcome.Matches(core.OutcomeBlock | core.OutcomeDodge | core.OutcomeParry) {
-				if procChance == 1.0 || sim.RandomFloat("Shield Specialization") < procChance {
+				if sim.Proc(procChance, "Shield Specialization") {
 					warrior.AddRage(sim, rageAdded, rageMetrics)
 				}
 			}


### PR DESCRIPTION
[core] add Proc() as a wrapper for RandomFloat() checks with "always" and "never" handling; this is used in quite a few places

[deathknight] Glyph of Anti-Magic Shield was reducing the CD instead of increasing the duration of AMS 

[rogue] Backstab, Hemorrhage, Sinister Strike, and FoK now use the correct OutcomeFunc for handling "in front of target"
[rogue] Tricks of the Trade's CD was too long
[rogue] Wound Poison correctly uses PPM now
[rogue] Mutilate's "hit spells" will now always land 
[rogue] Eviscerate now scales with 7% AP per combo point, as per testing (wrong tooltip) 
[rogue] Envenom aura duration is now independent of DP doses; it's base damage is multiplied by consumed doses (limited by combo points spent); non-consumed doses aren't removed anymore
