### PR TITLE
attempt at fixing hyperspeed accelerators

### DIFF
--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -45,637 +45,637 @@ character_stats_results: {
 dps_results: {
  key: "TestBalance-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 7077.1722
-  tps: 6923.28139
+  dps: 7057.91866
+  tps: 6906.54884
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7096.76652
-  tps: 6941.63101
+  dps: 7112.54692
+  tps: 6959.92163
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6991.80503
-  tps: 6837.91422
+  dps: 6979.10393
+  tps: 6827.73411
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7127.46487
-  tps: 6974.13998
+  dps: 7119.59564
+  tps: 6968.53721
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5735.73482
-  tps: 5570.27791
+  dps: 5641.99558
+  tps: 5475.75494
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7139.49801
-  tps: 6845.87919
+  dps: 7155.04084
+  tps: 6863.62139
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7331.13598
-  tps: 7176.4225
+  dps: 7315.93653
+  tps: 7163.74404
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7086.4026
-  tps: 6934.41865
+  dps: 7073.90036
+  tps: 6924.36399
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7118.9417
-  tps: 6966.94591
+  dps: 7099.49301
+  tps: 6950.79624
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 7068.93616
-  tps: 6921.76091
+  dps: 7045.34957
+  tps: 6898.44808
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 7068.93616
-  tps: 6921.76091
+  dps: 7045.34957
+  tps: 6898.44808
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7122.74644
-  tps: 6974.32051
+  dps: 7098.60055
+  tps: 6950.44896
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 7238.99389
-  tps: 7084.28042
+  dps: 7231.16722
+  tps: 7078.97473
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7006.25961
-  tps: 6853.64316
+  dps: 7007.95429
+  tps: 6857.29916
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6991.80503
-  tps: 6839.06646
+  dps: 6979.10393
+  tps: 6827.73411
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7124.40031
-  tps: 6969.50288
+  dps: 7135.80635
+  tps: 6983.71858
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 4548.13033
-  tps: 4381.36757
+  dps: 4263.65545
+  tps: 4093.51146
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DreamwalkerGarb"
  value: {
-  dps: 6066.80768
-  tps: 5905.54653
+  dps: 5995.91202
+  tps: 5836.00653
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7096.76652
-  tps: 6941.63101
+  dps: 7112.54692
+  tps: 6959.92163
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7105.40656
-  tps: 6948.61192
+  dps: 7163.96111
+  tps: 7011.43921
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7127.46487
-  tps: 6972.7514
+  dps: 7119.59564
+  tps: 6967.40315
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7124.23079
-  tps: 6969.46792
+  dps: 7119.64413
+  tps: 6967.35174
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7096.76652
-  tps: 6941.63101
+  dps: 7112.54692
+  tps: 6959.92163
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7148.74709
-  tps: 6998.42665
+  dps: 7132.46609
+  tps: 6984.5758
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7300.15131
-  tps: 7147.06249
+  dps: 7293.62096
+  tps: 7143.83153
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7200.05267
-  tps: 7046.67973
+  dps: 7267.47552
+  tps: 7118.70583
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7139.49801
-  tps: 6983.33416
+  dps: 7155.04084
+  tps: 7001.38722
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7130.95171
-  tps: 6974.99353
+  dps: 7146.54206
+  tps: 6993.0941
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6991.80503
-  tps: 6837.91422
+  dps: 6979.10393
+  tps: 6827.73411
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7126.50055
-  tps: 6968.66414
+  dps: 7113.65473
+  tps: 6957.18707
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 4903.7908
-  tps: 4744.1105
+  dps: 4515.21578
+  tps: 4350.97529
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 6793.35198
-  tps: 6619.34759
+  dps: 6847.14776
+  tps: 6677.81766
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 7238.99389
-  tps: 7084.28042
+  dps: 7231.16722
+  tps: 7078.97473
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 7238.99389
-  tps: 7084.28042
+  dps: 7231.16722
+  tps: 7078.97473
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 7418.33496
-  tps: 7267.71558
+  dps: 7501.5179
+  tps: 7355.69471
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 7252.27401
-  tps: 7098.18494
+  dps: 7282.17008
+  tps: 7130.53762
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 7238.99389
-  tps: 7084.28042
+  dps: 7231.16722
+  tps: 7078.97473
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7127.46487
-  tps: 6972.7514
+  dps: 7119.59564
+  tps: 6967.40315
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7124.23079
-  tps: 6969.46792
+  dps: 7119.64413
+  tps: 6967.35174
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6991.80503
-  tps: 6839.06646
+  dps: 6979.10393
+  tps: 6827.73411
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7062.98765
-  tps: 6911.60487
+  dps: 7121.47793
+  tps: 6974.83675
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7096.76652
-  tps: 6941.63101
+  dps: 7112.54692
+  tps: 6959.92163
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 4631.33655
-  tps: 4466.16761
+  dps: 4460.30073
+  tps: 4294.16825
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LasherweaveRegalia"
  value: {
-  dps: 8143.92494
-  tps: 7991.51206
+  dps: 8227.40545
+  tps: 8082.20609
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6991.80503
-  tps: 6839.06646
+  dps: 6979.10393
+  tps: 6827.73411
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7094.60195
-  tps: 6940.46192
+  dps: 7081.144
+  tps: 6929.51342
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 5128.22055
-  tps: 4970.44616
+  dps: 4732.55791
+  tps: 4569.5161
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 6789.9429
-  tps: 6631.45503
+  dps: 6807.60055
+  tps: 6650.82585
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7027.96714
-  tps: 6874.5942
+  dps: 7101.90873
+  tps: 6953.56851
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NightsongBattlegear"
  value: {
-  dps: 4775.88245
-  tps: 4613.16834
+  dps: 4450.84793
+  tps: 4283.57311
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NightsongGarb"
  value: {
-  dps: 6528.28407
-  tps: 6370.03782
+  dps: 6492.66941
+  tps: 6336.46405
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6991.80503
-  tps: 6838.86314
+  dps: 6979.10393
+  tps: 6827.73411
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7096.76652
-  tps: 6941.63101
+  dps: 7112.54692
+  tps: 6959.92163
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7096.76652
-  tps: 6941.63101
+  dps: 7112.54692
+  tps: 6959.92163
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7096.76652
-  tps: 6941.63101
+  dps: 7112.54692
+  tps: 6959.92163
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7096.76652
-  tps: 6941.63101
+  dps: 7112.54692
+  tps: 6959.92163
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6991.80503
-  tps: 6837.91422
+  dps: 6979.10393
+  tps: 6827.73411
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7492.75992
-  tps: 7332.22736
+  dps: 7482.42548
+  tps: 7325.17731
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7554.76757
-  tps: 7393.49461
+  dps: 7544.21471
+  tps: 7386.22613
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7297.41665
-  tps: 7142.28114
+  dps: 7308.19955
+  tps: 7155.57426
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7096.76652
-  tps: 6941.49936
+  dps: 7112.54692
+  tps: 6959.66519
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6991.80503
-  tps: 6839.06646
+  dps: 6979.10393
+  tps: 6827.73411
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Runetotem'sBattlegear"
  value: {
-  dps: 5128.22055
-  tps: 4970.44616
+  dps: 4732.55791
+  tps: 4569.5161
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Runetotem'sRegalia"
  value: {
-  dps: 6789.9429
-  tps: 6631.45503
+  dps: 6807.60055
+  tps: 6650.82585
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 7238.99389
-  tps: 7084.28042
+  dps: 7231.16722
+  tps: 7078.97473
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6991.80503
-  tps: 6839.06646
+  dps: 6979.10393
+  tps: 6827.73411
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6991.80503
-  tps: 6837.91422
+  dps: 6979.10393
+  tps: 6827.73411
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6991.80503
-  tps: 6838.51373
+  dps: 6979.10393
+  tps: 6827.73411
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SparkofLife-37657"
  value: {
-  dps: 7048.78068
-  tps: 6895.06703
+  dps: 7054.68412
+  tps: 6903.62721
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-StormshroudArmor"
  value: {
-  dps: 5187.52971
-  tps: 5020.82134
+  dps: 5013.40443
+  tps: 4846.71374
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7096.76652
-  tps: 6941.63101
+  dps: 7112.54692
+  tps: 6959.92163
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7096.76652
-  tps: 6941.63101
+  dps: 7112.54692
+  tps: 6959.92163
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7096.76652
-  tps: 6941.63101
+  dps: 7112.54692
+  tps: 6959.92163
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartHarness"
  value: {
-  dps: 3666.41159
-  tps: 3506.7123
+  dps: 3330.28382
+  tps: 3166.04135
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartRegalia"
  value: {
-  dps: 5112.42351
-  tps: 4953.90756
+  dps: 5099.94719
+  tps: 4943.0454
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7096.76652
-  tps: 6941.63101
+  dps: 7112.54692
+  tps: 6959.92163
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6991.80503
-  tps: 6837.91422
+  dps: 6979.10393
+  tps: 6827.73411
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6991.80503
-  tps: 6837.91422
+  dps: 6979.10393
+  tps: 6827.73411
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7139.49801
-  tps: 6983.33416
+  dps: 7155.04084
+  tps: 7001.38722
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7130.95171
-  tps: 6974.99353
+  dps: 7146.54206
+  tps: 6993.0941
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7130.95171
-  tps: 6974.99353
+  dps: 7146.54206
+  tps: 6993.0941
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7139.49801
-  tps: 6983.33416
+  dps: 7155.04084
+  tps: 7001.38722
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5297.96783
-  tps: 5133.18965
+  dps: 5019.45133
+  tps: 4852.32597
  }
 }
 dps_results: {
  key: "TestBalance-Average-Default"
  value: {
-  dps: 7299.38818
-  tps: 7140.46891
+  dps: 7332.55561
+  tps: 7176.90292
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9181.39881
-  tps: 10968.89689
+  dps: 9151.71183
+  tps: 11038.46353
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7086.5435
-  tps: 6932.44468
+  dps: 7058.15917
+  tps: 6905.73258
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7967.16239
-  tps: 7431.03257
+  dps: 8044.60654
+  tps: 7520.88032
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4097.75673
-  tps: 4542.55001
+  dps: 3836.96702
+  tps: 4233.8072
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2511.27275
-  tps: 2415.61641
+  dps: 2307.61461
+  tps: 2210.37479
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4337.6902
-  tps: 4080.02226
+  dps: 4445.10641
+  tps: 4190.90234
  }
 }
 dps_results: {
  key: "TestBalance-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7300.78993
-  tps: 7176.4225
+  dps: 7285.59048
+  tps: 7163.74404
  }
 }

--- a/sim/druid/balance/rotation.go
+++ b/sim/druid/balance/rotation.go
@@ -14,7 +14,7 @@ func (moonkin *BalanceDruid) OnGCDReady(sim *core.Simulation) {
 func (moonkin *BalanceDruid) tryUseGCD(sim *core.Simulation) {
 	if moonkin.Rotation.Type == proto.BalanceDruid_Rotation_Adaptive {
 		moonkin.Rotation.UseBattleRes = false
-		moonkin.Rotation.UseMf = false
+		moonkin.Rotation.UseMf = true
 		moonkin.Rotation.UseIs = true
 		moonkin.Rotation.UseStarfire = true
 		moonkin.Rotation.UseWrath = true
@@ -88,7 +88,7 @@ func (moonkin *BalanceDruid) rotation(sim *core.Simulation) *core.Spell {
 				if maximizeIsUptime && insectSwarmUptime <= 0 {
 					return moonkin.InsectSwarm
 				}
-				if moonfireUptime > 0 || float64(rotation.MfInsideEclipseThreshold) >= lunarUptime.Seconds() && rotation.UseStarfire {
+				if (moonfireUptime > 0 || float64(rotation.MfInsideEclipseThreshold) >= lunarUptime.Seconds()) && rotation.UseStarfire {
 					if (rotation.UseSmartCooldowns && lunarUptime > 14*time.Second) || sim.GetRemainingDuration() < 15*time.Second {
 						moonkin.castMajorCooldown(moonkin.hyperSpeedMCD, sim, target)
 						moonkin.castMajorCooldown(moonkin.potionSpeedMCD, sim, target)
@@ -137,8 +137,11 @@ func (moonkin *BalanceDruid) castMajorCooldown(mcd *core.MajorCooldown, sim *cor
 			return
 		}
 		mcd.Spell.Cast(sim, target)
+
 		if willUseOffensivePotion {
 			moonkin.potionUsed = true
 		}
+
+		moonkin.UpdateMajorCooldowns()
 	}
 }


### PR DESCRIPTION
Enable using MF in 'adaptive' rotation -- this is because adaptive rotation requires moonfire to be up in order to use starfire which is when HSA are activated.

Update MajorCooldowns when manually managing them

Should fix https://github.com/wowsims/wotlk/issues/1528