### PR TITLE
core: disable rage gain when not current power bar

### DIFF
--- a/sim/core/rage.go
+++ b/sim/core/rage.go
@@ -40,6 +40,9 @@ func (unit *Unit) EnableRageBar(options RageBarOptions, onRageGain OnRageGain) {
 			aura.Activate(sim)
 		},
 		OnSpellHitDealt: func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
+			if unit.GetCurrentPowerBar() != RageBar {
+				return
+			}
 			if result.Outcome.Matches(OutcomeMiss) {
 				return
 			}
@@ -83,6 +86,9 @@ func (unit *Unit) EnableRageBar(options RageBarOptions, onRageGain OnRageGain) {
 			unit.AddRage(sim, generatedRage, spell.ResourceMetrics)
 		},
 		OnSpellHitTaken: func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
+			if unit.GetCurrentPowerBar() != RageBar {
+				return
+			}
 			generatedRage := result.Damage * 2.5 / RageFactor
 			unit.AddRage(sim, generatedRage, rageFromDamageTakenMetrics)
 		},

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -677,7 +677,7 @@ dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
   dps: 4405.60437
-  tps: 3262.87977
+  tps: 3262.90829
  }
 }
 dps_results: {


### PR DESCRIPTION
 - really just fixes feral cat rage display, otherwise we 'gain rage' in cat, which looks weird

Signed-off-by: jarves <jarveson@gmail.com>