### PR TITLE
feral fixes

### DIFF
--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -60,9 +60,9 @@ func (cat *FeralDruid) checkQueueMaul(sim *core.Simulation) {
 		lacerateNext = !cat.LacerateDot.IsActive() || (cat.LacerateDot.GetStacks() < 5) || (cat.LacerateDot.RemainingDuration(sim) <= lacerateLeeway)
 		emergencyLeeway := gcdTimeToRdy + (3 * time.Second) + (2 * cat.latency)
 		emergencyLacerateNext = cat.LacerateDot.IsActive() && (cat.LacerateDot.RemainingDuration(sim) <= emergencyLeeway)
-		mangleNext = !lacerateNext && (!cat.MangleAura.IsActive() || (cat.MangleAura.RemainingDuration(sim) < gcdTimeToRdy+time.Second*3))
+		mangleNext = cat.MangleBear != nil && !lacerateNext && (!cat.MangleAura.IsActive() || (cat.MangleAura.RemainingDuration(sim) < gcdTimeToRdy+time.Second*3))
 	} else {
-		mangleNext = cat.MangleBear.TimeToReady(sim) < gcdTimeToRdy
+		mangleNext = cat.MangleBear != nil && cat.MangleBear.TimeToReady(sim) < gcdTimeToRdy
 		lacerateNext = cat.LacerateDot.IsActive() && (cat.LacerateDot.GetStacks() < 5 || cat.LacerateDot.RemainingDuration(sim) < gcdTimeToRdy+(time.Second*4))
 	}
 

--- a/ui/feral_druid/sim.ts
+++ b/ui/feral_druid/sim.ts
@@ -128,7 +128,6 @@ export class FeralDruidSimUI extends IndividualSimUI<Spec.SpecFeralDruid> {
 
 			// IconInputs to include in the 'Player' section on the settings tab.
 			playerIconInputs: [
-				DruidInputs.SelfInnervate,
 			],
 			// Inputs to include in the 'Rotation' section on the settings tab.
 			rotationInputs: DruidInputs.FeralDruidRotationConfig,


### PR DESCRIPTION
 - fixes #1381
 - hides ui innervate button for now, unneeded by rotation without odd talents / raid buffs