### PR TITLE
fix: blood tap logic

### DIFF
--- a/sim/core/runic_power.go
+++ b/sim/core/runic_power.go
@@ -791,7 +791,7 @@ func (rp *RunicPowerBar) UnholyRuneSpentAt(dur time.Duration) int32 {
 	return -1
 }
 
-func (rp *RunicPowerBar) RegenRune(regenAt time.Duration, slot int32) {
+func (rp *RunicPowerBar) RegenRune(regenAt time.Duration, slot int8) {
 	checkSpent := isSpents[slot]
 	if checkSpent&rp.runeStates > 0 {
 		rp.runeStates = ^checkSpent & rp.runeStates // unset spent flag for this rune.
@@ -970,7 +970,7 @@ func (rp *RunicPowerBar) Advance(sim *Simulation, newTime time.Duration) {
 	}
 }
 
-func (rp *RunicPowerBar) TryRegenRune(sim *Simulation, newTime time.Duration, slot int32) {
+func (rp *RunicPowerBar) TryRegenRune(sim *Simulation, newTime time.Duration, slot int8) {
 	if rp.runeMeta[slot].regenAt > newTime {
 		return
 	}

--- a/sim/core/runic_power.go
+++ b/sim/core/runic_power.go
@@ -420,8 +420,8 @@ func (rp *RunicPowerBar) ConvertToDeath(sim *Simulation, slot int8, revertOnSpen
 	}
 	rp.runeStates |= isDeaths[slot]
 
-	// revertOnSpend == true overrides anything
-	rp.runeMeta[slot].revertOnSpend = rp.runeMeta[slot].revertOnSpend || revertOnSpend
+	isBloodTapped := rp.btslot == slot
+	rp.runeMeta[slot].revertOnSpend = !isBloodTapped && (rp.runeMeta[slot].revertOnSpend || revertOnSpend)
 
 	if rp.runeMeta[slot].revertOnSpend {
 		rp.runeMeta[slot].revertAt = NeverExpires

--- a/sim/core/runic_power_helper.go
+++ b/sim/core/runic_power_helper.go
@@ -143,6 +143,8 @@ func (rp *RunicPowerBar) CorrectBloodTapConversion(sim *Simulation, bloodGainMet
 	if slot > -1 {
 		rp.btslot = slot
 		rp.ConvertToDeath(sim, slot, sim.CurrentTime+time.Second*20)
+		rp.GainRuneMetrics(sim, rp.deathRuneGainMetrics, 1)
+		rp.onDeathRuneGain(sim)
 	}
 
 	slot = -1
@@ -152,10 +154,7 @@ func (rp *RunicPowerBar) CorrectBloodTapConversion(sim *Simulation, bloodGainMet
 		slot = 1
 	}
 	if slot > -1 {
-		rp.runeStates = ^isSpents[slot] & rp.runeStates // unset spent flag for this rune.
-		rp.runeMeta[slot].regenAt = NeverExpires        // no regen timer if there was one
-		rp.GainRuneMetrics(sim, rp.deathRuneGainMetrics, 1)
-		rp.onDeathRuneGain(sim)
+		rp.RegenRune(sim.CurrentTime, slot)
 	}
 
 	// if PA isn't running, make it run 20s from now to disable BT

--- a/sim/core/runic_power_helper.go
+++ b/sim/core/runic_power_helper.go
@@ -152,16 +152,7 @@ func (rp *RunicPowerBar) CorrectBloodTapConversion(sim *Simulation, bloodGainMet
 		slot = 1
 	}
 	if slot > -1 {
-		rp.RegenRune(sim.CurrentTime, slot)
-
-		metrics := rp.bloodRuneGainMetrics
-		onGain := rp.onBloodRuneGain
-		if rp.runeStates&isDeaths[slot] == isDeaths[slot] {
-			metrics = rp.deathRuneGainMetrics
-			onGain = rp.onDeathRuneGain
-		}
-		rp.GainRuneMetrics(sim, metrics, 1)
-		onGain(sim)
+		rp.RegenRune(sim, sim.CurrentTime, slot)
 	}
 
 	// if PA isn't running, make it run 20s from now to disable BT

--- a/sim/core/runic_power_helper.go
+++ b/sim/core/runic_power_helper.go
@@ -141,8 +141,8 @@ func (rp *RunicPowerBar) CorrectBloodTapConversion(sim *Simulation, bloodGainMet
 		slot = 1
 	}
 	if slot > -1 {
-		rp.ConvertToDeath(sim, slot, false, sim.CurrentTime+time.Second*20)
 		rp.btslot = slot
+		rp.ConvertToDeath(sim, slot, sim.CurrentTime+time.Second*20)
 	}
 
 	slot = -1

--- a/sim/core/runic_power_helper.go
+++ b/sim/core/runic_power_helper.go
@@ -131,31 +131,24 @@ func (rp *RunicPowerBar) CancelBloodTap(sim *Simulation) {
 }
 
 func (rp *RunicPowerBar) CorrectBloodTapConversion(sim *Simulation, bloodGainMetrics *ResourceMetrics, deathGainMetrics *ResourceMetrics, spell *Spell) {
-	// so in english
-	// 1. try to convert active blood rune -> death rune
-	// 2. if no active blood, convert inactive blood rune -> death rune
+	// 1. converts a blood rune -> death rune
 	// 3. then convert one inactive blood or death rune -> active
 
 	slot := int8(-1)
-	if rp.runeStates&isSpentDeath[0] == 0 {
-		slot = 0 //
-	} else if rp.runeStates&isSpentDeath[1] == 0 {
-		slot = 1
-	} else if rp.runeStates&isDeaths[0] == 0 {
+	if rp.runeStates&isDeaths[0] == 0 {
 		slot = 0
 	} else if rp.runeStates&isDeaths[1] == 0 {
 		slot = 1
 	}
-	// If we found a blood rune, convert to death.
 	if slot > -1 {
 		rp.ConvertToDeath(sim, slot, false, sim.CurrentTime+time.Second*20)
 		rp.btslot = slot
 	}
 
 	slot = -1
-	if rp.runeStates&isSpents[0] > 0 {
+	if rp.runeStates&isSpents[0] == isSpents[0] {
 		slot = 0
-	} else if rp.runeStates&isSpents[1] > 0 {
+	} else if rp.runeStates&isSpents[1] == isSpents[1] {
 		slot = 1
 	}
 	if slot > -1 {

--- a/sim/core/runic_power_helper.go
+++ b/sim/core/runic_power_helper.go
@@ -143,8 +143,6 @@ func (rp *RunicPowerBar) CorrectBloodTapConversion(sim *Simulation, bloodGainMet
 	if slot > -1 {
 		rp.btslot = slot
 		rp.ConvertToDeath(sim, slot, sim.CurrentTime+time.Second*20)
-		rp.GainRuneMetrics(sim, rp.deathRuneGainMetrics, 1)
-		rp.onDeathRuneGain(sim)
 	}
 
 	slot = -1
@@ -155,6 +153,15 @@ func (rp *RunicPowerBar) CorrectBloodTapConversion(sim *Simulation, bloodGainMet
 	}
 	if slot > -1 {
 		rp.RegenRune(sim.CurrentTime, slot)
+
+		metrics := rp.bloodRuneGainMetrics
+		onGain := rp.onBloodRuneGain
+		if rp.runeStates&isDeaths[slot] == isDeaths[slot] {
+			metrics = rp.deathRuneGainMetrics
+			onGain = rp.onDeathRuneGain
+		}
+		rp.GainRuneMetrics(sim, metrics, 1)
+		onGain(sim)
 	}
 
 	// if PA isn't running, make it run 20s from now to disable BT

--- a/sim/core/runic_power_helper.go
+++ b/sim/core/runic_power_helper.go
@@ -132,7 +132,7 @@ func (rp *RunicPowerBar) CancelBloodTap(sim *Simulation) {
 
 func (rp *RunicPowerBar) CorrectBloodTapConversion(sim *Simulation, bloodGainMetrics *ResourceMetrics, deathGainMetrics *ResourceMetrics, spell *Spell) {
 	// 1. converts a blood rune -> death rune
-	// 3. then convert one inactive blood or death rune -> active
+	// 2. then convert one inactive blood or death rune -> active
 
 	slot := int8(-1)
 	if rp.runeStates&isDeaths[0] == 0 {

--- a/sim/core/runic_power_helper.go
+++ b/sim/core/runic_power_helper.go
@@ -121,7 +121,7 @@ func (rp *RunicPowerBar) GainDeathRuneMetrics(sim *Simulation, spell *Spell, cur
 }
 
 func (rp *RunicPowerBar) CancelBloodTap(sim *Simulation) {
-	if rp.btslot == -1 || rp.runeMeta[rp.btslot].revertOnSpend {
+	if rp.btslot == -1 {
 		return
 	}
 	rp.ConvertFromDeath(sim, rp.btslot)
@@ -134,7 +134,7 @@ func (rp *RunicPowerBar) CorrectBloodTapConversion(sim *Simulation, bloodGainMet
 	// so in english
 	// 1. try to convert active blood rune -> death rune
 	// 2. if no active blood, convert inactive blood rune -> death rune
-	// 3. then convert one inactive death rune -> active
+	// 3. then convert one inactive blood or death rune -> active
 
 	slot := int8(-1)
 	if rp.runeStates&isSpentDeath[0] == 0 {
@@ -153,9 +153,9 @@ func (rp *RunicPowerBar) CorrectBloodTapConversion(sim *Simulation, bloodGainMet
 	}
 
 	slot = -1
-	if rp.runeStates&isSpentDeath[0] == isSpentDeath[0] {
+	if rp.runeStates&isSpents[0] > 0 {
 		slot = 0
-	} else if rp.runeStates&isSpentDeath[1] == isSpentDeath[1] {
+	} else if rp.runeStates&isSpents[1] > 0 {
 		slot = 1
 	}
 	if slot > -1 {

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -45,456 +45,456 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7764.15938
-  tps: 4587.70882
+  dps: 7755.09436
+  tps: 4582.2536
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7693.25744
-  tps: 4553.10685
+  dps: 7699.03016
+  tps: 4556.35505
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7781.04157
-  tps: 4597.83814
+  dps: 7771.71239
+  tps: 4592.22442
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7473.26693
-  tps: 4415.41272
+  dps: 7517.22024
+  tps: 4441.65025
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6479.2423
-  tps: 3828.85541
+  dps: 6498.90232
+  tps: 3840.88667
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6372.36982
-  tps: 3767.72462
+  dps: 6356.04004
+  tps: 3757.84027
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6083.47932
-  tps: 3593.79763
+  dps: 6088.38947
+  tps: 3596.85462
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7758.18393
-  tps: 4492.44108
+  dps: 7749.12782
+  tps: 4487.10021
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7963.19969
-  tps: 4707.13301
+  dps: 7953.74535
+  tps: 4701.44419
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7647.65707
-  tps: 4525.64474
+  dps: 7639.09831
+  tps: 4520.49503
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7682.01025
-  tps: 4546.13837
+  dps: 7673.0316
+  tps: 4540.75118
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 7845.17831
-  tps: 4638.12879
+  dps: 7834.82032
+  tps: 4631.89819
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7768.72633
-  tps: 4592.2576
+  dps: 7759.55072
+  tps: 4586.73643
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7338.44621
-  tps: 4339.63726
+  dps: 7309.09106
+  tps: 4322.39028
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 6442.82689
-  tps: 3803.81216
+  dps: 6430.41666
+  tps: 3796.61023
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7441.18232
-  tps: 4393.92259
+  dps: 7432.05944
+  tps: 4388.43265
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7637.53948
-  tps: 4519.57419
+  dps: 7629.83395
+  tps: 4514.93641
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7560.82522
-  tps: 4473.54563
+  dps: 7551.97197
+  tps: 4468.21923
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7782.99041
-  tps: 4599.00744
+  dps: 7773.66123
+  tps: 4593.39373
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7758.18393
-  tps: 4584.12355
+  dps: 7749.12782
+  tps: 4578.67368
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7758.18393
-  tps: 4584.12355
+  dps: 7749.12782
+  tps: 4578.67368
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7781.04157
-  tps: 4597.83814
+  dps: 7771.71239
+  tps: 4592.22442
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7776.0287
-  tps: 4594.83042
+  dps: 7766.69952
+  tps: 4589.2167
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7758.18393
-  tps: 4584.12355
+  dps: 7749.12782
+  tps: 4578.67368
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7664.48655
-  tps: 4535.66627
+  dps: 7654.61574
+  tps: 4529.70678
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7633.2693
-  tps: 4517.01208
+  dps: 7623.96333
+  tps: 4511.41405
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7616.9029
-  tps: 4507.19224
+  dps: 7607.08469
+  tps: 4501.28686
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7758.18393
-  tps: 4584.12355
+  dps: 7749.12782
+  tps: 4578.67368
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7758.18393
-  tps: 4584.12355
+  dps: 7749.12782
+  tps: 4578.67368
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7441.85566
-  tps: 4394.32659
+  dps: 7432.73278
+  tps: 4388.83665
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7779.38789
-  tps: 4604.68323
+  dps: 7770.26968
+  tps: 4599.19785
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7541.48518
-  tps: 4461.94161
+  dps: 7532.66153
+  tps: 4456.63296
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7439.8792
-  tps: 4393.14072
+  dps: 7430.75632
+  tps: 4387.65078
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7541.48518
-  tps: 4461.94161
+  dps: 7532.66153
+  tps: 4456.63296
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7781.04157
-  tps: 4597.83814
+  dps: 7771.71239
+  tps: 4592.22442
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7776.0287
-  tps: 4594.83042
+  dps: 7766.69952
+  tps: 4589.2167
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7737.34
-  tps: 4579.4545
+  dps: 7727.91109
+  tps: 4573.7827
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7758.18393
-  tps: 4584.12355
+  dps: 7749.12782
+  tps: 4578.67368
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7789.09095
-  tps: 4602.66777
+  dps: 7779.99845
+  tps: 4597.19606
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7541.48518
-  tps: 4461.94161
+  dps: 7532.66153
+  tps: 4456.63296
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7541.48518
-  tps: 4461.94161
+  dps: 7532.66153
+  tps: 4456.63296
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7718.10553
-  tps: 4563.15767
+  dps: 7701.70306
+  tps: 4553.98244
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7553.99933
-  tps: 4469.4501
+  dps: 7545.15652
+  tps: 4464.12996
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7783.2039
-  tps: 4599.13554
+  dps: 7774.11833
+  tps: 4593.66798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7789.09095
-  tps: 4602.66777
+  dps: 7779.99845
+  tps: 4597.19606
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7758.18393
-  tps: 4584.12355
+  dps: 7749.12782
+  tps: 4578.67368
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7758.18393
-  tps: 4584.12355
+  dps: 7749.12782
+  tps: 4578.67368
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7541.48518
-  tps: 4461.94161
+  dps: 7532.66153
+  tps: 4456.63296
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7544.86035
-  tps: 4463.91971
+  dps: 7541.91338
+  tps: 4462.04114
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7545.78336
-  tps: 4464.47352
+  dps: 7542.8704
+  tps: 4462.61535
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7956.59992
-  tps: 4703.17315
+  dps: 7947.14396
+  tps: 4697.48336
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7442.64121
-  tps: 4394.79792
+  dps: 7433.51834
+  tps: 4389.30799
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7758.18393
-  tps: 4584.12355
+  dps: 7749.12782
+  tps: 4578.67368
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7541.48518
-  tps: 4461.94161
+  dps: 7532.66153
+  tps: 4456.63296
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7439.64559
-  tps: 4393.00055
+  dps: 7430.52271
+  tps: 4387.51061
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7126.06172
-  tps: 4212.87531
+  dps: 7117.06811
+  tps: 4207.43465
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 6411.77846
-  tps: 3785.7983
+  dps: 6416.60461
+  tps: 3788.74163
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8091.63025
-  tps: 4788.39719
+  dps: 8099.78518
+  tps: 4792.96803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6801.31665
-  tps: 4015.07557
+  dps: 6814.56288
+  tps: 4023.7542
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7560.09637
-  tps: 4473.10832
+  dps: 7551.25874
+  tps: 4467.79129
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7541.48518
-  tps: 4461.94161
+  dps: 7532.66153
+  tps: 4456.63296
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7454.26283
-  tps: 4401.7709
+  dps: 7443.74095
+  tps: 4395.44156
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7844.48443
-  tps: 4632.63705
+  dps: 7834.7233
+  tps: 4626.76326
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7875.666
-  tps: 4653.14582
+  dps: 7865.85987
+  tps: 4647.2456
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7541.48518
-  tps: 4461.94161
+  dps: 7532.66153
+  tps: 4456.63296
  }
 }
 dps_results: {
@@ -507,64 +507,64 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7702.03098
-  tps: 4557.77473
+  dps: 7708.34953
+  tps: 4561.74617
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StormshroudArmor"
  value: {
-  dps: 6005.66381
-  tps: 3547.57598
+  dps: 6037.29244
+  tps: 3566.95519
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7789.09095
-  tps: 4602.66777
+  dps: 7779.99845
+  tps: 4597.19606
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7783.2039
-  tps: 4599.13554
+  dps: 7774.11833
+  tps: 4593.66798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7772.90156
-  tps: 4592.95413
+  dps: 7763.82812
+  tps: 4587.49386
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7449.0918
-  tps: 4403.28939
+  dps: 7446.3754
+  tps: 4401.77842
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6493.26289
-  tps: 3834.01118
+  dps: 6487.45283
+  tps: 3830.7291
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6992.10964
-  tps: 4125.16584
+  dps: 6983.30738
+  tps: 4120.01533
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7771.38773
-  tps: 4591.17807
+  dps: 7780.82883
+  tps: 4597.0417
  }
 }
 dps_results: {
@@ -577,64 +577,64 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7737.24844
-  tps: 4579.34404
+  dps: 7743.70925
+  tps: 4583.25251
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7758.18393
-  tps: 4584.12355
+  dps: 7749.12782
+  tps: 4578.67368
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7758.18393
-  tps: 4584.12355
+  dps: 7749.12782
+  tps: 4578.67368
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7758.18393
-  tps: 4584.12355
+  dps: 7749.12782
+  tps: 4578.67368
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7758.18393
-  tps: 4584.12355
+  dps: 7749.12782
+  tps: 4578.67368
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6343.43841
-  tps: 3750.2391
+  dps: 6343.44473
+  tps: 3750.26579
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7541.48518
-  tps: 4461.94161
+  dps: 7532.66153
+  tps: 4456.63296
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7443.53899
-  tps: 4395.33659
+  dps: 7434.41612
+  tps: 4389.84666
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 7928.72144
-  tps: 4687.11278
+  dps: 7926.60775
+  tps: 4685.81692
  }
 }
 dps_results: {
@@ -668,8 +668,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3381.67093
-  tps: 1990.77378
+  dps: 3379.26952
+  tps: 1989.33294
  }
 }
 dps_results: {
@@ -710,8 +710,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3349.17529
-  tps: 1969.31163
+  dps: 3349.7051
+  tps: 1969.62951
  }
 }
 dps_results: {
@@ -724,7 +724,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7557.761
-  tps: 4468.53065
+  dps: 7547.84497
+  tps: 4462.94957
  }
 }

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -87,8 +87,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6088.38947
-  tps: 3596.85462
+  dps: 6088.40855
+  tps: 3596.86607
  }
 }
 dps_results: {
@@ -213,8 +213,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7654.61574
-  tps: 4529.70678
+  dps: 7654.64754
+  tps: 4529.72586
  }
 }
 dps_results: {
@@ -444,8 +444,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8099.78518
-  tps: 4792.96803
+  dps: 8099.83336
+  tps: 4792.99693
  }
 }
 dps_results: {
@@ -577,8 +577,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7743.70925
-  tps: 4583.25251
+  dps: 7743.75315
+  tps: 4583.27885
  }
 }
 dps_results: {
@@ -612,8 +612,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6343.44473
-  tps: 3750.26579
+  dps: 6343.47384
+  tps: 3750.28325
  }
 }
 dps_results: {
@@ -633,8 +633,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 7926.60775
-  tps: 4685.81692
+  dps: 7927.02328
+  tps: 4686.06623
  }
 }
 dps_results: {

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -45,596 +45,596 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7755.09436
-  tps: 4582.2536
+  dps: 7684.56704
+  tps: 4539.75682
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7699.03016
-  tps: 4556.35505
+  dps: 7656.19118
+  tps: 4530.73894
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7771.71239
-  tps: 4592.22442
+  dps: 7699.50241
+  tps: 4548.71804
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7517.22024
-  tps: 4441.65025
+  dps: 7447.48601
+  tps: 4399.88566
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6498.90232
-  tps: 3840.88667
+  dps: 6446.23871
+  tps: 3809.55674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6356.04004
-  tps: 3757.84027
+  dps: 6333.58123
+  tps: 3744.1338
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6088.40855
-  tps: 3596.86607
+  dps: 6052.47727
+  tps: 3575.71719
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7749.12782
-  tps: 4487.10021
+  dps: 7678.64277
+  tps: 4445.47821
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7953.74535
-  tps: 4701.44419
+  dps: 7879.84232
+  tps: 4656.92199
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7639.09831
-  tps: 4520.49503
+  dps: 7558.07744
+  tps: 4471.72091
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7673.0316
-  tps: 4540.75118
+  dps: 7610.12466
+  tps: 4503.01001
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 7834.82032
-  tps: 4631.89819
+  dps: 7758.36283
+  tps: 4585.84765
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7759.55072
-  tps: 4586.73643
+  dps: 7686.73937
+  tps: 4542.87357
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7309.09106
-  tps: 4322.39028
+  dps: 7316.5305
+  tps: 4326.76714
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 6430.41666
-  tps: 3796.61023
+  dps: 6389.34265
+  tps: 3771.88924
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7432.05944
-  tps: 4388.43265
+  dps: 7365.92175
+  tps: 4348.56965
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7629.83395
-  tps: 4514.93641
+  dps: 7553.26313
+  tps: 4468.83232
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7551.97197
-  tps: 4468.21923
+  dps: 7481.683
+  tps: 4425.88424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7773.66123
-  tps: 4593.39373
+  dps: 7702.25336
+  tps: 4550.36861
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7749.12782
-  tps: 4578.67368
+  dps: 7678.64277
+  tps: 4536.20226
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7749.12782
-  tps: 4578.67368
+  dps: 7678.64277
+  tps: 4536.20226
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7771.71239
-  tps: 4592.22442
+  dps: 7699.50241
+  tps: 4548.71804
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7766.69952
-  tps: 4589.2167
+  dps: 7693.99971
+  tps: 4545.41642
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7749.12782
-  tps: 4578.67368
+  dps: 7678.64277
+  tps: 4536.20226
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7654.64754
-  tps: 4529.72586
+  dps: 7578.89154
+  tps: 4484.12124
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7623.96333
-  tps: 4511.41405
+  dps: 7547.06688
+  tps: 4465.11457
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7607.08469
-  tps: 4501.28686
+  dps: 7533.15934
+  tps: 4456.77005
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7749.12782
-  tps: 4578.67368
+  dps: 7678.64277
+  tps: 4536.20226
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7749.12782
-  tps: 4578.67368
+  dps: 7678.64277
+  tps: 4536.20226
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7432.73278
-  tps: 4388.83665
+  dps: 7366.6217
+  tps: 4348.98962
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7770.26968
-  tps: 4599.19785
+  dps: 7698.27315
+  tps: 4555.83833
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7532.66153
-  tps: 4456.63296
+  dps: 7462.51208
+  tps: 4414.38169
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7430.75632
-  tps: 4387.65078
+  dps: 7364.55039
+  tps: 4347.74683
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7532.66153
-  tps: 4456.63296
+  dps: 7462.51208
+  tps: 4414.38169
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7771.71239
-  tps: 4592.22442
+  dps: 7699.50241
+  tps: 4548.71804
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7766.69952
-  tps: 4589.2167
+  dps: 7693.99971
+  tps: 4545.41642
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7727.91109
-  tps: 4573.7827
+  dps: 7655.66498
+  tps: 4530.27343
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7749.12782
-  tps: 4578.67368
+  dps: 7678.64277
+  tps: 4536.20226
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7779.99845
-  tps: 4597.19606
+  dps: 7709.28124
+  tps: 4554.58534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7532.66153
-  tps: 4456.63296
+  dps: 7462.51208
+  tps: 4414.38169
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7532.66153
-  tps: 4456.63296
+  dps: 7462.51208
+  tps: 4414.38169
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7701.70306
-  tps: 4553.98244
+  dps: 7679.03269
+  tps: 4540.1417
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7545.15652
-  tps: 4464.12996
+  dps: 7474.91679
+  tps: 4421.82452
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7774.11833
-  tps: 4593.66798
+  dps: 7703.44534
+  tps: 4551.0838
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7779.99845
-  tps: 4597.19606
+  dps: 7709.28124
+  tps: 4554.58534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7749.12782
-  tps: 4578.67368
+  dps: 7678.64277
+  tps: 4536.20226
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7749.12782
-  tps: 4578.67368
+  dps: 7678.64277
+  tps: 4536.20226
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7532.66153
-  tps: 4456.63296
+  dps: 7462.51208
+  tps: 4414.38169
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7541.91338
-  tps: 4462.04114
+  dps: 7467.33473
+  tps: 4417.09244
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7542.8704
-  tps: 4462.61535
+  dps: 7468.12045
+  tps: 4417.56387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7947.14396
-  tps: 4697.48336
+  dps: 7873.00556
+  tps: 4652.81993
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7433.51834
-  tps: 4389.30799
+  dps: 7367.4383
+  tps: 4349.47958
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7749.12782
-  tps: 4578.67368
+  dps: 7678.64277
+  tps: 4536.20226
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7532.66153
-  tps: 4456.63296
+  dps: 7462.51208
+  tps: 4414.38169
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7430.52271
-  tps: 4387.51061
+  dps: 7364.30944
+  tps: 4347.60226
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7117.06811
-  tps: 4207.43465
+  dps: 7051.03401
+  tps: 4167.7018
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 6416.60461
-  tps: 3788.74163
+  dps: 6370.81094
+  tps: 3761.24531
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8099.83336
-  tps: 4792.99693
+  dps: 8045.69159
+  tps: 4760.37349
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6814.56288
-  tps: 4023.7542
+  dps: 6746.7181
+  tps: 3982.67154
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7551.25874
-  tps: 4467.79129
+  dps: 7481.27405
+  tps: 4425.63887
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7532.66153
-  tps: 4456.63296
+  dps: 7462.51208
+  tps: 4414.38169
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7443.74095
-  tps: 4395.44156
+  dps: 7378.96413
+  tps: 4356.39507
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7834.7233
-  tps: 4626.76326
+  dps: 7765.08447
+  tps: 4584.78994
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7865.85987
-  tps: 4647.2456
+  dps: 7796.34823
+  tps: 4605.35471
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7532.66153
-  tps: 4456.63296
+  dps: 7462.51208
+  tps: 4414.38169
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 7613.97866
-  tps: 4504.91091
+  dps: 7495.44631
+  tps: 4433.47072
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7708.34953
-  tps: 4561.74617
+  dps: 7599.24549
+  tps: 4496.38954
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StormshroudArmor"
  value: {
-  dps: 6037.29244
-  tps: 3566.95519
+  dps: 5958.17881
+  tps: 3519.3701
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7779.99845
-  tps: 4597.19606
+  dps: 7709.28124
+  tps: 4554.58534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7774.11833
-  tps: 4593.66798
+  dps: 7703.44534
+  tps: 4551.0838
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7763.82812
-  tps: 4587.49386
+  dps: 7693.23252
+  tps: 4544.95611
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7446.3754
-  tps: 4401.77842
+  dps: 7421.00634
+  tps: 4386.36919
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6487.45283
-  tps: 3830.7291
+  dps: 6411.4611
+  tps: 3784.55393
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6983.30738
-  tps: 4120.01533
+  dps: 6912.73788
+  tps: 4077.53694
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7780.82883
-  tps: 4597.0417
+  dps: 7759.98597
+  tps: 4584.39717
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7712.45666
-  tps: 4564.81634
+  dps: 7596.46136
+  tps: 4495.13368
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7743.75315
-  tps: 4583.27885
+  dps: 7665.03753
+  tps: 4535.86672
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7749.12782
-  tps: 4578.67368
+  dps: 7678.64277
+  tps: 4536.20226
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7749.12782
-  tps: 4578.67368
+  dps: 7678.64277
+  tps: 4536.20226
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7749.12782
-  tps: 4578.67368
+  dps: 7678.64277
+  tps: 4536.20226
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7749.12782
-  tps: 4578.67368
+  dps: 7678.64277
+  tps: 4536.20226
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6343.47384
-  tps: 3750.28325
+  dps: 6319.65143
+  tps: 3735.70656
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7532.66153
-  tps: 4456.63296
+  dps: 7462.51208
+  tps: 4414.38169
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7434.41612
-  tps: 4389.84666
+  dps: 7368.37157
+  tps: 4350.03954
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 7927.02328
-  tps: 4686.06623
+  dps: 7855.9122
+  tps: 4643.41425
  }
 }
 dps_results: {
@@ -668,8 +668,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3379.26952
-  tps: 1989.33294
+  dps: 3379.36202
+  tps: 1989.38843
  }
 }
 dps_results: {
@@ -710,8 +710,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3349.7051
-  tps: 1969.62951
+  dps: 3349.82114
+  tps: 1969.69914
  }
 }
 dps_results: {
@@ -724,7 +724,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7547.84497
-  tps: 4462.94957
+  dps: 7486.07081
+  tps: 4425.84408
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -413,16 +413,16 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7623.64436
-  tps: 4812.7254
+  dps: 7623.6494
+  tps: 4812.73044
   hps: 271.30735
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7632.95899
-  tps: 4820.81885
+  dps: 7632.96403
+  tps: 4820.82388
   hps: 271.30735
  }
 }
@@ -469,8 +469,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7334.70409
-  tps: 4634.80637
+  dps: 7334.70675
+  tps: 4634.80903
   hps: 262.99243
  }
 }
@@ -701,8 +701,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 8156.2092
-  tps: 5096.28075
+  dps: 8156.48376
+  tps: 5096.46242
   hps: 272.99045
  }
 }
@@ -717,8 +717,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7569.7304
-  tps: 4843.96012
+  dps: 7569.73545
+  tps: 4843.96516
   hps: 205.40912
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -45,25 +45,25 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8071.43222
-  tps: 5017.49648
-  hps: 274.08545
+  dps: 8078.92749
+  tps: 5014.6546
+  hps: 276.02245
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7776.31753
-  tps: 4942.53239
-  hps: 271.30735
+  dps: 7775.15791
+  tps: 4939.43691
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8090.58136
-  tps: 5035.80396
-  hps: 269.08872
+  dps: 8098.81057
+  tps: 5035.01005
+  hps: 270.9904
  }
 }
 dps_results: {
@@ -77,8 +77,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6615.30038
-  tps: 4176.54037
+  dps: 6615.2488
+  tps: 4177.19642
   hps: 243.53664
  }
 }
@@ -101,369 +101,369 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8071.43222
-  tps: 4917.14655
-  hps: 269.08872
+  dps: 8078.92749
+  tps: 4914.36151
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8158.21766
-  tps: 5101.65476
-  hps: 269.08872
+  dps: 8166.51844
+  tps: 5100.81441
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7635.31645
-  tps: 4839.99516
-  hps: 269.08872
+  dps: 7646.26291
+  tps: 4840.35568
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7705.13137
-  tps: 4895.22183
-  hps: 270.67346
+  dps: 7702.4174
+  tps: 4892.79422
+  hps: 270.35651
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 7950.7746
-  tps: 4974.07652
-  hps: 269.08872
+  dps: 7959.6797
+  tps: 4973.15132
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7902.34343
-  tps: 4931.54498
-  hps: 269.08872
+  dps: 7910.40893
+  tps: 4930.80604
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7546.38054
-  tps: 4843.60555
-  hps: 257.57427
+  dps: 7541.61195
+  tps: 4847.20499
+  hps: 254.82436
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 6690.88428
-  tps: 4202.07829
-  hps: 293.82063
+  dps: 6690.85317
+  tps: 4198.86534
+  hps: 292.44764
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7618.68691
-  tps: 4820.69503
-  hps: 269.08872
+  dps: 7627.63843
+  tps: 4821.6197
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7539.88824
-  tps: 4745.77033
-  hps: 269.08872
+  dps: 7548.97384
+  tps: 4746.65428
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8093.23916
-  tps: 5038.70828
-  hps: 269.08872
+  dps: 8100.73111
+  tps: 5037.68148
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8071.43222
-  tps: 5017.49648
-  hps: 274.08545
+  dps: 8078.92749
+  tps: 5014.6546
+  hps: 276.02245
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8071.43222
-  tps: 5017.49648
-  hps: 269.08872
+  dps: 8078.92749
+  tps: 5014.6546
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8090.58136
-  tps: 5035.80396
-  hps: 269.08872
+  dps: 8098.81057
+  tps: 5035.01005
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8086.51557
-  tps: 5032.97545
-  hps: 269.08872
+  dps: 8094.9814
+  tps: 5032.18423
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8071.43222
-  tps: 5017.49648
-  hps: 269.08872
+  dps: 8078.92749
+  tps: 5014.6546
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7714.6514
-  tps: 4910.98324
-  hps: 272.57514
+  dps: 7704.59955
+  tps: 4899.79401
+  hps: 270.35651
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7622.34029
-  tps: 4827.59549
-  hps: 269.08872
+  dps: 7635.43007
+  tps: 4830.15944
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7607.48521
-  tps: 4812.86054
-  hps: 269.08872
+  dps: 7617.29744
+  tps: 4813.40379
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8071.43222
-  tps: 5017.49648
-  hps: 269.08872
+  dps: 8078.92749
+  tps: 5014.6546
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8071.43222
-  tps: 5017.49648
-  hps: 269.08872
+  dps: 8078.92749
+  tps: 5014.6546
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 8163.39064
-  tps: 5103.01454
-  hps: 269.08872
+  dps: 8172.16759
+  tps: 5102.53116
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7802.11814
-  tps: 4952.31895
-  hps: 269.08872
+  dps: 7811.44062
+  tps: 4953.08616
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7539.88824
-  tps: 4745.77033
-  hps: 269.08872
+  dps: 7548.97384
+  tps: 4746.65428
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 8105.91752
-  tps: 5055.62225
-  hps: 269.08872
+  dps: 8112.52337
+  tps: 5053.27284
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7539.88824
-  tps: 4745.77033
-  hps: 269.08872
+  dps: 7548.97384
+  tps: 4746.65428
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8090.58136
-  tps: 5035.80396
-  hps: 269.08872
+  dps: 8098.81057
+  tps: 5035.01005
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8086.51557
-  tps: 5032.97545
-  hps: 269.08872
+  dps: 8094.9814
+  tps: 5032.18423
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7704.75419
-  tps: 4880.40559
-  hps: 269.08872
+  dps: 7714.02511
+  tps: 4881.35279
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8071.43222
-  tps: 5017.49648
-  hps: 269.08872
+  dps: 8078.92749
+  tps: 5014.6546
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8105.91492
-  tps: 5044.62807
-  hps: 269.08872
+  dps: 8113.42961
+  tps: 5041.76169
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7539.88824
-  tps: 4745.77033
-  hps: 269.08872
+  dps: 7548.97384
+  tps: 4746.65428
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7539.88824
-  tps: 4745.77033
-  hps: 269.08872
+  dps: 7548.97384
+  tps: 4746.65428
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7539.88824
-  tps: 4745.77033
-  hps: 269.08872
+  dps: 7548.97384
+  tps: 4746.65428
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8099.34678
-  tps: 5039.46015
-  hps: 269.08872
+  dps: 8106.85777
+  tps: 5036.59843
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8105.91492
-  tps: 5044.62807
-  hps: 269.08872
+  dps: 8113.42961
+  tps: 5041.76169
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8071.43222
-  tps: 5017.49648
-  hps: 273.14857
+  dps: 8078.92749
+  tps: 5014.6546
+  hps: 275.07894
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8071.43222
-  tps: 5017.49648
-  hps: 274.08545
+  dps: 8078.92749
+  tps: 5014.6546
+  hps: 276.02245
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7539.88824
-  tps: 4745.77033
-  hps: 269.08872
+  dps: 7548.97384
+  tps: 4746.65428
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7618.48484
-  tps: 4812.25818
-  hps: 271.6243
+  dps: 7623.64436
+  tps: 4812.7254
+  hps: 271.30735
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7627.82548
-  tps: 4820.41141
-  hps: 271.6243
+  dps: 7632.95899
+  tps: 4820.81885
+  hps: 271.30735
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8145.83978
-  tps: 5089.00458
-  hps: 269.08872
+  dps: 8154.04586
+  tps: 5088.18274
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 8183.86663
-  tps: 5119.35949
-  hps: 269.08872
+  dps: 8193.3096
+  tps: 5119.27099
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8071.43222
-  tps: 5017.49648
-  hps: 269.08872
+  dps: 8078.92749
+  tps: 5014.6546
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7539.88824
-  tps: 4745.77033
-  hps: 269.08872
+  dps: 7548.97384
+  tps: 4746.65428
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 8100.50258
-  tps: 5051.47122
-  hps: 269.08872
+  dps: 8106.96644
+  tps: 5049.10315
+  hps: 270.9904
  }
 }
 dps_results: {
@@ -477,9 +477,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6716.43862
-  tps: 4202.83311
-  hps: 276.29628
+  dps: 6716.16235
+  tps: 4203.24023
+  hps: 275.97161
  }
 }
 dps_results: {
@@ -493,57 +493,57 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7301.29634
-  tps: 4702.31395
+  dps: 7295.24452
+  tps: 4695.10964
   hps: 321.15366
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7539.88824
-  tps: 4745.77033
-  hps: 269.08872
+  dps: 7548.97384
+  tps: 4746.65428
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7539.88824
-  tps: 4745.77033
-  hps: 269.08872
+  dps: 7548.97384
+  tps: 4746.65428
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 8067.30168
-  tps: 5027.82168
-  hps: 269.08872
+  dps: 8071.93338
+  tps: 5023.89164
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8290.5646
-  tps: 5178.15904
-  hps: 269.08872
+  dps: 8296.18192
+  tps: 5172.75542
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 8156.75421
-  tps: 5084.45944
-  hps: 269.08872
+  dps: 8156.6933
+  tps: 5079.37886
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7539.88824
-  tps: 4745.77033
-  hps: 304.69048
+  dps: 7548.97384
+  tps: 4746.65428
+  hps: 306.84377
  }
 }
 dps_results: {
@@ -557,8 +557,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7793.06903
-  tps: 4876.18902
+  dps: 7790.80006
+  tps: 4874.19486
   hps: 267.82092
  }
 }
@@ -573,32 +573,32 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8105.91492
-  tps: 5044.62807
-  hps: 269.08872
+  dps: 8113.42961
+  tps: 5041.76169
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8099.34678
-  tps: 5039.46015
-  hps: 269.08872
+  dps: 8106.85777
+  tps: 5036.59843
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8087.85255
-  tps: 5030.41628
-  hps: 269.08872
+  dps: 8095.35707
+  tps: 5027.56274
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7828.6922
-  tps: 5037.99256
+  dps: 7847.85152
+  tps: 5038.85072
   hps: 282.43656
  }
 }
@@ -629,97 +629,97 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7732.34978
-  tps: 4902.9263
-  hps: 272.89209
+  dps: 7720.29537
+  tps: 4895.21528
+  hps: 271.30735
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7771.93394
-  tps: 4926.16895
-  hps: 273.20904
+  dps: 7770.67746
+  tps: 4920.19329
+  hps: 272.89209
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8071.43222
-  tps: 5017.49648
-  hps: 269.08872
+  dps: 8078.92749
+  tps: 5014.6546
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8071.43222
-  tps: 5017.49648
-  hps: 269.08872
+  dps: 8078.92749
+  tps: 5014.6546
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8071.43222
-  tps: 5017.49648
-  hps: 269.08872
+  dps: 8078.92749
+  tps: 5014.6546
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8071.43222
-  tps: 5017.49648
-  hps: 269.08872
+  dps: 8078.92749
+  tps: 5014.6546
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6460.11491
-  tps: 4120.8529
-  hps: 234.77158
+  dps: 6472.48082
+  tps: 4125.61254
+  hps: 235.87899
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7539.88824
-  tps: 4745.77033
-  hps: 269.08872
+  dps: 7548.97384
+  tps: 4746.65428
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 8207.26778
-  tps: 5138.03943
-  hps: 269.08872
+  dps: 8217.47191
+  tps: 5138.40222
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 8156.44922
-  tps: 5096.20758
-  hps: 272.96251
+  dps: 8156.40233
+  tps: 5096.24714
+  hps: 272.9399
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30261.52614
-  tps: 31576.68524
+  dps: 30254.32199
+  tps: 31569.46241
   hps: 203.96258
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7570.17605
-  tps: 4848.73515
-  hps: 205.8913
+  dps: 7566.00809
+  tps: 4833.4937
+  hps: 207.09676
  }
 }
 dps_results: {
@@ -757,17 +757,17 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30614.91992
-  tps: 31819.02902
+  dps: 30607.81349
+  tps: 31811.89405
   hps: 204.55968
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7769.39837
-  tps: 4860.18116
-  hps: 204.80091
+  dps: 7779.59729
+  tps: 4862.77134
+  hps: 206.24826
  }
 }
 dps_results: {

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -45,681 +45,681 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8072.12738
-  tps: 5014.22875
-  hps: 274.40829
+  dps: 8070.18558
+  tps: 5006.59306
+  hps: 279.25079
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7775.15791
-  tps: 4939.43691
-  hps: 270.9904
+  dps: 7755.89756
+  tps: 4918.34341
+  hps: 271.6243
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8091.59062
-  tps: 5034.10195
-  hps: 269.40566
+  dps: 8090.48569
+  tps: 5026.84457
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7858.93063
-  tps: 4861.93516
-  hps: 263.76248
+  dps: 7840.70664
+  tps: 4845.80637
+  hps: 262.83591
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6613.72468
-  tps: 4174.26318
-  hps: 243.2528
+  dps: 6626.29868
+  tps: 4178.53486
+  hps: 241.2659
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6443.46109
-  tps: 4113.49947
-  hps: 227.61026
+  dps: 6434.04955
+  tps: 4081.29228
+  hps: 229.7677
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6214.05021
-  tps: 3908.11165
-  hps: 227.7306
+  dps: 6219.20988
+  tps: 3919.12024
+  hps: 226.66145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8072.12738
-  tps: 4913.94417
-  hps: 269.40566
+  dps: 8070.18558
+  tps: 4906.46119
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8159.09686
-  tps: 5099.76468
-  hps: 269.40566
+  dps: 8157.99929
+  tps: 5092.59656
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7638.84766
-  tps: 4839.17784
-  hps: 269.40566
+  dps: 7622.36801
+  tps: 4827.52377
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7702.4174
-  tps: 4892.79422
-  hps: 270.35651
+  dps: 7691.59799
+  tps: 4882.78015
+  hps: 272.89209
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 7952.32235
-  tps: 4971.33415
-  hps: 269.40566
+  dps: 7951.09245
+  tps: 4965.16475
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7902.98919
-  tps: 4929.633
-  hps: 269.40566
+  dps: 7903.03714
+  tps: 4922.5394
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7544.58238
-  tps: 4847.70143
-  hps: 256.35209
+  dps: 7544.1793
+  tps: 4825.67473
+  hps: 263.07407
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 6690.85317
-  tps: 4198.86534
-  hps: 292.44764
+  dps: 6664.38969
+  tps: 4179.56875
+  hps: 290.73139
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7618.32881
-  tps: 4817.67055
-  hps: 269.40566
+  dps: 7607.75847
+  tps: 4813.84209
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7541.80615
-  tps: 4745.33527
-  hps: 269.40566
+  dps: 7531.06435
+  tps: 4737.99648
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8093.21299
-  tps: 5036.49565
-  hps: 269.40566
+  dps: 8092.20255
+  tps: 5028.80654
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8072.12738
-  tps: 5014.22875
-  hps: 274.40829
+  dps: 8070.18558
+  tps: 5006.59306
+  hps: 279.25079
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8072.12738
-  tps: 5014.22875
-  hps: 269.40566
+  dps: 8070.18558
+  tps: 5006.59306
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8091.59062
-  tps: 5034.10195
-  hps: 269.40566
+  dps: 8090.48569
+  tps: 5026.84457
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8087.30439
-  tps: 5031.05226
-  hps: 269.40566
+  dps: 8086.36908
+  tps: 5023.0087
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8072.12738
-  tps: 5014.22875
-  hps: 269.40566
+  dps: 8070.18558
+  tps: 5006.59306
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7708.29483
-  tps: 4904.24255
-  hps: 270.67346
+  dps: 7698.13595
+  tps: 4895.93718
+  hps: 272.57514
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7625.87381
-  tps: 4826.75928
-  hps: 269.40566
+  dps: 7613.72032
+  tps: 4818.81722
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7610.13048
-  tps: 4811.56659
-  hps: 269.40566
+  dps: 7598.93805
+  tps: 4805.59676
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8072.12738
-  tps: 5014.22875
-  hps: 269.40566
+  dps: 8070.18558
+  tps: 5006.59306
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8072.12738
-  tps: 5014.22875
-  hps: 269.40566
+  dps: 8070.18558
+  tps: 5006.59306
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 8164.45565
-  tps: 5101.33135
-  hps: 269.40566
+  dps: 8164.12254
+  tps: 5093.92315
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7804.00495
-  tps: 4951.71411
-  hps: 269.40566
+  dps: 7792.81489
+  tps: 4944.10804
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7541.80615
-  tps: 4745.33527
-  hps: 269.40566
+  dps: 7531.06435
+  tps: 4737.99648
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 8105.51421
-  tps: 5051.97729
-  hps: 269.40566
+  dps: 8105.17261
+  tps: 5046.12741
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7541.80615
-  tps: 4745.33527
-  hps: 269.40566
+  dps: 7531.06435
+  tps: 4737.99648
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8091.59062
-  tps: 5034.10195
-  hps: 269.40566
+  dps: 8090.48569
+  tps: 5026.84457
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8087.30439
-  tps: 5031.05226
-  hps: 269.40566
+  dps: 8086.36908
+  tps: 5023.0087
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7706.8435
-  tps: 4880.08945
-  hps: 269.40566
+  dps: 7696.14245
+  tps: 4872.92218
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8072.12738
-  tps: 5014.22875
-  hps: 269.40566
+  dps: 8070.18558
+  tps: 5006.59306
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8106.60661
-  tps: 5041.33131
-  hps: 269.40566
+  dps: 8104.59972
+  tps: 5033.66145
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7541.80615
-  tps: 4745.33527
-  hps: 269.40566
+  dps: 7531.06435
+  tps: 4737.99648
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7541.80615
-  tps: 4745.33527
-  hps: 269.40566
+  dps: 7531.06435
+  tps: 4737.99648
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7541.80615
-  tps: 4745.33527
-  hps: 269.40566
+  dps: 7531.06435
+  tps: 4737.99648
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8100.03913
-  tps: 5036.16892
-  hps: 269.40566
+  dps: 8098.04464
+  tps: 5028.50557
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8106.60661
-  tps: 5041.33131
-  hps: 269.40566
+  dps: 8104.59972
+  tps: 5033.66145
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8072.12738
-  tps: 5014.22875
-  hps: 273.4703
+  dps: 8070.18558
+  tps: 5006.59306
+  hps: 278.29624
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8072.12738
-  tps: 5014.22875
-  hps: 274.40829
+  dps: 8070.18558
+  tps: 5006.59306
+  hps: 279.25079
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7541.80615
-  tps: 4745.33527
-  hps: 269.40566
+  dps: 7531.06435
+  tps: 4737.99648
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7623.6494
-  tps: 4812.73044
-  hps: 271.30735
+  dps: 7611.42844
+  tps: 4799.22214
+  hps: 273.52599
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7632.96403
-  tps: 4820.82388
-  hps: 271.30735
+  dps: 7620.82225
+  tps: 4807.43341
+  hps: 273.52599
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8146.46551
-  tps: 5087.00487
-  hps: 269.40566
+  dps: 8146.06283
+  tps: 5079.66027
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 8185.44414
-  tps: 5118.04558
-  hps: 269.40566
+  dps: 8185.19221
+  tps: 5110.56316
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8072.12738
-  tps: 5014.22875
-  hps: 269.40566
+  dps: 8070.18558
+  tps: 5006.59306
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7541.80615
-  tps: 4745.33527
-  hps: 269.40566
+  dps: 7531.06435
+  tps: 4737.99648
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 8099.96711
-  tps: 5047.83335
-  hps: 269.40566
+  dps: 8099.57922
+  tps: 5041.85026
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7334.70675
-  tps: 4634.80903
-  hps: 262.99243
+  dps: 7336.21957
+  tps: 4640.23045
+  hps: 267.62802
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6716.16235
-  tps: 4203.24023
-  hps: 275.97161
+  dps: 6711.43403
+  tps: 4188.48986
+  hps: 277.91964
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8076.81521
-  tps: 5274.15106
-  hps: 302.12622
+  dps: 8064.51532
+  tps: 5279.54694
+  hps: 301.06613
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7295.24452
-  tps: 4695.10964
-  hps: 321.15366
+  dps: 7294.1507
+  tps: 4695.67345
+  hps: 318.52434
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7541.80615
-  tps: 4745.33527
-  hps: 269.40566
+  dps: 7531.06435
+  tps: 4737.99648
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7541.80615
-  tps: 4745.33527
-  hps: 269.40566
+  dps: 7531.06435
+  tps: 4737.99648
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 8064.33068
-  tps: 5022.21329
-  hps: 269.40566
+  dps: 8065.41094
+  tps: 5019.98703
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8288.96272
-  tps: 5171.5048
-  hps: 269.40566
+  dps: 8276.04364
+  tps: 5166.75052
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 8151.67408
-  tps: 5079.20881
-  hps: 269.40566
+  dps: 8145.34811
+  tps: 5072.29896
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7541.80615
-  tps: 4745.33527
-  hps: 305.04936
+  dps: 7531.06435
+  tps: 4737.99648
+  hps: 310.43258
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 7651.50607
-  tps: 4804.9846
-  hps: 273.52599
+  dps: 7635.55231
+  tps: 4784.72498
+  hps: 277.01241
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7790.80006
-  tps: 4874.19486
-  hps: 267.82092
+  dps: 7792.32471
+  tps: 4867.25816
+  hps: 271.30735
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StormshroudArmor"
  value: {
-  dps: 6135.31912
-  tps: 3903.67112
-  hps: 212.51701
+  dps: 6144.52124
+  tps: 3909.20267
+  hps: 212.26903
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8106.60661
-  tps: 5041.33131
-  hps: 269.40566
+  dps: 8104.59972
+  tps: 5033.66145
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8100.03913
-  tps: 5036.16892
-  hps: 269.40566
+  dps: 8098.04464
+  tps: 5028.50557
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8088.54606
-  tps: 5027.13473
-  hps: 269.40566
+  dps: 8086.57327
+  tps: 5019.48277
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7849.85742
-  tps: 5042.24809
-  hps: 283.09878
+  dps: 7837.95789
+  tps: 5027.74998
+  hps: 277.46991
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6843.96444
-  tps: 4252.0113
-  hps: 297.63151
+  dps: 6825.85065
+  tps: 4249.23226
+  hps: 293.11668
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7529.21279
-  tps: 4636.78232
-  hps: 262.6484
+  dps: 7490.56189
+  tps: 4609.99821
+  hps: 262.03473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8115.95188
-  tps: 5024.20889
-  hps: 277.96326
+  dps: 8126.06177
+  tps: 5026.90596
+  hps: 275.74462
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7720.29537
-  tps: 4895.21528
-  hps: 271.30735
+  dps: 7740.67667
+  tps: 4914.18042
+  hps: 271.6243
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7770.67746
-  tps: 4920.19329
-  hps: 272.89209
+  dps: 7742.65206
+  tps: 4916.86883
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8072.12738
-  tps: 5014.22875
-  hps: 269.40566
+  dps: 8070.18558
+  tps: 5006.59306
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8072.12738
-  tps: 5014.22875
-  hps: 269.40566
+  dps: 8070.18558
+  tps: 5006.59306
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8072.12738
-  tps: 5014.22875
-  hps: 269.40566
+  dps: 8070.18558
+  tps: 5006.59306
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8072.12738
-  tps: 5014.22875
-  hps: 269.40566
+  dps: 8070.18558
+  tps: 5006.59306
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6472.48082
-  tps: 4125.61254
-  hps: 235.87899
+  dps: 6475.63956
+  tps: 4127.17351
+  hps: 238.64753
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7541.80615
-  tps: 4745.33527
-  hps: 269.40566
+  dps: 7531.06435
+  tps: 4737.99648
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 8209.43098
-  tps: 5137.14755
-  hps: 269.40566
+  dps: 8209.27182
+  tps: 5129.58033
+  hps: 274.15988
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 8156.48376
-  tps: 5096.46242
-  hps: 272.99045
+  dps: 8142.8681
+  tps: 5085.62796
+  hps: 271.95064
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30254.32199
-  tps: 31569.46241
-  hps: 203.96258
+  dps: 30549.04724
+  tps: 31988.11453
+  hps: 200.10513
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7569.73545
-  tps: 4843.96516
-  hps: 205.40912
+  dps: 7560.97675
+  tps: 4829.48025
+  hps: 206.13239
  }
 }
 dps_results: {
@@ -733,41 +733,41 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 17812.21958
-  tps: 20398.15732
-  hps: 122.15683
+  dps: 17772.57338
+  tps: 20369.64711
+  hps: 121.59325
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3676.92998
-  tps: 2739.1147
-  hps: 120.88877
+  dps: 3673.1238
+  tps: 2728.45212
+  hps: 120.32518
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5038.4541
-  tps: 2628.07553
+  dps: 5026.71409
+  tps: 2616.9687
   hps: 110.60336
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30607.81349
-  tps: 31811.89405
-  hps: 204.55968
+  dps: 30708.0132
+  tps: 31974.66142
+  hps: 202.8711
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7771.34954
-  tps: 4860.32624
-  hps: 205.04213
+  dps: 7771.69841
+  tps: 4854.08882
+  hps: 208.66052
  }
 }
 dps_results: {
@@ -781,32 +781,32 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 17990.04202
-  tps: 20532.56541
+  dps: 17935.02447
+  tps: 20512.08882
   hps: 120.13882
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3777.11342
-  tps: 2752.61894
-  hps: 120.98486
+  dps: 3763.24102
+  tps: 2747.12572
+  hps: 121.26688
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5259.61053
-  tps: 2656.53424
+  dps: 5248.00915
+  tps: 2645.26906
   hps: 111.39632
  }
 }
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7796.45831
-  tps: 4924.8572
-  hps: 268.77177
+  dps: 7764.70259
+  tps: 4905.14341
+  hps: 265.91924
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -45,9 +45,9 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8078.92749
-  tps: 5014.6546
-  hps: 276.02245
+  dps: 8072.12738
+  tps: 5014.22875
+  hps: 274.40829
  }
 }
 dps_results: {
@@ -61,9 +61,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8098.81057
-  tps: 5035.01005
-  hps: 270.9904
+  dps: 8091.59062
+  tps: 5034.10195
+  hps: 269.40566
  }
 }
 dps_results: {
@@ -77,9 +77,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6615.2488
-  tps: 4177.19642
-  hps: 243.53664
+  dps: 6613.72468
+  tps: 4174.26318
+  hps: 243.2528
  }
 }
 dps_results: {
@@ -101,25 +101,25 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8078.92749
-  tps: 4914.36151
-  hps: 270.9904
+  dps: 8072.12738
+  tps: 4913.94417
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8166.51844
-  tps: 5100.81441
-  hps: 270.9904
+  dps: 8159.09686
+  tps: 5099.76468
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7646.26291
-  tps: 4840.35568
-  hps: 270.9904
+  dps: 7638.84766
+  tps: 4839.17784
+  hps: 269.40566
  }
 }
 dps_results: {
@@ -133,25 +133,25 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 7959.6797
-  tps: 4973.15132
-  hps: 270.9904
+  dps: 7952.32235
+  tps: 4971.33415
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 7910.40893
-  tps: 4930.80604
-  hps: 270.9904
+  dps: 7902.98919
+  tps: 4929.633
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7541.61195
-  tps: 4847.20499
-  hps: 254.82436
+  dps: 7544.58238
+  tps: 4847.70143
+  hps: 256.35209
  }
 }
 dps_results: {
@@ -165,249 +165,249 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7627.63843
-  tps: 4821.6197
-  hps: 270.9904
+  dps: 7618.32881
+  tps: 4817.67055
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7548.97384
-  tps: 4746.65428
-  hps: 270.9904
+  dps: 7541.80615
+  tps: 4745.33527
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8100.73111
-  tps: 5037.68148
-  hps: 270.9904
+  dps: 8093.21299
+  tps: 5036.49565
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8078.92749
-  tps: 5014.6546
-  hps: 276.02245
+  dps: 8072.12738
+  tps: 5014.22875
+  hps: 274.40829
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8078.92749
-  tps: 5014.6546
-  hps: 270.9904
+  dps: 8072.12738
+  tps: 5014.22875
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8098.81057
-  tps: 5035.01005
-  hps: 270.9904
+  dps: 8091.59062
+  tps: 5034.10195
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8094.9814
-  tps: 5032.18423
-  hps: 270.9904
+  dps: 8087.30439
+  tps: 5031.05226
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8078.92749
-  tps: 5014.6546
-  hps: 270.9904
+  dps: 8072.12738
+  tps: 5014.22875
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7704.59955
-  tps: 4899.79401
-  hps: 270.35651
+  dps: 7708.29483
+  tps: 4904.24255
+  hps: 270.67346
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7635.43007
-  tps: 4830.15944
-  hps: 270.9904
+  dps: 7625.87381
+  tps: 4826.75928
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7617.29744
-  tps: 4813.40379
-  hps: 270.9904
+  dps: 7610.13048
+  tps: 4811.56659
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8078.92749
-  tps: 5014.6546
-  hps: 270.9904
+  dps: 8072.12738
+  tps: 5014.22875
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8078.92749
-  tps: 5014.6546
-  hps: 270.9904
+  dps: 8072.12738
+  tps: 5014.22875
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 8172.16759
-  tps: 5102.53116
-  hps: 270.9904
+  dps: 8164.45565
+  tps: 5101.33135
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7811.44062
-  tps: 4953.08616
-  hps: 270.9904
+  dps: 7804.00495
+  tps: 4951.71411
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7548.97384
-  tps: 4746.65428
-  hps: 270.9904
+  dps: 7541.80615
+  tps: 4745.33527
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 8112.52337
-  tps: 5053.27284
-  hps: 270.9904
+  dps: 8105.51421
+  tps: 5051.97729
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7548.97384
-  tps: 4746.65428
-  hps: 270.9904
+  dps: 7541.80615
+  tps: 4745.33527
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8098.81057
-  tps: 5035.01005
-  hps: 270.9904
+  dps: 8091.59062
+  tps: 5034.10195
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8094.9814
-  tps: 5032.18423
-  hps: 270.9904
+  dps: 8087.30439
+  tps: 5031.05226
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7714.02511
-  tps: 4881.35279
-  hps: 270.9904
+  dps: 7706.8435
+  tps: 4880.08945
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8078.92749
-  tps: 5014.6546
-  hps: 270.9904
+  dps: 8072.12738
+  tps: 5014.22875
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8113.42961
-  tps: 5041.76169
-  hps: 270.9904
+  dps: 8106.60661
+  tps: 5041.33131
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7548.97384
-  tps: 4746.65428
-  hps: 270.9904
+  dps: 7541.80615
+  tps: 4745.33527
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7548.97384
-  tps: 4746.65428
-  hps: 270.9904
+  dps: 7541.80615
+  tps: 4745.33527
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7548.97384
-  tps: 4746.65428
-  hps: 270.9904
+  dps: 7541.80615
+  tps: 4745.33527
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8106.85777
-  tps: 5036.59843
-  hps: 270.9904
+  dps: 8100.03913
+  tps: 5036.16892
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8113.42961
-  tps: 5041.76169
-  hps: 270.9904
+  dps: 8106.60661
+  tps: 5041.33131
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8078.92749
-  tps: 5014.6546
-  hps: 275.07894
+  dps: 8072.12738
+  tps: 5014.22875
+  hps: 273.4703
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8078.92749
-  tps: 5014.6546
-  hps: 276.02245
+  dps: 8072.12738
+  tps: 5014.22875
+  hps: 274.40829
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7548.97384
-  tps: 4746.65428
-  hps: 270.9904
+  dps: 7541.80615
+  tps: 4745.33527
+  hps: 269.40566
  }
 }
 dps_results: {
@@ -429,49 +429,49 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8154.04586
-  tps: 5088.18274
-  hps: 270.9904
+  dps: 8146.46551
+  tps: 5087.00487
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 8193.3096
-  tps: 5119.27099
-  hps: 270.9904
+  dps: 8185.44414
+  tps: 5118.04558
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8078.92749
-  tps: 5014.6546
-  hps: 270.9904
+  dps: 8072.12738
+  tps: 5014.22875
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7548.97384
-  tps: 4746.65428
-  hps: 270.9904
+  dps: 7541.80615
+  tps: 4745.33527
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 8106.96644
-  tps: 5049.10315
-  hps: 270.9904
+  dps: 8099.96711
+  tps: 5047.83335
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7333.18494
-  tps: 4629.19388
-  hps: 264.53762
+  dps: 7334.70409
+  tps: 4634.80637
+  hps: 262.99243
  }
 }
 dps_results: {
@@ -501,49 +501,49 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7548.97384
-  tps: 4746.65428
-  hps: 270.9904
+  dps: 7541.80615
+  tps: 4745.33527
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7548.97384
-  tps: 4746.65428
-  hps: 270.9904
+  dps: 7541.80615
+  tps: 4745.33527
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 8071.93338
-  tps: 5023.89164
-  hps: 270.9904
+  dps: 8064.33068
+  tps: 5022.21329
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8296.18192
-  tps: 5172.75542
-  hps: 270.9904
+  dps: 8288.96272
+  tps: 5171.5048
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 8156.6933
-  tps: 5079.37886
-  hps: 270.9904
+  dps: 8151.67408
+  tps: 5079.20881
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7548.97384
-  tps: 4746.65428
-  hps: 306.84377
+  dps: 7541.80615
+  tps: 4745.33527
+  hps: 305.04936
  }
 }
 dps_results: {
@@ -573,33 +573,33 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8113.42961
-  tps: 5041.76169
-  hps: 270.9904
+  dps: 8106.60661
+  tps: 5041.33131
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8106.85777
-  tps: 5036.59843
-  hps: 270.9904
+  dps: 8100.03913
+  tps: 5036.16892
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8095.35707
-  tps: 5027.56274
-  hps: 270.9904
+  dps: 8088.54606
+  tps: 5027.13473
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7847.85152
-  tps: 5038.85072
-  hps: 282.43656
+  dps: 7849.85742
+  tps: 5042.24809
+  hps: 283.09878
  }
 }
 dps_results: {
@@ -645,33 +645,33 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8078.92749
-  tps: 5014.6546
-  hps: 270.9904
+  dps: 8072.12738
+  tps: 5014.22875
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8078.92749
-  tps: 5014.6546
-  hps: 270.9904
+  dps: 8072.12738
+  tps: 5014.22875
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8078.92749
-  tps: 5014.6546
-  hps: 270.9904
+  dps: 8072.12738
+  tps: 5014.22875
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8078.92749
-  tps: 5014.6546
-  hps: 270.9904
+  dps: 8072.12738
+  tps: 5014.22875
+  hps: 269.40566
  }
 }
 dps_results: {
@@ -685,25 +685,25 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7548.97384
-  tps: 4746.65428
-  hps: 270.9904
+  dps: 7541.80615
+  tps: 4745.33527
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 8217.47191
-  tps: 5138.40222
-  hps: 270.9904
+  dps: 8209.43098
+  tps: 5137.14755
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 8156.40233
-  tps: 5096.24714
-  hps: 272.9399
+  dps: 8156.2092
+  tps: 5096.28075
+  hps: 272.99045
  }
 }
 dps_results: {
@@ -717,9 +717,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7566.00809
-  tps: 4833.4937
-  hps: 207.09676
+  dps: 7569.7304
+  tps: 4843.96012
+  hps: 205.40912
  }
 }
 dps_results: {
@@ -765,9 +765,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7779.59729
-  tps: 4862.77134
-  hps: 206.24826
+  dps: 7771.34954
+  tps: 4860.32624
+  hps: 205.04213
  }
 }
 dps_results: {

--- a/sim/deathknight/runespell.go
+++ b/sim/deathknight/runespell.go
@@ -41,17 +41,17 @@ func (rs *RuneSpell) OnResult(sim *core.Simulation, result *core.SpellResult) {
 		if (rs.ConvertType&RuneTypeBlood != 0 && (slot1 == 0 || slot1 == 1)) ||
 			(rs.ConvertType&RuneTypeFrost != 0 && (slot1 == 2 || slot1 == 3)) ||
 			rs.ConvertType&RuneTypeUnholy != 0 && (slot1 == 4 || slot1 == 5) {
-			rs.dk.ConvertToDeath(sim, slot1, true, core.NeverExpires)
+			rs.dk.ConvertToDeath(sim, slot1, core.NeverExpires)
 		}
 		if (rs.ConvertType&RuneTypeBlood != 0 && (slot2 == 0 || slot2 == 1)) ||
 			(rs.ConvertType&RuneTypeFrost != 0 && (slot2 == 2 || slot2 == 3)) ||
 			rs.ConvertType&RuneTypeUnholy != 0 && (slot2 == 4 || slot2 == 5) {
-			rs.dk.ConvertToDeath(sim, slot2, true, core.NeverExpires)
+			rs.dk.ConvertToDeath(sim, slot2, core.NeverExpires)
 		}
 		if (rs.ConvertType&RuneTypeBlood != 0 && (slot3 == 0 || slot3 == 1)) ||
 			(rs.ConvertType&RuneTypeFrost != 0 && (slot3 == 2 || slot3 == 3)) ||
 			rs.ConvertType&RuneTypeUnholy != 0 && (slot3 == 4 || slot3 == 5) {
-			rs.dk.ConvertToDeath(sim, slot3, true, core.NeverExpires)
+			rs.dk.ConvertToDeath(sim, slot3, core.NeverExpires)
 		}
 	}
 	// misses just don't get spent as a way to avoid having to cancel regeneration PAs

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -640,8 +640,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-Average-Default"
  value: {
-  dps: 1822.20132
-  tps: 6339.67025
+  dps: 1822.28719
+  tps: 6339.91256
   dtps: 252.23477
  }
 }

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -45,618 +45,618 @@ character_stats_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1427.50932
-  tps: 4619.58631
+  dps: 1426.85595
+  tps: 4616.24831
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1499.7072
-  tps: 4786.04622
+  dps: 1499.64688
+  tps: 4785.89265
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1431.24264
-  tps: 4639.67262
+  dps: 1430.59013
+  tps: 4636.33992
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1400.26633
-  tps: 4528.50781
+  dps: 1400.6951
+  tps: 4526.64128
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1326.70661
-  tps: 4237.00064
+  dps: 1322.12453
+  tps: 4230.55771
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1275.38452
-  tps: 4084.4662
+  dps: 1274.63676
+  tps: 4080.30243
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1200.02468
-  tps: 3876.63802
+  dps: 1195.94209
+  tps: 3864.52259
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1424.87914
-  tps: 4518.93418
+  dps: 1424.22663
+  tps: 4515.66813
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1443.07934
-  tps: 4679.43204
+  dps: 1442.46193
+  tps: 4676.12193
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1448.97634
-  tps: 4697.68413
+  dps: 1448.2252
+  tps: 4694.1434
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1490.21827
-  tps: 4770.25654
+  dps: 1489.0315
+  tps: 4761.49766
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 1522.74447
-  tps: 4937.32609
+  dps: 1521.8752
+  tps: 4933.39647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 1494.09504
-  tps: 4829.96018
+  dps: 1493.27939
+  tps: 4826.19884
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 1478.60202
-  tps: 4795.86169
+  dps: 1477.74699
+  tps: 4792.02105
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 1585.85333
-  tps: 5055.51612
+  dps: 1581.26836
+  tps: 5055.69464
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedPlate"
  value: {
-  dps: 1413.96404
-  tps: 4569.86879
+  dps: 1412.09271
+  tps: 4573.66934
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 1444.78687
-  tps: 4671.18072
+  dps: 1444.0761
+  tps: 4667.57324
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1440.61717
-  tps: 4670.41136
+  dps: 1439.99863
+  tps: 4667.14556
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1435.89824
-  tps: 4646.47051
+  dps: 1435.24217
+  tps: 4643.11559
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1432.01707
-  tps: 4641.27841
+  dps: 1431.36456
+  tps: 4637.9457
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1424.87914
-  tps: 4611.15733
+  dps: 1424.22663
+  tps: 4607.82462
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1424.87914
-  tps: 4611.15733
+  dps: 1424.22663
+  tps: 4607.82462
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1431.24264
-  tps: 4639.67262
+  dps: 1430.59013
+  tps: 4636.33992
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1431.04495
-  tps: 4636.80329
+  dps: 1430.39244
+  tps: 4633.47059
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1424.87914
-  tps: 4611.15733
+  dps: 1424.22663
+  tps: 4607.82462
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1477.09036
-  tps: 4749.92322
+  dps: 1478.05408
+  tps: 4746.57718
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1446.98308
-  tps: 4701.6478
+  dps: 1446.23194
+  tps: 4698.10707
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1444.54545
-  tps: 4696.59338
+  dps: 1443.94558
+  tps: 4693.36629
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1424.87914
-  tps: 4611.15733
+  dps: 1424.22663
+  tps: 4607.82462
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1424.87914
-  tps: 4611.15733
+  dps: 1424.22663
+  tps: 4607.82462
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 1448.24239
-  tps: 4681.49961
+  dps: 1447.52012
+  tps: 4677.83823
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1486.31436
-  tps: 4798.60177
+  dps: 1485.64052
+  tps: 4795.13589
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1427.50932
-  tps: 4619.58631
+  dps: 1426.85595
+  tps: 4616.24831
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 1437.86045
-  tps: 4646.98244
+  dps: 1437.22131
+  tps: 4643.82264
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1427.50932
-  tps: 4619.58631
+  dps: 1426.85595
+  tps: 4616.24831
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1431.24264
-  tps: 4639.67262
+  dps: 1430.59013
+  tps: 4636.33992
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1431.04495
-  tps: 4636.80329
+  dps: 1430.39244
+  tps: 4633.47059
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1471.32105
-  tps: 4743.62416
+  dps: 1470.62549
+  tps: 4740.15914
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1424.87914
-  tps: 4611.15733
+  dps: 1424.22663
+  tps: 4607.82462
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1433.20638
-  tps: 4637.84384
+  dps: 1432.55118
+  tps: 4634.49436
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1427.50932
-  tps: 4619.58631
+  dps: 1426.85595
+  tps: 4616.24831
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1427.50932
-  tps: 4619.58631
+  dps: 1426.85595
+  tps: 4616.24831
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1473.23149
-  tps: 4732.84099
+  dps: 1474.09553
+  tps: 4734.39428
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1456.82395
-  tps: 4671.75772
+  dps: 1454.99862
+  tps: 4667.16289
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1431.62024
-  tps: 4632.7607
+  dps: 1430.96555
+  tps: 4629.41441
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1433.20638
-  tps: 4637.84384
+  dps: 1432.55118
+  tps: 4634.49436
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1424.87914
-  tps: 4611.15733
+  dps: 1424.22663
+  tps: 4607.82462
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1424.87914
-  tps: 4611.15733
+  dps: 1424.22663
+  tps: 4607.82462
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1427.50932
-  tps: 4619.58631
+  dps: 1426.85595
+  tps: 4616.24831
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1430.44126
-  tps: 4602.78332
+  dps: 1431.72045
+  tps: 4611.52463
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1431.36528
-  tps: 4604.69928
+  dps: 1432.64004
+  tps: 4613.43139
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1441.95546
-  tps: 4661.32636
+  dps: 1441.33792
+  tps: 4658.01543
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 1452.27382
-  tps: 4693.5383
+  dps: 1451.53816
+  tps: 4689.81405
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1424.87914
-  tps: 4611.15733
+  dps: 1424.22663
+  tps: 4607.82462
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1427.50932
-  tps: 4619.58631
+  dps: 1426.85595
+  tps: 4616.24831
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 1436.68862
-  tps: 4643.881
+  dps: 1436.04787
+  tps: 4640.70101
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 1533.79172
-  tps: 4943.77216
+  dps: 1536.00539
+  tps: 4950.91699
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgebornePlate"
  value: {
-  dps: 1402.08937
-  tps: 4543.84713
+  dps: 1403.22695
+  tps: 4543.43056
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 1709.39207
-  tps: 5490.03524
+  dps: 1707.45326
+  tps: 5484.19032
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 1513.84774
-  tps: 4892.60482
+  dps: 1511.86654
+  tps: 4896.73772
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1433.8525
-  tps: 4637.15021
+  dps: 1433.22174
+  tps: 4633.82876
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1427.50932
-  tps: 4619.58631
+  dps: 1426.85595
+  tps: 4616.24831
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 1430.99619
-  tps: 4626.81634
+  dps: 1430.0852
+  tps: 4622.94415
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 1427.50932
-  tps: 4619.58631
+  dps: 1426.85595
+  tps: 4616.24831
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 1427.50932
-  tps: 4619.58631
+  dps: 1426.85595
+  tps: 4616.24831
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1427.50932
-  tps: 4619.58631
+  dps: 1426.85595
+  tps: 4616.24831
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 1443.802
-  tps: 4585.00003
+  dps: 1440.69967
+  tps: 4571.05763
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 1461.74704
-  tps: 4751.63287
+  dps: 1460.46084
+  tps: 4747.80795
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-StormshroudArmor"
  value: {
-  dps: 1182.34541
-  tps: 3835.8785
+  dps: 1180.91107
+  tps: 3825.83313
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1433.20638
-  tps: 4637.84384
+  dps: 1432.55118
+  tps: 4634.49436
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1431.62024
-  tps: 4632.7607
+  dps: 1430.96555
+  tps: 4629.41441
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1428.8445
-  tps: 4623.86519
+  dps: 1428.1907
+  tps: 4620.5245
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 1679.42846
-  tps: 5279.86756
+  dps: 1677.8183
+  tps: 5284.50417
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sPlate"
  value: {
-  dps: 1417.68205
-  tps: 4607.61435
+  dps: 1418.5588
+  tps: 4606.66009
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1424.7706
-  tps: 4607.63795
+  dps: 1427.78686
+  tps: 4614.93384
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1426.29004
-  tps: 4602.8711
+  dps: 1426.63856
+  tps: 4606.19428
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1469.52631
-  tps: 4719.8089
+  dps: 1468.33743
+  tps: 4714.03801
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1472.29431
-  tps: 4720.83805
+  dps: 1469.55841
+  tps: 4718.43792
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1424.87914
-  tps: 4611.15733
+  dps: 1424.22663
+  tps: 4607.82462
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1424.87914
-  tps: 4611.15733
+  dps: 1424.22663
+  tps: 4607.82462
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1424.87914
-  tps: 4611.15733
+  dps: 1424.22663
+  tps: 4607.82462
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1424.87914
-  tps: 4611.15733
+  dps: 1424.22663
+  tps: 4607.82462
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1270.50435
-  tps: 4075.67451
+  dps: 1268.45563
+  tps: 4060.14117
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-WingedTalisman-37844"
  value: {
-  dps: 1427.50932
-  tps: 4619.58631
+  dps: 1426.85595
+  tps: 4616.24831
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 1456.88116
-  tps: 4707.29681
+  dps: 1456.1302
+  tps: 4703.50069
  }
 }
 dps_results: {
  key: "TestBloodTank-Average-Default"
  value: {
-  dps: 1823.03019
-  tps: 6342.16547
-  dtps: 252.2295
+  dps: 1822.20132
+  tps: 6339.67025
+  dtps: 252.23477
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5206.45729
-  tps: 12428.61573
+  dps: 5227.24665
+  tps: 12469.80574
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1449.35599
-  tps: 4632.32154
+  dps: 1448.44402
+  tps: 4629.83321
  }
 }
 dps_results: {
@@ -669,15 +669,15 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3496.99877
-  tps: 8214.54546
+  dps: 3487.38364
+  tps: 8198.24958
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 816.59725
-  tps: 2653.77118
+  dps: 813.40133
+  tps: 2647.9278
  }
 }
 dps_results: {
@@ -690,15 +690,15 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5242.79667
-  tps: 12531.43834
+  dps: 5263.79491
+  tps: 12573.05956
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1461.89625
-  tps: 4685.49744
+  dps: 1460.96727
+  tps: 4682.97328
  }
 }
 dps_results: {
@@ -711,15 +711,15 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3522.87738
-  tps: 8288.35079
+  dps: 3513.45422
+  tps: 8272.21551
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 824.54054
-  tps: 2689.61811
+  dps: 821.3048
+  tps: 2683.55655
  }
 }
 dps_results: {
@@ -732,8 +732,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1827.72052
-  tps: 6291.09997
-  dtps: 252.87285
+  dps: 1831.39279
+  tps: 6295.55543
+  dtps: 252.91102
  }
 }

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -45,618 +45,618 @@ character_stats_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1426.85595
-  tps: 4616.24831
+  dps: 1423.27898
+  tps: 4602.47685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1499.64688
-  tps: 4785.89265
+  dps: 1500.78158
+  tps: 4798.78328
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1430.59013
-  tps: 4636.33992
+  dps: 1427.16991
+  tps: 4622.93962
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1400.6951
-  tps: 4526.64128
+  dps: 1395.65225
+  tps: 4514.84538
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1322.12453
-  tps: 4230.55771
+  dps: 1321.9344
+  tps: 4243.29843
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1274.63676
-  tps: 4080.30243
+  dps: 1282.2105
+  tps: 4097.2789
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1195.94209
-  tps: 3864.52259
+  dps: 1192.33395
+  tps: 3864.19533
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1424.22663
-  tps: 4515.66813
+  dps: 1420.6554
+  tps: 4502.19475
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1442.46193
-  tps: 4676.12193
+  dps: 1439.06241
+  tps: 4662.8914
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1448.2252
-  tps: 4694.1434
+  dps: 1444.72754
+  tps: 4680.84698
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1489.0315
-  tps: 4761.49766
+  dps: 1486.39326
+  tps: 4757.69985
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-42987"
  value: {
-  dps: 1521.8752
-  tps: 4933.39647
+  dps: 1517.65766
+  tps: 4917.57035
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-44253"
  value: {
-  dps: 1493.27939
-  tps: 4826.19884
+  dps: 1489.2014
+  tps: 4810.84276
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-44254"
  value: {
-  dps: 1477.74699
-  tps: 4792.02105
+  dps: 1473.62582
+  tps: 4776.58287
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 1581.26836
-  tps: 5055.69464
+  dps: 1575.70349
+  tps: 5066.54748
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedPlate"
  value: {
-  dps: 1412.09271
-  tps: 4573.66934
+  dps: 1410.37862
+  tps: 4565.5992
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 1444.0761
-  tps: 4667.57324
+  dps: 1440.47115
+  tps: 4653.54712
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1439.99863
-  tps: 4667.14556
+  dps: 1436.35837
+  tps: 4653.27778
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1435.24217
-  tps: 4643.11559
+  dps: 1431.64689
+  tps: 4629.27041
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1431.36456
-  tps: 4637.9457
+  dps: 1427.94434
+  tps: 4624.5454
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1424.22663
-  tps: 4607.82462
+  dps: 1420.6554
+  tps: 4594.07628
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1424.22663
-  tps: 4607.82462
+  dps: 1420.6554
+  tps: 4594.07628
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1430.59013
-  tps: 4636.33992
+  dps: 1427.16991
+  tps: 4622.93962
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1430.39244
-  tps: 4633.47059
+  dps: 1426.97222
+  tps: 4620.07029
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1424.22663
-  tps: 4607.82462
+  dps: 1420.6554
+  tps: 4594.07628
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1478.05408
-  tps: 4746.57718
+  dps: 1482.28901
+  tps: 4759.52938
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1446.23194
-  tps: 4698.10707
+  dps: 1442.86797
+  tps: 4685.08786
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1443.94558
-  tps: 4693.36629
+  dps: 1440.39509
+  tps: 4679.96033
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1424.22663
-  tps: 4607.82462
+  dps: 1420.6554
+  tps: 4594.07628
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1424.22663
-  tps: 4607.82462
+  dps: 1420.6554
+  tps: 4594.07628
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 1447.52012
-  tps: 4677.83823
+  dps: 1443.90959
+  tps: 4663.76118
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1485.64052
-  tps: 4795.13589
+  dps: 1481.92504
+  tps: 4780.80684
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1426.85595
-  tps: 4616.24831
+  dps: 1423.27898
+  tps: 4602.47685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 1437.22131
-  tps: 4643.82264
+  dps: 1433.65695
+  tps: 4630.16908
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1426.85595
-  tps: 4616.24831
+  dps: 1423.27898
+  tps: 4602.47685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1430.59013
-  tps: 4636.33992
+  dps: 1427.16991
+  tps: 4622.93962
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1430.39244
-  tps: 4633.47059
+  dps: 1426.97222
+  tps: 4620.07029
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1470.62549
-  tps: 4740.15914
+  dps: 1467.17172
+  tps: 4726.51809
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1424.22663
-  tps: 4607.82462
+  dps: 1420.6554
+  tps: 4594.07628
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1432.55118
-  tps: 4634.49436
+  dps: 1428.96177
+  tps: 4620.67283
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1426.85595
-  tps: 4616.24831
+  dps: 1423.27898
+  tps: 4602.47685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1426.85595
-  tps: 4616.24831
+  dps: 1423.27898
+  tps: 4602.47685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1474.09553
-  tps: 4734.39428
+  dps: 1475.57434
+  tps: 4718.92909
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1454.99862
-  tps: 4667.16289
+  dps: 1450.42194
+  tps: 4655.15436
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1430.96555
-  tps: 4629.41441
+  dps: 1427.37961
+  tps: 4615.60682
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1432.55118
-  tps: 4634.49436
+  dps: 1428.96177
+  tps: 4620.67283
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1424.22663
-  tps: 4607.82462
+  dps: 1420.6554
+  tps: 4594.07628
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1424.22663
-  tps: 4607.82462
+  dps: 1420.6554
+  tps: 4594.07628
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1426.85595
-  tps: 4616.24831
+  dps: 1423.27898
+  tps: 4602.47685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1431.72045
-  tps: 4611.52463
+  dps: 1429.51433
+  tps: 4601.44399
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1432.64004
-  tps: 4613.43139
+  dps: 1430.43244
+  tps: 4603.34767
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1441.33792
-  tps: 4658.01543
+  dps: 1437.94646
+  tps: 4644.76289
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 1451.53816
-  tps: 4689.81405
+  dps: 1447.92109
+  tps: 4675.67758
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1424.22663
-  tps: 4607.82462
+  dps: 1420.6554
+  tps: 4594.07628
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1426.85595
-  tps: 4616.24831
+  dps: 1423.27898
+  tps: 4602.47685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 1436.04787
-  tps: 4640.70101
+  dps: 1432.48208
+  tps: 4627.03411
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 1536.00539
-  tps: 4950.91699
+  dps: 1529.21592
+  tps: 4917.39754
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgebornePlate"
  value: {
-  dps: 1403.22695
-  tps: 4543.43056
+  dps: 1398.37436
+  tps: 4532.02347
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 1707.45326
-  tps: 5484.19032
+  dps: 1705.67596
+  tps: 5476.14997
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 1511.86654
-  tps: 4896.73772
+  dps: 1508.30735
+  tps: 4885.61451
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1433.22174
-  tps: 4633.82876
+  dps: 1429.6685
+  tps: 4619.93097
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1426.85595
-  tps: 4616.24831
+  dps: 1423.27898
+  tps: 4602.47685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 1430.0852
-  tps: 4622.94415
+  dps: 1426.53652
+  tps: 4609.23135
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 1426.85595
-  tps: 4616.24831
+  dps: 1423.27898
+  tps: 4602.47685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 1426.85595
-  tps: 4616.24831
+  dps: 1423.27898
+  tps: 4602.47685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1426.85595
-  tps: 4616.24831
+  dps: 1423.27898
+  tps: 4602.47685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 1440.69967
-  tps: 4571.05763
+  dps: 1441.44261
+  tps: 4594.4237
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 1460.46084
-  tps: 4747.80795
+  dps: 1457.71551
+  tps: 4734.17208
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-StormshroudArmor"
  value: {
-  dps: 1180.91107
-  tps: 3825.83313
+  dps: 1185.33199
+  tps: 3836.65219
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1432.55118
-  tps: 4634.49436
+  dps: 1428.96177
+  tps: 4620.67283
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1430.96555
-  tps: 4629.41441
+  dps: 1427.37961
+  tps: 4615.60682
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1428.1907
-  tps: 4620.5245
+  dps: 1424.61082
+  tps: 4606.7413
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 1677.8183
-  tps: 5284.50417
+  dps: 1673.2034
+  tps: 5282.97168
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sPlate"
  value: {
-  dps: 1418.5588
-  tps: 4606.66009
+  dps: 1415.05697
+  tps: 4595.30728
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1427.78686
-  tps: 4614.93384
+  dps: 1421.94374
+  tps: 4571.0022
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1426.63856
-  tps: 4606.19428
+  dps: 1435.75431
+  tps: 4618.66768
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1468.33743
-  tps: 4714.03801
+  dps: 1470.73898
+  tps: 4719.42816
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1469.55841
-  tps: 4718.43792
+  dps: 1474.52273
+  tps: 4723.86878
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1424.22663
-  tps: 4607.82462
+  dps: 1420.6554
+  tps: 4594.07628
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1424.22663
-  tps: 4607.82462
+  dps: 1420.6554
+  tps: 4594.07628
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1424.22663
-  tps: 4607.82462
+  dps: 1420.6554
+  tps: 4594.07628
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1424.22663
-  tps: 4607.82462
+  dps: 1420.6554
+  tps: 4594.07628
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1268.45563
-  tps: 4060.14117
+  dps: 1262.01842
+  tps: 4051.85177
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-WingedTalisman-37844"
  value: {
-  dps: 1426.85595
-  tps: 4616.24831
+  dps: 1423.27898
+  tps: 4602.47685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 1456.1302
-  tps: 4703.50069
+  dps: 1452.50567
+  tps: 4689.29632
  }
 }
 dps_results: {
  key: "TestBloodTank-Average-Default"
  value: {
-  dps: 1822.28719
-  tps: 6339.91256
-  dtps: 252.23477
+  dps: 1822.8457
+  tps: 6340.14276
+  dtps: 252.24483
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5227.24665
-  tps: 12469.80574
+  dps: 5228.52206
+  tps: 12478.66642
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1448.44402
-  tps: 4629.83321
+  dps: 1446.97717
+  tps: 4625.22441
  }
 }
 dps_results: {
@@ -669,15 +669,15 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3487.38364
-  tps: 8198.24958
+  dps: 3494.34815
+  tps: 8211.13526
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 813.40133
-  tps: 2647.9278
+  dps: 810.69838
+  tps: 2638.63955
  }
 }
 dps_results: {
@@ -690,15 +690,15 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5263.79491
-  tps: 12573.05956
+  dps: 5264.83485
+  tps: 12581.55853
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1460.96727
-  tps: 4682.97328
+  dps: 1459.50842
+  tps: 4678.2084
  }
 }
 dps_results: {
@@ -711,15 +711,15 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3513.45422
-  tps: 8272.21551
+  dps: 3520.94906
+  tps: 8285.93663
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 821.3048
-  tps: 2683.55655
+  dps: 818.60918
+  tps: 2674.39478
  }
 }
 dps_results: {
@@ -732,8 +732,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1831.39279
-  tps: 6295.55543
-  dtps: 252.91102
+  dps: 1826.26706
+  tps: 6284.65709
+  dtps: 253.38291
  }
 }

--- a/sim/paladin/protection/rotation.go
+++ b/sim/paladin/protection/rotation.go
@@ -19,7 +19,7 @@ func (prot *ProtectionPaladin) OnGCDReady(sim *core.Simulation) {
 func (prot *ProtectionPaladin) customRotation(sim *core.Simulation) {
 	// Setup
 	target := prot.CurrentTarget
-	
+
 	isExecutePhase := sim.IsExecutePhase20()
 
 	// Forced CD remaining on HotR/ShoR to cast the other. Can't be exactly 3sec or lusted consecration GCDs will desync us.
@@ -55,15 +55,19 @@ func (prot *ProtectionPaladin) customRotation(sim *core.Simulation) {
 				// Cast HotR if ready but only if you've spent a global since ShoR
 				prot.HammerOfTheRighteous.Cast(sim, target)
 
-			// Maximum WaitSlack checking here to see if we should delay casting anything else because it will clip our 6
-			// This callback method is probably inefficient, TODO perf improvement
+				// Maximum WaitSlack checking here to see if we should delay casting anything else because it will clip our 6
+				// This callback method is probably inefficient, TODO perf improvement
 			} else if (nextHammer < maxWait) && (nextShield < gapSlack-maxWait) {
-				if sim.Log != nil { prot.Log(sim, "Waiting %d ms to cast HotR...", int32(nextHammer.Milliseconds())) }
+				if sim.Log != nil {
+					prot.Log(sim, "Waiting %d ms to cast HotR...", int32(nextHammer.Milliseconds()))
+				}
 				prot.waitUntilNextEvent(sim, prot.customRotation)
-			} else if (nextShield < maxWait)  && (nextHammer < gapSlack-maxWait) {
-				if sim.Log != nil { prot.Log(sim, "Waiting %d ms to cast ShoR...", int32(nextShield.Milliseconds())) }
+			} else if (nextShield < maxWait) && (nextHammer < gapSlack-maxWait) {
+				if sim.Log != nil {
+					prot.Log(sim, "Waiting %d ms to cast ShoR...", int32(nextShield.Milliseconds()))
+				}
 				prot.waitUntilNextEvent(sim, prot.customRotation)
-				
+
 			} else if isExecutePhase && prot.HammerOfWrath.IsReady(sim) {
 				// TODO: Prio may depend on gear; consider Glyph behavior
 				prot.HammerOfWrath.Cast(sim, target)
@@ -122,7 +126,9 @@ func (prot *ProtectionPaladin) customRotation(sim *core.Simulation) {
 						prot.ShieldOfRighteousness.Cast(sim, target)
 						break rotationLoop
 					} else if (nextShield < maxWait) && (nextHammer < gapSlack-maxWait) {
-						if sim.Log != nil { prot.Log(sim, "Waiting %d ms to cast ShoR...", int32(nextShield.Milliseconds())) }
+						if sim.Log != nil {
+							prot.Log(sim, "Waiting %d ms to cast ShoR...", int32(nextShield.Milliseconds()))
+						}
 						prot.waitUntilNextEvent(sim, prot.customRotation)
 						break rotationLoop
 					}
@@ -135,8 +141,10 @@ func (prot *ProtectionPaladin) customRotation(sim *core.Simulation) {
 					if prot.HammerOfTheRighteous.IsReady(sim) && (nextShield < gapSlack) {
 						prot.HammerOfTheRighteous.Cast(sim, target)
 						break rotationLoop
-					} else if (nextHammer < maxWait && (nextShield < gapSlack-maxWait)) {
-						if sim.Log != nil { prot.Log(sim, "Waiting %d ms to cast HotR...", int32(nextHammer.Milliseconds())) }
+					} else if nextHammer < maxWait && (nextShield < gapSlack-maxWait) {
+						if sim.Log != nil {
+							prot.Log(sim, "Waiting %d ms to cast HotR...", int32(nextHammer.Milliseconds()))
+						}
 						prot.waitUntilNextEvent(sim, prot.customRotation)
 						break rotationLoop
 					}

--- a/sim/warlock/TestWarlock.results
+++ b/sim/warlock/TestWarlock.results
@@ -213,8 +213,8 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-AllItems-PlagueheartGarb"
  value: {
-  dps: 6319.59254
-  tps: 5638.86431
+  dps: 6326.25579
+  tps: 5644.95861
  }
 }
 dps_results: {

--- a/sim/warlock/TestWarlock.results
+++ b/sim/warlock/TestWarlock.results
@@ -213,8 +213,8 @@ dps_results: {
 dps_results: {
  key: "TestWarlock-AllItems-PlagueheartGarb"
  value: {
-  dps: 6326.25579
-  tps: 5644.95861
+  dps: 6319.59254
+  tps: 5638.86431
  }
 }
 dps_results: {


### PR DESCRIPTION
Fixes 3 things:
1. Blood Tap refreshes the CD on both blood or death runes, whichever rune comes first. Not just deaths.
2. Similarly, Blood Tap converts the first blood or death rune, fixed the code where it was prioritizing active runes
3. Using Blood Strike / Pestilence (Blood of the North) on a blood-tapped Death Rune should not cause it to stay as a Death rune when Blood Tap expires, this has been fixed.

Removes revertOnSpend because the attribute is no longer needed

Before:
Notice how both death runes regenerate back after the Blood Tap
![image](https://user-images.githubusercontent.com/9436142/204059110-5b4c46ae-fb0d-4c91-a01e-ea6fe6438860.png)

After:
Only one death rune regenerates back after the Blood Tap, the other is blood again
![image](https://user-images.githubusercontent.com/9436142/204059133-f5918e75-468b-4596-af4f-45c8a2ad5f76.png)
