### PR TITLE
Rolling dots

### DIFF
--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -45,540 +45,540 @@ character_stats_results: {
 dps_results: {
  key: "TestHunter-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 7455.52347
-  tps: 6477.24902
+  dps: 7449.94828
+  tps: 6470.61015
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 6709.30083
-  tps: 5705.77342
+  dps: 6704.87988
+  tps: 5701.87703
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6735.80842
-  tps: 5726.0473
+  dps: 6729.79592
+  tps: 5720.56903
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6820.12988
-  tps: 5810.22442
+  dps: 6815.76091
+  tps: 5806.41864
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6769.23785
-  tps: 5761.7449
+  dps: 6762.13644
+  tps: 5755.27394
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6678.68199
-  tps: 5683.7721
+  dps: 6673.37325
+  tps: 5680.39705
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 6380.31668
-  tps: 5375.3281
+  dps: 6374.53127
+  tps: 5369.53085
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5801.46196
-  tps: 4939.62695
+  dps: 5794.98987
+  tps: 4933.3912
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5587.0009
-  tps: 4739.57661
+  dps: 5584.35329
+  tps: 4736.98279
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6735.80842
-  tps: 5612.41092
+  dps: 6729.79592
+  tps: 5607.04221
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6891.42777
-  tps: 5881.50624
+  dps: 6885.41771
+  tps: 5876.03042
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 6230.05805
-  tps: 5268.51937
+  dps: 6224.27274
+  tps: 5262.57434
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6767.91783
-  tps: 5769.01935
+  dps: 6763.74523
+  tps: 5765.42266
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6802.05852
-  tps: 5803.70529
+  dps: 6797.57976
+  tps: 5799.7998
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 6789.566
-  tps: 5784.65641
+  dps: 6784.40939
+  tps: 5780.0637
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6791.09396
-  tps: 5786.18436
+  dps: 6785.92592
+  tps: 5781.58023
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6742.63999
-  tps: 5744.40133
+  dps: 6738.20122
+  tps: 5740.53849
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6657.85008
-  tps: 5659.77222
+  dps: 6653.42152
+  tps: 5655.90022
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6757.98309
-  tps: 5748.06119
+  dps: 6751.81989
+  tps: 5742.42972
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6735.80842
-  tps: 5726.0473
+  dps: 6729.79592
+  tps: 5720.56903
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6736.12415
-  tps: 5726.85286
+  dps: 6729.45591
+  tps: 5720.71648
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6754.98816
-  tps: 5745.06664
+  dps: 6749.17561
+  tps: 5739.78831
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6749.8851
-  tps: 5739.97914
+  dps: 6744.07254
+  tps: 5734.70081
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6735.80842
-  tps: 5726.0473
+  dps: 6729.79592
+  tps: 5720.56903
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6817.02815
-  tps: 5818.71621
+  dps: 6807.58758
+  tps: 5809.76397
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6746.621
-  tps: 5748.32755
+  dps: 6742.18202
+  tps: 5744.4504
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6727.81459
-  tps: 5729.53805
+  dps: 6723.25001
+  tps: 5725.53002
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6735.80842
-  tps: 5726.0473
+  dps: 6729.79592
+  tps: 5720.56903
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6735.80842
-  tps: 5726.0473
+  dps: 6729.79592
+  tps: 5720.56903
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6840.71166
-  tps: 5823.21029
+  dps: 6836.1468
+  tps: 5819.21325
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6657.85008
-  tps: 5659.77222
+  dps: 6653.42152
+  tps: 5655.90022
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 7089.33954
-  tps: 6137.34138
+  dps: 7084.11951
+  tps: 6132.1112
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5277.37781
-  tps: 4447.69197
+  dps: 5272.67031
+  tps: 4442.99196
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6657.85008
-  tps: 5659.77222
+  dps: 6653.42152
+  tps: 5655.90022
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6754.98816
-  tps: 5745.06664
+  dps: 6749.17561
+  tps: 5739.78831
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6749.8851
-  tps: 5739.97914
+  dps: 6744.07254
+  tps: 5734.70081
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6811.32547
-  tps: 5804.03081
+  dps: 6806.7668
+  tps: 5800.03386
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6933.88411
-  tps: 5931.53349
+  dps: 6925.66945
+  tps: 5923.47367
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6760.2957
-  tps: 5747.919
+  dps: 6754.25939
+  tps: 5742.41838
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6657.85008
-  tps: 5659.77222
+  dps: 6653.42152
+  tps: 5655.90022
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6659.36235
-  tps: 5661.2845
+  dps: 6654.94198
+  tps: 5657.42068
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6812.13896
-  tps: 5817.77055
+  dps: 6805.703
+  tps: 5811.3689
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6657.85008
-  tps: 5659.77222
+  dps: 6653.42152
+  tps: 5655.90022
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6755.63146
-  tps: 5743.75296
+  dps: 6749.59968
+  tps: 5738.2566
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6760.2957
-  tps: 5747.919
+  dps: 6754.25939
+  tps: 5742.41838
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6735.80842
-  tps: 5726.0473
+  dps: 6729.79592
+  tps: 5720.56903
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6735.80842
-  tps: 5726.0473
+  dps: 6729.79592
+  tps: 5720.56903
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6657.85008
-  tps: 5659.77222
+  dps: 6653.42152
+  tps: 5655.90022
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6657.85008
-  tps: 5659.77222
+  dps: 6653.42152
+  tps: 5655.90022
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6657.85008
-  tps: 5659.77222
+  dps: 6653.42152
+  tps: 5655.90022
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6898.1791
-  tps: 5886.91591
+  dps: 6892.27047
+  tps: 5881.54235
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6742.56807
-  tps: 5734.90974
+  dps: 6735.55009
+  tps: 5728.52214
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6657.85008
-  tps: 5659.77222
+  dps: 6653.42152
+  tps: 5655.90022
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 6500.74264
-  tps: 5539.71364
+  dps: 6499.49181
+  tps: 5540.24501
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6657.85008
-  tps: 5659.77222
+  dps: 6653.42152
+  tps: 5655.90022
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6657.85008
-  tps: 5659.77222
+  dps: 6653.42152
+  tps: 5655.90022
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6657.85008
-  tps: 5659.77222
+  dps: 6653.42152
+  tps: 5655.90022
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SparkofLife-37657"
  value: {
-  dps: 6913.30828
-  tps: 5909.21199
+  dps: 6905.09975
+  tps: 5902.00985
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6751.24703
-  tps: 5742.6884
+  dps: 6746.68552
+  tps: 5738.72484
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StormshroudArmor"
  value: {
-  dps: 5402.36165
-  tps: 4565.77024
+  dps: 5389.28147
+  tps: 4552.59122
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6760.2957
-  tps: 5747.919
+  dps: 6754.25939
+  tps: 5742.41838
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6755.63146
-  tps: 5743.75296
+  dps: 6749.59968
+  tps: 5738.2566
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6747.46903
-  tps: 5736.4624
+  dps: 6741.44519
+  tps: 5730.97348
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheFistsofFury"
  value: {
-  dps: 6590.76038
-  tps: 5600.79855
+  dps: 6585.88744
+  tps: 5595.9286
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6821.46764
-  tps: 5810.09984
+  dps: 6814.41471
+  tps: 5803.04095
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6658.10029
-  tps: 5660.02244
+  dps: 6653.67259
+  tps: 5656.15129
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6658.10029
-  tps: 5660.02244
+  dps: 6653.67259
+  tps: 5656.15129
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6735.80842
-  tps: 5726.0473
+  dps: 6729.79592
+  tps: 5720.56903
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6735.80842
-  tps: 5726.0473
+  dps: 6729.79592
+  tps: 5720.56903
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6735.80842
-  tps: 5726.0473
+  dps: 6729.79592
+  tps: 5720.56903
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6735.80842
-  tps: 5726.0473
+  dps: 6729.79592
+  tps: 5720.56903
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5736.57143
-  tps: 4876.48528
+  dps: 5735.94242
+  tps: 4876.36481
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 6892.53137
-  tps: 5900.2969
+  dps: 6890.41815
+  tps: 5897.15458
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6657.85008
-  tps: 5659.77222
+  dps: 6653.42152
+  tps: 5655.90022
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7470.43756
-  tps: 6464.10618
+  dps: 7459.28567
+  tps: 6452.94571
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 7670.71536
-  tps: 6664.31092
+  dps: 7663.31355
+  tps: 6656.85722
  }
 }
 dps_results: {
  key: "TestHunter-Average-Default"
  value: {
-  dps: 6924.64007
-  tps: 5920.41632
+  dps: 6920.24914
+  tps: 5916.14511
  }
 }
 dps_results: {
@@ -668,43 +668,43 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6608.69773
-  tps: 6488.41641
+  dps: 6605.10506
+  tps: 6484.79152
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6608.69773
-  tps: 5650.42873
+  dps: 6605.10506
+  tps: 5646.80384
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7716.83676
-  tps: 6609.62215
+  dps: 7700.64397
+  tps: 6594.59769
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3521.16577
-  tps: 4644.71762
+  dps: 3515.73145
+  tps: 4639.60709
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3521.16577
-  tps: 3185.89525
+  dps: 3515.73145
+  tps: 3180.78472
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Dwarf-P1-Marksman-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4390.69202
-  tps: 3935.46215
+  dps: 4382.89078
+  tps: 3927.7037
  }
 }
 dps_results: {
@@ -836,43 +836,43 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6635.6706
-  tps: 6466.67756
+  dps: 6631.4614
+  tps: 6462.44258
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6635.6706
-  tps: 5624.58379
+  dps: 6631.4614
+  tps: 5620.34881
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7774.77525
-  tps: 6601.32881
+  dps: 7760.84228
+  tps: 6588.67201
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3548.09657
-  tps: 4645.19089
+  dps: 3541.99643
+  tps: 4639.37593
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3548.09657
-  tps: 3187.93445
+  dps: 3541.99643
+  tps: 3182.11949
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-P1-Marksman-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4421.32658
-  tps: 3938.69206
+  dps: 4412.11594
+  tps: 3929.52635
  }
 }
 dps_results: {
@@ -920,7 +920,7 @@ dps_results: {
 dps_results: {
  key: "TestHunter-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6874.81088
-  tps: 5926.70726
+  dps: 6878.51403
+  tps: 5928.82655
  }
 }

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -45,567 +45,567 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5509.46423
-  tps: 4937.25158
+  dps: 5502.80046
+  tps: 4930.63625
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5293.04382
-  tps: 4743.45677
+  dps: 5251.55266
+  tps: 4704.53264
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5539.29882
-  tps: 4963.03868
+  dps: 5542.30383
+  tps: 4967.47553
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4475.53947
-  tps: 4009.01876
+  dps: 4436.99999
+  tps: 3972.42493
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 6257.72704
-  tps: 5608.176
+  dps: 6197.09556
+  tps: 5551.18632
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5545.64016
-  tps: 4871.38735
+  dps: 5538.94257
+  tps: 4864.86768
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 5694.21369
-  tps: 5102.26812
+  dps: 5693.42791
+  tps: 5102.96881
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5376.41545
-  tps: 4819.38493
+  dps: 5368.7297
+  tps: 4811.31344
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5434.73193
-  tps: 4878.22047
+  dps: 5471.46722
+  tps: 4908.01888
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 5305.25665
-  tps: 4754.06364
+  dps: 5290.87795
+  tps: 4742.03757
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 5305.25665
-  tps: 4754.06364
+  dps: 5290.87795
+  tps: 4742.03757
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 5340.94172
-  tps: 4782.62199
+  dps: 5351.35995
+  tps: 4794.82212
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5352.66023
-  tps: 4797.84031
+  dps: 5290.58947
+  tps: 4742.1916
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5293.04382
-  tps: 4743.45677
+  dps: 5251.55266
+  tps: 4704.53264
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5580.71225
-  tps: 5001.83022
+  dps: 5529.97505
+  tps: 4955.1785
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5509.46423
-  tps: 4937.25158
+  dps: 5502.80046
+  tps: 4930.63625
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5545.5018
-  tps: 4966.76064
+  dps: 5557.22435
+  tps: 4980.39533
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5552.50685
-  tps: 4974.73196
+  dps: 5550.98465
+  tps: 4974.76988
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5552.50685
-  tps: 4974.73196
+  dps: 5540.73245
+  tps: 4965.01684
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5509.46423
-  tps: 4937.25158
+  dps: 5502.80046
+  tps: 4930.63625
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5436.12588
-  tps: 4878.18314
+  dps: 5401.27581
+  tps: 4846.91323
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5553.27184
-  tps: 4976.76079
+  dps: 5540.3397
+  tps: 4965.32385
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5486.34793
-  tps: 4917.91985
+  dps: 5463.7796
+  tps: 4897.36313
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5545.64016
-  tps: 4969.25285
+  dps: 5538.94257
+  tps: 4962.59812
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5538.40497
-  tps: 4962.85259
+  dps: 5531.71414
+  tps: 4956.20574
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FrostfireGarb"
  value: {
-  dps: 4857.13142
-  tps: 4352.53242
+  dps: 4798.47721
+  tps: 4298.51476
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5293.04382
-  tps: 4743.45677
+  dps: 5251.55266
+  tps: 4704.53264
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5391.23424
-  tps: 4829.81465
+  dps: 5369.78804
+  tps: 4813.47745
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5573.90018
-  tps: 4993.80909
+  dps: 5531.26208
+  tps: 4953.75514
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5552.50685
-  tps: 4974.73196
+  dps: 5550.98465
+  tps: 4974.76988
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5552.50685
-  tps: 4974.73196
+  dps: 5540.73245
+  tps: 4965.01684
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5293.04382
-  tps: 4743.45677
+  dps: 5251.55266
+  tps: 4704.53264
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5576.08383
-  tps: 4992.97009
+  dps: 5517.67359
+  tps: 4941.17157
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5509.46423
-  tps: 4937.25158
+  dps: 5502.80046
+  tps: 4930.63625
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 5643.80017
-  tps: 5055.85171
+  dps: 5666.40487
+  tps: 5077.05303
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KirinTorGarb"
  value: {
-  dps: 5307.90465
-  tps: 4751.40849
+  dps: 5297.44479
+  tps: 4739.94007
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5293.04382
-  tps: 4743.45677
+  dps: 5251.55266
+  tps: 4704.53264
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5357.25324
-  tps: 4798.19613
+  dps: 5328.26562
+  tps: 4773.39995
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5369.09631
-  tps: 4812.9482
+  dps: 5344.50863
+  tps: 4790.69263
  }
 }
 dps_results: {
  key: "TestFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5293.04382
-  tps: 4743.45677
+  dps: 5251.55266
+  tps: 4704.53264
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5509.46423
-  tps: 4937.25158
+  dps: 5502.80046
+  tps: 4930.63625
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5509.46423
-  tps: 4937.25158
+  dps: 5502.80046
+  tps: 4930.63625
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5509.46423
-  tps: 4937.25158
+  dps: 5502.80046
+  tps: 4930.63625
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5509.46423
-  tps: 4937.25158
+  dps: 5502.80046
+  tps: 4930.63625
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5293.04382
-  tps: 4743.45677
+  dps: 5251.55266
+  tps: 4704.53264
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 5633.62355
-  tps: 5061.43108
+  dps: 5573.74319
+  tps: 5008.07762
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 5680.29682
-  tps: 5105.12408
+  dps: 5620.55905
+  tps: 5051.94616
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5649.08498
-  tps: 5062.91025
+  dps: 5642.8428
+  tps: 5056.67436
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5523.83587
-  tps: 4947.55737
+  dps: 5507.66259
+  tps: 4934.63544
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5293.04382
-  tps: 4743.45677
+  dps: 5251.55266
+  tps: 4704.53264
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5293.04382
-  tps: 4743.45677
+  dps: 5251.55266
+  tps: 4704.53264
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5293.04382
-  tps: 4743.45677
+  dps: 5251.55266
+  tps: 4704.53264
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5293.04382
-  tps: 4743.45677
+  dps: 5251.55266
+  tps: 4704.53264
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 5305.18418
-  tps: 4748.12252
+  dps: 5346.82387
+  tps: 4790.47267
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 5421.76105
-  tps: 4860.08409
+  dps: 5429.60169
+  tps: 4868.49563
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sunstrider'sRegalia"
  value: {
-  dps: 5463.46749
-  tps: 4891.41424
+  dps: 5472.8774
+  tps: 4903.45521
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5509.46423
-  tps: 4937.25158
+  dps: 5502.80046
+  tps: 4930.63625
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5509.46423
-  tps: 4937.25158
+  dps: 5502.80046
+  tps: 4930.63625
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5509.46423
-  tps: 4937.25158
+  dps: 5502.80046
+  tps: 4930.63625
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5509.46423
-  tps: 4937.25158
+  dps: 5502.80046
+  tps: 4930.63625
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5515.35781
-  tps: 4943.10927
+  dps: 5569.22076
+  tps: 4992.46622
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5515.35781
-  tps: 4943.10927
+  dps: 5569.22076
+  tps: 4992.46622
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5545.64016
-  tps: 4969.25285
+  dps: 5538.94257
+  tps: 4962.59812
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5538.40497
-  tps: 4962.85259
+  dps: 5531.71414
+  tps: 4956.20574
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5538.40497
-  tps: 4962.85259
+  dps: 5531.71414
+  tps: 4956.20574
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5545.64016
-  tps: 4969.25285
+  dps: 5538.94257
+  tps: 4962.59812
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WingedTalisman-37844"
  value: {
-  dps: 5409.05929
-  tps: 4847.87069
+  dps: 5368.25871
+  tps: 4809.56807
  }
 }
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
-  dps: 5785.9997
-  tps: 5184.44767
+  dps: 5779.80932
+  tps: 5178.79669
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17759.77004
-  tps: 20616.35828
+  dps: 17684.85183
+  tps: 20508.13039
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1726.08585
-  tps: 1600.31841
+  dps: 1688.02663
+  tps: 1563.28411
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2392.01395
-  tps: 2110.76528
+  dps: 2382.00262
+  tps: 2100.47794
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13870.76458
-  tps: 16517.63103
+  dps: 13862.41234
+  tps: 16513.5243
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 810.49659
-  tps: 740.17645
+  dps: 821.84628
+  tps: 749.1003
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1387.03949
-  tps: 1166.64919
+  dps: 1386.95811
+  tps: 1166.55064
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7953.23573
-  tps: 8860.45849
+  dps: 7936.78784
+  tps: 8843.09803
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5694.21369
-  tps: 5102.26812
+  dps: 5693.42791
+  tps: 5102.96881
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7005.6298
-  tps: 6173.28764
+  dps: 6989.40016
+  tps: 6159.49249
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4316.84002
-  tps: 5317.94224
+  dps: 4339.34623
+  tps: 5336.11254
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2363.68452
-  tps: 2104.82817
+  dps: 2323.13296
+  tps: 2069.16928
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3515.1582
-  tps: 3033.52711
+  dps: 3517.42206
+  tps: 3035.4536
  }
 }
 dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5694.21369
-  tps: 5102.26812
+  dps: 5693.42791
+  tps: 5102.96881
  }
 }

--- a/sim/mage/ignite.go
+++ b/sim/mage/ignite.go
@@ -23,7 +23,7 @@ func (mage *Mage) applyIgnite() {
 				return
 			}
 			if spell.SpellSchool.Matches(core.SpellSchoolFire) && result.Outcome.Matches(core.OutcomeCrit) {
-				mage.procIgnite(sim, result.Target, result.Damage)
+				mage.procIgnite(sim, result)
 			}
 		},
 		OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
@@ -31,22 +31,27 @@ func (mage *Mage) applyIgnite() {
 				return
 			}
 			if spell == mage.LivingBombDot.Spell && result.Outcome.Matches(core.OutcomeCrit) {
-				mage.procIgnite(sim, result.Target, result.Damage)
+				mage.procIgnite(sim, result)
 			}
 		},
 	})
 
 	mage.Ignite = mage.RegisterSpell(core.SpellConfig{
-		ActionID:         core.ActionID{SpellID: 12654},
-		SpellSchool:      core.SpellSchoolFire,
-		ProcMask:         core.ProcMaskEmpty,
-		Flags:            SpellFlagMage | core.SpellFlagIgnoreModifiers,
+		ActionID:    core.ActionID{SpellID: 12654},
+		SpellSchool: core.SpellSchoolFire,
+		ProcMask:    core.ProcMaskEmpty,
+		Flags:       SpellFlagMage | core.SpellFlagIgnoreModifiers,
+
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1 - 0.1*float64(mage.Talents.BurningSoul),
+
+		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+			mage.IgniteDots[target.Index].ApplyOrReset(sim)
+			spell.CalcAndDealOutcome(sim, target, spell.OutcomeAlwaysHit)
+		},
 	})
 
 	mage.IgniteDots = make([]*core.Dot, mage.Env.GetNumTargets())
-	mage.IgniteDamageBuffers = make([]float64, mage.Env.GetNumTargets())
 	for i := range mage.IgniteDots {
 		mage.IgniteDots[i] = core.NewDot(core.Dot{
 			Spell: mage.Ignite,
@@ -58,24 +63,25 @@ func (mage *Mage) applyIgnite() {
 			NumberOfTicks: 2,
 			TickLength:    time.Second * 2,
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
-				mage.IgniteDamageBuffers[target.Index] -= dot.SnapshotBaseDamage
-				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.Spell.OutcomeAlwaysHit)
+				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeTick)
 			},
 			SnapshotAttackerMultiplier: 1,
 		})
 	}
 }
 
-func (mage *Mage) procIgnite(sim *core.Simulation, target *core.Unit, spellDamage float64) {
-	dot := mage.IgniteDots[target.Index]
+func (mage *Mage) procIgnite(sim *core.Simulation, result *core.SpellResult) {
+	dot := mage.IgniteDots[result.Target.Index]
 
-	if !dot.IsActive() {
-		mage.IgniteDamageBuffers[target.Index] = 0
+	var outstandingDamage float64
+	if dot.IsActive() {
+		outstandingDamage = dot.SnapshotBaseDamage * float64(dot.NumberOfTicks-dot.TickCount)
 	}
 
-	mage.IgniteDamageBuffers[target.Index] += spellDamage * float64(mage.Talents.Ignite) * 0.08
-	dot.SnapshotBaseDamage = mage.IgniteDamageBuffers[target.Index] / 2
-	dot.Apply(sim)
+	newDamage := result.Damage * float64(mage.Talents.Ignite) * 0.08
+
+	dot.SnapshotBaseDamage = (outstandingDamage + newDamage) / float64(dot.NumberOfTicks)
+	mage.Ignite.Cast(sim, result.Target)
 }
 
 func (mage *Mage) applyEmpoweredFire() {

--- a/sim/mage/mage.go
+++ b/sim/mage/mage.go
@@ -106,8 +106,7 @@ type Mage struct {
 	// Used to prevent utilising Brain Freeze immediately after proccing it.
 	BrainFreezeActivatedAt time.Duration
 
-	IgniteDots          []*core.Dot
-	IgniteDamageBuffers []float64
+	IgniteDots []*core.Dot
 
 	MageTier MageTierSets
 

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -45,630 +45,630 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 7887.04128
-  tps: 6449.30305
+  dps: 7887.47219
+  tps: 6450.27646
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8171.66922
-  tps: 6681.52588
+  dps: 8115.67118
+  tps: 6632.1041
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8114.90412
-  tps: 6632.81631
+  dps: 8064.1663
+  tps: 6590.14665
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8206.50885
-  tps: 6709.73734
+  dps: 8170.71579
+  tps: 6677.45504
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 8067.0684
-  tps: 6602.40683
+  dps: 7992.00778
+  tps: 6535.33079
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6967.58148
-  tps: 5684.52881
+  dps: 6865.98261
+  tps: 5600.91114
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6957.68664
-  tps: 5679.98825
+  dps: 6878.49623
+  tps: 5611.55361
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6593.93597
-  tps: 5389.40411
+  dps: 6541.53632
+  tps: 5345.29026
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8164.86462
-  tps: 6542.72587
+  dps: 8127.60533
+  tps: 6511.8276
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8405.48463
-  tps: 6872.35978
+  dps: 8363.72773
+  tps: 6838.99771
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 8007.56443
-  tps: 6547.50603
+  dps: 7982.30501
+  tps: 6527.78178
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 8036.51662
-  tps: 6570.15365
+  dps: 8013.15486
+  tps: 6553.21728
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 7985.07089
-  tps: 6529.87234
+  dps: 7934.80017
+  tps: 6487.27408
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7870.78936
-  tps: 6435.45377
+  dps: 7844.43541
+  tps: 6413.71262
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 8009.34637
-  tps: 6548.60096
+  dps: 7914.76522
+  tps: 6470.49582
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7865.09332
-  tps: 6431.18726
+  dps: 7870.91909
+  tps: 6436.43713
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8229.62075
-  tps: 6728.55833
+  dps: 8160.81454
+  tps: 6670.28605
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 7429.5222
-  tps: 6081.60511
+  dps: 7393.26573
+  tps: 6053.74771
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8164.86462
-  tps: 6676.14407
+  dps: 8127.60533
+  tps: 6644.6168
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8164.86462
-  tps: 6676.14407
+  dps: 8127.60533
+  tps: 6644.6168
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8206.50885
-  tps: 6709.73734
+  dps: 8170.71579
+  tps: 6677.45504
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8194.22608
-  tps: 6699.52624
+  dps: 8155.17192
+  tps: 6665.26261
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8164.86462
-  tps: 6676.14407
+  dps: 8127.60533
+  tps: 6644.6168
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 8053.33939
-  tps: 6584.55346
+  dps: 7995.67877
+  tps: 6537.43652
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7987.22497
-  tps: 6531.50496
+  dps: 7952.12744
+  tps: 6503.8257
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7980.63547
-  tps: 6525.82897
+  dps: 7929.8553
+  tps: 6482.84182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8164.86462
-  tps: 6676.14407
+  dps: 8127.60533
+  tps: 6644.6168
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8164.86462
-  tps: 6676.14407
+  dps: 8127.60533
+  tps: 6644.6168
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8173.5725
-  tps: 6678.4077
+  dps: 8151.6191
+  tps: 6660.61379
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7870.78936
-  tps: 6435.45377
+  dps: 7844.43541
+  tps: 6413.71262
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 8083.80768
-  tps: 6566.69349
+  dps: 8020.61455
+  tps: 6519.18471
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7870.78936
-  tps: 6435.45377
+  dps: 7844.43541
+  tps: 6413.71262
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8206.50885
-  tps: 6709.73734
+  dps: 8170.71579
+  tps: 6677.45504
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8194.22608
-  tps: 6699.52624
+  dps: 8155.17192
+  tps: 6665.26261
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8101.60467
-  tps: 6626.09215
+  dps: 8127.82894
+  tps: 6647.21724
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8164.86462
-  tps: 6676.14407
+  dps: 8127.60533
+  tps: 6644.6168
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8203.18045
-  tps: 6707.19417
+  dps: 8163.0829
+  tps: 6671.63296
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7870.78936
-  tps: 6435.45377
+  dps: 7844.43541
+  tps: 6413.71262
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7870.78936
-  tps: 6435.45377
+  dps: 7844.43541
+  tps: 6413.71262
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8098.8145
-  tps: 6624.8367
+  dps: 8048.69877
+  tps: 6586.47079
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7858.74932
-  tps: 6425.62031
+  dps: 7872.60044
+  tps: 6438.44572
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtArmor"
  value: {
-  dps: 5561.48047
-  tps: 4538.81085
+  dps: 5558.04804
+  tps: 4534.25115
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 6448.64708
-  tps: 5251.6543
+  dps: 6435.00971
+  tps: 5235.52268
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8202.81193
-  tps: 6708.27968
+  dps: 8142.09609
+  tps: 6654.76745
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8203.18045
-  tps: 6707.19417
+  dps: 8163.0829
+  tps: 6671.63296
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8164.86462
-  tps: 6676.14407
+  dps: 8127.60533
+  tps: 6644.6168
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8164.86462
-  tps: 6676.14407
+  dps: 8127.60533
+  tps: 6644.6168
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7870.78936
-  tps: 6435.45377
+  dps: 7844.43541
+  tps: 6413.71262
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7870.78936
-  tps: 6435.45377
+  dps: 7844.43541
+  tps: 6413.71262
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7870.78936
-  tps: 6435.45377
+  dps: 7844.43541
+  tps: 6413.71262
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8416.53672
-  tps: 6881.33012
+  dps: 8360.54775
+  tps: 6837.43663
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8164.86462
-  tps: 6676.14407
+  dps: 8127.60533
+  tps: 6644.6168
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7870.78936
-  tps: 6435.45377
+  dps: 7844.43541
+  tps: 6413.71262
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7884.66847
-  tps: 6447.4636
+  dps: 7871.32893
+  tps: 6434.71841
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7870.78936
-  tps: 6435.45377
+  dps: 7844.43541
+  tps: 6413.71262
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 7852.52008
-  tps: 6422.47048
+  dps: 7778.83331
+  tps: 6366.77405
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7870.78936
-  tps: 6435.45377
+  dps: 7844.43541
+  tps: 6413.71262
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SparkofLife-37657"
  value: {
-  dps: 7949.34174
-  tps: 6502.53142
+  dps: 7907.38824
+  tps: 6468.7679
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 8210.67677
-  tps: 6714.02173
+  dps: 8107.50284
+  tps: 6628.22258
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StormshroudArmor"
  value: {
-  dps: 6564.80478
-  tps: 5358.6026
+  dps: 6541.49837
+  tps: 5338.82726
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8203.18045
-  tps: 6707.19417
+  dps: 8163.0829
+  tps: 6671.63296
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8202.81193
-  tps: 6708.27968
+  dps: 8142.09609
+  tps: 6654.76745
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8184.16559
-  tps: 6691.18323
+  dps: 8136.021
+  tps: 6649.32121
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheFistsofFury"
  value: {
-  dps: 4827.49728
-  tps: 4029.6384
+  dps: 4754.7668
+  tps: 3972.57059
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5104.33697
-  tps: 4258.54339
+  dps: 5051.43147
+  tps: 4213.04777
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8288.45016
-  tps: 6784.15081
+  dps: 8211.98874
+  tps: 6720.45387
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 8397.02818
-  tps: 6864.91299
+  dps: 8297.10296
+  tps: 6785.82417
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8442.7238
-  tps: 6899.88407
+  dps: 8318.92132
+  tps: 6802.41027
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8164.86462
-  tps: 6676.14407
+  dps: 8127.60533
+  tps: 6644.6168
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8164.86462
-  tps: 6676.14407
+  dps: 8127.60533
+  tps: 6644.6168
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8164.86462
-  tps: 6676.14407
+  dps: 8127.60533
+  tps: 6644.6168
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8164.86462
-  tps: 6676.14407
+  dps: 8127.60533
+  tps: 6644.6168
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6905.97673
-  tps: 5642.31308
+  dps: 6806.95144
+  tps: 5561.42739
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7870.78936
-  tps: 6435.45377
+  dps: 7844.43541
+  tps: 6413.71262
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 8251.76245
-  tps: 6731.96247
+  dps: 8185.16385
+  tps: 6675.68206
  }
 }
 dps_results: {
  key: "TestArms-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 8694.86852
-  tps: 7112.36503
+  dps: 8636.74777
+  tps: 7071.77929
  }
 }
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 8413.32194
-  tps: 6884.16993
+  dps: 8355.87739
+  tps: 6838.35565
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11005.09717
-  tps: 9380.76188
+  dps: 10970.22089
+  tps: 9352.84791
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8390.18961
-  tps: 6860.58765
+  dps: 8304.94858
+  tps: 6793.63073
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9152.92168
-  tps: 7552.54403
+  dps: 8878.0038
+  tps: 7329.65457
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6285.52962
-  tps: 5458.00474
+  dps: 6291.97113
+  tps: 5463.547
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4457.61728
-  tps: 3651.93563
+  dps: 4421.05358
+  tps: 3623.85546
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4452.77098
-  tps: 3678.65405
+  dps: 4358.26339
+  tps: 3603.50808
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11055.74969
-  tps: 9421.83344
+  dps: 11022.84753
+  tps: 9397.96034
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8405.48463
-  tps: 6872.35978
+  dps: 8363.72773
+  tps: 6838.99771
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9241.25266
-  tps: 7627.90486
+  dps: 8947.39282
+  tps: 7385.9545
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6375.53828
-  tps: 5528.38341
+  dps: 6312.12522
+  tps: 5477.11982
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4484.89841
-  tps: 3673.79536
+  dps: 4463.81908
+  tps: 3655.67378
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-Arms P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4518.65004
-  tps: 3729.40402
+  dps: 4404.16954
+  tps: 3638.06803
  }
 }
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7830.75952
-  tps: 6399.02212
+  dps: 7824.55468
+  tps: 6389.96807
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -45,630 +45,630 @@ character_stats_results: {
 dps_results: {
  key: "TestFury-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 6540.25845
-  tps: 4809.31556
+  dps: 6482.26922
+  tps: 4770.2299
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6739.91752
-  tps: 4956.44064
+  dps: 6647.50442
+  tps: 4892.31845
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6726.44488
-  tps: 4944.97566
+  dps: 6655.9588
+  tps: 4895.77917
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6783.41278
-  tps: 4987.71772
+  dps: 6709.42462
+  tps: 4939.90881
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6567.48357
-  tps: 4835.05797
+  dps: 6526.54563
+  tps: 4805.30611
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 5396.41951
-  tps: 3985.26083
+  dps: 5311.50925
+  tps: 3925.09441
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5328.92453
-  tps: 3938.18296
+  dps: 5320.41861
+  tps: 3933.26402
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5046.04486
-  tps: 3733.201
+  dps: 4989.36759
+  tps: 3692.08571
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6743.865
-  tps: 4861.31746
+  dps: 6664.43289
+  tps: 4807.98305
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6854.41758
-  tps: 5040.80522
+  dps: 6806.51367
+  tps: 5006.81051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6665.30809
-  tps: 4898.04731
+  dps: 6590.88816
+  tps: 4848.50832
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6700.63005
-  tps: 4924.33607
+  dps: 6644.80876
+  tps: 4884.61469
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 6625.3983
-  tps: 4872.05741
+  dps: 6557.47577
+  tps: 4824.31906
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 6480.06987
-  tps: 4766.33725
+  dps: 6489.39183
+  tps: 4776.86598
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6613.33517
-  tps: 4866.36941
+  dps: 6652.54749
+  tps: 4893.63275
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6526.78032
-  tps: 4799.61936
+  dps: 6464.26662
+  tps: 4754.54885
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6808.68422
-  tps: 5008.11147
+  dps: 6737.39207
+  tps: 4957.94657
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 5861.2516
-  tps: 4325.76174
+  dps: 5838.76372
+  tps: 4308.83534
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6743.865
-  tps: 4960.34377
+  dps: 6664.43289
+  tps: 4905.92125
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6743.865
-  tps: 4960.34377
+  dps: 6664.43289
+  tps: 4905.92125
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6783.41278
-  tps: 4987.71772
+  dps: 6709.42462
+  tps: 4939.90881
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6772.58141
-  tps: 4980.97927
+  dps: 6711.21656
+  tps: 4941.65609
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6743.865
-  tps: 4960.34377
+  dps: 6664.43289
+  tps: 4905.92125
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6712.53757
-  tps: 4933.12466
+  dps: 6614.97856
+  tps: 4864.73763
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6654.56245
-  tps: 4892.60717
+  dps: 6592.00911
+  tps: 4848.59276
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6623.02913
-  tps: 4870.59294
+  dps: 6585.90679
+  tps: 4843.98934
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6743.865
-  tps: 4960.34377
+  dps: 6664.43289
+  tps: 4905.92125
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6743.865
-  tps: 4960.34377
+  dps: 6664.43289
+  tps: 4905.92125
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6694.66424
-  tps: 4923.00168
+  dps: 6665.69158
+  tps: 4899.58176
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6480.06987
-  tps: 4766.33725
+  dps: 6489.39183
+  tps: 4776.86598
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 6428.44572
-  tps: 4726.12155
+  dps: 6376.25445
+  tps: 4690.06168
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6480.06987
-  tps: 4766.33725
+  dps: 6489.39183
+  tps: 4776.86598
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6783.41278
-  tps: 4987.71772
+  dps: 6709.42462
+  tps: 4939.90881
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6772.58141
-  tps: 4980.97927
+  dps: 6711.21656
+  tps: 4941.65609
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6753.07238
-  tps: 4963.46329
+  dps: 6673.35543
+  tps: 4905.39368
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6743.865
-  tps: 4960.34377
+  dps: 6664.43289
+  tps: 4905.92125
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6783.69132
-  tps: 4988.46813
+  dps: 6684.25818
+  tps: 4918.33553
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6480.06987
-  tps: 4766.33725
+  dps: 6489.39183
+  tps: 4776.86598
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6480.06987
-  tps: 4766.33725
+  dps: 6489.39183
+  tps: 4776.86598
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6706.40751
-  tps: 4928.80131
+  dps: 6680.85232
+  tps: 4916.23487
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6501.22455
-  tps: 4780.75785
+  dps: 6481.49828
+  tps: 4768.10778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtArmor"
  value: {
-  dps: 4079.2916
-  tps: 3028.67159
+  dps: 4077.17846
+  tps: 3025.74366
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 4912.95653
-  tps: 3634.18245
+  dps: 4875.23695
+  tps: 3607.52242
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6751.72431
-  tps: 4964.76889
+  dps: 6699.04294
+  tps: 4931.23441
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6783.69132
-  tps: 4988.46813
+  dps: 6684.25818
+  tps: 4918.33553
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6743.865
-  tps: 4960.34377
+  dps: 6664.43289
+  tps: 4905.92125
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6743.865
-  tps: 4960.34377
+  dps: 6664.43289
+  tps: 4905.92125
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6480.06987
-  tps: 4766.33725
+  dps: 6489.39183
+  tps: 4776.86598
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6480.06987
-  tps: 4766.33725
+  dps: 6489.39183
+  tps: 4776.86598
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6480.06987
-  tps: 4766.33725
+  dps: 6489.39183
+  tps: 4776.86598
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6870.12562
-  tps: 5053.41847
+  dps: 6800.09531
+  tps: 5002.44182
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6743.865
-  tps: 4960.34377
+  dps: 6664.43289
+  tps: 4905.92125
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6480.06987
-  tps: 4766.33725
+  dps: 6489.39183
+  tps: 4776.86598
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6476.99317
-  tps: 4762.83748
+  dps: 6445.04416
+  tps: 4741.33855
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6480.06987
-  tps: 4766.33725
+  dps: 6489.39183
+  tps: 4776.86598
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 6185.20073
-  tps: 4556.11947
+  dps: 6216.25822
+  tps: 4578.53802
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6480.06987
-  tps: 4766.33725
+  dps: 6489.39183
+  tps: 4776.86598
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SparkofLife-37657"
  value: {
-  dps: 6601.92481
-  tps: 4852.25636
+  dps: 6578.75418
+  tps: 4842.01689
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6761.73335
-  tps: 4973.34832
+  dps: 6698.3556
+  tps: 4930.30547
  }
 }
 dps_results: {
  key: "TestFury-AllItems-StormshroudArmor"
  value: {
-  dps: 4984.80828
-  tps: 3685.49837
+  dps: 4944.82348
+  tps: 3657.96025
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6783.69132
-  tps: 4988.46813
+  dps: 6684.25818
+  tps: 4918.33553
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6751.72431
-  tps: 4964.76889
+  dps: 6699.04294
+  tps: 4931.23441
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6726.12428
-  tps: 4946.12379
+  dps: 6656.08352
+  tps: 4899.13647
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 5071.59702
-  tps: 3743.04556
+  dps: 5000.74947
+  tps: 3692.94285
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5356.89991
-  tps: 3948.94623
+  dps: 5312.01978
+  tps: 3919.55162
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6724.54609
-  tps: 4946.89302
+  dps: 6722.11801
+  tps: 4946.78746
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6877.79952
-  tps: 5058.6391
+  dps: 6823.99962
+  tps: 5019.46207
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6906.14499
-  tps: 5080.00198
+  dps: 6891.95712
+  tps: 5065.05483
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6743.865
-  tps: 4960.34377
+  dps: 6664.43289
+  tps: 4905.92125
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6743.865
-  tps: 4960.34377
+  dps: 6664.43289
+  tps: 4905.92125
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6743.865
-  tps: 4960.34377
+  dps: 6664.43289
+  tps: 4905.92125
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6743.865
-  tps: 4960.34377
+  dps: 6664.43289
+  tps: 4905.92125
  }
 }
 dps_results: {
  key: "TestFury-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5343.85482
-  tps: 3945.41124
+  dps: 5320.68582
+  tps: 3930.79233
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6480.06987
-  tps: 4766.33725
+  dps: 6489.39183
+  tps: 4776.86598
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 6544.26735
-  tps: 4814.63309
+  dps: 6494.07719
+  tps: 4780.63432
  }
 }
 dps_results: {
  key: "TestFury-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 7123.37743
-  tps: 5245.57167
+  dps: 7108.12015
+  tps: 5235.91451
  }
 }
 dps_results: {
  key: "TestFury-Average-Default"
  value: {
-  dps: 6923.65271
-  tps: 5091.48649
+  dps: 6886.03735
+  tps: 5065.19461
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8849.74308
-  tps: 6879.86518
+  dps: 8786.83768
+  tps: 6841.33303
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6811.90977
-  tps: 5008.12625
+  dps: 6793.22263
+  tps: 4994.88074
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8055.03965
-  tps: 5913.98123
+  dps: 7847.56848
+  tps: 5764.58977
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4751.39632
-  tps: 3844.11646
+  dps: 4768.61145
+  tps: 3856.43077
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3309.08674
-  tps: 2462.81988
+  dps: 3294.70728
+  tps: 2453.28035
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3572.12974
-  tps: 2656.23064
+  dps: 3527.64203
+  tps: 2626.07403
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8923.33988
-  tps: 6939.37177
+  dps: 8888.44652
+  tps: 6918.08164
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6854.41758
-  tps: 5040.80522
+  dps: 6806.51367
+  tps: 5006.81051
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8192.16763
-  tps: 6019.23953
+  dps: 7946.95401
+  tps: 5841.12222
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4866.86365
-  tps: 3929.48871
+  dps: 4827.69837
+  tps: 3902.21168
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3312.88546
-  tps: 2465.33807
+  dps: 3316.16455
+  tps: 2469.53728
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-Fury P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3508.87443
-  tps: 2611.38249
+  dps: 3470.35877
+  tps: 2588.11608
  }
 }
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6342.54228
-  tps: 4667.6783
+  dps: 6306.39022
+  tps: 4639.94638
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -45,7 +45,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 0.81514
+  weights: 0.72129
   weights: 0
   weights: 0
   weights: 0
@@ -56,7 +56,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.13876
+  weights: 0.13778
   weights: 0
   weights: 0
   weights: 0
@@ -65,12 +65,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.01813
+  weights: -0.01878
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.43436
-  weights: 0.2588
+  weights: 0.435
+  weights: 0.12719
   weights: 0
   weights: 0
   weights: 0
@@ -89,632 +89,632 @@ stat_weights_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 2002.9354
-  tps: 5799.87838
+  dps: 2001.41397
+  tps: 5796.72367
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1976.00532
-  tps: 5732.64124
+  dps: 1973.68554
+  tps: 5727.83118
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2063.66365
-  tps: 5940.66746
+  dps: 2061.46016
+  tps: 5936.09851
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1989.50769
-  tps: 5758.18741
+  dps: 1986.98595
+  tps: 5752.95859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1948.10259
-  tps: 5644.05566
+  dps: 1945.52489
+  tps: 5638.7108
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1759.46944
-  tps: 5130.54064
+  dps: 1757.19871
+  tps: 5125.83229
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1740.50914
-  tps: 5071.68357
+  dps: 1736.83211
+  tps: 5061.9779
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1627.1703
-  tps: 4781.6918
+  dps: 1625.39817
+  tps: 4778.01729
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1974.22931
-  tps: 5606.67982
+  dps: 1972.14583
+  tps: 5602.44615
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2012.27016
-  tps: 5814.69996
+  dps: 2010.07805
+  tps: 5810.15461
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2046.49671
-  tps: 5899.6947
+  dps: 2043.59022
+  tps: 5893.66809
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2078.65308
-  tps: 5964.75256
+  dps: 2076.05597
+  tps: 5959.36745
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 2100.03605
-  tps: 6064.05685
+  dps: 2096.71923
+  tps: 6057.18301
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 2101.92561
-  tps: 6053.16841
+  dps: 2099.47459
+  tps: 6048.1283
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 2041.60523
-  tps: 5913.41824
+  dps: 2038.91389
+  tps: 5907.83775
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 2036.91768
-  tps: 5890.16438
+  dps: 2034.46278
+  tps: 5885.07416
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1993.86183
-  tps: 5769.20932
+  dps: 1991.37264
+  tps: 5764.04799
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 2118.90011
-  tps: 6074.03374
+  dps: 2136.70114
+  tps: 6125.82996
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1974.22931
-  tps: 5721.05082
+  dps: 1972.14583
+  tps: 5716.73074
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1974.22931
-  tps: 5721.05082
+  dps: 1972.14583
+  tps: 5716.73074
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1989.50769
-  tps: 5758.18741
+  dps: 1986.98595
+  tps: 5752.95859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1986.65426
-  tps: 5751.5131
+  dps: 1983.72244
+  tps: 5745.43398
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1987.28816
-  tps: 5756.25162
+  dps: 1985.20469
+  tps: 5751.93154
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2069.34602
-  tps: 5941.65384
+  dps: 2065.37649
+  tps: 5933.46762
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2031.08615
-  tps: 5863.61032
+  dps: 2028.5822
+  tps: 5858.41837
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2019.80446
-  tps: 5834.99497
+  dps: 2016.9798
+  tps: 5829.13804
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1974.22931
-  tps: 5721.05082
+  dps: 1972.14583
+  tps: 5716.73074
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1974.22931
-  tps: 5721.05082
+  dps: 1972.14583
+  tps: 5716.73074
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2041.3583
-  tps: 5904.65157
+  dps: 2039.48113
+  tps: 5900.75926
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1976.00532
-  tps: 5732.64124
+  dps: 1973.68554
+  tps: 5727.83118
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 2349.71126
-  tps: 6596.05721
+  dps: 2344.78171
+  tps: 6585.83579
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1976.00532
-  tps: 5732.64124
+  dps: 1973.68554
+  tps: 5727.83118
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1989.50769
-  tps: 5758.18741
+  dps: 1986.98595
+  tps: 5752.95859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1986.65426
-  tps: 5751.5131
+  dps: 1983.72244
+  tps: 5745.43398
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2062.36872
-  tps: 5954.3178
+  dps: 2059.5757
+  tps: 5948.52647
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1974.22931
-  tps: 5721.05082
+  dps: 1972.14583
+  tps: 5716.73074
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1976.70753
-  tps: 5721.18593
+  dps: 1973.92026
+  tps: 5715.40651
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1987.92579
-  tps: 5764.77344
+  dps: 1985.60601
+  tps: 5759.96338
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1976.00532
-  tps: 5732.64124
+  dps: 1973.68554
+  tps: 5727.83118
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2061.55588
-  tps: 5949.289
+  dps: 2058.77307
+  tps: 5943.51885
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1983.75654
-  tps: 5747.67539
+  dps: 1981.4368
+  tps: 5742.86542
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 1596.87788
-  tps: 4684.99878
+  dps: 1594.54102
+  tps: 4680.1533
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 1790.12054
-  tps: 5161.55378
+  dps: 1787.28887
+  tps: 5155.68233
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1982.41745
-  tps: 5745.14343
+  dps: 1980.58098
+  tps: 5741.33551
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1976.70753
-  tps: 5721.18593
+  dps: 1973.92026
+  tps: 5715.40651
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1974.22931
-  tps: 5721.05082
+  dps: 1972.14583
+  tps: 5716.73074
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1974.22931
-  tps: 5721.05082
+  dps: 1972.14583
+  tps: 5716.73074
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1976.00532
-  tps: 5732.64124
+  dps: 1973.68554
+  tps: 5727.83118
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1976.00532
-  tps: 5732.64124
+  dps: 1973.68554
+  tps: 5727.83118
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1976.00532
-  tps: 5732.64124
+  dps: 1973.68554
+  tps: 5727.83118
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1999.87133
-  tps: 5781.9813
+  dps: 1997.71838
+  tps: 5777.51715
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1974.22931
-  tps: 5721.05082
+  dps: 1972.14583
+  tps: 5716.73074
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1976.00532
-  tps: 5732.64124
+  dps: 1973.68554
+  tps: 5727.83118
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1973.87956
-  tps: 5722.56348
+  dps: 1971.25826
+  tps: 5717.12823
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1976.00532
-  tps: 5732.64124
+  dps: 1973.68554
+  tps: 5727.83118
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 2157.92737
-  tps: 6170.0384
+  dps: 2154.10753
+  tps: 6162.72074
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1976.00532
-  tps: 5732.64124
+  dps: 1973.68554
+  tps: 5727.83118
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SparkofLife-37657"
  value: {
-  dps: 1993.91419
-  tps: 5772.08232
+  dps: 1987.06961
+  tps: 5755.81578
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 2048.9071
-  tps: 5941.13032
+  dps: 2045.27151
+  tps: 5933.59194
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormshroudArmor"
  value: {
-  dps: 1597.09634
-  tps: 4692.15419
+  dps: 1594.83072
+  tps: 4687.45643
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1976.70753
-  tps: 5721.18593
+  dps: 1973.92026
+  tps: 5715.40651
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1982.41745
-  tps: 5745.14343
+  dps: 1980.58098
+  tps: 5741.33551
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1979.94858
-  tps: 5740.42288
+  dps: 1977.63782
+  tps: 5735.6315
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 1580.71132
-  tps: 4529.13126
+  dps: 1571.97541
+  tps: 4516.8015
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1739.40787
-  tps: 4944.85999
+  dps: 1728.34336
+  tps: 4918.93992
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1995.20031
-  tps: 5777.71374
+  dps: 1991.22652
+  tps: 5769.81194
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2086.53689
-  tps: 6034.63956
+  dps: 2082.37065
+  tps: 6026.00088
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2103.48725
-  tps: 6076.27182
+  dps: 2099.5459
+  tps: 6068.09945
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1974.22931
-  tps: 5721.05082
+  dps: 1972.14583
+  tps: 5716.73074
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1974.22931
-  tps: 5721.05082
+  dps: 1972.14583
+  tps: 5716.73074
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1974.22931
-  tps: 5721.05082
+  dps: 1972.14583
+  tps: 5716.73074
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1974.22931
-  tps: 5721.05082
+  dps: 1972.14583
+  tps: 5716.73074
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1725.66052
-  tps: 5029.67171
+  dps: 1723.31409
+  tps: 5024.80639
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WingedTalisman-37844"
  value: {
-  dps: 1976.00532
-  tps: 5732.64124
+  dps: 1973.68554
+  tps: 5727.83118
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 2310.55651
-  tps: 6540.8145
+  dps: 2305.80536
+  tps: 6530.963
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 2606.08043
-  tps: 7285.04174
+  dps: 2607.31799
+  tps: 7295.28323
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 2991.24697
-  tps: 7850.42651
-  dtps: 118.81527
+  dps: 2987.15779
+  tps: 7841.9434
+  dtps: 118.81739
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2026.4224
-  tps: 5426.74706
+  dps: 2023.09059
+  tps: 5419.83855
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2026.4224
-  tps: 5379.22163
+  dps: 2023.09059
+  tps: 5372.31313
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2193.59551
-  tps: 5776.03822
+  dps: 2180.23465
+  tps: 5748.33448
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1089.62095
-  tps: 2917.80638
+  dps: 1089.25982
+  tps: 2917.05759
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1089.62095
-  tps: 2870.19924
+  dps: 1089.25982
+  tps: 2869.45045
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1017.21049
-  tps: 2703.44043
+  dps: 1016.10545
+  tps: 2701.14914
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2057.29564
-  tps: 5512.26069
+  dps: 2053.79555
+  tps: 5505.00326
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2057.29564
-  tps: 5464.73436
+  dps: 2053.79555
+  tps: 5457.47693
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2275.2248
-  tps: 5983.62007
+  dps: 2258.86215
+  tps: 5949.69211
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1097.019
-  tps: 2945.66357
+  dps: 1096.6729
+  tps: 2944.94593
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1097.019
-  tps: 2898.0604
+  dps: 1096.6729
+  tps: 2897.34276
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1017.56702
-  tps: 2717.34824
+  dps: 1016.74964
+  tps: 2715.6534
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3101.33308
-  tps: 8149.37222
+  dps: 3097.37532
+  tps: 8139.36018
   dtps: 108.29049
  }
 }

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -77,10 +77,8 @@ type Warrior struct {
 	Bladestorm           *core.Spell
 	BladestormOH         *core.Spell
 
-	RendDots               *core.Dot
-	DeepWoundsDots         []*core.Dot
-	DeepWoundsTickDamage   []float64
-	DeepWoundsDamageBuffer []float64
+	RendDots       *core.Dot
+	DeepWoundsDots []*core.Dot
 
 	HeroicStrikeOrCleave     *core.Spell
 	HSOrCleaveQueueAura      *core.Aura
@@ -128,7 +126,7 @@ func (warrior *Warrior) AddRaidBuffs(raidBuffs *proto.RaidBuffs) {
 	}
 }
 
-func (warrior *Warrior) AddPartyBuffs(partyBuffs *proto.PartyBuffs) {
+func (warrior *Warrior) AddPartyBuffs(_ *proto.PartyBuffs) {
 }
 
 func (warrior *Warrior) Initialize() {
@@ -165,15 +163,13 @@ func (warrior *Warrior) Initialize() {
 
 	warrior.registerBloodrageCD()
 
-	warrior.DeepWoundsDamageBuffer = make([]float64, warrior.Env.GetNumTargets())
-	warrior.DeepWoundsTickDamage = make([]float64, warrior.Env.GetNumTargets())
 	warrior.DeepWoundsDots = make([]*core.Dot, warrior.Env.GetNumTargets())
-	for i := int32(0); i < warrior.Env.GetNumTargets(); i++ {
-		warrior.DeepWoundsDots[i] = warrior.newDeepWoundsDot(warrior.Env.GetTargetUnit(i))
+	for i := range warrior.DeepWoundsDots {
+		warrior.DeepWoundsDots[i] = warrior.newDeepWoundsDot(warrior.Env.GetTargetUnit(int32(i)))
 	}
 }
 
-func (warrior *Warrior) Reset(sim *core.Simulation) {
+func (warrior *Warrior) Reset(_ *core.Simulation) {
 	warrior.overpowerValidUntil = 0
 	warrior.rendValidUntil = 0
 


### PR DESCRIPTION
[core] added Dot.ApplyOrReset() for rolling dots like Ignite, Deep Wounds, etc.

[hunter] Piercing Shots now correctly resets the tick timer on proc; used Dot.SnapshotBaseDamage to model the rolling damage 

[mage] modelled Ignite like Piercing Shots, since that has much better "Timeline" support 

[warrior] dito for Deep Wounds, changing its base "average weapon damage" now includes all modifiers (dealt and taken), but Deep Wounds itself is only affected by Mangle*

The Deep Wounds "damage buffers" weren't reset in Reset() before, so DW damage was too high. All three dots had extra ticks when proc and tick happened at the same time (since cancelling the previous dot wrongly adds an extra tick in this case). The "damage buffers" were sometimes underflowing, and even producing negative ticks because of this.
"ApplyOrReset()" works around this, but I hope to change this "more fundamentally" in an upcoming patch.

*) @TheGroxEmpire I've updated [the](https://github.com/magey/wotlk-warrior/issues/26) accordingly