### PR TITLE
Fix Focus Magic talent calculation of added spell crit %

### DIFF
--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -9,7 +9,7 @@ character_stats_results: {
   final_stats: 2731.3455
   final_stats: 109
   final_stats: 295.696
-  final_stats: 1580.94502
+  final_stats: 1443.21502
   final_stats: 609
   final_stats: 0
   final_stats: 755.7
@@ -45,553 +45,553 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6688.29017
-  tps: 4013.96069
+  dps: 6579.0062
+  tps: 3949.17106
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6493.62486
-  tps: 3900.30321
+  dps: 6392.69521
+  tps: 3840.44022
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6703.99384
-  tps: 4023.64765
+  dps: 6596.3311
+  tps: 3959.87106
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5626.13663
-  tps: 3384.5735
+  dps: 5525.0423
+  tps: 3324.80377
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 7521.20442
-  tps: 4515.72132
+  dps: 7401.91093
+  tps: 4445.14743
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6726.77398
-  tps: 3957.36784
+  dps: 6616.864
+  tps: 3893.51017
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6859.17711
-  tps: 4116.42229
+  dps: 6743.94159
+  tps: 4048.02856
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6572.59691
-  tps: 3947.46675
+  dps: 6467.5608
+  tps: 3885.25742
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6587.57195
-  tps: 3979.17039
+  dps: 6481.88832
+  tps: 3916.32093
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6552.67808
-  tps: 3933.39194
+  dps: 6448.22007
+  tps: 3871.39347
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6552.67808
-  tps: 3933.39194
+  dps: 6448.22007
+  tps: 3871.39347
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6624.62601
-  tps: 3971.66099
+  dps: 6512.29938
+  tps: 3904.84894
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6521.61931
-  tps: 3917.06205
+  dps: 6409.24915
+  tps: 3850.22228
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6493.62486
-  tps: 3900.30321
+  dps: 6392.69521
+  tps: 3840.44022
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6703.72279
-  tps: 4023.11186
+  dps: 6597.37513
+  tps: 3960.08869
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6688.29017
-  tps: 4013.96069
+  dps: 6579.0062
+  tps: 3949.17106
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6739.21856
-  tps: 4044.23437
+  dps: 6632.67615
+  tps: 3981.13529
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6701.60438
-  tps: 4021.87865
+  dps: 6595.78083
+  tps: 3959.13211
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6698.69778
-  tps: 4020.13469
+  dps: 6590.53582
+  tps: 3955.9851
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6688.29017
-  tps: 4013.96069
+  dps: 6579.0062
+  tps: 3949.17106
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6566.58743
-  tps: 3943.67672
+  dps: 6461.17217
+  tps: 3881.23941
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6756.13857
-  tps: 4056.24745
+  dps: 6643.64329
+  tps: 3989.64433
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6707.41048
-  tps: 4027.79631
+  dps: 6597.16064
+  tps: 3962.5059
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6726.77398
-  tps: 4036.65288
+  dps: 6616.864
+  tps: 3971.49199
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6719.07721
-  tps: 4032.11445
+  dps: 6609.29244
+  tps: 3967.0278
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FrostfireGarb"
  value: {
-  dps: 5979.58347
-  tps: 3591.23938
+  dps: 5879.65615
+  tps: 3531.99096
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6493.62486
-  tps: 3900.30321
+  dps: 6392.69521
+  tps: 3840.44022
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6597.99288
-  tps: 3959.87742
+  dps: 6497.4543
+  tps: 3900.18419
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6797.37236
-  tps: 4080.8628
+  dps: 6691.64609
+  tps: 4018.1402
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6701.60438
-  tps: 4021.87865
+  dps: 6595.78083
+  tps: 3959.13211
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6698.69778
-  tps: 4020.13469
+  dps: 6590.53582
+  tps: 3955.9851
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6493.62486
-  tps: 3900.30321
+  dps: 6392.69521
+  tps: 3840.44022
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6706.33511
-  tps: 4027.68662
+  dps: 6600.63441
+  tps: 3965.11113
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6688.29017
-  tps: 4013.96069
+  dps: 6579.0062
+  tps: 3949.17106
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 6565.42398
-  tps: 3937.2642
+  dps: 6472.29683
+  tps: 3882.42726
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KirinTorGarb"
  value: {
-  dps: 6178.82232
-  tps: 3703.27623
+  dps: 6079.31082
+  tps: 3644.3064
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6493.62486
-  tps: 3900.30321
+  dps: 6392.69521
+  tps: 3840.44022
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6570.09116
-  tps: 3941.62417
+  dps: 6462.13963
+  tps: 3877.50994
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6552.03243
-  tps: 3935.00249
+  dps: 6443.87187
+  tps: 3870.96565
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6493.62486
-  tps: 3900.30321
+  dps: 6392.69521
+  tps: 3840.44022
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6688.29017
-  tps: 4013.96069
+  dps: 6579.0062
+  tps: 3949.17106
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6688.29017
-  tps: 4013.96069
+  dps: 6579.0062
+  tps: 3949.17106
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6688.29017
-  tps: 4013.96069
+  dps: 6579.0062
+  tps: 3949.17106
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6688.29017
-  tps: 4013.96069
+  dps: 6579.0062
+  tps: 3949.17106
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6493.62486
-  tps: 3900.30321
+  dps: 6392.69521
+  tps: 3840.44022
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6891.67081
-  tps: 4213.16479
+  dps: 6801.35403
+  tps: 4158.36294
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6944.25493
-  tps: 4254.32351
+  dps: 6852.72982
+  tps: 4198.46471
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6844.67521
-  tps: 4107.79172
+  dps: 6725.67279
+  tps: 4037.17102
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6689.44758
-  tps: 4014.14931
+  dps: 6578.92126
+  tps: 3948.68038
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6493.62486
-  tps: 3900.30321
+  dps: 6392.69521
+  tps: 3840.44022
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6493.62486
-  tps: 3900.30321
+  dps: 6392.69521
+  tps: 3840.44022
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6493.62486
-  tps: 3900.30321
+  dps: 6392.69521
+  tps: 3840.44022
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6493.62486
-  tps: 3900.30321
+  dps: 6392.69521
+  tps: 3840.44022
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SparkofLife-37657"
  value: {
-  dps: 6594.49535
-  tps: 3957.43094
+  dps: 6481.60523
+  tps: 3890.44441
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sunstrider'sRegalia"
  value: {
-  dps: 6482.24635
-  tps: 3888.39698
+  dps: 6382.252
+  tps: 3829.04849
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6688.29017
-  tps: 4013.96069
+  dps: 6579.0062
+  tps: 3949.17106
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6688.29017
-  tps: 4013.96069
+  dps: 6579.0062
+  tps: 3949.17106
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6688.29017
-  tps: 4013.96069
+  dps: 6579.0062
+  tps: 3949.17106
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6688.29017
-  tps: 4013.96069
+  dps: 6579.0062
+  tps: 3949.17106
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6607.40766
-  tps: 3965.27166
+  dps: 6499.10698
+  tps: 3901.03883
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6607.40766
-  tps: 3965.27166
+  dps: 6499.10698
+  tps: 3901.03883
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6726.77398
-  tps: 4036.65288
+  dps: 6616.864
+  tps: 3971.49199
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6719.07721
-  tps: 4032.11445
+  dps: 6609.29244
+  tps: 3967.0278
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6719.07721
-  tps: 4032.11445
+  dps: 6609.29244
+  tps: 3967.0278
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6726.77398
-  tps: 4036.65288
+  dps: 6616.864
+  tps: 3971.49199
  }
 }
 dps_results: {
  key: "TestArcane-Average-Default"
  value: {
-  dps: 6920.99102
-  tps: 4150.9497
+  dps: 6797.08582
+  tps: 4077.45576
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10624.00133
-  tps: 8526.33715
+  dps: 10431.63481
+  tps: 8411.71554
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1415.28543
-  tps: 885.10869
+  dps: 1393.58119
+  tps: 872.7276
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2249.20845
-  tps: 1342.38931
+  dps: 2222.12703
+  tps: 1327.69648
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6169.94579
-  tps: 5339.17893
+  dps: 6049.00827
+  tps: 5267.43233
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 738.5149
-  tps: 476.15257
+  dps: 724.78058
+  tps: 468.39513
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1549.85284
-  tps: 942.75487
+  dps: 1521.43268
+  tps: 926.57777
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6859.17711
-  tps: 5492.03948
+  dps: 6743.94159
+  tps: 5423.64575
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6859.17711
-  tps: 4116.42229
+  dps: 6743.94159
+  tps: 4048.02856
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8870.88947
-  tps: 5242.44384
+  dps: 8737.34566
+  tps: 5164.50638
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3778.14214
-  tps: 3483.60403
+  dps: 3707.03108
+  tps: 3441.70379
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3778.14214
-  tps: 2278.57897
+  dps: 3707.03108
+  tps: 2236.67872
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5038.9922
-  tps: 2930.25488
+  dps: 4939.71303
+  tps: 2872.03884
  }
 }
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6859.17711
-  tps: 4116.42229
+  dps: 6743.94159
+  tps: 4048.02856
  }
 }

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -9,7 +9,7 @@ character_stats_results: {
   final_stats: 2523
   final_stats: 109
   final_stats: 217
-  final_stats: 1515.30883
+  final_stats: 1377.57883
   final_stats: 609
   final_stats: 0
   final_stats: 755.7
@@ -45,553 +45,553 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5664.42894
-  tps: 5073.00656
+  dps: 5562.90155
+  tps: 4985.50588
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5494.31194
-  tps: 4922.40054
+  dps: 5376.03602
+  tps: 4817.40605
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5715.10448
-  tps: 5120.00347
+  dps: 5549.35736
+  tps: 4969.96279
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4673.5658
-  tps: 4185.96384
+  dps: 4515.64594
+  tps: 4044.05646
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 6467.95581
-  tps: 5793.40939
+  dps: 6280.11707
+  tps: 5626.14184
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5701.70927
-  tps: 5005.38006
+  dps: 5599.56666
+  tps: 4919.08127
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 5883.73527
-  tps: 5271.04995
+  dps: 5711.6233
+  tps: 5118.27662
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5614.3457
-  tps: 5033.56414
+  dps: 5465.71962
+  tps: 4897.95886
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5606.6615
-  tps: 5027.32209
+  dps: 5444.9734
+  tps: 4882.38944
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 5520.8254
-  tps: 4946.04218
+  dps: 5341.40066
+  tps: 4780.36326
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 5520.8254
-  tps: 4946.04218
+  dps: 5341.40066
+  tps: 4780.36326
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 5565.1819
-  tps: 4975.59732
+  dps: 5388.07815
+  tps: 4818.85725
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5515.7379
-  tps: 4942.00928
+  dps: 5424.36768
+  tps: 4860.57956
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5494.31194
-  tps: 4922.40054
+  dps: 5376.03602
+  tps: 4817.40605
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5732.24764
-  tps: 5134.65696
+  dps: 5554.28804
+  tps: 4977.56174
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5664.42894
-  tps: 5073.00656
+  dps: 5562.90155
+  tps: 4985.50588
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5740.46805
-  tps: 5142.66517
+  dps: 5564.13627
+  tps: 4982.36931
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5732.1875
-  tps: 5134.65696
+  dps: 5568.83323
+  tps: 4989.76555
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5732.08255
-  tps: 5134.65696
+  dps: 5574.01017
+  tps: 4995.21872
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5664.42894
-  tps: 5073.00656
+  dps: 5562.90155
+  tps: 4985.50588
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5639.74124
-  tps: 5059.38567
+  dps: 5442.68972
+  tps: 4879.64321
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5799.58589
-  tps: 5198.76676
+  dps: 5633.51016
+  tps: 5045.9922
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5720.14079
-  tps: 5128.33327
+  dps: 5567.19472
+  tps: 4988.26206
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5701.70927
-  tps: 5105.98323
+  dps: 5599.56666
+  tps: 5017.95821
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5694.2532
-  tps: 5099.38789
+  dps: 5592.23364
+  tps: 5011.46774
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FrostfireGarb"
  value: {
-  dps: 5044.73875
-  tps: 4521.35505
+  dps: 4890.24636
+  tps: 4382.53124
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5494.31194
-  tps: 4922.40054
+  dps: 5376.03602
+  tps: 4817.40605
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5563.41685
-  tps: 4983.16577
+  dps: 5433.26503
+  tps: 4864.31327
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5786.6087
-  tps: 5182.93125
+  dps: 5662.02079
+  tps: 5072.3759
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5732.1875
-  tps: 5134.65696
+  dps: 5568.83323
+  tps: 4989.76555
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5732.08255
-  tps: 5134.65696
+  dps: 5574.01017
+  tps: 4995.21872
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5494.31194
-  tps: 4922.40054
+  dps: 5376.03602
+  tps: 4817.40605
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5681.70176
-  tps: 5086.39001
+  dps: 5587.94866
+  tps: 5005.93705
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5664.42894
-  tps: 5073.00656
+  dps: 5562.90155
+  tps: 4985.50588
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 5844.54265
-  tps: 5233.44438
+  dps: 5675.45353
+  tps: 5082.28382
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KirinTorGarb"
  value: {
-  dps: 5428.64075
-  tps: 4856.25245
+  dps: 5295.66677
+  tps: 4736.19741
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5494.31194
-  tps: 4922.40054
+  dps: 5376.03602
+  tps: 4817.40605
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5577.5598
-  tps: 4994.24385
+  dps: 5429.07595
+  tps: 4859.4337
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5603.03077
-  tps: 5023.49914
+  dps: 5452.16219
+  tps: 4885.01823
  }
 }
 dps_results: {
  key: "TestFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5494.31194
-  tps: 4922.40054
+  dps: 5376.03602
+  tps: 4817.40605
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5664.42894
-  tps: 5073.00656
+  dps: 5562.90155
+  tps: 4985.50588
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5664.42894
-  tps: 5073.00656
+  dps: 5562.90155
+  tps: 4985.50588
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5664.42894
-  tps: 5073.00656
+  dps: 5562.90155
+  tps: 4985.50588
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5664.42894
-  tps: 5073.00656
+  dps: 5562.90155
+  tps: 4985.50588
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5494.31194
-  tps: 4922.40054
+  dps: 5376.03602
+  tps: 4817.40605
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 5837.33466
-  tps: 5247.02935
+  dps: 5707.04938
+  tps: 5129.21745
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 5892.16779
-  tps: 5298.30855
+  dps: 5759.50892
+  tps: 5178.22788
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5812.82596
-  tps: 5206.56387
+  dps: 5705.20971
+  tps: 5113.58323
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5696.48912
-  tps: 5102.43338
+  dps: 5517.87883
+  tps: 4941.83674
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5494.31194
-  tps: 4922.40054
+  dps: 5376.03602
+  tps: 4817.40605
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5494.31194
-  tps: 4922.40054
+  dps: 5376.03602
+  tps: 4817.40605
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5494.31194
-  tps: 4922.40054
+  dps: 5376.03602
+  tps: 4817.40605
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5494.31194
-  tps: 4922.40054
+  dps: 5376.03602
+  tps: 4817.40605
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 5568.28132
-  tps: 4986.56433
+  dps: 5376.49573
+  tps: 4814.09122
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sunstrider'sRegalia"
  value: {
-  dps: 5695.19479
-  tps: 5099.59607
+  dps: 5506.30189
+  tps: 4929.27833
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5664.42894
-  tps: 5073.00656
+  dps: 5562.90155
+  tps: 4985.50588
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5664.42894
-  tps: 5073.00656
+  dps: 5562.90155
+  tps: 4985.50588
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5664.42894
-  tps: 5073.00656
+  dps: 5562.90155
+  tps: 4985.50588
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5664.42894
-  tps: 5073.00656
+  dps: 5562.90155
+  tps: 4985.50588
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5724.82927
-  tps: 5130.96126
+  dps: 5531.2364
+  tps: 4955.39828
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5724.82927
-  tps: 5130.96126
+  dps: 5531.2364
+  tps: 4955.39828
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5701.70927
-  tps: 5105.98323
+  dps: 5599.56666
+  tps: 5017.95821
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5694.2532
-  tps: 5099.38789
+  dps: 5592.23364
+  tps: 5011.46774
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5694.2532
-  tps: 5099.38789
+  dps: 5592.23364
+  tps: 5011.46774
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5701.70927
-  tps: 5105.98323
+  dps: 5599.56666
+  tps: 5017.95821
  }
 }
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
-  dps: 5996.20124
-  tps: 5372.6619
+  dps: 5819.27528
+  tps: 5213.46286
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18132.58272
-  tps: 21007.78566
+  dps: 17759.77004
+  tps: 20616.35828
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1755.1958
-  tps: 1626.72487
+  dps: 1726.35012
+  tps: 1600.55624
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2417.03463
-  tps: 2130.6251
+  dps: 2392.01395
+  tps: 2110.76528
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14172.67917
-  tps: 16823.33355
+  dps: 13870.76458
+  tps: 16517.63103
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 833.1673
-  tps: 760.7737
+  dps: 810.49659
+  tps: 740.17645
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1407.43349
-  tps: 1185.71307
+  dps: 1387.03949
+  tps: 1166.64919
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8317.81263
-  tps: 9233.27983
+  dps: 8112.32052
+  tps: 8991.23362
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5883.73527
-  tps: 5271.04995
+  dps: 5711.6233
+  tps: 5118.27662
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7171.87346
-  tps: 6314.40564
+  dps: 6946.91845
+  tps: 6117.00824
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4668.79184
-  tps: 5706.19096
+  dps: 4503.41458
+  tps: 5495.64329
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2491.01162
-  tps: 2220.83096
+  dps: 2465.5435
+  tps: 2199.35696
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3610.75244
-  tps: 3119.55704
+  dps: 3530.08403
+  tps: 3047.78539
  }
 }
 dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5883.73527
-  tps: 5271.04995
+  dps: 5711.6233
+  tps: 5118.27662
  }
 }

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -9,7 +9,7 @@ character_stats_results: {
   final_stats: 2523
   final_stats: 109
   final_stats: 295.696
-  final_stats: 1104.90643
+  final_stats: 967.17643
   final_stats: 609
   final_stats: 0
   final_stats: 755.7
@@ -45,553 +45,553 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 4276.79456
-  tps: 3585.233
+  dps: 4193.75071
+  tps: 3512.71134
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 4150.80724
-  tps: 3485.86964
+  dps: 4061.04886
+  tps: 3406.588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 4289.19018
-  tps: 3595.96772
+  dps: 4202.67947
+  tps: 3520.23091
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 3652.47624
-  tps: 3056.14897
+  dps: 3566.65373
+  tps: 2979.66224
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 4748.28753
-  tps: 4008.73288
+  dps: 4645.74217
+  tps: 3917.89309
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 4305.67819
-  tps: 3537.93746
+  dps: 4222.06113
+  tps: 3466.37318
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 4390.82576
-  tps: 3687.36415
+  dps: 4296.72989
+  tps: 3604.80734
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 4208.28442
-  tps: 3537.36068
+  dps: 4129.2243
+  tps: 3467.28159
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 4229.83838
-  tps: 3555.31722
+  dps: 4152.04234
+  tps: 3486.33219
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 4200.31619
-  tps: 3538.21471
+  dps: 4108.5644
+  tps: 3456.77524
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 4200.31619
-  tps: 3538.21471
+  dps: 4108.5644
+  tps: 3456.77524
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 4199.45402
-  tps: 3536.72968
+  dps: 4107.75433
+  tps: 3455.33606
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 4170.1084
-  tps: 3502.84578
+  dps: 4082.60202
+  tps: 3425.56896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 4150.80724
-  tps: 3485.86964
+  dps: 4061.04886
+  tps: 3406.588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 4293.03622
-  tps: 3599.51064
+  dps: 4206.32945
+  tps: 3523.60905
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 4276.79456
-  tps: 3585.233
+  dps: 4193.75071
+  tps: 3512.71134
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 4309.30371
-  tps: 3612.69037
+  dps: 4226.50204
+  tps: 3540.02835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 4288.8435
-  tps: 3595.74886
+  dps: 4202.32903
+  tps: 3520.00867
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 4286.00663
-  tps: 3593.24439
+  dps: 4199.5737
+  tps: 3517.52887
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 4276.79456
-  tps: 3585.233
+  dps: 4193.75071
+  tps: 3512.71134
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 4233.87876
-  tps: 3557.82932
+  dps: 4153.78868
+  tps: 3487.24836
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 4347.02637
-  tps: 3655.51491
+  dps: 4265.01184
+  tps: 3583.17816
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 4293.32158
-  tps: 3608.9547
+  dps: 4212.54558
+  tps: 3537.60604
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 4305.67819
-  tps: 3609.64203
+  dps: 4222.06113
+  tps: 3536.61725
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 4299.90147
-  tps: 3604.76022
+  dps: 4216.39904
+  tps: 3531.83607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FrostfireGarb"
  value: {
-  dps: 3810.9526
-  tps: 3183.48175
+  dps: 3724.19408
+  tps: 3107.38792
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 4150.80724
-  tps: 3485.86964
+  dps: 4061.04886
+  tps: 3406.588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 4221.9353
-  tps: 3544.66791
+  dps: 4130.38624
+  tps: 3463.79816
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 4378.13078
-  tps: 3681.85623
+  dps: 4283.28066
+  tps: 3598.04969
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 4288.8435
-  tps: 3595.74886
+  dps: 4202.32903
+  tps: 3520.00867
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 4286.00663
-  tps: 3593.24439
+  dps: 4199.5737
+  tps: 3517.52887
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 4150.80724
-  tps: 3485.86964
+  dps: 4061.04886
+  tps: 3406.588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 4266.92496
-  tps: 3577.84043
+  dps: 4184.79747
+  tps: 3505.77446
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 4276.79456
-  tps: 3585.233
+  dps: 4193.75071
+  tps: 3512.71134
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 4303.79441
-  tps: 3614.47459
+  dps: 4214.47789
+  tps: 3535.90075
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KirinTorGarb"
  value: {
-  dps: 4101.95142
-  tps: 3439.41848
+  dps: 4027.94401
+  tps: 3374.28341
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 4150.80724
-  tps: 3485.86964
+  dps: 4061.04886
+  tps: 3406.588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 4140.57849
-  tps: 3471.62229
+  dps: 4050.84678
+  tps: 3392.36465
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 4192.8032
-  tps: 3522.87827
+  dps: 4116.46323
+  tps: 3455.51729
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 4150.80724
-  tps: 3485.86964
+  dps: 4061.04886
+  tps: 3406.588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 4276.79456
-  tps: 3585.233
+  dps: 4193.75071
+  tps: 3512.71134
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 4276.79456
-  tps: 3585.233
+  dps: 4193.75071
+  tps: 3512.71134
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 4276.79456
-  tps: 3585.233
+  dps: 4193.75071
+  tps: 3512.71134
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 4276.79456
-  tps: 3585.233
+  dps: 4193.75071
+  tps: 3512.71134
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 4150.80724
-  tps: 3485.86964
+  dps: 4061.04886
+  tps: 3406.588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 4484.04776
-  tps: 3790.88721
+  dps: 4391.66519
+  tps: 3706.98878
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 4522.45258
-  tps: 3826.07697
+  dps: 4427.84461
+  tps: 3739.9921
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 4377.72523
-  tps: 3675.90186
+  dps: 4287.42184
+  tps: 3596.85325
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 4276.48095
-  tps: 3585.06394
+  dps: 4193.44034
+  tps: 3512.5452
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 4150.80724
-  tps: 3485.86964
+  dps: 4061.04886
+  tps: 3406.588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 4150.80724
-  tps: 3485.86964
+  dps: 4061.04886
+  tps: 3406.588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 4150.80724
-  tps: 3485.86964
+  dps: 4061.04886
+  tps: 3406.588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 4150.80724
-  tps: 3485.86964
+  dps: 4061.04886
+  tps: 3406.588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 4206.92113
-  tps: 3531.29108
+  dps: 4120.40608
+  tps: 3454.89958
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sunstrider'sRegalia"
  value: {
-  dps: 4303.2239
-  tps: 3617.29401
+  dps: 4213.94797
+  tps: 3538.75671
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 4276.79456
-  tps: 3585.233
+  dps: 4193.75071
+  tps: 3512.71134
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 4276.79456
-  tps: 3585.233
+  dps: 4193.75071
+  tps: 3512.71134
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 4276.79456
-  tps: 3585.233
+  dps: 4193.75071
+  tps: 3512.71134
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 4282.16404
-  tps: 3590.45686
+  dps: 4200.47027
+  tps: 3519.14486
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 4275.03473
-  tps: 3591.15498
+  dps: 4181.38698
+  tps: 3508.82964
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 4275.03473
-  tps: 3591.15498
+  dps: 4181.38698
+  tps: 3508.82964
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 4305.67819
-  tps: 3609.64203
+  dps: 4222.06113
+  tps: 3536.61725
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 4299.90147
-  tps: 3604.76022
+  dps: 4216.39904
+  tps: 3531.83607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 4299.90147
-  tps: 3604.76022
+  dps: 4216.39904
+  tps: 3531.83607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 4305.67819
-  tps: 3609.64203
+  dps: 4222.06113
+  tps: 3536.61725
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 4500.02927
-  tps: 3785.53701
+  dps: 4405.07772
+  tps: 3701.64366
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8282.7076
+  dps: 8281.40263
   tps: 8567.862
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1194.79229
+  dps: 1193.45798
   tps: 874.7354
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2213.31608
+  dps: 2209.05696
   tps: 1525.40075
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4348.37457
+  dps: 4347.37658
   tps: 4438.2059
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 573.15981
+  dps: 572.17427
   tps: 410.09184
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1266.81437
+  dps: 1265.16511
   tps: 889.09103
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4390.82576
-  tps: 4151.22685
+  dps: 4296.72989
+  tps: 4068.67005
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4390.82576
-  tps: 3687.36415
+  dps: 4296.72989
+  tps: 3604.80734
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5534.95342
-  tps: 4490.6197
+  dps: 5388.05978
+  tps: 4361.55666
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2702.60488
-  tps: 3008.05339
+  dps: 2642.86134
+  tps: 2955.09964
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2702.60488
-  tps: 2269.51206
+  dps: 2642.86134
+  tps: 2216.55832
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3252.19248
-  tps: 2586.7608
+  dps: 3194.34064
+  tps: 2535.83737
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 4390.82576
-  tps: 3687.36415
+  dps: 4296.72989
+  tps: 3604.80734
  }
 }

--- a/sim/mage/talents.go
+++ b/sim/mage/talents.go
@@ -33,8 +33,7 @@ func (mage *Mage) ApplyTalents() {
 	}
 
 	if mage.Talents.FocusMagic {
-		// TODO: Pretty sure this should be 2 separate effects? One from talent, another from generic raid buff from another mage.
-		totalCritPercent := 3 + float64(mage.Options.FocusMagicPercentUptime*3)/100.0
+		totalCritPercent := float64(mage.Options.FocusMagicPercentUptime*3) / 100.0
 		mage.AddStat(stats.SpellCrit, totalCritPercent*core.CritRatingPerCritChance)
 	}
 


### PR DESCRIPTION
Fixes #1441

Talenting into Focus Magic was giving an additional static 3% spell crit, it should only add up to 3% based on the uptime configured by the user. The buff focus magic is currently configured via a raid buff in the misc category.