### PR TITLE
Move timeline scrollbar to be visible all the time, without scrolling all the way down

### DIFF
--- a/ui/scss/sims/detailed_results/_timeline.scss
+++ b/ui/scss/sims/detailed_results/_timeline.scss
@@ -207,7 +207,6 @@ $combo-points-color: #ffa07a;
 }
 .rotation-timeline {
 	display: inline-block;
-	overflow-x: scroll;
 }
 .rotation-timeline-row {
 	position: relative;


### PR DESCRIPTION
The main problem with this however is that the labels are hidden by scrolling.
![image](https://user-images.githubusercontent.com/12898988/205364925-d37d240b-9dbb-41aa-adb1-8fd6301e611c.png)
