### PR TITLE
fix: wait until death runes or we can't BT oblit

### DIFF
--- a/sim/deathknight/dps/rotation_frost_sub_unholy.go
+++ b/sim/deathknight/dps/rotation_frost_sub_unholy.go
@@ -87,6 +87,10 @@ func (dk *DpsDeathknight) RotationActionCallback_FrostSubUnholy_FS_KM(sim *core.
 }
 
 func (dk *DpsDeathknight) RotationActionCallback_FrostSubUnholy_Dump_Until_Deaths(sim *core.Simulation, target *core.Unit, s *deathknight.Sequence) time.Duration {
+	/*
+		We need two deaths (or at least, have the first on up) before we UA + BT + Oblit, since if only the 2nd
+		death rune is up, UA then Blood Tap will convert and refresh the first and the second will have a 10s CD from UA
+	*/
 	if dk.CurrentDeathRunes() == 2 {
 		s.Advance()
 		return sim.CurrentTime

--- a/sim/deathknight/dps/rotation_frost_sub_unholy.go
+++ b/sim/deathknight/dps/rotation_frost_sub_unholy.go
@@ -86,9 +86,26 @@ func (dk *DpsDeathknight) RotationActionCallback_FrostSubUnholy_FS_KM(sim *core.
 	return core.TernaryDuration(casted, -1, sim.CurrentTime)
 }
 
+func (dk *DpsDeathknight) RotationActionCallback_FrostSubUnholy_Dump_Until_Deaths(sim *core.Simulation, target *core.Unit, s *deathknight.Sequence) time.Duration {
+	if dk.CurrentDeathRunes() == 2 {
+		s.Advance()
+		return sim.CurrentTime
+	}
+
+	timeUntilDeaths := core.MinDuration(dk.DeathRuneRegenAt(0), dk.DeathRuneRegenAt(1))
+	spell := dk.RegularPrioPickSpell(sim, target, timeUntilDeaths)
+
+	if spell != nil {
+		spell.Cast(sim, target)
+	}
+
+	return -1
+}
+
 func (dk *DpsDeathknight) RotationActionCallback_FrostSubUnholy_UA_Check1(sim *core.Simulation, target *core.Unit, s *deathknight.Sequence) time.Duration {
 	if dk.UnbreakableArmor.CanCast(sim) && dk.BloodTap.CanCast(sim) {
 		s.Clear().
+			NewAction(dk.RotationActionCallback_FrostSubUnholy_Dump_Until_Deaths).
 			NewAction(dk.RotationActionCallback_UA_Frost).
 			NewAction(dk.RotationActionCallback_BT).
 			NewAction(dk.RotationActionCallback_FrostSubUnholy_Obli).


### PR DESCRIPTION
The sub unholy rotation was not waiting for double deaths before UA + BT + Oblit which was causing a problem if the second blood rune was up but the first one was not:

eg:
Before:
d D -> UA -> d d -> BT -> D d ----> Can't Oblit, second d is on ~10s CD

Now:
d D -> fillers -> D D -> UA -> d D -> BT -> D D -> Oblit

This problem only occurred after the Blood Tap logic (https://github.com/wowsims/wotlk/pull/1933) was fixed because the previous broken behaviour worked in its favour 

Before:
<img width="639" alt="image" src="https://user-images.githubusercontent.com/9436142/206721089-e5888043-0d4c-48be-8d1a-293e2826b340.png">

After:
<img width="620" alt="image" src="https://user-images.githubusercontent.com/9436142/206720994-7752a549-8742-4606-9cd5-9a60f3b08a5d.png">
