### PR TITLE
[Paladin] Fix regression for AS introduced in cc58dc

### DIFF
--- a/sim/paladin/avengers_shield.go
+++ b/sim/paladin/avengers_shield.go
@@ -41,9 +41,7 @@ func (paladin *Paladin) registerAvengersShieldSpell() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			constBaseDamage := 1100.0 +
-				.07*spell.SpellPower() +
-				.07*spell.MeleeAttackPower()
+			constBaseDamage := .07*spell.SpellPower() + .07*spell.MeleeAttackPower()
 
 			curTarget := target
 			for hitIndex := int32(0); hitIndex < numHits; hitIndex++ {


### PR DESCRIPTION
[cc58dc](https://github.com/wowsims/wotlk/commit/aae837f547e03294fb78c654f607ad02e9ae1c37#diff-5e4ee9c352a53859e105116449fef9faf2e45b79a2d5530dc040e5bdf7003e4b) introduced a regression for Avenger's Shield when switching to using `sim.Roll` since `constBaseDamage` already included the low-end and the previous bit of code only added the difference on top.
This made the ability deal 1100 dmg too much at all times :)