### PR TITLE
Remove "disableHsCleaveUntil"

### DIFF
--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -200,7 +200,7 @@ func (spell *Spell) wrapCastFuncGCD(config CastConfig, onCastComplete CastFunc) 
 
 	if config.DefaultCast.GCD == 0 { // mostly cooldowns (e.g. nature's swiftness, presence of mind)
 		return func(sim *Simulation, target *Unit) {
-			if hc := spell.Unit.Hardcast; hc.Expires != 0 {
+			if hc := spell.Unit.Hardcast; hc.Expires > sim.CurrentTime {
 				panic(fmt.Sprintf("Trying to cast %s but casting/channeling %v for %s, curTime = %s", spell.ActionID, hc.ActionID, hc.Expires-sim.CurrentTime, sim.CurrentTime))
 			}
 			onCastComplete(sim, target)
@@ -213,7 +213,7 @@ func (spell *Spell) wrapCastFuncGCD(config CastConfig, onCastComplete CastFunc) 
 			panic(fmt.Sprintf("Trying to cast %s but GCD on cooldown for %s, curTime = %s", spell.ActionID, spell.Unit.GCD.TimeToReady(sim), sim.CurrentTime))
 		}
 
-		if hc := spell.Unit.Hardcast; hc.Expires != 0 {
+		if hc := spell.Unit.Hardcast; hc.Expires > sim.CurrentTime {
 			panic(fmt.Sprintf("Trying to cast %s but casting/channeling %v for %s, curTime = %s", spell.ActionID, hc.ActionID, hc.Expires-sim.CurrentTime, sim.CurrentTime))
 		}
 

--- a/sim/core/gcd.go
+++ b/sim/core/gcd.go
@@ -109,7 +109,7 @@ func (unit *Unit) WaitUntil(sim *Simulation, readyTime time.Duration) {
 }
 
 func (unit *Unit) HardcastWaitUntil(sim *Simulation, readyTime time.Duration, onComplete CastFunc) {
-	if unit.Hardcast.Expires >= sim.CurrentTime && sim.CurrentTime != 0 {
+	if unit.Hardcast.Expires > sim.CurrentTime {
 		fmt.Printf("Sim current time: %0.2f\n", sim.CurrentTime.Seconds())
 		panic(fmt.Sprintf("Hardcast already in use, will finish at: %0.2f", unit.Hardcast.Expires.Seconds()))
 	}

--- a/sim/core/major_cooldown.go
+++ b/sim/core/major_cooldown.go
@@ -137,7 +137,7 @@ func (mcd *MajorCooldown) tryActivateHelper(sim *Simulation, character *Characte
 	}
 
 	// while casting or channeling, no other action is possible
-	if character.Hardcast.Expires != 0 {
+	if character.Hardcast.Expires > sim.CurrentTime {
 		return false
 	}
 

--- a/sim/hunter/silencing_shot.go
+++ b/sim/hunter/silencing_shot.go
@@ -49,7 +49,7 @@ func (hunter *Hunter) registerSilencingShotSpell() {
 				DoAt: sim.CurrentTime + hunter.SilencingShot.CD.Duration,
 				OnAction: func(sim *core.Simulation) {
 					// Need to check in case Readiness caused a shift in timing.
-					if hunter.SilencingShot.IsReady(sim) && hunter.Hardcast.Expires == 0 {
+					if hunter.SilencingShot.IsReady(sim) && hunter.Hardcast.Expires <= sim.CurrentTime {
 						hunter.SilencingShot.Cast(sim, hunter.CurrentTarget)
 					}
 				},

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -45,616 +45,616 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 7939.35901
-  tps: 6486.58396
+  dps: 8037.80839
+  tps: 6569.52492
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8179.38014
-  tps: 6688.22117
+  dps: 8243.44183
+  tps: 6750.14456
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8091.88076
-  tps: 6610.11543
+  dps: 8146.82315
+  tps: 6657.45136
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8209.6753
-  tps: 6715.06378
+  dps: 8272.78122
+  tps: 6771.67046
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 8093.11402
-  tps: 6615.39913
+  dps: 8076.61243
+  tps: 6602.36843
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6817.44537
-  tps: 5573.63629
+  dps: 6878.29251
+  tps: 5632.11435
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6799.57557
-  tps: 5568.41617
+  dps: 6880.16417
+  tps: 5633.35793
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6527.26197
-  tps: 5343.57823
+  dps: 6472.85643
+  tps: 5296.62574
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8168.56851
-  tps: 6544.836
+  dps: 8235.23296
+  tps: 6607.76304
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8395.42139
-  tps: 6861.48426
+  dps: 8422.99261
+  tps: 6899.21719
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 8101.74894
-  tps: 6621.34198
+  dps: 8162.64249
+  tps: 6677.57432
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 8154.36887
-  tps: 6663.24905
+  dps: 8180.69843
+  tps: 6690.6772
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 8081.78753
-  tps: 6605.44507
+  dps: 8119.79899
+  tps: 6641.20612
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7913.99657
-  tps: 6465.19675
+  dps: 7978.62053
+  tps: 6522.65926
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 8050.03554
-  tps: 6579.406
+  dps: 8140.38436
+  tps: 6660.4072
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7963.34017
-  tps: 6506.65975
+  dps: 7998.21279
+  tps: 6537.3341
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8206.55174
-  tps: 6713.57141
+  dps: 8280.64892
+  tps: 6778.05667
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 7227.00049
-  tps: 5912.35074
+  dps: 7309.10804
+  tps: 5981.22925
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8168.56851
-  tps: 6678.25474
+  dps: 8235.23296
+  tps: 6742.46242
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8168.56851
-  tps: 6678.25474
+  dps: 8235.23296
+  tps: 6742.46242
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8209.6753
-  tps: 6715.06378
+  dps: 8272.78122
+  tps: 6771.67046
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8204.3409
-  tps: 6711.77282
+  dps: 8273.42013
+  tps: 6774.06732
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8168.56851
-  tps: 6678.25474
+  dps: 8235.23296
+  tps: 6742.46242
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 8162.71953
-  tps: 6669.37543
+  dps: 8199.25775
+  tps: 6707.17203
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 8109.71551
-  tps: 6628.39839
+  dps: 8132.6335
+  tps: 6654.89982
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForgeEmber-37660"
  value: {
-  dps: 8089.45877
-  tps: 6612.42603
+  dps: 8113.74218
+  tps: 6638.03433
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8168.56851
-  tps: 6678.25474
+  dps: 8235.23296
+  tps: 6742.46242
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8168.56851
-  tps: 6678.25474
+  dps: 8235.23296
+  tps: 6742.46242
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8160.38526
-  tps: 6667.4639
+  dps: 8246.81904
+  tps: 6742.26524
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7913.99657
-  tps: 6465.19675
+  dps: 7978.62053
+  tps: 6522.65926
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 7892.1679
-  tps: 6445.72531
+  dps: 7926.67537
+  tps: 6469.82618
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7913.99657
-  tps: 6465.19675
+  dps: 7978.62053
+  tps: 6522.65926
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8209.6753
-  tps: 6715.06378
+  dps: 8272.78122
+  tps: 6771.67046
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8204.3409
-  tps: 6711.77282
+  dps: 8273.42013
+  tps: 6774.06732
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8166.36047
-  tps: 6675.44674
+  dps: 8227.71072
+  tps: 6729.08344
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8168.56851
-  tps: 6678.25474
+  dps: 8235.23296
+  tps: 6742.46242
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8193.63955
-  tps: 6699.07727
+  dps: 8290.20141
+  tps: 6788.35548
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7913.99657
-  tps: 6465.19675
+  dps: 7978.62053
+  tps: 6522.65926
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7913.99657
-  tps: 6465.19675
+  dps: 7978.62053
+  tps: 6522.65926
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8206.52594
-  tps: 6706.92467
+  dps: 8186.95149
+  tps: 6696.84583
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7922.44487
-  tps: 6471.9671
+  dps: 7985.89338
+  tps: 6527.26092
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtArmor"
  value: {
-  dps: 5528.45966
-  tps: 4522.99951
+  dps: 5530.20596
+  tps: 4520.74054
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 6367.67504
-  tps: 5198.6024
+  dps: 6380.67452
+  tps: 5213.15723
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8202.53131
-  tps: 6706.94904
+  dps: 8280.5453
+  tps: 6780.81573
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8193.63955
-  tps: 6699.07727
+  dps: 8290.20141
+  tps: 6788.35548
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8168.56851
-  tps: 6678.25474
+  dps: 8235.23296
+  tps: 6742.46242
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8168.56851
-  tps: 6678.25474
+  dps: 8235.23296
+  tps: 6742.46242
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7913.99657
-  tps: 6465.19675
+  dps: 7978.62053
+  tps: 6522.65926
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7913.99657
-  tps: 6465.19675
+  dps: 7978.62053
+  tps: 6522.65926
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7913.99657
-  tps: 6465.19675
+  dps: 7978.62053
+  tps: 6522.65926
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8395.24484
-  tps: 6860.36023
+  dps: 8418.52725
+  tps: 6895.37048
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8168.56851
-  tps: 6678.25474
+  dps: 8235.23296
+  tps: 6742.46242
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7913.99657
-  tps: 6465.19675
+  dps: 7978.62053
+  tps: 6522.65926
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7939.70413
-  tps: 6484.40548
+  dps: 8024.22985
+  tps: 6559.14064
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7913.99657
-  tps: 6465.19675
+  dps: 7978.62053
+  tps: 6522.65926
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 7626.82866
-  tps: 6238.17841
+  dps: 7647.48172
+  tps: 6256.49222
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7913.99657
-  tps: 6465.19675
+  dps: 7978.62053
+  tps: 6522.65926
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SparkofLife-37657"
  value: {
-  dps: 8085.2399
-  tps: 6607.14856
+  dps: 8106.99235
+  tps: 6631.81647
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StormshroudArmor"
  value: {
-  dps: 6439.91315
-  tps: 5266.26736
+  dps: 6398.75965
+  tps: 5232.90406
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8193.63955
-  tps: 6699.07727
+  dps: 8290.20141
+  tps: 6788.35548
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8202.53131
-  tps: 6706.94904
+  dps: 8280.5453
+  tps: 6780.81573
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8186.43421
-  tps: 6693.07627
+  dps: 8279.05639
+  tps: 6779.79182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheFistsofFury"
  value: {
-  dps: 4781.65299
-  tps: 3990.05938
+  dps: 4851.87987
+  tps: 4053.671
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5146.75548
-  tps: 4295.35713
+  dps: 5172.69353
+  tps: 4313.39797
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8272.18414
-  tps: 6764.34897
+  dps: 8326.27276
+  tps: 6817.31665
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 8367.55497
-  tps: 6843.58425
+  dps: 8437.25324
+  tps: 6898.96975
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8423.46978
-  tps: 6888.44156
+  dps: 8495.42594
+  tps: 6947.10078
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8168.56851
-  tps: 6678.25474
+  dps: 8235.23296
+  tps: 6742.46242
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8168.56851
-  tps: 6678.25474
+  dps: 8235.23296
+  tps: 6742.46242
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8168.56851
-  tps: 6678.25474
+  dps: 8235.23296
+  tps: 6742.46242
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8168.56851
-  tps: 6678.25474
+  dps: 8235.23296
+  tps: 6742.46242
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6805.57089
-  tps: 5566.94379
+  dps: 6833.11076
+  tps: 5591.00841
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 8047.97522
-  tps: 6573.37512
+  dps: 8085.47389
+  tps: 6607.63626
  }
 }
 dps_results: {
  key: "TestArms-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 8520.32167
-  tps: 6983.54157
+  dps: 8480.5699
+  tps: 6952.41021
  }
 }
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 8428.17775
-  tps: 6894.90627
+  dps: 8467.83205
+  tps: 6930.52458
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10977.21481
-  tps: 9411.01101
+  dps: 11061.69921
+  tps: 9483.15461
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8302.32054
-  tps: 6785.6499
+  dps: 8371.93459
+  tps: 6852.62733
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9093.97892
-  tps: 7502.00739
+  dps: 9004.7349
+  tps: 7445.26388
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6365.31806
-  tps: 5583.58486
+  dps: 6329.07924
+  tps: 5558.61149
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4456.8162
-  tps: 3654.26009
+  dps: 4441.3749
+  tps: 3642.28117
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4408.93878
-  tps: 3635.16743
+  dps: 4466.22421
+  tps: 3690.44025
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11139.3294
-  tps: 9549.2145
+  dps: 11149.23975
+  tps: 9556.67177
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8395.24484
-  tps: 6860.36023
+  dps: 8418.52725
+  tps: 6895.37048
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9184.26974
-  tps: 7574.79038
+  dps: 9088.33616
+  tps: 7518.8205
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6411.95629
-  tps: 5623.26148
+  dps: 6398.00791
+  tps: 5614.61102
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4509.52859
-  tps: 3694.02134
+  dps: 4536.68404
+  tps: 3719.06967
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4514.99827
-  tps: 3727.20095
+  dps: 4546.88456
+  tps: 3762.01394
  }
 }
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7796.72685
-  tps: 6366.2785
+  dps: 7841.91775
+  tps: 6406.58684
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -45,616 +45,616 @@ character_stats_results: {
 dps_results: {
  key: "TestFury-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 6564.46577
-  tps: 4827.94344
+  dps: 6607.10388
+  tps: 4863.19449
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6634.25839
-  tps: 4880.22106
+  dps: 6672.5339
+  tps: 4912.23099
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6729.02115
-  tps: 4949.05938
+  dps: 6771.13407
+  tps: 4978.46015
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6664.08399
-  tps: 4901.5595
+  dps: 6734.09994
+  tps: 4956.51718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6445.20705
-  tps: 4741.95307
+  dps: 6504.61936
+  tps: 4789.90719
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 5267.37173
-  tps: 3893.11052
+  dps: 5337.96848
+  tps: 3944.38182
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5250.93575
-  tps: 3878.18918
+  dps: 5303.90819
+  tps: 3916.5057
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4959.89052
-  tps: 3669.12863
+  dps: 5035.26176
+  tps: 3721.96987
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6641.15023
-  tps: 4787.24944
+  dps: 6687.55211
+  tps: 4824.54467
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6795.7451
-  tps: 4997.94543
+  dps: 6839.41356
+  tps: 5031.64046
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6678.05931
-  tps: 4910.45907
+  dps: 6706.84076
+  tps: 4936.80879
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6692.25342
-  tps: 4920.57649
+  dps: 6724.00401
+  tps: 4948.77973
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6612.81047
-  tps: 4866.26847
+  dps: 6647.88817
+  tps: 4892.75789
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6517.45265
-  tps: 4795.43945
+  dps: 6598.06924
+  tps: 4857.83334
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6621.04635
-  tps: 4869.97175
+  dps: 6673.94586
+  tps: 4912.06979
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6547.473
-  tps: 4813.35509
+  dps: 6571.34077
+  tps: 4838.25726
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6680.13944
-  tps: 4912.13223
+  dps: 6737.97624
+  tps: 4960.12934
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 5811.64988
-  tps: 4287.50719
+  dps: 5892.31753
+  tps: 4346.89974
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6641.15023
-  tps: 4884.73916
+  dps: 6687.55211
+  tps: 4922.788
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6641.15023
-  tps: 4884.73916
+  dps: 6687.55211
+  tps: 4922.788
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6664.08399
-  tps: 4901.5595
+  dps: 6734.09994
+  tps: 4956.51718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6668.14778
-  tps: 4903.87423
+  dps: 6729.65041
+  tps: 4953.78957
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6641.15023
-  tps: 4884.73916
+  dps: 6687.55211
+  tps: 4922.788
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6697.92133
-  tps: 4924.43593
+  dps: 6736.56464
+  tps: 4957.75054
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6655.14875
-  tps: 4894.95622
+  dps: 6679.95823
+  tps: 4918.0062
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6632.46945
-  tps: 4880.36834
+  dps: 6667.41535
+  tps: 4906.38586
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6641.15023
-  tps: 4884.73916
+  dps: 6687.55211
+  tps: 4922.788
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6641.15023
-  tps: 4884.73916
+  dps: 6687.55211
+  tps: 4922.788
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6707.44966
-  tps: 4932.39427
+  dps: 6787.21333
+  tps: 4993.04875
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6517.45265
-  tps: 4795.43945
+  dps: 6598.06924
+  tps: 4857.83334
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 6442.03214
-  tps: 4738.20709
+  dps: 6492.99667
+  tps: 4777.17646
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6517.45265
-  tps: 4795.43945
+  dps: 6598.06924
+  tps: 4857.83334
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6664.08399
-  tps: 4901.5595
+  dps: 6734.09994
+  tps: 4956.51718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6668.14778
-  tps: 4903.87423
+  dps: 6729.65041
+  tps: 4953.78957
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6744.86788
-  tps: 4959.77368
+  dps: 6764.67905
+  tps: 4976.84694
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6641.15023
-  tps: 4884.73916
+  dps: 6687.55211
+  tps: 4922.788
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6678.44659
-  tps: 4915.58039
+  dps: 6706.32836
+  tps: 4935.27566
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6517.45265
-  tps: 4795.43945
+  dps: 6598.06924
+  tps: 4857.83334
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6517.45265
-  tps: 4795.43945
+  dps: 6598.06924
+  tps: 4857.83334
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6738.11371
-  tps: 4953.5044
+  dps: 6792.82435
+  tps: 4996.65085
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6541.21409
-  tps: 4809.12529
+  dps: 6564.31435
+  tps: 4835.15277
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtArmor"
  value: {
-  dps: 4021.05135
-  tps: 2982.80494
+  dps: 4061.35126
+  tps: 3014.98245
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 4838.99417
-  tps: 3579.85645
+  dps: 4903.70859
+  tps: 3627.65429
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6669.21583
-  tps: 4907.05464
+  dps: 6705.05822
+  tps: 4934.03927
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6678.44659
-  tps: 4915.58039
+  dps: 6706.32836
+  tps: 4935.27566
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6641.15023
-  tps: 4884.73916
+  dps: 6687.55211
+  tps: 4922.788
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6641.15023
-  tps: 4884.73916
+  dps: 6687.55211
+  tps: 4922.788
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6517.45265
-  tps: 4795.43945
+  dps: 6598.06924
+  tps: 4857.83334
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6517.45265
-  tps: 4795.43945
+  dps: 6598.06924
+  tps: 4857.83334
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6517.45265
-  tps: 4795.43945
+  dps: 6598.06924
+  tps: 4857.83334
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6792.72515
-  tps: 4995.58071
+  dps: 6831.87151
+  tps: 5026.61121
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6641.15023
-  tps: 4884.73916
+  dps: 6687.55211
+  tps: 4922.788
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6517.45265
-  tps: 4795.43945
+  dps: 6598.06924
+  tps: 4857.83334
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6556.45195
-  tps: 4821.82691
+  dps: 6614.60136
+  tps: 4868.85402
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6517.45265
-  tps: 4795.43945
+  dps: 6598.06924
+  tps: 4857.83334
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 6134.6011
-  tps: 4517.90468
+  dps: 6197.72861
+  tps: 4565.30251
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6517.45265
-  tps: 4795.43945
+  dps: 6598.06924
+  tps: 4857.83334
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SparkofLife-37657"
  value: {
-  dps: 6605.69931
-  tps: 4861.43123
+  dps: 6633.58145
+  tps: 4880.6176
  }
 }
 dps_results: {
  key: "TestFury-AllItems-StormshroudArmor"
  value: {
-  dps: 4910.61035
-  tps: 3631.25386
+  dps: 4953.7481
+  tps: 3668.18905
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6678.44659
-  tps: 4915.58039
+  dps: 6706.32836
+  tps: 4935.27566
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6669.21583
-  tps: 4907.05464
+  dps: 6705.05822
+  tps: 4934.03927
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6640.98724
-  tps: 4884.44406
+  dps: 6655.16655
+  tps: 4899.52762
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 5050.71014
-  tps: 3727.25837
+  dps: 5057.14242
+  tps: 3734.4068
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5271.27567
-  tps: 3884.19723
+  dps: 5303.1446
+  tps: 3915.21642
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6686.97703
-  tps: 4918.89993
+  dps: 6744.64369
+  tps: 4962.52489
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6807.34549
-  tps: 5006.15653
+  dps: 6794.10124
+  tps: 4998.01571
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6825.97364
-  tps: 5017.99239
+  dps: 6888.01416
+  tps: 5067.7949
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6641.15023
-  tps: 4884.73916
+  dps: 6687.55211
+  tps: 4922.788
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6641.15023
-  tps: 4884.73916
+  dps: 6687.55211
+  tps: 4922.788
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6641.15023
-  tps: 4884.73916
+  dps: 6687.55211
+  tps: 4922.788
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6641.15023
-  tps: 4884.73916
+  dps: 6687.55211
+  tps: 4922.788
  }
 }
 dps_results: {
  key: "TestFury-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5242.66174
-  tps: 3871.98643
+  dps: 5290.14272
+  tps: 3906.40106
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 6516.54449
-  tps: 4791.17289
+  dps: 6597.6386
+  tps: 4852.02614
  }
 }
 dps_results: {
  key: "TestFury-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 7108.47891
-  tps: 5233.75565
+  dps: 7135.17175
+  tps: 5254.81618
  }
 }
 dps_results: {
  key: "TestFury-Average-Default"
  value: {
-  dps: 6845.81002
-  tps: 5035.18865
+  dps: 6882.56049
+  tps: 5064.68217
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8694.50728
-  tps: 6836.48688
+  dps: 8744.72076
+  tps: 6886.47535
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6611.71602
-  tps: 4867.29127
+  dps: 6664.76297
+  tps: 4905.86024
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7729.58083
-  tps: 5663.9409
+  dps: 7969.30884
+  tps: 5851.73918
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4720.53689
-  tps: 3892.71836
+  dps: 4730.06059
+  tps: 3903.98079
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3251.62764
-  tps: 2422.72537
+  dps: 3293.31184
+  tps: 2453.05307
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3476.40323
-  tps: 2587.32537
+  dps: 3454.39114
+  tps: 2574.03876
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8899.97436
-  tps: 6995.20853
+  dps: 8893.27989
+  tps: 6996.01394
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6792.72515
-  tps: 4995.58071
+  dps: 6831.87151
+  tps: 5026.61121
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7838.92004
-  tps: 5739.56327
+  dps: 8084.48554
+  tps: 5937.23253
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4837.22027
-  tps: 3980.92638
+  dps: 4841.23675
+  tps: 3989.06818
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3314.29807
-  tps: 2469.90112
+  dps: 3325.56877
+  tps: 2478.6994
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3508.91135
-  tps: 2613.37931
+  dps: 3567.86262
+  tps: 2660.76556
  }
 }
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6210.86439
-  tps: 4577.61965
+  dps: 6273.89649
+  tps: 4622.821
  }
 }

--- a/sim/warrior/heroic_strike_cleave.go
+++ b/sim/warrior/heroic_strike_cleave.go
@@ -54,7 +54,7 @@ func (warrior *Warrior) registerHeroicStrikeSpell() {
 
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
 
-			if sim.CurrentTime < warrior.disableHsCleaveUntil {
+			if sim.CurrentTime < warrior.Hardcast.Expires {
 				return
 			}
 			if !result.Landed() {
@@ -140,7 +140,7 @@ func (warrior *Warrior) TryHSOrCleave(sim *core.Simulation, mhSwingSpell *core.S
 		return nil
 	}
 
-	if sim.CurrentTime < warrior.disableHsCleaveUntil {
+	if sim.CurrentTime < warrior.Hardcast.Expires {
 		warrior.DequeueHSOrCleave(sim)
 		return nil
 	}
@@ -160,7 +160,7 @@ func (warrior *Warrior) TryHSOrCleave(sim *core.Simulation, mhSwingSpell *core.S
 }
 
 func (warrior *Warrior) ShouldQueueHSOrCleave(sim *core.Simulation) bool {
-	return warrior.CurrentRage() >= warrior.HSRageThreshold && sim.CurrentTime > warrior.disableHsCleaveUntil
+	return warrior.CurrentRage() >= warrior.HSRageThreshold && sim.CurrentTime >= warrior.Hardcast.Expires
 }
 
 func (warrior *Warrior) RegisterHSOrCleave(useCleave bool, rageThreshold float64) {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -45,7 +45,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 1.09111
+  weights: 1.12186
   weights: 0
   weights: 0
   weights: 0
@@ -56,7 +56,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.34809
+  weights: 0.36597
   weights: 0
   weights: 0
   weights: 0
@@ -65,12 +65,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.01501
+  weights: 0.015
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.42683
-  weights: -0.14066
+  weights: 0.42774
+  weights: -0.17886
   weights: 0
   weights: 0
   weights: 0
@@ -124,22 +124,22 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1719.07192
-  tps: 5016.03202
+  dps: 1718.05074
+  tps: 5014.47176
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1696.51454
-  tps: 4945.2116
+  dps: 1700.62816
+  tps: 4953.82787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1584.02358
-  tps: 4655.4223
+  dps: 1587.40455
+  tps: 4665.86485
  }
 }
 dps_results: {
@@ -299,8 +299,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 2303.96885
-  tps: 6465.84349
+  dps: 2299.8514
+  tps: 6456.80386
  }
 }
 dps_results: {
@@ -376,15 +376,15 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 1589.46797
-  tps: 4652.00479
+  dps: 1587.55041
+  tps: 4645.07048
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 1757.20398
-  tps: 5067.19206
+  dps: 1758.94438
+  tps: 5074.74917
  }
 }
 dps_results: {
@@ -495,8 +495,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormshroudArmor"
  value: {
-  dps: 1561.3091
-  tps: 4590.5936
+  dps: 1563.96999
+  tps: 4598.25242
  }
 }
 dps_results: {
@@ -586,8 +586,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1686.44187
-  tps: 4921.4934
+  dps: 1683.67646
+  tps: 4910.09654
  }
 }
 dps_results: {
@@ -607,9 +607,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 2891.32807
-  tps: 7581.17258
-  dtps: 111.46802
+  dps: 2891.66156
+  tps: 7582.04495
+  dtps: 111.47521
  }
 }
 dps_results: {
@@ -699,8 +699,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3017.75165
-  tps: 7912.8709
+  dps: 3020.02458
+  tps: 7916.81241
   dtps: 102.70828
  }
 }

--- a/sim/warrior/shattering_throw.go
+++ b/sim/warrior/shattering_throw.go
@@ -59,7 +59,6 @@ func (warrior *Warrior) RegisterShatteringThrowCD() {
 				}
 				if ShatteringThrowSpell.Cast(sim, character.CurrentTarget) {
 					warrior.AutoAttacks.StopMeleeUntil(sim, sim.CurrentTime+ShatteringThrowSpell.CurCast.CastTime)
-					warrior.disableHsCleaveUntil = sim.CurrentTime + ShatteringThrowSpell.CurCast.CastTime
 				}
 			}
 		},

--- a/sim/warrior/slam.go
+++ b/sim/warrior/slam.go
@@ -62,6 +62,5 @@ func (warrior *Warrior) CastSlam(sim *core.Simulation, target *core.Unit) bool {
 		return false
 	}
 	warrior.AutoAttacks.DelayMeleeBy(sim, warrior.Slam.CurCast.CastTime)
-	warrior.disableHsCleaveUntil = sim.CurrentTime + warrior.Slam.CurCast.CastTime
 	return true
 }

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -29,7 +29,7 @@ func (warrior *Warrior) ApplyTalents() {
 
 	// Shield Mastery, Shield Block, Glyph of Blocking, Eternal Earthsiege treated as additive sources
 	if warrior.Talents.ShieldMastery > 0 {
-		warrior.PseudoStats.BlockValueMultiplier += 0.15*float64(warrior.Talents.ShieldMastery)
+		warrior.PseudoStats.BlockValueMultiplier += 0.15 * float64(warrior.Talents.ShieldMastery)
 	}
 
 	if warrior.Talents.Vitality > 0 {
@@ -806,12 +806,15 @@ func (warrior *Warrior) RegisterBladestormCD() {
 
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
-				Cost: cost,
+				Cost:        cost,
+				ChannelTime: time.Second * 6,
+				GCD:         core.GCDDefault,
 			},
 			CD: core.Cooldown{
 				Timer:    warrior.NewTimer(),
 				Duration: core.TernaryDuration(warrior.HasMajorGlyph(proto.WarriorMajorGlyph_GlyphOfBladestorm), time.Second*75, time.Second*90),
 			},
+			IgnoreHaste: true,
 		},
 
 		DamageMultiplier: 1,
@@ -821,10 +824,6 @@ func (warrior *Warrior) RegisterBladestormCD() {
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, _ *core.Spell) {
 			bladestormDot.Apply(sim)
 			bladestormDot.TickOnce(sim)
-
-			// Using regular cast/channel options would disable melee swings, so do it manually instead.
-			warrior.SetGCDTimer(sim, sim.CurrentTime+time.Second*6)
-			warrior.disableHsCleaveUntil = sim.CurrentTime + time.Second*6
 		},
 	})
 

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -39,7 +39,6 @@ type Warrior struct {
 	shoutExpiresAt         time.Duration
 	revengeProcAura        *core.Aura
 	glyphOfRevengeProcAura *core.Aura
-	disableHsCleaveUntil   time.Duration
 	lastTasteForBloodProc  time.Duration
 	Ymirjar4pcProcAura     *core.Aura
 


### PR DESCRIPTION
[core] allow casts at sim.CurrentTime >= Hardcast.Expires, not just for Hardcast.Expires == 0, so handling is independent of pending action order

[warrior] bladestorm now has a ChannelTime (and a GCD), and will therefore set Hardcast.Expires; this can be used as a replacement for disableHsCleaveUntil now 

[warrior] disableHsCleaveUntil wasn't reset in Reset(), so HS/Cleave would sometimes be disabled for quite some time