### PR TITLE
Remove prereqLocation from coldSnap config

### DIFF
--- a/ui/core/talents/mage.ts
+++ b/ui/core/talents/mage.ts
@@ -958,11 +958,7 @@ export const mageTalentsConfig: TalentsConfig<MageTalents> = newTalentsConfig([
 				"spellIds": [
 					11958
 				],
-				"maxPoints": 1,
-				"prereqLocation": {
-					"rowIdx": 4,
-					"colIdx": 1
-				}
+				"maxPoints": 1
 			},
 			{
 				"fieldName": "improvedConeOfCold",


### PR DESCRIPTION
Fixes #1442

Cold Snap has no pre-requisites to talent, the existing config set a prereq of coldSnap itself.