### PR TITLE
Fixed Insect Swarm and Scorpid Sting debuffs to use correct WotLK values

### DIFF
--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -880,7 +880,7 @@ func InsectSwarmAura(target *Unit) *Aura {
 		ActionID: ActionID{SpellID: 27013},
 		Duration: time.Second * 12,
 	})
-	increasedMissEffect(aura, 0.02)
+	increasedMissEffect(aura, 0.03)
 	return aura
 }
 
@@ -890,7 +890,7 @@ func ScorpidStingAura(target *Unit) *Aura {
 		ActionID: ActionID{SpellID: 3043},
 		Duration: time.Second * 20,
 	})
-	increasedMissEffect(aura, 0.05)
+	increasedMissEffect(aura, 0.03)
 	return aura
 }
 

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -853,9 +853,9 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-Average-Default"
  value: {
-  dps: 1820.73308
-  tps: 6337.21966
-  dtps: 250.09767
+  dps: 1821.41335
+  tps: 6337.93628
+  dtps: 261.20585
  }
 }
 dps_results: {
@@ -945,8 +945,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1839.44703
-  tps: 6354.06542
-  dtps: 252.30916
+  dps: 1836.78805
+  tps: 6355.98608
+  dtps: 262.15577
  }
 }

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -1024,9 +1024,9 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-Average-Default"
  value: {
-  dps: 2662.05388
-  tps: 5589.09185
-  dtps: 50.70547
+  dps: 2665.76859
+  tps: 5597.49824
+  dtps: 54.41997
  }
 }
 dps_results: {
@@ -1077,8 +1077,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2752.0523
-  tps: 5778.37738
-  dtps: 45.42777
+  dps: 2775.1905
+  tps: 5828.19782
+  dtps: 43.07563
  }
 }

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -895,9 +895,9 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Average-Default"
  value: {
-  dps: 3569.68253
-  tps: 8562.74659
-  dtps: 14.89639
+  dps: 3584.58064
+  tps: 8597.07744
+  dtps: 16.18688
  }
 }
 dps_results: {
@@ -1155,8 +1155,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3744.77991
-  tps: 8982.61663
-  dtps: 11.47593
+  dps: 3758.67434
+  tps: 9009.73746
+  dtps: 13.2107
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -46,7 +46,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 1.08951
+  weights: 0.69251
   weights: 0
   weights: 0
   weights: 0
@@ -57,7 +57,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.33631
+  weights: 0.18939
   weights: 0
   weights: 0
   weights: 0
@@ -66,12 +66,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.00838
+  weights: 0.01502
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.46582
-  weights: -0.09165
+  weights: 0.46585
+  weights: 0.03036
   weights: 0
   weights: 0
   weights: 0
@@ -877,9 +877,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 3080.30277
-  tps: 8043.28092
-  dtps: 118.62556
+  dps: 3088.86529
+  tps: 8064.52552
+  dtps: 128.36531
  }
 }
 dps_results: {
@@ -969,8 +969,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3193.35235
-  tps: 8349.56844
-  dtps: 107.84556
+  dps: 3221.29196
+  tps: 8414.03102
+  dtps: 118.79006
  }
 }


### PR DESCRIPTION
of 3% miss chance increase for both.

 Changes to be committed:
	modified:   sim/core/debuffs.go
	modified:   sim/deathknight/tank/TestBloodTank.results
	modified:   sim/druid/tank/TestFeralTank.results
	modified:   sim/paladin/protection/TestProtection.results
	modified:   sim/warrior/protection/TestProtectionWarrior.results