### PR TITLE
Result cache

### DIFF
--- a/sim/common/tbc/enchant_effects.go
+++ b/sim/common/tbc/enchant_effects.go
@@ -270,7 +270,7 @@ func init() {
 				if result.Landed() {
 					debuffs[target.Index].Activate(sim)
 				}
-				spell.DealDamage(sim, &result)
+				spell.DealDamage(sim, result)
 			},
 		})
 

--- a/sim/common/tbc/melee_items.go
+++ b/sim/common/tbc/melee_items.go
@@ -174,7 +174,7 @@ func init() {
 					if result.Landed() {
 						debuffAuras[target.Index].Activate(sim)
 					}
-					spell.DealDamage(sim, &result)
+					spell.DealDamage(sim, result)
 					curTarget = sim.Environment.NextTargetUnit(target)
 				}
 			},

--- a/sim/common/tbc/melee_trinkets.go
+++ b/sim/common/tbc/melee_trinkets.go
@@ -400,7 +400,7 @@ func init() {
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 				baseDamage := sim.Roll(95, 115)
 				result := spell.CalcDamage(sim, target, baseDamage, outcomeApplier)
-				spell.DealDamage(sim, &result)
+				spell.DealDamage(sim, result)
 			},
 		})
 		outcomeApplier = procSpell.OutcomeCritFixedChance(0.03)

--- a/sim/core/spell.go
+++ b/sim/core/spell.go
@@ -146,6 +146,8 @@ type Spell struct {
 	initialCritMultiplier           float64
 	initialThreatMultiplier         float64
 	// Note that bonus expertise and armor pen are static, so we don't bother resetting them.
+
+	resultCache SpellEffect
 }
 
 func (unit *Unit) OnSpellRegistered(handler SpellRegisteredHandler) {
@@ -295,7 +297,7 @@ func (spell *Spell) finalize() {
 	spell.initialThreatMultiplier = spell.ThreatMultiplier
 }
 
-func (spell *Spell) reset(sim *Simulation) {
+func (spell *Spell) reset(_ *Simulation) {
 	if len(spell.SpellMetrics) != len(spell.Unit.Env.AllUnits) {
 		spell.SpellMetrics = make([]SpellMetrics, len(spell.Unit.Env.AllUnits))
 	} else {
@@ -435,7 +437,7 @@ func ApplyEffectFuncDirectDamage(baseEffect SpellEffect) ApplySpellEffects {
 			effect := &baseEffect
 			effect.Target = target
 			attackTable := spell.Unit.AttackTables[target.UnitIndex]
-
+			effect.Outcome = OutcomeEmpty
 			effect.OutcomeApplier(sim, spell, effect, attackTable)
 			effect.finalize(sim, spell)
 		}
@@ -538,7 +540,7 @@ func applyAOECap(effects []SpellEffect, outcomeMultipliers []float64, aoeCap flo
 	// Increased damage from crits doesn't count towards the cap, so need to
 	// tally pre-crit damage.
 	totalTowardsCap := 0.0
-	for i, _ := range effects {
+	for i := range effects {
 		effect := &effects[i]
 		if effect.Outcome.Matches(OutcomeCrit) {
 			totalTowardsCap += effect.Damage / outcomeMultipliers[i]
@@ -552,7 +554,7 @@ func applyAOECap(effects []SpellEffect, outcomeMultipliers []float64, aoeCap flo
 	}
 
 	capMultiplier := aoeCap / totalTowardsCap
-	for i, _ := range effects {
+	for i := range effects {
 		effect := &effects[i]
 		effect.Damage *= capMultiplier
 	}
@@ -565,7 +567,7 @@ func ApplyEffectFuncAOEDamageCapped(env *Environment, baseEffect SpellEffect) Ap
 	} else if numHits == 1 {
 		return ApplyEffectFuncDirectDamage(baseEffect)
 	} else if numHits < 4 {
-		// Just assume its impossible to hit AOE cap with <4 targets.
+		// Just assume it's impossible to hit AOE cap with <4 targets.
 		return ApplyEffectFuncAOEDamage(env, baseEffect)
 	}
 
@@ -607,6 +609,7 @@ func ApplyEffectFuncMultipleDamageCapped(baseEffects []SpellEffect, deferFinaliz
 			effect.applyAttackerModifiers(spell, attackTable)
 			effect.applyTargetModifiers(spell, attackTable, effect.IsPeriodic)
 			effect.applyResistances(sim, spell, effect.IsPeriodic, attackTable)
+			effect.Outcome = OutcomeEmpty
 			effect.OutcomeApplier(sim, spell, effect, attackTable)
 			if !deferFinalization {
 				effect.finalize(sim, spell)
@@ -630,6 +633,7 @@ func ApplyEffectFuncWithOutcome(baseEffects []SpellEffect, onOutcome func(*Simul
 				effect := &baseEffects[0]
 				effect.Target = target
 				attackTable := spell.Unit.AttackTables[target.UnitIndex]
+				effect.Outcome = OutcomeEmpty
 				effect.OutcomeApplier(sim, spell, effect, attackTable)
 				onOutcome(sim, effect.Outcome)
 				effect.finalize(sim, spell)
@@ -659,6 +663,7 @@ func ApplyEffectFuncWithOutcome(baseEffects []SpellEffect, onOutcome func(*Simul
 				effect.applyAttackerModifiers(spell, attackTable)
 				effect.applyTargetModifiers(spell, attackTable, effect.IsPeriodic)
 				effect.applyResistances(sim, spell, effect.IsPeriodic, attackTable)
+				effect.Outcome = OutcomeEmpty
 				effect.OutcomeApplier(sim, spell, effect, attackTable)
 				if i == 0 {
 					onOutcome(sim, effect.Outcome)

--- a/sim/core/spell_effect.go
+++ b/sim/core/spell_effect.go
@@ -204,19 +204,20 @@ func (spell *Spell) CalcOutcome(sim *Simulation, target *Unit, outcomeApplier Ne
 	return result
 }
 
-func (spell *Spell) calcDamageInternal(sim *Simulation, target *Unit, baseDamage float64, attackerMultiplier float64, isPeriodic bool, outcomeApplier NewOutcomeApplier) SpellEffect {
+func (spell *Spell) calcDamageInternal(sim *Simulation, target *Unit, baseDamage float64, attackerMultiplier float64, isPeriodic bool, outcomeApplier NewOutcomeApplier) *SpellEffect {
 	attackTable := spell.Unit.AttackTables[target.UnitIndex]
-	result := SpellEffect{
-		Target: target,
-		Damage: baseDamage,
-	}
+
+	result := &spell.resultCache
+	result.Target = target
+	result.Damage = baseDamage
+	result.Outcome = OutcomeEmpty // for blocks
 
 	if sim.Log == nil {
 		result.Damage *= attackerMultiplier
 		result.applyTargetModifiers(spell, attackTable, isPeriodic)
 		result.applyResistances(sim, spell, isPeriodic, attackTable)
-		outcomeApplier(sim, &result, attackTable)
-		spell.ApplyPostOutcomeDamageModifiers(sim, &result)
+		outcomeApplier(sim, result, attackTable)
+		spell.ApplyPostOutcomeDamageModifiers(sim, result)
 	} else {
 		result.Damage *= attackerMultiplier
 		afterAttackMods := result.Damage
@@ -224,9 +225,9 @@ func (spell *Spell) calcDamageInternal(sim *Simulation, target *Unit, baseDamage
 		afterTargetMods := result.Damage
 		result.applyResistances(sim, spell, isPeriodic, attackTable)
 		afterResistances := result.Damage
-		outcomeApplier(sim, &result, attackTable)
+		outcomeApplier(sim, result, attackTable)
 		afterOutcome := result.Damage
-		spell.ApplyPostOutcomeDamageModifiers(sim, &result)
+		spell.ApplyPostOutcomeDamageModifiers(sim, result)
 		afterPostOutcome := result.Damage
 
 		spell.Unit.Log(
@@ -237,15 +238,15 @@ func (spell *Spell) calcDamageInternal(sim *Simulation, target *Unit, baseDamage
 
 	return result
 }
-func (spell *Spell) CalcDamage(sim *Simulation, target *Unit, baseDamage float64, outcomeApplier NewOutcomeApplier) SpellEffect {
+func (spell *Spell) CalcDamage(sim *Simulation, target *Unit, baseDamage float64, outcomeApplier NewOutcomeApplier) *SpellEffect {
 	attackerMultiplier := spell.AttackerDamageMultiplier(spell.Unit.AttackTables[target.UnitIndex])
 	return spell.calcDamageInternal(sim, target, baseDamage, attackerMultiplier, false, outcomeApplier)
 }
-func (spell *Spell) CalcPeriodicDamage(sim *Simulation, target *Unit, baseDamage float64, outcomeApplier NewOutcomeApplier) SpellEffect {
+func (spell *Spell) CalcPeriodicDamage(sim *Simulation, target *Unit, baseDamage float64, outcomeApplier NewOutcomeApplier) *SpellEffect {
 	attackerMultiplier := spell.AttackerDamageMultiplier(spell.Unit.AttackTables[target.UnitIndex])
 	return spell.calcDamageInternal(sim, target, baseDamage, attackerMultiplier, true, outcomeApplier)
 }
-func (dot *Dot) CalcSnapshotDamage(sim *Simulation, target *Unit, outcomeApplier NewOutcomeApplier) SpellEffect {
+func (dot *Dot) CalcSnapshotDamage(sim *Simulation, target *Unit, outcomeApplier NewOutcomeApplier) *SpellEffect {
 	return dot.Spell.calcDamageInternal(sim, target, dot.SnapshotBaseDamage, dot.SnapshotAttackerMultiplier, true, outcomeApplier)
 }
 
@@ -287,39 +288,39 @@ func (spell *Spell) DealPeriodicDamage(sim *Simulation, result *SpellEffect) {
 	spell.dealDamageInternal(sim, true, result)
 }
 
-func (spell *Spell) CalcAndDealDamage(sim *Simulation, target *Unit, baseDamage float64, outcomeApplier NewOutcomeApplier) SpellEffect {
+func (spell *Spell) CalcAndDealDamage(sim *Simulation, target *Unit, baseDamage float64, outcomeApplier NewOutcomeApplier) *SpellEffect {
 	result := spell.CalcDamage(sim, target, baseDamage, outcomeApplier)
-	spell.DealDamage(sim, &result)
+	spell.DealDamage(sim, result)
 	return result
 }
-func (spell *Spell) CalcAndDealPeriodicDamage(sim *Simulation, target *Unit, baseDamage float64, outcomeApplier NewOutcomeApplier) SpellEffect {
+func (spell *Spell) CalcAndDealPeriodicDamage(sim *Simulation, target *Unit, baseDamage float64, outcomeApplier NewOutcomeApplier) *SpellEffect {
 	result := spell.CalcPeriodicDamage(sim, target, baseDamage, outcomeApplier)
-	spell.DealPeriodicDamage(sim, &result)
+	spell.DealPeriodicDamage(sim, result)
 	return result
 }
-func (dot *Dot) CalcAndDealPeriodicSnapshotDamage(sim *Simulation, target *Unit, outcomeApplier NewOutcomeApplier) SpellEffect {
+func (dot *Dot) CalcAndDealPeriodicSnapshotDamage(sim *Simulation, target *Unit, outcomeApplier NewOutcomeApplier) *SpellEffect {
 	result := dot.CalcSnapshotDamage(sim, target, outcomeApplier)
-	dot.Spell.DealPeriodicDamage(sim, &result)
+	dot.Spell.DealPeriodicDamage(sim, result)
 	return result
 }
 
-func (spell *Spell) calcHealingInternal(sim *Simulation, target *Unit, baseHealing float64, casterMultiplier float64, outcomeApplier NewOutcomeApplier) SpellEffect {
+func (spell *Spell) calcHealingInternal(sim *Simulation, target *Unit, baseHealing float64, casterMultiplier float64, outcomeApplier NewOutcomeApplier) *SpellEffect {
 	attackTable := spell.Unit.AttackTables[target.UnitIndex]
-	result := SpellEffect{
-		Target: target,
-		Damage: baseHealing,
-	}
+
+	result := &spell.resultCache
+	result.Target = target
+	result.Damage = baseHealing
 
 	if sim.Log == nil {
 		result.Damage *= casterMultiplier
 		result.Damage = spell.applyTargetHealingModifiers(result.Damage, attackTable)
-		outcomeApplier(sim, &result, attackTable)
+		outcomeApplier(sim, result, attackTable)
 	} else {
 		result.Damage *= casterMultiplier
 		afterCasterMods := result.Damage
 		result.Damage = spell.applyTargetHealingModifiers(result.Damage, attackTable)
 		afterTargetMods := result.Damage
-		outcomeApplier(sim, &result, attackTable)
+		outcomeApplier(sim, result, attackTable)
 		afterOutcome := result.Damage
 
 		spell.Unit.Log(
@@ -330,10 +331,10 @@ func (spell *Spell) calcHealingInternal(sim *Simulation, target *Unit, baseHeali
 
 	return result
 }
-func (spell *Spell) CalcHealing(sim *Simulation, target *Unit, baseHealing float64, outcomeApplier NewOutcomeApplier) SpellEffect {
+func (spell *Spell) CalcHealing(sim *Simulation, target *Unit, baseHealing float64, outcomeApplier NewOutcomeApplier) *SpellEffect {
 	return spell.calcHealingInternal(sim, target, baseHealing, spell.CasterHealingMultiplier(), outcomeApplier)
 }
-func (dot *Dot) CalcSnapshotHealing(sim *Simulation, target *Unit, outcomeApplier NewOutcomeApplier) SpellEffect {
+func (dot *Dot) CalcSnapshotHealing(sim *Simulation, target *Unit, outcomeApplier NewOutcomeApplier) *SpellEffect {
 	return dot.Spell.calcHealingInternal(sim, target, dot.SnapshotBaseDamage, dot.SnapshotAttackerMultiplier, outcomeApplier)
 }
 
@@ -368,18 +369,18 @@ func (spell *Spell) DealPeriodicHealing(sim *Simulation, result *SpellEffect) {
 	spell.dealHealingInternal(sim, true, result)
 }
 
-func (spell *Spell) CalcAndDealHealing(sim *Simulation, target *Unit, baseHealing float64, outcomeApplier NewOutcomeApplier) SpellEffect {
+func (spell *Spell) CalcAndDealHealing(sim *Simulation, target *Unit, baseHealing float64, outcomeApplier NewOutcomeApplier) *SpellEffect {
 	result := spell.CalcHealing(sim, target, baseHealing, outcomeApplier)
-	spell.DealHealing(sim, &result)
+	spell.DealHealing(sim, result)
 	return result
 }
-func (spell *Spell) CalcAndDealPeriodicHealing(sim *Simulation, target *Unit, baseHealing float64, outcomeApplier NewOutcomeApplier) SpellEffect {
+func (spell *Spell) CalcAndDealPeriodicHealing(sim *Simulation, target *Unit, baseHealing float64, outcomeApplier NewOutcomeApplier) *SpellEffect {
 	// This is currently identical to CalcAndDealHealing, but keeping it separate in case they become different in the future.
 	return spell.CalcAndDealHealing(sim, target, baseHealing, outcomeApplier)
 }
-func (dot *Dot) CalcAndDealPeriodicSnapshotHealing(sim *Simulation, target *Unit, outcomeApplier NewOutcomeApplier) SpellEffect {
+func (dot *Dot) CalcAndDealPeriodicSnapshotHealing(sim *Simulation, target *Unit, outcomeApplier NewOutcomeApplier) *SpellEffect {
 	result := dot.CalcSnapshotHealing(sim, target, outcomeApplier)
-	dot.Spell.DealPeriodicHealing(sim, &result)
+	dot.Spell.DealPeriodicHealing(sim, result)
 	return result
 }
 
@@ -408,6 +409,7 @@ func (spellEffect *SpellEffect) calcDamageSingle(sim *Simulation, spell *Spell, 
 		afterTargetMods := spellEffect.Damage
 		spellEffect.applyResistances(sim, spell, spellEffect.IsPeriodic, attackTable)
 		afterResistances := spellEffect.Damage
+		spellEffect.Outcome = OutcomeEmpty // for blocks
 		spellEffect.OutcomeApplier(sim, spell, spellEffect, attackTable)
 		afterOutcome := spellEffect.Damage
 		spell.Unit.Log(
@@ -418,12 +420,14 @@ func (spellEffect *SpellEffect) calcDamageSingle(sim *Simulation, spell *Spell, 
 		spellEffect.applyAttackerModifiers(spell, attackTable)
 		spellEffect.applyTargetModifiers(spell, attackTable, spellEffect.IsPeriodic)
 		spellEffect.applyResistances(sim, spell, spellEffect.IsPeriodic, attackTable)
+		spellEffect.Outcome = OutcomeEmpty
 		spellEffect.OutcomeApplier(sim, spell, spellEffect, attackTable)
 	}
 }
 func (spellEffect *SpellEffect) calcDamageTargetOnly(sim *Simulation, spell *Spell, attackTable *AttackTable) {
 	spellEffect.applyTargetModifiers(spell, attackTable, spellEffect.IsPeriodic)
 	spellEffect.applyResistances(sim, spell, spellEffect.IsPeriodic, attackTable)
+	spellEffect.Outcome = OutcomeEmpty // for blocks
 	spellEffect.OutcomeApplier(sim, spell, spellEffect, attackTable)
 }
 
@@ -493,7 +497,7 @@ func (spellEffect *SpellEffect) HealingString() string {
 }
 
 func (spellEffect *SpellEffect) applyAttackerModifiers(spell *Spell, attackTable *AttackTable) {
-	// For dot snapshots, everything has already been stored in spellEffect.snapshotDamageMultiplier.
+	// For dot snapshots, everything has already been stored in resultCache.snapshotDamageMultiplier.
 	if spellEffect.isSnapshot {
 		spellEffect.Damage *= spellEffect.snapshotDamageMultiplier
 		return

--- a/sim/core/spell_effect.go
+++ b/sim/core/spell_effect.go
@@ -373,6 +373,8 @@ func (spell *Spell) dealHealingInternal(sim *Simulation, isPeriodic bool, result
 		spell.Unit.OnHealDealt(sim, spell, result)
 		result.Target.OnHealTaken(sim, spell, result)
 	}
+	
+	result.inUse = false
 }
 func (spell *Spell) DealHealing(sim *Simulation, result *SpellEffect) {
 	spell.dealHealingInternal(sim, false, result)

--- a/sim/core/spell_outcome.go
+++ b/sim/core/spell_outcome.go
@@ -17,7 +17,7 @@ func (spell *Spell) OutcomeAlwaysHit(_ *Simulation, result *SpellEffect, _ *Atta
 }
 func (spell *Spell) CalcAndDealDamageAlwaysHit(sim *Simulation, target *Unit, baseDamage float64) {
 	result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeAlwaysHit)
-	spell.DealDamage(sim, &result)
+	spell.DealDamage(sim, result)
 }
 func (unit *Unit) OutcomeFuncAlwaysHit() OutcomeApplier {
 	return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
@@ -145,7 +145,7 @@ func (spell *Spell) OutcomeMagicHitAndCrit(sim *Simulation, result *SpellEffect,
 }
 func (spell *Spell) CalcAndDealDamageMagicHitAndCrit(sim *Simulation, target *Unit, baseDamage float64) {
 	result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
-	spell.DealDamage(sim, &result)
+	spell.DealDamage(sim, result)
 }
 func (unit *Unit) OutcomeFuncMagicHitAndCrit() OutcomeApplier {
 	return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
@@ -168,7 +168,7 @@ func (spell *Spell) OutcomeMagicCrit(sim *Simulation, result *SpellEffect, attac
 }
 func (spell *Spell) CalcAndDealDamageMagicCrit(sim *Simulation, target *Unit, baseDamage float64) {
 	result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicCrit)
-	spell.DealDamage(sim, &result)
+	spell.DealDamage(sim, result)
 }
 func (unit *Unit) OutcomeFuncMagicCrit() OutcomeApplier {
 	return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
@@ -229,7 +229,7 @@ func (spell *Spell) OutcomeMagicHit(sim *Simulation, result *SpellEffect, attack
 }
 func (spell *Spell) CalcAndDealDamageMagicHit(sim *Simulation, target *Unit, baseHealing float64) {
 	result := spell.CalcDamage(sim, target, baseHealing, spell.OutcomeMagicHit)
-	spell.DealDamage(sim, &result)
+	spell.DealDamage(sim, result)
 }
 func (unit *Unit) OutcomeFuncMagicHit() OutcomeApplier {
 	return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
@@ -262,7 +262,7 @@ func (spell *Spell) OutcomeMeleeWhite(sim *Simulation, result *SpellEffect, atta
 }
 func (spell *Spell) CalcAndDealDamageMeleeWhite(sim *Simulation, target *Unit, baseHealing float64) {
 	result := spell.CalcDamage(sim, target, baseHealing, spell.OutcomeMeleeWhite)
-	spell.DealDamage(sim, &result)
+	spell.DealDamage(sim, result)
 }
 
 func (spell *Spell) OutcomeMeleeSpecialHit(sim *Simulation, result *SpellEffect, attackTable *AttackTable) {
@@ -285,7 +285,7 @@ func (spell *Spell) OutcomeMeleeSpecialHit(sim *Simulation, result *SpellEffect,
 }
 func (spell *Spell) CalcAndDealDamageMeleeSpecialHit(sim *Simulation, target *Unit, baseHealing float64) {
 	result := spell.CalcDamage(sim, target, baseHealing, spell.OutcomeMeleeSpecialHit)
-	spell.DealDamage(sim, &result)
+	spell.DealDamage(sim, result)
 }
 func (unit *Unit) OutcomeFuncMeleeSpecialHit() OutcomeApplier {
 	return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
@@ -320,7 +320,7 @@ func (spell *Spell) OutcomeMeleeSpecialHitAndCrit(sim *Simulation, result *Spell
 }
 func (spell *Spell) CalcAndDealDamageMeleeSpecialHitAndCrit(sim *Simulation, target *Unit, baseHealing float64) {
 	result := spell.CalcDamage(sim, target, baseHealing, spell.OutcomeMeleeSpecialHitAndCrit)
-	spell.DealDamage(sim, &result)
+	spell.DealDamage(sim, result)
 }
 func (unit *Unit) OutcomeFuncMeleeSpecialHitAndCrit() OutcomeApplier {
 	return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
@@ -347,7 +347,7 @@ func (spell *Spell) OutcomeMeleeWeaponSpecialHitAndCrit(sim *Simulation, result 
 }
 func (spell *Spell) CalcAndDealDamageMeleeWeaponSpecialHitAndCrit(sim *Simulation, target *Unit, baseHealing float64) {
 	result := spell.CalcDamage(sim, target, baseHealing, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
-	spell.DealDamage(sim, &result)
+	spell.DealDamage(sim, result)
 }
 func (unit *Unit) OutcomeFuncMeleeWeaponSpecialHitAndCrit() OutcomeApplier {
 	return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
@@ -376,7 +376,7 @@ func (spell *Spell) OutcomeMeleeWeaponSpecialNoCrit(sim *Simulation, result *Spe
 }
 func (spell *Spell) CalcAndDealDamageMeleeWeaponSpecialNoCrit(sim *Simulation, target *Unit, baseHealing float64) {
 	result := spell.CalcDamage(sim, target, baseHealing, spell.OutcomeMeleeWeaponSpecialNoCrit)
-	spell.DealDamage(sim, &result)
+	spell.DealDamage(sim, result)
 }
 func (unit *Unit) OutcomeFuncMeleeWeaponSpecialNoCrit() OutcomeApplier {
 	return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
@@ -395,7 +395,7 @@ func (spell *Spell) OutcomeMeleeSpecialNoBlockDodgeParry(sim *Simulation, result
 }
 func (spell *Spell) CalcAndDealDamageMeleeSpecialNoBlockDodgeParry(sim *Simulation, target *Unit, baseHealing float64) {
 	result := spell.CalcDamage(sim, target, baseHealing, spell.OutcomeMeleeSpecialNoBlockDodgeParry)
-	spell.DealDamage(sim, &result)
+	spell.DealDamage(sim, result)
 }
 func (unit *Unit) OutcomeFuncMeleeSpecialNoBlockDodgeParry() OutcomeApplier {
 	return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
@@ -422,7 +422,7 @@ func (spell *Spell) OutcomeMeleeSpecialCritOnly(sim *Simulation, result *SpellEf
 }
 func (spell *Spell) CalcAndDealDamageMeleeSpecialCritOnly(sim *Simulation, target *Unit, baseHealing float64) {
 	result := spell.CalcDamage(sim, target, baseHealing, spell.OutcomeMeleeSpecialCritOnly)
-	spell.DealDamage(sim, &result)
+	spell.DealDamage(sim, result)
 }
 
 func (unit *Unit) OutcomeFuncMeleeSpecialCritOnly() OutcomeApplier {
@@ -441,7 +441,7 @@ func (spell *Spell) OutcomeRangedHit(sim *Simulation, result *SpellEffect, attac
 }
 func (spell *Spell) CalcAndDealDamageRangedHit(sim *Simulation, target *Unit, baseDamage float64) {
 	result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeRangedHit)
-	spell.DealDamage(sim, &result)
+	spell.DealDamage(sim, result)
 }
 func (unit *Unit) OutcomeFuncRangedHit() OutcomeApplier {
 	return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
@@ -493,7 +493,7 @@ func (dot *Dot) OutcomeRangedHitAndCritSnapshot(sim *Simulation, result *SpellEf
 }
 func (spell *Spell) CalcAndDealDamageRangedHitAndCrit(sim *Simulation, target *Unit, baseDamage float64) {
 	result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeRangedHitAndCrit)
-	spell.DealDamage(sim, &result)
+	spell.DealDamage(sim, result)
 }
 func (unit *Unit) OutcomeFuncRangedHitAndCrit() OutcomeApplier {
 	return func(sim *Simulation, spell *Spell, spellEffect *SpellEffect, attackTable *AttackTable) {
@@ -522,7 +522,7 @@ func (spell *Spell) OutcomeRangedCritOnly(sim *Simulation, result *SpellEffect, 
 }
 func (spell *Spell) CalcAndDealDamageRangedCritOnly(sim *Simulation, target *Unit, baseDamage float64) {
 	result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeRangedCritOnly)
-	spell.DealDamage(sim, &result)
+	spell.DealDamage(sim, result)
 }
 
 func (unit *Unit) OutcomeFuncEnemyMeleeWhite() OutcomeApplier {

--- a/sim/deathknight/death_coil.go
+++ b/sim/deathknight/death_coil.go
@@ -45,7 +45,7 @@ func (dk *Deathknight) registerDeathCoilSpell() {
 			if result.Landed() && dk.Talents.UnholyBlight {
 				dk.procUnholyBlight(sim, target, result.Damage)
 			}
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	}, func(sim *core.Simulation) bool {
 		return dk.CastCostPossible(sim, 40.0, 0, 0, 0) && dk.DeathCoil.IsReady(sim)

--- a/sim/deathknight/diseases.go
+++ b/sim/deathknight/diseases.go
@@ -36,7 +36,8 @@ func (dk *Deathknight) dkCountActiveDiseases(target *core.Unit) float64 {
 }
 
 // diseaseMultiplier calculates the bonus based on if you have DarkrunedBattlegear 4p.
-//  This function is slow so should only be used during initialization.
+//
+//	This function is slow so should only be used during initialization.
 func (dk *Deathknight) dkDiseaseMultiplier(multiplier float64) float64 {
 	if dk.Env.IsFinalized() {
 		panic("dont call dk.diseaseMultiplier function during runtime, cache result during initialization")
@@ -113,7 +114,7 @@ func (dk *Deathknight) registerFrostFever() {
 			},
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
 				result := dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.Spell.OutcomeAlwaysHit)
-				dk.doWanderingPlague(sim, dot.Spell, &result)
+				dk.doWanderingPlague(sim, dot.Spell, result)
 			},
 		})
 
@@ -181,13 +182,13 @@ func (dk *Deathknight) registerBloodPlague() {
 				}
 			},
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
-				var result core.SpellEffect
+				var result *core.SpellEffect
 				if canCrit {
 					result = dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeSnapshotCrit)
 				} else {
 					result = dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.Spell.OutcomeAlwaysHit)
 				}
-				dk.doWanderingPlague(sim, dot.Spell, &result)
+				dk.doWanderingPlague(sim, dot.Spell, result)
 			},
 		})
 
@@ -290,13 +291,13 @@ func (dk *Deathknight) registerDrwBloodPlague() {
 				}
 			},
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
-				var result core.SpellEffect
+				var result *core.SpellEffect
 				if canCrit {
 					result = dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeSnapshotCrit)
 				} else {
 					result = dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.Spell.OutcomeAlwaysHit)
 				}
-				dk.doWanderingPlague(sim, dot.Spell, &result)
+				dk.doWanderingPlague(sim, dot.Spell, result)
 			},
 		})
 

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -703,7 +703,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7532.48152
-  tps: 4456.74781
+  dps: 7531.74342
+  tps: 4456.30496
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -797,8 +797,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7599.38164
-  tps: 4626.89234
+  dps: 7599.45657
+  tps: 4626.95228
   hps: 140.07156
  }
 }

--- a/sim/deathknight/icy_touch.go
+++ b/sim/deathknight/icy_touch.go
@@ -110,7 +110,7 @@ func (dk *Deathknight) registerDrwIcyTouchSpell() {
 			if result.Landed() {
 				dk.RuneWeapon.FrostFeverSpell.Cast(sim, target)
 			}
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	})
 }

--- a/sim/deathknight/summon_gargoyle.go
+++ b/sim/deathknight/summon_gargoyle.go
@@ -151,7 +151,7 @@ func (garg *GargoylePet) registerGargoyleStrikeSpell() {
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := ((69.0-51.0)*sim.RandomFloat("Gargoyle Strike")+51.0)*2.05 + attackPowerModifier*spell.MeleeAttackPower()
 			result := spell.CalcDamage(sim, target, baseDamage, outcomeApplier)
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	})
 	outcomeApplier = garg.GargoyleStrike.OutcomeCritFixedChance(0.05)

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -66,15 +66,15 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1414.17927
-  tps: 4540.25273
+  dps: 1414.12654
+  tps: 4540.14338
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1321.15482
-  tps: 4227.2963
+  dps: 1321.02802
+  tps: 4227.03337
  }
 }
 dps_results: {
@@ -87,8 +87,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1200.82373
-  tps: 3852.4594
+  dps: 1200.7717
+  tps: 3852.3515
  }
 }
 dps_results: {
@@ -150,8 +150,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedPlate"
  value: {
-  dps: 1399.71863
-  tps: 4512.93146
+  dps: 1399.70817
+  tps: 4512.90976
  }
 }
 dps_results: {
@@ -346,8 +346,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1452.38561
-  tps: 4636.86766
+  dps: 1452.34369
+  tps: 4636.78073
  }
 }
 dps_results: {
@@ -388,15 +388,15 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1437.51578
-  tps: 4611.83765
+  dps: 1437.44447
+  tps: 4611.6898
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1438.43012
-  tps: 4613.73354
+  dps: 1438.35881
+  tps: 4613.58569
  }
 }
 dps_results: {
@@ -451,8 +451,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 1726.10346
-  tps: 5520.51848
+  dps: 1726.07008
+  tps: 5520.44927
  }
 }
 dps_results: {
@@ -507,15 +507,15 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 1434.991
-  tps: 4567.26283
+  dps: 1434.94068
+  tps: 4567.15851
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-StormshroudArmor"
  value: {
-  dps: 1184.06476
-  tps: 3823.87007
+  dps: 1183.94176
+  tps: 3823.61504
  }
 }
 dps_results: {
@@ -556,8 +556,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1442.94732
-  tps: 4591.80088
+  dps: 1442.89093
+  tps: 4591.68396
  }
 }
 dps_results: {
@@ -570,8 +570,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1478.55813
-  tps: 4709.15438
+  dps: 1478.51205
+  tps: 4709.05885
  }
 }
 dps_results: {
@@ -619,9 +619,9 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-Average-Default"
  value: {
-  dps: 1828.18144
-  tps: 6355.62853
-  dtps: 254.9449
+  dps: 1828.45286
+  tps: 6356.42719
+  dtps: 254.81533
  }
 }
 dps_results: {

--- a/sim/druid/demoralizing_roar.go
+++ b/sim/druid/demoralizing_roar.go
@@ -38,7 +38,7 @@ func (druid *Druid) registerDemoralizingRoarSpell() {
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			for _, aoeTarget := range sim.Encounter.Targets {
 				result := spell.CalcDamage(sim, &aoeTarget.Unit, 0, spell.OutcomeMagicHit)
-				spell.DealDamage(sim, &result)
+				spell.DealDamage(sim, result)
 				if result.Landed() {
 					drAuras[aoeTarget.Index].Activate(sim)
 				}

--- a/sim/druid/faerie_fire.go
+++ b/sim/druid/faerie_fire.go
@@ -58,7 +58,7 @@ func (druid *Druid) registerFaerieFireSpell() {
 			if result.Landed() {
 				druid.FaerieFireAura.Activate(sim)
 			}
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	})
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -675,7 +675,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6258.5392
-  tps: 4757.50799
+  dps: 6227.03048
+  tps: 4736.57195
  }
 }

--- a/sim/druid/moonfire.go
+++ b/sim/druid/moonfire.go
@@ -56,7 +56,7 @@ func (druid *Druid) registerMoonfireSpell() {
 					druid.AddMana(sim, 0.02*druid.MaxMana(), manaMetrics, true)
 				}
 			}
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	})
 

--- a/sim/druid/starfire.go
+++ b/sim/druid/starfire.go
@@ -89,7 +89,7 @@ func (druid *Druid) registerStarfireSpell() {
 					druid.MoonfireDot.UpdateExpires(druid.MoonfireDot.ExpiresAt() + time.Second*3)
 				}
 			}
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	})
 }

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -45,590 +45,590 @@ character_stats_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 1111.14907
-  tps: 1507.549
+  dps: 1106.71489
+  tps: 1505.30912
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1090.49425
-  tps: 1483.53048
+  dps: 1091.14777
+  tps: 1484.20402
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1162.17153
-  tps: 1579.48317
+  dps: 1156.17118
+  tps: 1574.05434
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1101.89867
-  tps: 1498.81104
+  dps: 1078.10326
+  tps: 1469.26765
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 964.70326
-  tps: 1277.4467
+  dps: 956.83255
+  tps: 1265.3536
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1090.49425
-  tps: 1454.01812
+  dps: 1091.14777
+  tps: 1454.67469
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1101.51303
-  tps: 1494.74111
+  dps: 1099.74067
+  tps: 1501.69793
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1089.6196
-  tps: 1481.86865
+  dps: 1105.88928
+  tps: 1504.40662
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1138.13709
-  tps: 1537.50444
+  dps: 1147.89652
+  tps: 1563.883
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 1149.99726
-  tps: 1562.48836
+  dps: 1143.7286
+  tps: 1555.69425
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 1109.69808
-  tps: 1506.31425
+  dps: 1104.37393
+  tps: 1507.74304
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 1101.70161
-  tps: 1500.18496
+  dps: 1080.81513
+  tps: 1468.80712
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 1108.07455
-  tps: 1502.55063
+  dps: 1098.34297
+  tps: 1486.12399
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1096.55503
-  tps: 1486.83194
+  dps: 1097.34895
+  tps: 1492.08133
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1074.9302
-  tps: 1460.51258
+  dps: 1074.94929
+  tps: 1457.56727
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1087.05335
-  tps: 1473.67456
+  dps: 1086.54495
+  tps: 1477.58241
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 1218.80987
-  tps: 1638.8217
+  dps: 1216.50797
+  tps: 1633.9952
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerGarb"
  value: {
-  dps: 951.25755
-  tps: 1259.37753
+  dps: 945.59115
+  tps: 1255.67865
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1090.49425
-  tps: 1483.53048
+  dps: 1091.14777
+  tps: 1484.20402
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1090.49425
-  tps: 1483.53048
+  dps: 1091.14777
+  tps: 1484.20402
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1101.89867
-  tps: 1498.81104
+  dps: 1078.10326
+  tps: 1469.26765
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1090.55373
-  tps: 1478.05233
+  dps: 1086.01384
+  tps: 1476.20901
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1090.49425
-  tps: 1483.53048
+  dps: 1091.14777
+  tps: 1484.20402
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1138.49486
-  tps: 1542.50733
+  dps: 1136.58971
+  tps: 1543.43727
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1110.88983
-  tps: 1513.46252
+  dps: 1108.60368
+  tps: 1504.97292
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1097.09972
-  tps: 1487.30135
+  dps: 1091.19565
+  tps: 1479.4592
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1090.49425
-  tps: 1483.53048
+  dps: 1091.14777
+  tps: 1484.20402
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1090.49425
-  tps: 1483.53048
+  dps: 1091.14777
+  tps: 1484.20402
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1140.07303
-  tps: 1547.79173
+  dps: 1144.82539
+  tps: 1553.52187
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1074.9302
-  tps: 1460.51258
+  dps: 1074.94929
+  tps: 1457.56727
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 1372.49419
-  tps: 1858.619
+  dps: 1361.30634
+  tps: 1836.76686
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 1000.24534
-  tps: 1337.97867
+  dps: 993.55347
+  tps: 1321.76486
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 1084.49166
-  tps: 1464.40497
+  dps: 1090.42899
+  tps: 1478.55039
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 1103.45543
-  tps: 1499.19315
+  dps: 1089.91546
+  tps: 1481.58099
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 1072.77014
-  tps: 1453.55374
+  dps: 1064.45751
+  tps: 1433.49296
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 1092.00313
-  tps: 1486.60224
+  dps: 1090.02058
+  tps: 1472.74078
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1074.9302
-  tps: 1460.51258
+  dps: 1074.94929
+  tps: 1457.56727
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1101.89867
-  tps: 1498.81104
+  dps: 1078.10326
+  tps: 1469.26765
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1090.55373
-  tps: 1478.05233
+  dps: 1086.01384
+  tps: 1476.20901
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1124.88416
-  tps: 1524.46698
+  dps: 1124.73881
+  tps: 1534.35379
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1090.49425
-  tps: 1483.53048
+  dps: 1091.14777
+  tps: 1484.20402
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1081.3918
-  tps: 1472.16801
+  dps: 1080.45328
+  tps: 1465.254
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 1504.79213
-  tps: 2002.77678
+  dps: 1489.0432
+  tps: 1975.15571
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveRegalia"
  value: {
-  dps: 1109.007
-  tps: 1486.51574
+  dps: 1122.92774
+  tps: 1504.34126
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1074.9302
-  tps: 1460.51258
+  dps: 1074.94929
+  tps: 1457.56727
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1074.9302
-  tps: 1460.51258
+  dps: 1074.94929
+  tps: 1457.56727
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 1361.671
-  tps: 1831.35206
+  dps: 1374.09719
+  tps: 1849.26973
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 1037.356
-  tps: 1377.26689
+  dps: 1016.07516
+  tps: 1350.83971
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1138.15654
-  tps: 1551.44437
+  dps: 1137.80456
+  tps: 1540.02229
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NightsongBattlegear"
  value: {
-  dps: 1250.92321
-  tps: 1682.7206
+  dps: 1282.83588
+  tps: 1726.33314
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NightsongGarb"
  value: {
-  dps: 979.72198
-  tps: 1299.11701
+  dps: 994.97216
+  tps: 1318.84479
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1074.9302
-  tps: 1460.51258
+  dps: 1074.94929
+  tps: 1457.56727
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1101.88084
-  tps: 1499.29699
+  dps: 1092.16329
+  tps: 1487.67532
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1081.3918
-  tps: 1472.16801
+  dps: 1080.45328
+  tps: 1465.254
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1090.49425
-  tps: 1483.53048
+  dps: 1091.14777
+  tps: 1484.20402
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1090.49425
-  tps: 1483.53048
+  dps: 1091.14777
+  tps: 1484.20402
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1074.9302
-  tps: 1460.51258
+  dps: 1074.94929
+  tps: 1457.56727
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1074.9302
-  tps: 1460.51258
+  dps: 1074.94929
+  tps: 1457.56727
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1074.9302
-  tps: 1460.51258
+  dps: 1074.94929
+  tps: 1457.56727
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1099.37665
-  tps: 1495.68283
+  dps: 1117.48004
+  tps: 1523.19372
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1090.49425
-  tps: 1483.53048
+  dps: 1091.14777
+  tps: 1484.20402
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1074.9302
-  tps: 1460.51258
+  dps: 1074.94929
+  tps: 1457.56727
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Runetotem'sBattlegear"
  value: {
-  dps: 1361.671
-  tps: 1831.35206
+  dps: 1374.09719
+  tps: 1849.26973
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Runetotem'sRegalia"
  value: {
-  dps: 1037.356
-  tps: 1377.26689
+  dps: 1016.07516
+  tps: 1350.83971
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 1093.42915
-  tps: 1483.9428
+  dps: 1089.35544
+  tps: 1476.5933
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1074.9302
-  tps: 1460.51258
+  dps: 1074.94929
+  tps: 1457.56727
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1074.9302
-  tps: 1460.51258
+  dps: 1074.94929
+  tps: 1457.56727
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1074.9302
-  tps: 1460.51258
+  dps: 1074.94929
+  tps: 1457.56727
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 1095.03664
-  tps: 1481.19758
+  dps: 1098.59454
+  tps: 1493.14202
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-StormshroudArmor"
  value: {
-  dps: 930.01258
-  tps: 1228.2329
+  dps: 928.06703
+  tps: 1223.16272
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1081.3918
-  tps: 1472.16801
+  dps: 1080.45328
+  tps: 1465.254
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1101.88084
-  tps: 1499.29699
+  dps: 1092.16329
+  tps: 1487.67532
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1083.37602
-  tps: 1470.83549
+  dps: 1082.86945
+  tps: 1468.10367
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartHarness"
  value: {
-  dps: 1059.43551
-  tps: 1411.18573
+  dps: 1042.65322
+  tps: 1382.32526
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartRegalia"
  value: {
-  dps: 897.58557
-  tps: 1143.27478
+  dps: 886.28435
+  tps: 1128.83064
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1095.78801
-  tps: 1488.71137
+  dps: 1099.42363
+  tps: 1500.48867
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1164.18818
-  tps: 1583.88721
+  dps: 1159.93249
+  tps: 1580.64629
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1186.51741
-  tps: 1619.63988
+  dps: 1175.19395
+  tps: 1602.11315
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1090.49425
-  tps: 1483.53048
+  dps: 1091.14777
+  tps: 1484.20402
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1090.49425
-  tps: 1483.53048
+  dps: 1091.14777
+  tps: 1484.20402
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1090.49425
-  tps: 1483.53048
+  dps: 1091.14777
+  tps: 1484.20402
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1090.49425
-  tps: 1483.53048
+  dps: 1091.14777
+  tps: 1484.20402
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1023.49282
-  tps: 1358.39487
+  dps: 1014.61153
+  tps: 1338.97975
  }
 }
 dps_results: {
  key: "TestFeralTank-Average-Default"
  value: {
-  dps: 1285.70904
-  tps: 1771.33467
-  dtps: 552.01498
+  dps: 1283.01232
+  tps: 1766.44819
+  dtps: 550.76509
  }
 }
 dps_results: {

--- a/sim/druid/wrath.go
+++ b/sim/druid/wrath.go
@@ -69,7 +69,7 @@ func (druid *Druid) registerWrathSpell() {
 						druid.SwiftStarfireAura.Activate(sim)
 					}
 				}
-				spell.DealDamage(sim, &result)
+				spell.DealDamage(sim, result)
 			})
 		},
 	})

--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -899,7 +899,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6803.0548
-  tps: 5857.04714
+  dps: 6802.56078
+  tps: 5856.61577
  }
 }

--- a/sim/hunter/arcane_shot.go
+++ b/sim/hunter/arcane_shot.go
@@ -53,7 +53,7 @@ func (hunter *Hunter) registerArcaneShotSpell(timer *core.Timer) {
 			if hasGlyph && result.Landed() && (hunter.SerpentStingDot.IsActive() || hunter.ScorpidStingAura.IsActive()) {
 				hunter.AddMana(sim, 0.2*hunter.ArcaneShot.DefaultCast.Cost, manaMetrics, false)
 			}
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	})
 }

--- a/sim/hunter/chimera_shot.go
+++ b/sim/hunter/chimera_shot.go
@@ -58,7 +58,7 @@ func (hunter *Hunter) registerChimeraShotSpell() {
 					hunter.ScorpidStingAura.Refresh(sim)
 				}
 			}
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	})
 }

--- a/sim/hunter/explosive_shot.go
+++ b/sim/hunter/explosive_shot.go
@@ -53,7 +53,7 @@ func (hunter *Hunter) registerExplosiveShotSpell(timer *core.Timer) {
 			if result.Landed() {
 				hunter.ExplosiveShotDot.Apply(sim)
 			}
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	})
 

--- a/sim/hunter/steady_shot.go
+++ b/sim/hunter/steady_shot.go
@@ -90,7 +90,7 @@ func (hunter *Hunter) registerSteadyShotSpell() {
 			if result.Landed() && impSSProcChance > 0 && sim.RandomFloat("Imp Steady Shot") < impSSProcChance {
 				hunter.ImprovedSteadyShotAura.Activate(sim)
 			}
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	})
 }

--- a/sim/mage/fireball.go
+++ b/sim/mage/fireball.go
@@ -52,7 +52,7 @@ func (mage *Mage) registerFireballSpell() {
 				if result.Landed() && !hasGlyph {
 					mage.FireballDot.Apply(sim)
 				}
-				spell.DealDamage(sim, &result)
+				spell.DealDamage(sim, result)
 			})
 		},
 	})

--- a/sim/mage/frostfire_bolt.go
+++ b/sim/mage/frostfire_bolt.go
@@ -51,7 +51,7 @@ func (mage *Mage) registerFrostfireBoltSpell() {
 				if result.Landed() {
 					mage.FrostfireDot.Apply(sim)
 				}
-				spell.DealDamage(sim, &result)
+				spell.DealDamage(sim, result)
 			})
 		},
 	})

--- a/sim/mage/pyroblast.go
+++ b/sim/mage/pyroblast.go
@@ -56,7 +56,7 @@ func (mage *Mage) registerPyroblastSpell() {
 				if result.Landed() {
 					mage.PyroblastDot.Apply(sim)
 				}
-				spell.DealDamage(sim, &result)
+				spell.DealDamage(sim, result)
 			})
 		},
 	})

--- a/sim/mage/scorch.go
+++ b/sim/mage/scorch.go
@@ -53,7 +53,7 @@ func (mage *Mage) registerScorchSpell() {
 					mage.ScorchAura.Activate(sim)
 				}
 			}
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	})
 }

--- a/sim/mage/winters_chill.go
+++ b/sim/mage/winters_chill.go
@@ -25,7 +25,7 @@ func (mage *Mage) registerWintersChillSpell() {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			result := spell.CalcDamage(sim, target, 0, spell.OutcomeMagicHit)
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 
 			if result.Landed() {
 				aura := wcAuras[target.Index]

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -675,9 +675,9 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Average-Default"
  value: {
-  dps: 3578.49396
-  tps: 8568.29142
-  dtps: 15.26131
+  dps: 3558.95215
+  tps: 8533.43836
+  dtps: 14.93484
  }
 }
 dps_results: {
@@ -935,8 +935,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3739.26077
-  tps: 8926.92057
+  dps: 3708.05929
+  tps: 8871.19758
   dtps: 14.43555
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -1340,7 +1340,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5570.44877
-  tps: 5668.90399
+  dps: 5567.45245
+  tps: 5665.90767
  }
 }

--- a/sim/priest/devouring_plague.go
+++ b/sim/priest/devouring_plague.go
@@ -50,7 +50,7 @@ func (priest *Priest) registerDevouringPlagueSpell() {
 				priest.AddShadowWeavingStack(sim)
 				priest.DevouringPlagueDot.Apply(sim)
 			}
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	})
 

--- a/sim/priest/holy_fire.go
+++ b/sim/priest/holy_fire.go
@@ -43,7 +43,7 @@ func (priest *Priest) RegisterHolyFireSpell(memeDream bool) {
 			if result.Landed() {
 				priest.HolyFireDot.Apply(sim)
 			}
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	})
 

--- a/sim/priest/mind_blast.go
+++ b/sim/priest/mind_blast.go
@@ -68,7 +68,7 @@ func (priest *Priest) registerMindBlastSpell() {
 			if result.DidCrit() && priest.ImprovedSpiritTap != nil {
 				priest.ImprovedSpiritTap.Activate(sim)
 			}
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	})
 }

--- a/sim/priest/mind_flay.go
+++ b/sim/priest/mind_flay.go
@@ -10,7 +10,8 @@ import (
 )
 
 // TODO Mind Flay (48156) now "periodically triggers" Mind Flay (58381), probably to allow haste to work.
-//  The first never deals damage, so the latter should probably be used as ActionID here.
+//
+//	The first never deals damage, so the latter should probably be used as ActionID here.
 func (priest *Priest) MindFlayActionID(numTicks int) core.ActionID {
 	return core.ActionID{SpellID: 48156, Tag: int32(numTicks)}
 }
@@ -125,7 +126,7 @@ func (priest *Priest) newMindFlayDot(numTicks int) *core.Dot {
 		},
 		OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
 			result := dot.CalcSnapshotDamage(sim, target, dot.OutcomeMagicHitAndSnapshotCrit)
-			dot.Spell.DealPeriodicDamage(sim, &result)
+			dot.Spell.DealPeriodicDamage(sim, result)
 
 			if result.Landed() {
 				priest.AddShadowWeavingStack(sim)

--- a/sim/priest/shadow_word_death.go
+++ b/sim/priest/shadow_word_death.go
@@ -61,7 +61,7 @@ func (priest *Priest) registerShadowWordDeathSpell() {
 			if result.DidCrit() && priest.ImprovedSpiritTap != nil {
 				priest.ImprovedSpiritTap.Activate(sim)
 			}
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	})
 }

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -871,7 +871,7 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6867.92875
-  tps: 4876.22942
+  dps: 6863.17973
+  tps: 4872.85761
  }
 }

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -878,7 +878,7 @@ dps_results: {
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6253.53575
-  tps: 4440.01038
+  dps: 6253.62601
+  tps: 4440.07447
  }
 }

--- a/sim/shaman/chain_lightning.go
+++ b/sim/shaman/chain_lightning.go
@@ -59,7 +59,7 @@ func (shaman *Shaman) newChainLightningSpell(isLightningOverload bool) *core.Spe
 				shaman.ChainLightningLOs[hitIndex].Cast(sim, curTarget)
 			}
 
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 
 			bounceCoeff *= dmgReductionPerBounce
 			curTarget = sim.Environment.NextTargetUnit(target)

--- a/sim/shaman/lavaburst.go
+++ b/sim/shaman/lavaburst.go
@@ -91,7 +91,7 @@ func (shaman *Shaman) registerLavaBurstSpell() {
 				lvbdotDmg = result.Damage * 0.1 // TODO: does this dot pool with the previous dot?
 				lvbDot.Apply(sim)               // will resnapshot dmg
 			}
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	})
 }

--- a/sim/shaman/lightning_bolt.go
+++ b/sim/shaman/lightning_bolt.go
@@ -100,7 +100,7 @@ func (shaman *Shaman) newLightningBoltSpell(isLightningOverload bool) *core.Spel
 			}
 		}
 
-		spell.DealDamage(sim, &result)
+		spell.DealDamage(sim, result)
 	}
 
 	return shaman.RegisterSpell(spellConfig)

--- a/sim/shaman/shocks.go
+++ b/sim/shaman/shocks.go
@@ -78,7 +78,7 @@ func (shaman *Shaman) registerFlameShockSpell(shockTimer *core.Timer) {
 		if result.Landed() {
 			shaman.FlameShockDot.Apply(sim)
 		}
-		spell.DealDamage(sim, &result)
+		spell.DealDamage(sim, result)
 	}
 
 	target := shaman.CurrentTarget

--- a/sim/warlock/conflagrate.go
+++ b/sim/warlock/conflagrate.go
@@ -62,7 +62,7 @@ func (warlock *Warlock) registerConflagrateSpell() {
 			if result.Landed() {
 				warlock.ConflagrateDot.Apply(sim)
 			}
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	})
 

--- a/sim/warlock/haunt.go
+++ b/sim/warlock/haunt.go
@@ -67,7 +67,7 @@ func (warlock *Warlock) registerHauntSpell() {
 				if result.Landed() {
 					HauntDebuffAura.Activate(sim)
 				}
-				spell.DealDamage(sim, &result)
+				spell.DealDamage(sim, result)
 			})
 		},
 	})

--- a/sim/warlock/immolate.go
+++ b/sim/warlock/immolate.go
@@ -45,7 +45,7 @@ func (warlock *Warlock) registerImmolateSpell() {
 			if result.Landed() {
 				warlock.ImmolateDot.Apply(sim)
 			}
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	})
 

--- a/sim/warlock/pet_abilities.go
+++ b/sim/warlock/pet_abilities.go
@@ -220,7 +220,7 @@ func (wp *WarlockPet) newShadowBite() *core.Spell {
 			if impFelhunter && result.Landed() {
 				wp.AddMana(sim, wp.MaxMana()*maxManaMult, petManaMetrics, true)
 			}
-			spell.DealDamage(sim, &result)
+			spell.DealDamage(sim, result)
 		},
 	})
 }

--- a/sim/warlock/shadowbolt.go
+++ b/sim/warlock/shadowbolt.go
@@ -58,7 +58,7 @@ func (warlock *Warlock) registerShadowBoltSpell() {
 						core.ShadowMasteryAura(target).Activate(sim) // calls refresh if already active.
 					}
 				}
-				spell.DealDamage(sim, &result)
+				spell.DealDamage(sim, result)
 			})
 		},
 	})

--- a/sim/warrior/demoralizing_shout.go
+++ b/sim/warrior/demoralizing_shout.go
@@ -38,7 +38,7 @@ func (warrior *Warrior) registerDemoralizingShoutSpell() {
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			for _, aoeTarget := range sim.Encounter.Targets {
 				result := spell.CalcDamage(sim, &aoeTarget.Unit, 0, spell.OutcomeMagicHit)
-				spell.DealDamage(sim, &result)
+				spell.DealDamage(sim, result)
 				if result.Landed() {
 					dsAuras[aoeTarget.Index].Activate(sim)
 				}

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -654,7 +654,7 @@ dps_results: {
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7868.00969
-  tps: 6433.03162
+  dps: 7883.65448
+  tps: 6451.53105
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -654,7 +654,7 @@ dps_results: {
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6268.58345
-  tps: 4618.06139
+  dps: 6221.98982
+  tps: 4591.48028
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -45,7 +45,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 0.90345
+  weights: 0.95138
   weights: 0
   weights: 0
   weights: 0
@@ -56,7 +56,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.22983
+  weights: 0.2313
   weights: 0
   weights: 0
   weights: 0
@@ -65,12 +65,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.04741
+  weights: -0.03497
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.50374
-  weights: -0.00396
+  weights: 0.51246
+  weights: -0.20307
   weights: 0
   weights: 0
   weights: 0
@@ -89,527 +89,527 @@ stat_weights_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 2037.67118
-  tps: 5893.94643
+  dps: 2032.6562
+  tps: 5883.54928
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 2018.68817
-  tps: 5839.65597
+  dps: 2012.86209
+  tps: 5827.57753
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2108.30902
-  tps: 6058.03397
+  dps: 2092.98224
+  tps: 6025.67043
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 2008.66685
-  tps: 5808.17581
+  dps: 2002.56187
+  tps: 5795.35619
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1977.2378
-  tps: 5719.88989
+  dps: 1972.11798
+  tps: 5709.27395
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1795.72037
-  tps: 5237.53272
+  dps: 1790.97209
+  tps: 5227.68823
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1757.60782
-  tps: 5111.27224
+  dps: 1752.62847
+  tps: 5100.96494
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1639.63475
-  tps: 4817.25256
+  dps: 1635.78399
+  tps: 4809.26803
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2000.06224
-  tps: 5674.20188
+  dps: 1993.25234
+  tps: 5660.3656
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2058.44805
-  tps: 5937.25696
+  dps: 2053.92256
+  tps: 5927.87337
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2081.52655
-  tps: 5990.6987
+  dps: 2075.73472
+  tps: 5978.55818
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2115.78043
-  tps: 6051.15733
+  dps: 2109.84783
+  tps: 6038.85641
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 2140.23198
-  tps: 6157.88948
+  dps: 2128.42233
+  tps: 6131.77309
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 2144.58267
-  tps: 6157.56592
+  dps: 2125.55295
+  tps: 6108.827
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 2079.66543
-  tps: 6002.27902
+  dps: 2073.59165
+  tps: 5993.17692
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 2064.14687
-  tps: 5943.34589
+  dps: 2057.68442
+  tps: 5930.05988
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1996.42857
-  tps: 5771.01336
+  dps: 1990.92979
+  tps: 5759.61163
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 2167.13126
-  tps: 6207.07331
+  dps: 2159.44466
+  tps: 6186.20329
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 2000.06224
-  tps: 5789.95083
+  dps: 1993.25234
+  tps: 5775.83217
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2000.06224
-  tps: 5789.95083
+  dps: 1993.25234
+  tps: 5775.83217
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 2008.66685
-  tps: 5808.17581
+  dps: 2002.56187
+  tps: 5795.35619
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2027.51373
-  tps: 5865.38917
+  dps: 2021.34665
+  tps: 5852.60173
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 2021.81092
-  tps: 5848.57548
+  dps: 2015.00104
+  tps: 5834.45689
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2123.40844
-  tps: 6077.29729
+  dps: 2117.28041
+  tps: 6064.57844
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2069.80909
-  tps: 5955.84093
+  dps: 2063.87648
+  tps: 5943.54
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2062.49162
-  tps: 5941.89459
+  dps: 2056.68403
+  tps: 5931.76687
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2000.06224
-  tps: 5789.95083
+  dps: 1993.25234
+  tps: 5775.83217
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2000.06224
-  tps: 5789.95083
+  dps: 1993.25234
+  tps: 5775.83217
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2097.65847
-  tps: 6054.07361
+  dps: 2078.24985
+  tps: 6002.39183
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2018.68817
-  tps: 5839.65597
+  dps: 2012.86209
+  tps: 5827.57753
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 2393.97651
-  tps: 6702.32433
+  dps: 2386.40731
+  tps: 6686.6296
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 2018.68817
-  tps: 5839.65597
+  dps: 2012.86209
+  tps: 5827.57753
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 2008.66685
-  tps: 5808.17581
+  dps: 2002.56187
+  tps: 5795.35619
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2027.51373
-  tps: 5865.38917
+  dps: 2021.34665
+  tps: 5852.60173
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2078.73882
-  tps: 5999.92317
+  dps: 2072.80363
+  tps: 5987.61655
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 2000.06224
-  tps: 5789.95083
+  dps: 1993.25234
+  tps: 5775.83217
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2010.20936
-  tps: 5819.76314
+  dps: 2005.77194
+  tps: 5810.65436
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2077.03863
-  tps: 5996.94254
+  dps: 2071.21261
+  tps: 5984.86428
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 2018.68817
-  tps: 5839.65597
+  dps: 2012.86209
+  tps: 5827.57753
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2112.37406
-  tps: 6076.14963
+  dps: 2107.20013
+  tps: 6065.42119
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2001.55353
-  tps: 5794.633
+  dps: 1996.51196
+  tps: 5784.30847
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 1657.41154
-  tps: 4842.48692
+  dps: 1661.69191
+  tps: 4872.62899
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 1839.70402
-  tps: 5291.1334
+  dps: 1832.91415
+  tps: 5277.0546
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 2009.35697
-  tps: 5814.39142
+  dps: 2003.95407
+  tps: 5803.18882
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2010.20936
-  tps: 5819.76314
+  dps: 2005.77194
+  tps: 5810.65436
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 2000.06224
-  tps: 5789.95083
+  dps: 1993.25234
+  tps: 5775.83217
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 2000.06224
-  tps: 5789.95083
+  dps: 1993.25234
+  tps: 5775.83217
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2018.68817
-  tps: 5839.65597
+  dps: 2012.86209
+  tps: 5827.57753
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 2018.68817
-  tps: 5839.65597
+  dps: 2012.86209
+  tps: 5827.57753
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 2018.68817
-  tps: 5839.65597
+  dps: 2012.86209
+  tps: 5827.57753
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2066.16626
-  tps: 5957.14586
+  dps: 2059.54804
+  tps: 5943.58548
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2000.06224
-  tps: 5789.95083
+  dps: 1993.25234
+  tps: 5775.83217
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2018.68817
-  tps: 5839.65597
+  dps: 2012.86209
+  tps: 5827.57753
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2008.62169
-  tps: 5816.57462
+  dps: 2002.95678
+  tps: 5804.72466
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2018.68817
-  tps: 5839.65597
+  dps: 2012.86209
+  tps: 5827.57753
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 2229.33617
-  tps: 6379.30509
+  dps: 2221.66668
+  tps: 6364.90064
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2018.68817
-  tps: 5839.65597
+  dps: 2012.86209
+  tps: 5827.57753
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SparkofLife-37657"
  value: {
-  dps: 2038.16321
-  tps: 5895.02404
+  dps: 2032.44872
+  tps: 5883.17511
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormshroudArmor"
  value: {
-  dps: 1619.14721
-  tps: 4763.37627
+  dps: 1615.30031
+  tps: 4755.58005
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2010.20936
-  tps: 5819.76314
+  dps: 2005.77194
+  tps: 5810.65436
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 2009.35697
-  tps: 5814.39142
+  dps: 2003.95407
+  tps: 5803.18882
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2007.74724
-  tps: 5814.2266
+  dps: 2001.80294
+  tps: 5801.90109
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 1605.07456
-  tps: 4584.61689
+  dps: 1597.21429
+  tps: 4568.31862
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1741.51247
-  tps: 4932.12752
+  dps: 1717.49703
+  tps: 4873.76903
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 2021.22197
-  tps: 5847.37516
+  dps: 2015.81319
+  tps: 5836.15884
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2152.52982
-  tps: 6215.47154
+  dps: 2140.60139
+  tps: 6185.3088
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2175.08209
-  tps: 6272.34511
+  dps: 2167.56852
+  tps: 6267.74022
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2000.06224
-  tps: 5789.95083
+  dps: 1993.25234
+  tps: 5775.83217
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2000.06224
-  tps: 5789.95083
+  dps: 1993.25234
+  tps: 5775.83217
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2000.06224
-  tps: 5789.95083
+  dps: 1993.25234
+  tps: 5775.83217
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2000.06224
-  tps: 5789.95083
+  dps: 1993.25234
+  tps: 5775.83217
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1766.91404
-  tps: 5144.84444
+  dps: 1761.51282
+  tps: 5133.64502
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 2393.48077
-  tps: 6765.69355
+  dps: 2386.00984
+  tps: 6750.09755
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 2647.15535
-  tps: 7375.59867
+  dps: 2628.00197
+  tps: 7329.28927
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 2953.45333
-  tps: 7736.11475
-  dtps: 113.2331
+  dps: 2940.83683
+  tps: 7709.80769
+  dtps: 113.02193
  }
 }
 dps_results: {
@@ -699,8 +699,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3079.98081
-  tps: 8084.71682
-  dtps: 109.11037
+  dps: 3097.80659
+  tps: 8113.54917
+  dtps: 108.3612
  }
 }

--- a/sim/warrior/thunder_clap.go
+++ b/sim/warrior/thunder_clap.go
@@ -52,7 +52,7 @@ func (warrior *Warrior) registerThunderClapSpell() {
 
 			for _, aoeTarget := range sim.Encounter.Targets {
 				result := spell.CalcDamage(sim, &aoeTarget.Unit, baseDamage, spell.OutcomeRangedHitAndCrit)
-				spell.DealDamage(sim, &result)
+				spell.DealDamage(sim, result)
 				if result.Landed() {
 					tcAuras[aoeTarget.Index].Activate(sim)
 				}


### PR DESCRIPTION
[core] add a result cache to Spell, speeding up the spell-based damage pipeline somewhat (since each cast would create a new SpellEffect on the heap)

[core] the spellEffect-based damage pipeline now correctly resets Outcome to OutcomeEmpty, so blocks are handled correctly 

[various] related changes (the spell-based damage pipeline now passes *SpellEffect rather than SpellEffect around)

For e.g. DK's dps tests, this reduces heap allocations by >80%, and wowsimwotlk runs >15% faster, consequently.