### PR TITLE
Cost reductions

### DIFF
--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -111,12 +111,6 @@ func (spell *Spell) wrapCastFuncInit(config CastConfig, onCastComplete CastSucce
 
 func (spell *Spell) wrapCastFuncResources(config CastConfig, onCastComplete CastFunc) CastSuccessFunc {
 	if spell.ResourceType == 0 || config.DefaultCast.Cost == 0 {
-		if spell.ResourceType != 0 {
-			panic("ResourceType set for spell " + spell.ActionID.String() + " but no cost")
-		}
-		if config.DefaultCast.Cost != 0 {
-			panic("Cost set for spell " + spell.ActionID.String() + " but no ResourceType")
-		}
 		return func(sim *Simulation, target *Unit) bool {
 			onCastComplete(sim, target)
 			return true

--- a/sim/core/item_sets.go
+++ b/sim/core/item_sets.go
@@ -97,14 +97,17 @@ func (character *Character) HasSetBonus(itemSet *ItemSet, numItems int32) bool {
 		panic(fmt.Sprintf("Item set %s does not have a bonus with %d pieces.", itemSet.Name, numItems))
 	}
 
-	count := int32(0)
+	var count int32
 	for _, item := range character.Equip {
 		if itemSet.ItemIsInSet(item.ID) {
 			count++
+			if count >= numItems {
+				return true
+			}
 		}
 	}
 
-	return count >= numItems
+	return false
 }
 
 type ActiveSetBonus struct {

--- a/sim/core/spell.go
+++ b/sim/core/spell.go
@@ -226,6 +226,14 @@ func (unit *Unit) RegisterSpell(config SpellConfig) *Spell {
 		spell.ResourceMetrics = spell.Unit.NewDeathRuneMetrics(spell.ActionID)
 	}
 
+	if spell.ResourceType != 0 && spell.DefaultCast.Cost == 0 {
+		panic("ResourceType set for spell " + spell.ActionID.String() + " but no cost")
+	}
+
+	if spell.ResourceType == 0 && spell.DefaultCast.Cost != 0 {
+		panic("Cost set for spell " + spell.ActionID.String() + " but no ResourceType")
+	}
+
 	spell.castFn = spell.makeCastFunc(config.Cast, spell.applyEffects)
 
 	if spell.ApplyEffects == nil {

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -45,29 +45,29 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7120.79232
-  tps: 5055.76254
+  dps: 7136.59324
+  tps: 5066.9812
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7196.89865
-  tps: 5109.79804
+  dps: 7178.29588
+  tps: 5096.59007
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7235.12007
-  tps: 5136.93525
+  dps: 7237.36346
+  tps: 5138.52805
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7199.12944
-  tps: 5111.38191
+  dps: 7224.47601
+  tps: 5129.37796
  }
 }
 dps_results: {
@@ -80,155 +80,155 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6275.27982
-  tps: 4455.44867
+  dps: 6322.18879
+  tps: 4488.75404
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7196.89865
-  tps: 5007.60208
+  dps: 7178.29588
+  tps: 4994.65827
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7315.24998
-  tps: 5193.82749
+  dps: 7341.12472
+  tps: 5212.19855
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7161.76189
-  tps: 5084.85094
+  dps: 7159.29127
+  tps: 5083.0968
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7193.74174
-  tps: 5107.55664
+  dps: 7201.68678
+  tps: 5113.19762
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 7256.6654
-  tps: 5152.23243
+  dps: 7275.62339
+  tps: 5165.69261
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7170.24111
-  tps: 5090.87119
+  dps: 7189.03266
+  tps: 5104.21319
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7126.22537
-  tps: 5059.62001
+  dps: 7116.40651
+  tps: 5052.64862
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7009.91432
-  tps: 4977.03917
+  dps: 7014.48292
+  tps: 4980.28287
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7189.89564
-  tps: 5104.8259
+  dps: 7228.52228
+  tps: 5132.25082
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7196.89865
-  tps: 5109.79804
+  dps: 7178.29588
+  tps: 5096.59007
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7196.89865
-  tps: 5109.79804
+  dps: 7178.29588
+  tps: 5096.59007
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7199.12944
-  tps: 5111.38191
+  dps: 7224.47601
+  tps: 5129.37796
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7186.04936
-  tps: 5102.09504
+  dps: 7220.32982
+  tps: 5126.43417
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7196.89865
-  tps: 5109.79804
+  dps: 7178.29588
+  tps: 5096.59007
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7126.77123
-  tps: 5060.00758
+  dps: 7125.0095
+  tps: 5058.75674
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7106.13301
-  tps: 5045.35443
+  dps: 7131.5459
+  tps: 5063.39759
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7095.28777
-  tps: 5037.65431
+  dps: 7109.1642
+  tps: 5047.50658
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7196.89865
-  tps: 5109.79804
+  dps: 7178.29588
+  tps: 5096.59007
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7196.89865
-  tps: 5109.79804
+  dps: 7178.29588
+  tps: 5096.59007
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7284.44498
-  tps: 5171.95594
+  dps: 7288.99575
+  tps: 5175.18698
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7009.91432
-  tps: 4977.03917
+  dps: 7014.48292
+  tps: 4980.28287
  }
 }
 dps_results: {
@@ -241,148 +241,148 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7009.91432
-  tps: 4977.03917
+  dps: 7014.48292
+  tps: 4980.28287
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7199.12944
-  tps: 5111.38191
+  dps: 7224.47601
+  tps: 5129.37796
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7186.04936
-  tps: 5102.09504
+  dps: 7220.32982
+  tps: 5126.43417
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7187.87184
-  tps: 5103.389
+  dps: 7192.27876
+  tps: 5106.51792
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7196.89865
-  tps: 5109.79804
+  dps: 7178.29588
+  tps: 5096.59007
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7233.27403
-  tps: 5135.62456
+  dps: 7214.62693
+  tps: 5122.38512
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7009.91432
-  tps: 4977.03917
+  dps: 7014.48292
+  tps: 4980.28287
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7009.91432
-  tps: 4977.03917
+  dps: 7014.48292
+  tps: 4980.28287
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7210.05316
-  tps: 5119.13775
+  dps: 7239.9899
+  tps: 5140.39283
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7009.91432
-  tps: 4977.03917
+  dps: 7014.48292
+  tps: 4980.28287
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7226.34539
-  tps: 5130.70522
+  dps: 7207.70673
+  tps: 5117.47178
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7233.27403
-  tps: 5135.62456
+  dps: 7214.62693
+  tps: 5122.38512
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7196.89865
-  tps: 5109.79804
+  dps: 7178.29588
+  tps: 5096.59007
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7196.89865
-  tps: 5109.79804
+  dps: 7178.29588
+  tps: 5096.59007
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7009.91432
-  tps: 4977.03917
+  dps: 7014.48292
+  tps: 4980.28287
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7217.64431
-  tps: 5124.52746
+  dps: 7215.01834
+  tps: 5122.66302
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7243.21763
-  tps: 5142.68452
+  dps: 7240.61492
+  tps: 5140.83659
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7300.42374
-  tps: 5183.30085
+  dps: 7357.89492
+  tps: 5224.10539
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7196.89865
-  tps: 5109.79804
+  dps: 7178.29588
+  tps: 5096.59007
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7009.91432
-  tps: 4977.03917
+  dps: 7014.48292
+  tps: 4980.28287
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7009.91432
-  tps: 4977.03917
+  dps: 7014.48292
+  tps: 4980.28287
  }
 }
 dps_results: {
@@ -395,15 +395,15 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7009.91432
-  tps: 4977.03917
+  dps: 7014.48292
+  tps: 4980.28287
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7009.91432
-  tps: 4977.03917
+  dps: 7014.48292
+  tps: 4980.28287
  }
 }
 dps_results: {
@@ -416,8 +416,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 7097.37559
-  tps: 5039.13667
+  dps: 7108.95317
+  tps: 5047.35675
  }
 }
 dps_results: {
@@ -430,22 +430,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7233.27403
-  tps: 5135.62456
+  dps: 7214.62693
+  tps: 5122.38512
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7226.34539
-  tps: 5130.70522
+  dps: 7207.70673
+  tps: 5117.47178
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7214.22026
-  tps: 5122.09638
+  dps: 7195.59638
+  tps: 5108.87343
  }
 }
 dps_results: {
@@ -458,57 +458,57 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-TheFistsofFury"
  value: {
-  dps: 6094.39465
-  tps: 4327.0202
+  dps: 6118.09168
+  tps: 4343.84509
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7236.69011
-  tps: 5138.04998
+  dps: 7242.50517
+  tps: 5142.17867
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7389.57777
-  tps: 5246.60022
+  dps: 7356.20405
+  tps: 5222.90488
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7388.34075
-  tps: 5245.72194
+  dps: 7368.28315
+  tps: 5231.48104
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7196.89865
-  tps: 5109.79804
+  dps: 7178.29588
+  tps: 5096.59007
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7196.89865
-  tps: 5109.79804
+  dps: 7178.29588
+  tps: 5096.59007
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7196.89865
-  tps: 5109.79804
+  dps: 7178.29588
+  tps: 5096.59007
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7196.89865
-  tps: 5109.79804
+  dps: 7178.29588
+  tps: 5096.59007
  }
 }
 dps_results: {
@@ -528,350 +528,350 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 7269.69781
-  tps: 5161.48545
+  dps: 7276.9989
+  tps: 5166.66922
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25707.42562
-  tps: 18252.27219
+  dps: 25708.89467
+  tps: 18253.31522
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7300.42374
-  tps: 5183.30085
+  dps: 7357.89492
+  tps: 5224.10539
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8300.53677
-  tps: 5893.38111
+  dps: 8302.93264
+  tps: 5895.08217
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15165.72209
-  tps: 10767.66268
+  dps: 15167.10031
+  tps: 10768.64122
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3594.62934
-  tps: 2552.18683
+  dps: 3603.93355
+  tps: 2558.79282
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3598.65967
-  tps: 2555.04836
+  dps: 3615.39913
+  tps: 2566.93338
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15830.85204
-  tps: 11239.90495
+  dps: 15861.76452
+  tps: 11261.85281
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5724.80678
-  tps: 4064.61281
+  dps: 5757.17335
+  tps: 4087.59307
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6725.47192
-  tps: 4775.08506
+  dps: 6722.98762
+  tps: 4773.32121
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8998.68534
-  tps: 6389.06659
+  dps: 8988.93348
+  tps: 6382.14277
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2586.43965
-  tps: 1836.37215
+  dps: 2602.66907
+  tps: 1847.89504
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2681.73403
-  tps: 1904.03116
+  dps: 2674.57618
+  tps: 1898.94909
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25707.42562
-  tps: 18252.27219
+  dps: 25708.89467
+  tps: 18253.31522
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7300.42374
-  tps: 5183.30085
+  dps: 7357.89492
+  tps: 5224.10539
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8300.53677
-  tps: 5893.38111
+  dps: 8302.93264
+  tps: 5895.08217
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15165.72209
-  tps: 10767.66268
+  dps: 15167.10031
+  tps: 10768.64122
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3594.62934
-  tps: 2552.18683
+  dps: 3603.93355
+  tps: 2558.79282
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3598.65967
-  tps: 2555.04836
+  dps: 3615.39913
+  tps: 2566.93338
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20007.19675
-  tps: 14205.10969
+  dps: 20001.57254
+  tps: 14201.11651
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4754.8496
-  tps: 3375.94321
+  dps: 4771.65049
+  tps: 3387.87185
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5412.61854
-  tps: 3842.95916
+  dps: 5416.9375
+  tps: 3846.02563
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12967.76594
-  tps: 9207.11381
+  dps: 12967.75498
+  tps: 9207.10603
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2370.4039
-  tps: 1682.98677
+  dps: 2375.95804
+  tps: 1686.93021
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2452.1917
-  tps: 1741.05611
+  dps: 2459.72067
+  tps: 1746.40168
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25946.06123
-  tps: 18421.70348
+  dps: 25955.47871
+  tps: 18428.38989
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7366.26808
-  tps: 5230.05034
+  dps: 7411.11857
+  tps: 5261.89419
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8399.6482
-  tps: 5963.75022
+  dps: 8403.223
+  tps: 5966.28833
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15338.651
-  tps: 10890.44221
+  dps: 15314.73946
+  tps: 10873.46501
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3616.45085
-  tps: 2567.6801
+  dps: 3621.40887
+  tps: 2571.2003
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3664.64037
-  tps: 2601.89467
+  dps: 3660.98527
+  tps: 2599.29954
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15928.67622
-  tps: 11309.36012
+  dps: 15926.29235
+  tps: 11307.66757
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5775.64818
-  tps: 4100.71021
+  dps: 5784.86877
+  tps: 4107.25682
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6810.96209
-  tps: 4835.78309
+  dps: 6808.36777
+  tps: 4833.94112
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9043.77525
-  tps: 6421.08043
+  dps: 9043.7352
+  tps: 6421.05199
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2609.04121
-  tps: 1852.41926
+  dps: 2622.09859
+  tps: 1861.69
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2717.87442
-  tps: 1929.69084
+  dps: 2695.18947
+  tps: 1913.58452
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25946.06123
-  tps: 18421.70348
+  dps: 25955.47871
+  tps: 18428.38989
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7366.26808
-  tps: 5230.05034
+  dps: 7411.11857
+  tps: 5261.89419
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8399.6482
-  tps: 5963.75022
+  dps: 8403.223
+  tps: 5966.28833
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15338.651
-  tps: 10890.44221
+  dps: 15314.73946
+  tps: 10873.46501
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3616.45085
-  tps: 2567.6801
+  dps: 3621.40887
+  tps: 2571.2003
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3664.64037
-  tps: 2601.89467
+  dps: 3660.98527
+  tps: 2599.29954
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20125.73625
-  tps: 14289.27274
+  dps: 20127.46456
+  tps: 14290.49984
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4801.66733
-  tps: 3409.18381
+  dps: 4800.88872
+  tps: 3408.63099
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5475.94171
-  tps: 3887.91861
+  dps: 5480.88047
+  tps: 3891.42513
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13046.98063
-  tps: 9263.35625
+  dps: 13041.78053
+  tps: 9259.66418
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2399.64848
-  tps: 1703.75042
+  dps: 2388.692
+  tps: 1695.97132
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2496.18106
-  tps: 1772.28856
+  dps: 2500.23202
+  tps: 1775.16474
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6815.11372
-  tps: 4838.73074
+  dps: 6879.72115
+  tps: 4884.60202
  }
 }

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -45,29 +45,29 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 6307.22305
-  tps: 4478.12837
+  dps: 6317.96925
+  tps: 4485.75817
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6353.66111
-  tps: 4511.09939
+  dps: 6362.25213
+  tps: 4517.19901
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6426.72566
-  tps: 4562.97522
+  dps: 6440.21126
+  tps: 4572.54999
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6377.69451
-  tps: 4528.16311
+  dps: 6386.56158
+  tps: 4534.45872
  }
 }
 dps_results: {
@@ -80,155 +80,155 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-BonescytheBattlegear"
  value: {
-  dps: 5702.26751
-  tps: 4048.60993
+  dps: 5708.62519
+  tps: 4053.12388
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6353.66111
-  tps: 4420.8774
+  dps: 6362.25213
+  tps: 4426.85503
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6492.7214
-  tps: 4609.8322
+  dps: 6501.87061
+  tps: 4616.32814
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6346.89431
-  tps: 4506.29496
+  dps: 6361.03948
+  tps: 4516.33803
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6387.05825
-  tps: 4534.81136
+  dps: 6395.80214
+  tps: 4541.01952
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6447.11494
-  tps: 4577.4516
+  dps: 6456.52283
+  tps: 4584.13121
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6370.49037
-  tps: 4523.04816
+  dps: 6379.64541
+  tps: 4529.54824
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6325.74561
-  tps: 4491.27938
+  dps: 6338.73313
+  tps: 4500.50052
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6225.81112
-  tps: 4420.3259
+  dps: 6240.29979
+  tps: 4430.61285
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6381.99606
-  tps: 4531.2172
+  dps: 6389.88067
+  tps: 4536.81527
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6353.66111
-  tps: 4511.09939
+  dps: 6362.25213
+  tps: 4517.19901
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6353.66111
-  tps: 4511.09939
+  dps: 6362.25213
+  tps: 4517.19901
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6377.69451
-  tps: 4528.16311
+  dps: 6386.56158
+  tps: 4534.45872
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6371.45436
-  tps: 4523.7326
+  dps: 6380.26093
+  tps: 4529.98526
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6353.66111
-  tps: 4511.09939
+  dps: 6362.25213
+  tps: 4517.19901
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6372.63498
-  tps: 4524.57083
+  dps: 6384.38546
+  tps: 4532.91368
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6329.01736
-  tps: 4493.60233
+  dps: 6340.74094
+  tps: 4501.92606
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6310.75701
-  tps: 4480.63747
+  dps: 6322.92165
+  tps: 4489.27437
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6353.66111
-  tps: 4511.09939
+  dps: 6362.25213
+  tps: 4517.19901
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6353.66111
-  tps: 4511.09939
+  dps: 6362.25213
+  tps: 4517.19901
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6469.0125
-  tps: 4592.99887
+  dps: 6484.48077
+  tps: 4603.98135
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6225.81112
-  tps: 4420.3259
+  dps: 6240.29979
+  tps: 4430.61285
  }
 }
 dps_results: {
@@ -241,148 +241,148 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6225.81112
-  tps: 4420.3259
+  dps: 6240.29979
+  tps: 4430.61285
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6377.69451
-  tps: 4528.16311
+  dps: 6386.56158
+  tps: 4534.45872
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6371.45436
-  tps: 4523.7326
+  dps: 6380.26093
+  tps: 4529.98526
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6411.88411
-  tps: 4552.43772
+  dps: 6428.69161
+  tps: 4564.37104
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6353.66111
-  tps: 4511.09939
+  dps: 6362.25213
+  tps: 4517.19901
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6385.78743
-  tps: 4533.90907
+  dps: 6394.47464
+  tps: 4540.07699
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6225.81112
-  tps: 4420.3259
+  dps: 6240.29979
+  tps: 4430.61285
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6225.81112
-  tps: 4420.3259
+  dps: 6240.29979
+  tps: 4430.61285
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6440.12476
-  tps: 4572.48858
+  dps: 6451.31337
+  tps: 4580.43249
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6225.81112
-  tps: 4420.3259
+  dps: 6240.29979
+  tps: 4430.61285
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6379.66813
-  tps: 4529.56437
+  dps: 6388.33702
+  tps: 4535.71928
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6385.78743
-  tps: 4533.90907
+  dps: 6394.47464
+  tps: 4540.07699
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6353.66111
-  tps: 4511.09939
+  dps: 6362.25213
+  tps: 4517.19901
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6353.66111
-  tps: 4511.09939
+  dps: 6362.25213
+  tps: 4517.19901
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6225.81112
-  tps: 4420.3259
+  dps: 6240.29979
+  tps: 4430.61285
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6374.72958
-  tps: 4526.058
+  dps: 6390.16163
+  tps: 4537.01476
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6393.51159
-  tps: 4539.39323
+  dps: 6409.09699
+  tps: 4550.45886
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6495.20571
-  tps: 4611.59606
+  dps: 6503.75746
+  tps: 4617.6678
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6353.66111
-  tps: 4511.09939
+  dps: 6362.25213
+  tps: 4517.19901
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6225.81112
-  tps: 4420.3259
+  dps: 6240.29979
+  tps: 4430.61285
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6225.81112
-  tps: 4420.3259
+  dps: 6240.29979
+  tps: 4430.61285
  }
 }
 dps_results: {
@@ -395,15 +395,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6225.81112
-  tps: 4420.3259
+  dps: 6240.29979
+  tps: 4430.61285
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6225.81112
-  tps: 4420.3259
+  dps: 6240.29979
+  tps: 4430.61285
  }
 }
 dps_results: {
@@ -416,8 +416,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-SparkofLife-37657"
  value: {
-  dps: 6320.07261
-  tps: 4487.25155
+  dps: 6321.24699
+  tps: 4488.08537
  }
 }
 dps_results: {
@@ -430,22 +430,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6385.78743
-  tps: 4533.90907
+  dps: 6394.47464
+  tps: 4540.07699
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6379.66813
-  tps: 4529.56437
+  dps: 6388.33702
+  tps: 4535.71928
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6368.95936
-  tps: 4521.96114
+  dps: 6377.59618
+  tps: 4528.09329
  }
 }
 dps_results: {
@@ -458,64 +458,64 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-TheFistsofFury"
  value: {
-  dps: 5660.76906
-  tps: 4019.14603
+  dps: 5667.07734
+  tps: 4023.62491
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5790.59655
-  tps: 4111.32355
+  dps: 5791.01354
+  tps: 4111.61961
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6414.84601
-  tps: 4554.54067
+  dps: 6399.44164
+  tps: 4543.60356
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6506.15663
-  tps: 4619.37121
+  dps: 6493.71463
+  tps: 4610.53739
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6528.18165
-  tps: 4635.00897
+  dps: 6533.94455
+  tps: 4639.10063
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6353.66111
-  tps: 4511.09939
+  dps: 6362.25213
+  tps: 4517.19901
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6353.66111
-  tps: 4511.09939
+  dps: 6362.25213
+  tps: 4517.19901
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6353.66111
-  tps: 4511.09939
+  dps: 6362.25213
+  tps: 4517.19901
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6353.66111
-  tps: 4511.09939
+  dps: 6362.25213
+  tps: 4517.19901
  }
 }
 dps_results: {
@@ -528,357 +528,357 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6020.34917
-  tps: 4274.44791
+  dps: 6047.20371
+  tps: 4293.51463
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 6427.38132
-  tps: 4563.44074
+  dps: 6428.30384
+  tps: 4564.09573
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14237.58554
-  tps: 10108.68573
+  dps: 14150.64059
+  tps: 10046.95482
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5513.5296
-  tps: 3914.60602
+  dps: 5521.9895
+  tps: 3920.61254
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6496.67972
-  tps: 4612.6426
+  dps: 6569.32024
+  tps: 4664.21737
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8645.82936
-  tps: 6138.53884
+  dps: 8672.26887
+  tps: 6157.31089
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2551.10167
-  tps: 1811.28218
+  dps: 2551.67597
+  tps: 1811.68994
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2725.75441
-  tps: 1935.28563
+  dps: 2731.87104
+  tps: 1939.62844
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19410.52032
-  tps: 13781.46942
+  dps: 19293.84689
+  tps: 13698.63129
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6495.20571
-  tps: 4611.59606
+  dps: 6503.75746
+  tps: 4617.6678
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7424.50503
-  tps: 5271.39857
+  dps: 7500.47719
+  tps: 5325.33881
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12166.6852
-  tps: 8638.34649
+  dps: 12209.6023
+  tps: 8668.81763
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3200.68418
-  tps: 2272.48577
+  dps: 3192.47843
+  tps: 2266.65969
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3323.18208
-  tps: 2359.45928
+  dps: 3331.92566
+  tps: 2365.66722
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19410.52032
-  tps: 13781.46942
+  dps: 19293.84689
+  tps: 13698.63129
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6495.20571
-  tps: 4611.59606
+  dps: 6503.75746
+  tps: 4617.6678
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7424.50503
-  tps: 5271.39857
+  dps: 7500.47719
+  tps: 5325.33881
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12166.6852
-  tps: 8638.34649
+  dps: 12209.6023
+  tps: 8668.81763
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3200.68418
-  tps: 2272.48577
+  dps: 3192.47843
+  tps: 2266.65969
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3323.18208
-  tps: 2359.45928
+  dps: 3331.92566
+  tps: 2365.66722
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18214.98836
-  tps: 12932.64173
+  dps: 18100.31483
+  tps: 12851.22353
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4793.34928
-  tps: 3403.27799
+  dps: 4800.64826
+  tps: 3408.46026
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5467.71575
-  tps: 3882.07818
+  dps: 5529.16374
+  tps: 3925.70626
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11898.90173
-  tps: 8448.22023
+  dps: 11964.44225
+  tps: 8494.754
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2377.78019
-  tps: 1688.22393
+  dps: 2374.58746
+  tps: 1685.95709
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2515.71044
-  tps: 1786.15441
+  dps: 2523.30384
+  tps: 1791.54573
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14366.25185
-  tps: 10200.03881
+  dps: 14273.86969
+  tps: 10134.44748
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5556.52214
-  tps: 3945.13072
+  dps: 5566.1341
+  tps: 3951.95521
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6581.59194
-  tps: 4672.93028
+  dps: 6654.51799
+  tps: 4724.70777
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8732.12146
-  tps: 6199.80623
+  dps: 8757.99608
+  tps: 6218.17722
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2575.37102
-  tps: 1828.51342
+  dps: 2575.51876
+  tps: 1828.61832
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2766.64888
-  tps: 1964.3207
+  dps: 2772.03249
+  tps: 1968.14307
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19568.49326
-  tps: 13893.63022
+  dps: 19446.4831
+  tps: 13807.003
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6545.43199
-  tps: 4647.25671
+  dps: 6554.13394
+  tps: 4653.4351
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7521.90914
-  tps: 5340.55549
+  dps: 7598.47837
+  tps: 5394.91964
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12275.41667
-  tps: 8715.54583
+  dps: 12318.39822
+  tps: 8746.06274
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3229.84919
-  tps: 2293.19292
+  dps: 3221.66707
+  tps: 2287.38362
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3372.86898
-  tps: 2394.73698
+  dps: 3381.02645
+  tps: 2400.52878
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19568.49326
-  tps: 13893.63022
+  dps: 19446.4831
+  tps: 13807.003
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6545.43199
-  tps: 4647.25671
+  dps: 6554.13394
+  tps: 4653.4351
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7521.90914
-  tps: 5340.55549
+  dps: 7598.47837
+  tps: 5394.91964
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12275.41667
-  tps: 8715.54583
+  dps: 12318.39822
+  tps: 8746.06274
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3229.84919
-  tps: 2293.19292
+  dps: 3221.66707
+  tps: 2287.38362
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3372.86898
-  tps: 2394.73698
+  dps: 3381.02645
+  tps: 2400.52878
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18361.38846
-  tps: 13036.58581
+  dps: 18241.73172
+  tps: 12951.62952
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4828.84391
-  tps: 3428.47918
+  dps: 4836.73231
+  tps: 3434.07994
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5536.59551
-  tps: 3930.98281
+  dps: 5598.79367
+  tps: 3975.1435
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12004.84479
-  tps: 8523.4398
+  dps: 12071.2065
+  tps: 8570.55662
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2399.12927
-  tps: 1703.38179
+  dps: 2395.75127
+  tps: 1700.9834
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2551.90258
-  tps: 1811.85083
+  dps: 2558.87459
+  tps: 1816.80096
  }
 }
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6224.48107
-  tps: 4419.38156
+  dps: 6239.44114
+  tps: 4430.00321
  }
 }

--- a/sim/rogue/TestRotation.results
+++ b/sim/rogue/TestRotation.results
@@ -43,15 +43,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 49.2
+   value: 48.2
   }
   casts: {
    key: "spell_id:48665"
-   value: 49.2
+   value: 48.2
   }
   casts: {
    key: "spell_id:48666"
-   value: 49.2
+   value: 48.2
   }
   casts: {
    key: "spell_id:48668 tag:1"
@@ -123,11 +123,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 160
+   value: 159.7
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 301.6
+   value: 300.4
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -135,7 +135,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 306.6
+   value: 305.4
   }
   casts: {
    key: "spell_id:57975"
@@ -151,23 +151,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:1"
-   value: 21.5
+   value: 23.2
   }
   casts: {
    key: "spell_id:57993 tag:2"
-   value: 1.9
+   value: 2.4
   }
   casts: {
    key: "spell_id:57993 tag:3"
-   value: 16
+   value: 16.2
   }
   casts: {
    key: "spell_id:57993 tag:4"
-   value: 7.2
+   value: 6.6
   }
   casts: {
    key: "spell_id:57993 tag:5"
-   value: 3.1
+   value: 2.4
   }
   casts: {
    key: "spell_id:58426"
@@ -183,7 +183,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 0.2
+   value: 0.1
   }
   casts: {
    key: "spell_id:6774 tag:3"
@@ -199,7 +199,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:8647 tag:1"
-   value: 2
+   value: 1.8
   }
   casts: {
    key: "spell_id:8647 tag:2"
@@ -207,7 +207,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:8647 tag:3"
-   value: 3.6
+   value: 3.5
   }
   casts: {
    key: "spell_id:8647 tag:4"
@@ -215,7 +215,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:8647 tag:5"
-   value: 4.5
+   value: 4.7
   }
  }
 }
@@ -264,15 +264,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 32.3
+   value: 32.4
   }
   casts: {
    key: "spell_id:48665"
-   value: 32.3
+   value: 32.4
   }
   casts: {
    key: "spell_id:48666"
-   value: 32.3
+   value: 32.4
   }
   casts: {
    key: "spell_id:48668 tag:1"
@@ -324,7 +324,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:51662"
-   value: 5.3
+   value: 5.2
   }
   casts: {
    key: "spell_id:51723"
@@ -344,11 +344,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 155.3
+   value: 154.9
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 294.7
+   value: 295.7
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -356,7 +356,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 299.7
+   value: 300.7
   }
   casts: {
    key: "spell_id:57975"
@@ -376,11 +376,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:2"
-   value: 5.2
+   value: 4.9
   }
   casts: {
    key: "spell_id:57993 tag:3"
-   value: 25.9
+   value: 26.2
   }
   casts: {
    key: "spell_id:57993 tag:4"
@@ -485,15 +485,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 32.3
+   value: 32.4
   }
   casts: {
    key: "spell_id:48665"
-   value: 32.3
+   value: 32.4
   }
   casts: {
    key: "spell_id:48666"
-   value: 32.3
+   value: 32.4
   }
   casts: {
    key: "spell_id:48668 tag:1"
@@ -545,7 +545,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:51662"
-   value: 5.3
+   value: 5.2
   }
   casts: {
    key: "spell_id:51723"
@@ -565,11 +565,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 155.3
+   value: 154.9
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 294.7
+   value: 295.7
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -577,7 +577,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 299.7
+   value: 300.7
   }
   casts: {
    key: "spell_id:57975"
@@ -597,11 +597,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:2"
-   value: 5.2
+   value: 4.9
   }
   casts: {
    key: "spell_id:57993 tag:3"
-   value: 25.9
+   value: 26.2
   }
   casts: {
    key: "spell_id:57993 tag:4"
@@ -766,7 +766,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:51662"
-   value: 5.2
+   value: 5.3
   }
   casts: {
    key: "spell_id:51723"
@@ -786,11 +786,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 156.8
+   value: 156.5
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 299.2
+   value: 299.6
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -798,7 +798,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 304.2
+   value: 304.6
   }
   casts: {
    key: "spell_id:57975"
@@ -814,15 +814,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:1"
-   value: 47.8
+   value: 47.6
   }
   casts: {
    key: "spell_id:57993 tag:2"
-   value: 5.1
+   value: 5.3
   }
   casts: {
    key: "spell_id:57993 tag:3"
-   value: 27.1
+   value: 26.9
   }
   casts: {
    key: "spell_id:57993 tag:4"
@@ -846,11 +846,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 0.1
+   value: 0.2
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 0.9
+   value: 0.8
   }
   casts: {
    key: "spell_id:6774 tag:4"
@@ -927,15 +927,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 32.3
+   value: 32.4
   }
   casts: {
    key: "spell_id:48665"
-   value: 32.3
+   value: 32.4
   }
   casts: {
    key: "spell_id:48666"
-   value: 32.3
+   value: 32.4
   }
   casts: {
    key: "spell_id:48668 tag:1"
@@ -987,7 +987,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:51662"
-   value: 5.3
+   value: 5.2
   }
   casts: {
    key: "spell_id:51723"
@@ -1007,11 +1007,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 155.3
+   value: 154.9
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 294.7
+   value: 295.7
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -1019,7 +1019,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 299.7
+   value: 300.7
   }
   casts: {
    key: "spell_id:57975"
@@ -1039,11 +1039,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:2"
-   value: 5.2
+   value: 4.9
   }
   casts: {
    key: "spell_id:57993 tag:3"
-   value: 25.9
+   value: 26.2
   }
   casts: {
    key: "spell_id:57993 tag:4"
@@ -1228,11 +1228,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 156.5
+   value: 157.4
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 299.2
+   value: 299.4
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -1240,7 +1240,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 304.2
+   value: 304.4
   }
   casts: {
    key: "spell_id:57975"
@@ -1264,7 +1264,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:3"
-   value: 27
+   value: 26.9
   }
   casts: {
    key: "spell_id:57993 tag:4"
@@ -1288,11 +1288,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 0.2
+   value: 0.1
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 0.8
+   value: 0.9
   }
   casts: {
    key: "spell_id:6774 tag:4"
@@ -1337,11 +1337,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 478
+   value: 477.9
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 371.9
+   value: 371.8
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -1365,7 +1365,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48638"
-   value: 81.1
+   value: 81.6
   }
   casts: {
    key: "spell_id:48659"
@@ -1385,7 +1385,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0.6
+   value: 0.5
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -1401,7 +1401,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:5"
-   value: 0.3
+   value: 0.2
   }
   casts: {
    key: "spell_id:48672"
@@ -1409,11 +1409,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 22.3
+   value: 21.9
   }
   casts: {
    key: "spell_id:48672 tag:2"
-   value: 1.9
+   value: 2.2
   }
   casts: {
    key: "spell_id:48672 tag:3"
@@ -1425,7 +1425,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:5"
-   value: 0.8
+   value: 0.9
+  }
+  casts: {
+   key: "spell_id:48676"
+   value: 0
   }
   casts: {
    key: "spell_id:48676"
@@ -1473,7 +1477,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 237.9
+   value: 237.8
   }
   casts: {
    key: "spell_id:57975"
@@ -1493,11 +1497,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:1"
-   value: 5.2
+   value: 5
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 4.2
+   value: 4.3
   }
   casts: {
    key: "spell_id:6774 tag:3"
@@ -1505,7 +1509,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:4"
-   value: 1.9
+   value: 2
   }
   casts: {
    key: "spell_id:6774 tag:5"
@@ -1513,11 +1517,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:8647 tag:1"
-   value: 15.3
+   value: 15.1
   }
   casts: {
    key: "spell_id:8647 tag:2"
-   value: 6.9
+   value: 6.6
   }
   casts: {
    key: "spell_id:8647 tag:3"
@@ -1525,11 +1529,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:8647 tag:4"
-   value: 1.3
+   value: 1.5
   }
   casts: {
    key: "spell_id:8647 tag:5"
-   value: 0.5
+   value: 0.4
   }
  }
 }
@@ -1546,11 +1550,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 476.8
+   value: 476.6
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 371
+   value: 370.8
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -1574,7 +1578,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48638"
-   value: 94.5
+   value: 94.9
   }
   casts: {
    key: "spell_id:48659"
@@ -1594,7 +1598,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 1.3
+   value: 1.4
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -1618,23 +1622,27 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 7.1
+   value: 6.7
   }
   casts: {
    key: "spell_id:48672 tag:2"
-   value: 3.7
+   value: 4.1
   }
   casts: {
    key: "spell_id:48672 tag:3"
-   value: 5.9
+   value: 5.6
   }
   casts: {
    key: "spell_id:48672 tag:4"
-   value: 5
+   value: 4.9
   }
   casts: {
    key: "spell_id:48672 tag:5"
-   value: 4.4
+   value: 4.5
+  }
+  casts: {
+   key: "spell_id:48676"
+   value: 0
   }
   casts: {
    key: "spell_id:48676"
@@ -1670,11 +1678,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 112.4
+   value: 112.6
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 226.8
+   value: 226.6
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -1682,7 +1690,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 231.9
+   value: 231.6
   }
   casts: {
    key: "spell_id:57975"
@@ -1706,19 +1714,19 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 3.3
+   value: 3
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 3.2
+   value: 3
   }
   casts: {
    key: "spell_id:6774 tag:4"
-   value: 2.6
+   value: 2.5
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 1.1
+   value: 1.4
   }
   casts: {
    key: "spell_id:8647 tag:1"
@@ -1755,11 +1763,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 471.3
+   value: 471.2
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 366.7
+   value: 366.6
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -1803,7 +1811,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 76.8
+   value: 76.7
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -1879,11 +1887,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 111.2
+   value: 111.1
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 222
+   value: 222.1
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -1891,7 +1899,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 227.1
+   value: 227.2
   }
   casts: {
    key: "spell_id:57975"
@@ -1964,11 +1972,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 478
+   value: 477.7
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 371.9
+   value: 371.6
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -2012,7 +2020,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 1.4
+   value: 1.3
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -2036,11 +2044,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 6
+   value: 6.1
   }
   casts: {
    key: "spell_id:48672 tag:2"
-   value: 3.7
+   value: 3.5
   }
   casts: {
    key: "spell_id:48672 tag:3"
@@ -2048,7 +2056,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:4"
-   value: 5.3
+   value: 5.4
   }
   casts: {
    key: "spell_id:48672 tag:5"
@@ -2088,11 +2096,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 112.9
+   value: 112.7
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 228.8
+   value: 228.7
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -2100,7 +2108,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 233.8
+   value: 233.7
   }
   casts: {
    key: "spell_id:57975"
@@ -2124,11 +2132,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 3.3
+   value: 3.2
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 2.6
+   value: 3
   }
   casts: {
    key: "spell_id:6774 tag:4"
@@ -2136,7 +2144,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 1.7
+   value: 1.4
   }
   casts: {
    key: "spell_id:8647 tag:1"
@@ -2173,11 +2181,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 476.8
+   value: 476.6
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 371
+   value: 370.8
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -2201,7 +2209,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48638"
-   value: 94.5
+   value: 94.9
   }
   casts: {
    key: "spell_id:48659"
@@ -2221,7 +2229,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 1.3
+   value: 1.4
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -2245,23 +2253,27 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 7.1
+   value: 6.7
   }
   casts: {
    key: "spell_id:48672 tag:2"
-   value: 3.7
+   value: 4.1
   }
   casts: {
    key: "spell_id:48672 tag:3"
-   value: 5.9
+   value: 5.6
   }
   casts: {
    key: "spell_id:48672 tag:4"
-   value: 5
+   value: 4.9
   }
   casts: {
    key: "spell_id:48672 tag:5"
-   value: 4.4
+   value: 4.5
+  }
+  casts: {
+   key: "spell_id:48676"
+   value: 0
   }
   casts: {
    key: "spell_id:48676"
@@ -2297,11 +2309,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 112.4
+   value: 112.6
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 226.8
+   value: 226.6
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -2309,7 +2321,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 231.9
+   value: 231.6
   }
   casts: {
    key: "spell_id:57975"
@@ -2333,19 +2345,19 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 3.3
+   value: 3
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 3.2
+   value: 3
   }
   casts: {
    key: "spell_id:6774 tag:4"
-   value: 2.6
+   value: 2.5
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 1.1
+   value: 1.4
   }
   casts: {
    key: "spell_id:8647 tag:1"
@@ -2382,11 +2394,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 477.9
+   value: 477.4
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 371.8
+   value: 371.5
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -2410,7 +2422,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48638"
-   value: 98.3
+   value: 98.6
   }
   casts: {
    key: "spell_id:48659"
@@ -2430,7 +2442,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 1.5
+   value: 1.4
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -2446,7 +2458,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:5"
-   value: 1.8
+   value: 1.7
   }
   casts: {
    key: "spell_id:48672"
@@ -2454,23 +2466,27 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 7.3
+   value: 7.1
   }
   casts: {
    key: "spell_id:48672 tag:2"
-   value: 3.3
+   value: 3.1
   }
   casts: {
    key: "spell_id:48672 tag:3"
-   value: 4.9
+   value: 4.6
   }
   casts: {
    key: "spell_id:48672 tag:4"
-   value: 4.5
+   value: 4.7
   }
   casts: {
    key: "spell_id:48672 tag:5"
-   value: 5.4
+   value: 5.6
+  }
+  casts: {
+   key: "spell_id:48676"
+   value: 0
   }
   casts: {
    key: "spell_id:48676"
@@ -2506,7 +2522,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 112.8
+   value: 112.5
   }
   casts: {
    key: "spell_id:57968 tag:1"
@@ -2538,23 +2554,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:1"
-   value: 5.3
+   value: 5.6
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 3
+   value: 2.8
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 2.9
-  }
-  casts: {
-   key: "spell_id:6774 tag:4"
    value: 2.7
   }
   casts: {
+   key: "spell_id:6774 tag:4"
+   value: 2.9
+  }
+  casts: {
    key: "spell_id:6774 tag:5"
-   value: 1.4
+   value: 1.2
   }
   casts: {
    key: "spell_id:8647 tag:1"

--- a/sim/rogue/backstab.go
+++ b/sim/rogue/backstab.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (rogue *Rogue) registerBackstabSpell() {
-	baseCost := 60.0 - 4.0*float64(rogue.Talents.SlaughterFromTheShadows)
+	baseCost := rogue.costModifier(60 - 4*float64(rogue.Talents.SlaughterFromTheShadows))
 	refundAmount := baseCost * 0.8
 
 	rogue.Backstab = rogue.RegisterSpell(core.SpellConfig{
@@ -25,7 +25,6 @@ func (rogue *Rogue) registerBackstabSpell() {
 				GCD:  time.Second,
 			},
 			IgnoreHaste: true,
-			ModifyCast:  rogue.CastModifier,
 		},
 
 		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0) +

--- a/sim/rogue/envenom.go
+++ b/sim/rogue/envenom.go
@@ -12,7 +12,7 @@ func (rogue *Rogue) makeEnvenom(comboPoints int32) *core.Spell {
 
 	chanceToRetainStacks := []float64{0, 0.33, 0.66, 1}[rogue.Talents.MasterPoisoner]
 
-	cost := 35.0
+	baseCost := 35.0
 	refundAmount := 0.4 * float64(rogue.Talents.QuickRecovery)
 
 	// TODO Envenom can only be cast if the target is afflicted by Deadly Poison
@@ -24,11 +24,11 @@ func (rogue *Rogue) makeEnvenom(comboPoints int32) *core.Spell {
 		ProcMask:     core.ProcMaskMeleeMHSpecial, // not core.ProcMaskSpellDamage
 		Flags:        core.SpellFlagMeleeMetrics | rogue.finisherFlags(),
 		ResourceType: stats.Energy,
-		BaseCost:     cost,
+		BaseCost:     baseCost,
 
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
-				Cost: cost,
+				Cost: baseCost,
 				GCD:  time.Second,
 			},
 			ModifyCast: func(sim *core.Simulation, spell *core.Spell, cast *core.Cast) {
@@ -37,7 +37,6 @@ func (rogue *Rogue) makeEnvenom(comboPoints int32) *core.Spell {
 				// See: https://github.com/where-fore/rogue-wotlk/issues/32
 				rogue.EnvenomAura.Duration = time.Second * time.Duration(1+comboPoints)
 				rogue.EnvenomAura.Activate(sim)
-				rogue.CastModifier(sim, spell, cast)
 			},
 			IgnoreHaste: true,
 		},

--- a/sim/rogue/eviscerate.go
+++ b/sim/rogue/eviscerate.go
@@ -13,7 +13,7 @@ func (rogue *Rogue) makeEviscerate(comboPoints int32) *core.Spell {
 	// tooltip implies 3..7% AP scaling, but testing show it's fixed at 7% (3.4.0.46158)
 	apRatio := 0.07 * float64(comboPoints)
 
-	cost := 35.0
+	baseCost := 35.0
 	refundAmount := 0.4 * float64(rogue.Talents.QuickRecovery)
 
 	return rogue.RegisterSpell(core.SpellConfig{
@@ -22,14 +22,13 @@ func (rogue *Rogue) makeEviscerate(comboPoints int32) *core.Spell {
 		ProcMask:     core.ProcMaskMeleeMHSpecial,
 		Flags:        core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | rogue.finisherFlags(),
 		ResourceType: stats.Energy,
-		BaseCost:     cost,
+		BaseCost:     baseCost,
 
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
-				Cost: cost,
+				Cost: baseCost,
 				GCD:  time.Second,
 			},
-			ModifyCast:  rogue.CastModifier,
 			IgnoreHaste: true,
 		},
 

--- a/sim/rogue/expose_armor.go
+++ b/sim/rogue/expose_armor.go
@@ -26,7 +26,6 @@ func (rogue *Rogue) makeExposeArmor(comboPoints int32) *core.Spell {
 				Cost: baseCost,
 				GCD:  time.Second,
 			},
-			ModifyCast:  rogue.CastModifier,
 			IgnoreHaste: true,
 		},
 

--- a/sim/rogue/fan_of_knives.go
+++ b/sim/rogue/fan_of_knives.go
@@ -37,7 +37,7 @@ func (rogue *Rogue) makeFanOfKnivesWeaponHitSpell(isMH bool) *core.Spell {
 }
 
 func (rogue *Rogue) registerFanOfKnives() {
-	energyCost := 50.0
+	baseCost := 50.0
 	mhSpell := rogue.makeFanOfKnivesWeaponHitSpell(true)
 	ohSpell := rogue.makeFanOfKnivesWeaponHitSpell(false)
 	results := make([]*core.SpellEffect, len(rogue.Env.Encounter.Targets))
@@ -48,14 +48,13 @@ func (rogue *Rogue) registerFanOfKnives() {
 		Flags:       core.SpellFlagMeleeMetrics,
 
 		ResourceType: stats.Energy,
-		BaseCost:     energyCost,
+		BaseCost:     baseCost,
 
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
-				Cost: energyCost,
+				Cost: baseCost,
 				GCD:  time.Second,
 			},
-			ModifyCast:  rogue.CastModifier,
 			IgnoreHaste: true,
 		},
 

--- a/sim/rogue/feint.go
+++ b/sim/rogue/feint.go
@@ -9,24 +9,23 @@ import (
 )
 
 func (rogue *Rogue) registerFeintSpell() {
-	cost := 20.0
-	castModifier := rogue.CastModifier
+	resourceType := stats.Energy
+	baseCost := 20.0
 	if rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfFeint) {
-		castModifier = func(sim *core.Simulation, spell *core.Spell, cast *core.Cast) {
-			cast.Cost = 0
-		}
+		resourceType = 0
+		baseCost = 0
 	}
 	rogue.Feint = rogue.RegisterSpell(core.SpellConfig{
 		ActionID:     core.ActionID{SpellID: 48659},
 		SpellSchool:  core.SpellSchoolPhysical,
 		ProcMask:     core.ProcMaskMeleeMHSpecial,
 		Flags:        core.SpellFlagMeleeMetrics,
-		ResourceType: stats.Energy,
-		BaseCost:     cost,
+		ResourceType: resourceType,
+		BaseCost:     baseCost,
 
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
-				Cost: cost,
+				Cost: baseCost,
 				GCD:  time.Second,
 			},
 			CD: core.Cooldown{
@@ -34,14 +33,13 @@ func (rogue *Rogue) registerFeintSpell() {
 				Duration: time.Second * 10,
 			},
 			IgnoreHaste: true,
-			ModifyCast:  castModifier,
 		},
 
-		DamageMultiplier: 0.0,
+		DamageMultiplier: 0,
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			spell.CalcAndDealOutcome(sim, target, spell.OutcomeMeleeSpecialNoBlockDodgeParryNoCrit)
+			spell.CalcAndDealOutcome(sim, target, spell.OutcomeMeleeSpecialHit)
 		},
 	})
 	// Feint

--- a/sim/rogue/garrote.go
+++ b/sim/rogue/garrote.go
@@ -8,13 +8,12 @@ import (
 	"github.com/wowsims/wotlk/sim/core/stats"
 )
 
-const GarroteEnergyCost = 50.0
 const GarroteSpellID = 48676
 
 func (rogue *Rogue) registerGarrote() {
 	refundAmount := 0.4 * float64(rogue.Talents.QuickRecovery)
 	numTicks := 6
-	baseCost := GarroteEnergyCost
+	baseCost := rogue.costModifier(50 - 10*float64(rogue.Talents.DirtyDeeds))
 	totalDamageMod := 1.0
 	if rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfGarrote) {
 		numTicks = 5
@@ -34,7 +33,6 @@ func (rogue *Rogue) registerGarrote() {
 				Cost: baseCost,
 				GCD:  time.Second,
 			},
-			ModifyCast:  rogue.CastModifier,
 			IgnoreHaste: true,
 		},
 

--- a/sim/rogue/hemorrhage.go
+++ b/sim/rogue/hemorrhage.go
@@ -38,7 +38,7 @@ func (rogue *Rogue) registerHemorrhageSpell() {
 		},
 	})
 
-	baseCost := 35.0 - float64(rogue.Talents.SlaughterFromTheShadows)
+	baseCost := rogue.costModifier(35 - float64(rogue.Talents.SlaughterFromTheShadows))
 	refundAmount := baseCost * 0.8
 	daggerMH := rogue.Equip[proto.ItemSlot_ItemSlotMainHand].WeaponType == proto.WeaponType_WeaponTypeDagger
 	rogue.Hemorrhage = rogue.RegisterSpell(core.SpellConfig{
@@ -55,7 +55,6 @@ func (rogue *Rogue) registerHemorrhageSpell() {
 				GCD:  time.Second,
 			},
 			IgnoreHaste: true,
-			ModifyCast:  rogue.CastModifier,
 		},
 
 		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0),

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -69,6 +69,7 @@ func (rogue *Rogue) registerMutilateSpell() {
 	if rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfMutilate) {
 		baseCost -= 5
 	}
+	baseCost = rogue.costModifier(baseCost)
 	refundAmount := baseCost * 0.8
 
 	rogue.Mutilate = rogue.RegisterSpell(core.SpellConfig{
@@ -85,7 +86,6 @@ func (rogue *Rogue) registerMutilateSpell() {
 				GCD:  time.Second,
 			},
 			IgnoreHaste: true,
-			ModifyCast:  rogue.CastModifier,
 		},
 
 		ThreatMultiplier: 1,

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -84,7 +84,6 @@ type Rogue struct {
 
 	AdrenalineRushAura   *core.Aura
 	BladeFlurryAura      *core.Aura
-	VanCleefsProcAura    *core.Aura
 	EnvenomAura          *core.Aura
 	ExposeArmorAura      *core.Aura
 	HungerForBloodAura   *core.Aura
@@ -99,7 +98,7 @@ type Rogue struct {
 
 	QuickRecoveryMetrics *core.ResourceMetrics
 
-	CastModifier               func(*core.Simulation, *core.Spell, *core.Cast)
+	costModifier               func(float64) float64
 	finishingMoveEffectApplier func(sim *core.Simulation, numPoints int32)
 }
 
@@ -145,7 +144,7 @@ func (rogue *Rogue) Initialize() {
 		rogue.QuickRecoveryMetrics = rogue.NewEnergyMetrics(core.ActionID{SpellID: 31245})
 	}
 
-	rogue.CastModifier = rogue.makeCastModifier()
+	rogue.costModifier = rogue.makeCostModifier()
 
 	rogue.registerBackstabSpell()
 	rogue.registerDeadlyPoisonSpell()

--- a/sim/rogue/rupture.go
+++ b/sim/rogue/rupture.go
@@ -30,7 +30,6 @@ func (rogue *Rogue) makeRupture(comboPoints int32) *core.Spell {
 				Cost: baseCost,
 				GCD:  time.Second,
 			},
-			ModifyCast:  rogue.CastModifier,
 			IgnoreHaste: true,
 		},
 

--- a/sim/rogue/shiv.go
+++ b/sim/rogue/shiv.go
@@ -9,9 +9,9 @@ import (
 )
 
 func (rogue *Rogue) registerShivSpell() {
-	cost := 20.0
-	if rogue.GetOHWeapon() != nil {
-		cost = 20 + 10*rogue.GetOHWeapon().SwingSpeed
+	baseCost := 20.0
+	if ohWeapon := rogue.GetOHWeapon(); ohWeapon != nil {
+		baseCost = rogue.costModifier(20 + 10*ohWeapon.SwingSpeed)
 	}
 
 	rogue.Shiv = rogue.RegisterSpell(core.SpellConfig{
@@ -20,15 +20,14 @@ func (rogue *Rogue) registerShivSpell() {
 		ProcMask:     core.ProcMaskMeleeOHSpecial,
 		Flags:        core.SpellFlagMeleeMetrics | SpellFlagBuilder,
 		ResourceType: stats.Energy,
-		BaseCost:     cost,
+		BaseCost:     baseCost,
 
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
-				Cost: cost,
+				Cost: baseCost,
 				GCD:  time.Second,
 			},
 			IgnoreHaste: true,
-			ModifyCast:  rogue.CastModifier,
 		},
 
 		DamageMultiplier: (1 +

--- a/sim/rogue/sinister_strike.go
+++ b/sim/rogue/sinister_strike.go
@@ -8,13 +8,9 @@ import (
 	"github.com/wowsims/wotlk/sim/core/stats"
 )
 
-func (rogue *Rogue) SinisterStrikeEnergyCost() float64 {
-	return []float64{45, 42, 40}[rogue.Talents.ImprovedSinisterStrike]
-}
-
 func (rogue *Rogue) registerSinisterStrikeSpell() {
-	energyCost := rogue.SinisterStrikeEnergyCost()
-	refundAmount := energyCost * 0.8
+	baseCost := rogue.costModifier([]float64{45, 42, 40}[rogue.Talents.ImprovedSinisterStrike])
+	refundAmount := baseCost * 0.8
 	hasGlyphOfSinisterStrike := rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfSinisterStrike)
 
 	rogue.SinisterStrike = rogue.RegisterSpell(core.SpellConfig{
@@ -23,15 +19,14 @@ func (rogue *Rogue) registerSinisterStrikeSpell() {
 		ProcMask:     core.ProcMaskMeleeMHSpecial,
 		Flags:        core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | SpellFlagBuilder,
 		ResourceType: stats.Energy,
-		BaseCost:     energyCost,
+		BaseCost:     baseCost,
 
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
-				Cost: energyCost,
+				Cost: baseCost,
 				GCD:  time.Second,
 			},
 			IgnoreHaste: true,
-			ModifyCast:  rogue.CastModifier,
 		},
 
 		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0) +

--- a/sim/rogue/slice_and_dice.go
+++ b/sim/rogue/slice_and_dice.go
@@ -30,7 +30,6 @@ func (rogue *Rogue) makeSliceAndDice(comboPoints int32) *core.Spell {
 				Cost: baseCost,
 				GCD:  time.Second,
 			},
-			ModifyCast:  rogue.CastModifier,
 			IgnoreHaste: true,
 		},
 

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -76,23 +76,14 @@ func (rogue *Rogue) makeFinishingMoveEffectApplier() func(sim *core.Simulation, 
 	}
 }
 
-func (rogue *Rogue) makeCastModifier() func(*core.Simulation, *core.Spell, *core.Cast) {
-	builderCostMultiplier := 1.0
-	costReduction := 40.0
+func (rogue *Rogue) makeCostModifier() func(baseCost float64) float64 {
 	if rogue.HasSetBonus(ItemSetBonescythe, 4) {
-		builderCostMultiplier -= 0.05
+		return func(baseCost float64) float64 {
+			return math.RoundToEven(0.95 * baseCost)
+		}
 	}
-	return func(sim *core.Simulation, spell *core.Spell, cast *core.Cast) {
-		costMultiplier := 1.0
-		if spell.Flags.Matches(SpellFlagBuilder) { // note: this also applies to openers, as per https://www.wowhead.com/wotlk/spell=60163/cheaper-combo-moves
-			costMultiplier *= builderCostMultiplier
-		}
-		cast.Cost *= costMultiplier
-		cast.Cost = math.Ceil(cast.Cost)
-		if rogue.VanCleefsProcAura.IsActive() {
-			cast.Cost = core.MaxFloat(0, cast.Cost-costReduction)
-			rogue.VanCleefsProcAura.Deactivate(sim)
-		}
+	return func(baseCost float64) float64 {
+		return baseCost
 	}
 }
 

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -45,29 +45,29 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 8083.04482
-  tps: 6627.97824
+  dps: 8121.38278
+  tps: 6651.54623
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8318.9744
-  tps: 6835.26418
+  dps: 8340.21874
+  tps: 6846.67819
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8293.01033
-  tps: 6796.69725
+  dps: 8262.84321
+  tps: 6768.54164
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8330.57746
-  tps: 6836.60175
+  dps: 8395.63006
+  tps: 6891.10714
  }
 }
 dps_results: {
@@ -101,155 +101,155 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8341.70204
-  tps: 6712.66742
+  dps: 8312.80214
+  tps: 6686.99306
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8481.28287
-  tps: 6963.45082
+  dps: 8509.04675
+  tps: 6987.59131
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 8265.44128
-  tps: 6781.04566
+  dps: 8156.89817
+  tps: 6687.59807
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 8241.32563
-  tps: 6758.07077
+  dps: 8243.09832
+  tps: 6757.93757
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 8169.78838
-  tps: 6696.12686
+  dps: 8172.59702
+  tps: 6706.06536
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 8059.09074
-  tps: 6604.40862
+  dps: 8072.98151
+  tps: 6617.13159
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 8146.41633
-  tps: 6679.10711
+  dps: 8147.32495
+  tps: 6685.05833
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Defender'sCode-40257"
  value: {
-  dps: 8123.87674
-  tps: 6662.46063
+  dps: 8033.72507
+  tps: 6587.43714
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8321.42812
-  tps: 6833.53136
+  dps: 8351.95004
+  tps: 6855.50455
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 7367.42506
-  tps: 6048.58496
+  dps: 7341.33481
+  tps: 6023.57348
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8341.70204
-  tps: 6849.3842
+  dps: 8312.80214
+  tps: 6823.18776
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8341.70204
-  tps: 6849.3842
+  dps: 8312.80214
+  tps: 6823.18776
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8330.57746
-  tps: 6836.60175
+  dps: 8395.63006
+  tps: 6891.10714
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8333.0144
-  tps: 6841.63728
+  dps: 8296.58721
+  tps: 6811.83464
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8341.70204
-  tps: 6849.3842
+  dps: 8312.80214
+  tps: 6823.18776
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 8222.73979
-  tps: 6738.50346
+  dps: 8192.2784
+  tps: 6717.70472
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 8216.78056
-  tps: 6741.64753
+  dps: 8168.29249
+  tps: 6698.28306
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForgeEmber-37660"
  value: {
-  dps: 8160.62946
-  tps: 6685.08817
+  dps: 8137.51698
+  tps: 6670.05884
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8341.70204
-  tps: 6849.3842
+  dps: 8312.80214
+  tps: 6823.18776
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8341.70204
-  tps: 6849.3842
+  dps: 8312.80214
+  tps: 6823.18776
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8290.5367
-  tps: 6787.85209
+  dps: 8289.29191
+  tps: 6783.15067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuturesightRune-38763"
  value: {
-  dps: 8059.09074
-  tps: 6604.40862
+  dps: 8072.98151
+  tps: 6617.13159
  }
 }
 dps_results: {
@@ -262,71 +262,71 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 8059.09074
-  tps: 6604.40862
+  dps: 8072.98151
+  tps: 6617.13159
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8330.57746
-  tps: 6836.60175
+  dps: 8395.63006
+  tps: 6891.10714
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8333.0144
-  tps: 6841.63728
+  dps: 8296.58721
+  tps: 6811.83464
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8218.19121
-  tps: 6737.00524
+  dps: 8295.06139
+  tps: 6802.67326
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8341.70204
-  tps: 6849.3842
+  dps: 8312.80214
+  tps: 6823.18776
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8345.61142
-  tps: 6849.1635
+  dps: 8338.56965
+  tps: 6848.69923
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 8059.09074
-  tps: 6604.40862
+  dps: 8072.98151
+  tps: 6617.13159
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 8059.09074
-  tps: 6604.40862
+  dps: 8072.98151
+  tps: 6617.13159
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8346.50055
-  tps: 6840.63247
+  dps: 8311.30863
+  tps: 6819.16987
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 8065.03004
-  tps: 6616.82777
+  dps: 8045.94052
+  tps: 6601.08007
  }
 }
 dps_results: {
@@ -346,85 +346,85 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8320.48272
-  tps: 6832.35705
+  dps: 8337.24714
+  tps: 6842.06266
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8345.61142
-  tps: 6849.1635
+  dps: 8338.56965
+  tps: 6848.69923
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8341.70204
-  tps: 6849.3842
+  dps: 8312.80214
+  tps: 6823.18776
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8341.70204
-  tps: 6849.3842
+  dps: 8312.80214
+  tps: 6823.18776
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 8059.09074
-  tps: 6604.40862
+  dps: 8072.98151
+  tps: 6617.13159
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 8059.09074
-  tps: 6604.40862
+  dps: 8072.98151
+  tps: 6617.13159
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 8059.09074
-  tps: 6604.40862
+  dps: 8072.98151
+  tps: 6617.13159
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8499.20829
-  tps: 6970.18742
+  dps: 8515.96994
+  tps: 6994.06429
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8341.70204
-  tps: 6849.3842
+  dps: 8312.80214
+  tps: 6823.18776
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 8059.09074
-  tps: 6604.40862
+  dps: 8072.98151
+  tps: 6617.13159
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 8063.90341
-  tps: 6611.07343
+  dps: 8056.53603
+  tps: 6615.23795
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 8059.09074
-  tps: 6604.40862
+  dps: 8072.98151
+  tps: 6617.13159
  }
 }
 dps_results: {
@@ -437,15 +437,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 8059.09074
-  tps: 6604.40862
+  dps: 8072.98151
+  tps: 6617.13159
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SparkofLife-37657"
  value: {
-  dps: 8167.4625
-  tps: 6692.81002
+  dps: 8121.02158
+  tps: 6665.58086
  }
 }
 dps_results: {
@@ -458,85 +458,85 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8345.61142
-  tps: 6849.1635
+  dps: 8338.56965
+  tps: 6848.69923
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8320.48272
-  tps: 6832.35705
+  dps: 8337.24714
+  tps: 6842.06266
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8332.45162
-  tps: 6843.2464
+  dps: 8341.68758
+  tps: 6850.216
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheFistsofFury"
  value: {
-  dps: 4929.24405
-  tps: 4134.24418
+  dps: 4907.26331
+  tps: 4113.67826
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5223.78133
-  tps: 4376.55337
+  dps: 5225.09945
+  tps: 4376.21933
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8352.86306
-  tps: 6858.63306
+  dps: 8400.78033
+  tps: 6896.37604
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 8516.92471
-  tps: 6984.85717
+  dps: 8487.50647
+  tps: 6961.35945
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8544.91373
-  tps: 7012.56225
+  dps: 8593.7282
+  tps: 7052.60674
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8341.70204
-  tps: 6849.3842
+  dps: 8312.80214
+  tps: 6823.18776
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8341.70204
-  tps: 6849.3842
+  dps: 8312.80214
+  tps: 6823.18776
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8341.70204
-  tps: 6849.3842
+  dps: 8312.80214
+  tps: 6823.18776
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8341.70204
-  tps: 6849.3842
+  dps: 8312.80214
+  tps: 6823.18776
  }
 }
 dps_results: {
@@ -563,98 +563,98 @@ dps_results: {
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 8462.22508
-  tps: 6937.69485
+  dps: 8463.57937
+  tps: 6939.12941
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11076.70986
-  tps: 9629.83562
+  dps: 11103.72266
+  tps: 9635.89716
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8424.88084
-  tps: 6916.77378
+  dps: 8440.65854
+  tps: 6932.73167
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9023.90291
-  tps: 7458.0241
+  dps: 9099.44827
+  tps: 7514.79139
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6356.69799
-  tps: 5689.77286
+  dps: 6423.36396
+  tps: 5733.23662
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4538.72382
-  tps: 3735.19617
+  dps: 4536.05831
+  tps: 3731.19722
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4584.24276
-  tps: 3797.37733
+  dps: 4461.13144
+  tps: 3692.13468
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11153.48953
-  tps: 9689.90474
+  dps: 11215.11215
+  tps: 9738.3648
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8499.20829
-  tps: 6970.18742
+  dps: 8515.96994
+  tps: 6994.06429
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9122.08838
-  tps: 7538.20058
+  dps: 9122.47069
+  tps: 7545.5487
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6396.76825
-  tps: 5718.53266
+  dps: 6430.33448
+  tps: 5741.25665
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4569.81708
-  tps: 3761.61305
+  dps: 4570.96818
+  tps: 3761.93165
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4501.63962
-  tps: 3730.41526
+  dps: 4509.38638
+  tps: 3746.57638
  }
 }
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7875.65333
-  tps: 6440.81074
+  dps: 7894.59675
+  tps: 6457.32348
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -45,29 +45,29 @@ character_stats_results: {
 dps_results: {
  key: "TestFury-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 6646.37142
-  tps: 4893.71952
+  dps: 6609.50731
+  tps: 4865.33764
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6711.02246
-  tps: 4940.15366
+  dps: 6671.50221
+  tps: 4913.07848
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6781.64917
-  tps: 4991.50643
+  dps: 6790.86921
+  tps: 4994.95397
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6726.71526
-  tps: 4954.14677
+  dps: 6711.76645
+  tps: 4939.05209
  }
 }
 dps_results: {
@@ -101,155 +101,155 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6698.96265
-  tps: 4831.22039
+  dps: 6698.2587
+  tps: 4832.80569
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6848.96294
-  tps: 5042.64096
+  dps: 6899.46246
+  tps: 5082.41443
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6715.90298
-  tps: 4942.13614
+  dps: 6742.24221
+  tps: 4958.14109
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6802.82178
-  tps: 5003.64307
+  dps: 6743.09623
+  tps: 4961.60084
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6735.6452
-  tps: 4957.15034
+  dps: 6713.81147
+  tps: 4944.41122
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6571.01591
-  tps: 4840.0268
+  dps: 6590.10901
+  tps: 4854.26761
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6708.3193
-  tps: 4935.34092
+  dps: 6718.69546
+  tps: 4946.93949
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6583.02787
-  tps: 4847.42343
+  dps: 6577.30699
+  tps: 4841.97024
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6735.18012
-  tps: 4959.68629
+  dps: 6671.12504
+  tps: 4911.93269
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 5918.65402
-  tps: 4367.16464
+  dps: 5876.57672
+  tps: 4337.93964
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6698.96265
-  tps: 4929.59587
+  dps: 6698.2587
+  tps: 4931.21385
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6698.96265
-  tps: 4929.59587
+  dps: 6698.2587
+  tps: 4931.21385
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6726.71526
-  tps: 4954.14677
+  dps: 6711.76645
+  tps: 4939.05209
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6741.62688
-  tps: 4961.76343
+  dps: 6698.02667
+  tps: 4934.88783
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6698.96265
-  tps: 4929.59587
+  dps: 6698.2587
+  tps: 4931.21385
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6749.75863
-  tps: 4967.42506
+  dps: 6749.1652
+  tps: 4967.24528
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6718.31294
-  tps: 4942.49897
+  dps: 6695.07366
+  tps: 4926.384
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6721.9807
-  tps: 4945.08648
+  dps: 6697.69065
+  tps: 4930.21499
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6698.96265
-  tps: 4929.59587
+  dps: 6698.2587
+  tps: 4931.21385
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6698.96265
-  tps: 4929.59587
+  dps: 6698.2587
+  tps: 4931.21385
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6776.84566
-  tps: 4987.46818
+  dps: 6789.9358
+  tps: 4994.56873
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6571.01591
-  tps: 4840.0268
+  dps: 6590.10901
+  tps: 4854.26761
  }
 }
 dps_results: {
@@ -262,71 +262,71 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6571.01591
-  tps: 4840.0268
+  dps: 6590.10901
+  tps: 4854.26761
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6726.71526
-  tps: 4954.14677
+  dps: 6711.76645
+  tps: 4939.05209
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6741.62688
-  tps: 4961.76343
+  dps: 6698.02667
+  tps: 4934.88783
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6818.59082
-  tps: 5015.20999
+  dps: 6845.85848
+  tps: 5039.79584
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6698.96265
-  tps: 4929.59587
+  dps: 6698.2587
+  tps: 4931.21385
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6738.74532
-  tps: 4961.21294
+  dps: 6753.99353
+  tps: 4972.37197
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6571.01591
-  tps: 4840.0268
+  dps: 6590.10901
+  tps: 4854.26761
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6571.01591
-  tps: 4840.0268
+  dps: 6590.10901
+  tps: 4854.26761
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6841.88578
-  tps: 5032.68583
+  dps: 6806.96704
+  tps: 5006.57683
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6591.26612
-  tps: 4854.55388
+  dps: 6583.68452
+  tps: 4846.99318
  }
 }
 dps_results: {
@@ -346,85 +346,85 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6720.36694
-  tps: 4948.96006
+  dps: 6707.02664
+  tps: 4941.72596
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6738.74532
-  tps: 4961.21294
+  dps: 6753.99353
+  tps: 4972.37197
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6698.96265
-  tps: 4929.59587
+  dps: 6698.2587
+  tps: 4931.21385
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6698.96265
-  tps: 4929.59587
+  dps: 6698.2587
+  tps: 4931.21385
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6571.01591
-  tps: 4840.0268
+  dps: 6590.10901
+  tps: 4854.26761
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6571.01591
-  tps: 4840.0268
+  dps: 6590.10901
+  tps: 4854.26761
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6571.01591
-  tps: 4840.0268
+  dps: 6590.10901
+  tps: 4854.26761
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6827.22044
-  tps: 5024.84416
+  dps: 6825.05829
+  tps: 5025.70158
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6698.96265
-  tps: 4929.59587
+  dps: 6698.2587
+  tps: 4931.21385
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6571.01591
-  tps: 4840.0268
+  dps: 6590.10901
+  tps: 4854.26761
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6571.68171
-  tps: 4838.78486
+  dps: 6609.38813
+  tps: 4866.62567
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6571.01591
-  tps: 4840.0268
+  dps: 6590.10901
+  tps: 4854.26761
  }
 }
 dps_results: {
@@ -437,15 +437,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6571.01591
-  tps: 4840.0268
+  dps: 6590.10901
+  tps: 4854.26761
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SparkofLife-37657"
  value: {
-  dps: 6645.95035
-  tps: 4893.21973
+  dps: 6649.35765
+  tps: 4897.42435
  }
 }
 dps_results: {
@@ -458,85 +458,85 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6738.74532
-  tps: 4961.21294
+  dps: 6753.99353
+  tps: 4972.37197
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6720.36694
-  tps: 4948.96006
+  dps: 6707.02664
+  tps: 4941.72596
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6717.55981
-  tps: 4945.75497
+  dps: 6706.18502
+  tps: 4936.60582
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 5039.54903
-  tps: 3722.93797
+  dps: 5075.38061
+  tps: 3749.47212
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5315.62324
-  tps: 3922.62214
+  dps: 5304.47049
+  tps: 3913.80393
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6764.49994
-  tps: 4981.33498
+  dps: 6760.96804
+  tps: 4977.23375
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6865.14701
-  tps: 5049.65794
+  dps: 6840.61497
+  tps: 5034.01847
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6884.46766
-  tps: 5063.29517
+  dps: 6904.04666
+  tps: 5079.84931
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6698.96265
-  tps: 4929.59587
+  dps: 6698.2587
+  tps: 4931.21385
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6698.96265
-  tps: 4929.59587
+  dps: 6698.2587
+  tps: 4931.21385
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6698.96265
-  tps: 4929.59587
+  dps: 6698.2587
+  tps: 4931.21385
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6698.96265
-  tps: 4929.59587
+  dps: 6698.2587
+  tps: 4931.21385
  }
 }
 dps_results: {
@@ -563,98 +563,98 @@ dps_results: {
 dps_results: {
  key: "TestFury-Average-Default"
  value: {
-  dps: 6790.59055
-  tps: 4999.58693
+  dps: 6791.38663
+  tps: 5000.59029
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8776.01781
-  tps: 6914.34759
+  dps: 8778.43257
+  tps: 6921.34251
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6734.05145
-  tps: 4958.35104
+  dps: 6719.94282
+  tps: 4946.3789
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7945.96696
-  tps: 5839.82823
+  dps: 8003.76542
+  tps: 5884.92177
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4817.69581
-  tps: 3977.04578
+  dps: 4734.94262
+  tps: 3910.62895
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3297.1745
-  tps: 2458.76991
+  dps: 3303.06332
+  tps: 2467.08196
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3557.77624
-  tps: 2660.80543
+  dps: 3608.77434
+  tps: 2698.74689
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8856.93988
-  tps: 6976.86702
+  dps: 8953.00585
+  tps: 7045.509
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6827.22044
-  tps: 5024.84416
+  dps: 6825.05829
+  tps: 5025.70158
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8181.06497
-  tps: 6005.62602
+  dps: 8178.56806
+  tps: 6008.33327
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4863.62073
-  tps: 4015.64713
+  dps: 4868.93955
+  tps: 4019.33874
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3355.46856
-  tps: 2503.95216
+  dps: 3329.6267
+  tps: 2485.80693
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3670.95992
-  tps: 2742.4379
+  dps: 3661.42263
+  tps: 2737.76401
  }
 }
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6261.28598
-  tps: 4613.45532
+  dps: 6267.8165
+  tps: 4620.67058
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -209,7 +209,7 @@ dps_results: {
  key: "TestProtectionWarrior-AllItems-DreadnaughtBattlegear"
  value: {
   dps: 2152.0769
-  tps: 6159.72388
+  tps: 6160.98824
  }
 }
 dps_results: {

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -557,20 +557,10 @@ func (warrior *Warrior) applySuddenDeath() {
 		return
 	}
 
-	var rage_refund float64
-	var procChance float64
 	rageMetrics := warrior.NewRageMetrics(core.ActionID{SpellID: 29724})
 
-	if warrior.Talents.SuddenDeath == 1 {
-		rage_refund = 3.0
-		procChance = 0.03
-	} else if warrior.Talents.SuddenDeath == 2 {
-		rage_refund = 7.0
-		procChance = 0.06
-	} else if warrior.Talents.SuddenDeath == 3 {
-		rage_refund = 10.0
-		procChance = 0.09
-	}
+	rageRefund := []float64{0, 3, 7, 10}[warrior.Talents.SuddenDeath]
+	procChance := []float64{0, 0.03, 0.06, 0.09}[warrior.Talents.SuddenDeath]
 
 	Ymirjar4Set := warrior.HasSetBonus(ItemSetYmirjarLordsBattlegear, 4)
 
@@ -590,7 +580,7 @@ func (warrior *Warrior) applySuddenDeath() {
 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
 			if warrior.SuddenDeathAura.IsActive() && spell == warrior.Execute {
 				warrior.SuddenDeathAura.RemoveStack(sim)
-				warrior.AddRage(sim, rage_refund, rageMetrics)
+				warrior.AddRage(sim, rageRefund, rageMetrics)
 			}
 
 			if !spellEffect.Landed() {


### PR DESCRIPTION
[core] validate cast costs at creation rather than dynamically (in wrapCastFuncResources())

[rogue] static spell cost reduction from 4t7 are now also statically applied (into Spell.BaseCost and Spell.DefaultCast.Cost), so that actual costs are available for rotation planning 

[rogue] the 4t7 cost reduction is now (most likely) modelled correctly, based on additional testing 

[rogue] Feint can now miss, be dodged, be parried or be blocked 

[rogue] the 2t9 dynamic cost reduction is now handled via PseudoStats.CostReduction, and has mostly reliable energy metric 

[warrior] dito for the warrior's 4t7 dynamic cost reduction, which now handles 4t7 procs during Slam casts correctly