### PR TITLE
Fix import textarea color

### DIFF
--- a/ui/core/components/importers.ts
+++ b/ui/core/components/importers.ts
@@ -73,7 +73,7 @@ export abstract class Importer extends Popup {
 			<div class="import-description">
 			</div>
 			<div class="import-content">
-				<textarea class="importer-textarea"></textarea>
+				<textarea class="importer-textarea form-control"></textarea>
 			</div>
 			<div class="actions-row">
 		`;


### PR DESCRIPTION
I had added the Bootstrap `form-control` to export's textarea, but not import's. This meant that the white text color style was not being applied.

<img width="895" alt="image" src="https://user-images.githubusercontent.com/12898988/205369997-255bf3f8-ddd5-4c72-a067-baaf5a1500de.png">
