### PR TITLE
Fix textarea color styling

### DIFF
--- a/ui/core/_sim_ui.scss
+++ b/ui/core/_sim_ui.scss
@@ -14,6 +14,11 @@ td, th {
   padding: auto;
 }
 
+// TODO: Remove once individual sims are using the Bootstrap node module
+input, textarea {
+  color: white;
+}
+
 .sim-root {
   height: 100%;
   display: flex;


### PR DESCRIPTION
https://discord.com/channels/891730968493305867/909597996449157160/1045814272468459551

![image](https://user-images.githubusercontent.com/12898988/204061052-eed60b19-8d99-4762-9e68-f18314b036ef.png)

Using the Bootstrap node module this should get set by the global `$body-color` variable, but individual sims are still using the CDN, so for now this works