### PR TITLE
Rename SpellEffect --> SpellResult

### DIFF
--- a/sim/common/tbc/caster_items.go
+++ b/sim/common/tbc/caster_items.go
@@ -30,11 +30,11 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
 					return
 				}
-				if !spellEffect.Landed() {
+				if !result.Landed() {
 					return
 				}
 				if !icd.IsReady(sim) || sim.RandomFloat("Robe of the Elder Scribe") > proc { // can't activate if on CD or didn't proc
@@ -63,11 +63,11 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
 					return
 				}
-				if !spellEffect.Landed() {
+				if !result.Landed() {
 					return
 				}
 				if !icd.IsReady(sim) || sim.RandomFloat("Band of the Eternal Sage") > proc { // can't activate if on CD or didn't proc
@@ -110,13 +110,13 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if !icd.IsReady(sim) || sim.RandomFloat("timbals") > proc { // can't activate if on CD or didn't proc
 					return
 				}
 				icd.Use(sim)
 
-				timbalsSpell.Cast(sim, spellEffect.Target)
+				timbalsSpell.Cast(sim, result.Target)
 			},
 		})
 	})
@@ -158,11 +158,11 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if !spell.ProcMask.Matches(core.ProcMaskSpellDamage) {
 					return
 				}
-				if !spellEffect.Landed() {
+				if !result.Landed() {
 					return
 				}
 				if !icd.IsReady(sim) || sim.RandomFloat("pendant of acumen") > proc { // can't activate if on CD or didn't proc
@@ -173,7 +173,7 @@ func init() {
 				if character.ShattFaction == proto.ShattrathFaction_ShattrathFactionAldor {
 					aldorAura.Activate(sim)
 				} else if character.ShattFaction == proto.ShattrathFaction_ShattrathFactionScryer {
-					scryerSpell.Cast(sim, spellEffect.Target)
+					scryerSpell.Cast(sim, result.Target)
 				}
 			},
 		})

--- a/sim/common/tbc/caster_trinkets.go
+++ b/sim/common/tbc/caster_trinkets.go
@@ -73,11 +73,11 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if !spell.ProcMask.Matches(core.ProcMaskSpellDamage) {
 					return
 				}
-				if !icd.IsReady(sim) || !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+				if !icd.IsReady(sim) || !result.Outcome.Matches(core.OutcomeCrit) {
 					return
 				}
 				if sim.RandomFloat("Shiffar's Nexus-Horn") > 0.2 {
@@ -99,20 +99,20 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if !spell.ProcMask.Matches(core.ProcMaskSpellDamage) {
 					return
 				}
-				if !spellEffect.Outcome.Matches(core.OutcomeMiss) {
+				if !result.Outcome.Matches(core.OutcomeMiss) {
 					return
 				}
 				procAura.Activate(sim)
 			},
-			OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if !spell.ProcMask.Matches(core.ProcMaskSpellDamage) {
 					return
 				}
-				if !spellEffect.Outcome.Matches(core.OutcomeMiss) {
+				if !result.Outcome.Matches(core.OutcomeMiss) {
 					return
 				}
 				procAura.Activate(sim)
@@ -135,11 +135,11 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if !spell.ProcMask.Matches(core.ProcMaskSpellDamage) {
 					return
 				}
-				if !spellEffect.Outcome.Matches(core.OutcomeCrit) || !icd.IsReady(sim) {
+				if !result.Outcome.Matches(core.OutcomeCrit) || !icd.IsReady(sim) {
 					return
 				}
 				if sim.RandomFloat("Sextant of Unstable Currents") > 0.2 {
@@ -188,13 +188,13 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
 					apAura.Activate(sim)
 					apAura.AddStack(sim)
 					apAura.Refresh(sim)
 				} else if spell.ProcMask.Matches(core.ProcMaskSpellDamage) {
-					if !spellEffect.Landed() {
+					if !result.Landed() {
 						return
 					}
 					spAura.Activate(sim)

--- a/sim/common/tbc/enchant_effects.go
+++ b/sim/common/tbc/enchant_effects.go
@@ -79,8 +79,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 
@@ -121,8 +121,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 
@@ -170,8 +170,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 
@@ -203,8 +203,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if spellEffect.Damage == 0 {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if result.Damage == 0 {
 					return
 				}
 
@@ -212,13 +212,13 @@ func init() {
 					if !ppmm.Proc(sim, spell.ProcMask, "Deathfrost") {
 						return
 					}
-					procSpell.Cast(sim, spellEffect.Target)
+					procSpell.Cast(sim, result.Target)
 				} else if spell.ProcMask.Matches(core.ProcMaskSpellDamage) {
 					if !icd.IsReady(sim) || sim.RandomFloat("Deathfrost") > 0.5 {
 						return
 					}
 					icd.Use(sim)
-					procSpell.Cast(sim, spellEffect.Target)
+					procSpell.Cast(sim, result.Target)
 				}
 			},
 		})

--- a/sim/common/tbc/lightning_capacitor.go
+++ b/sim/common/tbc/lightning_capacitor.go
@@ -38,7 +38,7 @@ func init() {
 				charges = 0
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if !icd.IsReady(sim) {
 					return
 				}
@@ -47,14 +47,14 @@ func init() {
 					return
 				}
 
-				if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+				if !result.Outcome.Matches(core.OutcomeCrit) {
 					return
 				}
 
 				icd.Use(sim)
 				charges++
 				if charges >= 3 {
-					tlcSpell.Cast(sim, spellEffect.Target)
+					tlcSpell.Cast(sim, result.Target)
 					charges = 0
 				}
 			},

--- a/sim/common/tbc/melee_items.go
+++ b/sim/common/tbc/melee_items.go
@@ -45,13 +45,13 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				// https://wotlk.wowhead.com/spell=16615/add-lightning-dam-weap-03, proc mask = 20.
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 
-				procSpell.Cast(sim, spellEffect.Target)
+				procSpell.Cast(sim, result.Target)
 			},
 		})
 	})
@@ -79,13 +79,13 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				// https://wotlk.wowhead.com/spell=7711/add-fire-dam-weap-02, proc mask = 20.
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 
-				procSpell.Cast(sim, spellEffect.Target)
+				procSpell.Cast(sim, result.Target)
 			},
 		})
 	})
@@ -104,8 +104,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(procMask) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(procMask) {
 					return
 				}
 				if sim.RandomFloat("EmpyreanDemolisher") > procChance {
@@ -186,16 +186,16 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(procMask) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(procMask) {
 					return
 				}
 				if !ppmm.Proc(sim, spell.ProcMask, "Thunderfury") {
 					return
 				}
 
-				singleTargetSpell.Cast(sim, spellEffect.Target)
-				bounceSpell.Cast(sim, spellEffect.Target)
+				singleTargetSpell.Cast(sim, result.Target)
+				bounceSpell.Cast(sim, result.Target)
 			},
 		})
 	})
@@ -212,9 +212,9 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				// https://wotlk.wowhead.com/spell=16916/strength-of-the-champion, proc mask = 0. Handled in-game via script.
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 				if sim.RandomFloat("KhoriumChampion") > procChance {
@@ -244,9 +244,9 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				// https://wotlk.wowhead.com/spell=33489/blinding-speed, proc mask = 0. Handled in-game via script.
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(procMask) {
+				if !result.Landed() || !spell.ProcMask.Matches(procMask) {
 					return
 				}
 				if sim.RandomFloat("BlackoutTruncheon") > procChance {
@@ -270,9 +270,9 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				// https://wotlk.wowhead.com/spell=34513/lionheart, proc mask = 0. Handled in-game via script.
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 				if sim.RandomFloat("LionheartChampion") > procChance {
@@ -296,8 +296,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 				if sim.RandomFloat("LionheartExecutioner") > procChance {
@@ -323,8 +323,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(procMask) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(procMask) {
 					return
 				}
 				if sim.RandomFloat("DrakefistHammer") > procChance {
@@ -350,8 +350,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(procMask) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(procMask) {
 					return
 				}
 				if sim.RandomFloat("Dragonmaw") > procChance {
@@ -377,8 +377,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(procMask) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(procMask) {
 					return
 				}
 				if sim.RandomFloat("Dragonstrike") > procChance {
@@ -417,16 +417,16 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				// ProcMask: 20
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 				if sim.RandomFloat("Despair") > procChance {
 					return
 				}
 
-				procSpell.Cast(sim, spellEffect.Target)
+				procSpell.Cast(sim, result.Target)
 			},
 		})
 	})
@@ -495,15 +495,15 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 				if sim.RandomFloat("GlaiveOfThePit") > procChance {
 					return
 				}
 
-				procSpell.Cast(sim, spellEffect.Target)
+				procSpell.Cast(sim, result.Target)
 			},
 		})
 	})
@@ -525,8 +525,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || spell.SpellSchool != core.SpellSchoolPhysical {
+			OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || spell.SpellSchool != core.SpellSchoolPhysical {
 					return
 				}
 				if !icd.IsReady(sim) {
@@ -557,9 +557,9 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				// mask 340
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
 					return
 				}
 				if !icd.IsReady(sim) {
@@ -587,8 +587,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeMH) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeMH) {
 					return
 				}
 				if sim.RandomFloat("The Bladefist") > procChance {
@@ -614,8 +614,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(procMask) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(procMask) {
 					return
 				}
 
@@ -651,8 +651,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(procMask) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(procMask) {
 					return
 				}
 
@@ -684,8 +684,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					procAura.Deactivate(sim)
 					return
 				}
@@ -726,8 +726,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(procMask) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(procMask) {
 					return
 				}
 				if sim.RandomFloat("WarpSlicer") > procChance {
@@ -764,8 +764,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 				if sim.RandomFloat("Devastation") > procChance {
@@ -803,15 +803,15 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(procMask) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(procMask) {
 					return
 				}
 				if sim.RandomFloat("BladeOfUnquenchedThirst") > procChance {
 					return
 				}
 
-				procSpell.Cast(sim, spellEffect.Target)
+				procSpell.Cast(sim, result.Target)
 			},
 		})
 	})
@@ -828,8 +828,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 				if sim.RandomFloat("SingingCrystalAxe") > procChance {
@@ -868,8 +868,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(procMask) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(procMask) {
 					return
 				}
 
@@ -882,7 +882,7 @@ func init() {
 				}
 				icd.Use(sim)
 
-				aura.Unit.AutoAttacks.MaybeReplaceMHSwing(sim, blinkstrikeSpell).Cast(sim, spellEffect.Target)
+				aura.Unit.AutoAttacks.MaybeReplaceMHSwing(sim, blinkstrikeSpell).Cast(sim, result.Target)
 			},
 		})
 	})
@@ -909,8 +909,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(procMask) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(procMask) {
 					return
 				}
 				if sim.RandomFloat("The Night Blade") > procChance {
@@ -947,12 +947,12 @@ func init() {
 			Label:    "Siphon Essence",
 			ActionID: core.ActionID{SpellID: 40291},
 			Duration: time.Second * 6,
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 
-				procSpell.Cast(sim, spellEffect.Target)
+				procSpell.Cast(sim, result.Target)
 			},
 		})
 
@@ -962,8 +962,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 
@@ -986,8 +986,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if spellEffect.Landed() && spell.SpellSchool == core.SpellSchoolPhysical && sim.RandomFloat("Bulwark of Azzinoth") < procChance {
+			OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if result.Landed() && spell.SpellSchool == core.SpellSchoolPhysical && sim.RandomFloat("Bulwark of Azzinoth") < procChance {
 					procAura.Activate(sim)
 				}
 			},
@@ -1010,8 +1010,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 
@@ -1068,11 +1068,11 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
 					return
 				}
-				if !spellEffect.Landed() {
+				if !result.Landed() {
 					return
 				}
 				if !icd.IsReady(sim) || sim.RandomFloat("pendant of acumen") > proc { // can't activate if on CD or didn't proc
@@ -1083,7 +1083,7 @@ func init() {
 				if character.ShattFaction == proto.ShattrathFaction_ShattrathFactionAldor {
 					aldorAura.Activate(sim)
 				} else if character.ShattFaction == proto.ShattrathFaction_ShattrathFactionScryer {
-					scryerSpell.Cast(sim, spellEffect.Target)
+					scryerSpell.Cast(sim, result.Target)
 				}
 			},
 		})
@@ -1101,8 +1101,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(procMask) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(procMask) {
 					return
 				}
 				if !ppmm.Proc(sim, spell.ProcMask, "Felstriker") {

--- a/sim/common/tbc/melee_sets.go
+++ b/sim/common/tbc/melee_sets.go
@@ -38,15 +38,15 @@ var ItemSetFistsOfFury = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-					if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+					if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 						return
 					}
 					if !ppmm.Proc(sim, spell.ProcMask, "The Fists of Fury") {
 						return
 					}
 
-					procSpell.Cast(sim, spellEffect.Target)
+					procSpell.Cast(sim, result.Target)
 				},
 			})
 		},
@@ -78,15 +78,15 @@ var ItemSetStormshroud = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-					if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+					if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 						return
 					}
 					chance := 0.05
 					if sim.RandomFloat("Stormshroud Armor 2pc") > chance {
 						return
 					}
-					proc.Cast(sim, spellEffect.Target)
+					proc.Cast(sim, result.Target)
 				},
 			})
 		},
@@ -110,15 +110,15 @@ var ItemSetStormshroud = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-					if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+					if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 						return
 					}
 					chance := 0.02
 					if sim.RandomFloat("Stormshroud Armor 2pc") > chance {
 						return
 					}
-					proc.Cast(sim, spellEffect.Target)
+					proc.Cast(sim, result.Target)
 				},
 			})
 
@@ -152,8 +152,8 @@ var ItemSetTwinBladesOfAzzinoth = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-					if !spellEffect.Landed() {
+				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+					if !result.Landed() {
 						return
 					}
 

--- a/sim/common/tbc/melee_trinkets.go
+++ b/sim/common/tbc/melee_trinkets.go
@@ -90,9 +90,9 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				// https://wotlk.wowhead.com/spell=15600/hand-of-justice, proc mask = 20.
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 
@@ -105,7 +105,7 @@ func init() {
 				}
 				icd.Use(sim)
 
-				aura.Unit.AutoAttacks.MaybeReplaceMHSwing(sim, handOfJusticeSpell).Cast(sim, spellEffect.Target)
+				aura.Unit.AutoAttacks.MaybeReplaceMHSwing(sim, handOfJusticeSpell).Cast(sim, result.Target)
 			},
 		})
 	})
@@ -156,8 +156,8 @@ func init() {
 			OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 				procAura.Deactivate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() {
 					return
 				}
 				if !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
@@ -218,8 +218,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Outcome.Matches(core.OutcomeCrit) {
 					return
 				}
 				if !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
@@ -263,16 +263,16 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				// mask 340
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
 					return
 				}
 				if !ppmm.Proc(sim, spell.ProcMask, "RomulosPoisonVial") {
 					return
 				}
 
-				procSpell.Cast(sim, spellEffect.Target)
+				procSpell.Cast(sim, result.Target)
 			},
 		})
 	})
@@ -293,9 +293,9 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				// mask: 340
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
 					return
 				}
 				if !icd.IsReady(sim) {
@@ -327,8 +327,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Outcome.Matches(core.OutcomeCrit) {
 					return
 				}
 				if !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
@@ -367,13 +367,13 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				// mask 340
 				if !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
 					return
 				}
 
-				if spellEffect.Outcome.Matches(core.OutcomeCrit) {
+				if result.Outcome.Matches(core.OutcomeCrit) {
 					procAura.Deactivate(sim)
 				} else {
 					procAura.Activate(sim)
@@ -386,7 +386,7 @@ func init() {
 	core.NewItemEffect(31858, func(agent core.Agent) {
 		character := agent.GetCharacter()
 		actionID := core.ActionID{ItemID: 31858}
-		var outcomeApplier core.NewOutcomeApplier
+		var outcomeApplier core.OutcomeApplier
 
 		procSpell := character.RegisterSpell(core.SpellConfig{
 			ActionID:    actionID,
@@ -421,9 +421,9 @@ func init() {
 		// Can also proc when the player's melee attacks trigger a Seal of Light proc.
 		var onSpellHitDealt core.OnSpellHit
 		if procChanceOnHitDealt > 0 {
-			onSpellHitDealt = func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if spellEffect.Landed() && spell.ProcMask.Matches(core.ProcMaskMelee) && sim.RandomFloat("DMC Vengeance") < procChanceOnHitDealt {
-					procSpell.Cast(sim, spellEffect.Target)
+			onSpellHitDealt = func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if result.Landed() && spell.ProcMask.Matches(core.ProcMaskMelee) && sim.RandomFloat("DMC Vengeance") < procChanceOnHitDealt {
+					procSpell.Cast(sim, result.Target)
 				}
 			}
 		}
@@ -434,8 +434,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if spellEffect.Landed() && sim.RandomFloat("DMC Vengeance") < procChance {
+			OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if result.Landed() && sim.RandomFloat("DMC Vengeance") < procChance {
 					procSpell.Cast(sim, spell.Unit)
 				}
 			},
@@ -455,9 +455,9 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				// mask 340
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
 					return
 				}
 				if !ppmm.Proc(sim, spell.ProcMask, "Madness of the Betrayer") {
@@ -484,8 +484,8 @@ func init() {
 			OnStacksChange: func(aura *core.Aura, sim *core.Simulation, oldStacks int32, newStacks int32) {
 				character.AddStatsDynamic(sim, bonusPerStack.Multiply(float64(newStacks-oldStacks)))
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if spellEffect.Landed() && spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if result.Landed() && spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
 					aura.AddStack(sim)
 				}
 			},
@@ -504,9 +504,9 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				// mask 340
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
 					return
 				}
 				if !icd.IsReady(sim) {
@@ -538,8 +538,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
 					return
 				}
 				if !icd.IsReady(sim) {

--- a/sim/common/tbc/metagems.go
+++ b/sim/common/tbc/metagems.go
@@ -80,9 +80,9 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				// Mask 68, melee or ranged auto attacks.
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskWhiteHit) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskWhiteHit) {
 					return
 				}
 				if !icd.IsReady(sim) {

--- a/sim/common/wotlk/capacitors.go
+++ b/sim/common/wotlk/capacitors.go
@@ -70,7 +70,7 @@ func newCapacitorDamageEffect(config CapacitorDamageEffect) {
 		})
 
 		config.Trigger.Name = config.Name + " Trigger"
-		config.Trigger.Handler = func(sim *core.Simulation, _ *core.Spell, _ *core.SpellEffect) {
+		config.Trigger.Handler = func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
 			capacitorAura.Activate(sim)
 			capacitorAura.AddStack(sim)
 		}
@@ -227,7 +227,7 @@ func init() {
 				ProcMask:   core.ProcMaskMelee,
 				Outcome:    core.OutcomeLanded,
 				ProcChance: 0.45,
-				Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellEffect) {
+				Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
 					capacitorAura.Activate(sim)
 					capacitorAura.AddStack(sim)
 				},

--- a/sim/common/wotlk/damage_procs.go
+++ b/sim/common/wotlk/damage_procs.go
@@ -36,7 +36,7 @@ func newProcDamageEffect(config ProcDamageEffect) {
 		})
 
 		triggerConfig := config.Trigger
-		triggerConfig.Handler = func(sim *core.Simulation, _ *core.Spell, _ *core.SpellEffect) {
+		triggerConfig.Handler = func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
 			damageSpell.Cast(sim, character.CurrentTarget)
 		}
 		MakeProcTriggerAura(&character.Unit, triggerConfig)

--- a/sim/common/wotlk/enchant_effects.go
+++ b/sim/common/wotlk/enchant_effects.go
@@ -41,17 +41,17 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 
-				if spellEffect.Target.MobType != proto.MobType_MobTypeGiant {
+				if result.Target.MobType != proto.MobType_MobTypeGiant {
 					return
 				}
 
 				if ppmm.Proc(sim, spell.ProcMask, "Giant Slayer") {
-					procSpell.Cast(sim, spellEffect.Target)
+					procSpell.Cast(sim, result.Target)
 				}
 			},
 		})
@@ -87,13 +87,13 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 
 				if ppmm.Proc(sim, spell.ProcMask, "Icebreaker") {
-					procSpell.Cast(sim, spellEffect.Target)
+					procSpell.Cast(sim, result.Target)
 				}
 			},
 		})
@@ -135,8 +135,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if spellEffect.Landed() && spell.ProcMask.Matches(core.ProcMaskMelee) {
+			OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if result.Landed() && spell.ProcMask.Matches(core.ProcMaskMelee) {
 					procSpell.Cast(sim, spell.Unit)
 				}
 			},
@@ -189,8 +189,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 
@@ -224,8 +224,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 
@@ -251,8 +251,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskSpellDamage) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskSpellDamage) {
 					return
 				}
 
@@ -397,8 +397,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() {
 					return
 				}
 
@@ -474,8 +474,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() {
 					return
 				}
 
@@ -594,8 +594,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
 					return
 				}
 

--- a/sim/common/wotlk/highest_stat_effects.go
+++ b/sim/common/wotlk/highest_stat_effects.go
@@ -65,7 +65,7 @@ func init() {
 				Harmful:    true,
 				ProcChance: 0.35,
 				ICD:        time.Second * 45,
-				Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellEffect) {
+				Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
 					hsa.Get(character).Activate(sim)
 				},
 			})
@@ -98,7 +98,7 @@ func init() {
 				Harmful:    true,
 				ProcChance: 0.35,
 				ICD:        time.Second * 45,
-				Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellEffect) {
+				Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
 					hsa.Get(character).Activate(sim)
 				},
 			})

--- a/sim/common/wotlk/item_sets.go
+++ b/sim/common/wotlk/item_sets.go
@@ -75,7 +75,7 @@ func applyShardOfTheGods(character *core.Character, isHeroic bool) {
 		Outcome:    core.OutcomeLanded,
 		ProcChance: 0.25,
 		ICD:        time.Second * 50,
-		Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellEffect) {
+		Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
 			dot.Apply(sim)
 		},
 	})

--- a/sim/common/wotlk/metagems.go
+++ b/sim/common/wotlk/metagems.go
@@ -61,9 +61,9 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				// Mask 68, melee or ranged auto attacks.
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskWhiteHit) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskWhiteHit) {
 					return
 				}
 				if !icd.IsReady(sim) {

--- a/sim/common/wotlk/other_effects.go
+++ b/sim/common/wotlk/other_effects.go
@@ -19,9 +19,9 @@ func init() {
 			Duration: time.Second * 10,
 		})
 
-		character.AddDynamicDamageTakenModifier(func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		character.AddDynamicDamageTakenModifier(func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if procAura.IsActive() {
-				spellEffect.Damage = core.MaxFloat(0, spellEffect.Damage-140)
+				result.Damage = core.MaxFloat(0, result.Damage-140)
 			}
 		})
 
@@ -32,7 +32,7 @@ func init() {
 			Harmful:    true,
 			ProcChance: 0.05,
 			ICD:        time.Second * 50,
-			Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellEffect) {
+			Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
 				procAura.Activate(sim)
 			},
 		})
@@ -98,7 +98,7 @@ func init() {
 				Outcome:    core.OutcomeLanded,
 				ProcChance: 0.35,
 				ICD:        time.Second * 105,
-				Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellEffect) {
+				Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
 					rand := sim.RandomFloat("Deathbringer's Will")
 					if rand < 1.0/3.0 {
 						auras[0].Activate(sim)
@@ -124,7 +124,7 @@ func init() {
 			Outcome:    core.OutcomeCrit,
 			ProcChance: 0.25,
 			ICD:        time.Second * 45,
-			Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellEffect) {
+			Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
 				character.AddMana(sim, 900, manaMetrics, false)
 			},
 		})
@@ -202,7 +202,7 @@ func init() {
 			Callback: OnSpellHitDealt,
 			ProcMask: core.ProcMaskSpellDamage,
 			Outcome:  core.OutcomeCrit,
-			Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellEffect) {
+			Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
 				activeAura.RemoveStack(sim)
 			},
 		})
@@ -294,7 +294,7 @@ func init() {
 				Callback: OnSpellHitTaken,
 				ProcMask: core.ProcMaskMelee,
 				Harmful:  true,
-				Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellEffect) {
+				Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
 					if icd.IsReady(sim) && character.CurrentHealthPercent() < 0.35 {
 						icd.Use(sim)
 						procAura.Activate(sim)
@@ -335,7 +335,7 @@ func init() {
 				Harmful:    true,
 				ProcChance: 0.10,
 				ICD:        time.Second * 45,
-				Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellEffect) {
+				Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
 					procAura.Activate(sim)
 					core.StartPeriodicAction(sim, core.PeriodicActionOptions{
 						NumTicks:        10,

--- a/sim/common/wotlk/proc_helpers.go
+++ b/sim/common/wotlk/proc_helpers.go
@@ -21,7 +21,7 @@ const (
 	OnCastComplete
 )
 
-type ProcHandler func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect)
+type ProcHandler func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult)
 
 type ProcTrigger struct {
 	Name       string
@@ -51,14 +51,14 @@ func applyProcTriggerCallback(unit *core.Unit, aura *core.Aura, config ProcTrigg
 	}
 
 	handler := config.Handler
-	callback := func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+	callback := func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 		if config.ProcMask != core.ProcMaskUnknown && !spell.ProcMask.Matches(config.ProcMask) {
 			return
 		}
-		if config.Outcome != core.OutcomeEmpty && !spellEffect.Outcome.Matches(config.Outcome) {
+		if config.Outcome != core.OutcomeEmpty && !result.Outcome.Matches(config.Outcome) {
 			return
 		}
-		if config.Harmful && spellEffect.Damage == 0 {
+		if config.Harmful && result.Damage == 0 {
 			return
 		}
 		if icd.Duration != 0 && !icd.IsReady(sim) {
@@ -73,7 +73,7 @@ func applyProcTriggerCallback(unit *core.Unit, aura *core.Aura, config ProcTrigg
 		if icd.Duration != 0 {
 			icd.Use(sim)
 		}
-		handler(sim, spell, spellEffect)
+		handler(sim, spell, result)
 	}
 
 	if config.Callback.Matches(OnSpellHitDealt) {

--- a/sim/common/wotlk/shadowmourne.go
+++ b/sim/common/wotlk/shadowmourne.go
@@ -48,7 +48,7 @@ func init() {
 
 		core.MakePermanent(player.GetOrRegisterAura(core.Aura{
 			Label: "Shadowmourne",
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}

--- a/sim/common/wotlk/stat_bonus_procs.go
+++ b/sim/common/wotlk/stat_bonus_procs.go
@@ -29,12 +29,12 @@ func newProcStatBonusEffect(config ProcStatBonusEffect) {
 		character := agent.GetCharacter()
 		procAura := character.NewTemporaryStatsAura(config.Name+" Proc", core.ActionID{ItemID: config.ID}, config.Bonus, config.Duration)
 
-		handler := func(sim *core.Simulation, _ *core.Spell, _ *core.SpellEffect) {
+		handler := func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
 			procAura.Activate(sim)
 		}
 		if config.IgnoreSpellID != 0 {
 			ignoreSpellID := config.IgnoreSpellID
-			handler = func(sim *core.Simulation, spell *core.Spell, _ *core.SpellEffect) {
+			handler = func(sim *core.Simulation, spell *core.Spell, _ *core.SpellResult) {
 				if !spell.IsSpellAction(ignoreSpellID) {
 					procAura.Activate(sim)
 				}

--- a/sim/common/wotlk/stat_bonus_stacking.go
+++ b/sim/common/wotlk/stat_bonus_stacking.go
@@ -57,7 +57,7 @@ func newStackingStatBonusEffect(config StackingStatBonusEffect) {
 			Outcome:    config.Outcome,
 			Harmful:    config.Harmful,
 			ProcChance: config.ProcChance,
-			Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellEffect) {
+			Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
 				procAura.Activate(sim)
 				procAura.AddStack(sim)
 			},
@@ -101,7 +101,7 @@ func newStackingStatBonusCD(config StackingStatBonusCD) {
 			Outcome:    config.Outcome,
 			Harmful:    config.Harmful,
 			ProcChance: config.ProcChance,
-			Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellEffect) {
+			Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
 				buffAura.AddStack(sim)
 			},
 		})
@@ -150,8 +150,8 @@ func init() {
 				ActionID:  core.ActionID{ItemID: 38212},
 				Duration:  time.Second * 20,
 				MaxStacks: 10,
-				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-					if spellEffect.Landed() && spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
+				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+					if result.Landed() && spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
 						aura.AddStack(sim)
 					}
 				},
@@ -166,7 +166,7 @@ func init() {
 			Outcome:    core.OutcomeLanded,
 			ProcChance: 0.1,
 			ICD:        time.Second * 45,
-			Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellEffect) {
+			Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
 				procAura.Activate(sim)
 			},
 		})

--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -716,8 +716,8 @@ func (unit *Unit) applyParryHaste() {
 		OnReset: func(aura *Aura, sim *Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
-			if !spellEffect.Outcome.Matches(OutcomeParry) {
+		OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
+			if !result.Outcome.Matches(OutcomeParry) {
 				return
 			}
 

--- a/sim/core/aura.go
+++ b/sim/core/aura.go
@@ -820,70 +820,70 @@ func (at *auraTracker) AfterCast(sim *Simulation, spell *Spell) {
 }
 
 // Invokes the OnSpellHit event for all tracked Auras.
-func (at *auraTracker) OnSpellHitDealt(sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
+func (at *auraTracker) OnSpellHitDealt(sim *Simulation, spell *Spell, result *SpellResult) {
 	for _, aura := range at.onSpellHitDealtAuras {
 		// this check is to handle a case where auras are deactivated during iteration.
 		if !aura.active {
 			continue
 		}
-		aura.OnSpellHitDealt(aura, sim, spell, spellEffect)
+		aura.OnSpellHitDealt(aura, sim, spell, result)
 	}
 }
-func (at *auraTracker) OnSpellHitTaken(sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
+func (at *auraTracker) OnSpellHitTaken(sim *Simulation, spell *Spell, result *SpellResult) {
 	for _, aura := range at.onSpellHitTakenAuras {
 		// this check is to handle a case where auras are deactivated during iteration.
 		if !aura.active {
 			continue
 		}
-		aura.OnSpellHitTaken(aura, sim, spell, spellEffect)
+		aura.OnSpellHitTaken(aura, sim, spell, result)
 	}
 }
 
 // Invokes the OnPeriodicDamage
 //   As a debuff when target is being hit by dot.
 //   As a buff when caster's dots are ticking.
-func (at *auraTracker) OnPeriodicDamageDealt(sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
+func (at *auraTracker) OnPeriodicDamageDealt(sim *Simulation, spell *Spell, result *SpellResult) {
 	for _, aura := range at.onPeriodicDamageDealtAuras {
-		aura.OnPeriodicDamageDealt(aura, sim, spell, spellEffect)
+		aura.OnPeriodicDamageDealt(aura, sim, spell, result)
 	}
 }
-func (at *auraTracker) OnPeriodicDamageTaken(sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
+func (at *auraTracker) OnPeriodicDamageTaken(sim *Simulation, spell *Spell, result *SpellResult) {
 	for _, aura := range at.onPeriodicDamageTakenAuras {
-		aura.OnPeriodicDamageTaken(aura, sim, spell, spellEffect)
+		aura.OnPeriodicDamageTaken(aura, sim, spell, result)
 	}
 }
 
 // Invokes the OnHeal event for all tracked Auras.
-func (at *auraTracker) OnHealDealt(sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
+func (at *auraTracker) OnHealDealt(sim *Simulation, spell *Spell, result *SpellResult) {
 	for _, aura := range at.onHealDealtAuras {
 		// this check is to handle a case where auras are deactivated during iteration.
 		if !aura.active {
 			continue
 		}
-		aura.OnHealDealt(aura, sim, spell, spellEffect)
+		aura.OnHealDealt(aura, sim, spell, result)
 	}
 }
-func (at *auraTracker) OnHealTaken(sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
+func (at *auraTracker) OnHealTaken(sim *Simulation, spell *Spell, result *SpellResult) {
 	for _, aura := range at.onHealTakenAuras {
 		// this check is to handle a case where auras are deactivated during iteration.
 		if !aura.active {
 			continue
 		}
-		aura.OnHealTaken(aura, sim, spell, spellEffect)
+		aura.OnHealTaken(aura, sim, spell, result)
 	}
 }
 
 // Invokes the OnPeriodicHeal
 //   As a debuff when target is being hit by dot.
 //   As a buff when caster's dots are ticking.
-func (at *auraTracker) OnPeriodicHealDealt(sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
+func (at *auraTracker) OnPeriodicHealDealt(sim *Simulation, spell *Spell, result *SpellResult) {
 	for _, aura := range at.onPeriodicHealDealtAuras {
-		aura.OnPeriodicHealDealt(aura, sim, spell, spellEffect)
+		aura.OnPeriodicHealDealt(aura, sim, spell, result)
 	}
 }
-func (at *auraTracker) OnPeriodicHealTaken(sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
+func (at *auraTracker) OnPeriodicHealTaken(sim *Simulation, spell *Spell, result *SpellResult) {
 	for _, aura := range at.onPeriodicHealTakenAuras {
-		aura.OnPeriodicHealTaken(aura, sim, spell, spellEffect)
+		aura.OnPeriodicHealTaken(aura, sim, spell, result)
 	}
 }
 
@@ -918,7 +918,7 @@ func MakePermanent(aura *Aura) *Aura {
 
 func (character *Character) StatProcWithICD(auraLabel string, actionID ActionID,
 	tempStats stats.Stats, duration time.Duration, cooldown time.Duration,
-	applyProcAura func(sim *Simulation, spell *Spell, spellEffect *SpellEffect) bool) {
+	applyProcAura func(sim *Simulation, spell *Spell, result *SpellResult) bool) {
 
 	icd := Cooldown{
 		Timer:    character.NewTimer(),
@@ -933,12 +933,12 @@ func (character *Character) StatProcWithICD(auraLabel string, actionID ActionID,
 		OnReset: func(aura *Aura, sim *Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *Aura, sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
+		OnSpellHitDealt: func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
 			if !icd.IsReady(sim) {
 				return
 			}
 
-			if applyProcAura(sim, spell, spellEffect) {
+			if applyProcAura(sim, spell, result) {
 				icd.Use(sim)
 				procAura.Activate(sim)
 			}

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -396,8 +396,8 @@ func RetributionAura(character *Character, sanctifiedRetribution bool) *Aura {
 		OnReset: func(aura *Aura, sim *Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
-			if spellEffect.Landed() && spell.SpellSchool == SpellSchoolPhysical {
+		OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
+			if result.Landed() && spell.SpellSchool == SpellSchoolPhysical {
 				procSpell.Cast(sim, spell.Unit)
 			}
 		},
@@ -429,8 +429,8 @@ func ThornsAura(character *Character, points int32) *Aura {
 		OnReset: func(aura *Aura, sim *Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
-			if spellEffect.Landed() && spell.SpellSchool == SpellSchoolPhysical {
+		OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
+			if result.Landed() && spell.SpellSchool == SpellSchoolPhysical {
 				procSpell.Cast(sim, spell.Unit)
 			}
 		},
@@ -451,8 +451,8 @@ func BlessingOfSanctuaryAura(character *Character) {
 		OnReset: func(aura *Aura, sim *Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
-			if spellEffect.Outcome.Matches(OutcomeBlock | OutcomeDodge | OutcomeParry) {
+		OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
+			if result.Outcome.Matches(OutcomeBlock | OutcomeDodge | OutcomeParry) {
 				character.AddMana(sim, 0.02*character.MaxMana(), manaMetrics, false)
 			}
 		},

--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -291,8 +291,8 @@ func applyConsumeEffects(agent Agent, raidBuffs proto.RaidBuffs, partyBuffs prot
 				OnReset: func(aura *Aura, sim *Simulation) {
 					aura.Activate(sim)
 				},
-				OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
-					if spellEffect.Landed() &&
+				OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
+					if result.Landed() &&
 						spell.SpellSchool == SpellSchoolPhysical &&
 						sim.RandomFloat("Gift of Arthas") < 0.3 {
 						goaProc.Cast(sim, spell.Unit)
@@ -1073,15 +1073,15 @@ func makeConjuredActivation(conjuredType proto.Conjured, character *Character) (
 				}
 			},
 		})
-		flameCapAura.OnSpellHitDealt = func(aura *Aura, sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
-			if !spellEffect.Landed() || !spell.ProcMask.Matches(ProcMaskMeleeOrRanged) {
+		flameCapAura.OnSpellHitDealt = func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
+			if !result.Landed() || !spell.ProcMask.Matches(ProcMaskMeleeOrRanged) {
 				return
 			}
 			if sim.RandomFloat("Flame Cap Melee") > procChance {
 				return
 			}
 
-			flameCapProc.Cast(sim, spellEffect.Target)
+			flameCapProc.Cast(sim, result.Target)
 		}
 
 		return MajorCooldown{

--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -235,13 +235,13 @@ func JudgementOfWisdomAura(target *Unit) *Aura {
 		Label:    JudgementOfWisdomAuraLabel,
 		ActionID: actionID,
 		Duration: time.Second * 20,
-		OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
+		OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
 			if spell.ProcMask.Matches(ProcMaskEmpty) {
 				return // Phantom spells (Romulo's, Lightning Capacitor, etc) don't proc JoW.
 			}
 
 			// Melee claim that wisdom can proc on misses.
-			if !spell.ProcMask.Matches(ProcMaskMeleeOrRanged) && !spellEffect.Landed() {
+			if !spell.ProcMask.Matches(ProcMaskMeleeOrRanged) && !result.Landed() {
 				return
 			}
 
@@ -270,8 +270,8 @@ func JudgementOfLightAura(target *Unit) *Aura {
 		Label:    JudgementOfLightAuraLabel,
 		ActionID: actionID,
 		Duration: time.Second * 20,
-		OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
-			if !spell.ProcMask.Matches(ProcMaskMelee) || !spellEffect.Landed() {
+		OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
+			if !spell.ProcMask.Matches(ProcMaskMelee) || !result.Landed() {
 				return
 			}
 
@@ -942,7 +942,7 @@ func MarkOfBloodAura(target *Unit) *Aura {
 				healthMetrics = target.NewHealthMetrics(actionId)
 			}
 		},
-		OnSpellHitDealt: func(aura *Aura, sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
+		OnSpellHitDealt: func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
 			target := aura.Unit.CurrentTarget
 
 			// TODO: Does vampiric blood make it so this health gain is increased?

--- a/sim/core/health.go
+++ b/sim/core/health.go
@@ -102,9 +102,9 @@ func (character *Character) trackChanceOfDeath(healingModel *proto.HealingModel)
 		OnReset: func(aura *Aura, sim *Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
-			if spellEffect.Damage > 0 {
-				aura.Unit.RemoveHealth(sim, spellEffect.Damage)
+		OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
+			if result.Damage > 0 {
+				aura.Unit.RemoveHealth(sim, result.Damage)
 
 				if aura.Unit.CurrentHealth() <= 0 && !aura.Unit.Metrics.Died {
 					aura.Unit.Metrics.Died = true
@@ -114,9 +114,9 @@ func (character *Character) trackChanceOfDeath(healingModel *proto.HealingModel)
 				}
 			}
 		},
-		OnPeriodicDamageTaken: func(aura *Aura, sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
-			if spellEffect.Damage > 0 {
-				aura.Unit.RemoveHealth(sim, spellEffect.Damage)
+		OnPeriodicDamageTaken: func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
+			if result.Damage > 0 {
+				aura.Unit.RemoveHealth(sim, result.Damage)
 
 				if aura.Unit.CurrentHealth() <= 0 && !aura.Unit.Metrics.Died {
 					aura.Unit.Metrics.Died = true

--- a/sim/core/rage.go
+++ b/sim/core/rage.go
@@ -39,8 +39,8 @@ func (unit *Unit) EnableRageBar(options RageBarOptions, onRageGain OnRageGain) {
 		OnReset: func(aura *Aura, sim *Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *Aura, sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
-			if spellEffect.Outcome.Matches(OutcomeMiss) {
+		OnSpellHitDealt: func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
+			if result.Outcome.Matches(OutcomeMiss) {
 				return
 			}
 			if !spell.ProcMask.Matches(ProcMaskWhiteHit) {
@@ -62,14 +62,14 @@ func (unit *Unit) EnableRageBar(options RageBarOptions, onRageGain OnRageGain) {
 				speed = options.OHSwingSpeed
 			}
 
-			if spellEffect.Outcome.Matches(OutcomeCrit) {
+			if result.Outcome.Matches(OutcomeCrit) {
 				hitFactor *= 2
 			}
 
-			damage := spellEffect.Damage
-			if spellEffect.Outcome.Matches(OutcomeDodge | OutcomeParry) {
+			damage := result.Damage
+			if result.Outcome.Matches(OutcomeDodge | OutcomeParry) {
 				// Rage is still generated for dodges/parries, based on the damage it WOULD have done.
-				damage = spellEffect.PreOutcomeDamage
+				damage = result.PreOutcomeDamage
 			}
 
 			// generatedRage is capped for very low damage swings
@@ -82,8 +82,8 @@ func (unit *Unit) EnableRageBar(options RageBarOptions, onRageGain OnRageGain) {
 			}
 			unit.AddRage(sim, generatedRage, spell.ResourceMetrics)
 		},
-		OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, spellEffect *SpellEffect) {
-			generatedRage := spellEffect.Damage * 2.5 / RageFactor
+		OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
+			generatedRage := result.Damage * 2.5 / RageFactor
 			unit.AddRage(sim, generatedRage, rageFromDamageTakenMetrics)
 		},
 	})

--- a/sim/core/spell.go
+++ b/sim/core/spell.go
@@ -7,9 +7,9 @@ import (
 	"github.com/wowsims/wotlk/sim/core/stats"
 )
 
-type ApplySpellEffects func(sim *Simulation, target *Unit, spell *Spell)
-type DynamicThreatBonusFunc func(spellEffect *SpellEffect, spell *Spell) float64
-type DynamicThreatMultiplierFunc func(spellEffect *SpellEffect, spell *Spell) float64
+type ApplySpellResults func(sim *Simulation, target *Unit, spell *Spell)
+type DynamicThreatBonusFunc func(result *SpellResult, spell *Spell) float64
+type DynamicThreatMultiplierFunc func(result *SpellResult, spell *Spell) float64
 
 type SpellConfig struct {
 	// See definition of Spell (below) for comments on these.
@@ -23,7 +23,7 @@ type SpellConfig struct {
 
 	Cast CastConfig
 
-	ApplyEffects ApplySpellEffects
+	ApplyEffects ApplySpellResults
 
 	BonusHitRating       float64
 	BonusCritRating      float64
@@ -109,7 +109,7 @@ type Spell struct {
 
 	SpellMetrics []SpellMetrics
 
-	ApplyEffects ApplySpellEffects
+	ApplyEffects ApplySpellResults
 
 	// The current or most recent cast data.
 	CurCast Cast
@@ -146,7 +146,7 @@ type Spell struct {
 	initialThreatMultiplier         float64
 	// Note that bonus expertise and armor pen are static, so we don't bother resetting them.
 
-	resultCache SpellEffect
+	resultCache SpellResult
 }
 
 func (unit *Unit) OnSpellRegistered(handler SpellRegisteredHandler) {

--- a/sim/core/spell_resistances.go
+++ b/sim/core/spell_resistances.go
@@ -7,13 +7,13 @@ import (
 	"strings"
 )
 
-func (spellEffect *SpellEffect) applyResistances(sim *Simulation, spell *Spell, isPeriodic bool, attackTable *AttackTable) {
-	// TODO check why spellEffect.Outcome isn't updated with resists anymore
+func (result *SpellResult) applyResistances(sim *Simulation, spell *Spell, isPeriodic bool, attackTable *AttackTable) {
+	// TODO check why result.Outcome isn't updated with resists anymore
 	resistanceMultiplier := spell.ResistanceMultiplier(sim, isPeriodic, attackTable)
-	spellEffect.Damage *= resistanceMultiplier
+	result.Damage *= resistanceMultiplier
 
-	spellEffect.ResistanceMultiplier = resistanceMultiplier
-	spellEffect.PreOutcomeDamage = spellEffect.Damage
+	result.ResistanceMultiplier = resistanceMultiplier
+	result.PreOutcomeDamage = result.Damage
 }
 
 // Modifies damage based on Armor or Magic resistances, depending on the damage type.

--- a/sim/core/spell_resistances_test.go
+++ b/sim/core/spell_resistances_test.go
@@ -60,15 +60,15 @@ func Test_PartialResistsVsPlayer(t *testing.T) {
 		outcomes := make(map[HitOutcome]int, n)
 		var totalDamage float64
 		for iter := 0; iter < n; iter++ {
-			spellEffect := SpellEffect{
+			result := SpellResult{
 				Outcome: OutcomeHit,
 				Damage:  1000,
 			}
 
-			spellEffect.applyResistances(sim, spell, false, attackTable)
+			result.applyResistances(sim, spell, false, attackTable)
 
-			outcomes[spellEffect.Outcome]++
-			totalDamage += spellEffect.Damage
+			outcomes[result.Outcome]++
+			totalDamage += result.Damage
 		}
 
 		if math.Abs(expectedAr-(1-totalDamage/float64(1000*n))) > 0.01 {
@@ -130,15 +130,15 @@ func Test_PartialResistsVsBoss(t *testing.T) {
 		outcomes := make(map[HitOutcome]int, n)
 		var totalDamage float64
 		for iter := 0; iter < n; iter++ {
-			spellEffect := SpellEffect{
+			result := SpellResult{
 				Outcome: OutcomeHit,
 				Damage:  1000,
 			}
 
-			spellEffect.applyResistances(sim, spell, false, attackTable)
+			result.applyResistances(sim, spell, false, attackTable)
 
-			outcomes[spellEffect.Outcome]++
-			totalDamage += spellEffect.Damage
+			outcomes[result.Outcome]++
+			totalDamage += result.Damage
 		}
 
 		if math.Abs(expectedAr-(1-totalDamage/float64(1000*n))) > 0.01 {

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -25,7 +25,7 @@ const (
 	RunicPower
 )
 
-type DynamicDamageTakenModifier func(sim *Simulation, spell *Spell, spellEffect *SpellEffect)
+type DynamicDamageTakenModifier func(sim *Simulation, spell *Spell, result *SpellResult)
 
 // Unit is an abstraction of a Character/Boss/Pet/etc, containing functionality
 // shared by all of them.

--- a/sim/deathknight/anti_magic_shell.go
+++ b/sim/deathknight/anti_magic_shell.go
@@ -105,13 +105,13 @@ func (dk *Deathknight) registerAntiMagicShellSpell() {
 			dk.PseudoStats.PeriodicShadowDamageTakenMultiplier /= spellDmgTakenMult
 		},
 
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Damage > 0 && physDmgTakenMult != 1.0 {
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Damage > 0 && physDmgTakenMult != 1.0 {
 				coeff := core.TernaryFloat64(spell.SpellSchool == core.SpellSchoolPhysical, physDmgTakenMult, spellDmgTakenMult)
-				absorbedDmg := (1.0 - coeff) * spellEffect.Damage / coeff
+				absorbedDmg := (1.0 - coeff) * result.Damage / coeff
 				dk.AddRunicPower(sim, absorbedDmg/69.0, rpMetrics)
-			} else if spellEffect.Damage > 0 && spell.SpellSchool != core.SpellSchoolPhysical {
-				absorbedDmg := (1.0 - spellDmgTakenMult) * spellEffect.Damage / spellDmgTakenMult
+			} else if result.Damage > 0 && spell.SpellSchool != core.SpellSchoolPhysical {
+				absorbedDmg := (1.0 - spellDmgTakenMult) * result.Damage / spellDmgTakenMult
 				dk.AddRunicPower(sim, absorbedDmg/69.0, rpMetrics)
 			}
 		},

--- a/sim/deathknight/bone_shield.go
+++ b/sim/deathknight/bone_shield.go
@@ -27,7 +27,7 @@ func (dk *Deathknight) registerBoneShieldSpell() {
 			dk.BoneShieldAura.UpdateExpires(sim.CurrentTime + time.Minute*5)
 			dk.BoneShieldAura.SetStacks(sim, dk.BoneShieldAura.MaxStacks)
 		},
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			aura.RemoveStack(sim)
 			if aura.GetStacks() == 0 {
 				aura.Deactivate(sim)

--- a/sim/deathknight/diseases.go
+++ b/sim/deathknight/diseases.go
@@ -182,7 +182,7 @@ func (dk *Deathknight) registerBloodPlague() {
 				}
 			},
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
-				var result *core.SpellEffect
+				var result *core.SpellResult
 				if canCrit {
 					result = dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeSnapshotCrit)
 				} else {
@@ -291,7 +291,7 @@ func (dk *Deathknight) registerDrwBloodPlague() {
 				}
 			},
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
-				var result *core.SpellEffect
+				var result *core.SpellResult
 				if canCrit {
 					result = dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeSnapshotCrit)
 				} else {
@@ -305,7 +305,7 @@ func (dk *Deathknight) registerDrwBloodPlague() {
 	}
 }
 
-func (dk *Deathknight) doWanderingPlague(sim *core.Simulation, spell *core.Spell, result *core.SpellEffect) {
+func (dk *Deathknight) doWanderingPlague(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 	if dk.Talents.WanderingPlague == 0 {
 		return
 	}

--- a/sim/deathknight/icy_touch.go
+++ b/sim/deathknight/icy_touch.go
@@ -82,7 +82,7 @@ func (dk *Deathknight) registerIcyTouchSpell() {
 		return dk.CastCostPossible(sim, 0.0, 0, 1, 0) && dk.IcyTouch.IsReady(sim)
 	}, nil)
 
-	dk.IcyTouch.DynamicThreatMultiplier = func(spellEffect *core.SpellEffect, spell *core.Spell) float64 {
+	dk.IcyTouch.DynamicThreatMultiplier = func(result *core.SpellResult, spell *core.Spell) float64 {
 		if dk.FrostPresenceAura.IsActive() {
 			return 7.0
 		}

--- a/sim/deathknight/items.go
+++ b/sim/deathknight/items.go
@@ -346,8 +346,8 @@ func init() {
 				aura.Unit.PseudoStats.FrostDamageDealtMultiplier /= cinderBonusCoeff
 				dk.modifyShadowDamageModifier(-0.2)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Outcome.Matches(core.OutcomeLanded) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Outcome.Matches(core.OutcomeLanded) {
 					return
 				}
 
@@ -367,8 +367,8 @@ func init() {
 
 		core.MakePermanent(character.GetOrRegisterAura(core.Aura{
 			Label: "Rune of Cinderglacier",
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() {
 					return
 				}
 

--- a/sim/deathknight/presences.go
+++ b/sim/deathknight/presences.go
@@ -102,9 +102,9 @@ func (dk *Deathknight) registerBloodPresenceAura(timer *core.Timer) {
 	}
 
 	if !isDps {
-		aura.OnSpellHitDealt = func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Damage > 0 {
-				healthGain := (0.04 * spellEffect.Damage) * (1.0 + core.TernaryFloat64(dk.VampiricBloodAura.IsActive(), 0.35, 0.0))
+		aura.OnSpellHitDealt = func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Damage > 0 {
+				healthGain := (0.04 * result.Damage) * (1.0 + core.TernaryFloat64(dk.VampiricBloodAura.IsActive(), 0.35, 0.0))
 				dk.GainHealth(sim, healthGain, healthMetrics)
 			}
 		}

--- a/sim/deathknight/rune_strike.go
+++ b/sim/deathknight/rune_strike.go
@@ -62,8 +62,8 @@ func (dk *Deathknight) registerRuneStrikeSpell() {
 	core.MakePermanent(dk.GetOrRegisterAura(core.Aura{
 		Label:    "Rune Strike Trigger",
 		Duration: core.NeverExpires,
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Outcome.Matches(core.OutcomeDodge | core.OutcomeParry) {
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Outcome.Matches(core.OutcomeDodge | core.OutcomeParry) {
 				dk.RuneStrikeAura.Activate(sim)
 			}
 		},

--- a/sim/deathknight/runespell.go
+++ b/sim/deathknight/runespell.go
@@ -28,7 +28,7 @@ type RuneSpell struct {
 	onCast  RuneSpellOnCast
 }
 
-func (rs *RuneSpell) OnResult(sim *core.Simulation, result *core.SpellEffect) {
+func (rs *RuneSpell) OnResult(sim *core.Simulation, result *core.SpellResult) {
 	cost := core.RuneCost(rs.Spell.CurCast.Cost) // cost was already optimized in RuneSpell.Cast
 	if cost == 0 {
 		return // it was free this time. we don't care

--- a/sim/deathknight/summon_gargoyle.go
+++ b/sim/deathknight/summon_gargoyle.go
@@ -127,7 +127,7 @@ var gargoyleBaseStats = stats.Stats{
 
 func (garg *GargoylePet) registerGargoyleStrikeSpell() {
 	attackPowerModifier := (1.0 + 0.04*float64(garg.dkOwner.Talents.Impurity)) / 3.0
-	var outcomeApplier core.NewOutcomeApplier
+	var outcomeApplier core.OutcomeApplier
 
 	garg.GargoyleStrike = garg.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 51963},

--- a/sim/deathknight/talents_blood.go
+++ b/sim/deathknight/talents_blood.go
@@ -95,12 +95,12 @@ func (dk *Deathknight) applySpellDeflection() {
 		return
 	}
 
-	dk.AddDynamicDamageTakenModifier(func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+	dk.AddDynamicDamageTakenModifier(func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 		if spell.ProcMask.Matches(core.ProcMaskSpellDamage) {
 			procChance := dk.PseudoStats.BaseParry + dk.Unit.GetDiminishedParryChance()
 			dmgMult := 1.0 - 0.15*float64(dk.Talents.SpellDeflection)
 			if sim.RandomFloat("Spell Deflection Roll") < procChance {
-				spellEffect.Damage *= dmgMult
+				result.Damage *= dmgMult
 			}
 		}
 	})
@@ -118,10 +118,10 @@ func (dk *Deathknight) applyWillOfTheNecropolis() {
 		Duration: core.NeverExpires,
 	})
 
-	dk.AddDynamicDamageTakenModifier(func(sim *core.Simulation, _ *core.Spell, spellEffect *core.SpellEffect) {
-		if (dk.CurrentHealth()-spellEffect.Damage)/dk.MaxHealth() <= 0.35 {
-			spellEffect.Damage *= 0.85
-			if (dk.CurrentHealth()-spellEffect.Damage)/dk.MaxHealth() <= 0.35 {
+	dk.AddDynamicDamageTakenModifier(func(sim *core.Simulation, _ *core.Spell, result *core.SpellResult) {
+		if (dk.CurrentHealth()-result.Damage)/dk.MaxHealth() <= 0.35 {
+			result.Damage *= 0.85
+			if (dk.CurrentHealth()-result.Damage)/dk.MaxHealth() <= 0.35 {
 				dk.WillOfTheNecropolis.Activate(sim)
 				return
 			}
@@ -149,7 +149,7 @@ func (dk *Deathknight) applyScentOfBlood() {
 			aura.SetStacks(sim, aura.MaxStacks)
 		},
 
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !spell.ProcMask.Matches(core.ProcMaskMelee) {
 				return
 			}
@@ -161,7 +161,7 @@ func (dk *Deathknight) applyScentOfBlood() {
 
 	core.MakePermanent(dk.GetOrRegisterAura(core.Aura{
 		Label: "Scent of Blood",
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if sim.RandomFloat("Scent Of Blood Proc Chance") <= procChance {
 				dk.ScentOfBloodAura.Activate(sim)
 			}
@@ -273,8 +273,8 @@ func (dk *Deathknight) applyBloodyVengeance() {
 	core.MakePermanent(dk.RegisterAura(core.Aura{
 		ActionID: actionID,
 		Label:    "Bloody Vengeance",
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
 
@@ -303,8 +303,8 @@ func (dk *Deathknight) applySuddenDoom() {
 
 	core.MakePermanent(dk.RegisterAura(core.Aura{
 		Label: "Sudden Doom",
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() {
 				return
 			}
 
@@ -345,7 +345,7 @@ func (dk *Deathknight) applyBloodGorged() {
 
 	core.MakePermanent(dk.RegisterAura(core.Aura{
 		Label: "Blood Gorged",
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			isActive := procAura.IsActive()
 			shouldBeActive := aura.Unit.CurrentHealthPercent() >= 0.75
 			if isActive && !shouldBeActive {
@@ -383,7 +383,7 @@ func (dk *Deathknight) applyBloodworms() {
 
 	core.MakePermanent(dk.RegisterAura(core.Aura{
 		Label: "Bloodworms Proc",
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !spell.ProcMask.Matches(core.ProcMaskMelee) {
 				return
 			}
@@ -394,7 +394,7 @@ func (dk *Deathknight) applyBloodworms() {
 
 			if sim.RandomFloat("Bloodworms proc") < procChance {
 				icd.Use(sim)
-				procSpell.Cast(sim, spellEffect.Target)
+				procSpell.Cast(sim, result.Target)
 			}
 		},
 	}))

--- a/sim/deathknight/talents_frost.go
+++ b/sim/deathknight/talents_frost.go
@@ -186,8 +186,8 @@ func (dk *Deathknight) applyKillingMachine() {
 
 	core.MakePermanent(dk.GetOrRegisterAura(core.Aura{
 		Label: "Killing Machine",
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() {
 				return
 			}
 
@@ -254,8 +254,8 @@ func (dk *Deathknight) applyDeathchill() {
 				dk.HowlingBlast.Spell.BonusCritRating -= 100 * core.CritRatingPerCritChance
 			}
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() {
 				return
 			}
 
@@ -316,7 +316,7 @@ func (dk *Deathknight) threatOfThassarianProcMask(isMH bool) core.ProcMask {
 	}
 }
 
-func (dk *Deathknight) threatOfThassarianOutcomeApplier(spell *core.Spell) core.NewOutcomeApplier {
+func (dk *Deathknight) threatOfThassarianOutcomeApplier(spell *core.Spell) core.OutcomeApplier {
 	if spell.ProcMask.Matches(core.ProcMaskMeleeMH) {
 		return spell.OutcomeMeleeSpecialHitAndCrit
 	} else {
@@ -324,8 +324,8 @@ func (dk *Deathknight) threatOfThassarianOutcomeApplier(spell *core.Spell) core.
 	}
 }
 
-func (dk *Deathknight) threatOfThassarianProc(sim *core.Simulation, spellEffect *core.SpellEffect, ohSpell *RuneSpell) {
+func (dk *Deathknight) threatOfThassarianProc(sim *core.Simulation, result *core.SpellResult, ohSpell *RuneSpell) {
 	if dk.threatOfThassarianWillProc(sim) && dk.GetOHWeapon() != nil {
-		ohSpell.Cast(sim, spellEffect.Target)
+		ohSpell.Cast(sim, result.Target)
 	}
 }

--- a/sim/deathknight/talents_unholy.go
+++ b/sim/deathknight/talents_unholy.go
@@ -128,13 +128,13 @@ func (dk *Deathknight) applyNecrosis() {
 	dk.NecrosisAura = core.MakePermanent(dk.RegisterAura(core.Aura{
 		Label: "Necrosis",
 		// ActionID: core.ActionID{SpellID: 51465}, // hide from metrics
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Damage == 0 || !spell.ProcMask.Matches(core.ProcMaskMeleeWhiteHit) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Damage == 0 || !spell.ProcMask.Matches(core.ProcMaskMeleeWhiteHit) {
 				return
 			}
 
-			curDmg = spellEffect.Damage
-			necrosisHit.Cast(sim, spellEffect.Target)
+			curDmg = result.Damage
+			necrosisHit.Cast(sim, result.Target)
 		},
 	}))
 }
@@ -151,17 +151,17 @@ func (dk *Deathknight) applyBloodCakedBlade() {
 	dk.BloodCakedBladeAura = core.MakePermanent(dk.RegisterAura(core.Aura{
 		Label: "Blood-Caked Blade",
 		// ActionID: core.ActionID{SpellID: 49628}, // Hide from metrics
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Damage == 0 || !spell.ProcMask.Matches(core.ProcMaskMeleeWhiteHit) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Damage == 0 || !spell.ProcMask.Matches(core.ProcMaskMeleeWhiteHit) {
 				return
 			}
 
 			if sim.RandomFloat("Blood-Caked Blade Roll") < procChance {
 				isMh := spell.ProcMask.Matches(core.ProcMaskMeleeMHAuto)
 				if isMh {
-					bloodCakedBladeHitMh.Cast(sim, spellEffect.Target)
+					bloodCakedBladeHitMh.Cast(sim, result.Target)
 				} else {
-					bloodCakedBladeHitOh.Cast(sim, spellEffect.Target)
+					bloodCakedBladeHitOh.Cast(sim, result.Target)
 				}
 			}
 		},

--- a/sim/druid/items.go
+++ b/sim/druid/items.go
@@ -170,7 +170,7 @@ var ItemSetNightsongBattlegear = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+				OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 					isLacerate := druid.LacerateDot != nil && druid.LacerateDot.Spell == spell
 					if spell != druid.Rake && spell != druid.Rip && !isLacerate {
 						return
@@ -266,7 +266,7 @@ func init() {
 					procAura.Activate(sim)
 				}
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
@@ -298,7 +298,7 @@ func init() {
 
 		core.MakePermanent(druid.RegisterAura(core.Aura{
 			Label: "Ashtongue Talisman",
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell == druid.Starfire {
 					if sim.RandomFloat("Ashtongue Talisman") < 0.25 {
 						procAura.Activate(sim)
@@ -320,7 +320,7 @@ func init() {
 
 		core.MakePermanent(druid.RegisterAura(core.Aura{
 			Label: "Idol of the White Stag",
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if druid.IsMangle(spell) {
 					procAura.Activate(sim)
 				}
@@ -342,7 +342,7 @@ func init() {
 
 		core.MakePermanent(druid.RegisterAura(core.Aura{
 			Label: "Idol of Terror",
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if !druid.IsMangle(spell) {
 					return
 				}
@@ -371,7 +371,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell == druid.Moonfire {
 					if sim.RandomFloat("Idol of the Unseen Moon") > 0.5 {
 						return
@@ -404,7 +404,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				procAura.Activate(sim)
 				procAura.AddStack(sim)
 			},
@@ -434,7 +434,7 @@ func init() {
 		}
 		core.MakePermanent(druid.RegisterAura(core.Aura{
 			Label: "Idol of the Plainstalker",
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if !druid.IsMangle(spell) {
 					return
 				}
@@ -461,7 +461,7 @@ func init() {
 		procChance := 0.85
 		core.MakePermanent(druid.RegisterAura(core.Aura{
 			Label: "Idol of the Corruptor",
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if !druid.IsMangle(spell) {
 					return
 				}
@@ -485,7 +485,7 @@ func init() {
 		}
 		core.MakePermanent(druid.RegisterAura(core.Aura{
 			Label: "Idol of the Wastes",
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if druid.Shred != spell && druid.IsSwipeSpell(spell) {
 					return
 				}
@@ -510,7 +510,7 @@ func init() {
 
 		core.MakePermanent(druid.RegisterAura(core.Aura{
 			Label: "Savage Gladiator's Idol of Resolve",
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if !druid.IsMangle(spell) {
 					return
 				}
@@ -526,7 +526,7 @@ func init() {
 
 		core.MakePermanent(druid.RegisterAura(core.Aura{
 			Label: "Hateful Gladiator's Idol of Resolve",
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if !druid.IsMangle(spell) {
 					return
 				}
@@ -542,7 +542,7 @@ func init() {
 
 		core.MakePermanent(druid.RegisterAura(core.Aura{
 			Label: "Deadly Gladiator's Idol of Resolve",
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if !druid.IsMangle(spell) {
 					return
 				}

--- a/sim/druid/talents.go
+++ b/sim/druid/talents.go
@@ -112,8 +112,8 @@ func (druid *Druid) setupNaturesGrace() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
 			if (spell == druid.Starfire || spell == druid.Wrath) && float64(druid.Talents.NaturesGrace)*(1.0/3.0) >= sim.RandomFloat("Natures Grace") {
@@ -191,16 +191,16 @@ func (druid *Druid) applyPrimalFury() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if druid.InForm(Bear) {
-				if spellEffect.Outcome.Matches(core.OutcomeCrit) {
+				if result.Outcome.Matches(core.OutcomeCrit) {
 					if sim.Proc(procChance, "Primal Fury") {
 						druid.AddRage(sim, 5, rageMetrics)
 					}
 				}
 			} else if druid.InForm(Cat) {
 				if druid.IsMangle(spell) || spell == druid.Shred || spell == druid.Rake {
-					if spellEffect.Outcome.Matches(core.OutcomeCrit) {
+					if result.Outcome.Matches(core.OutcomeCrit) {
 						if sim.Proc(procChance, "Primal Fury") {
 							druid.AddComboPoints(sim, 1, cpMetrics)
 						}
@@ -279,8 +279,8 @@ func (druid *Druid) applyOmenOfClarity() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() {
 				return
 			}
 			if ppmm.Proc(sim, spell.ProcMask, "Omen of Clarity") { // Melee
@@ -336,8 +336,8 @@ func (druid *Druid) applyEclipse() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
 			if spell != druid.Starfire {
@@ -378,8 +378,8 @@ func (druid *Druid) applyEclipse() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
 			if spell != druid.Wrath {
@@ -418,11 +418,11 @@ func (druid *Druid) applyImprovedLotp() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() {
 				return
 			}
-			if !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) || !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+			if !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) || !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
 			if !icd.IsReady(sim) {

--- a/sim/hunter/aspects.go
+++ b/sim/hunter/aspects.go
@@ -54,7 +54,7 @@ func (hunter *Hunter) registerAspectOfTheDragonhawkSpell() {
 				}
 			}
 
-			aura.OnSpellHitDealt = func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			aura.OnSpellHitDealt = func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell != hunter.AutoAttacks.RangedAuto {
 					return
 				}
@@ -114,7 +114,7 @@ func (hunter *Hunter) registerAspectOfTheViperSpell() {
 			tickPA.Cancel(sim)
 			tickPA = nil
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell.ProcMask.Matches(core.ProcMaskRanged) {
 				hunter.AddMana(sim, manaPerRangedHit, hunter.AspectOfTheViper.ResourceMetrics, false)
 			} else if spell.ProcMask.Matches(core.ProcMaskMeleeMH) {

--- a/sim/hunter/items.go
+++ b/sim/hunter/items.go
@@ -31,8 +31,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskRanged) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskRanged) {
 					return
 				}
 				hunter.AddMana(sim, manaGain, manaMetrics, false)
@@ -52,7 +52,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell != hunter.SteadyShot {
 					return
 				}

--- a/sim/hunter/kill_command.go
+++ b/sim/hunter/kill_command.go
@@ -32,7 +32,7 @@ func (hunter *Hunter) registerKillCommandCD() {
 				hunter.pet.specialAbility.BonusCritRating -= bonusPetSpecialCrit
 			}
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell.ProcMask.Matches(core.ProcMaskMeleeSpecial | core.ProcMaskSpellDamage) {
 				aura.RemoveStack(sim)
 			}

--- a/sim/hunter/pet_abilities.go
+++ b/sim/hunter/pet_abilities.go
@@ -198,12 +198,12 @@ type PetSpecialAbilityConfig struct {
 	MaxDmg  float64
 	APRatio float64
 
-	OnSpellHitDealt func(*core.Simulation, *core.Spell, *core.SpellEffect)
+	OnSpellHitDealt func(*core.Simulation, *core.Spell, *core.SpellResult)
 }
 
 func (hp *HunterPet) newSpecialAbility(config PetSpecialAbilityConfig) PetAbility {
 	var flags core.SpellFlag
-	var applyEffects core.ApplySpellEffects
+	var applyEffects core.ApplySpellResults
 	var procMask core.ProcMask
 	if config.School == core.SpellSchoolPhysical {
 		flags = core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage
@@ -281,8 +281,8 @@ func (hp *HunterPet) newDemoralizingScreech() PetAbility {
 		MinDmg:  85,
 		MaxDmg:  129,
 		APRatio: 0.07,
-		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Landed() {
+		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Landed() {
 				for _, debuff := range debuffs {
 					debuff.Activate(sim)
 				}
@@ -305,8 +305,8 @@ func (hp *HunterPet) newFireBreath() PetAbility {
 		MinDmg:  43,
 		MaxDmg:  57,
 		APRatio: 0.049,
-		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Landed() {
+		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Landed() {
 				dot.Apply(sim)
 			}
 		},
@@ -445,8 +445,8 @@ func (hp *HunterPet) newMonstrousBite() PetAbility {
 		MinDmg:  91,
 		MaxDmg:  123,
 		APRatio: 0.07,
-		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Landed() {
+		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Landed() {
 				procAura.Activate(sim)
 				procAura.AddStack(sim)
 			}
@@ -598,8 +598,8 @@ func (hp *HunterPet) newRake() PetAbility {
 		MinDmg:  47,
 		MaxDmg:  67,
 		APRatio: 0.0175,
-		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Landed() {
+		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Landed() {
 				dot.Apply(sim)
 			}
 		},
@@ -817,8 +817,8 @@ func (hp *HunterPet) newSpiritStrike() PetAbility {
 		MinDmg:  49,
 		MaxDmg:  65,
 		APRatio: 0.04,
-		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Landed() {
+		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Landed() {
 				dot.Apply(sim)
 			}
 		},
@@ -922,8 +922,8 @@ func (hp *HunterPet) newStampede() PetAbility {
 		MinDmg:  182,
 		MaxDmg:  264,
 		APRatio: 0.07,
-		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Landed() {
+		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Landed() {
 				debuff.Activate(sim)
 			}
 		},
@@ -942,8 +942,8 @@ func (hp *HunterPet) newSting() PetAbility {
 		MinDmg:  64,
 		MaxDmg:  86,
 		APRatio: 0.049,
-		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Landed() {
+		OnSpellHitDealt: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Landed() {
 				debuff.Activate(sim)
 			}
 		},

--- a/sim/hunter/pet_talents.go
+++ b/sim/hunter/pet_talents.go
@@ -72,7 +72,7 @@ func (hp *HunterPet) applyOwlsFocus() {
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			hp.PseudoStats.NoCost = false
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell.ProcMask.Matches(core.ProcMaskSpecial) {
 				aura.Deactivate(sim)
 			}
@@ -85,7 +85,7 @@ func (hp *HunterPet) applyOwlsFocus() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell.ProcMask.Matches(core.ProcMaskSpecial) && sim.RandomFloat("Owls Focus") < procChance {
 				procAura.Activate(sim)
 			}
@@ -122,8 +122,8 @@ func (hp *HunterPet) applyCullingTheHerd() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Outcome.Matches(core.OutcomeCrit) && (spell.IsSpellAction(BiteSpellID) || spell.IsSpellAction(ClawSpellID) || spell.IsSpellAction(SmackSpellID)) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Outcome.Matches(core.OutcomeCrit) && (spell.IsSpellAction(BiteSpellID) || spell.IsSpellAction(ClawSpellID) || spell.IsSpellAction(SmackSpellID)) {
 				petAura.Activate(sim)
 				ownerAura.Activate(sim)
 			}
@@ -222,8 +222,8 @@ func (hp *HunterPet) registerRabidCD() {
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			procAura.Deactivate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() {
 				return
 			}
 			if !spell.ProcMask.Matches(core.ProcMaskMelee) {
@@ -336,8 +336,8 @@ func (hp *HunterPet) registerWolverineBite() {
 			wbValidUntil = 0
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.DidCrit() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.DidCrit() {
 				wbValidUntil = sim.CurrentTime + time.Second*5
 			}
 		},

--- a/sim/hunter/steady_shot.go
+++ b/sim/hunter/steady_shot.go
@@ -40,7 +40,7 @@ func (hunter *Hunter) registerSteadyShotSpell() {
 					hunter.ChimeraShot.CostMultiplier += 0.2
 				}
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell == hunter.AimedShot || spell == hunter.ArcaneShot || spell == hunter.ChimeraShot {
 					aura.Deactivate(sim)
 				}

--- a/sim/hunter/talents.go
+++ b/sim/hunter/talents.go
@@ -178,12 +178,12 @@ func (hunter *Hunter) applyInvigoration() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !spell.ProcMask.Matches(core.ProcMaskMeleeSpecial | core.ProcMaskSpellDamage) {
 				return
 			}
 
-			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
 
@@ -219,7 +219,7 @@ func (hunter *Hunter) applyCobraStrikes() {
 				hunter.pet.specialAbility.BonusCritRating -= 100 * core.CritRatingPerCritChance
 			}
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell.ProcMask.Matches(core.ProcMaskMeleeSpecial | core.ProcMaskSpellDamage) {
 				aura.RemoveStack(sim)
 			}
@@ -232,8 +232,8 @@ func (hunter *Hunter) applyCobraStrikes() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
 
@@ -298,18 +298,18 @@ func (hunter *Hunter) applyPiercingShots() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
 			if spell != hunter.AimedShot && spell != hunter.SteadyShot && spell != hunter.ChimeraShot {
 				return
 			}
 
-			totalDmg := spellEffect.Damage * dmgMultiplier
+			totalDmg := result.Damage * dmgMultiplier
 			// Specifically account for bleed modifiers, since it still affects the spell
 			// but we're ignoring all modifiers.
-			totalDmg *= spellEffect.Target.PseudoStats.PeriodicPhysicalDamageTakenMultiplier
+			totalDmg *= result.Target.PseudoStats.PeriodicPhysicalDamageTakenMultiplier
 
 			if psDot.IsActive() {
 				remainingTicks := 8 - psDot.TickCount
@@ -318,7 +318,7 @@ func (hunter *Hunter) applyPiercingShots() {
 
 			currentTickDmg = totalDmg / 8
 
-			psSpell.Cast(sim, spellEffect.Target)
+			psSpell.Cast(sim, result.Target)
 		},
 	})
 }
@@ -354,13 +354,13 @@ func (hunter *Hunter) applyWildQuiver() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell != hunter.AutoAttacks.RangedAuto {
 				return
 			}
 
 			if sim.RandomFloat("Wild Quiver") < procChance {
-				wqSpell.Cast(sim, spellEffect.Target)
+				wqSpell.Cast(sim, result.Target)
 			}
 		},
 	})
@@ -399,8 +399,8 @@ func (hunter *Hunter) applyFrenzy() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
 			if sim.Proc(procChance, "Frenzy") {
@@ -502,8 +502,8 @@ func (hunter *Hunter) applyGoForTheThroat() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spell.ProcMask.Matches(core.ProcMaskRanged) || !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !spell.ProcMask.Matches(core.ProcMaskRanged) || !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
 			if !hunter.pet.IsEnabled() {
@@ -572,7 +572,7 @@ func (hunter *Hunter) applyLockAndLoad() {
 				hunter.ExplosiveShot.CostMultiplier += 1
 			}
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell == hunter.ArcaneShot || spell == hunter.ExplosiveShot {
 				aura.RemoveStack(sim)
 				hunter.ArcaneShot.CD.Reset() // Shares the CD with explosive shot.
@@ -586,7 +586,7 @@ func (hunter *Hunter) applyLockAndLoad() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell != hunter.BlackArrow && spell != hunter.ExplosiveTrapDot.Spell {
 				return
 			}
@@ -618,13 +618,13 @@ func (hunter *Hunter) applyThrillOfTheHunt() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			// mask 256
 			if !spell.ProcMask.Matches(core.ProcMaskRangedSpecial) {
 				return
 			}
 
-			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
 
@@ -665,12 +665,12 @@ func (hunter *Hunter) applyExposeWeakness() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !spell.ProcMask.Matches(core.ProcMaskRanged) && spell != hunter.ExplosiveTrap {
 				return
 			}
 
-			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
 
@@ -678,12 +678,12 @@ func (hunter *Hunter) applyExposeWeakness() {
 				procAura.Activate(sim)
 			}
 		},
-		OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell != hunter.ExplosiveTrapDot.Spell {
 				return
 			}
 
-			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
 
@@ -710,8 +710,8 @@ func (hunter *Hunter) applyMasterTactician() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spell.ProcMask.Matches(core.ProcMaskRanged) || !spellEffect.Landed() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !spell.ProcMask.Matches(core.ProcMaskRanged) || !result.Landed() {
 				return
 			}
 

--- a/sim/hunter/wotlk_items.go
+++ b/sim/hunter/wotlk_items.go
@@ -65,8 +65,8 @@ var ItemSetScourgestalkerBattlegear = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-					if !spellEffect.Landed() || spell != hunter.SteadyShot {
+				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+					if !result.Landed() || spell != hunter.SteadyShot {
 						return
 					}
 					if !icd.IsReady(sim) {
@@ -109,8 +109,8 @@ var ItemSetWindrunnersPursuit = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-					if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskRanged) {
+				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+					if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskRanged) {
 						return
 					}
 					if !icd.IsReady(sim) {
@@ -154,7 +154,7 @@ var ItemSetAhnKaharBloodHuntersBattlegear = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 					if spell == hunter.AutoAttacks.RangedAuto && sim.RandomFloat("AhnKahar 2pc") < procChance {
 						procAura.Activate(sim)
 					}
@@ -190,7 +190,7 @@ var ItemSetAhnKaharBloodHuntersBattlegear = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+				OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 					if spell == hunter.SerpentSting && sim.RandomFloat("AhnKahar 4pc") < procChance {
 						procAura.Activate(sim)
 					}
@@ -243,7 +243,7 @@ func init() {
 				ProcMask:   core.ProcMaskRanged,
 				Outcome:    core.OutcomeLanded,
 				ProcChance: procChance,
-				Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellEffect) {
+				Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
 					rangedSpell.Cast(sim, hunter.CurrentTarget)
 				},
 			})

--- a/sim/mage/blizzard.go
+++ b/sim/mage/blizzard.go
@@ -11,7 +11,7 @@ func (mage *Mage) registerBlizzardSpell() {
 	actionID := core.ActionID{SpellID: 42939}
 	baseCost := .74 * mage.BaseMana
 
-	results := make([]*core.SpellEffect, len(mage.Env.Encounter.Targets))
+	results := make([]*core.SpellResult, len(mage.Env.Encounter.Targets))
 	blizzardDot := core.NewDot(core.Dot{
 		Aura: mage.RegisterAura(core.Aura{
 			Label:    "Blizzard",

--- a/sim/mage/ignite.go
+++ b/sim/mage/ignite.go
@@ -79,12 +79,12 @@ func (mage *Mage) applyIgnite() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
 				return
 			}
-			if spell.SpellSchool.Matches(core.SpellSchoolFire) && spellEffect.Outcome.Matches(core.OutcomeCrit) {
-				mage.procIgnite(sim, spellEffect.Target, spellEffect.Damage)
+			if spell.SpellSchool.Matches(core.SpellSchoolFire) && result.Outcome.Matches(core.OutcomeCrit) {
+				mage.procIgnite(sim, result.Target, result.Damage)
 			}
 		},
 	})

--- a/sim/mage/items.go
+++ b/sim/mage/items.go
@@ -28,7 +28,7 @@ var ItemSetKirinTorGarb = core.NewItemSet(core.ItemSet{
 	Bonuses: map[int32]core.ApplyEffect{
 		2: func(agent core.Agent) {
 
-			applyProcAura := func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) bool {
+			applyProcAura := func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) bool {
 				if !spell.Flags.Matches(BarrageSpells) {
 					return false
 				}

--- a/sim/mage/talents.go
+++ b/sim/mage/talents.go
@@ -92,12 +92,12 @@ func (mage *Mage) applyHotStreak() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !spell.Flags.Matches(HotStreakSpells) {
 				return
 			}
 
-			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+			if !result.Outcome.Matches(core.OutcomeCrit) {
 				heatingUp = false
 				return
 			} else {
@@ -139,7 +139,7 @@ func (mage *Mage) applyArcaneConcentration() {
 			mage.AddStatDynamic(sim, stats.SpellCrit, -bonusCrit)
 			mage.PseudoStats.NoCost = false
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !spell.Flags.Matches(SpellFlagMage) {
 				return
 			}
@@ -169,7 +169,7 @@ func (mage *Mage) applyArcaneConcentration() {
 			}
 			curCastIdx++
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !spell.Flags.Matches(SpellFlagMage) {
 				return
 			}
@@ -180,7 +180,7 @@ func (mage *Mage) applyArcaneConcentration() {
 			}
 			lastCheckedCastIdx = curCastIdx
 
-			if !spellEffect.Landed() {
+			if !result.Landed() {
 				return
 			}
 
@@ -352,11 +352,11 @@ func (mage *Mage) applyMasterOfElements() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
 				return
 			}
-			if spellEffect.Outcome.Matches(core.OutcomeCrit) {
+			if result.Outcome.Matches(core.OutcomeCrit) {
 				if refundCoeff < 0 {
 					mage.SpendMana(sim, spell.BaseCost*refundCoeff, manaMetrics)
 				} else {
@@ -417,14 +417,14 @@ func (mage *Mage) registerCombustionCD() {
 				spell.BonusCritRating += bonusCrit
 			}
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell.SpellSchool != core.SpellSchoolFire || !spell.Flags.Matches(SpellFlagMage) {
 				return
 			}
 			if spell.SameAction(IgniteActionID) || spell.SameAction(core.ActionID{SpellID: 55359}) || spell.SameAction(core.ActionID{SpellID: 44457}) { //LB dot action should be ignored
 				return
 			}
-			if !spellEffect.Landed() {
+			if !result.Landed() {
 				return
 			}
 			if numCrits >= 3 {
@@ -434,7 +434,7 @@ func (mage *Mage) registerCombustionCD() {
 			// TODO: This wont work properly with flamestrike
 			aura.AddStack(sim)
 
-			if spellEffect.Outcome.Matches(core.OutcomeCrit) {
+			if result.Outcome.Matches(core.OutcomeCrit) {
 				numCrits++
 				if numCrits == 3 {
 					aura.Deactivate(sim)
@@ -617,7 +617,7 @@ func (mage *Mage) applyFingersOfFrost() {
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			mage.AddStatDynamic(sim, stats.SpellCrit, -bonusCrit)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			aura.RemoveStack(sim)
 		},
 	})
@@ -629,7 +629,7 @@ func (mage *Mage) applyFingersOfFrost() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if mage.hasChillEffect(spell) && sim.RandomFloat("Fingers of Frost") < procChance {
 				mage.FingersOfFrostAura.Activate(sim)
 				mage.FingersOfFrostAura.SetStacks(sim, 2)
@@ -663,7 +663,7 @@ func (mage *Mage) applyBrainFreeze() {
 			mage.FrostfireBolt.CostMultiplier += 1
 			mage.FrostfireBolt.CastTimeMultiplier += 1
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell == mage.FrostfireBolt || spell == mage.Fireball {
 				aura.Deactivate(sim)
 				mage.BrainFreezeActivatedAt = 0
@@ -678,7 +678,7 @@ func (mage *Mage) applyBrainFreeze() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if mage.hasChillEffect(spell) && sim.RandomFloat("Brain Freeze") < procChance {
 				mage.BrainFreezeAura.Activate(sim)
 				if mage.BrainFreezeActivatedAt == 0 {

--- a/sim/mage/winters_chill.go
+++ b/sim/mage/winters_chill.go
@@ -51,14 +51,14 @@ func (mage *Mage) applyWintersChill() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() {
 				return
 			}
 
 			if spell.SpellSchool == core.SpellSchoolFrost && spell != mage.WintersChill {
 				if sim.Proc(procChance, "Winters Chill") {
-					mage.WintersChill.Cast(sim, spellEffect.Target)
+					mage.WintersChill.Cast(sim, result.Target)
 				}
 			}
 		},

--- a/sim/paladin/avengers_shield.go
+++ b/sim/paladin/avengers_shield.go
@@ -14,7 +14,7 @@ func (paladin *Paladin) registerAvengersShieldSpell() {
 	glyphedSingleTargetAS := paladin.HasMajorGlyph(proto.PaladinMajorGlyph_GlyphOfAvengerSShield)
 	// Glyph to single target, OR apply to up to 3 targets
 	numHits := core.TernaryInt32(glyphedSingleTargetAS, 1, core.MinInt32(3, paladin.Env.GetNumTargets()))
-	results := make([]*core.SpellEffect, numHits)
+	results := make([]*core.SpellResult, numHits)
 
 	paladin.AvengersShield = paladin.RegisterSpell(core.SpellConfig{
 		ActionID:     core.ActionID{SpellID: 48827},

--- a/sim/paladin/divine_storm.go
+++ b/sim/paladin/divine_storm.go
@@ -13,7 +13,7 @@ func (paladin *Paladin) registerDivineStormSpell() {
 	bonusDmg := core.TernaryFloat64(paladin.Equip[proto.ItemSlot_ItemSlotRanged].ID == 45510, 235, 0) + // Libram of Discord
 		core.TernaryFloat64(paladin.Equip[proto.ItemSlot_ItemSlotRanged].ID == 38362, 81, 0) // Venture Co. Libram of Retribution
 	numHits := core.MinInt32(4, paladin.Env.GetNumTargets())
-	results := make([]*core.SpellEffect, numHits)
+	results := make([]*core.SpellResult, numHits)
 
 	paladin.DivineStorm = paladin.RegisterSpell(core.SpellConfig{
 		ActionID:     core.ActionID{SpellID: 53385},

--- a/sim/paladin/hammer_of_the_righteous.go
+++ b/sim/paladin/hammer_of_the_righteous.go
@@ -12,7 +12,7 @@ func (paladin *Paladin) registerHammerOfTheRighteousSpell() {
 	baseCost := paladin.BaseMana * 0.06
 
 	numHits := core.MinInt32(core.TernaryInt32(paladin.HasMajorGlyph(proto.PaladinMajorGlyph_GlyphOfHammerOfTheRighteous), 4, 3), paladin.Env.GetNumTargets())
-	results := make([]*core.SpellEffect, numHits)
+	results := make([]*core.SpellResult, numHits)
 
 	paladin.HammerOfTheRighteous = paladin.RegisterSpell(core.SpellConfig{
 		ActionID:     core.ActionID{SpellID: 53595},

--- a/sim/paladin/holy_shield.go
+++ b/sim/paladin/holy_shield.go
@@ -45,9 +45,9 @@ func (paladin *Paladin) registerHolyShieldSpell() {
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			paladin.AddStatDynamic(sim, stats.Block, -blockBonus)
 		},
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Outcome.Matches(core.OutcomeBlock) {
-				// TODO: Shouldn't this be spellEffect.Target instead of spell.Unit?
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Outcome.Matches(core.OutcomeBlock) {
+				// TODO: Shouldn't this be result.Target instead of spell.Unit?
 				procSpell.Cast(sim, spell.Unit)
 				aura.RemoveStack(sim)
 			}

--- a/sim/paladin/holy_wrath.go
+++ b/sim/paladin/holy_wrath.go
@@ -11,7 +11,7 @@ import (
 func (paladin *Paladin) registerHolyWrathSpell() {
 	// From the perspective of max rank.
 	baseCost := paladin.BaseMana * 0.20
-	results := make([]*core.SpellEffect, len(paladin.Env.Encounter.Targets))
+	results := make([]*core.SpellResult, len(paladin.Env.Encounter.Targets))
 
 	paladin.HolyWrath = paladin.RegisterSpell(core.SpellConfig{
 		ActionID:     core.ActionID{SpellID: 48817},

--- a/sim/paladin/items.go
+++ b/sim/paladin/items.go
@@ -23,7 +23,7 @@ var ItemSetLightbringerBattlegear = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 					if !spell.ProcMask.Matches(core.ProcMaskMelee) {
 						return
 					}
@@ -124,7 +124,7 @@ var ItemSetLightswornBattlegear = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 					if !spell.ProcMask.Matches(core.ProcMaskMeleeWhiteHit) {
 						return
 					}
@@ -284,7 +284,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell.Flags.Matches(SpellFlagSecondaryJudgement) {
 					procAura.Activate(sim)
 				}
@@ -302,7 +302,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell.Flags.Matches(SpellFlagSecondaryJudgement) {
 					procAura.Activate(sim)
 				}
@@ -320,7 +320,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if paladin.CurrentSeal == paladin.SealOfCommandAura && spell.Flags.Matches(SpellFlagSecondaryJudgement) {
 					if sim.RandomFloat("Libram of Reciprocation") > 0.15 {
 						return
@@ -341,7 +341,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if paladin.CurrentSeal == paladin.SealOfCommandAura && spell.Flags.Matches(SpellFlagSecondaryJudgement) {
 					if sim.RandomFloat("Libram of Divine Judgement") > 0.40 {
 						return
@@ -362,7 +362,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell.SpellID == paladin.CrusaderStrike.SpellID {
 					procAura.Activate(sim)
 				}
@@ -380,7 +380,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell.SpellID == paladin.CrusaderStrike.SpellID {
 					procAura.Activate(sim)
 				}
@@ -398,7 +398,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell.SpellID == paladin.CrusaderStrike.SpellID {
 					procAura.Activate(sim)
 				}
@@ -416,7 +416,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell.SpellID == paladin.CrusaderStrike.SpellID {
 					procAura.Activate(sim)
 				}
@@ -434,7 +434,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell.SpellID == paladin.CrusaderStrike.SpellID {
 					procAura.Activate(sim)
 				}
@@ -452,7 +452,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell.SpellID == paladin.CrusaderStrike.SpellID {
 					procAura.Activate(sim)
 				}
@@ -471,7 +471,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell.SpellID == paladin.CrusaderStrike.SpellID {
 					procAura.Activate(sim)
 					procAura.AddStack(sim)
@@ -495,7 +495,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				isVengeanceDot := false
 				for _, vengeanceDot := range paladin.SealOfVengeanceDots {
 					if spell == vengeanceDot.Spell {
@@ -524,7 +524,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell.Flags.Matches(SpellFlagPrimaryJudgement) {
 					procAura.Activate(sim)
 				}
@@ -542,7 +542,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell.Flags.Matches(SpellFlagPrimaryJudgement) {
 					procAura.Activate(sim)
 				}
@@ -560,7 +560,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell.SpellID == paladin.HolyShield.SpellID {
 					procAura.Activate(sim)
 				}
@@ -632,7 +632,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell.Flags.Matches(SpellFlagPrimaryJudgement) && sim.RandomFloat("AshtongueTalismanOfZeal") < 0.5 {
 					judgementDot.Apply(sim)
 				}

--- a/sim/paladin/judgement.go
+++ b/sim/paladin/judgement.go
@@ -94,8 +94,8 @@ func (paladin *Paladin) registerJudgementOfLightSpell(cdTimer *core.Timer) {
 // 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 // 			aura.Activate(sim)
 // 		},
-// 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-// 			if spellEffect.Landed() && spell.ProcMask.Matches(core.ProcMaskMeleeWhiteHit) {
+// 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+// 			if result.Landed() && spell.ProcMask.Matches(core.ProcMaskMeleeWhiteHit) {
 // 				if paladin.CurrentJudgement != nil && paladin.CurrentJudgement.IsActive() {
 // 					// Refresh the judgement
 // 					paladin.CurrentJudgement.Refresh(sim)

--- a/sim/paladin/soc.go
+++ b/sim/paladin/soc.go
@@ -26,7 +26,7 @@ func (paladin *Paladin) registerSealOfCommandSpellAndAura() {
 	 */
 
 	numHits := core.MinInt32(3, paladin.Env.GetNumTargets()) // primary target + 2 others
-	results := make([]*core.SpellEffect, numHits)
+	results := make([]*core.SpellResult, numHits)
 
 	baseMultiplierAdditive := 1 +
 		paladin.getItemSetLightswornBattlegearBonus4() +
@@ -99,31 +99,31 @@ func (paladin *Paladin) registerSealOfCommandSpellAndAura() {
 		ActionID: auraActionID,
 		Duration: SealDuration,
 
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if glyphManaMetrics != nil && spell.Flags.Matches(SpellFlagPrimaryJudgement) {
 				paladin.AddMana(sim, glyphManaGain, glyphManaMetrics, false)
 			}
 
 			// Don't proc on misses or our own procs.
-			if !spellEffect.Landed() || spell == onJudgementProc || spell.SameAction(onSpecialOrSwingActionID) {
+			if !result.Landed() || spell == onJudgementProc || spell.SameAction(onSpecialOrSwingActionID) {
 				return
 			}
 
 			// Differ between judgements and other melee abilities.
 			if spell.Flags.Matches(SpellFlagPrimaryJudgement) {
-				onJudgementProc.Cast(sim, spellEffect.Target)
+				onJudgementProc.Cast(sim, result.Target)
 				if paladin.Talents.JudgementsOfTheJust > 0 {
 					// Special JoJ talent behavior, procs swing seal on judgements
 					// For SoC this is a cleave.
-					onSpecialOrSwingProcCleave.Cast(sim, spellEffect.Target)
+					onSpecialOrSwingProcCleave.Cast(sim, result.Target)
 				}
 			} else {
 				if spell.IsMelee() {
 					// Temporary check to avoid AOE double procing.
 					if spell.SpellID == paladin.HammerOfTheRighteous.SpellID || spell.SpellID == paladin.DivineStorm.SpellID {
-						onSpecialOrSwingProc.Cast(sim, spellEffect.Target)
+						onSpecialOrSwingProc.Cast(sim, result.Target)
 					} else {
-						onSpecialOrSwingProcCleave.Cast(sim, spellEffect.Target)
+						onSpecialOrSwingProcCleave.Cast(sim, result.Target)
 					}
 				}
 			}

--- a/sim/paladin/sor.go
+++ b/sim/paladin/sor.go
@@ -81,25 +81,25 @@ func (paladin *Paladin) registerSealOfRighteousnessSpellAndAura() {
 		ActionID: auraActionID,
 		Duration: SealDuration,
 
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			// Don't proc on misses or our own procs.
-			if !spellEffect.Landed() || spell.SpellID == onJudgementProc.SpellID || spell.SpellID == onSpecialOrSwingProc.SpellID {
+			if !result.Landed() || spell.SpellID == onJudgementProc.SpellID || spell.SpellID == onSpecialOrSwingProc.SpellID {
 				return
 			}
 
 			// Differ between judgements and other melee abilities.
 			if spell.Flags.Matches(SpellFlagPrimaryJudgement) {
 				// SoR is the only seal that can proc off its own judgement.
-				onSpecialOrSwingProc.Cast(sim, spellEffect.Target)
-				onJudgementProc.Cast(sim, spellEffect.Target)
+				onSpecialOrSwingProc.Cast(sim, result.Target)
+				onJudgementProc.Cast(sim, result.Target)
 				if paladin.Talents.JudgementsOfTheJust > 0 {
 					// Special JoJ talent behavior, procs swing seal on judgements
 					// Yes, for SoR this means it proces TWICE on one judgement.
-					onSpecialOrSwingProc.Cast(sim, spellEffect.Target)
+					onSpecialOrSwingProc.Cast(sim, result.Target)
 				}
 			} else {
 				if spell.IsMelee() {
-					onSpecialOrSwingProc.Cast(sim, spellEffect.Target)
+					onSpecialOrSwingProc.Cast(sim, result.Target)
 				}
 			}
 		},

--- a/sim/paladin/sov.go
+++ b/sim/paladin/sov.go
@@ -140,34 +140,34 @@ func (paladin *Paladin) registerSealOfVengeanceSpellAndAura() {
 			}
 		},
 
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			// Don't proc on misses or our own procs.
-			dot := paladin.SealOfVengeanceDots[spellEffect.Target.Index]
+			dot := paladin.SealOfVengeanceDots[result.Target.Index]
 
-			if !spellEffect.Landed() || spell.SpellID == onSwingProc.SpellID || spell.SpellID == onJudgementProc.SpellID || spell.SpellID == onSpecialOrSwingProc.SpellID {
+			if !result.Landed() || spell.SpellID == onSwingProc.SpellID || spell.SpellID == onJudgementProc.SpellID || spell.SpellID == onSpecialOrSwingProc.SpellID {
 				return
 			}
 
 			// Differ between judgements and other melee abilities.
 			if spell.Flags.Matches(SpellFlagPrimaryJudgement) {
-				onJudgementProc.Cast(sim, spellEffect.Target)
+				onJudgementProc.Cast(sim, result.Target)
 				if paladin.Talents.JudgementsOfTheJust > 0 {
 					// Special JoJ talent behavior, procs swing seal on judgements
 					if dot.GetStacks() > 0 {
-						onSpecialOrSwingProc.Cast(sim, spellEffect.Target)
+						onSpecialOrSwingProc.Cast(sim, result.Target)
 					}
 				}
 			} else {
 				if spell.IsMelee() {
 					if dot.GetStacks() > 0 {
-						onSpecialOrSwingProc.Cast(sim, spellEffect.Target)
+						onSpecialOrSwingProc.Cast(sim, result.Target)
 					}
 				}
 			}
 
 			// Only white hits and HotR can trigger this. (SoV dot)
 			if spell.ProcMask.Matches(core.ProcMaskMeleeWhiteHit) || spell.SpellID == paladin.HammerOfTheRighteous.SpellID {
-				onSwingProc.Cast(sim, spellEffect.Target)
+				onSwingProc.Cast(sim, result.Target)
 			}
 
 		},

--- a/sim/paladin/spiritual_attunement.go
+++ b/sim/paladin/spiritual_attunement.go
@@ -20,16 +20,16 @@ func (paladin *Paladin) registerSpiritualAttunement() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			// We assume we were instantly healed for the damage.
-			if spellEffect.Damage > 0 {
-				paladin.AddMana(sim, spellEffect.Damage*SpiritualAttunementScalar, paladin.SpiritualAttunementMetrics, false)
+			if result.Damage > 0 {
+				paladin.AddMana(sim, result.Damage*SpiritualAttunementScalar, paladin.SpiritualAttunementMetrics, false)
 			}
 		},
-		OnPeriodicDamageTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnPeriodicDamageTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			// We assume we were instantly healed for the damage.
-			if spellEffect.Damage > 0 {
-				paladin.AddMana(sim, spellEffect.Damage*SpiritualAttunementScalar, paladin.SpiritualAttunementMetrics, false)
+			if result.Damage > 0 {
+				paladin.AddMana(sim, result.Damage*SpiritualAttunementScalar, paladin.SpiritualAttunementMetrics, false)
 			}
 		},
 	})

--- a/sim/paladin/talents.go
+++ b/sim/paladin/talents.go
@@ -153,8 +153,8 @@ func (paladin *Paladin) applyRedoubt() {
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			paladin.AddStatDynamic(sim, stats.Block, -bonusBlockRating)
 		},
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Outcome.Matches(core.OutcomeBlock) {
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Outcome.Matches(core.OutcomeBlock) {
 				aura.RemoveStack(sim)
 			}
 		},
@@ -166,8 +166,8 @@ func (paladin *Paladin) applyRedoubt() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Landed() && spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Landed() && spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
 				if sim.RandomFloat("Redoubt") < 0.1 {
 					procAura.Activate(sim)
 					procAura.SetStacks(sim, 5)
@@ -204,9 +204,9 @@ func (paladin *Paladin) applyReckoning() {
 				ApplyEffects:     paladin.AutoAttacks.MHConfig.ApplyEffects,
 			})
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell == paladin.AutoAttacks.MHAuto {
-				reckoningSpell.Cast(sim, spellEffect.Target)
+				reckoningSpell.Cast(sim, result.Target)
 			}
 		},
 	})
@@ -217,8 +217,8 @@ func (paladin *Paladin) applyReckoning() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Landed() && sim.RandomFloat("Reckoning") < procChance {
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Landed() && sim.RandomFloat("Reckoning") < procChance {
 				procAura.Activate(sim)
 				procAura.SetStacks(sim, 4)
 			}
@@ -252,7 +252,7 @@ func (paladin *Paladin) applyArdentDefender() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if aura.Unit.CurrentHealthPercent() < 0.35 {
 				procAura.Activate(sim)
 			}
@@ -346,8 +346,8 @@ func (paladin *Paladin) applyVengeance() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Outcome.Matches(core.OutcomeCrit) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Outcome.Matches(core.OutcomeCrit) {
 				procAura.Activate(sim)
 				procAura.AddStack(sim)
 			}
@@ -366,11 +366,11 @@ func (paladin *Paladin) applyHeartOfTheCrusader() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !spell.Flags.Matches(SpellFlagSecondaryJudgement) {
 				return
 			}
-			debuffAura := core.HeartoftheCrusaderDebuff(spellEffect.Target, float64(paladin.Talents.HeartOfTheCrusader))
+			debuffAura := core.HeartoftheCrusaderDebuff(result.Target, float64(paladin.Talents.HeartOfTheCrusader))
 			debuffAura.Activate(sim)
 		},
 	})
@@ -393,12 +393,12 @@ func (paladin *Paladin) applyArtOfWar() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !spell.IsMelee() && !spell.Flags.Matches(SpellFlagSecondaryJudgement) {
 				return
 			}
 
-			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
 
@@ -428,8 +428,8 @@ func (paladin *Paladin) applyJudgmentsOfTheWise() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spell.Flags.Matches(SpellFlagSecondaryJudgement) || !spellEffect.Landed() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !spell.Flags.Matches(SpellFlagSecondaryJudgement) || !result.Landed() {
 				return
 			}
 
@@ -504,20 +504,20 @@ func (paladin *Paladin) applyRighteousVengeance() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.DidCrit() || !spellEffect.Landed() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.DidCrit() || !result.Landed() {
 				return
 			}
 
 			if spell.SpellID == paladin.CrusaderStrike.SpellID || spell.SpellID == paladin.DivineStorm.SpellID || spell.Flags.Matches(SpellFlagSecondaryJudgement) {
-				paladin.RighteousVengeancePools[spellEffect.Target.Index] += spellEffect.Damage * (0.10 * float64(paladin.Talents.RighteousVengeance))
-				paladin.RighteousVengeanceDamage[spellEffect.Target.Index] = paladin.RighteousVengeancePools[spellEffect.Target.Index] / 4
+				paladin.RighteousVengeancePools[result.Target.Index] += result.Damage * (0.10 * float64(paladin.Talents.RighteousVengeance))
+				paladin.RighteousVengeanceDamage[result.Target.Index] = paladin.RighteousVengeancePools[result.Target.Index] / 4
 
-				if !paladin.RighteousVengeanceDots[spellEffect.Target.Index].IsActive() {
-					paladin.RighteousVengeanceDots[spellEffect.Target.Index].Apply(sim)
+				if !paladin.RighteousVengeanceDots[result.Target.Index].IsActive() {
+					paladin.RighteousVengeanceDots[result.Target.Index].Apply(sim)
 				}
 
-				paladin.RighteousVengeanceDots[spellEffect.Target.Index].Refresh(sim)
+				paladin.RighteousVengeanceDots[result.Target.Index].Refresh(sim)
 			}
 		},
 	})
@@ -550,8 +550,8 @@ func (paladin *Paladin) applyGuardedByTheLight() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() {
 				return
 			}
 

--- a/sim/priest/items.go
+++ b/sim/priest/items.go
@@ -191,13 +191,13 @@ var ItemSetCrimsonAcolytesRaiment = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnHealDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+				OnHealDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 					if spell != priest.FlashHeal || sim.RandomFloat("Crimson Acolytes Raiment 2pc") >= 0.33 {
 						return
 					}
 
-					curAmount = spellEffect.Damage
-					hot := hots[spellEffect.Target.UnitIndex]
+					curAmount = result.Damage
+					hot := hots[result.Target.UnitIndex]
 					hot.Apply(sim)
 				},
 			})
@@ -248,7 +248,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell != priest.ShadowWordPain {
 					return
 				}

--- a/sim/priest/prayer_of_mending.go
+++ b/sim/priest/prayer_of_mending.go
@@ -110,8 +110,8 @@ func (priest *Priest) makePrayerOfMendingAura(target *core.Unit) *core.Aura {
 				})
 			}
 		},
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !autoProc && spellEffect.Damage > 0 {
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !autoProc && result.Damage > 0 {
 				priest.ProcPrayerOfMending(sim, aura.Unit, priest.PrayerOfMending)
 			}
 		},

--- a/sim/priest/priest.go
+++ b/sim/priest/priest.go
@@ -68,7 +68,7 @@ type Priest struct {
 	PWSShields    []*core.Shield
 	WeakenedSouls []*core.Aura
 
-	ProcPrayerOfMending core.ApplySpellEffects
+	ProcPrayerOfMending core.ApplySpellResults
 
 	// set bonus cache
 	// The mana cost of your Mind Blast is reduced by 10%.

--- a/sim/priest/shadow_effects.go
+++ b/sim/priest/shadow_effects.go
@@ -34,18 +34,18 @@ func (priest *Priest) ApplyShadowOnHitEffects() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		//OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) { // Needs to be replaced by replensishment (when VT is active MB now gives mana return)
-		//	priest.applySWforMF(sim, spellEffect.Damage)
+		//OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) { // Needs to be replaced by replensishment (when VT is active MB now gives mana return)
+		//	priest.applySWforMF(sim, result.Damage)
 		//	},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() {
 				return
 			}
-			//priest.ApplyShadowWeaving(sim, spellEffect.Target)
-			// priest.ApplyVampiricTouchManaReturn(sim, spellEffect.Damage) // Needs to be replaced by replensishment (when VT is active MB now gives mana return)
+			//priest.ApplyShadowWeaving(sim, result.Target)
+			// priest.ApplyVampiricTouchManaReturn(sim, result.Damage) // Needs to be replaced by replensishment (when VT is active MB now gives mana return)
 
 			if spell == priest.ShadowWordPain || spell == priest.VampiricTouch || spell.ActionID.SpellID == priest.MindFlay[1].ActionID.SpellID {
-				priest.ApplyMisery(sim, spellEffect.Target)
+				priest.ApplyMisery(sim, result.Target)
 			}
 		},
 	})

--- a/sim/priest/talents.go
+++ b/sim/priest/talents.go
@@ -110,10 +110,10 @@ func (priest *Priest) applyDivineAegis() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnHealDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Outcome.Matches(core.OutcomeCrit) {
-				shield := shields[spellEffect.Target.UnitIndex]
-				shield.Apply(sim, spellEffect.Damage*multiplier)
+		OnHealDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Outcome.Matches(core.OutcomeCrit) {
+				shield := shields[result.Target.UnitIndex]
+				shield.Apply(sim, result.Damage*multiplier)
 			}
 		},
 	})
@@ -149,10 +149,10 @@ func (priest *Priest) applyGrace() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnHealDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnHealDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell == priest.FlashHeal || spell == priest.GreaterHeal || spell == priest.PenanceHeal {
 				if sim.Proc(procChance, "Grace") {
-					aura := auras[spellEffect.Target.UnitIndex]
+					aura := auras[result.Target.UnitIndex]
 					aura.Activate(sim)
 					aura.AddStack(sim)
 				}
@@ -215,7 +215,7 @@ func (priest *Priest) applyInspiration() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnHealDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnHealDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell == priest.FlashHeal ||
 				spell == priest.GreaterHeal ||
 				spell == priest.BindingHeal ||
@@ -223,7 +223,7 @@ func (priest *Priest) applyInspiration() {
 				spell == priest.PrayerOfHealing ||
 				spell == priest.CircleOfHealing ||
 				spell == priest.PenanceHeal {
-				auras[spellEffect.Target.UnitIndex].Activate(sim)
+				auras[result.Target.UnitIndex].Activate(sim)
 			}
 		},
 	})
@@ -254,8 +254,8 @@ func (priest *Priest) applyHolyConcentration() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnHealDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.DidCrit() &&
+		OnHealDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.DidCrit() &&
 				(spell == priest.FlashHeal || spell == priest.GreaterHeal || spell == priest.EmpoweredRenew) {
 				procAura.Activate(sim)
 			}
@@ -329,7 +329,7 @@ func (priest *Priest) applySurgeOfLight() {
 				priest.FlashHeal.BonusCritRating += 100 * core.CritRatingPerCritChance
 			}
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell == priest.Smite || (priest.FlashHeal != nil && spell == priest.FlashHeal) {
 				aura.Deactivate(sim)
 			}
@@ -348,8 +348,8 @@ func (priest *Priest) applySurgeOfLight() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if icd.IsReady(sim) && spellEffect.Outcome.Matches(core.OutcomeCrit) && sim.RandomFloat("SurgeOfLight") < procChance {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if icd.IsReady(sim) && result.Outcome.Matches(core.OutcomeCrit) && sim.RandomFloat("SurgeOfLight") < procChance {
 				icd.Use(sim)
 				priest.SurgeOfLightProcAura.Activate(sim)
 			}
@@ -425,7 +425,7 @@ func (priest *Priest) registerInnerFocus() {
 			priest.AddStatDynamic(sim, stats.SpellCrit, -25*core.CritRatingPerCritChance)
 			priest.PseudoStats.NoCost = false
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			// Remove the buff and put skill on CD
 			aura.Deactivate(sim)
 			priest.InnerFocus.CD.Use(sim)

--- a/sim/rogue/fan_of_knives.go
+++ b/sim/rogue/fan_of_knives.go
@@ -40,7 +40,7 @@ func (rogue *Rogue) registerFanOfKnives() {
 	baseCost := 50.0
 	mhSpell := rogue.makeFanOfKnivesWeaponHitSpell(true)
 	ohSpell := rogue.makeFanOfKnivesWeaponHitSpell(false)
-	results := make([]*core.SpellEffect, len(rogue.Env.Encounter.Targets))
+	results := make([]*core.SpellResult, len(rogue.Env.Encounter.Targets))
 
 	rogue.FanOfKnives = rogue.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: FanOfKnivesSpellID},

--- a/sim/rogue/hack_and_slash.go
+++ b/sim/rogue/hack_and_slash.go
@@ -36,8 +36,8 @@ func (rogue *Rogue) registerHackAndSlash(mask core.ProcMask) {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() {
 				return
 			}
 			if !spell.ProcMask.Matches(mask) {
@@ -50,7 +50,7 @@ func (rogue *Rogue) registerHackAndSlash(mask core.ProcMask) {
 				return
 			}
 			icd.Use(sim)
-			hackAndSlashSpell.Cast(sim, spellEffect.Target)
+			hackAndSlashSpell.Cast(sim, result.Target)
 		},
 	})
 }

--- a/sim/rogue/hemorrhage.go
+++ b/sim/rogue/hemorrhage.go
@@ -26,11 +26,11 @@ func (rogue *Rogue) registerHemorrhageSpell() {
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			target.PseudoStats.BonusPhysicalDamageTaken -= bonusDamage
 		},
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell.SpellSchool != core.SpellSchoolPhysical {
 				return
 			}
-			if !spellEffect.Landed() || spellEffect.Damage == 0 {
+			if !result.Landed() || result.Damage == 0 {
 				return
 			}
 

--- a/sim/rogue/items.go
+++ b/sim/rogue/items.go
@@ -39,7 +39,7 @@ var ItemSetVanCleefs = core.NewItemSet(core.ItemSet{
 				OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 					rogue.PseudoStats.CostReduction -= 40
 				},
-				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, _ *core.SpellEffect) {
+				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, _ *core.SpellResult) {
 					if !spell.ProcMask.Matches(core.ProcMaskMeleeSpecial) {
 						return
 					}
@@ -63,8 +63,8 @@ var ItemSetVanCleefs = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-					if !spellEffect.Landed() {
+				OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+					if !result.Landed() {
 						return
 					}
 					if !spell.ActionID.IsSpellAction(RuptureSpellID) {
@@ -120,8 +120,8 @@ var ItemSetShadowblades = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-					if !spellEffect.Landed() {
+				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+					if !result.Landed() {
 						return
 					}
 					if !spell.Flags.Matches(SpellFlagFinisher) {
@@ -182,8 +182,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() {
 					return
 				}
 
@@ -234,7 +234,7 @@ func init() {
 					}
 				}
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if !spell.Flags.Matches(SpellFlagFinisher) {
 					return
 				}

--- a/sim/rogue/poisons.go
+++ b/sim/rogue/poisons.go
@@ -118,7 +118,7 @@ func (rogue *Rogue) registerDeadlyPoisonSpell() {
 
 		if rogue.HasSetBonus(ItemSetTerrorblade, 2) {
 			metrics := rogue.NewEnergyMetrics(core.ActionID{SpellID: 64914})
-			dot.OnPeriodicDamageDealt = func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			dot.OnPeriodicDamageDealt = func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				rogue.AddEnergy(sim, 1, metrics)
 			}
 		}
@@ -127,9 +127,9 @@ func (rogue *Rogue) registerDeadlyPoisonSpell() {
 	}
 }
 
-func (rogue *Rogue) procDeadlyPoison(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+func (rogue *Rogue) procDeadlyPoison(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 	rogue.lastDeadlyPoisonProcMask = spell.ProcMask
-	rogue.DeadlyPoison.Cast(sim, spellEffect.Target)
+	rogue.DeadlyPoison.Cast(sim, result.Target)
 }
 
 func (rogue *Rogue) applyDeadlyPoison() {
@@ -146,14 +146,14 @@ func (rogue *Rogue) applyDeadlyPoison() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() || !spell.ProcMask.Matches(procMask) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() || !spell.ProcMask.Matches(procMask) {
 				return
 			}
 			if sim.RandomFloat("Deadly Poison") > rogue.GetDeadlyPoisonProcChance(procMask) {
 				return
 			}
-			rogue.procDeadlyPoison(sim, spell, spellEffect)
+			rogue.procDeadlyPoison(sim, spell, result)
 		},
 	})
 }
@@ -176,12 +176,12 @@ func (rogue *Rogue) applyWoundPoison() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() || !spell.ProcMask.Matches(procMask) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() || !spell.ProcMask.Matches(procMask) {
 				return
 			}
 			if rogue.woundPoisonPPMM.Proc(sim, spell.ProcMask, "Wound Poison") {
-				rogue.WoundPoison[NormalProc].Cast(sim, spellEffect.Target)
+				rogue.WoundPoison[NormalProc].Cast(sim, result.Target)
 			}
 		},
 	})
@@ -233,7 +233,7 @@ func (rogue *Rogue) makeWoundPoison(procSource PoisonProcSource) *core.Spell {
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := 231 + 0.04*spell.MeleeAttackPower()
 
-			var result *core.SpellEffect
+			var result *core.SpellResult
 			if isShivProc {
 				result = spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMagicHit)
 			} else {
@@ -327,12 +327,12 @@ func (rogue *Rogue) applyInstantPoison() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() || !spell.ProcMask.Matches(procMask) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() || !spell.ProcMask.Matches(procMask) {
 				return
 			}
 			if rogue.instantPoisonPPMM.Proc(sim, spell.ProcMask, "Instant Poison") {
-				rogue.InstantPoison[NormalProc].Cast(sim, spellEffect.Target)
+				rogue.InstantPoison[NormalProc].Cast(sim, result.Target)
 			}
 		},
 	})

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -170,7 +170,7 @@ func (rogue *Rogue) registerColdBloodCD() {
 				spell.BonusCritRating -= 100 * core.CritRatingPerCritChance
 			}
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			for _, affectedSpell := range affectedSpells {
 				if spell == affectedSpell {
 					aura.Deactivate(sim)
@@ -214,12 +214,12 @@ func (rogue *Rogue) applySealFate() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !spell.Flags.Matches(SpellFlagBuilder) {
 				return
 			}
 
-			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
 
@@ -290,8 +290,8 @@ func (rogue *Rogue) applyCombatPotency() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() {
 				return
 			}
 
@@ -328,8 +328,8 @@ func (rogue *Rogue) applyFocusedAttacks() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spell.ProcMask.Matches(core.ProcMaskMelee) || !spellEffect.DidCrit() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !spell.ProcMask.Matches(core.ProcMaskMelee) || !result.DidCrit() {
 				return
 			}
 			// Fan of Knives OH hits do not trigger focused attacks
@@ -381,11 +381,11 @@ func (rogue *Rogue) registerBladeFlurryCD() {
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			rogue.MultiplyMeleeSpeed(sim, inverseHasteBonus)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if sim.GetNumTargets() < 2 {
 				return
 			}
-			if spellEffect.Damage == 0 || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			if result.Damage == 0 || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 				return
 			}
 			// Fan of Knives off-hand hits are not cloned
@@ -394,10 +394,10 @@ func (rogue *Rogue) registerBladeFlurryCD() {
 			}
 
 			// Undo armor reduction to get the raw damage value.
-			curDmg = spellEffect.Damage / spellEffect.ResistanceMultiplier
+			curDmg = result.Damage / result.ResistanceMultiplier
 
-			bfHit.Cast(sim, rogue.Env.NextTargetUnit(spellEffect.Target))
-			bfHit.SpellMetrics[spellEffect.Target.UnitIndex].Casts--
+			bfHit.Cast(sim, rogue.Env.NextTargetUnit(result.Target))
+			bfHit.SpellMetrics[result.Target.UnitIndex].Casts--
 		},
 	})
 

--- a/sim/shaman/items.go
+++ b/sim/shaman/items.go
@@ -205,8 +205,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() {
 					return
 				}
 
@@ -251,8 +251,8 @@ func registerSpellPVPTotem(name string, id int32, sp float64, seconds float64) {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() {
 					return
 				}
 

--- a/sim/shaman/items_wotlk.go
+++ b/sim/shaman/items_wotlk.go
@@ -59,7 +59,7 @@ var ItemSetFrostWitchRegalia = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 					if spell == shaman.LavaBurst && shaman.FlameShockDot.IsActive() { // Doesn't have to hit from tooltip
 						// Modify dot to last 6 more seconds than it has left, and refresh aura
 						shaman.FlameShockDot.Duration = shaman.FlameShockDot.RemainingDuration(sim) + time.Second*6
@@ -142,8 +142,8 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() { //TODO: verify it needs to land
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() { //TODO: verify it needs to land
 					return
 				}
 				if spell == shaman.Stormstrike {
@@ -176,7 +176,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell.ActionID.SpellID == FlameshockID {
 					procAura.Activate(sim)
 					procAura.AddStack(sim)

--- a/sim/shaman/lightning_shield.go
+++ b/sim/shaman/lightning_shield.go
@@ -56,18 +56,18 @@ func (shaman *Shaman) registerLightningShieldSpell() {
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			aura.SetStacks(sim, 3+(2*shaman.Talents.StaticShock))
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spell.ProcMask.Matches(core.ProcMaskMelee) || !spellEffect.Landed() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !spell.ProcMask.Matches(core.ProcMaskMelee) || !result.Landed() {
 				return
 			}
 			if sim.RandomFloat("Static Shock") > procChance {
 				return
 			}
-			procSpell.Cast(sim, spellEffect.Target)
+			procSpell.Cast(sim, result.Target)
 			aura.RemoveStack(sim)
 		},
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spell.ProcMask.Matches(core.ProcMaskMelee) || !spellEffect.Landed() {
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !spell.ProcMask.Matches(core.ProcMaskMelee) || !result.Landed() {
 				return
 			}
 

--- a/sim/shaman/shamanistic_rage.go
+++ b/sim/shaman/shamanistic_rage.go
@@ -36,9 +36,9 @@ func (shaman *Shaman) registerShamanisticRageCD() {
 				aura.Unit.PseudoStats.DamageDealtMultiplier /= 1.12
 			}
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			// proc mask: 20
-			if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 				return
 			}
 			if !ppmm.Proc(sim, spell.ProcMask, "shamanistic rage") {

--- a/sim/shaman/stormstrike.go
+++ b/sim/shaman/stormstrike.go
@@ -26,14 +26,14 @@ func (shaman *Shaman) StormstrikeDebuffAura(target *core.Unit) *core.Aura {
 			shaman.AttackTables[aura.Unit.UnitIndex].NatureDamageTakenMultiplier /= core.TernaryFloat64(shaman.HasMajorGlyph(proto.ShamanMajorGlyph_GlyphOfStormstrike), 1.28, 1.2)
 
 		},
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell.Unit != &shaman.Unit {
 				return
 			}
 			if spell.SpellSchool != core.SpellSchoolNature {
 				return
 			}
-			if !spellEffect.Landed() || spellEffect.Damage == 0 {
+			if !result.Landed() || result.Damage == 0 {
 				return
 			}
 			aura.RemoveStack(sim)

--- a/sim/shaman/talents.go
+++ b/sim/shaman/talents.go
@@ -102,11 +102,11 @@ func (shaman *Shaman) applyElementalFocus() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !spell.Flags.Matches(SpellFlagShock | SpellFlagFocusable) {
 				return
 			}
-			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
 			shaman.ClearcastingAura.Activate(sim)
@@ -143,11 +143,11 @@ func (shaman *Shaman) applyElementalDevastation() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !spell.ProcMask.Matches(core.ProcMaskSpellDamage) {
 				return
 			}
-			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
 			procAura.Activate(sim)
@@ -187,7 +187,7 @@ func (shaman *Shaman) registerElementalMasteryCD() {
 		Label:    "Elemental Mastery",
 		ActionID: eleMasterActionID,
 		Duration: core.NeverExpires,
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !spell.Flags.Matches(SpellFlagElectric) {
 				// Only LB / CL / LvB use EM
 				if spell != shaman.LavaBurst {
@@ -228,7 +228,7 @@ func (shaman *Shaman) registerElementalMasteryCD() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if (spell == shaman.LightningBolt || spell == shaman.ChainLightning) && !eleMastSpell.CD.IsReady(sim) {
 					*eleMastSpell.CD.Timer = core.Timer(time.Duration(*eleMastSpell.CD.Timer) - time.Second*2)
 					shaman.UpdateMajorCooldowns() // this could get expensive because it will be called all the time.
@@ -324,12 +324,12 @@ func (shaman *Shaman) applyFlurry() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !spell.ProcMask.Matches(core.ProcMaskMelee) {
 				return
 			}
 
-			if spellEffect.Outcome.Matches(core.OutcomeCrit) {
+			if result.Outcome.Matches(core.OutcomeCrit) {
 				procAura.Activate(sim)
 				procAura.SetStacks(sim, 3)
 				icd.Reset() // the "charge protection" ICD isn't up yet
@@ -386,7 +386,7 @@ func (shaman *Shaman) applyMaelstromWeapon() {
 				}
 			}
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !spell.Flags.Matches(SpellFlagElectric) {
 				return
 			}
@@ -404,8 +404,8 @@ func (shaman *Shaman) applyMaelstromWeapon() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spell.ProcMask.Matches(core.ProcMaskMelee) || !spellEffect.Landed() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !spell.ProcMask.Matches(core.ProcMaskMelee) || !result.Landed() {
 				return
 			}
 			if !ppmm.Proc(sim, spell.ProcMask, "Maelstrom Weapon") {

--- a/sim/shaman/weapon_imbues.go
+++ b/sim/shaman/weapon_imbues.go
@@ -82,9 +82,9 @@ func (shaman *Shaman) ApplyWindfuryImbue(mh bool, oh bool) {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			// ProcMask: 20
-			if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 				return
 			}
 
@@ -101,9 +101,9 @@ func (shaman *Shaman) ApplyWindfuryImbue(mh bool, oh bool) {
 			icd.Use(sim)
 
 			if isMHHit {
-				mhSpell.Cast(sim, spellEffect.Target)
+				mhSpell.Cast(sim, result.Target)
 			} else {
-				ohSpell.Cast(sim, spellEffect.Target)
+				ohSpell.Cast(sim, result.Target)
 			}
 		},
 	})
@@ -171,8 +171,8 @@ func (shaman *Shaman) ApplyFlametongueImbue(mh bool, oh bool) {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 				return
 			}
 
@@ -186,9 +186,9 @@ func (shaman *Shaman) ApplyFlametongueImbue(mh bool, oh bool) {
 			ftIcd.Use(sim)
 
 			if isMHHit {
-				mhSpell.Cast(sim, spellEffect.Target)
+				mhSpell.Cast(sim, result.Target)
 			} else {
-				ohSpell.Cast(sim, spellEffect.Target)
+				ohSpell.Cast(sim, result.Target)
 			}
 		},
 	})
@@ -256,8 +256,8 @@ func (shaman *Shaman) ApplyFlametongueDownrankImbue(mh bool, oh bool) {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 				return
 			}
 
@@ -271,9 +271,9 @@ func (shaman *Shaman) ApplyFlametongueDownrankImbue(mh bool, oh bool) {
 			ftDownrankIcd.Use(sim)
 
 			if isMHHit {
-				mhSpell.Cast(sim, spellEffect.Target)
+				mhSpell.Cast(sim, result.Target)
 			} else {
-				ohSpell.Cast(sim, spellEffect.Target)
+				ohSpell.Cast(sim, result.Target)
 			}
 		},
 	})
@@ -284,7 +284,7 @@ func (shaman *Shaman) FrostbrandDebuffAura(target *core.Unit) *core.Aura {
 		Label:    "Frostbrand Attack-" + shaman.Label,
 		ActionID: core.ActionID{SpellID: 58799},
 		Duration: time.Second * 8,
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell.Unit != &shaman.Unit {
 				return
 			}
@@ -331,8 +331,8 @@ func (shaman *Shaman) ApplyFrostbrandImbue(mh bool, oh bool) {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() || !spell.ProcMask.Matches(procMask) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() || !spell.ProcMask.Matches(procMask) {
 				return
 			}
 
@@ -341,9 +341,9 @@ func (shaman *Shaman) ApplyFrostbrandImbue(mh bool, oh bool) {
 			}
 
 			if spell.IsMH() {
-				mhSpell.Cast(sim, spellEffect.Target)
+				mhSpell.Cast(sim, result.Target)
 			} else {
-				ohSpell.Cast(sim, spellEffect.Target)
+				ohSpell.Cast(sim, result.Target)
 			}
 			shaman.FrostbrandDebuffAura(shaman.CurrentTarget).Activate(sim)
 		},

--- a/sim/warlock/corruption.go
+++ b/sim/warlock/corruption.go
@@ -76,9 +76,9 @@ func (warlock *Warlock) registerCorruptionSpell() {
 	})
 }
 
-func applyDotOnLanded(dot **core.Dot) func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-	return func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-		if spellEffect.Landed() {
+func applyDotOnLanded(dot **core.Dot) func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+	return func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+		if result.Landed() {
 			(*dot).Apply(sim)
 		}
 	}

--- a/sim/warlock/curses.go
+++ b/sim/warlock/curses.go
@@ -231,9 +231,9 @@ func (warlock *Warlock) registerCurseOfDoomSpell() {
 	})
 }
 
-func applyAuraOnLanded(aura *core.Aura) func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-	return func(sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-		if spellEffect.Landed() {
+func applyAuraOnLanded(aura *core.Aura) func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+	return func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+		if result.Landed() {
 			aura.Activate(sim)
 		}
 	}

--- a/sim/warlock/items.go
+++ b/sim/warlock/items.go
@@ -54,7 +54,7 @@ var ItemSetPlagueheartGarb = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+				OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 					if spell == warlock.Corruption || spell == warlock.Immolate {
 						if sim.RandomFloat("2pT7") < 0.15 {
 							DemonicSoulAura.Activate(sim)
@@ -171,7 +171,7 @@ var ItemSetDarkCovensRegalia = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+				OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 					if spell == warlock.UnstableAffliction || spell == warlock.ImmolateDot.Spell {
 						if sim.RandomFloat("4pT10") < 0.15 {
 							DeviousMindsAura.Activate(sim)
@@ -255,7 +255,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell == warlock.Corruption && sim.RandomFloat("Ashtongue Talisman of Insight") < 0.2 {
 					procAura.Activate(sim)
 				}

--- a/sim/warlock/pet.go
+++ b/sim/warlock/pet.go
@@ -150,8 +150,8 @@ func (warlock *Warlock) NewWarlockPet() *WarlockPet {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 					return
 				}
 				DemonicFrenzyAura.Activate(sim)

--- a/sim/warlock/seed.go
+++ b/sim/warlock/seed.go
@@ -99,17 +99,17 @@ func (warlock *Warlock) makeSeed(targetIdx int, numTargets int) {
 		Aura: target.RegisterAura(core.Aura{
 			Label:    "Seed-" + strconv.Itoa(int(warlock.Index)),
 			ActionID: actionID,
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() {
 					return
 				}
 				if spell.ActionID.SpellID == actionID.SpellID {
 					return // Seed can't pop seed.
 				}
-				trySeedPop(sim, spellEffect.Damage)
+				trySeedPop(sim, result.Damage)
 			},
-			OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				trySeedPop(sim, spellEffect.Damage)
+			OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				trySeedPop(sim, result.Damage)
 			},
 			OnGain: func(aura *core.Aura, sim *core.Simulation) {
 				seedDmgTracker = 0

--- a/sim/warlock/talents.go
+++ b/sim/warlock/talents.go
@@ -180,8 +180,8 @@ func (warlock *Warlock) setupEmpoweredImp() {
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			warlock.AddStatDynamic(sim, stats.SpellCrit, -100*core.CritRatingPerCritChance)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Outcome.Matches(core.OutcomeCrit) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Outcome.Matches(core.OutcomeCrit) {
 				aura.Deactivate(sim)
 			}
 		},
@@ -193,8 +193,8 @@ func (warlock *Warlock) setupEmpoweredImp() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Outcome.Matches(core.OutcomeCrit) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Outcome.Matches(core.OutcomeCrit) {
 				warlock.EmpoweredImpAura.Activate(sim)
 				warlock.EmpoweredImpAura.Refresh(sim)
 			}
@@ -212,7 +212,7 @@ func (warlock *Warlock) setupDecimation() {
 	decimation := warlock.RegisterAura(core.Aura{
 		Label:    "Decimation Talent Hidden Aura",
 		Duration: core.NeverExpires,
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell == warlock.ShadowBolt || spell == warlock.Incinerate || spell == warlock.SoulFire {
 				warlock.DecimationAura.Activate(sim)
 				warlock.DecimationAura.Refresh(sim)
@@ -252,8 +252,8 @@ func (warlock *Warlock) setupPyroclasm() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spell == warlock.Conflagrate && spellEffect.Outcome.Matches(core.OutcomeCrit) { // || spell == warlock.SearingPain
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if spell == warlock.Conflagrate && result.Outcome.Matches(core.OutcomeCrit) { // || spell == warlock.SearingPain
 				warlock.PyroclasmAura.Activate(sim)
 			}
 		},
@@ -283,7 +283,7 @@ func (warlock *Warlock) setupEradication() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell == warlock.Corruption {
 				if sim.RandomFloat("Eradication") < 0.06 {
 					warlock.EradicationAura.Activate(sim)
@@ -317,7 +317,7 @@ func (warlock *Warlock) setupShadowEmbrace() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell == warlock.ShadowBolt || spell == warlock.Haunt {
 				if !ShadowEmbraceAura.IsActive() {
 					ShadowEmbraceAura.Activate(sim)
@@ -353,7 +353,7 @@ func (warlock *Warlock) setupNightfall() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell == warlock.Corruption { // TODO: also works on drain life...
 				if sim.RandomFloat("Nightfall") < nightfallProcChance {
 					warlock.NightfallProcAura.Activate(sim)
@@ -402,7 +402,7 @@ func (warlock *Warlock) setupMoltenCore() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell == warlock.Corruption {
 				if sim.RandomFloat("Molten Core") < 0.04*float64(warlock.Talents.MoltenCore) {
 					warlock.MoltenCoreAura.Activate(sim)
@@ -433,7 +433,7 @@ func (warlock *Warlock) setupBackdraft() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell == warlock.Conflagrate {
 				warlock.BackdraftAura.Activate(sim)
 				warlock.BackdraftAura.SetStacks(sim, 3)
@@ -459,8 +459,8 @@ func (warlock *Warlock) setupEverlastingAffliction() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() {
 				return
 			}
 			if spell == warlock.ShadowBolt || spell == warlock.Haunt || spell == warlock.DrainSoul { // TODO: also works on drain life...
@@ -494,7 +494,7 @@ func (warlock *Warlock) setupImprovedSoulLeech() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell == warlock.Conflagrate || spell == warlock.ShadowBolt || spell == warlock.ChaosBolt || spell == warlock.SoulFire || spell == warlock.Incinerate {
 				if sim.RandomFloat("SoulLeech") < soulLeechProcChance {
 					warlock.AddMana(sim, warlock.MaxMana()*float64(warlock.Talents.ImprovedSoulLeech)/100, improvedSoulLeechManaMetric, true)
@@ -547,8 +547,8 @@ func (warlock *Warlock) setupDemonicPact() {
 				}
 			}
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Outcome.Matches(core.OutcomeCrit) && icd.IsReady(sim) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Outcome.Matches(core.OutcomeCrit) && icd.IsReady(sim) {
 				icd.Use(sim)
 				newSPBonus := warlock.GetStat(stats.SpellPower) * demonicPactMultiplier
 				for i, party := range warlock.Party.Raid.Parties {

--- a/sim/warrior/deep_wounds.go
+++ b/sim/warrior/deep_wounds.go
@@ -30,14 +30,14 @@ func (warrior *Warrior) applyDeepWounds() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell.ProcMask.Matches(core.ProcMaskEmpty) || !spell.SpellSchool.Matches(core.SpellSchoolPhysical) {
 				return
 			}
-			if spellEffect.Outcome.Matches(core.OutcomeCrit) {
+			if result.Outcome.Matches(core.OutcomeCrit) {
 				warrior.DeepWounds.Cast(sim, nil)
-				warrior.procDeepWounds(sim, spellEffect.Target, spell.IsMH())
-				warrior.procBloodFrenzy(sim, spellEffect, time.Second*6)
+				warrior.procDeepWounds(sim, result.Target, spell.IsMH())
+				warrior.procBloodFrenzy(sim, result, time.Second*6)
 			}
 		},
 	})

--- a/sim/warrior/devastate.go
+++ b/sim/warrior/devastate.go
@@ -22,8 +22,8 @@ func (warrior *Warrior) registerDevastateSpell() {
 
 		core.MakePermanent(warrior.GetOrRegisterAura(core.Aura{
 			Label: "Sword And Board Trigger",
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() {
 					return
 				}
 
@@ -69,7 +69,7 @@ func (warrior *Warrior) registerDevastateSpell() {
 		CritMultiplier:   warrior.critMultiplier(mh),
 		ThreatMultiplier: 1,
 		FlatThreatBonus:  flatThreatBonus,
-		DynamicThreatBonus: func(spellEffect *core.SpellEffect, spell *core.Spell) float64 {
+		DynamicThreatBonus: func(result *core.SpellResult, spell *core.Spell) float64 {
 			return dynaThreatBonus * spell.MeleeAttackPower()
 		},
 

--- a/sim/warrior/heroic_strike_cleave.go
+++ b/sim/warrior/heroic_strike_cleave.go
@@ -75,7 +75,7 @@ func (warrior *Warrior) registerCleaveSpell() {
 
 	targets := core.TernaryInt32(warrior.HasMajorGlyph(proto.WarriorMajorGlyph_GlyphOfCleaving), 3, 2)
 	numHits := core.MinInt32(targets, warrior.Env.GetNumTargets())
-	results := make([]*core.SpellEffect, numHits)
+	results := make([]*core.SpellResult, numHits)
 
 	warrior.HeroicStrikeOrCleave = warrior.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 47520},

--- a/sim/warrior/items.go
+++ b/sim/warrior/items.go
@@ -79,7 +79,7 @@ var ItemSetDreadnaughtBattlegear = core.NewItemSet(core.ItemSet{
 				OnExpire: func(_ *core.Aura, sim *core.Simulation) {
 					warrior.PseudoStats.CostReduction -= 5
 				},
-				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, _ *core.SpellEffect) {
+				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, _ *core.SpellResult) {
 					if !spell.ProcMask.Matches(core.ProcMaskMeleeSpecial) {
 						return
 					}
@@ -103,8 +103,8 @@ var ItemSetDreadnaughtBattlegear = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnPeriodicDamageDealt: func(_ *core.Aura, sim *core.Simulation, _ *core.Spell, spellEffect *core.SpellEffect) {
-					if spellEffect.Landed() && sim.RandomFloat("Dreadnaught Battlegear 4pc") < 0.1 {
+				OnPeriodicDamageDealt: func(_ *core.Aura, sim *core.Simulation, _ *core.Spell, result *core.SpellResult) {
+					if result.Landed() && sim.RandomFloat("Dreadnaught Battlegear 4pc") < 0.1 {
 						procAura.Activate(sim)
 					}
 				},
@@ -138,11 +138,11 @@ var ItemSetSiegebreakerBattlegear = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 					if spell.ActionID.SpellID != 47450 && spell != warrior.Slam {
 						return
 					}
-					if spellEffect.Landed() && sim.RandomFloat("Siegebreaker Battlegear 2pc") < 0.4 {
+					if result.Landed() && sim.RandomFloat("Siegebreaker Battlegear 2pc") < 0.4 {
 						procAura.Activate(sim)
 					}
 				},
@@ -197,11 +197,11 @@ var ItemSetYmirjarLordsBattlegear = core.NewItemSet(core.ItemSet{
 				OnReset: func(aura *core.Aura, sim *core.Simulation) {
 					aura.Activate(sim)
 				},
-				OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+				OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 					if spell != warrior.DeepWounds {
 						return
 					}
-					if spellEffect.Landed() && sim.RandomFloat("Ymirjar Lord's Battlegear 2pc") < 0.03 {
+					if result.Landed() && sim.RandomFloat("Ymirjar Lord's Battlegear 2pc") < 0.03 {
 						procAura.Activate(sim)
 					}
 				},
@@ -233,7 +233,7 @@ func init() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell != warrior.ShieldSlam && spell != warrior.Bloodthirst && spell != warrior.MortalStrike {
 					return
 				}

--- a/sim/warrior/overpower.go
+++ b/sim/warrior/overpower.go
@@ -19,8 +19,8 @@ func (warrior *Warrior) registerOverpowerSpell(cdTimer *core.Timer) {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Outcome.Matches(outcomeMask) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Outcome.Matches(outcomeMask) {
 				warrior.overpowerValidUntil = sim.CurrentTime + time.Second*5
 			}
 		},

--- a/sim/warrior/recklessness.go
+++ b/sim/warrior/recklessness.go
@@ -51,8 +51,8 @@ func (warrior *Warrior) RegisterRecklessnessCD() {
 				}
 			}
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeSpecial) || spellEffect.Damage <= 0 {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeSpecial) || result.Damage <= 0 {
 				return
 			}
 			aura.RemoveStack(sim)

--- a/sim/warrior/revenge.go
+++ b/sim/warrior/revenge.go
@@ -31,8 +31,8 @@ func (warrior *Warrior) registerRevengeSpell(cdTimer *core.Timer) {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Outcome.Matches(core.OutcomeBlock | core.OutcomeDodge | core.OutcomeParry) {
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Outcome.Matches(core.OutcomeBlock | core.OutcomeDodge | core.OutcomeParry) {
 				warrior.revengeProcAura.Activate(sim)
 			}
 		},

--- a/sim/warrior/stances.go
+++ b/sim/warrior/stances.go
@@ -95,8 +95,8 @@ func (warrior *Warrior) registerDefensiveStanceAura() {
 		core.MakePermanent(warrior.GetOrRegisterAura(core.Aura{
 			Label:    "Enrage Trigger",
 			Duration: core.NeverExpires,
-			OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if spellEffect.Outcome.Matches(core.OutcomeBlock | core.OutcomeDodge | core.OutcomeParry) {
+			OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if result.Outcome.Matches(core.OutcomeBlock | core.OutcomeDodge | core.OutcomeParry) {
 					if sim.RandomFloat("Enrage Trigger Chance") <= 0.5*float64(warrior.Talents.ImprovedDefensiveStance) {
 						enrageAura.Activate(sim)
 					}

--- a/sim/warrior/sunder_armor.go
+++ b/sim/warrior/sunder_armor.go
@@ -36,7 +36,7 @@ func (warrior *Warrior) newSunderArmorSpell(isDevastateEffect bool) *core.Spell 
 
 		ThreatMultiplier: 1,
 		FlatThreatBonus:  360,
-		DynamicThreatBonus: func(spellEffect *core.SpellEffect, spell *core.Spell) float64 {
+		DynamicThreatBonus: func(result *core.SpellResult, spell *core.Spell) float64 {
 			return 0.05 * spell.MeleeAttackPower()
 		},
 	}
@@ -55,7 +55,7 @@ func (warrior *Warrior) newSunderArmorSpell(isDevastateEffect bool) *core.Spell 
 	}
 
 	config.ApplyEffects = func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-		var result *core.SpellEffect
+		var result *core.SpellResult
 		if isDevastateEffect {
 			result = spell.CalcOutcome(sim, target, spell.OutcomeAlwaysHit)
 		} else {

--- a/sim/warrior/sweeping_strikes.go
+++ b/sim/warrior/sweeping_strikes.go
@@ -38,8 +38,8 @@ func (warrior *Warrior) registerSweepingStrikesCD() {
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			aura.SetStacks(sim, 5)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if aura.GetStacks() == 0 || spellEffect.Damage == 0 || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if aura.GetStacks() == 0 || result.Damage == 0 || !spell.ProcMask.Matches(core.ProcMaskMelee) {
 				return
 			}
 
@@ -47,10 +47,10 @@ func (warrior *Warrior) registerSweepingStrikesCD() {
 			//  do a normalized MH hit instead. This is true for Sudden Death procs as well.
 
 			// Undo armor reduction to get the raw damage value.
-			curDmg = spellEffect.Damage / spellEffect.ResistanceMultiplier
+			curDmg = result.Damage / result.ResistanceMultiplier
 
-			ssHit.Cast(sim, warrior.Env.NextTargetUnit(spellEffect.Target))
-			ssHit.SpellMetrics[spellEffect.Target.UnitIndex].Casts--
+			ssHit.Cast(sim, warrior.Env.NextTargetUnit(result.Target))
+			ssHit.SpellMetrics[result.Target.UnitIndex].Casts--
 			if aura.GetStacks() > 0 {
 				aura.RemoveStack(sim)
 			}

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -75,12 +75,12 @@ func (warrior *Warrior) applyCriticalBlock() {
 		Flags:    core.SpellFlagMeleeMetrics | core.SpellFlagNoOnCastComplete,
 	})
 
-	warrior.AddDynamicDamageTakenModifier(func(sim *core.Simulation, _ *core.Spell, spellEffect *core.SpellEffect) {
-		if spellEffect.Outcome.Matches(core.OutcomeBlock) && !spellEffect.Outcome.Matches(core.OutcomeMiss) && !spellEffect.Outcome.Matches(core.OutcomeParry) && !spellEffect.Outcome.Matches(core.OutcomeDodge) {
+	warrior.AddDynamicDamageTakenModifier(func(sim *core.Simulation, _ *core.Spell, result *core.SpellResult) {
+		if result.Outcome.Matches(core.OutcomeBlock) && !result.Outcome.Matches(core.OutcomeMiss) && !result.Outcome.Matches(core.OutcomeParry) && !result.Outcome.Matches(core.OutcomeDodge) {
 			procChance := 0.2 * float64(warrior.Talents.CriticalBlock)
 			if sim.RandomFloat("Critical Block Roll") <= procChance {
 				blockValue := warrior.GetStat(stats.BlockValue)
-				spellEffect.Damage = core.MaxFloat(0, spellEffect.Damage-blockValue)
+				result.Damage = core.MaxFloat(0, result.Damage-blockValue)
 				dummyCriticalBlockSpell.Cast(sim, warrior.CurrentTarget)
 			}
 		}
@@ -111,8 +111,8 @@ func (warrior *Warrior) applyDamageShield() {
 	core.MakePermanent(warrior.GetOrRegisterAura(core.Aura{
 		Label:    "Damage Shield Trigger",
 		Duration: core.NeverExpires,
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Landed() && !spellEffect.Outcome.Matches(core.OutcomeBlock) {
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Landed() && !result.Outcome.Matches(core.OutcomeBlock) {
 				return
 			}
 
@@ -166,7 +166,7 @@ func (warrior *Warrior) applyTasteForBlood() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell != warrior.Rend {
 				return
 			}
@@ -202,11 +202,11 @@ func (warrior *Warrior) applyTrauma() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
-			proc := warrior.TraumaAuras[spellEffect.Target.Index]
+			proc := warrior.TraumaAuras[result.Target.Index]
 			proc.Duration = time.Minute * 1
 			proc.Activate(sim)
 		},
@@ -243,13 +243,13 @@ func (warrior *Warrior) applyBloodsurge() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell == warrior.Slam && warrior.BloodsurgeAura.IsActive() {
 				warrior.BloodsurgeAura.RemoveStack(sim)
 				return
 			}
 
-			if !spellEffect.Landed() {
+			if !result.Landed() {
 				return
 			}
 
@@ -296,12 +296,12 @@ func (warrior *Warrior) applyBloodFrenzy() {
 	warrior.PseudoStats.MeleeSpeedMultiplier *= 1 + 0.05*float64(warrior.Talents.BloodFrenzy)
 }
 
-func (warrior *Warrior) procBloodFrenzy(sim *core.Simulation, effect *core.SpellEffect, dur time.Duration) {
+func (warrior *Warrior) procBloodFrenzy(sim *core.Simulation, result *core.SpellResult, dur time.Duration) {
 	if warrior.Talents.BloodFrenzy == 0 {
 		return
 	}
 
-	aura := warrior.BloodFrenzyAuras[effect.Target.Index]
+	aura := warrior.BloodFrenzyAuras[result.Target.Index]
 	aura.Duration = dur
 	aura.Activate(sim)
 }
@@ -407,8 +407,8 @@ func (warrior *Warrior) applyWeaponSpecializations() {
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-				if !spellEffect.Landed() {
+			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !result.Landed() {
 					return
 				}
 
@@ -430,7 +430,7 @@ func (warrior *Warrior) applyWeaponSpecializations() {
 				}
 				icd.Use(sim)
 
-				aura.Unit.AutoAttacks.MaybeReplaceMHSwing(sim, swordSpecializationSpell).Cast(sim, spellEffect.Target)
+				aura.Unit.AutoAttacks.MaybeReplaceMHSwing(sim, swordSpecializationSpell).Cast(sim, result.Target)
 			},
 		})
 	}
@@ -450,8 +450,8 @@ func (warrior *Warrior) applyUnbridledWrath() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Damage == 0 {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Damage == 0 {
 				return
 			}
 
@@ -495,12 +495,12 @@ func (warrior *Warrior) applyFlurry() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !spell.ProcMask.Matches(core.ProcMaskMelee) {
 				return
 			}
 
-			if spellEffect.Outcome.Matches(core.OutcomeCrit) {
+			if result.Outcome.Matches(core.OutcomeCrit) {
 				procAura.Activate(sim)
 				procAura.SetStacks(sim, 3)
 				return
@@ -538,12 +538,12 @@ func (warrior *Warrior) applyWreckingCrew() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !spell.ProcMask.Matches(core.ProcMaskMelee) {
 				return
 			}
 
-			if !spellEffect.Outcome.Matches(core.OutcomeCrit) {
+			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
 
@@ -577,13 +577,13 @@ func (warrior *Warrior) applySuddenDeath() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if warrior.SuddenDeathAura.IsActive() && spell == warrior.Execute {
 				warrior.SuddenDeathAura.RemoveStack(sim)
 				warrior.AddRage(sim, rageRefund, rageMetrics)
 			}
 
-			if !spellEffect.Landed() {
+			if !result.Landed() {
 				return
 			}
 
@@ -626,8 +626,8 @@ func (warrior *Warrior) applyShieldSpecialization() {
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
-		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, spellEffect *core.SpellEffect) {
-			if spellEffect.Outcome.Matches(core.OutcomeBlock | core.OutcomeDodge | core.OutcomeParry) {
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Outcome.Matches(core.OutcomeBlock | core.OutcomeDodge | core.OutcomeParry) {
 				if sim.Proc(procChance, "Shield Specialization") {
 					warrior.AddRage(sim, rageAdded, rageMetrics)
 				}
@@ -759,7 +759,7 @@ func (warrior *Warrior) RegisterBladestormCD() {
 	actionID := core.ActionID{SpellID: 46924}
 	cost := 25.0 - float64(warrior.Talents.FocusedRage)
 	numHits := core.MinInt32(4, warrior.Env.GetNumTargets())
-	results := make([]*core.SpellEffect, numHits)
+	results := make([]*core.SpellResult, numHits)
 
 	if warrior.AutoAttacks.IsDualWielding {
 		warrior.BladestormOH = warrior.RegisterSpell(core.SpellConfig{

--- a/sim/warrior/whirlwind.go
+++ b/sim/warrior/whirlwind.go
@@ -12,7 +12,7 @@ func (warrior *Warrior) registerWhirlwindSpell() {
 	actionID := core.ActionID{SpellID: 1680}
 	cost := 25.0 - float64(warrior.Talents.FocusedRage)
 	numHits := core.MinInt32(4, warrior.Env.GetNumTargets())
-	results := make([]*core.SpellEffect, numHits)
+	results := make([]*core.SpellResult, numHits)
 
 	if warrior.AutoAttacks.IsDualWielding && warrior.GetOHWeapon().WeaponType != proto.WeaponType_WeaponTypeStaff &&
 		warrior.GetOHWeapon().WeaponType != proto.WeaponType_WeaponTypePolearm {


### PR DESCRIPTION
This better reflects the new usage of the struct as a result. Also rename NewOutcomeApplier --> OutcomeApplier.