### PR TITLE
Nil pointer when setting Innervate target

### DIFF
--- a/sim/druid/balance/balance.go
+++ b/sim/druid/balance/balance.go
@@ -29,10 +29,9 @@ func NewBalanceDruid(character core.Character, options *proto.Player) *BalanceDr
 	balanceOptions := options.GetBalanceDruid()
 	selfBuffs := druid.SelfBuffs{}
 
+	selfBuffs.InnervateTarget = &proto.RaidTarget{TargetIndex: -1}
 	if balanceOptions.Options.InnervateTarget != nil {
 		selfBuffs.InnervateTarget = balanceOptions.Options.InnervateTarget
-	} else {
-		selfBuffs.InnervateTarget.TargetIndex = -1
 	}
 
 	moonkin := &BalanceDruid{

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -27,12 +27,11 @@ func RegisterFeralDruid() {
 
 func NewFeralDruid(character core.Character, options *proto.Player) *FeralDruid {
 	feralOptions := options.GetFeralDruid()
-
 	selfBuffs := druid.SelfBuffs{}
+
+	selfBuffs.InnervateTarget = &proto.RaidTarget{TargetIndex: -1}
 	if feralOptions.Options.InnervateTarget != nil {
 		selfBuffs.InnervateTarget = feralOptions.Options.InnervateTarget
-	} else {
-		selfBuffs.InnervateTarget.TargetIndex = -1
 	}
 
 	cat := &FeralDruid{

--- a/sim/druid/tank/tank.go
+++ b/sim/druid/tank/tank.go
@@ -28,12 +28,11 @@ func RegisterFeralTankDruid() {
 
 func NewFeralTankDruid(character core.Character, options *proto.Player) *FeralTankDruid {
 	tankOptions := options.GetFeralTankDruid()
-
 	selfBuffs := druid.SelfBuffs{}
+
+	selfBuffs.InnervateTarget = &proto.RaidTarget{TargetIndex: -1}
 	if tankOptions.Options.InnervateTarget != nil {
 		selfBuffs.InnervateTarget = tankOptions.Options.InnervateTarget
-	} else {
-		selfBuffs.InnervateTarget.TargetIndex = -1
 	}
 
 	bear := &FeralTankDruid{


### PR DESCRIPTION
[druid] fix nil pointer when setting druid's InnervateTarget (formerly a proto.RaidTarget, now a *proto.RaidTarget)