### PR TITLE
Post-BS 5 Upgrade Style Fixes

### DIFF
--- a/ui/core/_sim_ui.scss
+++ b/ui/core/_sim_ui.scss
@@ -151,7 +151,6 @@ td, th {
 	}
 
 	.sim-tabs {
-		padding-top: var(--bs-gap);
 		border-bottom: 0;
 	}
 

--- a/ui/core/components/_input.scss
+++ b/ui/core/components/_input.scss
@@ -15,5 +15,5 @@
 }
 
 .input-root.hide {
-	display: none;
+	display: none !important;
 }


### PR DESCRIPTION
1. Some inputs in the `Settings` tab were not being properly hidden
2. The sim nav tabs were distorted on ultrawide screen sizes because of spacing issues