### PR TITLE
ui: fix wowhead tooltips for set bonus highlighting

### DIFF
--- a/ui/core/components/gear_picker.ts
+++ b/ui/core/components/gear_picker.ts
@@ -33,6 +33,7 @@ import { makeShowMatchingGemsSelector } from './other_inputs.js';
 
 declare var $: any;
 declare var tippy: any;
+declare var WowSim: any;
 
 export class GearPicker extends Component {
 	// ItemSlot is used as the index
@@ -153,6 +154,16 @@ class ItemPicker extends Component {
 				this.player.setWowheadData(this._equippedItem, this.iconElem);
 			}
 		});
+
+		// Use hacky wowhead xhr override to 'preprocess' tooltips
+		WowSim.WhOnLoadHook = (a:any) => {
+			if (a.tooltip) {
+				// This fixes wowhead being able to parse 'pcs' aka set bonus highlighting in tooltip
+				// Their internal regex looks for 'href="/item=' but for wotlk we get 'href="/wotlk/item="'
+				a.tooltip = (<String>a.tooltip).replaceAll("href=\"/wotlk/item", "href=\"/item");
+			}
+			return a;
+		}
 	}
 
 	set item(newItem: EquippedItem | null) {

--- a/ui/index_template.html
+++ b/ui/index_template.html
@@ -35,6 +35,45 @@
   <!-- Load wowhead scripts after done loading everything else -->
   <script>const whTooltips = {colorLinks: true};</script>
   <script src="https://wow.zamimg.com/js/tooltips.js"></script>
+  <script>
+    var WowSim = {};
+    // Override wowheads xhrjsonrequest for our own usage of preprocessing
+    // This is basically a copy paste of WH.xhrJsonRequest, but with WhOnLoadHook hook
+    if (WH && WH.xhrJsonRequest) {   
+      WH.xhrJsonRequest = function(e, t) {
+      var a = new XMLHttpRequest;
+      a.onload = function(e) {
+          var a = e.target.response;
+          switch (e.target.responseType) {
+          case "json":
+              break;
+          case "":
+          case "text":
+              try {
+                  a = JSON.parse(a)
+              } catch (a) {
+                  WH.error("Could not parse expected JSON response", e.target);
+                  return t()
+              }
+              break;
+          default:
+              WH.error("Unexpected response type from JSON request", e.target);
+              return t()
+          }
+          if (WowSim.WhOnLoadHook)
+            a = WowSim.WhOnLoadHook(a)
+          return t(a)
+      };
+      a.onerror = function() {
+          return t()
+      };
+      a.open("GET", e, true);
+      a.responseType = "json";
+      a.send()
+    };
+  }
+
+  </script>
 	<!--<script>const aowow_tooltips = {colorlinks: true}</script>
 	<script type="text/javascript" src="https://wotlk.evowow.com/static/widgets/power.js"></script>-->
 </html>


### PR DESCRIPTION
 -  semi hacky but internal wowhead code doesnt give a nice way of fixing this, they have an internal regex that won't match otherwise

Signed-off-by: jarves <jarveson@gmail.com>