### PR TITLE
Use nodemon for development file watching

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "scripts": {
         "build": "bazel build //...",
         "test": "bazel test //...",
-        "watch-frontend": "npx nodemon -e ts,proto --ignore dist/ --exec make ",
-        "watch-backend": "npx nodemon -e go,proto --ignore dist/ --signal SIGTERM --exec make rundevserver ",
+        "watch-frontend": "npx nodemon -e ts,proto --ignore dist/ --exec make",
+        "watch-backend": "npx nodemon -e go,proto --ignore dist/ --signal SIGTERM --exec 'make rundevserver || exit 1'",
         "watch": "npm run watch-frontend & npm run watch-backend"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     },
     "scripts": {
         "build": "bazel build //...",
-        "test": "bazel test //..."
+        "test": "bazel test //...",
+        "watch-frontend": "npx nodemon -e ts,proto --ignore dist/ --exec make ",
+        "watch-backend": "npx nodemon -e go,proto --ignore dist/ --signal SIGTERM --exec make rundevserver ",
+        "watch": "npm run watch-frontend & npm run watch-backend"
     },
     "dependencies": {
         "@popperjs/core": "^2.11.6",


### PR DESCRIPTION
Not sure if we have a faster "development only" frontend build path, but here are some rough examples of usage