### PR TITLE
Mage and druid fixes

### DIFF
--- a/sim/core/dot.go
+++ b/sim/core/dot.go
@@ -13,7 +13,7 @@ type Dot struct {
 	// Embed Aura so we can use IsActive/Refresh/etc directly.
 	*Aura
 
-	NumberOfTicks int           // number of ticks over the whole duration
+	NumberOfTicks int32         // number of ticks over the whole duration
 	TickLength    time.Duration // time between each tick
 
 	// If true, tick length will be shortened based on casting speed.
@@ -30,7 +30,7 @@ type Dot struct {
 	tickPeriod time.Duration
 
 	// Number of ticks since last call to Apply().
-	TickCount int
+	TickCount int32
 
 	lastTickTime time.Duration
 }

--- a/sim/deathknight/diseases.go
+++ b/sim/deathknight/diseases.go
@@ -99,7 +99,7 @@ func (dk *Deathknight) registerFrostFever() {
 		}
 		dk.FrostFeverDisease[target.Index] = core.NewDot(core.Dot{
 			Aura:          target.RegisterAura(aura),
-			NumberOfTicks: 5 + int(dk.Talents.Epidemic),
+			NumberOfTicks: 5 + dk.Talents.Epidemic,
 			TickLength:    time.Second * 3,
 			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
 				firstTsApply := !flagTs[target.Index]
@@ -166,7 +166,7 @@ func (dk *Deathknight) registerBloodPlague() {
 					}
 				},
 			}),
-			NumberOfTicks: 5 + int(dk.Talents.Epidemic),
+			NumberOfTicks: 5 + dk.Talents.Epidemic,
 			TickLength:    time.Second * 3,
 
 			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
@@ -227,7 +227,7 @@ func (dk *Deathknight) registerDrwFrostFever() {
 				Label:    "DrwFrostFever-" + strconv.Itoa(int(dk.RuneWeapon.Index)),
 				ActionID: actionID,
 			}),
-			NumberOfTicks: 5 + int(dk.Talents.Epidemic),
+			NumberOfTicks: 5 + dk.Talents.Epidemic,
 			TickLength:    time.Second * 3,
 			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
 				// 80.0 * 0.32 * 1.15 base, 0.055 * 1.15
@@ -278,7 +278,7 @@ func (dk *Deathknight) registerDrwBloodPlague() {
 				Label:    "DrwBloodPlague-" + strconv.Itoa(int(dk.RuneWeapon.Index)),
 				ActionID: actionID,
 			}),
-			NumberOfTicks: 5 + int(dk.Talents.Epidemic),
+			NumberOfTicks: 5 + dk.Talents.Epidemic,
 			TickLength:    time.Second * 3,
 
 			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -45,658 +45,658 @@ character_stats_results: {
 dps_results: {
  key: "TestBalance-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 7260.9986
-  tps: 7102.33771
+  dps: 7272.32487
+  tps: 7113.67554
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7287.8505
-  tps: 7127.38645
+  dps: 7294.70547
+  tps: 7134.34256
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7172.75058
-  tps: 7014.0897
+  dps: 7182.30592
+  tps: 7023.6566
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7312.2951
-  tps: 7153.90239
+  dps: 7322.59952
+  tps: 7164.33871
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5663.39341
-  tps: 5502.61567
+  dps: 5679.83388
+  tps: 5520.01223
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7331.02686
-  tps: 7028.34146
+  dps: 7337.93094
+  tps: 7035.20859
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7515.61104
-  tps: 7356.11732
+  dps: 7525.70638
+  tps: 7366.22423
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7326.02655
-  tps: 7171.10418
+  dps: 7279.77161
+  tps: 7123.49796
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7343.75446
-  tps: 7187.64903
+  dps: 7383.061
+  tps: 7228.38985
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 7231.54472
-  tps: 7077.27264
+  dps: 7236.51947
+  tps: 7082.79567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 7231.54472
-  tps: 7077.27264
+  dps: 7236.51947
+  tps: 7082.79567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7285.75523
-  tps: 7130.22166
+  dps: 7290.74963
+  tps: 7135.76434
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 7421.3121
-  tps: 7261.81838
+  dps: 7430.56341
+  tps: 7271.08126
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7226.56772
-  tps: 7069.21911
+  dps: 7180.76268
+  tps: 7022.40097
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7172.75058
-  tps: 7014.0897
+  dps: 7182.30592
+  tps: 7023.6566
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7322.26949
-  tps: 7162.97602
+  dps: 7320.24484
+  tps: 7160.72802
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 4113.82876
-  tps: 3946.90366
+  dps: 4086.72713
+  tps: 3919.25327
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DreamwalkerGarb"
  value: {
-  dps: 6033.85762
-  tps: 5869.93094
+  dps: 6057.82547
+  tps: 5894.30398
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7287.8505
-  tps: 7127.38645
+  dps: 7294.70547
+  tps: 7134.34256
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7345.30088
-  tps: 7185.03417
+  dps: 7354.13064
+  tps: 7193.71454
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7312.2951
-  tps: 7152.80138
+  dps: 7322.59952
+  tps: 7163.11737
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7307.56249
-  tps: 7148.0408
+  dps: 7324.85644
+  tps: 7165.51469
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7287.8505
-  tps: 7127.38645
+  dps: 7294.70547
+  tps: 7134.34256
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7322.75897
-  tps: 7167.35028
+  dps: 7391.04938
+  tps: 7237.7407
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7524.91795
-  tps: 7368.41345
+  dps: 7474.46135
+  tps: 7316.54046
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7459.98625
-  tps: 7303.92451
+  dps: 7419.2423
+  tps: 7262.12839
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7331.02686
-  tps: 7169.52178
+  dps: 7337.93094
+  tps: 7176.52699
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7322.39159
-  tps: 7161.09471
+  dps: 7329.28585
+  tps: 7168.09011
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7172.75058
-  tps: 7014.0897
+  dps: 7182.30592
+  tps: 7023.6566
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7309.95081
-  tps: 7146.12909
+  dps: 7319.75993
+  tps: 7155.94978
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 4454.75051
-  tps: 4294.49162
+  dps: 4435.23315
+  tps: 4274.97131
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 6736.67263
-  tps: 6558.5556
+  dps: 6812.74788
+  tps: 6636.32174
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 7421.3121
-  tps: 7261.81838
+  dps: 7430.56341
+  tps: 7271.08126
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 7421.3121
-  tps: 7261.81838
+  dps: 7430.56341
+  tps: 7271.08126
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 7681.29601
-  tps: 7528.55382
+  dps: 7685.33701
+  tps: 7532.10189
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 7499.57229
-  tps: 7341.99545
+  dps: 7439.56489
+  tps: 7280.55076
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 7421.3121
-  tps: 7261.81838
+  dps: 7430.56341
+  tps: 7271.08126
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 7421.3121
-  tps: 7261.81838
+  dps: 7430.56341
+  tps: 7271.08126
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7312.2951
-  tps: 7152.80138
+  dps: 7322.59952
+  tps: 7163.11737
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7307.56249
-  tps: 7148.0408
+  dps: 7324.85644
+  tps: 7165.51469
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7172.75058
-  tps: 7014.0897
+  dps: 7182.30592
+  tps: 7023.6566
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7302.07675
-  tps: 7148.33741
+  dps: 7310.84813
+  tps: 7157.28685
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7287.8505
-  tps: 7127.38645
+  dps: 7294.70547
+  tps: 7134.34256
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 4192.90733
-  tps: 4027.21076
+  dps: 4211.35531
+  tps: 4046.16617
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LasherweaveRegalia"
  value: {
-  dps: 8165.34573
-  tps: 8013.60453
+  dps: 8185.92129
+  tps: 8034.70518
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7172.75058
-  tps: 7014.0897
+  dps: 7182.30592
+  tps: 7023.6566
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7276.61673
-  tps: 7117.70354
+  dps: 7286.33566
+  tps: 7127.43404
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 4676.98448
-  tps: 4518.88512
+  dps: 4636.70057
+  tps: 4477.53015
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 6712.13957
-  tps: 6547.99888
+  dps: 6757.30409
+  tps: 6593.79478
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7278.20491
-  tps: 7122.14318
+  dps: 7240.76616
+  tps: 7083.65225
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NightsongBattlegear"
  value: {
-  dps: 4309.8446
-  tps: 4145.68555
+  dps: 4202.30972
+  tps: 4036.58066
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NightsongGarb"
  value: {
-  dps: 6507.37014
-  tps: 6345.28665
+  dps: 6548.23875
+  tps: 6386.26138
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7172.75058
-  tps: 7014.0897
+  dps: 7182.30592
+  tps: 7023.6566
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7287.8505
-  tps: 7127.38645
+  dps: 7294.70547
+  tps: 7134.34256
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7287.8505
-  tps: 7127.38645
+  dps: 7294.70547
+  tps: 7134.34256
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7287.8505
-  tps: 7127.38645
+  dps: 7294.70547
+  tps: 7134.34256
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7287.8505
-  tps: 7127.38645
+  dps: 7294.70547
+  tps: 7134.34256
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7172.75058
-  tps: 7014.0897
+  dps: 7182.30592
+  tps: 7023.6566
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7631.54641
-  tps: 7465.19807
+  dps: 7639.08261
+  tps: 7473.68252
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7693.02497
-  tps: 7525.92708
+  dps: 7700.48428
+  tps: 7534.33465
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7489.25319
-  tps: 7328.78914
+  dps: 7495.76439
+  tps: 7335.40148
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7287.8505
-  tps: 7127.11617
+  dps: 7294.70547
+  tps: 7134.0726
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7172.75058
-  tps: 7014.0897
+  dps: 7182.30592
+  tps: 7023.6566
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Runetotem'sBattlegear"
  value: {
-  dps: 4676.98448
-  tps: 4518.88512
+  dps: 4636.70057
+  tps: 4477.53015
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Runetotem'sRegalia"
  value: {
-  dps: 6712.13957
-  tps: 6547.99888
+  dps: 6757.30409
+  tps: 6593.79478
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 7421.3121
-  tps: 7261.81838
+  dps: 7430.56341
+  tps: 7271.08126
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7172.75058
-  tps: 7014.0897
+  dps: 7182.30592
+  tps: 7023.6566
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7172.75058
-  tps: 7014.0897
+  dps: 7182.30592
+  tps: 7023.6566
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7172.75058
-  tps: 7014.0897
+  dps: 7182.30592
+  tps: 7023.6566
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SparkofLife-37657"
  value: {
-  dps: 7226.53298
-  tps: 7068.19786
+  dps: 7216.62565
+  tps: 7058.1115
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7172.75058
-  tps: 7014.0897
+  dps: 7182.30592
+  tps: 7023.6566
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-StormshroudArmor"
  value: {
-  dps: 4826.9373
-  tps: 4660.93727
+  dps: 4831.7209
+  tps: 4665.58995
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7287.8505
-  tps: 7127.38645
+  dps: 7294.70547
+  tps: 7134.34256
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7287.8505
-  tps: 7127.38645
+  dps: 7294.70547
+  tps: 7134.34256
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7287.8505
-  tps: 7127.38645
+  dps: 7294.70547
+  tps: 7134.34256
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartHarness"
  value: {
-  dps: 3253.19144
-  tps: 3089.6034
+  dps: 3262.58899
+  tps: 3099.03675
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartRegalia"
  value: {
-  dps: 5062.66047
-  tps: 4907.53192
+  dps: 5036.01473
+  tps: 4880.18011
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7287.8505
-  tps: 7127.38645
+  dps: 7294.70547
+  tps: 7134.34256
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7172.75058
-  tps: 7014.0897
+  dps: 7182.30592
+  tps: 7023.6566
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7172.75058
-  tps: 7014.0897
+  dps: 7182.30592
+  tps: 7023.6566
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7331.02686
-  tps: 7169.52178
+  dps: 7337.93094
+  tps: 7176.52699
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7322.39159
-  tps: 7161.09471
+  dps: 7329.28585
+  tps: 7168.09011
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7322.39159
-  tps: 7161.09471
+  dps: 7329.28585
+  tps: 7168.09011
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7331.02686
-  tps: 7169.52178
+  dps: 7337.93094
+  tps: 7176.52699
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 4846.67071
-  tps: 4680.90637
+  dps: 4867.34973
+  tps: 4702.06701
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7322.16721
-  tps: 7149.09834
+  dps: 7332.20512
+  tps: 7159.14781
  }
 }
 dps_results: {
  key: "TestBalance-Average-Default"
  value: {
-  dps: 7572.4413
-  tps: 7414.50672
+  dps: 7619.37373
+  tps: 7462.27104
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9548.61679
-  tps: 11604.63828
+  dps: 9598.38413
+  tps: 11671.47658
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7218.97416
-  tps: 7059.21431
+  dps: 7254.19621
+  tps: 7094.88062
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8332.49414
-  tps: 7800.05118
+  dps: 8284.88784
+  tps: 7751.49319
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3853.34898
-  tps: 4450.65732
+  dps: 3866.3251
+  tps: 4467.79468
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2383.28293
-  tps: 2291.05277
+  dps: 2410.16704
+  tps: 2319.22374
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Starfire-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4522.44334
-  tps: 4259.67999
+  dps: 4518.45959
+  tps: 4254.5377
  }
 }
 dps_results: {
  key: "TestBalance-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7484.12536
-  tps: 7356.11732
+  dps: 7494.22071
+  tps: 7366.22423
  }
 }

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -8,6 +8,10 @@ import (
 	"github.com/wowsims/wotlk/sim/core/stats"
 )
 
+const (
+	SpellFlagNaturesGrace = core.SpellFlagAgentReserved1
+)
+
 type Druid struct {
 	core.Character
 	SelfBuffs
@@ -98,7 +102,7 @@ type talentBonuses struct {
 	moonglow        float64
 	naturesMajesty  float64
 	vengeance       float64
-	naturesSplendor int
+	naturesSplendor int32
 	starlightWrath  time.Duration
 }
 
@@ -132,7 +136,7 @@ func (druid *Druid) RegisterTalentsBonuses() {
 		moonglow:        1 - 0.03*float64(druid.Talents.Moonglow),                // cost reduction
 		naturesMajesty:  2 * float64(druid.Talents.NaturesMajesty) * core.CritRatingPerCritChance,
 		vengeance:       0.2 * float64(druid.Talents.Vengeance),
-		naturesSplendor: core.TernaryInt(druid.Talents.NaturesSplendor, 1, 0),
+		naturesSplendor: core.TernaryInt32(druid.Talents.NaturesSplendor, 1, 0),
 		starlightWrath:  time.Millisecond * 100 * time.Duration(druid.Talents.StarlightWrath),
 	}
 }

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -78,7 +78,7 @@ type FeralDruid struct {
 	readyToShift   bool
 	waitingForTick bool
 	latency        time.Duration
-	maxRipTicks    int
+	maxRipTicks    int32
 }
 
 func (cat *FeralDruid) GetDruid() *druid.Druid {

--- a/sim/druid/moonfire.go
+++ b/sim/druid/moonfire.go
@@ -28,6 +28,7 @@ func (druid *Druid) registerMoonfireSpell() {
 		ActionID:     core.ActionID{SpellID: 48463},
 		SpellSchool:  core.SpellSchoolArcane,
 		ProcMask:     core.ProcMaskSpellDamage,
+		Flags:        SpellFlagNaturesGrace,
 		ResourceType: stats.Mana,
 		BaseCost:     baseCost,
 
@@ -84,7 +85,7 @@ func (druid *Druid) registerMoonfireSpell() {
 				druid.Starfire.BonusCritRating -= core.CritRatingPerCritChance * float64(druid.Talents.ImprovedInsectSwarm)
 			},
 		}),
-		NumberOfTicks: 4 + core.TernaryInt(druid.setBonuses.balance_t6_2, 1, 0) + druid.talentBonuses.naturesSplendor,
+		NumberOfTicks: 4 + core.TernaryInt32(druid.setBonuses.balance_t6_2, 1, 0) + druid.talentBonuses.naturesSplendor,
 		TickLength:    time.Second * 3,
 
 		OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
@@ -95,8 +96,7 @@ func (druid *Druid) registerMoonfireSpell() {
 		},
 		OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
 			if dotCanCrit {
-				// TODO: This allows misses... probably a bug.
-				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeMagicHitAndSnapshotCrit)
+				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeSnapshotCrit)
 			} else {
 				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeTick)
 			}
@@ -104,10 +104,10 @@ func (druid *Druid) registerMoonfireSpell() {
 	})
 }
 
-func (druid *Druid) maxMoonfireTicks() int {
-	base := 4
-	thunderhearthRegalia := core.TernaryInt(druid.setBonuses.balance_t6_2, 1, 0)
+func (druid *Druid) maxMoonfireTicks() int32 {
+	base := int32(4)
+	thunderhearthRegalia := core.TernaryInt32(druid.setBonuses.balance_t6_2, 1, 0)
 	natureSplendor := druid.talentBonuses.naturesSplendor
-	starfireGlyph := core.TernaryInt(druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfStarfire), 3, 0)
+	starfireGlyph := core.TernaryInt32(druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfStarfire), 3, 0)
 	return base + thunderhearthRegalia + natureSplendor + starfireGlyph
 }

--- a/sim/druid/rake.go
+++ b/sim/druid/rake.go
@@ -15,7 +15,7 @@ func (druid *Druid) registerRakeSpell() {
 
 	mangleAura := core.MangleAura(druid.CurrentTarget)
 
-	t9bonus := core.TernaryInt(druid.HasT9FeralSetBonus(2), 1, 0)
+	t9bonus := core.TernaryInt32(druid.HasT9FeralSetBonus(2), 1, 0)
 
 	druid.Rake = druid.RegisterSpell(core.SpellConfig{
 		ActionID:     actionID,

--- a/sim/druid/rip.go
+++ b/sim/druid/rip.go
@@ -13,11 +13,11 @@ import (
 func (druid *Druid) registerRipSpell() {
 	actionID := core.ActionID{SpellID: 49800}
 	baseCost := 30.0 - core.TernaryFloat64(druid.HasSetBonus(ItemSetLasherweaveBattlegear, 2), 10.0, 0.0)
-	refundPercent := (0.4 * float64(druid.Talents.PrimalPrecision))
+	refundPercent := 0.4 * float64(druid.Talents.PrimalPrecision)
 
 	ripBaseNumTicks := 6 +
-		core.TernaryInt(druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfRip), 2, 0) +
-		core.TernaryInt(druid.HasSetBonus(ItemSetDreamwalkerBattlegear, 2), 2, 0)
+		core.TernaryInt32(druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfRip), 2, 0) +
+		core.TernaryInt32(druid.HasSetBonus(ItemSetDreamwalkerBattlegear, 2), 2, 0)
 
 	comboPointCoeff := 93.0
 	if druid.Equip[items.ItemSlotRanged].ID == 28372 { // Idol of Feral Shadows
@@ -92,11 +92,11 @@ func (druid *Druid) registerRipSpell() {
 	})
 }
 
-func (druid *Druid) MaxRipTicks() int {
-	base := 6
-	t7bonus := core.TernaryInt(druid.HasSetBonus(ItemSetDreamwalkerBattlegear, 2), 2, 0)
-	ripGlyphBonus := core.TernaryInt(druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfRip), 2, 0)
-	shredGlyphBonus := core.TernaryInt(druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfShred), 3, 0)
+func (druid *Druid) MaxRipTicks() int32 {
+	base := int32(6)
+	t7bonus := core.TernaryInt32(druid.HasSetBonus(ItemSetDreamwalkerBattlegear, 2), 2, 0)
+	ripGlyphBonus := core.TernaryInt32(druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfRip), 2, 0)
+	shredGlyphBonus := core.TernaryInt32(druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfShred), 3, 0)
 	return base + ripGlyphBonus + shredGlyphBonus + t7bonus
 }
 

--- a/sim/druid/starfall.go
+++ b/sim/druid/starfall.go
@@ -18,7 +18,7 @@ func (druid *Druid) registerStarfallSpell() {
 
 	baseCost := druid.BaseMana * 0.35
 	target := druid.CurrentTarget
-	numberOfTicks := core.TernaryInt(druid.Env.GetNumTargets() > 1, 20, 10)
+	numberOfTicks := core.TernaryInt32(druid.Env.GetNumTargets() > 1, 20, 10)
 	tickLength := core.TernaryDuration(druid.Env.GetNumTargets() > 1, time.Millisecond*500, time.Millisecond*1000)
 
 	// Nature's Majesty
@@ -28,6 +28,7 @@ func (druid *Druid) registerStarfallSpell() {
 		ActionID:     core.ActionID{SpellID: 53201},
 		SpellSchool:  core.SpellSchoolArcane,
 		ProcMask:     core.ProcMaskSpellDamage,
+		Flags:        SpellFlagNaturesGrace,
 		ResourceType: stats.Mana,
 		BaseCost:     baseCost,
 

--- a/sim/druid/starfire.go
+++ b/sim/druid/starfire.go
@@ -37,6 +37,7 @@ func (druid *Druid) registerStarfireSpell() {
 		ActionID:     actionID,
 		SpellSchool:  core.SpellSchoolArcane,
 		ProcMask:     core.ProcMaskSpellDamage,
+		Flags:        SpellFlagNaturesGrace,
 		ResourceType: stats.Mana,
 		BaseCost:     baseCost,
 

--- a/sim/druid/talents.go
+++ b/sim/druid/talents.go
@@ -91,9 +91,10 @@ func (druid *Druid) ApplyTalents() {
 }
 
 func (druid *Druid) setupNaturesGrace() {
-	if druid.Talents.NaturesGrace < 1 {
+	if druid.Talents.NaturesGrace == 0 {
 		return
 	}
+
 	druid.NaturesGraceProcAura = druid.RegisterAura(core.Aura{
 		Label:    "Natures Grace Proc",
 		ActionID: core.ActionID{SpellID: 16886},
@@ -106,6 +107,8 @@ func (druid *Druid) setupNaturesGrace() {
 		},
 	})
 
+	procChance := []float64{0, .33, .66, 1}[druid.Talents.NaturesGrace]
+
 	druid.RegisterAura(core.Aura{
 		Label:    "Natures Grace",
 		Duration: core.NeverExpires,
@@ -116,7 +119,7 @@ func (druid *Druid) setupNaturesGrace() {
 			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
-			if (spell == druid.Starfire || spell == druid.Wrath) && float64(druid.Talents.NaturesGrace)*(1.0/3.0) >= sim.RandomFloat("Natures Grace") {
+			if spell.Flags.Matches(SpellFlagNaturesGrace) && sim.Proc(procChance, "Natures Grace") {
 				druid.NaturesGraceProcAura.Activate(sim)
 			}
 		},

--- a/sim/druid/wrath.go
+++ b/sim/druid/wrath.go
@@ -23,6 +23,7 @@ func (druid *Druid) registerWrathSpell() {
 		ActionID:     actionID,
 		SpellSchool:  core.SpellSchoolNature,
 		ProcMask:     core.ProcMaskSpellDamage,
+		Flags:        SpellFlagNaturesGrace,
 		ResourceType: stats.Mana,
 		BaseCost:     baseCost,
 		MissileSpeed: 20,

--- a/sim/hunter/serpent_sting.go
+++ b/sim/hunter/serpent_sting.go
@@ -72,7 +72,7 @@ func (hunter *Hunter) registerSerpentStingSpell() {
 				}
 			},
 		}),
-		NumberOfTicks: 5 + int(core.TernaryInt32(hunter.HasMajorGlyph(proto.HunterMajorGlyph_GlyphOfSerpentSting), 2, 0)),
+		NumberOfTicks: 5 + core.TernaryInt32(hunter.HasMajorGlyph(proto.HunterMajorGlyph_GlyphOfSerpentSting), 2, 0),
 		TickLength:    time.Second * 3,
 
 		OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -45,477 +45,477 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5562.90155
-  tps: 4985.50588
+  dps: 5509.46423
+  tps: 4937.25158
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5376.03602
-  tps: 4817.40605
+  dps: 5293.04382
+  tps: 4743.45677
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5549.35736
-  tps: 4969.96279
+  dps: 5539.29882
+  tps: 4963.03868
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4515.64594
-  tps: 4044.05646
+  dps: 4475.53947
+  tps: 4009.01876
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 6280.11707
-  tps: 5626.14184
+  dps: 6257.72704
+  tps: 5608.176
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5599.56666
-  tps: 4919.08127
+  dps: 5545.64016
+  tps: 4871.38735
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 5711.6233
-  tps: 5118.27662
+  dps: 5694.21369
+  tps: 5102.26812
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5465.71962
-  tps: 4897.95886
+  dps: 5376.41545
+  tps: 4819.38493
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5444.9734
-  tps: 4882.38944
+  dps: 5434.73193
+  tps: 4878.22047
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 5341.40066
-  tps: 4780.36326
+  dps: 5305.25665
+  tps: 4754.06364
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 5341.40066
-  tps: 4780.36326
+  dps: 5305.25665
+  tps: 4754.06364
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 5388.07815
-  tps: 4818.85725
+  dps: 5340.94172
+  tps: 4782.62199
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5424.36768
-  tps: 4860.57956
+  dps: 5352.66023
+  tps: 4797.84031
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5376.03602
-  tps: 4817.40605
+  dps: 5293.04382
+  tps: 4743.45677
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5554.28804
-  tps: 4977.56174
+  dps: 5580.71225
+  tps: 5001.83022
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5562.90155
-  tps: 4985.50588
+  dps: 5509.46423
+  tps: 4937.25158
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5564.13627
-  tps: 4982.36931
+  dps: 5545.5018
+  tps: 4966.76064
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5568.83323
-  tps: 4989.76555
+  dps: 5552.50685
+  tps: 4974.73196
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5574.01017
-  tps: 4995.21872
+  dps: 5552.50685
+  tps: 4974.73196
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5562.90155
-  tps: 4985.50588
+  dps: 5509.46423
+  tps: 4937.25158
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5442.68972
-  tps: 4879.64321
+  dps: 5436.12588
+  tps: 4878.18314
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5633.51016
-  tps: 5045.9922
+  dps: 5553.27184
+  tps: 4976.76079
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5567.19472
-  tps: 4988.26206
+  dps: 5486.34793
+  tps: 4917.91985
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5599.56666
-  tps: 5017.95821
+  dps: 5545.64016
+  tps: 4969.25285
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5592.23364
-  tps: 5011.46774
+  dps: 5538.40497
+  tps: 4962.85259
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FrostfireGarb"
  value: {
-  dps: 4890.24636
-  tps: 4382.53124
+  dps: 4857.13142
+  tps: 4352.53242
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5376.03602
-  tps: 4817.40605
+  dps: 5293.04382
+  tps: 4743.45677
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5433.26503
-  tps: 4864.31327
+  dps: 5391.23424
+  tps: 4829.81465
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5662.02079
-  tps: 5072.3759
+  dps: 5573.90018
+  tps: 4993.80909
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5568.83323
-  tps: 4989.76555
+  dps: 5552.50685
+  tps: 4974.73196
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5574.01017
-  tps: 4995.21872
+  dps: 5552.50685
+  tps: 4974.73196
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5376.03602
-  tps: 4817.40605
+  dps: 5293.04382
+  tps: 4743.45677
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5587.94866
-  tps: 5005.93705
+  dps: 5576.08383
+  tps: 4992.97009
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5562.90155
-  tps: 4985.50588
+  dps: 5509.46423
+  tps: 4937.25158
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 5675.45353
-  tps: 5082.28382
+  dps: 5643.80017
+  tps: 5055.85171
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KirinTorGarb"
  value: {
-  dps: 5295.66677
-  tps: 4736.19741
+  dps: 5307.90465
+  tps: 4751.40849
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5376.03602
-  tps: 4817.40605
+  dps: 5293.04382
+  tps: 4743.45677
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5429.07595
-  tps: 4859.4337
+  dps: 5357.25324
+  tps: 4798.19613
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5452.16219
-  tps: 4885.01823
+  dps: 5369.09631
+  tps: 4812.9482
  }
 }
 dps_results: {
  key: "TestFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5376.03602
-  tps: 4817.40605
+  dps: 5293.04382
+  tps: 4743.45677
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5562.90155
-  tps: 4985.50588
+  dps: 5509.46423
+  tps: 4937.25158
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5562.90155
-  tps: 4985.50588
+  dps: 5509.46423
+  tps: 4937.25158
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5562.90155
-  tps: 4985.50588
+  dps: 5509.46423
+  tps: 4937.25158
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5562.90155
-  tps: 4985.50588
+  dps: 5509.46423
+  tps: 4937.25158
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5376.03602
-  tps: 4817.40605
+  dps: 5293.04382
+  tps: 4743.45677
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 5707.04938
-  tps: 5129.21745
+  dps: 5633.62355
+  tps: 5061.43108
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 5759.50892
-  tps: 5178.22788
+  dps: 5680.29682
+  tps: 5105.12408
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5705.20971
-  tps: 5113.58323
+  dps: 5649.08498
+  tps: 5062.91025
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5517.87883
-  tps: 4941.83674
+  dps: 5523.83587
+  tps: 4947.55737
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5376.03602
-  tps: 4817.40605
+  dps: 5293.04382
+  tps: 4743.45677
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5376.03602
-  tps: 4817.40605
+  dps: 5293.04382
+  tps: 4743.45677
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5376.03602
-  tps: 4817.40605
+  dps: 5293.04382
+  tps: 4743.45677
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5376.03602
-  tps: 4817.40605
+  dps: 5293.04382
+  tps: 4743.45677
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 5376.49573
-  tps: 4814.09122
+  dps: 5305.18418
+  tps: 4748.12252
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 5459.20249
-  tps: 4892.74532
+  dps: 5421.76105
+  tps: 4860.08409
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sunstrider'sRegalia"
  value: {
-  dps: 5506.30189
-  tps: 4929.27833
+  dps: 5463.46749
+  tps: 4891.41424
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5562.90155
-  tps: 4985.50588
+  dps: 5509.46423
+  tps: 4937.25158
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5562.90155
-  tps: 4985.50588
+  dps: 5509.46423
+  tps: 4937.25158
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5562.90155
-  tps: 4985.50588
+  dps: 5509.46423
+  tps: 4937.25158
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5562.90155
-  tps: 4985.50588
+  dps: 5509.46423
+  tps: 4937.25158
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5531.2364
-  tps: 4955.39828
+  dps: 5515.35781
+  tps: 4943.10927
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5531.2364
-  tps: 4955.39828
+  dps: 5515.35781
+  tps: 4943.10927
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5599.56666
-  tps: 5017.95821
+  dps: 5545.64016
+  tps: 4969.25285
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5592.23364
-  tps: 5011.46774
+  dps: 5538.40497
+  tps: 4962.85259
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5592.23364
-  tps: 5011.46774
+  dps: 5538.40497
+  tps: 4962.85259
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5599.56666
-  tps: 5017.95821
+  dps: 5545.64016
+  tps: 4969.25285
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WingedTalisman-37844"
  value: {
-  dps: 5494.28994
-  tps: 4923.83458
+  dps: 5409.05929
+  tps: 4847.87069
  }
 }
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
-  dps: 5819.27528
-  tps: 5213.46286
+  dps: 5785.9997
+  tps: 5184.44767
  }
 }
 dps_results: {
@@ -528,8 +528,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1726.35012
-  tps: 1600.55624
+  dps: 1726.08585
+  tps: 1600.31841
  }
 }
 dps_results: {
@@ -563,49 +563,49 @@ dps_results: {
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8112.32052
-  tps: 8991.23362
+  dps: 7953.23573
+  tps: 8860.45849
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5711.6233
-  tps: 5118.27662
+  dps: 5694.21369
+  tps: 5102.26812
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6946.91845
-  tps: 6117.00824
+  dps: 7005.6298
+  tps: 6173.28764
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4503.41458
-  tps: 5495.64329
+  dps: 4316.84002
+  tps: 5317.94224
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2465.5435
-  tps: 2199.35696
+  dps: 2363.68452
+  tps: 2104.82817
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3530.08403
-  tps: 3047.78539
+  dps: 3515.1582
+  tps: 3033.52711
  }
 }
 dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5711.6233
-  tps: 5118.27662
+  dps: 5694.21369
+  tps: 5102.26812
  }
 }

--- a/sim/mage/ignite.go
+++ b/sim/mage/ignite.go
@@ -7,67 +7,6 @@ import (
 	"github.com/wowsims/wotlk/sim/core"
 )
 
-var IgniteActionID = core.ActionID{SpellID: 12848}
-var empoweredFireActionId = core.ActionID{SpellID: 31658}
-
-// TODO: Global variables very bad. This will break the raid sim, where there can be multiple mages.
-var manaMetrics *core.ResourceMetrics
-
-func (mage *Mage) registerIgniteSpell() {
-	manaMetrics = mage.NewManaMetrics(empoweredFireActionId)
-	mage.Ignite = mage.RegisterSpell(core.SpellConfig{
-		ActionID:         IgniteActionID,
-		SpellSchool:      core.SpellSchoolFire,
-		ProcMask:         core.ProcMaskSpellDamage,
-		Flags:            SpellFlagMage | core.SpellFlagIgnoreModifiers,
-		DamageMultiplier: 1,
-		ThreatMultiplier: 1 - 0.1*float64(mage.Talents.BurningSoul),
-	})
-}
-
-func (mage *Mage) newIgniteDot(target *core.Unit) *core.Dot {
-	return core.NewDot(core.Dot{
-		Spell: mage.Ignite,
-		Aura: target.RegisterAura(core.Aura{
-			Label:    "Ignite-" + strconv.Itoa(int(mage.Index)),
-			ActionID: IgniteActionID,
-		}),
-		NumberOfTicks: 2,
-		TickLength:    time.Second * 2,
-	})
-}
-
-func (mage *Mage) procIgnite(sim *core.Simulation, target *core.Unit, damageFromProccingSpell float64) {
-	igniteDot := mage.IgniteDots[target.Index]
-
-	newIgniteDamage := damageFromProccingSpell * float64(mage.Talents.Ignite) * 0.08
-	if igniteDot.IsActive() {
-		newIgniteDamage += mage.IgniteTickDamage[target.Index] * float64(2-igniteDot.TickCount)
-	}
-
-	newTickDamage := newIgniteDamage / 2
-	mage.IgniteTickDamage[target.Index] = newTickDamage
-
-	// Hacky: mimic the logs in sim/core/cast.go, to get Ignite to show up in the timeline as a cast.
-	// TODO: Just make this a spell.
-	if sim.Log != nil {
-		mage.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s)", IgniteActionID, 0.0, time.Duration(0))
-		mage.Log(sim, "Completed cast %s", IgniteActionID)
-	}
-	mage.Ignite.SpellMetrics[target.UnitIndex].Casts++
-	mage.Ignite.SpellMetrics[target.UnitIndex].Hits++
-
-	// Reassign the effect to apply the new damage value.
-	igniteDot.OnTick = func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
-		baseDamage := newTickDamage
-		dot.Spell.CalcAndDealPeriodicDamage(sim, target, baseDamage, dot.OutcomeTick)
-		if float64(mage.Talents.EmpoweredFire)/3.0 > sim.RandomFloat("EmpoweredFireIgniteMana") {
-			mage.AddMana(sim, mage.Unit.BaseMana*.02, manaMetrics, false)
-		}
-	}
-	igniteDot.Apply(sim)
-}
-
 func (mage *Mage) applyIgnite() {
 	if mage.Talents.Ignite == 0 {
 		return
@@ -80,11 +19,85 @@ func (mage *Mage) applyIgnite() {
 			aura.Activate(sim)
 		},
 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-			if spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
+			if !spell.ProcMask.Matches(core.ProcMaskSpellDamage) {
 				return
 			}
 			if spell.SpellSchool.Matches(core.SpellSchoolFire) && result.Outcome.Matches(core.OutcomeCrit) {
 				mage.procIgnite(sim, result.Target, result.Damage)
+			}
+		},
+		OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !spell.ProcMask.Matches(core.ProcMaskSpellDamage) {
+				return
+			}
+			if spell == mage.LivingBombDot.Spell && result.Outcome.Matches(core.OutcomeCrit) {
+				mage.procIgnite(sim, result.Target, result.Damage)
+			}
+		},
+	})
+
+	mage.Ignite = mage.RegisterSpell(core.SpellConfig{
+		ActionID:         core.ActionID{SpellID: 12654},
+		SpellSchool:      core.SpellSchoolFire,
+		ProcMask:         core.ProcMaskEmpty,
+		Flags:            SpellFlagMage | core.SpellFlagIgnoreModifiers,
+		DamageMultiplier: 1,
+		ThreatMultiplier: 1 - 0.1*float64(mage.Talents.BurningSoul),
+	})
+
+	mage.IgniteDots = make([]*core.Dot, mage.Env.GetNumTargets())
+	mage.IgniteDamageBuffers = make([]float64, mage.Env.GetNumTargets())
+	for i := range mage.IgniteDots {
+		mage.IgniteDots[i] = core.NewDot(core.Dot{
+			Spell: mage.Ignite,
+			Aura: mage.Env.GetTargetUnit(int32(i)).RegisterAura(core.Aura{
+				Label:    "Ignite-" + strconv.Itoa(int(mage.Index)),
+				ActionID: mage.Ignite.ActionID,
+				Tag:      "Ignite",
+			}),
+			NumberOfTicks: 2,
+			TickLength:    time.Second * 2,
+			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
+				mage.IgniteDamageBuffers[target.Index] -= dot.SnapshotBaseDamage
+				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.Spell.OutcomeAlwaysHit)
+			},
+			SnapshotAttackerMultiplier: 1,
+		})
+	}
+}
+
+func (mage *Mage) procIgnite(sim *core.Simulation, target *core.Unit, spellDamage float64) {
+	dot := mage.IgniteDots[target.Index]
+
+	if !dot.IsActive() {
+		mage.IgniteDamageBuffers[target.Index] = 0
+	}
+
+	mage.IgniteDamageBuffers[target.Index] += spellDamage * float64(mage.Talents.Ignite) * 0.08
+	dot.SnapshotBaseDamage = mage.IgniteDamageBuffers[target.Index] / 2
+	dot.Apply(sim)
+}
+
+func (mage *Mage) applyEmpoweredFire() {
+	if mage.Talents.EmpoweredFire == 0 {
+		return
+	}
+
+	var actionId = core.ActionID{SpellID: 67545}
+
+	procChance := []float64{0, .33, .67, 1}[mage.Talents.EmpoweredFire]
+	manaMetrics := mage.NewManaMetrics(actionId)
+
+	mage.RegisterAura(core.Aura{
+		Label:    "Empowered Fire",
+		ActionID: actionId,
+		Duration: core.NeverExpires,
+		OnReset: func(aura *core.Aura, sim *core.Simulation) {
+			aura.Activate(sim)
+		},
+		OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if spell == mage.Ignite && sim.Proc(procChance, "Empowered Fire") {
+				mage.AddMana(sim, mage.Unit.BaseMana*0.02, manaMetrics, false)
 			}
 		},
 	})

--- a/sim/mage/living_bomb.go
+++ b/sim/mage/living_bomb.go
@@ -10,15 +10,11 @@ import (
 )
 
 func (mage *Mage) registerLivingBombSpell() {
-
-	actionID := core.ActionID{SpellID: 55360}
-	actionIDDot := core.ActionID{SpellID: 55359} // I want the dot to be separately trackable for metrics
-	actionIDSpell := core.ActionID{SpellID: 44457}
 	baseCost := .22 * mage.BaseMana
 	bonusCrit := float64(mage.Talents.WorldInFlames+mage.Talents.CriticalMass) * 2 * core.CritRatingPerCritChance
 
 	livingBombExplosionSpell := mage.RegisterSpell(core.SpellConfig{
-		ActionID:    actionID,
+		ActionID:    core.ActionID{SpellID: 55362},
 		SpellSchool: core.SpellSchoolFire,
 		ProcMask:    core.ProcMaskSpellDamage,
 		Flags:       SpellFlagMage | HotStreakSpells,
@@ -29,7 +25,7 @@ func (mage *Mage) registerLivingBombSpell() {
 		ThreatMultiplier: 1 - 0.1*float64(mage.Talents.BurningSoul),
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := 690 + (1.5/3.5)*spell.SpellPower()
+			baseDamage := 690 + 0.4*spell.SpellPower()
 			baseDamage *= sim.Encounter.AOECapMultiplier()
 			for _, aoeTarget := range sim.Encounter.Targets {
 				spell.CalcAndDealDamage(sim, &aoeTarget.Unit, baseDamage, spell.OutcomeMagicHitAndCrit)
@@ -37,13 +33,10 @@ func (mage *Mage) registerLivingBombSpell() {
 		},
 	})
 
-	target := mage.CurrentTarget
-	hasGlyphOfLivingBomb := mage.HasMajorGlyph(proto.MageMajorGlyph_GlyphOfLivingBomb)
-
 	mage.LivingBomb = mage.RegisterSpell(core.SpellConfig{
-		ActionID:     actionIDSpell,
+		ActionID:     core.ActionID{SpellID: 55360},
 		SpellSchool:  core.SpellSchoolFire,
-		ProcMask:     core.ProcMaskEmpty,
+		ProcMask:     core.ProcMaskSpellDamage,
 		Flags:        SpellFlagMage,
 		ResourceType: stats.Mana,
 		BaseCost:     baseCost,
@@ -51,63 +44,54 @@ func (mage *Mage) registerLivingBombSpell() {
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
 				Cost: baseCost,
-
-				GCD: core.GCDDefault,
+				GCD:  core.GCDDefault,
 			},
 		},
 
-		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			result := spell.CalcOutcome(sim, target, spell.OutcomeMagicHit)
-			// TODO: Uncomment this
-			// if result.Landed() {
-			mage.LivingBombDots[mage.CurrentTarget.Index].Apply(sim)
-			// }
-			spell.DealOutcome(sim, result)
-		},
-	})
-
-	livingBombDotSpell := mage.RegisterSpell(core.SpellConfig{
-		ActionID:         actionIDDot,
-		SpellSchool:      core.SpellSchoolFire,
-		ProcMask:         core.ProcMaskEmpty,
-		Flags:            SpellFlagMage,
-		Cast:             core.CastConfig{},
 		BonusCritRating:  bonusCrit,
 		DamageMultiplier: mage.spellDamageMultiplier,
 		CritMultiplier:   mage.SpellCritMultiplier(1, mage.bonusCritDamage),
 		ThreatMultiplier: 1 - 0.1*float64(mage.Talents.BurningSoul),
+
+		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+			result := spell.CalcOutcome(sim, target, spell.OutcomeMagicHit)
+			if result.Landed() {
+				mage.LivingBombDot.Apply(sim)
+			}
+			spell.DealOutcome(sim, result)
+		},
 	})
 
-	mage.LivingBombDots[target.Index] = core.NewDot(core.Dot{
-		Spell: livingBombDotSpell,
+	target := mage.CurrentTarget
+
+	onTick := func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
+		dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeTick)
+	}
+	if mage.HasMajorGlyph(proto.MageMajorGlyph_GlyphOfLivingBomb) {
+		onTick = func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
+			dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeSnapshotCrit)
+		}
+	}
+
+	mage.LivingBombDot = core.NewDot(core.Dot{
+		Spell: mage.LivingBomb,
 		Aura: target.RegisterAura(core.Aura{
 			Label:    "LivingBomb-" + strconv.Itoa(int(mage.Index)),
-			ActionID: actionID,
+			ActionID: mage.LivingBomb.ActionID,
 			Tag:      "LivingBomb",
-			OnGain: func(aura *core.Aura, sim *core.Simulation) {
-				mage.LivingBombNotActive.Dequeue()
-			},
 			OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 				livingBombExplosionSpell.Cast(sim, target)
-				mage.LivingBombNotActive.Enqueue(target)
 			},
 		}),
 
-		NumberOfTicks:       4,
-		TickLength:          time.Second * 3,
-		AffectedByCastSpeed: false,
+		NumberOfTicks: 4,
+		TickLength:    time.Second * 3,
 
 		OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, _ bool) {
 			dot.SnapshotBaseDamage = 345 + 0.2*dot.Spell.SpellPower()
 			dot.SnapshotCritChance = dot.Spell.SpellCritChance(target)
 			dot.SnapshotAttackerMultiplier = dot.Spell.AttackerDamageMultiplier(dot.Spell.Unit.AttackTables[target.UnitIndex])
 		},
-		OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
-			if hasGlyphOfLivingBomb {
-				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeMagicHitAndSnapshotCrit)
-			} else {
-				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeTick)
-			}
-		},
+		OnTick: onTick,
 	})
 }

--- a/sim/mage/rotations.go
+++ b/sim/mage/rotations.go
@@ -77,7 +77,7 @@ func (mage *Mage) doFireRotation(sim *core.Simulation) *core.Spell {
 		return mage.Scorch
 	}
 
-	if !mage.LivingBombNotActive.Empty() && (!mage.HotStreakAura.IsActive() || mage.Rotation.LbBeforeHotstreak) {
+	if !mage.LivingBombDot.IsActive() && (!mage.HotStreakAura.IsActive() || mage.Rotation.LbBeforeHotstreak) {
 		return mage.LivingBomb
 	}
 

--- a/sim/mage/talents.go
+++ b/sim/mage/talents.go
@@ -11,6 +11,7 @@ import (
 func (mage *Mage) ApplyTalents() {
 	mage.applyArcaneConcentration()
 	mage.applyIgnite()
+	mage.applyEmpoweredFire()
 	mage.applyMasterOfElements()
 	mage.applyWintersChill()
 	mage.applyMoltenFury()
@@ -420,7 +421,7 @@ func (mage *Mage) registerCombustionCD() {
 			if spell.SpellSchool != core.SpellSchoolFire || !spell.Flags.Matches(SpellFlagMage) {
 				return
 			}
-			if spell.SameAction(IgniteActionID) || spell.SameAction(core.ActionID{SpellID: 55359}) || spell.SameAction(core.ActionID{SpellID: 44457}) { //LB dot action should be ignored
+			if spell == mage.Ignite || spell == mage.LivingBomb { //LB dot action should be ignored
 				return
 			}
 			if !result.Landed() {

--- a/sim/paladin/consecration.go
+++ b/sim/paladin/consecration.go
@@ -24,7 +24,7 @@ func (paladin *Paladin) registerConsecrationSpell() {
 			Label:    "Consecration",
 			ActionID: actionID,
 		}),
-		NumberOfTicks: 8 + core.TernaryInt(paladin.HasMajorGlyph(proto.PaladinMajorGlyph_GlyphOfConsecration), 2, 0),
+		NumberOfTicks: 8 + core.TernaryInt32(paladin.HasMajorGlyph(proto.PaladinMajorGlyph_GlyphOfConsecration), 2, 0),
 		TickLength:    time.Second * 1,
 
 		OnSnapshot: func(sim *core.Simulation, _ *core.Unit, dot *core.Dot, _ bool) {

--- a/sim/priest/mind_flay.go
+++ b/sim/priest/mind_flay.go
@@ -12,11 +12,11 @@ import (
 // TODO Mind Flay (48156) now "periodically triggers" Mind Flay (58381), probably to allow haste to work.
 //
 //	The first never deals damage, so the latter should probably be used as ActionID here.
-func (priest *Priest) MindFlayActionID(numTicks int) core.ActionID {
-	return core.ActionID{SpellID: 48156, Tag: int32(numTicks)}
+func (priest *Priest) MindFlayActionID(numTicks int32) core.ActionID {
+	return core.ActionID{SpellID: 48156, Tag: numTicks}
 }
 
-func (priest *Priest) newMindFlaySpell(numTicks int) *core.Spell {
+func (priest *Priest) newMindFlaySpell(numTicks int32) *core.Spell {
 	baseCost := priest.BaseMana * 0.09
 
 	channelTime := time.Second * time.Duration(numTicks)
@@ -75,7 +75,7 @@ func (priest *Priest) newMindFlaySpell(numTicks int) *core.Spell {
 	})
 }
 
-func (priest *Priest) newMindFlayDot(numTicks int) *core.Dot {
+func (priest *Priest) newMindFlayDot(numTicks int32) *core.Dot {
 	target := priest.CurrentTarget
 
 	miseryCoeff := 0.257 * (1 + 0.05*float64(priest.Talents.Misery))
@@ -95,7 +95,7 @@ func (priest *Priest) newMindFlayDot(numTicks int) *core.Dot {
 	return core.NewDot(core.Dot{
 		Spell: priest.MindFlay[numTicks],
 		Aura: target.RegisterAura(core.Aura{
-			Label:    "MindFlay-" + strconv.Itoa(numTicks) + "-" + strconv.Itoa(int(priest.Index)),
+			Label:    "MindFlay-" + strconv.Itoa(int(numTicks)) + "-" + strconv.Itoa(int(priest.Index)),
 			ActionID: priest.MindFlayActionID(numTicks),
 		}),
 

--- a/sim/priest/mind_sear.go
+++ b/sim/priest/mind_sear.go
@@ -12,11 +12,11 @@ import (
 // TODO see Mind Flay: Mind Sear (53023) now "periodically triggers" Mind Sear (53022).
 //
 //	Since Mind Flay no longer is a binary spell, Mind Sear likely isn't, either.
-func (priest *Priest) MindSearActionID(numTicks int) core.ActionID {
-	return core.ActionID{SpellID: 53023, Tag: int32(numTicks)}
+func (priest *Priest) MindSearActionID(numTicks int32) core.ActionID {
+	return core.ActionID{SpellID: 53023, Tag: numTicks}
 }
 
-func (priest *Priest) newMindSearSpell(numTicks int) *core.Spell {
+func (priest *Priest) newMindSearSpell(numTicks int32) *core.Spell {
 	baseCost := priest.BaseMana * 0.28
 	channelTime := time.Second * time.Duration(numTicks)
 
@@ -52,18 +52,18 @@ func (priest *Priest) newMindSearSpell(numTicks int) *core.Spell {
 	})
 }
 
-func (priest *Priest) newMindSearDot(numTicks int) *core.Dot {
+func (priest *Priest) newMindSearDot(numTicks int32) *core.Dot {
 	target := priest.CurrentTarget
 
 	miseryCoeff := 0.2861 * (1 + 0.05*float64(priest.Talents.Misery))
 	hasGlyphOfShadow := priest.HasGlyph(int32(proto.PriestMajorGlyph_GlyphOfShadow))
 
-	normMod := (1 + float64(priest.Talents.Darkness)*0.02 + float64(priest.Talents.TwinDisciplines)*0.01) // initialize modifier
+	normMod := 1 + float64(priest.Talents.Darkness)*0.02 + float64(priest.Talents.TwinDisciplines)*0.01 // initialize modifier
 
 	return core.NewDot(core.Dot{
 		Spell: priest.MindSear[numTicks],
 		Aura: target.RegisterAura(core.Aura{
-			Label:    "MindSear-" + strconv.Itoa(numTicks) + "-" + strconv.Itoa(int(priest.Index)),
+			Label:    "MindSear-" + strconv.Itoa(int(numTicks)) + "-" + strconv.Itoa(int(priest.Index)),
 			ActionID: priest.MindSearActionID(numTicks),
 		}),
 

--- a/sim/priest/renew.go
+++ b/sim/priest/renew.go
@@ -93,8 +93,8 @@ func (priest *Priest) makeRenewHot(target *core.Unit) *core.Dot {
 	})
 }
 
-func (priest *Priest) renewTicks() int {
-	return 5 - core.TernaryInt(priest.HasMajorGlyph(proto.PriestMajorGlyph_GlyphOfRenew), 1, 0)
+func (priest *Priest) renewTicks() int32 {
+	return 5 - core.TernaryInt32(priest.HasMajorGlyph(proto.PriestMajorGlyph_GlyphOfRenew), 1, 0)
 }
 
 func (priest *Priest) renewHealingMultiplier() float64 {

--- a/sim/priest/shadow_word_pain.go
+++ b/sim/priest/shadow_word_pain.go
@@ -60,7 +60,7 @@ func (priest *Priest) registerShadowWordPainSpell() {
 		}),
 
 		NumberOfTicks: 6 +
-			core.TernaryInt(priest.HasSetBonus(ItemSetAbsolution, 2), 1, 0),
+			core.TernaryInt32(priest.HasSetBonus(ItemSetAbsolution, 2), 1, 0),
 		TickLength: time.Second * 3,
 
 		OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {

--- a/sim/priest/vampiric_touch.go
+++ b/sim/priest/vampiric_touch.go
@@ -11,7 +11,7 @@ import (
 func (priest *Priest) registerVampiricTouchSpell() {
 	actionID := core.ActionID{SpellID: 48160}
 	baseCost := priest.BaseMana * 0.16
-	numTicks := 5 + core.TernaryInt(priest.HasSetBonus(ItemSetZabras, 2), 2, 0)
+	numTicks := 5 + core.TernaryInt32(priest.HasSetBonus(ItemSetZabras, 2), 2, 0)
 
 	priest.VampiricTouch = priest.RegisterSpell(core.SpellConfig{
 		ActionID:     actionID,

--- a/sim/rogue/garrote.go
+++ b/sim/rogue/garrote.go
@@ -15,7 +15,7 @@ func (rogue *Rogue) registerGarrote() {
 	refundAmount := 0.8
 	baseCost := rogue.costModifier(50 - 10*float64(rogue.Talents.DirtyDeeds))
 
-	numTicks := 6
+	numTicks := int32(6)
 	var glyphMultiplier float64
 	if rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfGarrote) {
 		numTicks = 5

--- a/sim/rogue/rupture.go
+++ b/sim/rogue/rupture.go
@@ -46,7 +46,7 @@ func (rogue *Rogue) makeRupture(comboPoints int32) *core.Spell {
 			result := spell.CalcOutcome(sim, target, spell.OutcomeMeleeSpecialHit)
 			if result.Landed() {
 				rogue.ruptureDot.Spell = spell
-				rogue.ruptureDot.NumberOfTicks = int(numTicks)
+				rogue.ruptureDot.NumberOfTicks = numTicks
 				rogue.ruptureDot.RecomputeAuraDuration()
 				rogue.ruptureDot.Apply(sim)
 				rogue.ApplyFinisher(sim, spell)

--- a/sim/shaman/shocks.go
+++ b/sim/shaman/shocks.go
@@ -105,7 +105,7 @@ func (shaman *Shaman) registerFlameShockSpell(shockTimer *core.Timer) {
 			},
 		}),
 		// TODO: is this bonus ticks or bonus time that results in extra ticks?
-		NumberOfTicks:       6 + core.TernaryInt(shaman.HasSetBonus(ItemSetThrallsRegalia, 2), 3, 0),
+		NumberOfTicks:       6 + core.TernaryInt32(shaman.HasSetBonus(ItemSetThrallsRegalia, 2), 3, 0),
 		TickLength:          time.Second * 3,
 		AffectedByCastSpeed: true,
 

--- a/sim/warlock/curses.go
+++ b/sim/warlock/curses.go
@@ -123,7 +123,7 @@ func (warlock *Warlock) registerCurseOfAgonySpell() {
 	actionID := core.ActionID{SpellID: 47864}
 	spellSchool := core.SpellSchoolShadow
 	baseCost := 0.1 * warlock.BaseMana
-	numberOfTicks := 12
+	numberOfTicks := int32(12)
 	totalBaseDmg := 1740.0
 	agonyEffect := totalBaseDmg * 0.056
 	if warlock.HasMajorGlyph(proto.WarlockMajorGlyph_GlyphOfCurseOfAgony) {

--- a/sim/warlock/drain_soul.go
+++ b/sim/warlock/drain_soul.go
@@ -8,7 +8,7 @@ import (
 	"github.com/wowsims/wotlk/sim/core/stats"
 )
 
-func (warlock *Warlock) channelCheck(sim *core.Simulation, dot *core.Dot, maxTicks int) *core.Spell {
+func (warlock *Warlock) channelCheck(sim *core.Simulation, dot *core.Dot, maxTicks int32) *core.Spell {
 	if dot.IsActive() && dot.TickCount+1 < maxTicks {
 		return warlock.DrainSoulChannelling
 	} else {

--- a/sim/warlock/immolate.go
+++ b/sim/warlock/immolate.go
@@ -74,7 +74,7 @@ func (warlock *Warlock) registerImmolateSpell() {
 				warlock.Incinerate.DamageMultiplierAdditive -= fireAndBrimstoneBonus
 			},
 		}),
-		NumberOfTicks: 5 + int(warlock.Talents.MoltenCore),
+		NumberOfTicks: 5 + warlock.Talents.MoltenCore,
 		TickLength:    time.Second * 3,
 
 		OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {

--- a/sim/warrior/rend.go
+++ b/sim/warrior/rend.go
@@ -17,7 +17,7 @@ func (warrior *Warrior) RegisterRendSpell(rageThreshold float64, healthThreshold
 	refundAmount := cost * 0.8
 
 	dotDuration := time.Second * 15
-	dotTicks := 5
+	dotTicks := int32(5)
 	if warrior.HasMajorGlyph(proto.WarriorMajorGlyph_GlyphOfRending) {
 		dotDuration += time.Second * 6
 		dotTicks += 2


### PR DESCRIPTION
[core] changed dot.NumberOfTicks and dot.TickCount from int to int32

[mage] Living Bomb's dot application can now miss, and its splash damage scaling corrected
[mage] multiple Living Bomb applications are no longer supported, they were both buggy and effectively unused 
[mage] Ignite is now procced by Living Bomb's crit ticks; cleaned up & simplified 

[druid] Moonfire ticks can no longer miss
[druid] Nature's Grace is now additionally procced by Starfall and Moonfire

I've removed Living Bomb's split into an "applier" and "dot" spell. This makes the "Detailed Results / Damage" section less readable (since misses, hits, and crits are combined), but helps the "Timeline", since it now displays actual tick bars.

Actual dots should probably count "tickHit" and "tickCrit" or the like, so these can be displayed correctly in the "Damage" section - ideally split into "applier" and "dot", using the same SpellID (and icon), so the individual sims can display both, without introducing dummy spells.
 
For Ignite, I've likewise removed the "pseudo-cast". I've no idea how the timeline decides whether to display ticks or not, but with "tickHit" and "tickCrit" support this should work as well.
