### PR TITLE
Prot spec fixes

### DIFF
--- a/sim/common/wotlk/stat_bonus_cds.go
+++ b/sim/common/wotlk/stat_bonus_cds.go
@@ -122,7 +122,14 @@ func init() {
 	newArmorActive(45313, 5448, time.Second*20, time.Minute*2) // Furnace Stone
 
 	newBlockValueActive := testFirstOnly(func(itemID int32, bonus float64, duration time.Duration, cooldown time.Duration) {
-		core.NewSimpleStatDefensiveTrinketEffect(itemID, stats.Stats{stats.BlockValue: bonus}, duration, cooldown)
+		//core.NewSimpleStatDefensiveTrinketEffect(itemID, stats.Stats{stats.BlockValue: bonus}, duration, cooldown)
+		// Hack for Lavanthor's Talisman Shared CD being shorter than its effect
+		core.NewSimpleStatItemActiveEffect(itemID, stats.Stats{stats.BlockValue: bonus}, duration, cooldown, func(character *core.Character) core.Cooldown {
+			return core.Cooldown{
+				Timer:    character.GetDefensiveTrinketCD(),
+				Duration: time.Second*20,
+			}
+		}, nil)
 	})
 	newBlockValueActive(37872, 440, time.Second*40, time.Minute*2) // Lavanthor's Talisman
 

--- a/sim/paladin/avenging_wrath.go
+++ b/sim/paladin/avenging_wrath.go
@@ -47,6 +47,10 @@ func (paladin *Paladin) RegisterAvengingWrathCD() {
 				Timer:    paladin.NewTimer(),
 				Duration: time.Minute*3 - (time.Second * time.Duration(30*paladin.Talents.SanctifiedWrath)),
 			},
+			SharedCD: core.Cooldown{
+				Timer:    paladin.GetMutualLockoutDPAW(),
+				Duration: 30*time.Second,
+			},
 		},
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, _ *core.Spell) {
 			paladin.AvengingWrathAura.Activate(sim)

--- a/sim/paladin/divine_protection.go
+++ b/sim/paladin/divine_protection.go
@@ -1,0 +1,78 @@
+package paladin
+
+import (
+	"time"
+
+	"github.com/wowsims/wotlk/sim/core"
+)
+
+func (paladin *Paladin) registerDivineProtectionSpell() {
+
+	duration := time.Second*12 + core.TernaryDuration(paladin.HasSetBonus(ItemSetRedemptionPlate, 4), time.Second*3, 0)
+
+	actionID := core.ActionID{SpellID: 498}
+	paladin.DivineProtectionAura = paladin.RegisterAura(core.Aura{
+		Label:    "Divine Protection",
+		ActionID: actionID,
+		Duration: duration,
+		OnGain: func(aura *core.Aura, sim *core.Simulation) {
+			paladin.PseudoStats.DamageTakenMultiplier *= 0.5
+		},
+		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
+			paladin.PseudoStats.DamageTakenMultiplier /= 0.5
+		},
+	})
+
+	cooldownDur := time.Minute*3 -
+		30*time.Second*time.Duration(paladin.Talents.SacredDuty) -
+		core.TernaryDuration(paladin.HasSetBonus(ItemSetTuralyonsPlate, 4), 30*time.Second, 0)
+
+	paladin.DivineProtection = paladin.RegisterSpell(core.SpellConfig{
+		ActionID: actionID,
+
+		Cast: core.CastConfig{
+			DefaultCast: core.Cast{
+				GCD: 0,
+			},
+			IgnoreHaste: true,
+			CD: core.Cooldown{
+				Timer:    paladin.NewTimer(),
+				Duration: cooldownDur,
+			},
+			SharedCD: core.Cooldown{
+				Timer:    paladin.GetMutualLockoutDPAW(),
+				Duration: 30*time.Second,
+			},
+		},
+
+		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
+			paladin.DivineProtectionAura.Activate(sim)
+			paladin.ForbearanceAura.Activate(sim)
+		},
+	})
+
+	paladin.AddMajorCooldown(core.MajorCooldown{
+		Spell: paladin.DivineProtection,
+		Type:  core.CooldownTypeSurvival,
+		CanActivate: func(sim *core.Simulation, character *core.Character) bool {
+			usable := !paladin.ForbearanceAura.IsActive()
+			// Prevent Ret from screwing up their rotation by using this. TODO better logic
+			if usable && paladin.Talents.TheArtOfWar > 0 {
+				usable = false
+			}
+			return usable
+		},
+	})
+}
+
+func (paladin *Paladin) registerForbearanceDebuff() {
+	
+	actionID := core.ActionID{SpellID: 25771}
+	duration := core.TernaryDuration(paladin.HasSetBonus(ItemSetTuralyonsPlate, 4), 90*time.Second, 120*time.Second)
+	paladin.ForbearanceAura = paladin.RegisterAura(core.Aura{
+		Label:    "Forbearance",
+		ActionID: actionID,
+		Duration: duration,
+	})
+	
+}

--- a/sim/paladin/items.go
+++ b/sim/paladin/items.go
@@ -78,22 +78,10 @@ func (paladin *Paladin) getItemSetAegisBattlegearBonus2() float64 {
 	return core.TernaryFloat64(paladin.HasSetBonus(ItemSetAegisBattlegear, 2), .1, 0)
 }
 
-// Tier 9 ret (Alliance)
+// Tier 9 ret (Alliance/Horde)
 var ItemSetTuralyonsBattlegear = core.NewItemSet(core.ItemSet{
 	Name: "Turalyon's Battlegear",
-	Bonuses: map[int32]core.ApplyEffect{
-		2: func(agent core.Agent) {
-			// Implemented in talents.go (Righteous Vengeance)
-		},
-		4: func(agent core.Agent) {
-			// Implemented in soc.go, sor.go, sov.go
-		},
-	},
-})
-
-// Tier 9 ret (Horde)
-var ItemSetLiadrinsBattlegear = core.NewItemSet(core.ItemSet{
-	Name: "Liadrin's Battlegear",
+	AlternativeName: "Liadrin's Battlegear",
 	Bonuses: map[int32]core.ApplyEffect{
 		2: func(agent core.Agent) {
 			// Implemented in talents.go (Righteous Vengeance)
@@ -170,7 +158,8 @@ var ItemSetRedemptionPlate = core.NewItemSet(core.ItemSet{
 			// Implemented in hammer_of_the_righteous.go
 		},
 		4: func(agent core.Agent) {
-			// TODO: increase duration of divine shield and divine protection by 3sec
+			// TODO: increase duration of divine shield by 3sec
+			// Implemented in divine_protection.go
 		},
 	},
 })
@@ -210,36 +199,23 @@ func (paladin *Paladin) getItemSetAegisPlateBonus2() float64 {
 	return core.TernaryFloat64(paladin.HasSetBonus(ItemSetAegisPlate, 2), .1, 0)
 }
 
-// Tier 9 prot (Alliance)
+// Tier 9 prot (Alliance/Horde)
 var ItemSetTuralyonsPlate = core.NewItemSet(core.ItemSet{
 	Name: "Turalyon's Plate",
+	AlternativeName: "Liadrin's Plate",
 	Bonuses: map[int32]core.ApplyEffect{
 		2: func(agent core.Agent) {
 			// Implemented in hammer_of_the_righteous.go
 			// TODO: Implement Hand of Reckoning bonus, if it ever becomes relevant
 		},
 		4: func(agent core.Agent) {
-			// TODO: Decreases the cooldown of Divine Protection and duration of Forbearance by 30sec
-		},
-	},
-})
-
-// Tier 9 prot (Horde)
-var ItemSetLiadrinsPlate = core.NewItemSet(core.ItemSet{
-	Name: "Liadrin's Plate",
-	Bonuses: map[int32]core.ApplyEffect{
-		2: func(agent core.Agent) {
-			// Implemented in hammer_of_the_righteous.go
-			// TODO: Implement Hand of Reckoning bonus, if it ever becomes relevant
-		},
-		4: func(agent core.Agent) {
-			// TODO: Decreases the cooldown of Divine Protection and duration of Forbearance by 30sec
+			// Implemented in divine_protection.go
 		},
 	},
 })
 
 func (paladin *Paladin) getItemSetT9PlateBonus2() float64 {
-	return core.TernaryFloat64(paladin.HasSetBonus(ItemSetTuralyonsPlate, 2) || paladin.HasSetBonus(ItemSetLiadrinsPlate, 2), .05, 0)
+	return core.TernaryFloat64(paladin.HasSetBonus(ItemSetTuralyonsPlate, 2), .05, 0)
 }
 
 // Tier 10 prot

--- a/sim/paladin/paladin.go
+++ b/sim/paladin/paladin.go
@@ -38,6 +38,7 @@ type Paladin struct {
 	SealOfRighteousness   *core.Spell
 	SealOfCommand         *core.Spell
 	AvengingWrath         *core.Spell
+	DivineProtection      *core.Spell
 	// SealOfWisdom        *core.Spell
 	// SealOfLight         *core.Spell
 
@@ -53,6 +54,8 @@ type Paladin struct {
 	SealOfCommandAura       *core.Aura
 	SealOfRighteousnessAura *core.Aura
 	AvengingWrathAura       *core.Aura
+	DivineProtectionAura    *core.Aura
+	ForbearanceAura         *core.Aura
 
 	// SealOfWisdomAura        *core.Aura
 	// SealOfLightAura         *core.Aura
@@ -67,6 +70,8 @@ type Paladin struct {
 
 	AvoidClippingConsecration           bool
 	HoldLastAvengingWrathUntilExecution bool
+	
+	mutualLockoutDPAW *core.Timer
 }
 
 // Implemented by each Paladin spec.
@@ -105,6 +110,11 @@ func (paladin *Paladin) AddRaidBuffs(raidBuffs *proto.RaidBuffs) {
 	if paladin.Talents.SwiftRetribution == 3 {
 		raidBuffs.SwiftRetribution = paladin.Talents.SwiftRetribution == 3 // TODO: Fix-- though having something between 0/3 and 3/3 is unlikely
 	}
+	
+	// TODO: Figure out a way to just start with 1 DG cooldown available without making a redundant Spell
+	//if paladin.Talents.DivineGuardian == 2 {
+	//	raidBuffs.divineGuardians++
+	//}
 }
 
 func (paladin *Paladin) AddPartyBuffs(_ *proto.PartyBuffs) {
@@ -138,6 +148,8 @@ func (paladin *Paladin) Initialize() {
 
 	paladin.registerSpiritualAttunement()
 	paladin.registerDivinePleaSpell()
+	paladin.registerDivineProtectionSpell()
+	paladin.registerForbearanceDebuff()
 
 	paladin.SealOfVengeanceDots = make([]*core.Dot, paladin.Env.GetNumTargets())
 	for i := range paladin.SealOfVengeanceDots {
@@ -164,7 +176,8 @@ func NewPaladin(character core.Character, talents *proto.PaladinTalents) *Paladi
 		Talents:   talents,
 	}
 
-	paladin.HasTuralyonsOrLiadrinsBattlegear2Pc = paladin.HasSetBonus(ItemSetTuralyonsBattlegear, 2) || paladin.HasSetBonus(ItemSetLiadrinsBattlegear, 2)
+	// This is used to cache its effect in talents.go
+	paladin.HasTuralyonsOrLiadrinsBattlegear2Pc = paladin.HasSetBonus(ItemSetTuralyonsBattlegear, 2)
 
 	paladin.PseudoStats.CanParry = true
 
@@ -192,6 +205,11 @@ func NewPaladin(character core.Character, talents *proto.PaladinTalents) *Paladi
 	paladin.PseudoStats.BaseParry += 0.05
 
 	return paladin
+}
+
+// Shared 30sec cooldown for Divine Protection and Avenging Wrath
+func (paladin *Paladin) GetMutualLockoutDPAW() *core.Timer {
+	return paladin.Character.GetOrInitTimer(&paladin.mutualLockoutDPAW)
 }
 
 func init() {

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -95,15 +95,15 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 3176.62314
-  tps: 22886.19299
+  dps: 3176.65992
+  tps: 23104.99734
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 3176.62314
-  tps: 22886.19299
+  dps: 3176.65992
+  tps: 23104.99734
  }
 }
 dps_results: {
@@ -313,8 +313,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 3232.6039
-  tps: 7789.8927
+  dps: 3232.63608
+  tps: 7789.97554
  }
 }
 dps_results: {
@@ -411,8 +411,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 3199.78149
-  tps: 7718.7928
+  dps: 3199.81375
+  tps: 7718.87584
  }
 }
 dps_results: {
@@ -440,7 +440,7 @@ dps_results: {
  key: "TestProtection-AllItems-InsightfulEarthsiegeDiamond"
  value: {
   dps: 3203.35218
-  tps: 7740.75464
+  tps: 7740.73106
  }
 }
 dps_results: {
@@ -456,20 +456,6 @@ dps_results: {
  value: {
   dps: 3195.79595
   tps: 7708.53402
- }
-}
-dps_results: {
- key: "TestProtection-AllItems-Liadrin'sBattlegear"
- value: {
-  dps: 3363.61315
-  tps: 8035.75669
- }
-}
-dps_results: {
- key: "TestProtection-AllItems-Liadrin'sPlate"
- value: {
-  dps: 3117.99013
-  tps: 7506.48577
  }
 }
 dps_results: {
@@ -721,7 +707,7 @@ dps_results: {
  key: "TestProtection-AllItems-SparkofLife-37657"
  value: {
   dps: 3264.84365
-  tps: 7870.18871
+  tps: 7870.19853
  }
 }
 dps_results: {
@@ -896,8 +882,8 @@ dps_results: {
  key: "TestProtection-Average-Default"
  value: {
   dps: 3584.58064
-  tps: 8597.07744
-  dtps: 16.18688
+  tps: 8597.07268
+  dtps: 15.01878
  }
 }
 dps_results: {
@@ -1157,6 +1143,6 @@ dps_results: {
  value: {
   dps: 3758.67434
   tps: 9009.73746
-  dtps: 13.2107
+  dtps: 12.47426
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -510,22 +510,6 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestRetribution-AllItems-Liadrin'sBattlegear"
- value: {
-  dps: 5625.20277
-  tps: 5724.06755
-  dtps: 9.92959
- }
-}
-dps_results: {
- key: "TestRetribution-AllItems-Liadrin'sPlate"
- value: {
-  dps: 4976.26492
-  tps: 5074.40293
-  dtps: 8.90286
- }
-}
-dps_results: {
  key: "TestRetribution-AllItems-LibramofFuriousBlows-37574"
  value: {
   dps: 5872.30378

--- a/sim/paladin/soc.go
+++ b/sim/paladin/soc.go
@@ -35,7 +35,7 @@ func (paladin *Paladin) registerSealOfCommandSpellAndAura() {
 		Flags:       core.SpellFlagMeleeMetrics | SpellFlagSecondaryJudgement,
 
 		BonusCritRating: (6 * float64(paladin.Talents.Fanaticism) * core.CritRatingPerCritChance) +
-			(core.TernaryFloat64(paladin.HasSetBonus(ItemSetTuralyonsBattlegear, 4) || paladin.HasSetBonus(ItemSetLiadrinsBattlegear, 4), 5, 0) * core.CritRatingPerCritChance),
+			(core.TernaryFloat64(paladin.HasSetBonus(ItemSetTuralyonsBattlegear, 4), 5, 0) * core.CritRatingPerCritChance),
 
 		DamageMultiplier: 1 *
 			(1 + paladin.getItemSetLightswornBattlegearBonus4() +

--- a/sim/paladin/sor.go
+++ b/sim/paladin/sor.go
@@ -32,7 +32,7 @@ func (paladin *Paladin) registerSealOfRighteousnessSpellAndAura() {
 		Flags:       core.SpellFlagMeleeMetrics | SpellFlagSecondaryJudgement,
 
 		BonusCritRating: (6 * float64(paladin.Talents.Fanaticism) * core.CritRatingPerCritChance) +
-			(core.TernaryFloat64(paladin.HasSetBonus(ItemSetTuralyonsBattlegear, 4) || paladin.HasSetBonus(ItemSetLiadrinsBattlegear, 4), 5, 0) * core.CritRatingPerCritChance),
+			(core.TernaryFloat64(paladin.HasSetBonus(ItemSetTuralyonsBattlegear, 4), 5, 0) * core.CritRatingPerCritChance),
 
 		DamageMultiplier: 1 *
 			(1 + paladin.getItemSetLightswornBattlegearBonus4() + paladin.getTalentSealsOfThePureBonus() +

--- a/sim/paladin/sov.go
+++ b/sim/paladin/sov.go
@@ -69,7 +69,7 @@ func (paladin *Paladin) registerSealOfVengeanceSpellAndAura() {
 		Flags:       core.SpellFlagMeleeMetrics | SpellFlagSecondaryJudgement,
 
 		BonusCritRating: (6 * float64(paladin.Talents.Fanaticism) * core.CritRatingPerCritChance) +
-			(core.TernaryFloat64(paladin.HasSetBonus(ItemSetTuralyonsBattlegear, 4) || paladin.HasSetBonus(ItemSetLiadrinsBattlegear, 4), 5, 0) * core.CritRatingPerCritChance),
+			(core.TernaryFloat64(paladin.HasSetBonus(ItemSetTuralyonsBattlegear, 4), 5, 0) * core.CritRatingPerCritChance),
 		DamageMultiplier: 1 *
 			(1 + paladin.getItemSetLightswornBattlegearBonus4() +
 				paladin.getTalentSealsOfThePureBonus() + paladin.getMajorGlyphOfJudgementBonus() + paladin.getTalentTheArtOfWarBonus()) *

--- a/sim/warrior/devastate.go
+++ b/sim/warrior/devastate.go
@@ -46,6 +46,7 @@ func (warrior *Warrior) registerDevastateSpell() {
 	dynaThreatBonus := core.TernaryFloat64(hasGlyph, 0.1, 0.05)
 
 	weaponMulti := 1.2
+	overallMulti := core.TernaryFloat64(warrior.HasSetBonus(ItemSetWrynnsPlate, 2), 1.05, 1.00)
 
 	warrior.Devastate = warrior.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 47498},
@@ -67,7 +68,7 @@ func (warrior *Warrior) registerDevastateSpell() {
 		BonusCritRating: 5*core.CritRatingPerCritChance*float64(warrior.Talents.SwordAndBoard) +
 			core.TernaryFloat64(warrior.HasSetBonus(ItemSetSiegebreakerPlate, 2), 10*core.CritRatingPerCritChance, 0),
 
-		DamageMultiplier: weaponMulti * core.TernaryFloat64(warrior.HasSetBonus(ItemSetWrynnsPlate, 2), 1.05, 1.00),
+		DamageMultiplier: overallMulti,
 		CritMultiplier:   warrior.critMultiplier(mh),
 		ThreatMultiplier: 1,
 		FlatThreatBonus:  flatThreatBonus,
@@ -80,7 +81,7 @@ func (warrior *Warrior) registerDevastateSpell() {
 				sunderBonus = 242 * float64(core.MinInt32(saStacks+1, 5))
 			}
 
-			baseDamage := spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower()) + sunderBonus
+			baseDamage := (weaponMulti * spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())) + sunderBonus
 
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
 			result.Threat = spell.ThreatFromDamage(result.Outcome, result.Damage+dynaThreatBonus*spell.MeleeAttackPower())

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -46,7 +46,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 0.69251
+  weights: 0.92553
   weights: 0
   weights: 0
   weights: 0
@@ -57,7 +57,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.18939
+  weights: 0.42708
   weights: 0
   weights: 0
   weights: 0
@@ -66,12 +66,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.01502
+  weights: 0.01099
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.46585
-  weights: 0.03036
+  weights: 0.47291
+  weights: -0.07369
   weights: 0
   weights: 0
   weights: 0
@@ -91,886 +91,886 @@ stat_weights_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 1950.15851
-  tps: 5660.80847
+  dps: 1942.3818
+  tps: 5651.77089
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2028.7405
-  tps: 5849.80764
+  dps: 2030.23333
+  tps: 5862.03315
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 1913.74858
-  tps: 19537.01035
+  dps: 1931.52334
+  tps: 19657.8426
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 1913.74858
-  tps: 19537.01035
+  dps: 1931.52334
+  tps: 19657.8426
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1936.5521
-  tps: 5622.03779
+  dps: 1944.64448
+  tps: 5651.54621
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1899.67263
-  tps: 5513.34963
+  dps: 1917.86627
+  tps: 5574.65937
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1664.3033
-  tps: 4879.6404
+  dps: 1667.98284
+  tps: 4892.05634
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1620.29595
-  tps: 4742.37196
+  dps: 1629.15623
+  tps: 4771.19852
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1526.81037
-  tps: 4503.17919
+  dps: 1525.18194
+  tps: 4509.91465
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1895.69557
-  tps: 5406.06299
+  dps: 1937.23439
+  tps: 5521.98762
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1972.67787
-  tps: 5717.76394
+  dps: 1972.31694
+  tps: 5715.7887
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
   hps: 64
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2001.17468
-  tps: 5783.98963
+  dps: 1995.25365
+  tps: 5776.30199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2037.94233
-  tps: 5854.67739
+  dps: 2044.02853
+  tps: 5873.3869
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 2011.24198
-  tps: 5826.10211
+  dps: 2006.67784
+  tps: 5817.67861
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Death'sChoice-47464"
  value: {
-  dps: 2108.72458
-  tps: 6088.12134
+  dps: 2126.36955
+  tps: 6141.74254
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1984.55362
-  tps: 5735.63657
+  dps: 1988.18319
+  tps: 5756.94615
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 2113.21504
-  tps: 6063.57385
+  dps: 2141.92919
+  tps: 6147.36368
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 2141.24715
-  tps: 6138.77036
+  dps: 2135.2463
+  tps: 6125.53223
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1939.17936
-  tps: 5627.25049
+  dps: 1947.24428
+  tps: 5657.36819
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 2002.33648
-  tps: 5813.91572
+  dps: 1990.04315
+  tps: 5783.33446
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 1994.22051
-  tps: 5783.32706
+  dps: 1978.26756
+  tps: 5741.0565
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 2081.4689
-  tps: 5968.36448
+  dps: 2102.7507
+  tps: 6035.04039
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DreadnaughtPlate"
  value: {
-  dps: 1840.28305
-  tps: 5357.12641
+  dps: 1848.03457
+  tps: 5388.62415
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1895.69557
-  tps: 5516.33979
+  dps: 1937.23439
+  tps: 5634.63023
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1895.69557
-  tps: 5516.33979
+  dps: 1937.23439
+  tps: 5634.63023
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1936.5521
-  tps: 5622.03779
+  dps: 1944.64448
+  tps: 5651.54621
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1938.09402
-  tps: 5626.20992
+  dps: 1945.44419
+  tps: 5654.14785
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 1964.42761
-  tps: 5698.87609
+  dps: 1973.76893
+  tps: 5733.91903
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1909.29818
-  tps: 5553.00632
+  dps: 1951.32539
+  tps: 5672.61323
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2037.88538
-  tps: 5863.10846
+  dps: 2035.97674
+  tps: 5860.85715
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1995.96282
-  tps: 5770.82601
+  dps: 2001.90606
+  tps: 5789.12101
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1985.49215
-  tps: 5745.20497
+  dps: 1984.88875
+  tps: 5746.91968
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1895.69557
-  tps: 5516.33979
+  dps: 1937.23439
+  tps: 5634.63023
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1895.69557
-  tps: 5516.33979
+  dps: 1937.23439
+  tps: 5634.63023
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1994.65307
-  tps: 5784.64729
+  dps: 2009.71367
+  tps: 5833.56409
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 2242.05889
-  tps: 6316.39056
+  dps: 2239.581
+  tps: 6318.53023
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 2017.64945
-  tps: 5811.70911
+  dps: 2024.4584
+  tps: 5832.39581
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Heartpierce-49982"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Heartpierce-50641"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1936.5521
-  tps: 5622.03779
+  dps: 1944.64448
+  tps: 5651.54621
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1938.09402
-  tps: 5626.20992
+  dps: 1945.44419
+  tps: 5654.14785
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2010.79973
-  tps: 5821.76981
+  dps: 2007.119
+  tps: 5815.47506
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1895.69557
-  tps: 5516.33979
+  dps: 1937.23439
+  tps: 5634.63023
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1937.6516
-  tps: 5636.9828
-  hps: 17.63102
+  dps: 1938.87119
+  tps: 5640.61754
+  hps: 18.27017
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1927.67289
-  tps: 5601.65423
+  dps: 1945.45308
+  tps: 5660.34792
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1996.94191
-  tps: 5779.05364
+  dps: 2015.8572
+  tps: 5831.53824
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 2012.56696
-  tps: 5810.46749
+  dps: 2014.80118
+  tps: 5813.2617
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1929.32438
-  tps: 5609.46217
+  dps: 1949.57543
+  tps: 5675.73244
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 1492.36492
-  tps: 4403.92347
+  dps: 1506.06878
+  tps: 4435.67786
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 1683.02861
-  tps: 4874.63455
+  dps: 1691.98286
+  tps: 4910.67568
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1929.39148
-  tps: 5614.32334
+  dps: 1940.28891
+  tps: 5654.13716
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1937.6516
-  tps: 5636.9828
+  dps: 1938.87119
+  tps: 5640.61754
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 1946.21469
-  tps: 5653.31091
+  dps: 1969.79407
+  tps: 5724.19988
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 1940.36174
-  tps: 5632.45825
+  dps: 1959.9219
+  tps: 5694.16996
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1895.69557
-  tps: 5516.33979
+  dps: 1937.23439
+  tps: 5634.63023
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1895.69557
-  tps: 5516.33979
+  dps: 1937.23439
+  tps: 5634.63023
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1969.04379
-  tps: 5707.6697
+  dps: 1972.23004
+  tps: 5715.66389
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1895.69557
-  tps: 5516.33979
+  dps: 1937.23439
+  tps: 5634.63023
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1915.71545
-  tps: 5575.60722
+  dps: 1939.51527
+  tps: 5643.16254
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Shadowmourne-49623"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 2134.72507
-  tps: 6123.40694
+  dps: 2153.09612
+  tps: 6171.98845
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SiegebreakerPlate"
  value: {
-  dps: 1928.186
-  tps: 5556.99668
+  dps: 1960.75764
+  tps: 5656.32119
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SouloftheDead-40382"
  value: {
-  dps: 2001.99138
-  tps: 5788.69154
+  dps: 2000.30481
+  tps: 5786.90389
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SparkofHope-45703"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SparkofLife-37657"
  value: {
-  dps: 1956.76298
-  tps: 5686.25149
+  dps: 1978.35072
+  tps: 5755.40323
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 1998.62271
-  tps: 5802.06576
+  dps: 2005.66042
+  tps: 5824.45608
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormshroudArmor"
  value: {
-  dps: 1506.00966
-  tps: 4440.3059
+  dps: 1532.66167
+  tps: 4527.92527
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1937.6516
-  tps: 5636.9828
+  dps: 1938.87119
+  tps: 5640.61754
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1929.39148
-  tps: 5614.32334
+  dps: 1940.28891
+  tps: 5654.13716
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1930.10039
-  tps: 5612.21015
+  dps: 1932.46358
+  tps: 5618.15929
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 1447.67743
-  tps: 4181.67857
+  dps: 1447.24014
+  tps: 4180.77185
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1587.11208
-  tps: 4536.85146
+  dps: 1586.67479
+  tps: 4535.94474
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1936.94969
-  tps: 5637.71948
+  dps: 1952.4842
+  tps: 5682.41255
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2015.74697
-  tps: 5861.98181
+  dps: 2044.09443
+  tps: 5935.4059
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2032.34619
-  tps: 5897.80265
+  dps: 2060.61132
+  tps: 5984.62454
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1895.69557
-  tps: 5516.33979
+  dps: 1937.23439
+  tps: 5634.63023
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1895.69557
-  tps: 5516.33979
+  dps: 1937.23439
+  tps: 5634.63023
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 1930.92544
-  tps: 5606.85161
+  dps: 1945.56215
+  tps: 5651.67229
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1895.69557
-  tps: 5516.33979
+  dps: 1937.23439
+  tps: 5634.63023
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1895.69557
-  tps: 5516.33979
+  dps: 1937.23439
+  tps: 5634.63023
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1639.78323
-  tps: 4795.80335
+  dps: 1637.91223
+  tps: 4801.93622
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 1774.82124
-  tps: 5186.38367
+  dps: 1777.56954
+  tps: 5203.19902
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WingedTalisman-37844"
  value: {
-  dps: 1913.85402
-  tps: 5564.40478
+  dps: 1931.73949
+  tps: 5623.38224
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 2188.07906
-  tps: 6227.79872
+  dps: 2198.90242
+  tps: 6257.85236
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Wrynn'sPlate"
  value: {
-  dps: 1887.0105
-  tps: 5464.42265
+  dps: 1906.98249
+  tps: 5525.52519
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 2492.54342
-  tps: 6998.02399
+  dps: 2467.38241
+  tps: 6935.11291
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-YmirjarLord'sPlate"
  value: {
-  dps: 2036.76563
-  tps: 5897.74595
+  dps: 2041.43795
+  tps: 5917.5994
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 3088.86529
-  tps: 8064.52552
-  dtps: 128.36531
+  dps: 3100.66459
+  tps: 8096.55071
+  dtps: 128.2678
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1962.99932
-  tps: 5283.48468
+  dps: 1976.16246
+  tps: 5324.79979
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1962.99932
-  tps: 5235.98468
+  dps: 1976.16246
+  tps: 5277.29979
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2140.42256
-  tps: 5677.69871
+  dps: 2169.04539
+  tps: 5765.96968
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1052.91381
-  tps: 2829.59082
+  dps: 1007.94039
+  tps: 2736.34156
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1052.91381
-  tps: 2782.09082
+  dps: 1007.94039
+  tps: 2688.84156
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 963.62752
-  tps: 2579.88322
+  dps: 929.39646
+  tps: 2508.90513
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1981.4579
-  tps: 5329.79687
+  dps: 2003.97513
+  tps: 5394.94304
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1981.4579
-  tps: 5282.29687
+  dps: 2003.97513
+  tps: 5347.44304
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2151.49499
-  tps: 5696.89427
+  dps: 2187.16297
+  tps: 5801.72123
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1058.33558
-  tps: 2844.48078
+  dps: 1012.90956
+  tps: 2754.22246
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1058.33558
-  tps: 2796.98078
+  dps: 1012.90956
+  tps: 2706.72246
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 989.50031
-  tps: 2645.00796
+  dps: 953.78512
+  tps: 2570.95252
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3221.29196
-  tps: 8414.03102
-  dtps: 118.79006
+  dps: 3278.09119
+  tps: 8558.27534
+  dtps: 118.11237
  }
 }

--- a/sim/warrior/shield_wall.go
+++ b/sim/warrior/shield_wall.go
@@ -12,7 +12,7 @@ func (warrior *Warrior) RegisterShieldWallCD() {
 		return
 	}
 
-	duration := time.Second*10 + time.Second*2*time.Duration(warrior.Talents.ImprovedDisciplines)
+	duration := time.Second*12 + core.TernaryDuration(warrior.HasSetBonus(ItemSetDreadnaughtPlate, 4), time.Second*3, 0)
 	hasGlyph := warrior.HasMajorGlyph(proto.WarriorMajorGlyph_GlyphOfShieldWall)
 	//This is the inverse of the tooltip since it is a damage TAKEN coefficient
 	damageTaken := core.TernaryFloat64(hasGlyph, 0.4, 0.6)
@@ -39,7 +39,7 @@ func (warrior *Warrior) RegisterShieldWallCD() {
 
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
-				GCD: core.GCDDefault,
+				GCD: 0,
 			},
 			IgnoreHaste: true,
 			CD: core.Cooldown{

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -751,9 +751,12 @@ func (warrior *Warrior) registerLastStandCD() {
 		ActionID: actionID,
 
 		Cast: core.CastConfig{
+			DefaultCast: core.Cast{
+				GCD: 0,
+			},
 			CD: core.Cooldown{
 				Timer:    warrior.NewTimer(),
-				Duration: time.Minute * 3,
+				Duration: core.TernaryDuration(warrior.HasMajorGlyph(proto.WarriorMajorGlyph_GlyphOfLastStand), time.Minute*3, time.Minute*2),
 			},
 		},
 


### PR DESCRIPTION
- Paladin: Implemented Divine Protection cooldown with Avenging Wrath Shared CD; Ret is forbidden from using currently to prevent issues with this lockout
- Paladin: T9 set bonuses now use the Alternative setname feature to remove redundant references
- Warrior: Last Stand and Shield Wall removed GCD, fixed some talent/glyph interactions
- Warrior: Fixed Devastate bug applying the 120% weapon modifier to the BonusDamage portion also
- Item: Lavanthor's Talisman now properly only has a shared CD of 20sec, shorter than its effect. This is also true with the TBC trinkets but this was a bit of a hack to implement so I left those alone for now.

NOTE: In testing this I noted that Warrior Test suite does not seem to be using Devastate. Not sure why it isn't using the fallback rotation.