### PR TITLE
feral: hide 'revit uptime' textbox

### DIFF
--- a/ui/feral_druid/inputs.ts
+++ b/ui/feral_druid/inputs.ts
@@ -75,7 +75,8 @@ export const FeralDruidRotationConfig = {
 			fieldName: 'hotUptime',
 			label: 'Revitalize Hot Uptime',
 			labelTooltip: 'Hot uptime percentage to assume when theorizing energy gains',
-			percent: true
+			percent: true,
+			showWhen: (player: Player<Spec.SpecFeralDruid>) => player.getRotation().useBite == true && player.getRotation().biteModeType == BiteModeType.Analytical,
 		}),
 		InputHelpers.makeRotationNumberInput<Spec.SpecFeralDruid>({
 			fieldName: 'maxRoarOffset',


### PR DESCRIPTION
 - actually unused currently, its for other bite model which was never ported over

Signed-off-by: jarves <jarveson@gmail.com>