### PR TITLE
Work around expertise rating floating point issues

### DIFF
--- a/ui/core/components/character_stats.ts
+++ b/ui/core/components/character_stats.ts
@@ -139,7 +139,7 @@ export class CharacterStats extends Component {
 		} else if (stat == Stat.StatSpellHaste) {
 			displayStr += ` (${(rawValue / Mechanics.HASTE_RATING_PER_HASTE_PERCENT).toFixed(2)}%)`;
 		} else if (stat == Stat.StatExpertise) {
-			displayStr += ` (${(Math.floor(rawValue / Mechanics.EXPERTISE_PER_QUARTER_PERCENT_REDUCTION)).toFixed(0)})`;
+			displayStr += ` (${(Math.floor(Number(rawValue.toFixed(2)) / Mechanics.EXPERTISE_PER_QUARTER_PERCENT_REDUCTION)).toFixed(0)})`;
 		} else if (stat == Stat.StatDefense) {
 			displayStr += ` (${(Mechanics.CHARACTER_LEVEL * 5 + rawValue / Mechanics.DEFENSE_RATING_PER_DEFENSE).toFixed(1)})`;
 		} else if (stat == Stat.StatBlock) {


### PR DESCRIPTION
Fixes #1394

Somewhere there is a float precision error happening with expertise rating causing an expertise bonus of 4 to be calculated as 32.78999999 rather than 32.79 (4 * 8.1975). Fixing at two decimals will be rounded up to 32.79 giving the correct expertise of 4

![image](https://user-images.githubusercontent.com/47377278/198424238-5602e009-8e93-41a3-aa1e-029062e23ecc.png)
![image](https://user-images.githubusercontent.com/47377278/198424298-da398e90-6fe8-4c3a-8ecf-479fd12b94c9.png)
