### PR TITLE
Fix medium/lower device sim header

### DIFF
--- a/ui/core/_sim_ui.scss
+++ b/ui/core/_sim_ui.scss
@@ -259,3 +259,22 @@ td, th {
 .hide-in-front-of-target .in-front-of-target {
 	display: none !important;
 }
+
+// TODO: Replace with Bootstrap media query once on to node module
+@media only screen and (max-width: 992px) {
+	.sim-header {
+		overflow-x: scroll;
+
+		.sim-tabs {
+			flex-wrap: nowrap;
+
+			.sim-link {
+				white-space: nowrap;
+			}
+		}
+	}
+
+	.known-issues {
+		white-space: nowrap;
+	}
+}


### PR DESCRIPTION
See https://discord.com/channels/891730968493305867/909597996449157160/1045153850081947699 for context

The header now overflows and can be "scrolled" by swiping
<img width="395" alt="image" src="https://user-images.githubusercontent.com/12898988/203689014-ffa589f1-803b-43c1-8e54-27e831453046.png">



<img width="407" alt="image" src="https://user-images.githubusercontent.com/12898988/203689053-7ed93dea-5d47-4f42-96a8-3cfa32b7434d.png">
