### PR TITLE
vigo/exp-slices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/emirpasic/gods v1.18.1
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/satori/go.uuid v1.2.0
+	golang.org/x/exp v0.0.0-20221028150844-83b7d23a625f
 	google.golang.org/protobuf v1.28.1
 )
 
 require (
-	github.com/google/go-cmp v0.5.8 // indirect
-	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,7 +3,6 @@ github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FM
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
-github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -13,9 +12,11 @@ github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+golang.org/x/exp v0.0.0-20221028150844-83b7d23a625f h1:Al51T6tzvuh3oiwX11vex3QgJ2XTedFPGmbEVh8cdoc=
+golang.org/x/exp v0.0.0-20221028150844-83b7d23a625f/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=

--- a/makefile
+++ b/makefile
@@ -157,9 +157,9 @@ rundevserver: devserver
 	./wowsimwotlk --usefs=true --launch=false
 
 release: wowsimwotlk
-	GOOS=windows GOARCH=amd64 go build -o wowsimwotlk-windows.exe -ldflags="-X 'main.Version=$(VERSION)' -s -w" ./sim/web/main.go
-	GOOS=darwin GOARCH=amd64 go build -o wowsimwotlk-amd64-darwin -ldflags="-X 'main.Version=$(VERSION)' -s -w" ./sim/web/main.go
-	GOOS=linux GOARCH=amd64 go build -o wowsimwotlk-amd64-linux   -ldflags="-X 'main.Version=$(VERSION)' -s -w" ./sim/web/main.go
+	GOOS=windows GOARCH=amd64 GOAMD64=v3 go build -o wowsimwotlk-windows.exe -ldflags="-X 'main.Version=$(VERSION)' -s -w" ./sim/web/main.go
+	GOOS=darwin GOARCH=amd64 GOAMD64=v3 go build -o wowsimwotlk-amd64-darwin -ldflags="-X 'main.Version=$(VERSION)' -s -w" ./sim/web/main.go
+	GOOS=linux GOARCH=amd64 GOAMD64=v3 go build -o wowsimwotlk-amd64-linux   -ldflags="-X 'main.Version=$(VERSION)' -s -w" ./sim/web/main.go
 # Now compress into a zip because the files are getting large.
 	zip wowsimwotlk-windows.exe.zip wowsimwotlk-windows.exe
 	zip wowsimwotlk-amd64-darwin.zip wowsimwotlk-amd64-darwin

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -332,7 +332,7 @@ func (character *Character) Finalize(playerStats *proto.PlayerStats) {
 
 	character.Unit.finalize()
 
-	character.majorCooldownManager.finalize(character)
+	character.majorCooldownManager.finalize()
 
 	if playerStats != nil {
 		playerStats.FinalStats = character.GetStats().ToFloatArray()

--- a/sim/core/item_sets.go
+++ b/sim/core/item_sets.go
@@ -2,9 +2,8 @@ package core
 
 import (
 	"fmt"
-	"sort"
-
 	"github.com/wowsims/wotlk/sim/core/items"
+	"golang.org/x/exp/slices"
 )
 
 type ItemSet struct {
@@ -22,14 +21,12 @@ type ItemSet struct {
 }
 
 func (set ItemSet) ItemIDs() []int32 {
-	ids := []int32{}
+	ids := make([]int32, 0, len(set.Items))
 	for id := range set.Items {
 		ids = append(ids, id)
 	}
 	// Sort so the order of IDs is always consistent, for tests.
-	sort.Slice(ids, func(i, j int) bool {
-		return ids[i] < ids[j]
-	})
+	slices.Sort(ids)
 	return ids
 }
 
@@ -38,7 +35,7 @@ func (set ItemSet) ItemIsInSet(itemID int32) bool {
 	return ok
 }
 
-var sets = []*ItemSet{}
+var sets []*ItemSet
 
 func GetAllItemSets() []*ItemSet {
 	// Defensive copy to prevent modifications.

--- a/sim/core/major_cooldown.go
+++ b/sim/core/major_cooldown.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	"sort"
+	"golang.org/x/exp/slices"
 	"time"
 
 	"github.com/wowsims/wotlk/sim/core/proto"
@@ -187,11 +187,7 @@ func (mcdm *majorCooldownManager) initialize(character *Character) {
 	mcdm.character = character
 }
 
-func (mcdm *majorCooldownManager) finalize(character *Character) {
-	if mcdm.initialMajorCooldowns == nil {
-		mcdm.initialMajorCooldowns = []MajorCooldown{}
-	}
-
+func (mcdm *majorCooldownManager) finalize() {
 	// Match user-specified cooldown configs to existing cooldowns.
 	for i := range mcdm.initialMajorCooldowns {
 		mcd := &mcdm.initialMajorCooldowns[i]
@@ -443,11 +439,9 @@ func (mcdm *majorCooldownManager) UpdateMajorCooldowns() {
 }
 
 func (mcdm *majorCooldownManager) sort() {
-	sort.SliceStable(mcdm.majorCooldowns, func(i, j int) bool {
+	slices.SortStableFunc(mcdm.majorCooldowns, func(m1, m2 *MajorCooldown) bool {
 		// Since we're just comparing and don't actually care about the remaining CD, ok to use 0 instead of sim.CurrentTime.
-		cdA := mcdm.majorCooldowns[i].ReadyAt()
-		cdB := mcdm.majorCooldowns[j].ReadyAt()
-		return cdA < cdB || (cdA == cdB && mcdm.majorCooldowns[i].Priority > mcdm.majorCooldowns[j].Priority)
+		return m1.ReadyAt() < m2.ReadyAt() || (m1.ReadyAt() == m2.ReadyAt() && m1.Priority > m2.Priority)
 	})
 }
 

--- a/sim/core/raid.go
+++ b/sim/core/raid.go
@@ -1,11 +1,10 @@
 package core
 
 import (
-	googleProto "google.golang.org/protobuf/proto"
-	"sort"
-
 	"github.com/wowsims/wotlk/sim/core/proto"
 	"github.com/wowsims/wotlk/sim/core/stats"
+	"golang.org/x/exp/slices"
+	googleProto "google.golang.org/protobuf/proto"
 )
 
 type Party struct {
@@ -254,8 +253,8 @@ func (raid *Raid) GetRaidBuffs(baseRaidBuffs *proto.RaidBuffs) *proto.RaidBuffs 
 
 // Precompute the playersAndPets array for each party.
 func (raid *Raid) updatePlayersAndPets() {
-	raidPlayers := []*Unit{}
-	raidPets := []*Unit{}
+	var raidPlayers []*Unit
+	var raidPets []*Unit
 
 	for _, party := range raid.Parties {
 		party.Pets = []PetAgent{}
@@ -277,8 +276,8 @@ func (raid *Raid) updatePlayersAndPets() {
 
 	raid.AllUnits = append(raidPlayers, raidPets...)
 
-	sort.Slice(raid.AllUnits, func(i, j int) bool {
-		return raid.AllUnits[i].Index < raid.AllUnits[j].Index
+	slices.SortFunc(raid.AllUnits, func(u1, u2 *Unit) bool {
+		return u1.Index < u2.Index
 	})
 }
 

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -1,7 +1,7 @@
 package feral
 
 import (
-	"sort"
+	"golang.org/x/exp/slices"
 	"time"
 
 	"github.com/wowsims/wotlk/sim/core"
@@ -251,8 +251,8 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) {
 		pendingActions = append(pendingActions, pendingAction{cat.SavageRoarAura.ExpiresAt(), roarCost})
 	}
 
-	sort.SliceStable(pendingActions, func(i, j int) bool {
-		return pendingActions[i].refreshTime < pendingActions[j].refreshTime
+	slices.SortStableFunc(pendingActions, func(p1, p2 pendingAction) bool {
+		return p1.refreshTime < p2.refreshTime
 	})
 
 	latencySecs := cat.latency.Seconds()

--- a/sim/warlock/TestWarlock.results
+++ b/sim/warlock/TestWarlock.results
@@ -395,43 +395,43 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Destro Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5839.06239
-  tps: 6239.79545
+  dps: 5840.93479
+  tps: 6251.15442
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Destro Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5839.06239
-  tps: 4320.24626
+  dps: 5840.93479
+  tps: 4325.70978
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Destro Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6341.93982
-  tps: 4605.83235
+  dps: 6363.52946
+  tps: 4616.92768
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Destro Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2989.76442
-  tps: 4439.49074
+  dps: 3024.37381
+  tps: 4465.51676
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Destro Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2989.76442
-  tps: 2428.6354
+  dps: 3024.37381
+  tps: 2454.79046
  }
 }
 dps_results: {
  key: "TestWarlock-Settings-Orc-P1-Destro Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3096.95602
-  tps: 2258.76129
+  dps: 3093.65099
+  tps: 2256.19208
  }
 }
 dps_results: {

--- a/sim/warlock/chaos_bolt.go
+++ b/sim/warlock/chaos_bolt.go
@@ -50,7 +50,7 @@ func (warlock *Warlock) registerChaosBoltSpell() {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := sim.Roll(1429, 1813) + spellCoeff*spell.SpellPower()
-			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
+			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMagicCrit)
 		},
 	})
 }

--- a/tools/gen_web_db/main.go
+++ b/tools/gen_web_db/main.go
@@ -4,10 +4,10 @@ import (
 	"bufio"
 	"encoding/json"
 	"flag"
+	"golang.org/x/exp/slices"
 	"log"
 	"os"
 	"regexp"
-	"sort"
 	"strconv"
 )
 
@@ -49,8 +49,8 @@ func main() {
 		})
 	}
 
-	sort.Slice(items, func(i, j int) bool {
-		return items[i].ID < items[j].ID
+	slices.SortFunc(items, func(i1, i2 ItemData) bool {
+		return i1.ID < i2.ID
 	})
 
 	file, _ := json.Marshal(items)

--- a/tools/generate_items/main.go
+++ b/tools/generate_items/main.go
@@ -6,9 +6,9 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"golang.org/x/exp/slices"
 	"log"
 	"os"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -147,29 +147,29 @@ func main() {
 		panic("invalid item database source")
 	}
 
-	sort.SliceStable(gemsData, func(i, j int) bool {
-		if gemsData[i].Response == nil {
+	slices.SortStableFunc(gemsData, func(g1, g2 GemData) bool {
+		if g1.Response == nil {
 			return false
-		} else if gemsData[j].Response == nil {
+		} else if g2.Response == nil {
 			return true
 		}
-		if gemsData[i].Response.GetName() == gemsData[j].Response.GetName() {
-			return gemsData[i].Declaration.ID < gemsData[j].Declaration.ID
+		if g1.Response.GetName() == g2.Response.GetName() {
+			return g1.Declaration.ID < g2.Declaration.ID
 		}
-		return gemsData[i].Response.GetName() < gemsData[j].Response.GetName()
+		return g1.Response.GetName() < g2.Response.GetName()
 	})
 	writeGemFile(*outDir, gemsData)
 
-	sort.SliceStable(itemsData, func(i, j int) bool {
-		if itemsData[i].Response == nil {
+	slices.SortStableFunc(itemsData, func(i1, i2 ItemData) bool {
+		if i1.Response == nil {
 			return false
-		} else if itemsData[j].Response == nil {
+		} else if i2.Response == nil {
 			return true
 		}
-		if itemsData[i].Response.GetName() == itemsData[j].Response.GetName() {
-			return itemsData[i].Declaration.ID < itemsData[j].Declaration.ID
+		if i1.Response.GetName() == i2.Response.GetName() {
+			return i1.Declaration.ID < i2.Declaration.ID
 		}
-		return itemsData[i].Response.GetName() < itemsData[j].Response.GetName()
+		return i1.Response.GetName() < i2.Response.GetName()
 	})
 	writeItemFile(*outDir, itemsData)
 


### PR DESCRIPTION
[core] wowsimwotlk is now build using GOAMD64=v3, for some potential speedup, and assuming most developers are using post-2009 machines
[core] added golang.org/x/exp as dependency, for slices.Sort and variants 
[diverse] replaced sort.Slice variants with their slices.Sort counterparts; they're both faster and easier to use 

[warlock] Chaos Bolt cannot miss anymore