### PR TITLE
fix: sub unholy opener when less than 2/2 CotG

### DIFF
--- a/sim/deathknight/dps/rotation_frost_sub_unholy.go
+++ b/sim/deathknight/dps/rotation_frost_sub_unholy.go
@@ -24,6 +24,7 @@ func (dk *DpsDeathknight) setupFrostSubUnholyERWOpener() {
 		NewAction(dk.RotationActionCallback_FrostSubUnholy_Obli).
 		NewAction(dk.RotationActionCallback_Frost_FS_HB).
 		NewAction(dk.RotationActionCallback_FrostSubUnholy_Obli).
+		NewAction(dk.RotationAction_CancelBT).
 		NewAction(dk.RotationActionCallback_RD).
 		NewAction(dk.RotationActionCallback_Frost_FS_HB).
 		NewAction(dk.RotationActionCallback_Frost_FS_HB).


### PR DESCRIPTION
Taking a point out of Chill of the Grave and putting it into KM caused the opener to be a bit weird, since there was not enough RP for 2 frost strikes before the pesti which caused pesti to be casted much earlier (before Blood Tap expired). Then when Blood Tap expired it came back as a blood instead of a death

Before:
![image](https://user-images.githubusercontent.com/9436142/208199632-272b7b7a-e1ed-47c9-81f3-3c35bd982f16.png)

After:
![image](https://user-images.githubusercontent.com/9436142/208199582-a90e1b36-ad07-4c11-96bb-25b26e01b008.png)
