### PR TITLE
Illustration of the dragon soul should only proc on harmful spells

### DIFF
--- a/sim/common/wotlk/stat_bonus_stacking.go
+++ b/sim/common/wotlk/stat_bonus_stacking.go
@@ -197,6 +197,7 @@ func init() {
 		MaxStacks: 10,
 		Bonus:     stats.Stats{stats.SpellPower: 20},
 		Callback:  OnCastComplete,
+		Harmful:   true,
 	})
 	newStackingStatBonusEffect(StackingStatBonusEffect{
 		Name:       "DMC Berserker",


### PR DESCRIPTION
Fixes #1773 