### PR TITLE
Melee auto attack changes

### DIFF
--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -239,7 +239,7 @@ func (unit *Unit) EnableAutoAttacks(agent Agent, options AutoAttackOptions) {
 		ActionID:    ActionID{OtherID: proto.OtherAction_OtherActionAttack, Tag: 1},
 		SpellSchool: unit.AutoAttacks.MH.GetSpellSchool(),
 		ProcMask:    ProcMaskMeleeMHAuto,
-		Flags:       SpellFlagMeleeMetrics | SpellFlagIncludeTargetBonusDamage,
+		Flags:       SpellFlagMeleeMetrics | SpellFlagIncludeTargetBonusDamage | SpellFlagNoOnCastComplete,
 
 		DamageMultiplier: 1,
 		CritMultiplier:   options.MainHand.CritMultiplier,
@@ -257,7 +257,7 @@ func (unit *Unit) EnableAutoAttacks(agent Agent, options AutoAttackOptions) {
 		ActionID:    ActionID{OtherID: proto.OtherAction_OtherActionAttack, Tag: 2},
 		SpellSchool: unit.AutoAttacks.OH.GetSpellSchool(),
 		ProcMask:    ProcMaskMeleeOHAuto,
-		Flags:       SpellFlagMeleeMetrics | SpellFlagIncludeTargetBonusDamage,
+		Flags:       SpellFlagMeleeMetrics | SpellFlagIncludeTargetBonusDamage | SpellFlagNoOnCastComplete,
 
 		DamageMultiplier: 1,
 		CritMultiplier:   options.OffHand.CritMultiplier,
@@ -275,7 +275,7 @@ func (unit *Unit) EnableAutoAttacks(agent Agent, options AutoAttackOptions) {
 		ActionID:    ActionID{OtherID: proto.OtherAction_OtherActionShoot},
 		SpellSchool: SpellSchoolPhysical,
 		ProcMask:    ProcMaskRangedAuto,
-		Flags:       SpellFlagMeleeMetrics | SpellFlagIncludeTargetBonusDamage,
+		Flags:       SpellFlagMeleeMetrics | SpellFlagIncludeTargetBonusDamage | SpellFlagNoOnCastComplete,
 
 		Cast: CastConfig{
 			IgnoreHaste: true,

--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -275,7 +275,7 @@ func (unit *Unit) EnableAutoAttacks(agent Agent, options AutoAttackOptions) {
 		ActionID:    ActionID{OtherID: proto.OtherAction_OtherActionShoot},
 		SpellSchool: SpellSchoolPhysical,
 		ProcMask:    ProcMaskRangedAuto,
-		Flags:       SpellFlagMeleeMetrics | SpellFlagIncludeTargetBonusDamage | SpellFlagNoOnCastComplete,
+		Flags:       SpellFlagMeleeMetrics | SpellFlagIncludeTargetBonusDamage,
 
 		Cast: CastConfig{
 			IgnoreHaste: true,

--- a/sim/core/flags.go
+++ b/sim/core/flags.go
@@ -185,7 +185,7 @@ const (
 	SpellFlagChanneled                                      // Spell is channeled
 	SpellFlagDisease                                        // Spell is categorized as disease
 	SpellFlagMeleeMetrics                                   // Marks a spell as a melee ability for metrics.
-	SpellFlagNoOnCastComplete                               // Disables OnCastComplete callbacks.
+	SpellFlagNoOnCastComplete                               // Disables OnCastComplete and AfterCast callbacks.
 	SpellFlagNoMetrics                                      // Disables metrics for a spell.
 	SpellFlagNoLogs                                         // Disables logs for a spell.
 

--- a/sim/deathknight/summon_gargoyle.go
+++ b/sim/deathknight/summon_gargoyle.go
@@ -139,7 +139,7 @@ func (garg *GargoylePet) registerGargoyleStrikeSpell() {
 				CastTime: time.Millisecond * 2000,
 			},
 			OnCastComplete: func(sim *core.Simulation, spell *core.Spell) {
-				// Gargoyle doesnt use GCD so we recast the spell over and over
+				// Gargoyle doesn't use GCD, so we recast the spell over and over
 				garg.GargoyleStrike.Cast(sim, garg.CurrentTarget)
 			},
 		},

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -326,7 +326,7 @@ dps_results: {
  key: "TestFeral-AllItems-InsightfulEarthsiegeDiamond"
  value: {
   dps: 7226.61846
-  tps: 5522.77224
+  tps: 5522.64373
  }
 }
 dps_results: {
@@ -522,7 +522,7 @@ dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
   dps: 7186.89371
-  tps: 5480.49118
+  tps: 5480.81604
  }
 }
 dps_results: {

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -234,8 +234,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 3135.62641
-  tps: 7525.32814
+  dps: 3135.59481
+  tps: 7525.24681
  }
 }
 dps_results: {
@@ -297,8 +297,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 3103.39099
-  tps: 7454.33267
+  dps: 3103.35896
+  tps: 7454.25022
  }
 }
 dps_results: {
@@ -326,7 +326,7 @@ dps_results: {
  key: "TestProtection-AllItems-InsightfulEarthsiegeDiamond"
  value: {
   dps: 3179.93477
-  tps: 7658.48832
+  tps: 7657.58761
  }
 }
 dps_results: {
@@ -556,8 +556,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-SparkofLife-37657"
  value: {
-  dps: 3165.24175
-  tps: 7594.64483
+  dps: 3161.61961
+  tps: 7597.55715
  }
 }
 dps_results: {

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -220,8 +220,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5812.74139
-  tps: 5911.14391
+  dps: 5812.67523
+  tps: 5911.07775
  }
 }
 dps_results: {
@@ -276,8 +276,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5758.5599
-  tps: 5856.98538
+  dps: 5758.49796
+  tps: 5856.92344
  }
 }
 dps_results: {
@@ -304,8 +304,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5810.82845
-  tps: 5911.02731
+  dps: 5810.73901
+  tps: 5910.77993
  }
 }
 dps_results: {
@@ -542,8 +542,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-SparkofLife-37657"
  value: {
-  dps: 5764.44046
-  tps: 5858.47197
+  dps: 5753.98484
+  tps: 5848.48236
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -234,8 +234,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6753.18813
-  tps: 3810.41203
+  dps: 6753.16246
+  tps: 3810.39406
  }
 }
 dps_results: {
@@ -318,8 +318,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6689.47582
-  tps: 3775.79602
+  dps: 6689.36926
+  tps: 3775.73034
  }
 }
 dps_results: {
@@ -346,8 +346,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6623.99058
-  tps: 3738.96205
+  dps: 6611.42688
+  tps: 3723.36592
  }
 }
 dps_results: {
@@ -507,8 +507,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-SparkofLife-37657"
  value: {
-  dps: 6627.80948
-  tps: 3738.78579
+  dps: 6637.45592
+  tps: 3736.70502
  }
 }
 dps_results: {

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -45,29 +45,29 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 8100.24297
-  tps: 6638.63761
+  dps: 8071.9304
+  tps: 6619.0867
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8314.16149
-  tps: 6827.76484
+  dps: 8308.32048
+  tps: 6826.74104
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8250.46175
-  tps: 6762.91309
+  dps: 8286.02486
+  tps: 6791.10887
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8328.16979
-  tps: 6840.40034
+  dps: 8321.42246
+  tps: 6829.27775
  }
 }
 dps_results: {
@@ -101,155 +101,155 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8279.75548
-  tps: 6662.12076
+  dps: 8330.0048
+  tps: 6703.49679
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8568.99218
-  tps: 7032.99451
+  dps: 8471.7709
+  tps: 6955.84124
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 8176.27811
-  tps: 6711.23196
+  dps: 8252.72699
+  tps: 6770.87423
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 8254.8911
-  tps: 6776.49042
+  dps: 8231.39021
+  tps: 6750.12243
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 8199.2229
-  tps: 6726.53912
+  dps: 8158.55729
+  tps: 6687.14198
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 8037.57224
-  tps: 6586.6686
+  dps: 8049.22119
+  tps: 6596.51298
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 8116.77036
-  tps: 6656.90004
+  dps: 8136.49186
+  tps: 6671.16754
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Defender'sCode-40257"
  value: {
-  dps: 8060.15384
-  tps: 6606.94924
+  dps: 8113.84268
+  tps: 6654.43337
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8384.68084
-  tps: 6881.97943
+  dps: 8310.5205
+  tps: 6824.80526
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 7372.74801
-  tps: 6052.6745
+  dps: 7358.73657
+  tps: 6041.63417
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8279.75548
-  tps: 6797.80524
+  dps: 8330.0048
+  tps: 6840.02641
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8279.75548
-  tps: 6797.80524
+  dps: 8330.0048
+  tps: 6840.02641
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8328.16979
-  tps: 6840.40034
+  dps: 8321.42246
+  tps: 6829.27775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8307.31623
-  tps: 6825.76232
+  dps: 8322.71315
+  tps: 6833.39629
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8279.75548
-  tps: 6797.80524
+  dps: 8330.0048
+  tps: 6840.02641
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 8252.14082
-  tps: 6768.82965
+  dps: 8212.68263
+  tps: 6730.45773
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 8192.5824
-  tps: 6717.7359
+  dps: 8206.63232
+  tps: 6733.52894
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForgeEmber-37660"
  value: {
-  dps: 8171.97552
-  tps: 6706.05249
+  dps: 8148.81719
+  tps: 6675.63836
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8279.75548
-  tps: 6797.80524
+  dps: 8330.0048
+  tps: 6840.02641
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8279.75548
-  tps: 6797.80524
+  dps: 8330.0048
+  tps: 6840.02641
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8257.40358
-  tps: 6766.31623
+  dps: 8281.53741
+  tps: 6780.65265
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuturesightRune-38763"
  value: {
-  dps: 8037.57224
-  tps: 6586.6686
+  dps: 8049.22119
+  tps: 6596.51298
  }
 }
 dps_results: {
@@ -262,71 +262,71 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 8037.57224
-  tps: 6586.6686
+  dps: 8049.22119
+  tps: 6596.51298
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8328.16979
-  tps: 6840.40034
+  dps: 8321.42246
+  tps: 6829.27775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8307.31623
-  tps: 6825.76232
+  dps: 8322.71315
+  tps: 6833.39629
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8280.08105
-  tps: 6790.56929
+  dps: 8207.47299
+  tps: 6728.43066
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8279.75548
-  tps: 6797.80524
+  dps: 8330.0048
+  tps: 6840.02641
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8339.33935
-  tps: 6847.77166
+  dps: 8334.39536
+  tps: 6840.19066
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 8037.57224
-  tps: 6586.6686
+  dps: 8049.22119
+  tps: 6596.51298
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 8037.57224
-  tps: 6586.6686
+  dps: 8049.22119
+  tps: 6596.51298
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8270.26948
-  tps: 6785.52343
+  dps: 8336.79247
+  tps: 6832.866
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 8107.93414
-  tps: 6649.1771
+  dps: 8056.69552
+  tps: 6610.16016
  }
 }
 dps_results: {
@@ -346,85 +346,85 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8365.22132
-  tps: 6869.95738
+  dps: 8311.97062
+  tps: 6825.54737
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8339.33935
-  tps: 6847.77166
+  dps: 8334.39536
+  tps: 6840.19066
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8279.75548
-  tps: 6797.80524
+  dps: 8330.0048
+  tps: 6840.02641
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8279.75548
-  tps: 6797.80524
+  dps: 8330.0048
+  tps: 6840.02641
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 8037.57224
-  tps: 6586.6686
+  dps: 8049.22119
+  tps: 6596.51298
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 8037.57224
-  tps: 6586.6686
+  dps: 8049.22119
+  tps: 6596.51298
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 8037.57224
-  tps: 6586.6686
+  dps: 8049.22119
+  tps: 6596.51298
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8495.57178
-  tps: 6973.78214
+  dps: 8491.75666
+  tps: 6964.22612
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8279.75548
-  tps: 6797.80524
+  dps: 8330.0048
+  tps: 6840.02641
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 8037.57224
-  tps: 6586.6686
+  dps: 8049.22119
+  tps: 6596.51298
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 8063.9188
-  tps: 6612.3933
+  dps: 8053.32945
+  tps: 6602.61426
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 8037.57224
-  tps: 6586.6686
+  dps: 8049.22119
+  tps: 6596.51298
  }
 }
 dps_results: {
@@ -437,15 +437,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 8037.57224
-  tps: 6586.6686
+  dps: 8049.22119
+  tps: 6596.51298
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SparkofLife-37657"
  value: {
-  dps: 8123.20137
-  tps: 6661.01059
+  dps: 8154.8829
+  tps: 6682.74633
  }
 }
 dps_results: {
@@ -458,85 +458,85 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8339.33935
-  tps: 6847.77166
+  dps: 8334.39536
+  tps: 6840.19066
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8365.22132
-  tps: 6869.95738
+  dps: 8311.97062
+  tps: 6825.54737
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8342.95518
-  tps: 6848.80019
+  dps: 8320.89748
+  tps: 6834.00309
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheFistsofFury"
  value: {
-  dps: 4920.36689
-  tps: 4126.09278
+  dps: 4925.36939
+  tps: 4131.14446
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5221.64134
-  tps: 4377.96334
+  dps: 5219.95672
+  tps: 4373.49368
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8387.74879
-  tps: 6884.06463
+  dps: 8341.52563
+  tps: 6849.56311
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 8481.30963
-  tps: 6961.25666
+  dps: 8507.81418
+  tps: 6977.56874
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8541.32416
-  tps: 7010.26959
+  dps: 8534.30176
+  tps: 7004.07268
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8279.75548
-  tps: 6797.80524
+  dps: 8330.0048
+  tps: 6840.02641
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8279.75548
-  tps: 6797.80524
+  dps: 8330.0048
+  tps: 6840.02641
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8279.75548
-  tps: 6797.80524
+  dps: 8330.0048
+  tps: 6840.02641
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8279.75548
-  tps: 6797.80524
+  dps: 8330.0048
+  tps: 6840.02641
  }
 }
 dps_results: {
@@ -563,98 +563,98 @@ dps_results: {
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 8451.8745
-  tps: 6929.35007
+  dps: 8452.75539
+  tps: 6930.1191
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11127.71085
-  tps: 9663.35491
+  dps: 11055.93689
+  tps: 9613.21724
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8457.89486
-  tps: 6941.18608
+  dps: 8413.94014
+  tps: 6908.02122
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9112.47214
-  tps: 7541.86646
+  dps: 9019.96214
+  tps: 7454.87148
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6345.99689
-  tps: 5672.22325
+  dps: 6343.96473
+  tps: 5679.58625
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4544.15005
-  tps: 3740.60746
+  dps: 4534.26043
+  tps: 3731.62546
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4565.3639
-  tps: 3781.56894
+  dps: 4581.34446
+  tps: 3795.05869
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11170.93263
-  tps: 9697.6129
+  dps: 11132.25861
+  tps: 9672.92001
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8495.57178
-  tps: 6973.78214
+  dps: 8491.75666
+  tps: 6964.22612
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9076.74582
-  tps: 7510.22295
+  dps: 9116.18853
+  tps: 7533.48071
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6392.46087
-  tps: 5716.55295
+  dps: 6383.98245
+  tps: 5708.30402
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4634.44094
-  tps: 3816.39735
+  dps: 4564.60592
+  tps: 3757.44413
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4692.41235
-  tps: 3894.15587
+  dps: 4497.75848
+  tps: 3727.31035
  }
 }
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7859.37718
-  tps: 6426.12561
+  dps: 7879.88313
+  tps: 6448.67623
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -45,29 +45,29 @@ character_stats_results: {
 dps_results: {
  key: "TestFury-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 6651.06755
-  tps: 4896.63476
+  dps: 6649.14499
+  tps: 4895.66102
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6724.12957
-  tps: 4953.00189
+  dps: 6713.34836
+  tps: 4941.78178
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6743.44731
-  tps: 4963.89937
+  dps: 6783.49451
+  tps: 4992.79817
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6701.04759
-  tps: 4933.63173
+  dps: 6729.34627
+  tps: 4955.98847
  }
 }
 dps_results: {
@@ -101,155 +101,155 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6699.80347
-  tps: 4835.40721
+  dps: 6700.67278
+  tps: 4832.39354
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6906.87398
-  tps: 5082.59059
+  dps: 6850.49005
+  tps: 5043.70994
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6741.21124
-  tps: 4960.54214
+  dps: 6718.31725
+  tps: 4943.82614
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6776.98607
-  tps: 4984.82433
+  dps: 6805.15233
+  tps: 5005.27446
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6701.71146
-  tps: 4934.66664
+  dps: 6737.98252
+  tps: 4958.78646
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6583.67912
-  tps: 4851.01995
+  dps: 6573.39084
+  tps: 4841.68924
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6720.7293
-  tps: 4946.24979
+  dps: 6710.38792
+  tps: 4936.78896
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6597.00146
-  tps: 4859.2925
+  dps: 6585.47223
+  tps: 4849.13449
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6721.54177
-  tps: 4950.73616
+  dps: 6737.83409
+  tps: 4961.54408
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 5878.15106
-  tps: 4337.42059
+  dps: 5920.81225
+  tps: 4368.67541
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6699.80347
-  tps: 4933.863
+  dps: 6700.67278
+  tps: 4930.79296
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6699.80347
-  tps: 4933.863
+  dps: 6700.67278
+  tps: 4930.79296
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6701.04759
-  tps: 4933.63173
+  dps: 6729.34627
+  tps: 4955.98847
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6720.23016
-  tps: 4950.24264
+  dps: 6743.82274
+  tps: 4963.30053
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6699.80347
-  tps: 4933.863
+  dps: 6700.67278
+  tps: 4930.79296
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6777.74474
-  tps: 4988.49364
+  dps: 6751.67618
+  tps: 4968.76735
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6719.88307
-  tps: 4946.36601
+  dps: 6720.4038
+  tps: 4943.96257
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6731.98514
-  tps: 4955.57507
+  dps: 6724.34214
+  tps: 4946.73948
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6699.80347
-  tps: 4933.863
+  dps: 6700.67278
+  tps: 4930.79296
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6699.80347
-  tps: 4933.863
+  dps: 6700.67278
+  tps: 4930.79296
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6795.33303
-  tps: 5001.5008
+  dps: 6778.70912
+  tps: 4988.7726
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6583.67912
-  tps: 4851.01995
+  dps: 6573.39084
+  tps: 4841.68924
  }
 }
 dps_results: {
@@ -262,71 +262,71 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6583.67912
-  tps: 4851.01995
+  dps: 6573.39084
+  tps: 4841.68924
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6701.04759
-  tps: 4933.63173
+  dps: 6729.34627
+  tps: 4955.98847
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6720.23016
-  tps: 4950.24264
+  dps: 6743.82274
+  tps: 4963.30053
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6820.31358
-  tps: 5017.63256
+  dps: 6820.7142
+  tps: 5016.69635
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6699.80347
-  tps: 4933.863
+  dps: 6700.67278
+  tps: 4930.79296
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6745.8929
-  tps: 4963.29659
+  dps: 6741.26569
+  tps: 4962.9772
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6583.67912
-  tps: 4851.01995
+  dps: 6573.39084
+  tps: 4841.68924
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6583.67912
-  tps: 4851.01995
+  dps: 6573.39084
+  tps: 4841.68924
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6788.43408
-  tps: 4996.35895
+  dps: 6843.5539
+  tps: 5033.85351
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6586.92795
-  tps: 4852.61744
+  dps: 6594.50875
+  tps: 4856.82371
  }
 }
 dps_results: {
@@ -346,85 +346,85 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6744.39734
-  tps: 4964.47403
+  dps: 6723.54533
+  tps: 4951.18494
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6745.8929
-  tps: 4963.29659
+  dps: 6741.26569
+  tps: 4962.9772
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6699.80347
-  tps: 4933.863
+  dps: 6700.67278
+  tps: 4930.79296
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6699.80347
-  tps: 4933.863
+  dps: 6700.67278
+  tps: 4930.79296
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6583.67912
-  tps: 4851.01995
+  dps: 6573.39084
+  tps: 4841.68924
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6583.67912
-  tps: 4851.01995
+  dps: 6573.39084
+  tps: 4841.68924
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6583.67912
-  tps: 4851.01995
+  dps: 6573.39084
+  tps: 4841.68924
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6847.83114
-  tps: 5040.01922
+  dps: 6829.45343
+  tps: 5026.40726
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6699.80347
-  tps: 4933.863
+  dps: 6700.67278
+  tps: 4930.79296
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6583.67912
-  tps: 4851.01995
+  dps: 6573.39084
+  tps: 4841.68924
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6606.87226
-  tps: 4864.7374
+  dps: 6573.46525
+  tps: 4840.03335
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6583.67912
-  tps: 4851.01995
+  dps: 6573.39084
+  tps: 4841.68924
  }
 }
 dps_results: {
@@ -437,15 +437,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6583.67912
-  tps: 4851.01995
+  dps: 6573.39084
+  tps: 4841.68924
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SparkofLife-37657"
  value: {
-  dps: 6663.80109
-  tps: 4905.1842
+  dps: 6647.56387
+  tps: 4894.34919
  }
 }
 dps_results: {
@@ -458,85 +458,85 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6745.8929
-  tps: 4963.29659
+  dps: 6741.26569
+  tps: 4962.9772
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6744.39734
-  tps: 4964.47403
+  dps: 6723.54533
+  tps: 4951.18494
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6704.67999
-  tps: 4935.42265
+  dps: 6720.43232
+  tps: 4947.76573
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 5075.42598
-  tps: 3749.27183
+  dps: 5040.49642
+  tps: 3723.60114
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5319.116
-  tps: 3925.35029
+  dps: 5316.81832
+  tps: 3923.4587
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6780.65233
-  tps: 4992.3329
+  dps: 6766.63628
+  tps: 4982.83042
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6852.46627
-  tps: 5047.69442
+  dps: 6867.52057
+  tps: 5051.31944
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6918.73294
-  tps: 5094.32408
+  dps: 6887.01591
+  tps: 5065.07894
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6699.80347
-  tps: 4933.863
+  dps: 6700.67278
+  tps: 4930.79296
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6699.80347
-  tps: 4933.863
+  dps: 6700.67278
+  tps: 4930.79296
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6699.80347
-  tps: 4933.863
+  dps: 6700.67278
+  tps: 4930.79296
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6699.80347
-  tps: 4933.863
+  dps: 6700.67278
+  tps: 4930.79296
  }
 }
 dps_results: {
@@ -563,98 +563,98 @@ dps_results: {
 dps_results: {
  key: "TestFury-Average-Default"
  value: {
-  dps: 6794.72166
-  tps: 5003.12109
+  dps: 6792.8433
+  tps: 5001.16386
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8786.81591
-  tps: 6926.59108
+  dps: 8778.50925
+  tps: 6916.09161
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6753.55564
-  tps: 4973.47691
+  dps: 6736.83247
+  tps: 4960.29775
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7981.2826
-  tps: 5866.36567
+  dps: 7949.82906
+  tps: 5842.5317
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4749.60229
-  tps: 3939.97852
+  dps: 4818.65132
+  tps: 3977.71464
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3256.88077
-  tps: 2434.72674
+  dps: 3297.51989
+  tps: 2459.01168
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3636.61259
-  tps: 2722.96776
+  dps: 3558.25798
+  tps: 2661.14265
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8912.1227
-  tps: 7028.35342
+  dps: 8860.23654
+  tps: 6979.17467
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6847.83114
-  tps: 5040.01922
+  dps: 6829.45343
+  tps: 5026.40726
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8127.74704
-  tps: 5973.64675
+  dps: 8182.65901
+  tps: 6006.74185
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4880.71948
-  tps: 4046.17034
+  dps: 4864.43771
+  tps: 4016.21902
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3362.93009
-  tps: 2509.83902
+  dps: 3356.15855
+  tps: 2504.43515
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3744.33573
-  tps: 2796.07226
+  dps: 3671.37997
+  tps: 2742.73193
  }
 }
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6270.60773
-  tps: 4619.47839
+  dps: 6298.97558
+  tps: 4639.89226
  }
 }

--- a/sim/warrior/items.go
+++ b/sim/warrior/items.go
@@ -73,9 +73,17 @@ var ItemSetDreadnaughtBattlegear = core.NewItemSet(core.ItemSet{
 				Label:    "Dreadnaught Battlegear 4pc Proc",
 				ActionID: core.ActionID{SpellID: 61571},
 				Duration: time.Second * 30,
-				OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
-					warrior.AddRage(sim, 5, rageMetrics)
-					aura.Deactivate(sim)
+				OnGain: func(_ *core.Aura, sim *core.Simulation) {
+					warrior.PseudoStats.CostReduction = 5
+				},
+				OnExpire: func(_ *core.Aura, sim *core.Simulation) {
+					rageMetrics.AddEvent(5, 5) // this is only "mostly correct", but should suffice for statistics
+					warrior.PseudoStats.CostReduction = 0
+				},
+				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+					if spell.ProcMask.Matches(core.ProcMaskMeleeSpecial) {
+						aura.Deactivate(sim)
+					}
 				},
 			})
 
@@ -86,7 +94,7 @@ var ItemSetDreadnaughtBattlegear = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+				OnPeriodicDamageDealt: func(_ *core.Aura, sim *core.Simulation, _ *core.Spell, spellEffect *core.SpellEffect) {
 					if spellEffect.Landed() && sim.RandomFloat("Dreadnaught Battlegear 4pc") < 0.1 {
 						procAura.Activate(sim)
 					}

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -208,8 +208,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 2167.26527
-  tps: 6207.35117
+  dps: 2151.9959
+  tps: 6159.65279
  }
 }
 dps_results: {


### PR DESCRIPTION
[core] melee auto attacks have SpellFlagNoOnCastComplete
[warrior] improve t7-4pc handling to only reduce costs for abilities

Quite a few "on successful spellcast" procs aren't checking proc masks at all, and simply assume "OnCastComplete" to imply a (magic) spell cast. This only removes auto attacks, but since setting SpellFlagNoCastComplete is also a very slight perf gain, this seems like a win.