### PR TITLE
Apply `!important` to `hide` class

### DIFF
--- a/ui/scss/global_old.scss
+++ b/ui/scss/global_old.scss
@@ -15,7 +15,7 @@
 }
 
 .hide {
-	display: none;
+	display: none !important;
 }
 
 @font-face {


### PR DESCRIPTION
Some elements with the `hide` class are not being properly hidden when other selectors with a different `display` style are being preferred. `hide` should take precedence.