### PR TITLE
Put Mirror Image on GCD

### DIFF
--- a/sim/mage/mirror_image.go
+++ b/sim/mage/mirror_image.go
@@ -22,10 +22,7 @@ func (mage *Mage) registerMirrorImageCD() {
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
 				Cost: baseCost,
-				// GCD:  core.GCDDefault,
-			},
-			ModifyCast: func(sim *core.Simulation, spell *core.Spell, cast *core.Cast) {
-				spell.DefaultCast.GCD = core.GCDDefault
+				GCD:  core.GCDDefault,
 			},
 			CD: core.Cooldown{
 				Timer:    mage.NewTimer(),


### PR DESCRIPTION
Fixes #1200 

Mirror Image is on the normal GCD, [wowhead](https://www.wowhead.com/wotlk/spell=55342/mirror-image)