### PR TITLE
Simpler Major Cooldowns

### DIFF
--- a/sim/common/gcd_scheduler.go
+++ b/sim/common/gcd_scheduler.go
@@ -232,7 +232,7 @@ func (gs *GCDScheduler) ScheduleMCD(character *core.Character, mcdID core.Action
 			if success {
 				character.UpdateMajorCooldowns()
 			} else {
-				character.EnableMajorCooldown(gs.managedMCDIDs[mcdIdx])
+				gs.managedMCDs[mcdIdx].Enable()
 				gs.managedMCDs[mcdIdx].Spell.DefaultCast.GCD = 0
 			}
 			return success
@@ -266,7 +266,7 @@ func (gs *GCDScheduler) Reset(sim *core.Simulation, character *core.Character) {
 
 	for i, mcdID := range gs.managedMCDIDs {
 		gs.managedMCDs[i] = character.GetMajorCooldown(mcdID)
-		character.DisableMajorCooldown(mcdID)
+		gs.managedMCDs[i].Disable()
 	}
 }
 

--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -23,10 +23,6 @@ type Hardcast struct {
 	Target     *Unit
 }
 
-func (hc *Hardcast) OnExpire(sim *Simulation) {
-	hc.OnComplete(sim, hc.Target)
-}
-
 // Input for constructing the CastSpell function for a spell.
 type CastConfig struct {
 	// Default cast values with all static effects applied.
@@ -65,6 +61,10 @@ type Cast struct {
 	AfterCastDelay time.Duration
 }
 
+func (c *Cast) empty() bool {
+	return c.Cost == 0 && c.GCD == 0 && c.CastTime == 0 && c.ChannelTime == 0 && c.AfterCastDelay == 0
+}
+
 type CastFunc func(*Simulation, *Unit)
 type CastSuccessFunc func(*Simulation, *Unit) bool
 
@@ -89,8 +89,7 @@ func (spell *Spell) ApplyCostModifiers(cost float64) float64 {
 }
 
 func (spell *Spell) wrapCastFuncInit(config CastConfig, onCastComplete CastSuccessFunc) CastSuccessFunc {
-	empty := Cast{}
-	if config.DefaultCast == empty {
+	if config.DefaultCast.empty() {
 		return onCastComplete
 	}
 
@@ -196,14 +195,27 @@ func (spell *Spell) wrapCastFuncHaste(config CastConfig, onCastComplete CastFunc
 }
 
 func (spell *Spell) wrapCastFuncGCD(config CastConfig, onCastComplete CastFunc) CastFunc {
-	if config.DefaultCast.GCD == 0 {
+	if config.DefaultCast.empty() { // spells that are not actually cast (e.g. auto attacks, procs)
 		return onCastComplete
+	}
+
+	if config.DefaultCast.GCD == 0 { // mostly cooldowns (e.g. nature's swiftness, presence of mind)
+		return func(sim *Simulation, target *Unit) {
+			if expires := spell.Unit.Hardcast.Expires; expires != 0 {
+				panic(fmt.Sprintf("Trying to cast %s but casting/channeling for %s, curTime = %s", spell.ActionID, expires-sim.CurrentTime, sim.CurrentTime))
+			}
+			onCastComplete(sim, target)
+		}
 	}
 
 	return func(sim *Simulation, target *Unit) {
 		// By panicking if spell is on CD, we force each sim to properly check for their own CDs.
 		if spell.CurCast.GCD != 0 && !spell.Unit.GCD.IsReady(sim) {
 			panic(fmt.Sprintf("Trying to cast %s but GCD on cooldown for %s, curTime = %s", spell.ActionID, spell.Unit.GCD.TimeToReady(sim), sim.CurrentTime))
+		}
+
+		if expires := spell.Unit.Hardcast.Expires; expires != 0 {
+			panic(fmt.Sprintf("Trying to cast %s but casting/channeling for %s, curTime = %s", spell.ActionID, expires-sim.CurrentTime, sim.CurrentTime))
 		}
 
 		gcd := spell.CurCast.GCD
@@ -294,6 +306,21 @@ func (spell *Spell) makeCastFuncWait(config CastConfig, onCastComplete CastFunc)
 		}
 	}
 
+	if config.DefaultCast.ChannelTime > 0 {
+		return func(sim *Simulation, target *Unit) {
+			spell.Unit.Hardcast = Hardcast{Expires: sim.CurrentTime + spell.CurCast.ChannelTime}
+			if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
+				// Hunter fake cast has no ID.
+				if !spell.ActionID.IsEmptyAction() {
+					spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s)",
+						spell.ActionID, MaxFloat(0, spell.CurCast.Cost), spell.CurCast.CastTime)
+					spell.Unit.Log(sim, "Completed cast %s", spell.ActionID)
+				}
+			}
+			onCastComplete(sim, target)
+		}
+	}
+
 	if config.DefaultCast.CastTime == 0 {
 		if spell.Flags.Matches(SpellFlagNoLogs) {
 			return onCastComplete
@@ -334,9 +361,11 @@ func (spell *Spell) makeCastFuncWait(config CastConfig, onCastComplete CastFunc)
 			if spell.CurCast.CastTime == 0 {
 				onCastComplete(sim, target)
 			} else {
-				spell.Unit.Hardcast.Expires = sim.CurrentTime + spell.CurCast.CastTime
-				spell.Unit.Hardcast.OnComplete = onCastComplete
-				spell.Unit.Hardcast.Target = target
+				spell.Unit.Hardcast = Hardcast{
+					Expires:    sim.CurrentTime + spell.CurCast.CastTime,
+					OnComplete: onCastComplete,
+					Target:     target,
+				}
 
 				// If hardcast and GCD happen at the same time then we don't need a separate action.
 				if spell.Unit.Hardcast.Expires != spell.Unit.NextGCDAt() {

--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -19,6 +19,7 @@ type AfterCast func(aura *Aura, sim *Simulation, spell *Spell)
 
 type Hardcast struct {
 	Expires    time.Duration
+	ActionID   ActionID
 	OnComplete func(*Simulation, *Unit)
 	Target     *Unit
 }
@@ -61,9 +62,7 @@ type Cast struct {
 	AfterCastDelay time.Duration
 }
 
-func (c *Cast) empty() bool {
-	return c.Cost == 0 && c.GCD == 0 && c.CastTime == 0 && c.ChannelTime == 0 && c.AfterCastDelay == 0
-}
+var emptyCast Cast
 
 type CastFunc func(*Simulation, *Unit)
 type CastSuccessFunc func(*Simulation, *Unit) bool
@@ -89,7 +88,7 @@ func (spell *Spell) ApplyCostModifiers(cost float64) float64 {
 }
 
 func (spell *Spell) wrapCastFuncInit(config CastConfig, onCastComplete CastSuccessFunc) CastSuccessFunc {
-	if config.DefaultCast.empty() {
+	if config.DefaultCast == emptyCast {
 		return onCastComplete
 	}
 
@@ -195,14 +194,14 @@ func (spell *Spell) wrapCastFuncHaste(config CastConfig, onCastComplete CastFunc
 }
 
 func (spell *Spell) wrapCastFuncGCD(config CastConfig, onCastComplete CastFunc) CastFunc {
-	if config.DefaultCast.empty() { // spells that are not actually cast (e.g. auto attacks, procs)
+	if config.DefaultCast == emptyCast { // spells that are not actually cast (e.g. auto attacks, procs)
 		return onCastComplete
 	}
 
 	if config.DefaultCast.GCD == 0 { // mostly cooldowns (e.g. nature's swiftness, presence of mind)
 		return func(sim *Simulation, target *Unit) {
-			if expires := spell.Unit.Hardcast.Expires; expires != 0 {
-				panic(fmt.Sprintf("Trying to cast %s but casting/channeling for %s, curTime = %s", spell.ActionID, expires-sim.CurrentTime, sim.CurrentTime))
+			if hc := spell.Unit.Hardcast; hc.Expires != 0 {
+				panic(fmt.Sprintf("Trying to cast %s but casting/channeling %v for %s, curTime = %s", spell.ActionID, hc.ActionID, hc.Expires-sim.CurrentTime, sim.CurrentTime))
 			}
 			onCastComplete(sim, target)
 		}
@@ -214,8 +213,8 @@ func (spell *Spell) wrapCastFuncGCD(config CastConfig, onCastComplete CastFunc) 
 			panic(fmt.Sprintf("Trying to cast %s but GCD on cooldown for %s, curTime = %s", spell.ActionID, spell.Unit.GCD.TimeToReady(sim), sim.CurrentTime))
 		}
 
-		if expires := spell.Unit.Hardcast.Expires; expires != 0 {
-			panic(fmt.Sprintf("Trying to cast %s but casting/channeling for %s, curTime = %s", spell.ActionID, expires-sim.CurrentTime, sim.CurrentTime))
+		if hc := spell.Unit.Hardcast; hc.Expires != 0 {
+			panic(fmt.Sprintf("Trying to cast %s but casting/channeling %v for %s, curTime = %s", spell.ActionID, hc.ActionID, hc.Expires-sim.CurrentTime, sim.CurrentTime))
 		}
 
 		gcd := spell.CurCast.GCD
@@ -308,7 +307,7 @@ func (spell *Spell) makeCastFuncWait(config CastConfig, onCastComplete CastFunc)
 
 	if config.DefaultCast.ChannelTime > 0 {
 		return func(sim *Simulation, target *Unit) {
-			spell.Unit.Hardcast = Hardcast{Expires: sim.CurrentTime + spell.CurCast.ChannelTime}
+			spell.Unit.Hardcast = Hardcast{Expires: sim.CurrentTime + spell.CurCast.ChannelTime, ActionID: spell.ActionID}
 			if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
 				// Hunter fake cast has no ID.
 				if !spell.ActionID.IsEmptyAction() {
@@ -363,6 +362,7 @@ func (spell *Spell) makeCastFuncWait(config CastConfig, onCastComplete CastFunc)
 			} else {
 				spell.Unit.Hardcast = Hardcast{
 					Expires:    sim.CurrentTime + spell.CurCast.CastTime,
+					ActionID:   spell.ActionID,
 					OnComplete: onCastComplete,
 					Target:     target,
 				}

--- a/sim/core/gcd.go
+++ b/sim/core/gcd.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// Note that this is only used when the hardcast and GCD actions
+// Note that this is only used when the hardcast and GCD actions happen at different times.
 func (unit *Unit) newHardcastAction(sim *Simulation) {
 	if unit.hardcastAction != nil && !unit.hardcastAction.consumed {
 		unit.hardcastAction.Cancel(sim)

--- a/sim/core/major_cooldown.go
+++ b/sim/core/major_cooldown.go
@@ -99,6 +99,18 @@ func (mcd *MajorCooldown) IsEnabled() bool {
 	return !mcd.disabled
 }
 
+func (mcd *MajorCooldown) Enable() {
+	if mcd != nil && mcd.disabled {
+		mcd.disabled = false
+	}
+}
+
+func (mcd *MajorCooldown) Disable() {
+	if mcd != nil && !mcd.disabled {
+		mcd.disabled = true
+	}
+}
+
 func (mcd *MajorCooldown) GetTimings() []time.Duration {
 	return mcd.timings
 }
@@ -302,7 +314,6 @@ func (mcdm *majorCooldownManager) GetInitialMajorCooldown(actionID ActionID) Maj
 			return mcd
 		}
 	}
-
 	return MajorCooldown{}
 }
 
@@ -312,7 +323,6 @@ func (mcdm *majorCooldownManager) GetMajorCooldown(actionID ActionID) *MajorCool
 			return mcd
 		}
 	}
-
 	return nil
 }
 
@@ -327,44 +337,6 @@ func (mcdm *majorCooldownManager) GetMajorCooldownIDs() []*proto.ActionID {
 		ids[i] = mcd.Spell.ActionID.ToProto()
 	}
 	return ids
-}
-
-func (mcdm *majorCooldownManager) HasMajorCooldown(actionID ActionID) bool {
-	return mcdm.GetMajorCooldown(actionID) != nil
-}
-
-func (mcdm *majorCooldownManager) DisableMajorCooldown(actionID ActionID) {
-	mcd := mcdm.GetMajorCooldown(actionID)
-	if mcd != nil {
-		mcd.disabled = true
-	}
-}
-
-func (mcdm *majorCooldownManager) EnableMajorCooldown(actionID ActionID) {
-	mcd := mcdm.GetMajorCooldown(actionID)
-	if mcd != nil {
-		mcd.disabled = false
-	}
-}
-
-// Disabled all MCDs that are currently enabled, and returns a list of the MCDs
-// which were disabled by this call.
-// If cooldownType is not CooldownTypeUnknown, then will be restricted to cooldowns of that type.
-func (mcdm *majorCooldownManager) DisableAllEnabledCooldowns(cooldownType CooldownType) []*MajorCooldown {
-	disabledMCDs := []*MajorCooldown{}
-	for _, mcd := range mcdm.majorCooldowns {
-		if mcd.IsEnabled() && (cooldownType == CooldownTypeUnknown || mcd.Type.Matches(cooldownType)) {
-			mcdm.DisableMajorCooldown(mcd.Spell.ActionID)
-			disabledMCDs = append(disabledMCDs, mcd)
-		}
-	}
-	return disabledMCDs
-}
-
-func (mcdm *majorCooldownManager) EnableAllCooldowns(mcdsToEnable []*MajorCooldown) {
-	for _, mcd := range mcdsToEnable {
-		mcdm.EnableMajorCooldown(mcd.Spell.ActionID)
-	}
 }
 
 func (mcdm *majorCooldownManager) TryUseCooldowns(sim *Simulation) {

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -117,8 +117,9 @@ type Unit struct {
 	GCD       *Timer
 	doNothing bool // flags that this character chose to do nothing.
 
-	// Used for applying the effects of hardcast / channeled spells at a later time.
-	// By definition there can be only 1 hardcast spell being cast at any moment.
+	// Used for applying the effect of a hardcast spell when casting finishes.
+	//  For channeled spells, only Expires is set.
+	// No more than one cast may be active at any given time.
 	Hardcast Hardcast
 
 	// GCD-related PendingActions.

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -423,9 +423,11 @@ func (unit *Unit) reset(sim *Simulation, agent Agent) {
 func (unit *Unit) advance(sim *Simulation, elapsedTime time.Duration) {
 	unit.auraTracker.advance(sim)
 
-	if unit.Hardcast.Expires != 0 && unit.Hardcast.Expires <= sim.CurrentTime {
-		unit.Hardcast.Expires = 0
-		unit.Hardcast.OnExpire(sim)
+	if hc := &unit.Hardcast; hc.Expires != 0 && hc.Expires <= sim.CurrentTime {
+		hc.Expires = 0
+		if hc.OnComplete != nil {
+			hc.OnComplete(sim, hc.Target)
+		}
 	}
 }
 

--- a/sim/deathknight/dps/proc_trackers.go
+++ b/sim/deathknight/dps/proc_trackers.go
@@ -131,8 +131,7 @@ func (dk *DpsDeathknight) setupGargoyleCooldowns() {
 }
 
 func (dk *DpsDeathknight) gargoyleCooldownSync(actionID core.ActionID, isPotion bool) {
-	if dk.Character.HasMajorCooldown(actionID) {
-		majorCd := dk.Character.GetMajorCooldown(actionID)
+	if majorCd := dk.Character.GetMajorCooldown(actionID); majorCd != nil {
 		dk.ur.majorCds = append(dk.ur.majorCds, majorCd)
 
 		majorCd.ShouldActivate = func(sim *core.Simulation, character *core.Character) bool {

--- a/sim/deathknight/dps/rotation_frost.go
+++ b/sim/deathknight/dps/rotation_frost.go
@@ -47,22 +47,15 @@ func (fr *FrostRotation) Reset(sim *core.Simulation) {
 }
 
 func (dk *DpsDeathknight) addOnUseTrinketCooldown(actionID core.ActionID) {
-	if dk.Character.HasMajorCooldown(actionID) {
-		majorCd := dk.Character.GetMajorCooldown(actionID)
-		majorCd.ShouldActivate = func(sim *core.Simulation, character *core.Character) bool {
-			return false
-		}
-
+	if majorCd := dk.Character.GetMajorCooldown(actionID); majorCd != nil {
+		majorCd.Disable()
 		dk.fr.onUseTrinkets = append(dk.fr.onUseTrinkets, majorCd)
 	}
 }
 
 func (dk *DpsDeathknight) getMajorCooldown(actionID core.ActionID) *core.MajorCooldown {
-	if dk.Character.HasMajorCooldown(actionID) {
-		majorCd := dk.Character.GetMajorCooldown(actionID)
-		majorCd.ShouldActivate = func(sim *core.Simulation, character *core.Character) bool {
-			return false
-		}
+	if majorCd := dk.Character.GetMajorCooldown(actionID); majorCd != nil {
+		majorCd.Disable()
 		return majorCd
 	}
 	return nil

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -619,9 +619,9 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-Average-Default"
  value: {
-  dps: 1823.38649
-  tps: 6340.48552
-  dtps: 254.55651
+  dps: 1822.35237
+  tps: 6337.17657
+  dtps: 254.53531
  }
 }
 dps_results: {
@@ -711,8 +711,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1820.34127
-  tps: 6330.97674
-  dtps: 258.33297
+  dps: 1818.82993
+  tps: 6325.10182
+  dtps: 258.15055
  }
 }

--- a/sim/druid/balance/balance.go
+++ b/sim/druid/balance/balance.go
@@ -124,11 +124,8 @@ func (moonkin *BalanceDruid) Reset(sim *core.Simulation) {
 
 // Takes out a Cooldown from the generic MajorCooldownManager and adds it to a custom Slice of Cooldowns
 func (moonkin *BalanceDruid) getBalanceMajorCooldown(actionID core.ActionID) *core.MajorCooldown {
-	if moonkin.Character.HasMajorCooldown(actionID) {
-		majorCd := moonkin.Character.GetMajorCooldown(actionID)
-		majorCd.ShouldActivate = func(sim *core.Simulation, character *core.Character) bool {
-			return false
-		}
+	if majorCd := moonkin.Character.GetMajorCooldown(actionID); majorCd != nil {
+		majorCd.Disable()
 		return majorCd
 	}
 	return nil

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -306,19 +306,19 @@ func (druid *Druid) registerBearFormSpell() {
 }
 
 func (druid *Druid) manageCooldownsEnabled(sim *core.Simulation) {
-
 	// Disable cooldowns not usable in form and/or delay others
 	if druid.StartingForm.Matches(Cat | Bear) {
-
-		druid.EnableAllCooldowns(druid.disabledMCDs)
+		for _, mcd := range druid.disabledMCDs {
+			mcd.Enable()
+		}
 		druid.disabledMCDs = nil
 
 		if druid.InForm(Humanoid) {
 			// Disable cooldown that incurs a gcd, so we dont get stuck out of form when we dont need to (Greater Drums)
-			for _, cd := range druid.GetMajorCooldowns() {
-				if cd.Spell.DefaultCast.GCD > 0 {
-					druid.DisableMajorCooldown(cd.Spell.ActionID)
-					druid.disabledMCDs = append(druid.disabledMCDs, cd)
+			for _, mcd := range druid.GetMajorCooldowns() {
+				if mcd.Spell.DefaultCast.GCD > 0 {
+					mcd.Disable()
+					druid.disabledMCDs = append(druid.disabledMCDs, mcd)
 				}
 			}
 		}

--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -45,554 +45,554 @@ character_stats_results: {
 dps_results: {
  key: "TestHunter-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 7381.94317
-  tps: 6402.77683
+  dps: 7387.62205
+  tps: 6416.09104
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 6552.37113
-  tps: 5556.86351
+  dps: 6556.69933
+  tps: 5562.80185
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6592.77503
-  tps: 5590.08455
+  dps: 6594.77543
+  tps: 5588.96397
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6660.83503
-  tps: 5658.7136
+  dps: 6661.42578
+  tps: 5661.05954
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6661.73986
-  tps: 5657.34357
+  dps: 6610.46719
+  tps: 5614.63183
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6526.92508
-  tps: 5541.87736
+  dps: 6510.58882
+  tps: 5525.15354
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 6198.34317
-  tps: 5201.6157
+  dps: 6262.96558
+  tps: 5269.70736
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5633.14618
-  tps: 4769.33035
+  dps: 5619.89162
+  tps: 4752.36323
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5441.31194
-  tps: 4601.23059
+  dps: 5387.16971
+  tps: 4542.41508
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6592.77503
-  tps: 5479.18425
+  dps: 6594.77543
+  tps: 5478.08102
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6742.44221
-  tps: 5739.75173
+  dps: 6744.91952
+  tps: 5739.10807
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 6069.65368
-  tps: 5110.56755
+  dps: 6062.81228
+  tps: 5111.3572
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6594.27499
-  tps: 5603.25437
+  dps: 6598.81654
+  tps: 5608.952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6632.94288
-  tps: 5641.70686
+  dps: 6642.10155
+  tps: 5647.89558
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6635.51567
-  tps: 5638.29937
+  dps: 6651.50104
+  tps: 5656.28891
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6640.44809
-  tps: 5644.91783
+  dps: 6624.79899
+  tps: 5635.67224
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6574.72756
-  tps: 5583.41536
+  dps: 6587.43458
+  tps: 5594.48538
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6501.85759
-  tps: 5511.64543
+  dps: 6505.32834
+  tps: 5516.75722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6613.1483
-  tps: 5608.46381
+  dps: 6619.08345
+  tps: 5613.272
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6592.77503
-  tps: 5590.08455
+  dps: 6594.77543
+  tps: 5588.96397
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6607.66452
-  tps: 5597.31512
+  dps: 6604.74554
+  tps: 5600.5906
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6613.29233
-  tps: 5610.60185
+  dps: 6615.7444
+  tps: 5609.93295
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6609.0471
-  tps: 5606.35662
+  dps: 6613.31012
+  tps: 5607.49866
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6592.77503
-  tps: 5590.08455
+  dps: 6594.77543
+  tps: 5588.96397
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6644.4056
-  tps: 5653.34395
+  dps: 6644.17626
+  tps: 5650.79352
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6578.78581
-  tps: 5587.76519
+  dps: 6589.68263
+  tps: 5595.49394
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6561.24677
-  tps: 5570.22615
+  dps: 6568.11113
+  tps: 5573.92243
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6592.77503
-  tps: 5590.08455
+  dps: 6594.77543
+  tps: 5588.96397
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6592.77503
-  tps: 5590.08455
+  dps: 6594.77543
+  tps: 5588.96397
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6501.85759
-  tps: 5511.64543
+  dps: 6505.32834
+  tps: 5516.75722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 6906.0622
-  tps: 5957.37785
+  dps: 6876.92859
+  tps: 5931.53206
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5172.25193
-  tps: 4349.26991
+  dps: 5165.88051
+  tps: 4347.34238
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6501.85759
-  tps: 5511.64543
+  dps: 6505.32834
+  tps: 5516.75722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6613.29233
-  tps: 5610.60185
+  dps: 6615.7444
+  tps: 5609.93295
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6609.0471
-  tps: 5606.35662
+  dps: 6613.31012
+  tps: 5607.49866
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6650.42904
-  tps: 5651.06349
+  dps: 6654.29759
+  tps: 5656.58581
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6767.49604
-  tps: 5775.86467
+  dps: 6772.41923
+  tps: 5776.31035
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6616.72089
-  tps: 5611.42889
+  dps: 6618.74062
+  tps: 5610.32049
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6501.85759
-  tps: 5511.64543
+  dps: 6505.32834
+  tps: 5516.75722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6533.91373
-  tps: 5551.93776
+  dps: 6487.38181
+  tps: 5504.54175
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6659.58148
-  tps: 5673.46863
+  dps: 6604.81855
+  tps: 5619.09299
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6501.85759
-  tps: 5511.64543
+  dps: 6505.32834
+  tps: 5516.75722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6612.15977
-  tps: 5607.3633
+  dps: 6614.17582
+  tps: 5606.25258
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6616.72089
-  tps: 5611.42889
+  dps: 6618.74062
+  tps: 5610.32049
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6592.77503
-  tps: 5590.08455
+  dps: 6594.77543
+  tps: 5588.96397
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6592.77503
-  tps: 5590.08455
+  dps: 6594.77543
+  tps: 5588.96397
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6501.85759
-  tps: 5511.64543
+  dps: 6505.32834
+  tps: 5516.75722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6501.85759
-  tps: 5511.64543
+  dps: 6505.32834
+  tps: 5516.75722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6501.85759
-  tps: 5511.64543
+  dps: 6505.32834
+  tps: 5516.75722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6748.56968
-  tps: 5744.39113
+  dps: 6750.40531
+  tps: 5743.10169
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6620.50116
-  tps: 5612.52899
+  dps: 6595.03115
+  tps: 5594.9884
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6501.85759
-  tps: 5511.64543
+  dps: 6505.32834
+  tps: 5516.75722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 6430.47966
-  tps: 5477.81776
+  dps: 6398.77412
+  tps: 5451.8359
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6501.85759
-  tps: 5511.64543
+  dps: 6505.32834
+  tps: 5516.75722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6501.85759
-  tps: 5511.64543
+  dps: 6505.32834
+  tps: 5516.75722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6501.85759
-  tps: 5511.64543
+  dps: 6505.32834
+  tps: 5516.75722
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SparkofLife-37657"
  value: {
-  dps: 6682.87451
-  tps: 5692.85816
+  dps: 6700.387
+  tps: 5708.30693
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StormshroudArmor"
  value: {
-  dps: 5267.51337
-  tps: 4425.66381
+  dps: 5280.48729
+  tps: 4448.5547
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6616.72089
-  tps: 5611.42889
+  dps: 6618.74062
+  tps: 5610.32049
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6612.15977
-  tps: 5607.3633
+  dps: 6614.17582
+  tps: 5606.25258
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6604.17782
-  tps: 5600.24852
+  dps: 6606.18742
+  tps: 5599.13374
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheFistsofFury"
  value: {
-  dps: 6437.9862
-  tps: 5451.25998
+  dps: 6434.1702
+  tps: 5454.37686
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6654.6535
-  tps: 5653.07282
+  dps: 6664.26647
+  tps: 5658.24859
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6502.09161
-  tps: 5511.87944
+  dps: 6505.58383
+  tps: 5517.01271
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6502.09161
-  tps: 5511.87944
+  dps: 6505.58383
+  tps: 5517.01271
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6592.77503
-  tps: 5590.08455
+  dps: 6594.77543
+  tps: 5588.96397
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6592.77503
-  tps: 5590.08455
+  dps: 6594.77543
+  tps: 5588.96397
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6592.77503
-  tps: 5590.08455
+  dps: 6594.77543
+  tps: 5588.96397
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6592.77503
-  tps: 5590.08455
+  dps: 6594.77543
+  tps: 5588.96397
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5589.01333
-  tps: 4730.47703
+  dps: 5594.15682
+  tps: 4736.72962
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 6794.02798
-  tps: 5796.21865
+  dps: 6833.24686
+  tps: 5841.55858
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7217.07904
-  tps: 6216.89298
+  dps: 7171.20674
+  tps: 6172.76369
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 7416.34295
-  tps: 6419.60249
+  dps: 7357.19131
+  tps: 6369.14234
  }
 }
 dps_results: {
  key: "TestHunter-Average-Default"
  value: {
-  dps: 6790.46154
-  tps: 5784.08708
+  dps: 6793.0731
+  tps: 5790.08888
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16710.2742
-  tps: 16642.43028
+  dps: 16714.32567
+  tps: 16646.25999
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6882.89565
-  tps: 5804.84606
+  dps: 6879.03082
+  tps: 5804.82524
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-AOE-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7746.01677
-  tps: 6482.61506
+  tps: 6482.70801
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9373.25137
-  tps: 10462.16498
+  dps: 9376.69822
+  tps: 10465.48295
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3401.07048
-  tps: 3053.4203
+  dps: 3400.86781
+  tps: 3053.41803
  }
 }
 dps_results: {
@@ -605,15 +605,15 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-BM-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6160.1525
-  tps: 4680.73917
+  dps: 6162.41246
+  tps: 4676.29803
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-BM-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6160.1525
-  tps: 3765.40942
+  dps: 6162.41246
+  tps: 3755.39833
  }
 }
 dps_results: {
@@ -626,78 +626,78 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-BM-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2976.11737
-  tps: 3651.46208
+  dps: 2986.71736
+  tps: 3665.68929
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-BM-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2976.11737
-  tps: 2148.99565
+  dps: 2986.71736
+  tps: 2162.29203
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-BM-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3519.74373
-  tps: 2526.87795
+  dps: 3519.5974
+  tps: 2526.80732
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6474.17702
-  tps: 6389.10336
+  dps: 6456.87866
+  tps: 6366.55662
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6474.17702
-  tps: 5523.33376
+  dps: 6456.87866
+  tps: 5510.67268
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7561.87369
-  tps: 6454.10964
+  dps: 7543.43759
+  tps: 6438.58041
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3422.92265
-  tps: 4554.51989
+  dps: 3415.39843
+  tps: 4544.68908
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3422.92265
-  tps: 3087.95257
+  dps: 3415.39843
+  tps: 3080.72075
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4139.90654
-  tps: 3688.95418
+  dps: 4177.6123
+  tps: 3729.17555
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6818.4366
-  tps: 6727.19271
+  dps: 6808.46694
+  tps: 6721.52793
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6818.4366
-  tps: 5733.15907
+  dps: 6808.46694
+  tps: 5725.4697
  }
 }
 dps_results: {
@@ -710,15 +710,15 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3370.8018
-  tps: 4525.24184
+  dps: 3367.60981
+  tps: 4521.16717
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-SV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3370.8018
-  tps: 3020.62651
+  dps: 3367.60981
+  tps: 3017.36309
  }
 }
 dps_results: {
@@ -731,36 +731,36 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16810.8868
-  tps: 16685.56466
+  dps: 16814.8336
+  tps: 16689.24747
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6957.89708
-  tps: 5812.73519
+  dps: 6927.00802
+  tps: 5793.14142
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-AOE-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7852.25882
-  tps: 6514.69157
+  tps: 6514.78485
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9427.9847
-  tps: 10486.82356
+  dps: 9429.72943
+  tps: 10488.75086
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3403.86301
-  tps: 3031.02561
+  dps: 3404.42591
+  tps: 3031.00675
  }
 }
 dps_results: {
@@ -773,15 +773,15 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6284.52792
-  tps: 4673.66536
+  dps: 6276.09007
+  tps: 4665.63388
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6284.52792
-  tps: 3751.88846
+  dps: 6276.09007
+  tps: 3743.8519
  }
 }
 dps_results: {
@@ -794,78 +794,78 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3008.89165
-  tps: 3638.10707
+  dps: 2997.3582
+  tps: 3630.2702
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3008.89165
-  tps: 2134.25366
+  dps: 2997.3582
+  tps: 2125.72259
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-BM-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3559.24468
-  tps: 2524.57748
+  dps: 3558.91293
+  tps: 2524.55657
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6499.30069
-  tps: 6362.72478
+  dps: 6507.77549
+  tps: 6369.74502
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6499.30069
-  tps: 5493.75207
+  dps: 6507.77549
+  tps: 5505.3677
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7645.23377
-  tps: 6470.77945
+  dps: 7633.42582
+  tps: 6462.2186
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3431.88844
-  tps: 4545.15263
+  dps: 3422.80348
+  tps: 4531.95557
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3431.88844
-  tps: 3074.02645
+  dps: 3422.80348
+  tps: 3064.34923
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4213.36643
-  tps: 3739.24031
+  dps: 4157.30374
+  tps: 3680.01906
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6852.17864
-  tps: 6684.3134
+  dps: 6836.32231
+  tps: 6681.32809
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6852.17864
-  tps: 5700.11496
+  dps: 6836.32231
+  tps: 5697.71597
  }
 }
 dps_results: {
@@ -878,15 +878,15 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3369.15974
-  tps: 4503.53009
+  dps: 3365.86199
+  tps: 4502.14692
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-SV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3369.15974
-  tps: 2996.48072
+  dps: 3365.86199
+  tps: 2995.66036
  }
 }
 dps_results: {
@@ -899,7 +899,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6676.2591
-  tps: 5731.51774
+  dps: 6674.08105
+  tps: 5736.04817
  }
 }

--- a/sim/hunter/silencing_shot.go
+++ b/sim/hunter/silencing_shot.go
@@ -49,7 +49,7 @@ func (hunter *Hunter) registerSilencingShotSpell() {
 				DoAt: sim.CurrentTime + hunter.SilencingShot.CD.Duration,
 				OnAction: func(sim *core.Simulation) {
 					// Need to check in case Readiness caused a shift in timing.
-					if hunter.SilencingShot.IsReady(sim) {
+					if hunter.SilencingShot.IsReady(sim) && hunter.Hardcast.Expires == 0 {
 						hunter.SilencingShot.Cast(sim, hunter.CurrentTarget)
 					}
 				},

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -45,553 +45,553 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6736.47776
-  tps: 4041.19474
+  dps: 6712.76626
+  tps: 4024.96175
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6572.48431
-  tps: 3945.96826
+  dps: 6551.70742
+  tps: 3933.08806
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6759.79015
-  tps: 4050.45526
+  dps: 6770.69927
+  tps: 4055.53941
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5683.3328
-  tps: 3418.20451
+  dps: 5674.22191
+  tps: 3411.64214
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 7571.72354
-  tps: 4543.43869
+  dps: 7563.59114
+  tps: 4537.79407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6775.19587
-  tps: 3984.19738
+  dps: 6751.43209
+  tps: 3968.2128
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6915.84287
-  tps: 4148.50904
+  dps: 6885.6227
+  tps: 4128.42028
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6644.9027
-  tps: 3989.20406
+  dps: 6617.34334
+  tps: 3971.95806
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6692.76951
-  tps: 4040.05438
+  dps: 6693.09791
+  tps: 4038.77849
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6656.29912
-  tps: 3989.38402
+  dps: 6662.03144
+  tps: 3994.20869
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6656.29912
-  tps: 3989.38402
+  dps: 6662.03144
+  tps: 3994.20869
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6660.1882
-  tps: 3988.83445
+  dps: 6696.27797
+  tps: 4011.63827
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6599.38805
-  tps: 3962.07268
+  dps: 6570.77823
+  tps: 3944.39386
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6572.48431
-  tps: 3945.96826
+  dps: 6551.70742
+  tps: 3933.08806
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6755.56943
-  tps: 4052.2693
+  dps: 6726.53596
+  tps: 4032.9304
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6736.47776
-  tps: 4041.19474
+  dps: 6712.76626
+  tps: 4024.96175
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6799.09592
-  tps: 4073.6282
+  dps: 6780.80221
+  tps: 4062.21542
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6752.88935
-  tps: 4050.73693
+  dps: 6724.962
+  tps: 4032.02386
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6748.643
-  tps: 4048.26258
+  dps: 6722.60075
+  tps: 4030.64494
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6736.47776
-  tps: 4041.19474
+  dps: 6712.76626
+  tps: 4024.96175
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6643.59053
-  tps: 3988.4241
+  dps: 6613.43198
+  tps: 3969.32038
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6833.6551
-  tps: 4101.31856
+  dps: 6804.61854
+  tps: 4082.85054
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6785.47038
-  tps: 4072.83067
+  dps: 6762.63417
+  tps: 4058.28972
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6775.19587
-  tps: 4064.01746
+  dps: 6751.43209
+  tps: 4047.754
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6767.45225
-  tps: 4059.45292
+  dps: 6743.69893
+  tps: 4043.19555
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FrostfireGarb"
  value: {
-  dps: 6001.23486
-  tps: 3602.27786
+  dps: 5999.51552
+  tps: 3600.79248
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6572.48431
-  tps: 3945.96826
+  dps: 6551.70742
+  tps: 3933.08806
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6724.68115
-  tps: 4033.07369
+  dps: 6655.72248
+  tps: 3993.41631
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6879.6329
-  tps: 4128.47569
+  dps: 6858.10332
+  tps: 4115.16258
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6752.88935
-  tps: 4050.73693
+  dps: 6724.962
+  tps: 4032.02386
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6748.643
-  tps: 4048.26258
+  dps: 6722.60075
+  tps: 4030.64494
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6572.48431
-  tps: 3945.96826
+  dps: 6551.70742
+  tps: 3933.08806
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6795.66537
-  tps: 4075.16001
+  dps: 6801.93848
+  tps: 4080.29943
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6736.47776
-  tps: 4041.19474
+  dps: 6712.76626
+  tps: 4024.96175
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 6641.63245
-  tps: 3975.7586
+  dps: 6640.57701
+  tps: 3974.6341
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KirinTorGarb"
  value: {
-  dps: 6217.05365
-  tps: 3723.79625
+  dps: 6215.23992
+  tps: 3720.63436
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6572.48431
-  tps: 3945.96826
+  dps: 6551.70742
+  tps: 3933.08806
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6653.58776
-  tps: 3986.04702
+  dps: 6688.40265
+  tps: 4003.25004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6627.07837
-  tps: 3978.64903
+  dps: 6602.62311
+  tps: 3963.16243
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6572.48431
-  tps: 3945.96826
+  dps: 6551.70742
+  tps: 3933.08806
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6736.47776
-  tps: 4041.19474
+  dps: 6712.76626
+  tps: 4024.96175
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6736.47776
-  tps: 4041.19474
+  dps: 6712.76626
+  tps: 4024.96175
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6736.47776
-  tps: 4041.19474
+  dps: 6712.76626
+  tps: 4024.96175
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6736.47776
-  tps: 4041.19474
+  dps: 6712.76626
+  tps: 4024.96175
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6572.48431
-  tps: 3945.96826
+  dps: 6551.70742
+  tps: 3933.08806
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7039.631
-  tps: 4304.32635
+  dps: 7064.14737
+  tps: 4317.48928
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7093.06941
-  tps: 4346.11306
+  dps: 7117.83768
+  tps: 4359.49079
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6897.99995
-  tps: 4138.10805
+  dps: 6872.36765
+  tps: 4120.72258
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6758.18238
-  tps: 4050.5961
+  dps: 6741.66583
+  tps: 4039.22964
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6572.48431
-  tps: 3945.96826
+  dps: 6551.70742
+  tps: 3933.08806
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6572.48431
-  tps: 3945.96826
+  dps: 6551.70742
+  tps: 3933.08806
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6572.48431
-  tps: 3945.96826
+  dps: 6551.70742
+  tps: 3933.08806
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6572.48431
-  tps: 3945.96826
+  dps: 6551.70742
+  tps: 3933.08806
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SparkofLife-37657"
  value: {
-  dps: 6680.71884
-  tps: 4006.55756
+  dps: 6682.02222
+  tps: 4008.61723
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sunstrider'sRegalia"
  value: {
-  dps: 6542.5867
-  tps: 3917.16832
+  dps: 6557.91562
+  tps: 3925.55779
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6736.47776
-  tps: 4041.19474
+  dps: 6712.76626
+  tps: 4024.96175
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6736.47776
-  tps: 4041.19474
+  dps: 6712.76626
+  tps: 4024.96175
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6736.47776
-  tps: 4041.19474
+  dps: 6712.76626
+  tps: 4024.96175
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6736.47776
-  tps: 4041.19474
+  dps: 6712.76626
+  tps: 4024.96175
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6661.36728
-  tps: 3996.64942
+  dps: 6643.13084
+  tps: 3983.23215
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6661.36728
-  tps: 3996.64942
+  dps: 6643.13084
+  tps: 3983.23215
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6775.19587
-  tps: 4064.01746
+  dps: 6751.43209
+  tps: 4047.754
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6767.45225
-  tps: 4059.45292
+  dps: 6743.69893
+  tps: 4043.19555
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6767.45225
-  tps: 4059.45292
+  dps: 6743.69893
+  tps: 4043.19555
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6775.19587
-  tps: 4064.01746
+  dps: 6751.43209
+  tps: 4047.754
  }
 }
 dps_results: {
  key: "TestArcane-Average-Default"
  value: {
-  dps: 6939.38007
-  tps: 4161.88127
+  dps: 6933.32162
+  tps: 4157.58158
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10592.98725
-  tps: 8525.76765
+  dps: 10587.5118
+  tps: 8501.19831
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1448.37573
-  tps: 906.45733
+  dps: 1434.76023
+  tps: 898.76428
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2337.35746
-  tps: 1402.78927
+  dps: 2315.64518
+  tps: 1392.99525
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6244.19176
-  tps: 5350.23355
+  dps: 6255.14279
+  tps: 5375.90677
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 750.76464
-  tps: 477.80888
+  dps: 746.25674
+  tps: 476.85868
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1591.4396
-  tps: 959.6109
+  dps: 1588.24232
+  tps: 957.48094
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6915.84287
-  tps: 5535.76085
+  dps: 6885.6227
+  tps: 5471.60784
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6915.84287
-  tps: 4148.50904
+  dps: 6885.6227
+  tps: 4128.42028
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9224.00101
-  tps: 5450.2765
+  dps: 9252.51782
+  tps: 5470.86082
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3805.60146
-  tps: 3513.52648
+  dps: 3892.35086
+  tps: 3542.43615
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3805.60146
-  tps: 2295.39294
+  dps: 3892.35086
+  tps: 2346.1338
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5119.3674
-  tps: 2972.86725
+  dps: 5060.47602
+  tps: 2943.06945
  }
 }
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6915.84287
-  tps: 4148.50904
+  dps: 6885.6227
+  tps: 4128.42028
  }
 }

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -45,553 +45,553 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5829.49
-  tps: 5222.23849
+  dps: 5799.64049
+  tps: 5196.53786
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5616.43901
-  tps: 5032.58162
+  dps: 5670.49977
+  tps: 5082.14184
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5829.5167
-  tps: 5219.37517
+  dps: 5891.04874
+  tps: 5276.92583
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4707.47504
-  tps: 4216.68947
+  dps: 4728.8653
+  tps: 4235.31502
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 6659.7535
-  tps: 5967.16228
+  dps: 6580.87457
+  tps: 5896.31255
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5867.84225
-  tps: 5152.58053
+  dps: 5837.85179
+  tps: 5127.29983
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 5983.81022
-  tps: 5360.71308
+  dps: 6046.76203
+  tps: 5413.63711
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5722.86815
-  tps: 5130.10866
+  dps: 5755.93435
+  tps: 5161.54115
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5805.52964
-  tps: 5208.83527
+  dps: 5791.10387
+  tps: 5196.67347
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 5670.51709
-  tps: 5079.04305
+  dps: 5704.87252
+  tps: 5114.33682
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 5670.51709
-  tps: 5079.04305
+  dps: 5704.87252
+  tps: 5114.33682
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 5688.80916
-  tps: 5090.25381
+  dps: 5732.45133
+  tps: 5134.26427
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5686.07904
-  tps: 5096.3777
+  dps: 5687.29804
+  tps: 5097.73681
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5616.43901
-  tps: 5032.58162
+  dps: 5670.49977
+  tps: 5082.14184
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5871.03707
-  tps: 5256.79957
+  dps: 5875.57986
+  tps: 5261.1548
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5829.49
-  tps: 5222.23849
+  dps: 5799.64049
+  tps: 5196.53786
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5871.24957
-  tps: 5259.5797
+  dps: 5895.23462
+  tps: 5279.97879
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5828.33785
-  tps: 5220.78794
+  dps: 5888.03478
+  tps: 5270.78258
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5828.33785
-  tps: 5220.78794
+  dps: 5869.52074
+  tps: 5254.99589
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5829.49
-  tps: 5222.23849
+  dps: 5799.64049
+  tps: 5196.53786
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5832.17673
-  tps: 5233.35269
+  dps: 5781.16417
+  tps: 5184.23112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5908.8537
-  tps: 5290.73342
+  dps: 5914.04936
+  tps: 5297.14457
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5801.65281
-  tps: 5194.02193
+  dps: 5838.74877
+  tps: 5230.57866
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5867.84225
-  tps: 5256.17376
+  dps: 5837.85179
+  tps: 5230.33538
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5860.1718
-  tps: 5249.38671
+  dps: 5830.20953
+  tps: 5223.57588
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FrostfireGarb"
  value: {
-  dps: 5132.6475
-  tps: 4599.67945
+  dps: 5158.84802
+  tps: 4623.10053
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5616.43901
-  tps: 5032.58162
+  dps: 5670.49977
+  tps: 5082.14184
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5707.3436
-  tps: 5114.14605
+  dps: 5810.04466
+  tps: 5206.10629
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5914.96244
-  tps: 5298.69403
+  dps: 5971.19656
+  tps: 5350.24128
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5828.33785
-  tps: 5220.78794
+  dps: 5888.03478
+  tps: 5270.78258
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5828.33785
-  tps: 5220.78794
+  dps: 5869.52074
+  tps: 5254.99589
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5616.43901
-  tps: 5032.58162
+  dps: 5670.49977
+  tps: 5082.14184
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5847.83212
-  tps: 5240.71001
+  dps: 5897.176
+  tps: 5284.56511
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5829.49
-  tps: 5222.23849
+  dps: 5799.64049
+  tps: 5196.53786
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 5937.18154
-  tps: 5317.51155
+  dps: 5945.05114
+  tps: 5326.19345
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KirinTorGarb"
  value: {
-  dps: 5580.45345
-  tps: 4996.1232
+  dps: 5596.02471
+  tps: 5011.05643
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5616.43901
-  tps: 5032.58162
+  dps: 5670.49977
+  tps: 5082.14184
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5729.2896
-  tps: 5133.77055
+  dps: 5761.24418
+  tps: 5163.56476
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5684.416
-  tps: 5089.45861
+  dps: 5720.55922
+  tps: 5125.37502
  }
 }
 dps_results: {
  key: "TestFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5616.43901
-  tps: 5032.58162
+  dps: 5670.49977
+  tps: 5082.14184
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5829.49
-  tps: 5222.23849
+  dps: 5799.64049
+  tps: 5196.53786
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5829.49
-  tps: 5222.23849
+  dps: 5799.64049
+  tps: 5196.53786
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5829.49
-  tps: 5222.23849
+  dps: 5799.64049
+  tps: 5196.53786
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5829.49
-  tps: 5222.23849
+  dps: 5799.64049
+  tps: 5196.53786
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5616.43901
-  tps: 5032.58162
+  dps: 5670.49977
+  tps: 5082.14184
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6195.64069
-  tps: 5576.21132
+  dps: 6138.0582
+  tps: 5520.88176
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6253.97071
-  tps: 5630.796
+  dps: 6196.33453
+  tps: 5575.41064
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5985.66435
-  tps: 5362.79541
+  dps: 5954.19723
+  tps: 5335.63892
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5830.24121
-  tps: 5223.32494
+  dps: 5834.19514
+  tps: 5223.65457
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5616.43901
-  tps: 5032.58162
+  dps: 5670.49977
+  tps: 5082.14184
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5616.43901
-  tps: 5032.58162
+  dps: 5670.49977
+  tps: 5082.14184
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5616.43901
-  tps: 5032.58162
+  dps: 5670.49977
+  tps: 5082.14184
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5616.43901
-  tps: 5032.58162
+  dps: 5670.49977
+  tps: 5082.14184
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 5775.82917
-  tps: 5175.65816
+  dps: 5716.49698
+  tps: 5121.67533
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sunstrider'sRegalia"
  value: {
-  dps: 5779.99966
-  tps: 5174.42145
+  dps: 5805.49422
+  tps: 5199.72759
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5829.49
-  tps: 5222.23849
+  dps: 5799.64049
+  tps: 5196.53786
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5829.49
-  tps: 5222.23849
+  dps: 5799.64049
+  tps: 5196.53786
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5829.49
-  tps: 5222.23849
+  dps: 5799.64049
+  tps: 5196.53786
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5829.49
-  tps: 5222.23849
+  dps: 5799.64049
+  tps: 5196.53786
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5853.87272
-  tps: 5244.59386
+  dps: 5843.22144
+  tps: 5234.7865
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5853.87272
-  tps: 5244.59386
+  dps: 5843.22144
+  tps: 5234.7865
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5867.84225
-  tps: 5256.17376
+  dps: 5837.85179
+  tps: 5230.33538
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5860.1718
-  tps: 5249.38671
+  dps: 5830.20953
+  tps: 5223.57588
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5860.1718
-  tps: 5249.38671
+  dps: 5830.20953
+  tps: 5223.57588
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5867.84225
-  tps: 5256.17376
+  dps: 5837.85179
+  tps: 5230.33538
  }
 }
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
-  dps: 6018.99949
-  tps: 5392.9608
+  dps: 6013.33126
+  tps: 5388.15512
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18213.37363
-  tps: 21061.03887
+  dps: 18234.54844
+  tps: 21092.78091
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1806.94062
-  tps: 1674.26096
+  dps: 1813.44898
+  tps: 1679.06941
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2518.32338
-  tps: 2217.64454
+  dps: 2518.41851
+  tps: 2216.41259
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14216.35641
-  tps: 16865.42863
+  dps: 14263.93047
+  tps: 16915.22142
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 847.8778
-  tps: 772.97833
+  dps: 855.50327
+  tps: 780.31088
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1395.044
-  tps: 1180.03909
+  dps: 1407.6883
+  tps: 1190.00699
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8368.12975
-  tps: 9292.78969
+  dps: 8420.20458
+  tps: 9339.0746
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5983.81022
-  tps: 5360.71308
+  dps: 6046.76203
+  tps: 5413.63711
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7436.14033
-  tps: 6540.07402
+  dps: 7392.69634
+  tps: 6507.91247
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4708.16477
-  tps: 5756.18303
+  dps: 4713.87871
+  tps: 5755.83689
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2571.82334
-  tps: 2290.83497
+  dps: 2528.35673
+  tps: 2252.3934
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3604.02579
-  tps: 3111.14452
+  dps: 3568.74199
+  tps: 3084.02051
  }
 }
 dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5983.81022
-  tps: 5360.71308
+  dps: 6046.76203
+  tps: 5413.63711
  }
 }

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -45,553 +45,553 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 4438.15558
-  tps: 3731.87738
+  dps: 4408.5199
+  tps: 3706.50763
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 4245.20921
-  tps: 3566.14919
+  dps: 4278.3891
+  tps: 3600.11471
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 4448.55305
-  tps: 3740.79049
+  dps: 4420.54618
+  tps: 3717.31248
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 3758.22086
-  tps: 3148.4256
+  dps: 3773.36172
+  tps: 3163.48306
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 4847.82939
-  tps: 4093.41529
+  dps: 4843.01887
+  tps: 4090.33124
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 4468.04652
-  tps: 3682.57027
+  dps: 4438.27385
+  tps: 3657.57433
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 4562.15115
-  tps: 3843.00332
+  dps: 4532.03208
+  tps: 3817.22225
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 4310.4125
-  tps: 3624.43699
+  dps: 4344.71998
+  tps: 3659.05434
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 4369.24596
-  tps: 3684.40616
+  dps: 4371.54807
+  tps: 3684.23198
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 4328.05635
-  tps: 3651.32075
+  dps: 4297.97957
+  tps: 3622.9413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 4328.05635
-  tps: 3651.32075
+  dps: 4297.97957
+  tps: 3622.9413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 4327.1599
-  tps: 3650.10009
+  dps: 4297.00185
+  tps: 3621.078
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 4262.99666
-  tps: 3581.89195
+  dps: 4297.2936
+  tps: 3616.85427
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 4245.07863
-  tps: 3565.81904
+  dps: 4278.3891
+  tps: 3600.11471
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 4454.97896
-  tps: 3746.77458
+  dps: 4426.61379
+  tps: 3722.51875
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 4438.15558
-  tps: 3731.87738
+  dps: 4408.5199
+  tps: 3706.50763
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 4470.3208
-  tps: 3758.17633
+  dps: 4442.55642
+  tps: 3735.40563
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 4449.8969
-  tps: 3742.20073
+  dps: 4420.9034
+  tps: 3717.42442
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 4447.06959
-  tps: 3739.65615
+  dps: 4417.86101
+  tps: 3714.70211
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 4438.15558
-  tps: 3731.87738
+  dps: 4408.5199
+  tps: 3706.50763
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 4347.80514
-  tps: 3659.65406
+  dps: 4380.18953
+  tps: 3688.48239
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 4448.18381
-  tps: 3742.37355
+  dps: 4488.21648
+  tps: 3782.10844
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 4391.43827
-  tps: 3693.14331
+  dps: 4422.74904
+  tps: 3725.7859
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 4468.04652
-  tps: 3757.18681
+  dps: 4438.27385
+  tps: 3731.70708
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 4462.06833
-  tps: 3752.12492
+  dps: 4432.32306
+  tps: 3726.66719
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FrostfireGarb"
  value: {
-  dps: 3954.79941
-  tps: 3314.69713
+  dps: 3940.74593
+  tps: 3304.11541
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 4245.20921
-  tps: 3566.14919
+  dps: 4278.3891
+  tps: 3600.11471
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 4315.84421
-  tps: 3624.07933
+  dps: 4349.52774
+  tps: 3659.91303
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 4477.01956
-  tps: 3766.07681
+  dps: 4512.37741
+  tps: 3802.06503
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 4449.8969
-  tps: 3742.20073
+  dps: 4420.9034
+  tps: 3717.42442
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 4447.06959
-  tps: 3739.65615
+  dps: 4417.86101
+  tps: 3714.70211
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 4245.07863
-  tps: 3565.81904
+  dps: 4278.3891
+  tps: 3600.11471
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 4424.41515
-  tps: 3719.64074
+  dps: 4398.27445
+  tps: 3698.55736
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 4438.15558
-  tps: 3731.87738
+  dps: 4408.5199
+  tps: 3706.50763
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 4397.01039
-  tps: 3690.49695
+  dps: 4394.72208
+  tps: 3692.06285
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KirinTorGarb"
  value: {
-  dps: 4215.78735
-  tps: 3538.89055
+  dps: 4229.75864
+  tps: 3550.34933
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 4245.07863
-  tps: 3565.81904
+  dps: 4278.3891
+  tps: 3600.11471
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 4236.502
-  tps: 3554.26248
+  dps: 4266.05817
+  tps: 3583.72662
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 4292.53066
-  tps: 3608.18586
+  dps: 4327.13977
+  tps: 3643.43867
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 4245.20921
-  tps: 3566.14919
+  dps: 4278.3891
+  tps: 3600.11471
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 4438.15558
-  tps: 3731.87738
+  dps: 4408.5199
+  tps: 3706.50763
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 4438.15558
-  tps: 3731.87738
+  dps: 4408.5199
+  tps: 3706.50763
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 4438.15558
-  tps: 3731.87738
+  dps: 4408.5199
+  tps: 3706.50763
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 4438.15558
-  tps: 3731.87738
+  dps: 4408.5199
+  tps: 3706.50763
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 4245.20921
-  tps: 3566.14919
+  dps: 4278.3891
+  tps: 3600.11471
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 4659.92993
-  tps: 3951.56194
+  dps: 4583.01592
+  tps: 3875.5886
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 4700.88187
-  tps: 3989.21496
+  dps: 4622.9009
+  tps: 3912.18377
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 4549.37559
-  tps: 3831.75087
+  dps: 4518.554
+  tps: 3805.32295
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 4434.88908
-  tps: 3727.33745
+  dps: 4406.96799
+  tps: 3704.84525
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 4245.07863
-  tps: 3565.81904
+  dps: 4278.3891
+  tps: 3600.11471
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 4245.07863
-  tps: 3565.81904
+  dps: 4278.3891
+  tps: 3600.11471
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 4245.20921
-  tps: 3566.14919
+  dps: 4278.3891
+  tps: 3600.11471
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 4245.07863
-  tps: 3565.81904
+  dps: 4278.3891
+  tps: 3600.11471
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 4350.017
-  tps: 3659.58147
+  dps: 4343.20937
+  tps: 3653.06588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sunstrider'sRegalia"
  value: {
-  dps: 4397.01039
-  tps: 3693.56197
+  dps: 4394.72208
+  tps: 3696.39947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 4438.15558
-  tps: 3731.87738
+  dps: 4408.5199
+  tps: 3706.50763
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 4438.15558
-  tps: 3731.87738
+  dps: 4408.5199
+  tps: 3706.50763
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 4438.15558
-  tps: 3731.87738
+  dps: 4408.5199
+  tps: 3706.50763
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 4420.30018
-  tps: 3721.34145
+  dps: 4401.93003
+  tps: 3698.87775
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 4398.26848
-  tps: 3707.92465
+  dps: 4408.20691
+  tps: 3715.56972
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 4398.26848
-  tps: 3707.92465
+  dps: 4408.20691
+  tps: 3715.56972
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 4468.04652
-  tps: 3757.18681
+  dps: 4438.27385
+  tps: 3731.70708
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 4462.06833
-  tps: 3752.12492
+  dps: 4432.32306
+  tps: 3726.66719
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 4462.06833
-  tps: 3752.12492
+  dps: 4432.32306
+  tps: 3726.66719
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 4468.04652
-  tps: 3757.18681
+  dps: 4438.27385
+  tps: 3731.70708
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 4516.50256
-  tps: 3802.7827
+  dps: 4510.78243
+  tps: 3796.60137
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8370.05588
-  tps: 8697.98556
+  dps: 8265.87523
+  tps: 8544.50188
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1207.58982
-  tps: 887.76474
+  dps: 1197.20389
+  tps: 874.07365
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2225.40794
-  tps: 1535.82907
+  dps: 2203.4685
+  tps: 1526.93331
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4405.99627
-  tps: 4512.67683
+  dps: 4420.75077
+  tps: 4580.39804
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 580.27147
-  tps: 417.07672
+  dps: 583.97916
+  tps: 420.9006
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1267.08273
-  tps: 888.9305
+  dps: 1268.60209
+  tps: 889.15624
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4562.15115
-  tps: 4343.83558
+  dps: 4532.03208
+  tps: 4293.54601
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4562.15115
-  tps: 3843.00332
+  dps: 4532.03208
+  tps: 3817.22225
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5779.52275
-  tps: 4680.38911
+  dps: 5862.21518
+  tps: 4755.25327
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2786.01343
-  tps: 3067.85295
+  dps: 2767.9527
+  tps: 3041.86288
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2786.01343
-  tps: 2342.53086
+  dps: 2767.9527
+  tps: 2322.25825
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3292.68678
-  tps: 2600.23276
+  dps: 3390.76397
+  tps: 2693.25085
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 4562.15115
-  tps: 3843.00332
+  dps: 4532.03208
+  tps: 3817.22225
  }
 }

--- a/sim/mage/mage.go
+++ b/sim/mage/mage.go
@@ -197,8 +197,9 @@ func (mage *Mage) launchExecuteCDOptimizer(sim *core.Simulation) {
 	pa.OnAction = func(sim *core.Simulation) {
 		if sim.IsExecutePhase35() {
 			for _, mcd := range mage.disabledMCDs {
-				mage.EnableMajorCooldown(mcd.Spell.ActionID)
+				mcd.Enable()
 			}
+			// TODO looks fishy, since disabledMCDs isn't emptied; also, this could use an executePhaseCallback instead
 		} else {
 			for _, mcd := range mage.GetMajorCooldowns() {
 				isBloodLust := mcd.Spell.ActionID == core.ActionID{SpellID: 2825, Tag: -1} //ignore blood lust as it shouldn't be saved
@@ -206,7 +207,7 @@ func (mage *Mage) launchExecuteCDOptimizer(sim *core.Simulation) {
 				isPotionOfSpeed := mcd.Spell.ActionID == core.ActionID{ItemID: 40211}
 				if mcd.Spell.CD.Duration > (sim.Duration-sim.CurrentTime) && mcd.Type.Matches(core.CooldownTypeDPS) &&
 					!isBloodLust && !isFlameCap || isPotionOfSpeed {
-					mage.DisableMajorCooldown(mcd.Spell.ActionID)
+					mcd.Disable()
 					mage.disabledMCDs = append(mage.disabledMCDs, mcd)
 				}
 			}

--- a/sim/mage/mana_gems.go
+++ b/sim/mage/mana_gems.go
@@ -68,7 +68,7 @@ func (mage *Mage) registerManaGemsCD() {
 			remainingManaGems--
 			if remainingManaGems == 0 {
 				// Disable this cooldown since we're out of emeralds.
-				mage.DisableMajorCooldown(actionID)
+				mage.GetMajorCooldown(actionID).Disable()
 			}
 		},
 	})

--- a/sim/mage/rotations.go
+++ b/sim/mage/rotations.go
@@ -38,12 +38,12 @@ func (mage *Mage) doArcaneRotation(sim *core.Simulation) *core.Spell {
 	numStacks := mage.ArcaneBlastAura.GetStacks()
 
 	if sim.GetRemainingDuration() < 12*time.Second {
-		mage.DisableMajorCooldown(core.ActionID{SpellID: EvocationId})
+		mage.GetMajorCooldown(core.ActionID{SpellID: EvocationId}).Disable()
 	}
 
 	burstDuration := time.Duration(mage.Character.CurrentManaPercent()*40) * time.Second
 	if sim.GetRemainingDuration() < burstDuration {
-		mage.DisableMajorCooldown(core.ActionID{SpellID: EvocationId})
+		mage.GetMajorCooldown(core.ActionID{SpellID: EvocationId}).Disable()
 		if mage.Character.CurrentMana() < mage.ArcaneBlast.CurCast.Cost {
 			return mage.ArcaneMissiles
 		} else {

--- a/sim/mage/talents.go
+++ b/sim/mage/talents.go
@@ -587,7 +587,7 @@ func (mage *Mage) applyMoltenFury() {
 
 	mage.RegisterResetEffect(func(sim *core.Simulation) {
 		sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int) {
-			mage.DisableMajorCooldown(core.ActionID{SpellID: EvocationId})
+			mage.GetMajorCooldown(core.ActionID{SpellID: EvocationId}).Disable()
 			if isExecute == 35 {
 				mage.PseudoStats.DamageDealtMultiplier *= multiplier
 			}

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -689,8 +689,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7473.97251
-  tps: 8760.93551
+  dps: 7535.10368
+  tps: 8807.42001
  }
 }
 dps_results: {
@@ -731,8 +731,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6304.23023
-  tps: 7585.70073
+  dps: 6371.77662
+  tps: 7644.09296
  }
 }
 dps_results: {
@@ -773,8 +773,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7027.80152
-  tps: 8322.80994
+  dps: 7076.70229
+  tps: 8349.01862
  }
 }
 dps_results: {
@@ -815,8 +815,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6778.54678
-  tps: 8065.50978
+  dps: 6866.77141
+  tps: 8139.08775
  }
 }
 dps_results: {

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -52,29 +52,29 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-AshtongueTalismanofAcumen-32490"
  value: {
-  dps: 5222.63271
-  tps: 4029.47898
+  dps: 5228.40785
+  tps: 4032.66663
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5300.54659
-  tps: 4086.47715
+  dps: 5306.25931
+  tps: 4089.59225
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5145.36142
-  tps: 3971.18098
+  dps: 5151.68096
+  tps: 3974.78405
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5321.0524
-  tps: 4101.72251
+  dps: 5317.07939
+  tps: 4100.08794
  }
 }
 dps_results: {
@@ -87,15 +87,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5335.26627
-  tps: 4031.79382
+  dps: 5341.00194
+  tps: 4034.85489
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 5419.33285
-  tps: 4178.42192
+  dps: 5425.81445
+  tps: 4182.10581
  }
 }
 dps_results: {
@@ -115,15 +115,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5239.91802
-  tps: 4044.85159
+  dps: 5241.42494
+  tps: 4045.66304
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5291.76189
-  tps: 4100.88369
+  dps: 5291.31051
+  tps: 4100.60937
  }
 }
 dps_results: {
@@ -143,113 +143,113 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 5195.2606
-  tps: 4006.2124
+  dps: 5194.46027
+  tps: 4005.88329
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5171.32513
-  tps: 3991.46345
+  dps: 5177.43409
+  tps: 3994.83304
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5145.36142
-  tps: 3971.18098
+  dps: 5151.68096
+  tps: 3974.78405
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5325.60853
-  tps: 4105.80504
+  dps: 5330.69151
+  tps: 4108.42589
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5300.54659
-  tps: 4086.47715
+  dps: 5306.25931
+  tps: 4089.59225
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5344.862
-  tps: 4119.47875
+  dps: 5340.51254
+  tps: 4117.63624
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5321.77588
-  tps: 4102.83637
+  dps: 5327.67453
+  tps: 4106.11277
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5319.11975
-  tps: 4100.81771
+  dps: 5324.51128
+  tps: 4103.68177
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5300.54659
-  tps: 4086.47715
+  dps: 5306.25931
+  tps: 4089.59225
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5303.09523
-  tps: 4109.15809
+  dps: 5302.54349
+  tps: 4108.53923
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5404.47687
-  tps: 4169.19917
+  dps: 5405.60618
+  tps: 4169.68566
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5356.90657
-  tps: 4133.31432
+  dps: 5359.05279
+  tps: 4134.66679
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5335.26627
-  tps: 4112.75524
+  dps: 5341.00194
+  tps: 4115.88342
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5328.32234
-  tps: 4107.49962
+  dps: 5334.05341
+  tps: 4110.62518
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5145.36142
-  tps: 3971.18098
+  dps: 5151.68096
+  tps: 3974.78405
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5232.13836
-  tps: 4037.30645
+  dps: 5228.95257
+  tps: 4034.88294
  }
 }
 dps_results: {
@@ -276,22 +276,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5321.77588
-  tps: 4102.83637
+  dps: 5327.67453
+  tps: 4106.11277
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5319.11975
-  tps: 4100.81771
+  dps: 5324.51128
+  tps: 4103.68177
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5145.36142
-  tps: 3971.18098
+  dps: 5151.68096
+  tps: 3974.78405
  }
 }
 dps_results: {
@@ -304,15 +304,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5300.54659
-  tps: 4086.47715
+  dps: 5306.25931
+  tps: 4089.59225
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5145.36142
-  tps: 3971.18098
+  dps: 5151.68096
+  tps: 3974.78405
  }
 }
 dps_results: {
@@ -325,50 +325,50 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5216.52307
-  tps: 4026.80966
+  dps: 5218.41755
+  tps: 4027.81619
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5145.36142
-  tps: 3971.18098
+  dps: 5151.68096
+  tps: 3974.78405
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5300.54659
-  tps: 4086.47715
+  dps: 5306.25931
+  tps: 4089.59225
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5300.54659
-  tps: 4086.47715
+  dps: 5306.25931
+  tps: 4089.59225
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5300.54659
-  tps: 4086.47715
+  dps: 5306.25931
+  tps: 4089.59225
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5300.54659
-  tps: 4086.47715
+  dps: 5306.25931
+  tps: 4089.59225
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5145.36142
-  tps: 3971.18098
+  dps: 5151.68096
+  tps: 3974.78405
  }
 }
 dps_results: {
@@ -381,36 +381,36 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 5502.37171
-  tps: 4278.60996
+  dps: 5500.89498
+  tps: 4276.70452
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 5546.52725
-  tps: 4316.57125
+  dps: 5544.89445
+  tps: 4314.50728
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5396.2438
-  tps: 4160.62985
+  dps: 5402.54621
+  tps: 4164.15653
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5293.38634
-  tps: 4081.99788
+  dps: 5289.68232
+  tps: 4080.10667
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5145.36142
-  tps: 3971.18098
+  dps: 5151.68096
+  tps: 3974.78405
  }
 }
 dps_results: {
@@ -430,22 +430,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5145.36142
-  tps: 3971.18098
+  dps: 5151.68096
+  tps: 3974.78405
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5145.36142
-  tps: 3971.18098
+  dps: 5151.68096
+  tps: 3974.78405
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5145.36142
-  tps: 3971.18098
+  dps: 5151.68096
+  tps: 3974.78405
  }
 }
 dps_results: {
@@ -458,71 +458,71 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5300.54659
-  tps: 4086.47715
+  dps: 5306.25931
+  tps: 4089.59225
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5300.54659
-  tps: 4086.47715
+  dps: 5306.25931
+  tps: 4089.59225
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5300.54659
-  tps: 4086.47715
+  dps: 5306.25931
+  tps: 4089.59225
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5300.54659
-  tps: 4086.47715
+  dps: 5306.25931
+  tps: 4089.59225
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5149.28798
-  tps: 3974.73194
+  dps: 5150.90404
+  tps: 3976.00724
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5149.28798
-  tps: 3974.73194
+  dps: 5150.90404
+  tps: 3976.00724
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5335.26627
-  tps: 4112.75524
+  dps: 5341.00194
+  tps: 4115.88342
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5328.32234
-  tps: 4107.49962
+  dps: 5334.05341
+  tps: 4110.62518
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5328.32234
-  tps: 4107.49962
+  dps: 5334.05341
+  tps: 4110.62518
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5335.26627
-  tps: 4112.75524
+  dps: 5341.00194
+  tps: 4115.88342
  }
 }
 dps_results: {
@@ -549,8 +549,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Average-Default"
  value: {
-  dps: 5415.13123
-  tps: 4173.68424
+  dps: 5414.68565
+  tps: 4173.64242
  }
 }
 dps_results: {
@@ -640,15 +640,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4929.97171
-  tps: 5032.99079
+  dps: 4930.9197
+  tps: 5033.62077
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4929.97171
-  tps: 3808.57034
+  dps: 4930.9197
+  tps: 3809.42668
  }
 }
 dps_results: {
@@ -766,15 +766,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4923.22839
-  tps: 5030.94074
+  dps: 4926.1558
+  tps: 5033.06735
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4923.22839
-  tps: 3803.26663
+  dps: 4926.1558
+  tps: 3807.0881
  }
 }
 dps_results: {
@@ -892,15 +892,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4922.63836
-  tps: 5029.16251
+  dps: 4925.47566
+  tps: 5031.26167
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4922.63836
-  tps: 3802.72969
+  dps: 4925.47566
+  tps: 3806.50676
  }
 }
 dps_results: {
@@ -934,7 +934,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5405.39086
-  tps: 4178.42192
+  dps: 5411.71131
+  tps: 4182.10581
  }
 }

--- a/sim/priest/smite/TestSmite.results
+++ b/sim/priest/smite/TestSmite.results
@@ -578,7 +578,7 @@ dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
   dps: 3742.72661
-  tps: 3206.07346
+  tps: 3207.87889
  }
 }
 dps_results: {

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -45,833 +45,833 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7121.40496
-  tps: 5056.19752
+  dps: 7136.61785
+  tps: 5066.99867
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7188.39522
-  tps: 5103.7606
+  dps: 7192.8444
+  tps: 5106.91953
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7247.48764
-  tps: 5145.71622
+  dps: 7258.98686
+  tps: 5153.88067
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7234.07811
-  tps: 5136.19546
+  dps: 7215.36195
+  tps: 5122.90698
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5453.40064
-  tps: 3871.91446
+  dps: 5466.75066
+  tps: 3881.39297
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6319.02556
-  tps: 4486.50815
+  dps: 6347.1066
+  tps: 4506.44569
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7188.39522
-  tps: 5001.68539
+  dps: 7192.8444
+  tps: 5004.78114
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7351.9112
-  tps: 5219.85695
+  dps: 7332.97159
+  tps: 5206.40983
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7167.86726
-  tps: 5089.18576
+  dps: 7158.2377
+  tps: 5082.34877
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7230.28592
-  tps: 5133.503
+  dps: 7226.17347
+  tps: 5130.58316
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 7305.0484
-  tps: 5186.58436
+  dps: 7280.79208
+  tps: 5169.36238
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7218.13901
-  tps: 5124.8787
+  dps: 7194.06493
+  tps: 5107.7861
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7178.15028
-  tps: 5096.4867
+  dps: 7156.77591
+  tps: 5081.31089
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7020.01866
-  tps: 4984.21325
+  dps: 7032.11305
+  tps: 4992.80027
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7233.41529
-  tps: 5135.72486
+  dps: 7216.93243
+  tps: 5124.02203
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7188.39522
-  tps: 5103.7606
+  dps: 7192.8444
+  tps: 5106.91953
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7188.39522
-  tps: 5103.7606
+  dps: 7192.8444
+  tps: 5106.91953
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7234.07811
-  tps: 5136.19546
+  dps: 7215.36195
+  tps: 5122.90698
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7232.1018
-  tps: 5134.79228
+  dps: 7221.63849
+  tps: 5127.36332
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7188.39522
-  tps: 5103.7606
+  dps: 7192.8444
+  tps: 5106.91953
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7176.54141
-  tps: 5095.3444
+  dps: 7184.50707
+  tps: 5101.00002
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7161.22328
-  tps: 5084.46853
+  dps: 7164.12476
+  tps: 5086.52858
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7153.5392
-  tps: 5079.01283
+  dps: 7140.16334
+  tps: 5069.51597
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7188.39522
-  tps: 5103.7606
+  dps: 7192.8444
+  tps: 5106.91953
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7188.39522
-  tps: 5103.7606
+  dps: 7192.8444
+  tps: 5106.91953
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7295.22498
-  tps: 5179.60974
+  dps: 7307.31368
+  tps: 5188.19272
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7020.01866
-  tps: 4984.21325
+  dps: 7032.11305
+  tps: 4992.80027
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7047.73401
-  tps: 5003.89115
+  dps: 7041.4692
+  tps: 4999.44313
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7020.01866
-  tps: 4984.21325
+  dps: 7032.11305
+  tps: 4992.80027
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7234.07811
-  tps: 5136.19546
+  dps: 7215.36195
+  tps: 5122.90698
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7232.1018
-  tps: 5134.79228
+  dps: 7221.63849
+  tps: 5127.36332
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7199.93674
-  tps: 5111.95508
+  dps: 7212.00271
+  tps: 5120.52192
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7188.39522
-  tps: 5103.7606
+  dps: 7192.8444
+  tps: 5106.91953
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7224.84095
-  tps: 5129.63708
+  dps: 7229.27754
+  tps: 5132.78706
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7020.01866
-  tps: 4984.21325
+  dps: 7032.11305
+  tps: 4992.80027
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7020.01866
-  tps: 4984.21325
+  dps: 7032.11305
+  tps: 4992.80027
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7239.50256
-  tps: 5140.04682
+  dps: 7263.02612
+  tps: 5156.74855
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7020.01866
-  tps: 4984.21325
+  dps: 7032.11305
+  tps: 4992.80027
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7217.89891
-  tps: 5124.70822
+  dps: 7222.3379
+  tps: 5127.85991
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7224.84095
-  tps: 5129.63708
+  dps: 7229.27754
+  tps: 5132.78706
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7188.39522
-  tps: 5103.7606
+  dps: 7192.8444
+  tps: 5106.91953
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7188.39522
-  tps: 5103.7606
+  dps: 7192.8444
+  tps: 5106.91953
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7020.01866
-  tps: 4984.21325
+  dps: 7032.11305
+  tps: 4992.80027
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7220.71275
-  tps: 5126.70605
+  dps: 7237.82331
+  tps: 5138.85455
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7246.40324
-  tps: 5144.9463
+  dps: 7264.23693
+  tps: 5157.60822
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7332.98969
-  tps: 5206.42268
+  dps: 7333.60754
+  tps: 5206.86135
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7188.39522
-  tps: 5103.7606
+  dps: 7192.8444
+  tps: 5106.91953
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7020.01866
-  tps: 4984.21325
+  dps: 7032.11305
+  tps: 4992.80027
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7020.01866
-  tps: 4984.21325
+  dps: 7032.11305
+  tps: 4992.80027
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7461.46196
-  tps: 5297.63799
+  dps: 7453.34246
+  tps: 5291.87315
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7020.01866
-  tps: 4984.21325
+  dps: 7032.11305
+  tps: 4992.80027
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7020.01866
-  tps: 4984.21325
+  dps: 7032.11305
+  tps: 4992.80027
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 5362.42763
-  tps: 3807.32362
+  dps: 5364.67816
+  tps: 3808.92149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 7115.08262
-  tps: 5051.70866
+  dps: 7107.92025
+  tps: 5046.62338
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StormshroudArmor"
  value: {
-  dps: 5694.32046
-  tps: 4042.96752
+  dps: 5667.06127
+  tps: 4023.6135
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7224.84095
-  tps: 5129.63708
+  dps: 7229.27754
+  tps: 5132.78706
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7217.89891
-  tps: 5124.70822
+  dps: 7222.3379
+  tps: 5127.85991
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7205.75033
-  tps: 5116.08273
+  dps: 7210.19352
+  tps: 5119.2374
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6589.07126
-  tps: 4678.2406
+  dps: 6599.88163
+  tps: 4685.91596
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheFistsofFury"
  value: {
-  dps: 6160.31901
-  tps: 4373.8265
+  dps: 6144.16147
+  tps: 4362.35464
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7256.0646
-  tps: 5151.80587
+  dps: 7255.81355
+  tps: 5151.62762
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7359.58799
-  tps: 5225.30747
+  dps: 7362.30093
+  tps: 5227.23366
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7409.64632
-  tps: 5260.84889
+  dps: 7426.79701
+  tps: 5273.02588
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7188.39522
-  tps: 5103.7606
+  dps: 7192.8444
+  tps: 5106.91953
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7188.39522
-  tps: 5103.7606
+  dps: 7192.8444
+  tps: 5106.91953
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7188.39522
-  tps: 5103.7606
+  dps: 7192.8444
+  tps: 5106.91953
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7188.39522
-  tps: 5103.7606
+  dps: 7192.8444
+  tps: 5106.91953
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5804.60586
-  tps: 4121.27016
+  dps: 5820.55439
+  tps: 4132.59362
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6738.7802
-  tps: 4784.53394
+  dps: 6756.66768
+  tps: 4797.23405
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 7329.97082
-  tps: 5204.27928
+  dps: 7329.71863
+  tps: 5204.10023
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25694.58267
-  tps: 18243.15369
+  dps: 25465.11645
+  tps: 18080.23268
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7332.98969
-  tps: 5206.42268
+  dps: 7333.60754
+  tps: 5206.86135
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8478.33851
-  tps: 6019.62034
+  dps: 8472.69914
+  tps: 6015.61639
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14914.62451
-  tps: 10589.3834
+  dps: 14961.62569
+  tps: 10622.75424
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3587.2444
-  tps: 2546.94353
+  dps: 3595.19913
+  tps: 2552.59138
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3683.33884
-  tps: 2615.17058
+  dps: 3690.03272
+  tps: 2619.92323
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15695.93795
-  tps: 11144.11595
+  dps: 15705.69462
+  tps: 11151.04318
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5773.61854
-  tps: 4099.26916
+  dps: 5763.68051
+  tps: 4092.21317
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6798.26495
-  tps: 4826.76812
+  dps: 6806.75831
+  tps: 4832.7984
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8845.60126
-  tps: 6280.3769
+  dps: 8844.04319
+  tps: 6279.27066
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2606.08294
-  tps: 1850.31889
+  dps: 2608.89612
+  tps: 1852.31625
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2724.73673
-  tps: 1934.56308
+  dps: 2710.40842
+  tps: 1924.38998
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25694.58267
-  tps: 18243.15369
+  dps: 25465.11645
+  tps: 18080.23268
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7332.98969
-  tps: 5206.42268
+  dps: 7333.60754
+  tps: 5206.86135
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8478.33851
-  tps: 6019.62034
+  dps: 8472.69914
+  tps: 6015.61639
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14914.62451
-  tps: 10589.3834
+  dps: 14961.62569
+  tps: 10622.75424
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3587.2444
-  tps: 2546.94353
+  dps: 3595.19913
+  tps: 2552.59138
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3683.33884
-  tps: 2615.17058
+  dps: 3690.03272
+  tps: 2619.92323
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19938.88098
-  tps: 14156.60549
+  dps: 19950.86795
+  tps: 14165.11625
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4800.17961
-  tps: 3408.12753
+  dps: 4788.21175
+  tps: 3399.63034
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5519.91691
-  tps: 3919.141
+  dps: 5507.70314
+  tps: 3910.46923
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12848.88482
-  tps: 9122.70822
+  dps: 12851.80962
+  tps: 9124.78483
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2383.66588
-  tps: 1692.40278
+  dps: 2383.96807
+  tps: 1692.61733
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2499.2003
-  tps: 1774.43221
+  dps: 2498.28874
+  tps: 1773.78501
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25845.74044
-  tps: 18350.47571
+  dps: 25801.77069
+  tps: 18319.25719
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7378.40676
-  tps: 5238.6688
+  dps: 7367.08133
+  tps: 5230.62775
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8572.20097
-  tps: 6086.26269
+  dps: 8557.18102
+  tps: 6075.59852
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15014.48085
-  tps: 10660.2814
+  dps: 15117.9207
+  tps: 10733.7237
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3614.0269
-  tps: 2565.9591
+  dps: 3619.11562
+  tps: 2569.57209
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3728.80384
-  tps: 2647.45073
+  dps: 3735.41202
+  tps: 2652.14254
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15730.95775
-  tps: 11168.98
+  dps: 15733.93072
+  tps: 11171.09081
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5801.57836
-  tps: 4119.12064
+  dps: 5799.9426
+  tps: 4117.95925
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6869.31083
-  tps: 4877.21069
+  dps: 6868.85691
+  tps: 4876.8884
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8910.46056
-  tps: 6326.42699
+  dps: 8907.35845
+  tps: 6324.2245
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2634.86584
-  tps: 1870.75475
+  dps: 2634.95432
+  tps: 1870.81757
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2758.56111
-  tps: 1958.57838
+  dps: 2746.6714
+  tps: 1950.13669
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25845.74044
-  tps: 18350.47571
+  dps: 25801.77069
+  tps: 18319.25719
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7378.40676
-  tps: 5238.6688
+  dps: 7367.08133
+  tps: 5230.62775
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8572.20097
-  tps: 6086.26269
+  dps: 8557.18102
+  tps: 6075.59852
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15014.48085
-  tps: 10660.2814
+  dps: 15117.9207
+  tps: 10733.7237
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3614.0269
-  tps: 2565.9591
+  dps: 3619.11562
+  tps: 2569.57209
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3728.80384
-  tps: 2647.45073
+  dps: 3735.41202
+  tps: 2652.14254
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20035.82291
-  tps: 14225.43427
+  dps: 20048.07807
+  tps: 14234.13543
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4832.94835
-  tps: 3431.39333
+  dps: 4819.68089
+  tps: 3421.97343
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5564.10522
-  tps: 3950.51471
+  dps: 5555.38006
+  tps: 3944.31984
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12935.48623
-  tps: 9184.19522
+  dps: 12958.98108
+  tps: 9200.87657
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2398.02512
-  tps: 1702.59784
+  dps: 2399.8956
+  tps: 1703.92588
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2530.02065
-  tps: 1796.31466
+  dps: 2528.8552
+  tps: 1795.48719
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6921.12102
-  tps: 4913.99592
+  dps: 6936.56938
+  tps: 4924.96426
  }
 }

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -45,190 +45,190 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 6225.44215
-  tps: 4420.06392
+  dps: 6244.49155
+  tps: 4433.589
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6262.38641
-  tps: 4446.29435
+  dps: 6281.04663
+  tps: 4459.5431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6348.9207
-  tps: 4507.7337
+  dps: 6366.67526
+  tps: 4520.33943
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6286.55164
-  tps: 4463.45166
+  dps: 6304.98535
+  tps: 4476.5396
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4878.62286
-  tps: 3463.82223
+  dps: 4891.09946
+  tps: 3472.68061
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BonescytheBattlegear"
  value: {
-  dps: 5634.46575
-  tps: 4000.47068
+  dps: 5651.33716
+  tps: 4012.44939
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6262.38641
-  tps: 4357.36847
+  dps: 6281.04663
+  tps: 4370.35224
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6398.77328
-  tps: 4543.12903
+  dps: 6417.54404
+  tps: 4556.45627
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6263.85233
-  tps: 4447.33516
+  dps: 6277.44507
+  tps: 4456.986
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6300.64074
-  tps: 4473.45493
+  dps: 6316.23013
+  tps: 4484.52339
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6358.53029
-  tps: 4514.5565
+  dps: 6378.13058
+  tps: 4528.47271
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6282.67525
-  tps: 4460.69943
+  dps: 6302.21145
+  tps: 4474.57013
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6247.57211
-  tps: 4435.7762
+  dps: 6266.66339
+  tps: 4449.33101
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6151.01805
-  tps: 4367.22281
+  dps: 6167.50825
+  tps: 4378.93085
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6289.69145
-  tps: 4465.68093
+  dps: 6309.271
+  tps: 4479.58241
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6262.38641
-  tps: 4446.29435
+  dps: 6281.04663
+  tps: 4459.5431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6262.38641
-  tps: 4446.29435
+  dps: 6281.04663
+  tps: 4459.5431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6286.55164
-  tps: 4463.45166
+  dps: 6304.98535
+  tps: 4476.5396
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6282.05806
-  tps: 4460.26122
+  dps: 6299.94456
+  tps: 4472.96064
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6262.38641
-  tps: 4446.29435
+  dps: 6281.04663
+  tps: 4459.5431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6285.90489
-  tps: 4462.99247
+  dps: 6299.402
+  tps: 4472.57542
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6243.21868
-  tps: 4432.68527
+  dps: 6257.34025
+  tps: 4442.71158
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6229.61644
-  tps: 4423.02768
+  dps: 6244.32891
+  tps: 4433.47352
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6262.38641
-  tps: 4446.29435
+  dps: 6281.04663
+  tps: 4459.5431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6262.38641
-  tps: 4446.29435
+  dps: 6281.04663
+  tps: 4459.5431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6392.14287
-  tps: 4538.42143
+  dps: 6408.78756
+  tps: 4550.23916
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6151.01805
-  tps: 4367.22281
+  dps: 6167.50825
+  tps: 4378.93085
  }
 }
 dps_results: {
@@ -241,148 +241,148 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6151.01805
-  tps: 4367.22281
+  dps: 6167.50825
+  tps: 4378.93085
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6286.55164
-  tps: 4463.45166
+  dps: 6304.98535
+  tps: 4476.5396
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6282.05806
-  tps: 4460.26122
+  dps: 6299.94456
+  tps: 4472.96064
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6335.46984
-  tps: 4498.18359
+  dps: 6352.89667
+  tps: 4510.55664
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6262.38641
-  tps: 4446.29435
+  dps: 6281.04663
+  tps: 4459.5431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6294.17068
-  tps: 4468.86118
+  dps: 6312.85613
+  tps: 4482.12785
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6151.01805
-  tps: 4367.22281
+  dps: 6167.50825
+  tps: 4378.93085
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6151.01805
-  tps: 4367.22281
+  dps: 6167.50825
+  tps: 4378.93085
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6343.19024
-  tps: 4503.66507
+  dps: 6358.75236
+  tps: 4514.71418
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6151.01805
-  tps: 4367.22281
+  dps: 6167.50825
+  tps: 4378.93085
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6288.11653
-  tps: 4464.56274
+  dps: 6306.79718
+  tps: 4477.826
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6294.17068
-  tps: 4468.86118
+  dps: 6312.85613
+  tps: 4482.12785
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6262.38641
-  tps: 4446.29435
+  dps: 6281.04663
+  tps: 4459.5431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6262.38641
-  tps: 4446.29435
+  dps: 6281.04663
+  tps: 4459.5431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6151.01805
-  tps: 4367.22281
+  dps: 6167.50825
+  tps: 4378.93085
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6308.07071
-  tps: 4478.7302
+  dps: 6323.74268
+  tps: 4489.85731
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6327.002
-  tps: 4492.17142
+  dps: 6343.13706
+  tps: 4503.62731
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6401.73779
-  tps: 4545.23383
+  dps: 6420.95801
+  tps: 4558.88019
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6262.38641
-  tps: 4446.29435
+  dps: 6281.04663
+  tps: 4459.5431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6151.01805
-  tps: 4367.22281
+  dps: 6167.50825
+  tps: 4378.93085
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6151.01805
-  tps: 4367.22281
+  dps: 6167.50825
+  tps: 4378.93085
  }
 }
 dps_results: {
@@ -395,490 +395,490 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6151.01805
-  tps: 4367.22281
+  dps: 6167.50825
+  tps: 4378.93085
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6151.01805
-  tps: 4367.22281
+  dps: 6167.50825
+  tps: 4378.93085
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Slayer'sArmor"
  value: {
-  dps: 4799.2825
-  tps: 3407.49057
+  dps: 4791.9047
+  tps: 3402.25234
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SparkofLife-37657"
  value: {
-  dps: 6248.15291
-  tps: 4436.18856
+  dps: 6245.79672
+  tps: 4434.51567
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StormshroudArmor"
  value: {
-  dps: 4949.83042
-  tps: 3514.37959
+  dps: 4937.3462
+  tps: 3505.5158
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6294.17068
-  tps: 4468.86118
+  dps: 6312.85613
+  tps: 4482.12785
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6288.11653
-  tps: 4464.56274
+  dps: 6306.79718
+  tps: 4477.826
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6277.52178
-  tps: 4457.04046
+  dps: 6296.19401
+  tps: 4470.29775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 5923.17834
-  tps: 4205.45662
+  dps: 5927.41934
+  tps: 4208.46773
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheFistsofFury"
  value: {
-  dps: 5577.79818
-  tps: 3960.23671
+  dps: 5597.4772
+  tps: 3974.20881
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5724.70681
-  tps: 4064.54184
+  dps: 5715.45016
+  tps: 4057.96961
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6328.84048
-  tps: 4493.47674
+  dps: 6364.92963
+  tps: 4519.10004
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6432.90647
-  tps: 4567.36359
+  dps: 6448.5643
+  tps: 4578.48065
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6471.53981
-  tps: 4594.79327
+  dps: 6482.09443
+  tps: 4602.28704
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6262.38641
-  tps: 4446.29435
+  dps: 6281.04663
+  tps: 4459.5431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6262.38641
-  tps: 4446.29435
+  dps: 6281.04663
+  tps: 4459.5431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6262.38641
-  tps: 4446.29435
+  dps: 6281.04663
+  tps: 4459.5431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6262.38641
-  tps: 4446.29435
+  dps: 6281.04663
+  tps: 4459.5431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5192.52314
-  tps: 3686.69143
+  dps: 5191.59997
+  tps: 3686.03598
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6000.93257
-  tps: 4260.66212
+  dps: 5989.04104
+  tps: 4252.21913
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 6426.1996
-  tps: 4562.60172
+  dps: 6427.07993
+  tps: 4563.22675
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14114.91253
-  tps: 10021.5879
+  dps: 14198.20993
+  tps: 10080.72905
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5455.84165
-  tps: 3873.64757
+  dps: 5472.76125
+  tps: 3885.66049
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6557.96484
-  tps: 4656.15504
+  dps: 6598.8227
+  tps: 4685.16412
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8609.35901
-  tps: 6112.6449
+  dps: 8612.74744
+  tps: 6115.05068
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2549.10093
-  tps: 1809.86166
+  dps: 2550.81409
+  tps: 1811.078
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2654.10799
-  tps: 1884.41667
+  dps: 2676.24907
+  tps: 1900.13684
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19299.4519
-  tps: 13702.61085
+  dps: 19346.57361
+  tps: 13736.06727
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6401.73779
-  tps: 4545.23383
+  dps: 6420.95801
+  tps: 4558.88019
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7534.90201
-  tps: 5349.78043
+  dps: 7594.7055
+  tps: 5392.2409
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12142.71703
-  tps: 8621.32909
+  dps: 12180.51098
+  tps: 8648.16279
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3161.46817
-  tps: 2244.6424
+  dps: 3160.02918
+  tps: 2243.62072
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3254.6216
-  tps: 2310.78133
+  dps: 3269.47425
+  tps: 2321.32672
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19299.4519
-  tps: 13702.61085
+  dps: 19346.57361
+  tps: 13736.06727
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6401.73779
-  tps: 4545.23383
+  dps: 6420.95801
+  tps: 4558.88019
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7534.90201
-  tps: 5349.78043
+  dps: 7594.7055
+  tps: 5392.2409
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12142.71703
-  tps: 8621.32909
+  dps: 12180.51098
+  tps: 8648.16279
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3161.46817
-  tps: 2244.6424
+  dps: 3160.02918
+  tps: 2243.62072
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3254.6216
-  tps: 2310.78133
+  dps: 3269.47425
+  tps: 2321.32672
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18070.03285
-  tps: 12829.72332
+  dps: 18200.24691
+  tps: 12922.17531
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4721.39971
-  tps: 3352.1938
+  dps: 4736.32859
+  tps: 3362.7933
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5536.09829
-  tps: 3930.62979
+  dps: 5571.51321
+  tps: 3955.77438
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11876.71189
-  tps: 8432.46545
+  dps: 11848.61151
+  tps: 8412.51417
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2363.79508
-  tps: 1678.2945
+  dps: 2361.40403
+  tps: 1676.59686
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2451.60973
-  tps: 1740.64291
+  dps: 2462.88073
+  tps: 1748.64532
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14237.00451
-  tps: 10108.2732
+  dps: 14323.68023
+  tps: 10169.81297
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5498.42097
-  tps: 3903.87889
+  dps: 5515.9666
+  tps: 3916.33629
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6644.82599
-  tps: 4717.82645
+  dps: 6685.20923
+  tps: 4746.49856
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8694.73429
-  tps: 6173.26135
+  dps: 8698.48802
+  tps: 6175.92649
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2573.32261
-  tps: 1827.05905
+  dps: 2574.52009
+  tps: 1827.90926
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2695.73244
-  tps: 1913.97003
+  dps: 2717.68617
+  tps: 1929.55718
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19450.31455
-  tps: 13809.72333
+  dps: 19499.38472
+  tps: 13844.56315
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6450.57246
-  tps: 4579.90645
+  dps: 6471.30938
+  tps: 4594.62966
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7636.19198
-  tps: 5421.6963
+  dps: 7697.06874
+  tps: 5464.91881
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12250.84123
-  tps: 8698.09727
+  dps: 12290.65505
+  tps: 8726.36508
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3191.06107
-  tps: 2265.65336
+  dps: 3189.12252
+  tps: 2264.27699
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3305.96807
-  tps: 2347.23733
+  dps: 3319.78893
+  tps: 2357.05014
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19450.31455
-  tps: 13809.72333
+  dps: 19499.38472
+  tps: 13844.56315
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6450.57246
-  tps: 4579.90645
+  dps: 6471.30938
+  tps: 4594.62966
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7636.19198
-  tps: 5421.6963
+  dps: 7697.06874
+  tps: 5464.91881
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12250.84123
-  tps: 8698.09727
+  dps: 12290.65505
+  tps: 8726.36508
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3191.06107
-  tps: 2265.65336
+  dps: 3189.12252
+  tps: 2264.27699
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3305.96807
-  tps: 2347.23733
+  dps: 3319.78893
+  tps: 2357.05014
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18210.44774
-  tps: 12929.4179
+  dps: 18343.17691
+  tps: 13023.6556
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4756.56027
-  tps: 3377.15779
+  dps: 4772.34905
+  tps: 3388.36782
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5608.27866
-  tps: 3981.87785
+  dps: 5643.48325
+  tps: 4006.87311
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11982.19538
-  tps: 8507.35872
+  dps: 11954.52334
+  tps: 8487.71157
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2385.39565
-  tps: 1693.63091
+  dps: 2382.66477
+  tps: 1691.69199
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2489.35687
-  tps: 1767.44338
+  dps: 2500.03511
+  tps: 1775.02493
  }
 }
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6160.82563
-  tps: 4374.1862
+  dps: 6168.35019
+  tps: 4379.52863
  }
 }

--- a/sim/rogue/TestRotation.results
+++ b/sim/rogue/TestRotation.results
@@ -264,15 +264,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 60.4
+   value: 60.3
   }
   casts: {
    key: "spell_id:48665"
-   value: 60.4
+   value: 60.3
   }
   casts: {
    key: "spell_id:48666"
-   value: 60.4
+   value: 60.3
   }
   casts: {
    key: "spell_id:48668 tag:1"
@@ -344,11 +344,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 179.4
+   value: 179.7
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 313.9
+   value: 313.8
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -356,7 +356,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 318.9
+   value: 318.8
   }
   casts: {
    key: "spell_id:57975"
@@ -384,11 +384,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:4"
-   value: 20.1
+   value: 20.6
   }
   casts: {
    key: "spell_id:57993 tag:5"
-   value: 19.1
+   value: 18.8
   }
   casts: {
    key: "spell_id:58426"
@@ -485,15 +485,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 60.4
+   value: 60.3
   }
   casts: {
    key: "spell_id:48665"
-   value: 60.4
+   value: 60.3
   }
   casts: {
    key: "spell_id:48666"
-   value: 60.4
+   value: 60.3
   }
   casts: {
    key: "spell_id:48668 tag:1"
@@ -565,11 +565,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 179.4
+   value: 179.7
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 313.9
+   value: 313.8
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -577,7 +577,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 318.9
+   value: 318.8
   }
   casts: {
    key: "spell_id:57975"
@@ -605,11 +605,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:4"
-   value: 20.1
+   value: 20.6
   }
   casts: {
    key: "spell_id:57993 tag:5"
-   value: 19.1
+   value: 18.8
   }
   casts: {
    key: "spell_id:58426"
@@ -927,15 +927,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48664"
-   value: 60.4
+   value: 60.3
   }
   casts: {
    key: "spell_id:48665"
-   value: 60.4
+   value: 60.3
   }
   casts: {
    key: "spell_id:48666"
-   value: 60.4
+   value: 60.3
   }
   casts: {
    key: "spell_id:48668 tag:1"
@@ -1007,11 +1007,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 179.4
+   value: 179.7
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 313.9
+   value: 313.8
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -1019,7 +1019,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 318.9
+   value: 318.8
   }
   casts: {
    key: "spell_id:57975"
@@ -1047,11 +1047,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57993 tag:4"
-   value: 20.1
+   value: 20.6
   }
   casts: {
    key: "spell_id:57993 tag:5"
-   value: 19.1
+   value: 18.8
   }
   casts: {
    key: "spell_id:58426"
@@ -1337,11 +1337,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 477.4
+   value: 477.6
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 371.5
+   value: 371.6
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -1365,7 +1365,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48638"
-   value: 80.7
+   value: 81
   }
   casts: {
    key: "spell_id:48659"
@@ -1385,7 +1385,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 0.5
+   value: 0.6
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -1401,7 +1401,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:5"
-   value: 0.3
+   value: 0.2
   }
   casts: {
    key: "spell_id:48672"
@@ -1409,7 +1409,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 22
+   value: 21.7
   }
   casts: {
    key: "spell_id:48672 tag:2"
@@ -1417,15 +1417,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:3"
-   value: 1.3
+   value: 1.4
   }
   casts: {
    key: "spell_id:48672 tag:4"
-   value: 0.5
+   value: 0.4
   }
   casts: {
    key: "spell_id:48672 tag:5"
-   value: 0.7
+   value: 0.9
   }
   casts: {
    key: "spell_id:48676"
@@ -1461,11 +1461,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 113.2
+   value: 113.5
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 232.6
+   value: 232.5
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -1473,7 +1473,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 237.6
+   value: 237.5
   }
   casts: {
    key: "spell_id:57975"
@@ -1493,39 +1493,39 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:1"
-   value: 4.9
+   value: 5
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 4.3
+   value: 4.6
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 3.3
+   value: 3.2
   }
   casts: {
    key: "spell_id:6774 tag:4"
-   value: 2
+   value: 2.1
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 1
+   value: 0.8
   }
   casts: {
    key: "spell_id:8647 tag:1"
-   value: 14.9
+   value: 14.8
   }
   casts: {
    key: "spell_id:8647 tag:2"
-   value: 6.9
+   value: 6.8
   }
   casts: {
    key: "spell_id:8647 tag:3"
-   value: 4.1
+   value: 4.2
   }
   casts: {
    key: "spell_id:8647 tag:4"
-   value: 1.5
+   value: 1.4
   }
   casts: {
    key: "spell_id:8647 tag:5"
@@ -1546,11 +1546,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 476.1
+   value: 476.5
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 370.5
+   value: 370.7
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -1574,7 +1574,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48638"
-   value: 94.5
+   value: 93.9
   }
   casts: {
    key: "spell_id:48659"
@@ -1594,7 +1594,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 1.2
+   value: 1.5
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -1610,7 +1610,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:5"
-   value: 1.4
+   value: 1.5
   }
   casts: {
    key: "spell_id:48672"
@@ -1618,11 +1618,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 6.6
+   value: 7.3
   }
   casts: {
    key: "spell_id:48672 tag:2"
-   value: 4.1
+   value: 4
   }
   casts: {
    key: "spell_id:48672 tag:3"
@@ -1630,11 +1630,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:4"
-   value: 5.1
+   value: 5.3
   }
   casts: {
    key: "spell_id:48672 tag:5"
-   value: 4.4
+   value: 3.8
   }
   casts: {
    key: "spell_id:48676"
@@ -1670,11 +1670,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 113.2
+   value: 113.1
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 226
+   value: 226.6
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -1682,7 +1682,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 231.1
+   value: 231.6
   }
   casts: {
    key: "spell_id:57975"
@@ -1702,15 +1702,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:1"
-   value: 4.6
+   value: 4.5
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 3.2
+   value: 3.1
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 3.2
+   value: 3.1
   }
   casts: {
    key: "spell_id:6774 tag:4"
@@ -1718,7 +1718,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 1.4
+   value: 1.6
   }
   casts: {
    key: "spell_id:8647 tag:1"
@@ -1755,7 +1755,7 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 470.6
+   value: 470.7
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
@@ -1803,7 +1803,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 76.8
+   value: 76.7
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -1879,11 +1879,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 111.7
+   value: 111.8
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 221.5
+   value: 221.1
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -1891,7 +1891,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 226.6
+   value: 226.2
   }
   casts: {
    key: "spell_id:57975"
@@ -1964,11 +1964,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 477.5
+   value: 477.3
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 371.5
+   value: 371.3
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -1992,7 +1992,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48638"
-   value: 97.9
+   value: 98
   }
   casts: {
    key: "spell_id:48659"
@@ -2012,7 +2012,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 1.3
+   value: 1.5
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -2028,7 +2028,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:5"
-   value: 1.8
+   value: 1.7
   }
   casts: {
    key: "spell_id:48672"
@@ -2036,23 +2036,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 6.2
+   value: 6
   }
   casts: {
    key: "spell_id:48672 tag:2"
-   value: 3.9
+   value: 3.8
   }
   casts: {
    key: "spell_id:48672 tag:3"
-   value: 5.7
+   value: 5.6
   }
   casts: {
    key: "spell_id:48672 tag:4"
-   value: 5.5
+   value: 5.4
   }
   casts: {
    key: "spell_id:48672 tag:5"
-   value: 4.5
+   value: 4.9
   }
   casts: {
    key: "spell_id:48676"
@@ -2088,11 +2088,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 113.3
+   value: 113.2
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 228.2
+   value: 228.3
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -2120,23 +2120,23 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:1"
-   value: 4.9
+   value: 4.8
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 3
+   value: 3.2
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 3.1
+   value: 3
   }
   casts: {
    key: "spell_id:6774 tag:4"
-   value: 2.5
+   value: 2.6
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 1.5
+   value: 1.4
   }
   casts: {
    key: "spell_id:8647 tag:1"
@@ -2173,11 +2173,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 476.1
+   value: 476.5
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 370.5
+   value: 370.7
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -2201,7 +2201,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48638"
-   value: 94.5
+   value: 93.9
   }
   casts: {
    key: "spell_id:48659"
@@ -2221,7 +2221,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:1"
-   value: 1.2
+   value: 1.5
   }
   casts: {
    key: "spell_id:48668 tag:2"
@@ -2237,7 +2237,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48668 tag:5"
-   value: 1.4
+   value: 1.5
   }
   casts: {
    key: "spell_id:48672"
@@ -2245,11 +2245,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 6.6
+   value: 7.3
   }
   casts: {
    key: "spell_id:48672 tag:2"
-   value: 4.1
+   value: 4
   }
   casts: {
    key: "spell_id:48672 tag:3"
@@ -2257,11 +2257,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:4"
-   value: 5.1
+   value: 5.3
   }
   casts: {
    key: "spell_id:48672 tag:5"
-   value: 4.4
+   value: 3.8
   }
   casts: {
    key: "spell_id:48676"
@@ -2297,11 +2297,11 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968"
-   value: 113.2
+   value: 113.1
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 226
+   value: 226.6
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -2309,7 +2309,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 231.1
+   value: 231.6
   }
   casts: {
    key: "spell_id:57975"
@@ -2329,15 +2329,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:1"
-   value: 4.6
+   value: 4.5
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 3.2
+   value: 3.1
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 3.2
+   value: 3.1
   }
   casts: {
    key: "spell_id:6774 tag:4"
@@ -2345,7 +2345,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 1.4
+   value: 1.6
   }
   casts: {
    key: "spell_id:8647 tag:1"
@@ -2382,11 +2382,11 @@ casts_results: {
   }
   casts: {
    key: "other_id:OtherActionAttack tag:1"
-   value: 477.3
+   value: 477.4
   }
   casts: {
    key: "other_id:OtherActionAttack tag:2"
-   value: 371.3
+   value: 371.4
   }
   casts: {
    key: "other_id:OtherActionShoot"
@@ -2410,7 +2410,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48638"
-   value: 97.9
+   value: 97.8
   }
   casts: {
    key: "spell_id:48659"
@@ -2454,19 +2454,19 @@ casts_results: {
   }
   casts: {
    key: "spell_id:48672 tag:1"
-   value: 7.3
+   value: 7.2
   }
   casts: {
    key: "spell_id:48672 tag:2"
-   value: 3.1
+   value: 3.3
   }
   casts: {
    key: "spell_id:48672 tag:3"
-   value: 5
+   value: 4.8
   }
   casts: {
    key: "spell_id:48672 tag:4"
-   value: 4.6
+   value: 4.8
   }
   casts: {
    key: "spell_id:48672 tag:5"
@@ -2510,7 +2510,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57968 tag:1"
-   value: 228.2
+   value: 228.7
   }
   casts: {
    key: "spell_id:57968 tag:2"
@@ -2518,7 +2518,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:57973"
-   value: 233.3
+   value: 233.8
   }
   casts: {
    key: "spell_id:57975"
@@ -2538,15 +2538,15 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:1"
-   value: 5.2
+   value: 5.1
   }
   casts: {
    key: "spell_id:6774 tag:2"
-   value: 2.5
+   value: 3
   }
   casts: {
    key: "spell_id:6774 tag:3"
-   value: 2.9
+   value: 2.7
   }
   casts: {
    key: "spell_id:6774 tag:4"
@@ -2554,7 +2554,7 @@ casts_results: {
   }
   casts: {
    key: "spell_id:6774 tag:5"
-   value: 1.8
+   value: 1.7
   }
   casts: {
    key: "spell_id:8647 tag:1"

--- a/sim/rogue/assassination_rotation.go
+++ b/sim/rogue/assassination_rotation.go
@@ -212,13 +212,16 @@ func (rogue *Rogue) setupAssassinationRotation(sim *core.Simulation) {
 		})
 	}
 
+	// TODO I'd assume this should only be used once, to re-enable MCDs when sensible?
 	// Enable CDs
 	rogue.assassinationPrios = append(rogue.assassinationPrios, assassinationPrio{
 		func(s *core.Simulation, r *Rogue) PriorityAction {
-			for _, mcd := range r.disabledMCDs {
-				mcd.Enable()
+			if r.allMCDsDisabled {
+				for _, mcd := range r.GetMajorCooldowns() {
+					mcd.Enable()
+				}
+				r.allMCDsDisabled = false
 			}
-			r.disabledMCDs = nil
 			return Skip
 		},
 		func(s *core.Simulation, r *Rogue) bool {

--- a/sim/rogue/assassination_rotation.go
+++ b/sim/rogue/assassination_rotation.go
@@ -215,10 +215,10 @@ func (rogue *Rogue) setupAssassinationRotation(sim *core.Simulation) {
 	// Enable CDs
 	rogue.assassinationPrios = append(rogue.assassinationPrios, assassinationPrio{
 		func(s *core.Simulation, r *Rogue) PriorityAction {
-			if r.disabledMCDs != nil {
-				r.EnableAllCooldowns(r.disabledMCDs)
-				r.disabledMCDs = nil
+			for _, mcd := range r.disabledMCDs {
+				mcd.Enable()
 			}
+			r.disabledMCDs = nil
 			return Skip
 		},
 		func(s *core.Simulation, r *Rogue) bool {

--- a/sim/rogue/killing_spree.go
+++ b/sim/rogue/killing_spree.go
@@ -91,8 +91,7 @@ func (rogue *Rogue) registerKillingSpreeSpell() {
 		Type:     core.CooldownTypeDPS,
 		Priority: core.CooldownPriorityLow,
 		ShouldActivate: func(sim *core.Simulation, c *core.Character) bool {
-			bladeFlurry := rogue.GetMajorCooldown(BladeFlurryActionID)
-			if bladeFlurry != nil && bladeFlurry.IsReady(sim) {
+			if bf := rogue.GetMajorCooldown(BladeFlurryActionID); bf != nil && bf.IsReady(sim) {
 				return false
 			}
 			if rogue.CurrentEnergy() > 60 || (rogue.CurrentEnergy() > 30 && rogue.AdrenalineRushAura.IsActive()) {

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -187,7 +187,13 @@ func (rogue *Rogue) ApplyEnergyTickMultiplier(multiplier float64) {
 }
 
 func (rogue *Rogue) Reset(sim *core.Simulation) {
-	rogue.disabledMCDs = rogue.DisableAllEnabledCooldowns(core.CooldownTypeUnknown)
+	rogue.disabledMCDs = nil
+	for _, mcd := range rogue.GetMajorCooldowns() {
+		if mcd.IsEnabled() {
+			mcd.Disable()
+			rogue.disabledMCDs = append(rogue.disabledMCDs, mcd)
+		}
+	}
 	rogue.initialArmorDebuffAura = rogue.CurrentTarget.GetActiveAuraWithTag(core.MajorArmorReductionTag)
 	rogue.lastDeadlyPoisonProcMask = core.ProcMaskEmpty
 	if rogue.OverkillAura != nil && rogue.Options.StartingOverkillDuration > 0 {

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -45,7 +45,8 @@ type Rogue struct {
 
 	sliceAndDiceDurations [6]time.Duration
 	exposeArmorDurations  [6]time.Duration
-	disabledMCDs          []*core.MajorCooldown
+
+	allMCDsDisabled bool
 
 	maxEnergy float64
 
@@ -187,13 +188,10 @@ func (rogue *Rogue) ApplyEnergyTickMultiplier(multiplier float64) {
 }
 
 func (rogue *Rogue) Reset(sim *core.Simulation) {
-	rogue.disabledMCDs = nil
 	for _, mcd := range rogue.GetMajorCooldowns() {
-		if mcd.IsEnabled() {
-			mcd.Disable()
-			rogue.disabledMCDs = append(rogue.disabledMCDs, mcd)
-		}
+		mcd.Disable()
 	}
+	rogue.allMCDsDisabled = true
 	rogue.initialArmorDebuffAura = rogue.CurrentTarget.GetActiveAuraWithTag(core.MajorArmorReductionTag)
 	rogue.lastDeadlyPoisonProcMask = core.ProcMaskEmpty
 	if rogue.OverkillAura != nil && rogue.Options.StartingOverkillDuration > 0 {

--- a/sim/rogue/rotation.go
+++ b/sim/rogue/rotation.go
@@ -327,10 +327,12 @@ func (rogue *Rogue) setPriorityItems(sim *core.Simulation) {
 			return 0
 		},
 		GetSpell: func(r *Rogue, cp int32) *core.Spell {
-			for _, mcd := range r.disabledMCDs {
-				mcd.Enable()
+			if r.allMCDsDisabled {
+				for _, mcd := range r.GetMajorCooldowns() {
+					mcd.Enable()
+				}
+				r.allMCDsDisabled = false
 			}
-			r.disabledMCDs = nil
 			return nil
 		},
 	})

--- a/sim/rogue/rotation.go
+++ b/sim/rogue/rotation.go
@@ -327,10 +327,10 @@ func (rogue *Rogue) setPriorityItems(sim *core.Simulation) {
 			return 0
 		},
 		GetSpell: func(r *Rogue, cp int32) *core.Spell {
-			if r.disabledMCDs != nil {
-				r.EnableAllCooldowns(r.disabledMCDs)
-				r.disabledMCDs = nil
+			for _, mcd := range r.disabledMCDs {
+				mcd.Enable()
 			}
+			r.disabledMCDs = nil
 			return nil
 		},
 	})

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -48,12 +48,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.17905
+  weights: 0.17338
   weights: 0
-  weights: 1.05197
+  weights: 1.04979
   weights: 0
-  weights: 2.04178
-  weights: 0.67428
+  weights: 2.5649
+  weights: 0.62313
   weights: 0
   weights: 0
   weights: 0
@@ -89,812 +89,812 @@ stat_weights_results: {
 dps_results: {
  key: "TestElemental-AllItems-AshtongueTalismanofVision-32491"
  value: {
-  dps: 4065.13899
-  tps: 3115.46977
+  dps: 4062.40167
+  tps: 3113.59873
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 4117.70766
-  tps: 3157.3866
+  dps: 4112.73228
+  tps: 3153.44585
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 4065.13899
-  tps: 3115.46977
+  dps: 4062.40167
+  tps: 3113.59873
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 4130.78204
-  tps: 3166.97392
+  dps: 4126.5509
+  tps: 3163.76858
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 4003.4222
-  tps: 3082.67676
+  dps: 3983.19547
+  tps: 3053.80877
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 4431.26924
-  tps: 3392.06499
+  dps: 4423.29448
+  tps: 3391.33254
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 3376.71995
-  tps: 2608.90102
+  dps: 3368.92716
+  tps: 2607.70655
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 3539.37131
-  tps: 2730.88955
+  dps: 3509.73489
+  tps: 2699.21842
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 4143.32461
-  tps: 3113.76587
+  dps: 4138.30677
+  tps: 3109.87468
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 4251.18923
-  tps: 3259.84892
+  dps: 4247.67747
+  tps: 3257.37526
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 4122.75958
-  tps: 3157.44781
+  dps: 4122.11668
+  tps: 3156.76745
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 4173.94189
-  tps: 3206.66059
+  dps: 4156.59282
+  tps: 3190.40722
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 4093.06578
-  tps: 3134.4809
+  dps: 4078.67767
+  tps: 3124.29138
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 4093.06578
-  tps: 3134.4809
+  dps: 4078.67767
+  tps: 3124.29138
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 4093.06578
-  tps: 3134.4809
+  dps: 4078.67767
+  tps: 3124.29138
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 4287.92242
-  tps: 3295.74233
+  dps: 4248.00192
+  tps: 3248.27377
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 4082.44917
-  tps: 3127.45046
+  dps: 4083.31626
+  tps: 3128.1445
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Defender'sCode-40257"
  value: {
-  dps: 4065.13899
-  tps: 3115.46977
+  dps: 4062.40167
+  tps: 3113.59873
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 4133.53431
-  tps: 3169.16485
+  dps: 4129.02804
+  tps: 3165.78457
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 3259.33713
-  tps: 2509.19646
+  dps: 3256.21551
+  tps: 2509.77475
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EarthshatterGarb"
  value: {
-  dps: 3714.22045
-  tps: 2857.74446
+  dps: 3709.83982
+  tps: 2847.18437
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 4117.70766
-  tps: 3157.3866
+  dps: 4112.73228
+  tps: 3153.44585
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 4146.25651
-  tps: 3178.52351
+  dps: 4142.47562
+  tps: 3175.9051
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 4130.78204
-  tps: 3166.90059
+  dps: 4126.5509
+  tps: 3163.84516
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 4128.38369
-  tps: 3165.07511
+  dps: 4123.97189
+  tps: 3162.00245
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 4117.70766
-  tps: 3157.3866
+  dps: 4112.73228
+  tps: 3153.44585
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 4159.16585
-  tps: 3195.94602
+  dps: 4168.68057
+  tps: 3202.83858
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 4247.92597
-  tps: 3250.86813
+  dps: 4247.58664
+  tps: 3250.46473
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForgeEmber-37660"
  value: {
-  dps: 4206.37204
-  tps: 3220.95449
+  dps: 4209.43946
+  tps: 3221.55687
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 4143.32461
-  tps: 3176.6318
+  dps: 4138.30677
+  tps: 3172.66232
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 4138.20122
-  tps: 3172.78276
+  dps: 4133.19187
+  tps: 3168.81902
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 3480.66125
-  tps: 2665.64893
+  dps: 3471.82712
+  tps: 2659.46097
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 4470.31893
-  tps: 3381.02992
+  dps: 4454.20223
+  tps: 3374.77994
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 4297.03919
-  tps: 3302.54934
+  dps: 4257.08955
+  tps: 3255.01853
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 4065.13899
-  tps: 3115.46977
+  dps: 4062.40167
+  tps: 3113.59873
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuturesightRune-38763"
  value: {
-  dps: 4129.41361
-  tps: 3163.71529
+  dps: 4126.65572
+  tps: 3161.84156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 3214.94409
-  tps: 2484.86006
+  dps: 3227.1779
+  tps: 2500.01971
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Gladiator'sWartide"
  value: {
-  dps: 3883.70571
-  tps: 2996.42106
+  dps: 3902.01712
+  tps: 3019.006
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 4264.35959
-  tps: 3278.29662
+  dps: 4225.1015
+  tps: 3231.22863
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 4270.11608
-  tps: 3269.08716
+  dps: 4267.33975
+  tps: 3267.27602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 4130.78204
-  tps: 3166.90059
+  dps: 4126.5509
+  tps: 3163.84516
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 4128.38369
-  tps: 3165.07511
+  dps: 4123.97189
+  tps: 3162.00245
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IncisorFragment-37723"
  value: {
-  dps: 4065.13899
-  tps: 3115.46977
+  dps: 4062.40167
+  tps: 3113.59873
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 4120.62124
-  tps: 3165.51938
+  dps: 4116.87441
+  tps: 3163.00594
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 4117.70766
-  tps: 3157.3866
+  dps: 4112.73228
+  tps: 3153.44585
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 4065.13899
-  tps: 3115.46977
+  dps: 4062.40167
+  tps: 3113.59873
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 4065.13899
-  tps: 3115.46977
+  dps: 4062.40167
+  tps: 3113.59873
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 4111.05816
-  tps: 3148.53749
+  dps: 4111.03551
+  tps: 3148.01518
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 4065.13899
-  tps: 3115.46977
+  dps: 4062.40167
+  tps: 3113.59873
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 4117.70766
-  tps: 3157.3866
+  dps: 4112.73228
+  tps: 3153.44585
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 4117.70766
-  tps: 3157.3866
+  dps: 4112.73228
+  tps: 3153.44585
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 4117.70766
-  tps: 3157.3866
+  dps: 4112.73228
+  tps: 3153.44585
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 4117.70766
-  tps: 3157.3866
+  dps: 4112.73228
+  tps: 3153.44585
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 4065.13899
-  tps: 3115.46977
+  dps: 4062.40167
+  tps: 3113.59873
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 4432.51158
-  tps: 3449.51434
+  dps: 4410.89527
+  tps: 3432.14689
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 4475.46228
-  tps: 3487.829
+  dps: 4453.66068
+  tps: 3470.29558
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 4236.93815
-  tps: 3249.46522
+  dps: 4232.61517
+  tps: 3246.04239
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 4308.10956
-  tps: 3310.81501
+  dps: 4268.12453
+  tps: 3263.20861
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 4117.70766
-  tps: 3157.46405
+  dps: 4112.73228
+  tps: 3153.49568
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 4065.13899
-  tps: 3115.46977
+  dps: 4062.40167
+  tps: 3113.59873
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 4260.80781
-  tps: 3275.62092
+  dps: 4221.46638
+  tps: 3228.53852
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 4065.13899
-  tps: 3115.46977
+  dps: 4062.40167
+  tps: 3113.59873
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 4065.13899
-  tps: 3115.46977
+  dps: 4062.40167
+  tps: 3113.59873
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 4065.13899
-  tps: 3115.46977
+  dps: 4053.68937
+  tps: 3109.22451
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkycallTotem-33506"
  value: {
-  dps: 4241.54481
-  tps: 3265.04845
+  dps: 4224.78497
+  tps: 3235.83768
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterHarness"
  value: {
-  dps: 2833.81448
-  tps: 2191.83479
+  dps: 2828.61769
+  tps: 2189.99041
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterRegalia"
  value: {
-  dps: 3359.46517
-  tps: 2585.90977
+  dps: 3357.16319
+  tps: 2583.67954
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SparkofLife-37657"
  value: {
-  dps: 4148.58017
-  tps: 3186.91036
+  dps: 4132.49251
+  tps: 3174.00959
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 4242.33855
-  tps: 3261.70724
+  dps: 4202.56377
+  tps: 3214.54994
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StormshroudArmor"
  value: {
-  dps: 3304.36337
-  tps: 2553.08192
+  dps: 3316.57912
+  tps: 2564.4538
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 4117.70766
-  tps: 3157.3866
+  dps: 4112.73228
+  tps: 3153.44585
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 4117.70766
-  tps: 3157.3866
+  dps: 4112.73228
+  tps: 3153.44585
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 4117.70766
-  tps: 3157.3866
+  dps: 4112.73228
+  tps: 3153.44585
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheFistsofFury"
  value: {
-  dps: 3673.18291
-  tps: 2829.86671
+  dps: 3674.36179
+  tps: 2825.73962
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 3507.18832
-  tps: 2698.23519
+  dps: 3504.05982
+  tps: 2697.09361
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Thrall'sRegalia"
  value: {
-  dps: 4221.71268
-  tps: 3216.78822
+  dps: 4210.19881
+  tps: 3215.44642
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 4117.70766
-  tps: 3157.3866
+  dps: 4112.73228
+  tps: 3153.44585
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TidefuryRaiment"
  value: {
-  dps: 3148.88564
-  tps: 2437.34252
+  dps: 3159.5242
+  tps: 2444.50247
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 4189.79839
-  tps: 3194.11601
+  dps: 4185.62863
+  tps: 3183.93359
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 4189.79839
-  tps: 3194.11601
+  dps: 4185.62863
+  tps: 3183.93359
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 4143.32461
-  tps: 3176.6318
+  dps: 4138.30677
+  tps: 3172.66232
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 4138.20122
-  tps: 3172.78276
+  dps: 4133.19187
+  tps: 3168.81902
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 4404.69402
-  tps: 3369.12015
+  dps: 4392.26701
+  tps: 3361.96299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 4242.33855
-  tps: 3261.70724
+  dps: 4202.56377
+  tps: 3214.54994
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 4138.20122
-  tps: 3172.78276
+  dps: 4133.19187
+  tps: 3168.81902
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 4143.32461
-  tps: 3176.6318
+  dps: 4138.30677
+  tps: 3172.66232
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 3340.4908
-  tps: 2580.72085
+  dps: 3329.74339
+  tps: 2568.73237
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 3362.41655
-  tps: 2583.01497
+  dps: 3351.06772
+  tps: 2572.51125
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WorldbreakerGarb"
  value: {
-  dps: 3910.68944
-  tps: 3019.35848
+  dps: 3904.47567
+  tps: 3010.80577
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 4319.83113
-  tps: 3319.56689
+  dps: 4279.80863
+  tps: 3271.88045
  }
 }
 dps_results: {
  key: "TestElemental-Average-Default"
  value: {
-  dps: 4240.18037
-  tps: 3254.72162
+  dps: 4230.27868
+  tps: 3246.6385
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6580.4852
-  tps: 6045.62702
+  dps: 6543.30084
+  tps: 6009.74205
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4255.31344
-  tps: 3257.62402
+  dps: 4234.05927
+  tps: 3238.85191
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4943.55214
-  tps: 3823.79614
+  dps: 4885.6577
+  tps: 3789.46915
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2148.26922
-  tps: 1736.18701
+  dps: 2133.11011
+  tps: 1722.71579
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1773.16994
-  tps: 1390.06399
+  dps: 1772.17345
+  tps: 1384.84995
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3546.71917
-  tps: 2708.48284
+  dps: 3543.73508
+  tps: 2731.06805
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8386.05636
-  tps: 5925.45844
+  dps: 8355.22869
+  tps: 5895.09256
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4666.27578
-  tps: 3209.37467
+  dps: 4655.90127
+  tps: 3200.45068
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5923.5778
-  tps: 3651.59793
+  dps: 5957.79356
+  tps: 3674.06209
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3823.12779
-  tps: 1632.7239
+  dps: 3889.30012
+  tps: 1685.89234
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2085.25846
-  tps: 1322.39766
+  dps: 2097.68339
+  tps: 1334.97811
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4461.96986
-  tps: 2653.89504
+  dps: 4403.2613
+  tps: 2610.79619
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6452.43624
-  tps: 5936.49102
+  dps: 6438.00454
+  tps: 5912.6499
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4251.18923
-  tps: 3259.84892
+  dps: 4247.67747
+  tps: 3257.37526
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4872.44676
-  tps: 3788.09365
+  dps: 4806.69769
+  tps: 3734.11378
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2099.09113
-  tps: 1699.16642
+  dps: 2090.28813
+  tps: 1690.67246
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1753.87777
-  tps: 1377.57848
+  dps: 1750.69357
+  tps: 1376.20707
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3529.39118
-  tps: 2714.7348
+  dps: 3515.36287
+  tps: 2722.98627
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8153.2709
-  tps: 5855.02322
+  dps: 8181.23221
+  tps: 5871.13201
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4629.0793
-  tps: 3221.48847
+  dps: 4617.9972
+  tps: 3208.76606
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5819.01029
-  tps: 3612.60211
+  dps: 5718.03217
+  tps: 3566.44763
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3648.66291
-  tps: 1596.18226
+  dps: 3668.73334
+  tps: 1613.82872
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2063.62649
-  tps: 1333.1954
+  dps: 2039.74791
+  tps: 1316.04064
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4330.89016
-  tps: 2641.14118
+  dps: 4245.40398
+  tps: 2565.558
  }
 }
 dps_results: {
  key: "TestElemental-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 4251.18923
-  tps: 3259.84892
+  dps: 4247.67747
+  tps: 3257.37526
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -45,812 +45,812 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-AshtongueTalismanofVision-32491"
  value: {
-  dps: 6614.88448
-  tps: 3725.25072
+  dps: 6631.60517
+  tps: 3735.09719
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6623.9243
-  tps: 3736.81772
+  dps: 6608.24354
+  tps: 3727.57733
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6739.0314
-  tps: 3805.43796
+  dps: 6747.68623
+  tps: 3814.79984
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6602.6197
-  tps: 3717.40479
+  dps: 6610.90582
+  tps: 3727.45939
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6406.29734
-  tps: 3591.87706
+  dps: 6403.62255
+  tps: 3596.93618
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 6983.26983
-  tps: 3954.80687
+  dps: 6998.08657
+  tps: 3957.80211
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5378.66717
-  tps: 3014.1444
+  dps: 5380.33103
+  tps: 3014.60392
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5309.78902
-  tps: 2989.62045
+  dps: 5328.1591
+  tps: 3000.28527
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6643.95904
-  tps: 3645.39975
+  dps: 6628.30871
+  tps: 3636.42244
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6790.67112
-  tps: 3828.18909
+  dps: 6751.36533
+  tps: 3803.76067
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6656.21286
-  tps: 3757.93351
+  dps: 6683.80334
+  tps: 3762.70379
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6705.79806
-  tps: 3784.99878
+  dps: 6702.43659
+  tps: 3788.99356
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6692.63301
-  tps: 3763.57287
+  dps: 6688.13869
+  tps: 3760.78236
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6706.49422
-  tps: 3776.74031
+  dps: 6758.35758
+  tps: 3802.44876
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6624.50926
-  tps: 3724.22119
+  dps: 6645.5537
+  tps: 3739.35529
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 6768.70113
-  tps: 3816.36531
+  dps: 6781.09148
+  tps: 3821.55636
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6657.36911
-  tps: 3749.66954
+  dps: 6613.43537
+  tps: 3724.78536
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6525.88097
-  tps: 3675.77157
+  dps: 6539.94901
+  tps: 3683.18124
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6643.27762
-  tps: 3752.35686
+  dps: 6630.58426
+  tps: 3736.6063
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 5844.55908
-  tps: 3276.66499
+  dps: 5871.50629
+  tps: 3299.09671
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterGarb"
  value: {
-  dps: 5548.68348
-  tps: 3126.67323
+  dps: 5544.54469
+  tps: 3122.58052
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6623.9243
-  tps: 3736.81772
+  dps: 6608.24354
+  tps: 3727.57733
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6641.3489
-  tps: 3745.0092
+  dps: 6647.02691
+  tps: 3754.50605
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6642.99533
-  tps: 3743.11687
+  dps: 6605.88691
+  tps: 3720.32752
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6626.4783
-  tps: 3733.94248
+  dps: 6640.72677
+  tps: 3743.8208
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6623.9243
-  tps: 3736.81772
+  dps: 6608.24354
+  tps: 3727.57733
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6701.05872
-  tps: 3779.30036
+  dps: 6692.54833
+  tps: 3770.42155
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6753.79765
-  tps: 3812.53614
+  dps: 6744.03646
+  tps: 3799.2154
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6653.95905
-  tps: 3749.19129
+  dps: 6696.2724
+  tps: 3773.73284
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6643.95904
-  tps: 3749.37667
+  dps: 6628.30871
+  tps: 3740.14056
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6639.9521
-  tps: 3746.86488
+  dps: 6624.29568
+  tps: 3737.62791
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 6703.82734
-  tps: 3759.18376
+  dps: 6688.65761
+  tps: 3745.73031
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 6331.72378
-  tps: 3585.48311
+  dps: 6329.02028
+  tps: 3580.91915
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 6779.93492
-  tps: 3823.38439
+  dps: 6792.32063
+  tps: 3828.57497
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6718.16854
-  tps: 3782.57956
+  dps: 6730.08687
+  tps: 3789.05685
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6574.98355
-  tps: 3706.44525
+  dps: 6589.14253
+  tps: 3713.90368
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 6451.86163
-  tps: 3623.63798
+  dps: 6434.57086
+  tps: 3614.54437
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sWartide"
  value: {
-  dps: 5424.18094
-  tps: 3060.44201
+  dps: 5431.15785
+  tps: 3068.88865
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 6747.85247
-  tps: 3802.80132
+  dps: 6759.70027
+  tps: 3807.64138
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6684.04218
-  tps: 3774.56536
+  dps: 6698.38567
+  tps: 3782.1182
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6642.99533
-  tps: 3743.11687
+  dps: 6605.88691
+  tps: 3720.32752
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6626.4783
-  tps: 3733.94248
+  dps: 6640.72677
+  tps: 3743.8208
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6650.82757
-  tps: 3741.76344
+  dps: 6663.94397
+  tps: 3751.24755
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6645.27424
-  tps: 3745.32313
+  dps: 6603.20584
+  tps: 3716.93947
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6646.13039
-  tps: 3746.07426
+  dps: 6633.63261
+  tps: 3741.67647
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6525.88097
-  tps: 3675.77157
+  dps: 6539.94901
+  tps: 3683.18124
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6525.88097
-  tps: 3675.77157
+  dps: 6539.94901
+  tps: 3683.18124
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6525.88097
-  tps: 3675.77157
+  dps: 6539.94901
+  tps: 3683.18124
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6622.52979
-  tps: 3736.8774
+  dps: 6628.7966
+  tps: 3738.9951
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6646.13039
-  tps: 3746.07426
+  dps: 6633.63261
+  tps: 3741.67647
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6623.9243
-  tps: 3736.81772
+  dps: 6608.24354
+  tps: 3727.57733
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6623.9243
-  tps: 3736.81772
+  dps: 6608.24354
+  tps: 3727.57733
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6525.88097
-  tps: 3675.77157
+  dps: 6539.94901
+  tps: 3683.18124
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6759.44345
-  tps: 3830.36384
+  dps: 6771.99638
+  tps: 3838.97512
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6787.05041
-  tps: 3848.61253
+  dps: 6799.25262
+  tps: 3856.98207
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6779.287
-  tps: 3822.98793
+  dps: 6759.06631
+  tps: 3815.79257
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 6793.57594
-  tps: 3831.90755
+  dps: 6805.95602
+  tps: 3837.09757
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6616.53302
-  tps: 3734.21655
+  dps: 6592.41906
+  tps: 3714.7421
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6525.88097
-  tps: 3675.77157
+  dps: 6539.94901
+  tps: 3683.18124
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 6742.15565
-  tps: 3799.32851
+  dps: 6754.0947
+  tps: 3804.22556
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6525.88097
-  tps: 3675.77157
+  dps: 6539.94901
+  tps: 3683.18124
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6525.88097
-  tps: 3675.77157
+  dps: 6539.94901
+  tps: 3683.18124
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6525.88097
-  tps: 3675.77157
+  dps: 6539.94901
+  tps: 3683.18124
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkycallTotem-33506"
  value: {
-  dps: 6726.79896
-  tps: 3793.13266
+  dps: 6702.69243
+  tps: 3782.81812
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterHarness"
  value: {
-  dps: 4792.49467
-  tps: 2682.84359
+  dps: 4780.98633
+  tps: 2675.60084
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterRegalia"
  value: {
-  dps: 4734.1964
-  tps: 2665.89694
+  dps: 4727.03788
+  tps: 2663.80529
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SparkofLife-37657"
  value: {
-  dps: 6634.832
-  tps: 3735.52325
+  dps: 6646.2876
+  tps: 3744.35937
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 6744.31013
-  tps: 3798.69175
+  dps: 6756.48255
+  tps: 3803.6308
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StormshroudArmor"
  value: {
-  dps: 5035.04232
-  tps: 2821.39574
+  dps: 5021.96292
+  tps: 2817.98335
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6646.13039
-  tps: 3746.07426
+  dps: 6633.63261
+  tps: 3741.67647
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6622.52979
-  tps: 3736.8774
+  dps: 6628.7966
+  tps: 3738.9951
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6614.06232
-  tps: 3732.18345
+  dps: 6620.33357
+  tps: 3734.29596
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheFistsofFury"
  value: {
-  dps: 5249.76422
-  tps: 2885.04035
+  dps: 5274.85275
+  tps: 2894.88152
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 6542.34513
-  tps: 3697.69469
+  dps: 6505.12286
+  tps: 3677.57008
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sRegalia"
  value: {
-  dps: 6129.77278
-  tps: 3488.6124
+  dps: 6122.32191
+  tps: 3478.64458
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6653.98476
-  tps: 3759.09962
+  dps: 6632.98059
+  tps: 3740.96772
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TidefuryRaiment"
  value: {
-  dps: 4750.2112
-  tps: 2657.82464
+  dps: 4780.66687
+  tps: 2683.06487
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6736.88138
-  tps: 3799.4019
+  dps: 6739.28051
+  tps: 3797.58946
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6761.99657
-  tps: 3819.09032
+  dps: 6808.90397
+  tps: 3846.6681
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6643.95904
-  tps: 3749.37667
+  dps: 6628.30871
+  tps: 3740.14056
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6639.9521
-  tps: 3746.86488
+  dps: 6624.29568
+  tps: 3737.62791
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 6918.71662
-  tps: 3904.86522
+  dps: 6931.49823
+  tps: 3917.99906
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 6967.19851
-  tps: 3921.55707
+  dps: 6978.80626
+  tps: 3932.86086
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheElementalPlane-40708"
  value: {
-  dps: 6748.24177
-  tps: 3809.29263
+  dps: 6725.04336
+  tps: 3795.67244
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6639.9521
-  tps: 3746.86488
+  dps: 6624.29568
+  tps: 3737.62791
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6643.95904
-  tps: 3749.37667
+  dps: 6628.30871
+  tps: 3740.14056
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5329.37342
-  tps: 2991.38668
+  dps: 5326.55255
+  tps: 2992.63461
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 6203.72952
-  tps: 3503.37301
+  dps: 6221.32387
+  tps: 3521.29213
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerGarb"
  value: {
-  dps: 5723.58871
-  tps: 3238.82399
+  dps: 5712.25317
+  tps: 3231.78762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 6808.01938
-  tps: 3840.93208
+  dps: 6820.3935
+  tps: 3846.12149
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 6785.49145
-  tps: 3829.65512
+  dps: 6787.98407
+  tps: 3830.67496
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17831.96448
-  tps: 10382.3168
+  dps: 17904.78924
+  tps: 10506.81833
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6786.34368
-  tps: 3812.86257
+  dps: 6768.94353
+  tps: 3811.24888
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8106.02247
-  tps: 4263.73757
+  dps: 8067.80978
+  tps: 4266.81669
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9004.69269
-  tps: 5333.24472
+  dps: 9096.75449
+  tps: 5432.9824
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2873.74048
-  tps: 1618.48201
+  dps: 2816.97504
+  tps: 1586.70494
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4986.806
-  tps: 2682.21541
+  dps: 4863.93696
+  tps: 2603.60623
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18413.95001
-  tps: 10276.44008
+  dps: 18345.08654
+  tps: 10223.71902
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6494.1205
-  tps: 3371.12674
+  dps: 6519.92214
+  tps: 3383.87564
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhFireElemental-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8029.01305
-  tps: 3747.57815
+  dps: 7979.79273
+  tps: 3706.2537
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhFireElemental-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12530.77468
-  tps: 7402.51345
+  dps: 12751.97465
+  tps: 7549.54245
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhFireElemental-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3665.25008
-  tps: 1878.60252
+  dps: 3711.02863
+  tps: 1902.94553
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhFireElemental-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5186.39597
-  tps: 2363.96464
+  dps: 5169.09317
+  tps: 2353.26807
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17831.16763
-  tps: 10397.95155
+  dps: 17822.09548
+  tps: 10422.77217
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6779.287
-  tps: 3822.98793
+  dps: 6759.06631
+  tps: 3815.79257
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7997.697
-  tps: 4243.09791
+  dps: 8043.67696
+  tps: 4270.35789
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9088.16935
-  tps: 5386.42944
+  dps: 9328.72227
+  tps: 5551.77609
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2958.27077
-  tps: 1670.83457
+  dps: 2837.45627
+  tps: 1608.01824
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4911.55887
-  tps: 2650.32444
+  dps: 4927.62894
+  tps: 2664.96278
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18074.98072
-  tps: 10233.86572
+  dps: 18020.36509
+  tps: 10205.88562
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6430.3171
-  tps: 3370.01335
+  dps: 6447.06901
+  tps: 3372.77957
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhFireElemental-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8051.92255
-  tps: 3842.69171
+  dps: 7909.39349
+  tps: 3756.54613
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhFireElemental-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12852.90956
-  tps: 7746.48383
+  dps: 12759.25195
+  tps: 7668.55747
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhFireElemental-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3680.04655
-  tps: 1923.92928
+  dps: 3766.73087
+  tps: 1967.71261
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhFireElemental-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5106.45226
-  tps: 2404.25704
+  dps: 5078.85667
+  tps: 2384.18857
  }
 }
 dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6397.55348
-  tps: 3582.28357
+  dps: 6423.86073
+  tps: 3602.28507
  }
 }

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -45,603 +45,603 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 7973.25287
-  tps: 6514.66101
+  dps: 8030.76427
+  tps: 6562.73571
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8204.49052
-  tps: 6709.19041
+  dps: 8264.66766
+  tps: 6760.24326
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8188.66583
-  tps: 6687.60609
+  dps: 8200.80296
+  tps: 6703.31822
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8277.90342
-  tps: 6770.62787
+  dps: 8202.5808
+  tps: 6711.78079
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 8116.3249
-  tps: 6641.1567
+  dps: 8088.3503
+  tps: 6608.64392
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6851.5883
-  tps: 5605.06181
+  dps: 6847.60907
+  tps: 5601.76185
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6835.44248
-  tps: 5591.45682
+  dps: 6758.95803
+  tps: 5524.39872
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6502.08042
-  tps: 5313.23626
+  dps: 6422.71688
+  tps: 5254.20395
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8181.18045
-  tps: 6555.82828
+  dps: 8259.35241
+  tps: 6618.13434
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8403.27665
-  tps: 6868.22779
+  dps: 8448.7818
+  tps: 6907.37687
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 8161.25749
-  tps: 6679.68953
+  dps: 8154.31524
+  tps: 6672.66737
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 8148.43734
-  tps: 6659.38829
+  dps: 8181.70525
+  tps: 6694.37353
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 8138.3531
-  tps: 6651.25818
+  dps: 8059.48094
+  tps: 6588.05441
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 8004.88488
-  tps: 6544.17919
+  dps: 7973.41354
+  tps: 6512.35667
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 8110.66574
-  tps: 6635.62319
+  dps: 8141.84823
+  tps: 6661.82863
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7999.60283
-  tps: 6533.31444
+  dps: 8042.63261
+  tps: 6574.41619
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8268.67542
-  tps: 6766.08793
+  dps: 8234.30665
+  tps: 6732.84451
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 7248.6559
-  tps: 5937.96446
+  dps: 7247.88197
+  tps: 5927.66722
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8181.18045
-  tps: 6689.46989
+  dps: 8259.35241
+  tps: 6753.0495
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8181.18045
-  tps: 6689.46989
+  dps: 8259.35241
+  tps: 6753.0495
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8277.90342
-  tps: 6770.62787
+  dps: 8202.5808
+  tps: 6711.78079
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8255.23676
-  tps: 6754.18134
+  dps: 8255.39783
+  tps: 6751.32402
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8181.18045
-  tps: 6689.46989
+  dps: 8259.35241
+  tps: 6753.0495
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 8243.93137
-  tps: 6743.9101
+  dps: 8189.36124
+  tps: 6691.61125
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 8107.70178
-  tps: 6626.44769
+  dps: 8127.92105
+  tps: 6651.73694
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForgeEmber-37660"
  value: {
-  dps: 8003.28964
-  tps: 6539.28993
+  dps: 8125.60559
+  tps: 6648.09294
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8181.18045
-  tps: 6689.46989
+  dps: 8259.35241
+  tps: 6753.0495
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8181.18045
-  tps: 6689.46989
+  dps: 8259.35241
+  tps: 6753.0495
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8177.4964
-  tps: 6675.49132
+  dps: 8203.67522
+  tps: 6706.18721
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuturesightRune-38763"
  value: {
-  dps: 8004.88488
-  tps: 6544.17919
+  dps: 7973.41354
+  tps: 6512.35667
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 8010.00991
-  tps: 6534.59407
+  dps: 7967.54917
+  tps: 6507.14043
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 8004.88488
-  tps: 6544.17919
+  dps: 7973.41354
+  tps: 6512.35667
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8277.90342
-  tps: 6770.62787
+  dps: 8202.5808
+  tps: 6711.78079
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8255.23676
-  tps: 6754.18134
+  dps: 8255.39783
+  tps: 6751.32402
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8209.12999
-  tps: 6708.91839
+  dps: 8215.47952
+  tps: 6716.66745
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8181.18045
-  tps: 6689.46989
+  dps: 8259.35241
+  tps: 6753.0495
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8272.17215
-  tps: 6765.32877
+  dps: 8240.09615
+  tps: 6738.95285
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 8004.88488
-  tps: 6544.17919
+  dps: 7973.41354
+  tps: 6512.35667
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 8004.88488
-  tps: 6544.17919
+  dps: 7973.41354
+  tps: 6512.35667
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8148.48909
-  tps: 6665.27301
+  dps: 8202.81585
+  tps: 6708.05917
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 8005.63755
-  tps: 6539.53557
+  dps: 7979.73159
+  tps: 6519.01636
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtArmor"
  value: {
-  dps: 5441.9453
-  tps: 4447.50423
+  dps: 5480.89831
+  tps: 4482.27476
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 6386.4131
-  tps: 5213.47919
+  dps: 6386.08102
+  tps: 5213.63095
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8232.0259
-  tps: 6733.57964
+  dps: 8194.77761
+  tps: 6702.7587
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8272.17215
-  tps: 6765.32877
+  dps: 8240.09615
+  tps: 6738.95285
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8181.18045
-  tps: 6689.46989
+  dps: 8259.35241
+  tps: 6753.0495
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8181.18045
-  tps: 6689.46989
+  dps: 8259.35241
+  tps: 6753.0495
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 8004.88488
-  tps: 6544.17919
+  dps: 7973.41354
+  tps: 6512.35667
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 8004.88488
-  tps: 6544.17919
+  dps: 7973.41354
+  tps: 6512.35667
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 8004.88488
-  tps: 6544.17919
+  dps: 7973.41354
+  tps: 6512.35667
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8428.0934
-  tps: 6888.62695
+  dps: 8436.5462
+  tps: 6898.26137
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8181.18045
-  tps: 6689.46989
+  dps: 8259.35241
+  tps: 6753.0495
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 8004.88488
-  tps: 6544.17919
+  dps: 7973.41354
+  tps: 6512.35667
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 8023.32811
-  tps: 6561.68549
+  dps: 8024.15265
+  tps: 6554.63659
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 8004.88488
-  tps: 6544.17919
+  dps: 7973.41354
+  tps: 6512.35667
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 7612.40152
-  tps: 6228.42327
+  dps: 7670.17686
+  tps: 6266.81879
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 8004.88488
-  tps: 6544.17919
+  dps: 7973.41354
+  tps: 6512.35667
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SparkofLife-37657"
  value: {
-  dps: 8062.63635
-  tps: 6594.02862
+  dps: 8040.69027
+  tps: 6580.82504
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StormshroudArmor"
  value: {
-  dps: 6454.98682
-  tps: 5280.89598
+  dps: 6451.4621
+  tps: 5278.79359
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8272.17215
-  tps: 6765.32877
+  dps: 8240.09615
+  tps: 6738.95285
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8232.0259
-  tps: 6733.57964
+  dps: 8194.77761
+  tps: 6702.7587
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8211.30448
-  tps: 6717.17115
+  dps: 8208.75008
+  tps: 6712.31048
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheFistsofFury"
  value: {
-  dps: 4854.61724
-  tps: 4051.73822
+  dps: 4805.5011
+  tps: 4011.44959
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5174.94933
-  tps: 4317.99136
+  dps: 5129.9536
+  tps: 4277.37274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8185.76416
-  tps: 6696.84316
+  dps: 8276.28337
+  tps: 6768.62906
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 8395.92744
-  tps: 6862.46395
+  dps: 8439.75496
+  tps: 6901.49847
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8489.22242
-  tps: 6941.27471
+  dps: 8430.73242
+  tps: 6892.8333
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8181.18045
-  tps: 6689.46989
+  dps: 8259.35241
+  tps: 6753.0495
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8181.18045
-  tps: 6689.46989
+  dps: 8259.35241
+  tps: 6753.0495
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8181.18045
-  tps: 6689.46989
+  dps: 8259.35241
+  tps: 6753.0495
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8181.18045
-  tps: 6689.46989
+  dps: 8259.35241
+  tps: 6753.0495
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6764.88211
-  tps: 5531.46215
+  dps: 6720.16088
+  tps: 5489.25933
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 8064.40191
-  tps: 6590.30911
+  dps: 8087.18563
+  tps: 6610.71247
  }
 }
 dps_results: {
  key: "TestArms-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 8494.64839
-  tps: 6961.60699
+  dps: 8503.20407
+  tps: 6969.68104
  }
 }
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 8438.46695
-  tps: 6903.60787
+  dps: 8432.545
+  tps: 6898.69287
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10962.32319
-  tps: 9388.56569
+  dps: 10943.30711
+  tps: 9379.3917
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8338.21749
-  tps: 6820.88647
+  dps: 8361.99267
+  tps: 6843.04723
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8872.43333
-  tps: 7316.369
+  dps: 8945.52025
+  tps: 7367.74178
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6358.94004
-  tps: 5577.93066
+  dps: 6328.63687
+  tps: 5547.27285
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4533.65751
-  tps: 3715.25399
+  dps: 4525.34146
+  tps: 3703.80094
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4527.28685
-  tps: 3743.4009
+  dps: 4518.92768
+  tps: 3734.45925
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10992.4854
-  tps: 9417.00484
+  dps: 11016.77716
+  tps: 9435.82865
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8428.0934
-  tps: 6888.62695
+  dps: 8436.5462
+  tps: 6898.26137
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9015.58189
-  tps: 7427.82137
+  dps: 9019.36815
+  tps: 7429.58875
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6367.19291
-  tps: 5588.46447
+  dps: 6389.09604
+  tps: 5603.31015
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4566.26748
-  tps: 3742.02218
+  dps: 4563.47409
+  tps: 3742.51733
  }
 }
 dps_results: {
@@ -654,7 +654,7 @@ dps_results: {
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7834.7647
-  tps: 6397.0864
+  dps: 7846.40125
+  tps: 6403.97112
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -45,36 +45,36 @@ character_stats_results: {
 dps_results: {
  key: "TestFury-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 6525.16968
-  tps: 4805.4986
+  dps: 6503.46672
+  tps: 4792.88322
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6594.13882
-  tps: 4858.00993
+  dps: 6601.86049
+  tps: 4860.77799
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6655.47011
-  tps: 4899.62578
+  dps: 6657.75398
+  tps: 4899.75692
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6640.81824
-  tps: 4887.3785
+  dps: 6619.764
+  tps: 4876.75745
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6431.96193
-  tps: 4738.64277
+  dps: 6442.35676
+  tps: 4744.66681
  }
 }
 dps_results: {
@@ -87,246 +87,246 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5253.43791
-  tps: 3882.50757
+  dps: 5253.45142
+  tps: 3882.52106
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4963.369
-  tps: 3676.54786
+  dps: 4975.49748
+  tps: 3685.55706
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6599.35405
-  tps: 4763.55325
+  dps: 6628.71443
+  tps: 4785.67359
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6770.03669
-  tps: 4983.76858
+  dps: 6785.29735
+  tps: 4996.11147
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6619.50413
-  tps: 4873.08553
+  dps: 6662.8089
+  tps: 4905.37155
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6657.49335
-  tps: 4898.27311
+  dps: 6665.33368
+  tps: 4903.64175
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6611.60127
-  tps: 4869.13414
+  dps: 6585.86535
+  tps: 4850.51352
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6461.04365
-  tps: 4758.87246
+  dps: 6488.21013
+  tps: 4777.45299
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6601.22077
-  tps: 4859.66716
+  dps: 6589.68296
+  tps: 4849.28406
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6458.08012
-  tps: 4756.6874
+  dps: 6476.21779
+  tps: 4770.89137
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6664.91982
-  tps: 4907.29711
+  dps: 6614.6666
+  tps: 4872.53032
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 5810.67167
-  tps: 4290.59938
+  dps: 5823.56978
+  tps: 4301.37041
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6599.35405
-  tps: 4860.55492
+  dps: 6628.71443
+  tps: 4883.12481
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6599.35405
-  tps: 4860.55492
+  dps: 6628.71443
+  tps: 4883.12481
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6640.81824
-  tps: 4887.3785
+  dps: 6619.764
+  tps: 4876.75745
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6633.16921
-  tps: 4884.44637
+  dps: 6613.32988
+  tps: 4871.04594
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6599.35405
-  tps: 4860.55492
+  dps: 6628.71443
+  tps: 4883.12481
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6647.93888
-  tps: 4894.37642
+  dps: 6643.40735
+  tps: 4892.41454
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6605.18094
-  tps: 4864.29685
+  dps: 6589.14059
+  tps: 4852.72841
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6584.90726
-  tps: 4850.01846
+  dps: 6605.90221
+  tps: 4864.95963
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6599.35405
-  tps: 4860.55492
+  dps: 6628.71443
+  tps: 4883.12481
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6599.35405
-  tps: 4860.55492
+  dps: 6628.71443
+  tps: 4883.12481
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6665.57381
-  tps: 4904.43849
+  dps: 6664.18507
+  tps: 4907.127
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6461.04365
-  tps: 4758.87246
+  dps: 6488.21013
+  tps: 4777.45299
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 6364.74646
-  tps: 4686.34321
+  dps: 6375.92702
+  tps: 4695.07461
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6461.04365
-  tps: 4758.87246
+  dps: 6488.21013
+  tps: 4777.45299
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6640.81824
-  tps: 4887.3785
+  dps: 6619.764
+  tps: 4876.75745
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6633.16921
-  tps: 4884.44637
+  dps: 6613.32988
+  tps: 4871.04594
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6699.95041
-  tps: 4932.71623
+  dps: 6685.24855
+  tps: 4922.9412
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6599.35405
-  tps: 4860.55492
+  dps: 6628.71443
+  tps: 4883.12481
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6672.23463
-  tps: 4911.14714
+  dps: 6587.20621
+  tps: 4850.5989
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6461.04365
-  tps: 4758.87246
+  dps: 6488.21013
+  tps: 4777.45299
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6461.04365
-  tps: 4758.87246
+  dps: 6488.21013
+  tps: 4777.45299
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6704.76212
-  tps: 4935.8052
+  dps: 6723.87294
+  tps: 4947.88383
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6457.80565
-  tps: 4757.58873
+  dps: 6482.9162
+  tps: 4773.19336
  }
 }
 dps_results: {
@@ -346,315 +346,315 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6618.84359
-  tps: 4871.98141
+  dps: 6612.00336
+  tps: 4868.02612
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6672.23463
-  tps: 4911.14714
+  dps: 6587.20621
+  tps: 4850.5989
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6599.35405
-  tps: 4860.55492
+  dps: 6628.71443
+  tps: 4883.12481
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6599.35405
-  tps: 4860.55492
+  dps: 6628.71443
+  tps: 4883.12481
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6461.04365
-  tps: 4758.87246
+  dps: 6488.21013
+  tps: 4777.45299
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6461.04365
-  tps: 4758.87246
+  dps: 6488.21013
+  tps: 4777.45299
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6461.04365
-  tps: 4758.87246
+  dps: 6488.21013
+  tps: 4777.45299
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6738.20608
-  tps: 4961.63832
+  dps: 6730.97607
+  tps: 4955.80825
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6599.35405
-  tps: 4860.55492
+  dps: 6628.71443
+  tps: 4883.12481
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6461.04365
-  tps: 4758.87246
+  dps: 6488.21013
+  tps: 4777.45299
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6467.74838
-  tps: 4763.34364
+  dps: 6523.18021
+  tps: 4805.70141
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6461.04365
-  tps: 4758.87246
+  dps: 6488.21013
+  tps: 4777.45299
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 6096.10149
-  tps: 4495.22088
+  dps: 6052.37139
+  tps: 4464.45634
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6461.04365
-  tps: 4758.87246
+  dps: 6488.21013
+  tps: 4777.45299
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SparkofLife-37657"
  value: {
-  dps: 6542.04776
-  tps: 4817.60964
+  dps: 6541.18426
+  tps: 4819.68031
  }
 }
 dps_results: {
  key: "TestFury-AllItems-StormshroudArmor"
  value: {
-  dps: 4941.45785
-  tps: 3658.23636
+  dps: 4926.17352
+  tps: 3647.65956
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6672.23463
-  tps: 4911.14714
+  dps: 6587.20621
+  tps: 4850.5989
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6618.84359
-  tps: 4871.98141
+  dps: 6612.00336
+  tps: 4868.02612
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6578.56256
-  tps: 4843.89241
+  dps: 6611.89595
+  tps: 4870.13306
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 5058.63516
-  tps: 3739.04382
+  dps: 5005.8249
+  tps: 3700.02445
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5243.59085
-  tps: 3869.41718
+  dps: 5233.86936
+  tps: 3859.63868
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6649.32795
-  tps: 4898.36383
+  dps: 6679.13423
+  tps: 4919.99667
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6762.34708
-  tps: 4979.95504
+  dps: 6750.66394
+  tps: 4971.53628
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6828.12923
-  tps: 5024.19342
+  dps: 6789.07499
+  tps: 4996.44343
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6599.35405
-  tps: 4860.55492
+  dps: 6628.71443
+  tps: 4883.12481
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6599.35405
-  tps: 4860.55492
+  dps: 6628.71443
+  tps: 4883.12481
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6599.35405
-  tps: 4860.55492
+  dps: 6628.71443
+  tps: 4883.12481
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6599.35405
-  tps: 4860.55492
+  dps: 6628.71443
+  tps: 4883.12481
  }
 }
 dps_results: {
  key: "TestFury-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5276.71105
-  tps: 3899.86504
+  dps: 5264.61798
+  tps: 3890.85014
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 6512.58766
-  tps: 4795.40621
+  dps: 6524.02439
+  tps: 4801.8529
  }
 }
 dps_results: {
  key: "TestFury-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 7039.60102
-  tps: 5193.35377
+  dps: 7055.509
+  tps: 5200.16027
  }
 }
 dps_results: {
  key: "TestFury-Average-Default"
  value: {
-  dps: 6803.46525
-  tps: 5008.99375
+  dps: 6801.33906
+  tps: 5007.4081
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8523.75972
-  tps: 6721.22549
+  dps: 8538.97955
+  tps: 6727.13648
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6616.19461
-  tps: 4877.99669
+  dps: 6604.06526
+  tps: 4865.70725
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7756.93162
-  tps: 5703.13917
+  dps: 7782.95234
+  tps: 5724.79265
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4681.19755
-  tps: 3861.54828
+  dps: 4671.81029
+  tps: 3859.14362
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3233.37297
-  tps: 2411.33007
+  dps: 3262.9559
+  tps: 2433.05177
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3535.96501
-  tps: 2633.52623
+  dps: 3603.72856
+  tps: 2691.3471
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8762.00897
-  tps: 6895.70469
+  dps: 8753.30263
+  tps: 6891.60879
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6738.20608
-  tps: 4961.63832
+  dps: 6730.97607
+  tps: 4955.80825
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7998.90991
-  tps: 5883.92753
+  dps: 7949.32252
+  tps: 5847.96695
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4801.75145
-  tps: 3957.67289
+  dps: 4834.34193
+  tps: 3983.04579
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3285.97681
-  tps: 2453.37408
+  dps: 3280.10918
+  tps: 2451.31782
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3618.79613
-  tps: 2703.73918
+  dps: 3639.0993
+  tps: 2725.63226
  }
 }
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6119.72917
-  tps: 4511.76605
+  dps: 6159.13149
+  tps: 4540.09018
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -45,7 +45,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 1.1384
+  weights: 1.13829
   weights: 0
   weights: 0
   weights: 0
@@ -56,7 +56,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.3176
+  weights: 0.318
   weights: 0
   weights: 0
   weights: 0
@@ -65,12 +65,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.44633
+  weights: 0.4466
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.35052
-  weights: -0.31623
+  weights: 0.3534
+  weights: -0.31404
   weights: 0
   weights: 0
   weights: 0
@@ -103,8 +103,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2043.5845
-  tps: 5883.44412
+  dps: 2043.80875
+  tps: 5884.04861
  }
 }
 dps_results: {
@@ -117,8 +117,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1935.95202
-  tps: 5609.55471
+  dps: 1935.9473
+  tps: 5609.54494
  }
 }
 dps_results: {
@@ -376,8 +376,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 1620.57926
-  tps: 4754.33632
+  dps: 1620.57037
+  tps: 4754.30564
  }
 }
 dps_results: {
@@ -607,9 +607,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 2937.15753
-  tps: 7701.1856
-  dtps: 112.0534
+  dps: 2933.50852
+  tps: 7693.09566
+  dtps: 112.49756
  }
 }
 dps_results: {
@@ -699,8 +699,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3060.83971
-  tps: 8012.59411
+  dps: 3060.66776
+  tps: 8012.16414
   dtps: 107.8176
  }
 }


### PR DESCRIPTION
[core] Unit.HardCast is now also tracking channeled spells (only Expire is set); trying to cast while any spell is casting or channeling fails now
[core] the MajorCooldownManager now honors this one-spell-at-a-time limit
[core] the MCDM doesn't stop early if a major cooldown invoking the GCD is activated

These are all bug fixes, more or less.

[core] MCDM's sortOne() is gone, as a simplification; the perf impact is within the noise
[core] add an early exit for TryUseCooldowns(), using the "minReady" time of MCDs (similar to "minExpires" for the aura tracker)

Since >99% of all calls aren't activating any CDs, this is actually a slight perf win.

[core] simplified MCDM's interface, and...
[diverse] ... changed all clients

Most clients simply wanted (temporary) control over MCDs, and had to do so quite inefficiently.

[hunter] fixed Silencing Shot being fired in the middle of another cast; it should probably become a major cooldown
[rogue] slightly simplified initial disabling and re-enabling of MCDs
