### PR TITLE
feral: updates

### DIFF
--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -27,6 +27,8 @@ type Druid struct {
 	RaidBuffTargets   int
 	PrePopBerserk     bool
 
+	ReplaceBearMHFunc core.ReplaceMHSwing
+
 	Barkskin             *core.Spell
 	Berserk              *core.Spell
 	DemoralizingRoar     *core.Spell
@@ -179,6 +181,10 @@ func (druid *Druid) HasMajorGlyph(glyph proto.DruidMajorGlyph) bool {
 }
 func (druid *Druid) HasMinorGlyph(glyph proto.DruidMinorGlyph) bool {
 	return druid.HasGlyph(int32(glyph))
+}
+
+func (druid *Druid) TryMaul(sim *core.Simulation, mhSwingSpell *core.Spell) *core.Spell {
+	return druid.MaulReplaceMH(sim, mhSwingSpell)
 }
 
 func (druid *Druid) Initialize() {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -46,919 +46,919 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 7187.2876
-  tps: 7697.34986
+  dps: 7151.49173
+  tps: 7574.17106
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7248.23576
-  tps: 7684.52923
+  dps: 7319.62256
+  tps: 7861.00645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7305.20835
-  tps: 7751.73808
+  dps: 7308.45265
+  tps: 7698.00125
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7173.00314
-  tps: 131230.76877
+  dps: 7142.96646
+  tps: 121069.95573
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7173.00314
-  tps: 131230.76877
+  dps: 7142.96646
+  tps: 121069.95573
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7286.02032
-  tps: 7732.25389
+  dps: 7324.26317
+  tps: 7834.18332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5790.0146
-  tps: 6149.25707
+  dps: 5869.25741
+  tps: 6227.35009
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7248.23576
-  tps: 7531.3148
+  dps: 7319.62256
+  tps: 7704.26149
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 7268.78877
-  tps: 7673.42767
+  dps: 7320.59689
+  tps: 7813.90647
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7430.75919
-  tps: 7870.1576
+  dps: 7467.93233
+  tps: 7979.70417
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7231.73457
-  tps: 7711.36338
+  dps: 7274.29663
+  tps: 7799.94854
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7283.70806
-  tps: 7757.84948
+  dps: 7309.10078
+  tps: 7795.26272
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7178.39973
-  tps: 7693.64032
+  dps: 7136.93923
+  tps: 7567.49831
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 7290.99542
-  tps: 7710.04041
+  dps: 7348.30058
+  tps: 7828.45129
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7525.82939
-  tps: 8057.66611
+  dps: 7566.49689
+  tps: 7962.25435
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7232.36624
-  tps: 7720.71197
+  dps: 7207.05326
+  tps: 7712.94558
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7554.21998
-  tps: 8051.77176
+  dps: 7560.36332
+  tps: 7994.34813
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7611.48263
-  tps: 8091.48386
+  dps: 7639.93412
+  tps: 8078.77627
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7308.70713
-  tps: 7760.31738
+  dps: 7339.47372
+  tps: 7881.78398
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7256.54193
-  tps: 7665.44071
+  dps: 7263.75648
+  tps: 7763.62279
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7240.30639
-  tps: 7695.25099
+  dps: 7268.71413
+  tps: 7745.82634
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 6733.52107
-  tps: 7215.72672
+  dps: 6776.51768
+  tps: 7227.19134
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreamwalkerGarb"
  value: {
-  dps: 5712.44588
-  tps: 6099.37241
+  dps: 5735.59576
+  tps: 6110.45914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7248.23576
-  tps: 7684.52923
+  dps: 7319.62256
+  tps: 7861.00645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7248.23576
-  tps: 7684.49089
+  dps: 7319.62256
+  tps: 7860.96758
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7286.02032
-  tps: 7732.31231
+  dps: 7324.26317
+  tps: 7834.24332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7275.31502
-  tps: 7711.70479
+  dps: 7320.60602
+  tps: 7828.01762
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7202.39018
-  tps: 7688.64084
+  dps: 7265.46853
+  tps: 7794.63582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7248.23576
-  tps: 7684.52923
+  dps: 7319.62256
+  tps: 7861.00645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7289.68683
-  tps: 7803.76094
+  dps: 7319.61549
+  tps: 7854.51033
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7238.19246
-  tps: 7717.23662
+  dps: 7266.73522
+  tps: 7781.01565
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7178.39973
-  tps: 7693.97031
+  dps: 7136.93923
+  tps: 7567.82867
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7217.0348
-  tps: 7699.50335
+  dps: 7218.4526
+  tps: 7695.38617
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7248.23576
-  tps: 7684.52923
+  dps: 7319.62256
+  tps: 7861.00645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7248.23576
-  tps: 7684.52923
+  dps: 7319.62256
+  tps: 7861.00645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 7297.36618
-  tps: 7714.62568
+  dps: 7357.59163
+  tps: 7835.11325
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7316.01139
-  tps: 7785.32077
+  dps: 7304.76937
+  tps: 7704.92938
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 7011.44288
-  tps: 7503.85905
+  dps: 7080.59123
+  tps: 7523.04809
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 5757.76193
-  tps: 6239.31612
+  dps: 5763.04429
+  tps: 6174.20781
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7273.21855
-  tps: 7733.88623
+  dps: 7263.58952
+  tps: 7750.06863
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 7278.20247
-  tps: 7684.49714
+  dps: 7331.12167
+  tps: 7826.55812
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-49982"
  value: {
-  dps: 7515.49442
-  tps: 8032.30959
+  dps: 7543.23513
+  tps: 7984.38798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 7550.1346
-  tps: 7970.85702
+  dps: 7583.59801
+  tps: 8004.25736
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 7493.23419
-  tps: 7992.14656
+  dps: 7497.03436
+  tps: 7940.00114
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 7310.85655
-  tps: 7734.40197
+  dps: 7334.6627
+  tps: 7815.65348
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 7528.81052
-  tps: 8011.65924
+  dps: 7527.35739
+  tps: 7979.99421
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 7268.78877
-  tps: 7673.42767
+  dps: 7320.59689
+  tps: 7813.90647
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 7334.8952
-  tps: 7773.72302
+  dps: 7369.36073
+  tps: 7848.23464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 7268.78877
-  tps: 7673.42767
+  dps: 7320.59689
+  tps: 7813.90647
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 7304.52444
-  tps: 7746.71897
+  dps: 7346.21274
+  tps: 7811.98073
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7286.02032
-  tps: 7732.31231
+  dps: 7324.26317
+  tps: 7834.24332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7275.31502
-  tps: 7711.70479
+  dps: 7320.60602
+  tps: 7828.01762
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7325.33701
-  tps: 7738.43712
+  dps: 7335.48071
+  tps: 7710.06746
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7248.23576
-  tps: 7684.56237
+  dps: 7319.62256
+  tps: 7861.11047
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7275.96586
-  tps: 7747.01335
-  hps: 12.96337
+  dps: 7354.00027
+  tps: 7865.79653
+  hps: 12.82775
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 7818.24689
-  tps: 8298.54603
+  dps: 7842.48966
+  tps: 8352.95559
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LasherweaveRegalia"
  value: {
-  dps: 5860.54113
-  tps: 6336.11379
+  dps: 5901.03978
+  tps: 6284.01781
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 6968.90116
-  tps: 7317.69294
+  dps: 7036.07343
+  tps: 7352.34643
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 5629.46191
-  tps: 6067.16673
+  dps: 5621.06463
+  tps: 6043.69787
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7289.94998
-  tps: 7822.09287
+  dps: 7294.50436
+  tps: 7786.64809
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7318.30618
-  tps: 7866.91042
+  dps: 7335.74637
+  tps: 7794.93214
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NightsongBattlegear"
  value: {
-  dps: 6963.03982
-  tps: 7315.29296
+  dps: 6966.83513
+  tps: 7325.01517
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NightsongGarb"
  value: {
-  dps: 5701.79499
-  tps: 6103.87231
+  dps: 5672.82378
+  tps: 6077.6265
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7270.87083
-  tps: 7740.76315
+  dps: 7346.08841
+  tps: 7865.91418
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7275.40603
-  tps: 7745.50323
+  dps: 7352.58994
+  tps: 7864.67671
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7248.23576
-  tps: 7684.52923
+  dps: 7319.62256
+  tps: 7861.00645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7248.23576
-  tps: 7684.52923
+  dps: 7319.62256
+  tps: 7861.00645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7424.33687
-  tps: 7851.63038
+  dps: 7474.63311
+  tps: 7990.8621
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 7300.55221
-  tps: 7718.07729
+  dps: 7359.27309
+  tps: 7838.96593
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7248.23576
-  tps: 7684.15661
+  dps: 7319.62256
+  tps: 7860.62924
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 7277.13677
-  tps: 7683.244
+  dps: 7329.93019
+  tps: 7825.12586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7178.39973
-  tps: 7694.31768
+  dps: 7136.93923
+  tps: 7568.18231
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7178.39973
-  tps: 7694.31768
+  dps: 7136.93923
+  tps: 7568.18231
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7235.9807
-  tps: 7730.48941
+  dps: 7270.52405
+  tps: 7782.8765
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofHope-45703"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 7184.5675
-  tps: 7649.93769
+  dps: 7275.72305
+  tps: 7732.06031
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7276.429
-  tps: 7783.79465
+  dps: 7328.37721
+  tps: 7838.26292
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StormshroudArmor"
  value: {
-  dps: 5897.65877
-  tps: 6200.16496
+  dps: 5903.68986
+  tps: 6182.14229
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7275.40603
-  tps: 7745.50323
+  dps: 7352.58994
+  tps: 7864.67671
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7270.87083
-  tps: 7740.76315
+  dps: 7346.08841
+  tps: 7865.91418
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7269.31344
-  tps: 7733.04931
+  dps: 7342.55026
+  tps: 7886.07817
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7178.39973
-  tps: 7693.68095
+  dps: 7136.93923
+  tps: 7567.53907
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartHarness"
  value: {
-  dps: 5681.82114
-  tps: 6079.67944
+  dps: 5773.07856
+  tps: 6171.64503
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartRegalia"
  value: {
-  dps: 4986.64255
-  tps: 5339.82067
+  dps: 4975.37728
+  tps: 5315.62769
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7244.92536
-  tps: 7758.28204
+  dps: 7271.38221
+  tps: 7789.90378
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7340.29981
-  tps: 7818.12861
+  dps: 7408.50277
+  tps: 7935.21827
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7373.89143
-  tps: 7919.53172
+  dps: 7431.18707
+  tps: 7952.27322
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7248.23576
-  tps: 7684.52923
+  dps: 7319.62256
+  tps: 7861.00645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7248.23576
-  tps: 7684.52923
+  dps: 7319.62256
+  tps: 7861.00645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7156.69428
-  tps: 7622.67732
+  dps: 7195.79159
+  tps: 7663.75099
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7248.23576
-  tps: 7684.52923
+  dps: 7319.62256
+  tps: 7861.00645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7248.23576
-  tps: 7684.52923
+  dps: 7319.62256
+  tps: 7861.00645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6103.39403
-  tps: 6460.26519
+  dps: 6093.89067
+  tps: 6501.60369
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6075.42727
-  tps: 6536.97615
+  dps: 6048.733
+  tps: 6459.29247
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 7268.78877
-  tps: 7673.42767
+  dps: 7320.59689
+  tps: 7813.90647
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7178.39973
-  tps: 7694.2673
+  dps: 7136.93923
+  tps: 7568.12568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 7303.87669
-  tps: 7728.31813
+  dps: 7365.90033
+  tps: 7847.37855
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 7478.2949
-  tps: 7972.01637
+  dps: 7511.72139
+  tps: 8006.85838
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6969.43037
-  tps: 7875.38448
+  dps: 7014.58547
+  tps: 7912.53749
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6969.43037
-  tps: 7419.56032
+  dps: 7014.58547
+  tps: 7466.7094
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7766.11121
-  tps: 7390.23399
+  dps: 7760.91889
+  tps: 7357.819
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4310.20155
-  tps: 5139.50551
+  dps: 4292.07844
+  tps: 5155.39272
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4310.20155
-  tps: 4577.41179
+  dps: 4292.07844
+  tps: 4574.68101
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4408.24623
-  tps: 4164.6356
+  dps: 4405.13657
+  tps: 4110.47232
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6276.88294
-  tps: 6784.62167
+  dps: 6356.29051
+  tps: 6823.73788
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -46,919 +46,919 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 7122.99527
-  tps: 7598.75623
+  dps: 7115.69446
+  tps: 7679.33503
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7226.58252
-  tps: 7822.35212
+  dps: 7172.06305
+  tps: 7714.3404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7250.86514
-  tps: 7805.2456
+  dps: 7253.73864
+  tps: 7817.82306
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7134.95654
-  tps: 127952.8871
+  dps: 7092.02946
+  tps: 129329.67948
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7134.95654
-  tps: 127952.8871
+  dps: 7092.02946
+  tps: 129329.67948
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7248.16437
-  tps: 7872.22457
+  dps: 7219.7433
+  tps: 7779.46435
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5756.8841
-  tps: 6171.09168
+  dps: 5802.26935
+  tps: 6224.47253
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7226.58252
-  tps: 7666.39359
+  dps: 7172.06305
+  tps: 7560.5386
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 7238.21731
-  tps: 7819.51414
+  dps: 7217.33892
+  tps: 7764.02291
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7382.86037
-  tps: 7986.61614
+  dps: 7359.41779
+  tps: 7926.07209
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7229.17771
-  tps: 7773.99971
+  dps: 7188.92433
+  tps: 7716.0888
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7258.28381
-  tps: 7822.35059
+  dps: 7259.61947
+  tps: 7784.8107
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7115.0788
-  tps: 7601.42145
+  dps: 7094.44813
+  tps: 7628.71713
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 7251.59879
-  tps: 7825.44223
+  dps: 7239.75188
+  tps: 7790.05618
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7518.6876
-  tps: 8032.32936
+  dps: 7473.2873
+  tps: 7975.11833
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7190.33668
-  tps: 7726.66088
+  dps: 7169.30374
+  tps: 7643.71961
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7482.121
-  tps: 8029.53214
+  dps: 7509.92875
+  tps: 8084.26693
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7549.33205
-  tps: 8073.88424
+  dps: 7522.18042
+  tps: 8126.90176
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7266.99728
-  tps: 7898.3204
+  dps: 7223.84642
+  tps: 7786.959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7234.95258
-  tps: 7732.55092
+  dps: 7217.20535
+  tps: 7712.23782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7214.88502
-  tps: 7747.11936
+  dps: 7220.135
+  tps: 7694.5088
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 6738.46846
-  tps: 7196.8231
+  dps: 6690.72249
+  tps: 7207.43834
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreamwalkerGarb"
  value: {
-  dps: 5678.23663
-  tps: 6080.46345
+  dps: 5680.3591
+  tps: 6111.0497
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7226.58252
-  tps: 7822.35212
+  dps: 7172.06305
+  tps: 7714.3404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7226.58252
-  tps: 7822.31255
+  dps: 7172.06305
+  tps: 7714.3014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7248.16437
-  tps: 7872.28664
+  dps: 7219.7433
+  tps: 7779.52595
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7248.38236
-  tps: 7864.39091
+  dps: 7222.01757
+  tps: 7791.51787
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7192.22099
-  tps: 7772.892
+  dps: 7178.6632
+  tps: 7742.92447
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7226.58252
-  tps: 7822.35212
+  dps: 7172.06305
+  tps: 7714.3404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7263.04517
-  tps: 7845.5813
+  dps: 7253.03467
+  tps: 7810.60556
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7215.1327
-  tps: 7777.07403
+  dps: 7208.01362
+  tps: 7754.32487
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7115.0788
-  tps: 7601.73389
+  dps: 7094.44813
+  tps: 7629.05706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7181.3056
-  tps: 7743.70573
+  dps: 7183.25637
+  tps: 7726.54528
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7226.58252
-  tps: 7822.35212
+  dps: 7172.06305
+  tps: 7714.3404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7226.58252
-  tps: 7822.35212
+  dps: 7172.06305
+  tps: 7714.3404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 7252.79807
-  tps: 7828.35471
+  dps: 7244.62662
+  tps: 7795.4087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7273.49908
-  tps: 7804.6069
+  dps: 7264.52465
+  tps: 7821.92333
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 6952.39304
-  tps: 7410.42761
+  dps: 6970.08929
+  tps: 7445.55771
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 5726.54839
-  tps: 6199.95753
+  dps: 5703.37176
+  tps: 6139.97433
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7221.25889
-  tps: 7772.52304
+  dps: 7227.17629
+  tps: 7767.87082
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 7243.52126
-  tps: 7823.54983
+  dps: 7226.56852
+  tps: 7774.83516
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-49982"
  value: {
-  dps: 7483.69601
-  tps: 8015.34306
+  dps: 7472.75783
+  tps: 7974.92308
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 7483.79091
-  tps: 7988.98111
+  dps: 7526.6884
+  tps: 8047.6558
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 7460.13601
-  tps: 8051.23228
+  dps: 7430.24419
+  tps: 7949.35181
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 7266.32441
-  tps: 7848.26378
+  dps: 7235.29603
+  tps: 7771.01374
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 7470.97507
-  tps: 8041.93386
+  dps: 7457.37454
+  tps: 7970.32706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 7238.21731
-  tps: 7819.51414
+  dps: 7217.33892
+  tps: 7764.02291
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 7284.25053
-  tps: 7856.69188
+  dps: 7261.66634
+  tps: 7827.86674
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 7238.21731
-  tps: 7819.51414
+  dps: 7217.33892
+  tps: 7764.02291
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 7264.18317
-  tps: 7836.54658
+  dps: 7246.73326
+  tps: 7776.63474
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7248.16437
-  tps: 7872.28664
+  dps: 7219.7433
+  tps: 7779.52595
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7248.38236
-  tps: 7864.39091
+  dps: 7222.01757
+  tps: 7791.51787
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7265.17062
-  tps: 7854.38351
+  dps: 7247.23759
+  tps: 7801.77519
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7226.58252
-  tps: 7822.50771
+  dps: 7172.06305
+  tps: 7714.40601
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7261.371
-  tps: 7857.99147
-  hps: 13.11986
+  dps: 7200.00989
+  tps: 7725.31875
+  hps: 13.01553
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 7738.44983
-  tps: 8255.42551
+  dps: 7752.11791
+  tps: 8253.75369
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LasherweaveRegalia"
  value: {
-  dps: 5879.9301
-  tps: 6368.54186
+  dps: 5844.13507
+  tps: 6282.36394
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.35973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 6967.41009
-  tps: 7398.89486
+  dps: 6923.74526
+  tps: 7283.79843
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 5573.48664
-  tps: 5996.68359
+  dps: 5603.54917
+  tps: 6003.15728
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7239.44848
-  tps: 7735.84181
+  dps: 7246.61865
+  tps: 7843.26401
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7274.38525
-  tps: 7720.24318
+  dps: 7285.45199
+  tps: 7804.46269
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NightsongBattlegear"
  value: {
-  dps: 6900.98486
-  tps: 7269.56863
+  dps: 6911.61334
+  tps: 7328.61482
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NightsongGarb"
  value: {
-  dps: 5636.3961
-  tps: 6003.62035
+  dps: 5638.33204
+  tps: 6050.56021
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7259.36346
-  tps: 7858.19719
+  dps: 7195.49344
+  tps: 7720.64401
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7262.22157
-  tps: 7859.1989
+  dps: 7199.99138
+  tps: 7725.38568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7226.58252
-  tps: 7822.35212
+  dps: 7172.06305
+  tps: 7714.3404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7226.58252
-  tps: 7822.35212
+  dps: 7172.06305
+  tps: 7714.3404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7392.63715
-  tps: 7999.21873
+  dps: 7370.20081
+  tps: 7941.06613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 7259.3777
-  tps: 7851.73994
+  dps: 7247.67333
+  tps: 7798.75403
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7226.58252
-  tps: 7821.97601
+  dps: 7172.06305
+  tps: 7713.96933
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 7242.34056
-  tps: 7822.17576
+  dps: 7225.52366
+  tps: 7773.61113
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7115.0788
-  tps: 7602.04477
+  dps: 7094.44813
+  tps: 7629.44512
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7115.0788
-  tps: 7602.04477
+  dps: 7094.44813
+  tps: 7629.44512
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7217.42125
-  tps: 7778.78402
+  dps: 7209.57429
+  tps: 7757.50946
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofHope-45703"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36061
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 7143.37543
-  tps: 7635.49038
+  dps: 7132.06761
+  tps: 7618.49483
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7268.43259
-  tps: 7863.73039
+  dps: 7174.5526
+  tps: 7756.32247
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StormshroudArmor"
  value: {
-  dps: 5859.53873
-  tps: 6146.17137
+  dps: 5850.58778
+  tps: 6149.16505
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7262.22157
-  tps: 7859.1989
+  dps: 7199.99138
+  tps: 7725.38568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7259.36346
-  tps: 7858.19719
+  dps: 7195.49344
+  tps: 7720.64401
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7243.01541
-  tps: 7842.12242
+  dps: 7187.62205
+  tps: 7712.34609
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.361
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7115.0788
-  tps: 7601.45917
+  dps: 7094.44813
+  tps: 7628.75913
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartHarness"
  value: {
-  dps: 5697.75832
-  tps: 6100.99719
+  dps: 5657.22638
+  tps: 6054.22674
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartRegalia"
  value: {
-  dps: 4983.53412
-  tps: 5394.62246
+  dps: 4977.36339
+  tps: 5371.93723
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7231.89646
-  tps: 7776.79124
+  dps: 7180.87256
+  tps: 7695.88811
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7355.85587
-  tps: 7905.98658
+  dps: 7340.73435
+  tps: 7985.96371
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7323.95202
-  tps: 7897.4047
+  dps: 7336.16214
+  tps: 7921.0474
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7226.58252
-  tps: 7822.35212
+  dps: 7172.06305
+  tps: 7714.3404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7226.58252
-  tps: 7822.35212
+  dps: 7172.06305
+  tps: 7714.3404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7160.50979
-  tps: 7730.86811
+  dps: 7087.1636
+  tps: 7630.91778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7226.58252
-  tps: 7822.35212
+  dps: 7172.06305
+  tps: 7714.3404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7226.58252
-  tps: 7822.35212
+  dps: 7172.06305
+  tps: 7714.3404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6071.60164
-  tps: 6520.89806
+  dps: 6046.8682
+  tps: 6468.20329
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6068.82724
-  tps: 6554.92159
+  dps: 6030.60565
+  tps: 6528.67696
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 7238.21731
-  tps: 7819.51414
+  dps: 7217.33892
+  tps: 7764.02291
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7115.0788
-  tps: 7602.01454
+  dps: 7094.44813
+  tps: 7629.36186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 7264.81216
-  tps: 7857.66361
+  dps: 7253.31382
+  tps: 7805.25774
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 7439.67515
-  tps: 7970.14782
+  dps: 7423.54111
+  tps: 7950.45604
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6899.46298
-  tps: 7759.03911
+  dps: 6877.159
+  tps: 7776.10646
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6899.46298
-  tps: 7318.50899
+  dps: 6877.159
+  tps: 7338.04504
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7548.69966
-  tps: 7018.98824
+  dps: 7593.70366
+  tps: 7194.32792
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4291.27325
-  tps: 5102.92999
+  dps: 4259.9461
+  tps: 5060.44331
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4291.27325
-  tps: 4541.93195
+  dps: 4259.9461
+  tps: 4513.67947
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4452.29019
-  tps: 4193.62754
+  dps: 4432.88591
+  tps: 4138.07475
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6187.78392
-  tps: 6678.32011
+  dps: 6195.92654
+  tps: 6664.51303
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -46,919 +46,919 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 7115.69446
-  tps: 7679.33503
+  dps: 7187.2876
+  tps: 7697.34986
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7172.06305
-  tps: 7714.3404
+  dps: 7248.23576
+  tps: 7684.52923
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7253.73864
-  tps: 7817.82306
+  dps: 7305.20835
+  tps: 7751.73808
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7092.02946
-  tps: 129329.67948
+  dps: 7173.00314
+  tps: 131230.76877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7092.02946
-  tps: 129329.67948
+  dps: 7173.00314
+  tps: 131230.76877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7219.7433
-  tps: 7779.46435
+  dps: 7286.02032
+  tps: 7732.25389
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5802.26935
-  tps: 6224.47253
+  dps: 5790.0146
+  tps: 6149.25707
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7172.06305
-  tps: 7560.5386
+  dps: 7248.23576
+  tps: 7531.3148
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 7217.33892
-  tps: 7764.02291
+  dps: 7268.78877
+  tps: 7673.42767
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7359.41779
-  tps: 7926.07209
+  dps: 7430.75919
+  tps: 7870.1576
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7188.92433
-  tps: 7716.0888
+  dps: 7231.73457
+  tps: 7711.36338
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7259.61947
-  tps: 7784.8107
+  dps: 7283.70806
+  tps: 7757.84948
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7094.44813
-  tps: 7628.71713
+  dps: 7178.39973
+  tps: 7693.64032
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 7239.75188
-  tps: 7790.05618
+  dps: 7290.99542
+  tps: 7710.04041
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7473.2873
-  tps: 7975.11833
+  dps: 7525.82939
+  tps: 8057.66611
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7169.30374
-  tps: 7643.71961
+  dps: 7232.36624
+  tps: 7720.71197
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7509.92875
-  tps: 8084.26693
+  dps: 7554.21998
+  tps: 8051.77176
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7522.18042
-  tps: 8126.90176
+  dps: 7611.48263
+  tps: 8091.48386
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7223.84642
-  tps: 7786.959
+  dps: 7308.70713
+  tps: 7760.31738
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7217.20535
-  tps: 7712.23782
+  dps: 7256.54193
+  tps: 7665.44071
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7220.135
-  tps: 7694.5088
+  dps: 7240.30639
+  tps: 7695.25099
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 6690.72249
-  tps: 7207.43834
+  dps: 6733.52107
+  tps: 7215.72672
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreamwalkerGarb"
  value: {
-  dps: 5680.3591
-  tps: 6111.0497
+  dps: 5712.44588
+  tps: 6099.37241
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7172.06305
-  tps: 7714.3404
+  dps: 7248.23576
+  tps: 7684.52923
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7172.06305
-  tps: 7714.3014
+  dps: 7248.23576
+  tps: 7684.49089
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7219.7433
-  tps: 7779.52595
+  dps: 7286.02032
+  tps: 7732.31231
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7222.01757
-  tps: 7791.51787
+  dps: 7275.31502
+  tps: 7711.70479
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7178.6632
-  tps: 7742.92447
+  dps: 7202.39018
+  tps: 7688.64084
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7172.06305
-  tps: 7714.3404
+  dps: 7248.23576
+  tps: 7684.52923
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7253.03467
-  tps: 7810.60556
+  dps: 7289.68683
+  tps: 7803.76094
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7208.01362
-  tps: 7754.32487
+  dps: 7238.19246
+  tps: 7717.23662
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7094.44813
-  tps: 7629.05706
+  dps: 7178.39973
+  tps: 7693.97031
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7183.25637
-  tps: 7726.54528
+  dps: 7217.0348
+  tps: 7699.50335
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7172.06305
-  tps: 7714.3404
+  dps: 7248.23576
+  tps: 7684.52923
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7172.06305
-  tps: 7714.3404
+  dps: 7248.23576
+  tps: 7684.52923
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 7244.62662
-  tps: 7795.4087
+  dps: 7297.36618
+  tps: 7714.62568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7264.52465
-  tps: 7821.92333
+  dps: 7316.01139
+  tps: 7785.32077
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 6970.08929
-  tps: 7445.55771
+  dps: 7011.44288
+  tps: 7503.85905
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 5703.37176
-  tps: 6139.97433
+  dps: 5757.76193
+  tps: 6239.31612
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7227.17629
-  tps: 7767.87082
+  dps: 7273.21855
+  tps: 7733.88623
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 7226.56852
-  tps: 7774.83516
+  dps: 7278.20247
+  tps: 7684.49714
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-49982"
  value: {
-  dps: 7472.75783
-  tps: 7974.92308
+  dps: 7515.49442
+  tps: 8032.30959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 7526.6884
-  tps: 8047.6558
+  dps: 7550.1346
+  tps: 7970.85702
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 7430.24419
-  tps: 7949.35181
+  dps: 7493.23419
+  tps: 7992.14656
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 7235.29603
-  tps: 7771.01374
+  dps: 7310.85655
+  tps: 7734.40197
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 7457.37454
-  tps: 7970.32706
+  dps: 7528.81052
+  tps: 8011.65924
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 7217.33892
-  tps: 7764.02291
+  dps: 7268.78877
+  tps: 7673.42767
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 7261.66634
-  tps: 7827.86674
+  dps: 7334.8952
+  tps: 7773.72302
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 7217.33892
-  tps: 7764.02291
+  dps: 7268.78877
+  tps: 7673.42767
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 7246.73326
-  tps: 7776.63474
+  dps: 7304.52444
+  tps: 7746.71897
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7219.7433
-  tps: 7779.52595
+  dps: 7286.02032
+  tps: 7732.31231
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7222.01757
-  tps: 7791.51787
+  dps: 7275.31502
+  tps: 7711.70479
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7247.23759
-  tps: 7801.77519
+  dps: 7325.33701
+  tps: 7738.43712
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7172.06305
-  tps: 7714.40601
+  dps: 7248.23576
+  tps: 7684.56237
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7200.00989
-  tps: 7725.31875
-  hps: 13.01553
+  dps: 7275.96586
+  tps: 7747.01335
+  hps: 12.96337
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 7752.11791
-  tps: 8253.75369
+  dps: 7818.24689
+  tps: 8298.54603
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LasherweaveRegalia"
  value: {
-  dps: 5844.13507
-  tps: 6282.36394
+  dps: 5860.54113
+  tps: 6336.11379
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7094.44813
-  tps: 7629.35973
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 6923.74526
-  tps: 7283.79843
+  dps: 6968.90116
+  tps: 7317.69294
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 5603.54917
-  tps: 6003.15728
+  dps: 5629.46191
+  tps: 6067.16673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7246.61865
-  tps: 7843.26401
+  dps: 7289.94998
+  tps: 7822.09287
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7285.45199
-  tps: 7804.46269
+  dps: 7318.30618
+  tps: 7866.91042
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NightsongBattlegear"
  value: {
-  dps: 6911.61334
-  tps: 7328.61482
+  dps: 6963.03982
+  tps: 7315.29296
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NightsongGarb"
  value: {
-  dps: 5638.33204
-  tps: 6050.56021
+  dps: 5701.79499
+  tps: 6103.87231
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7195.49344
-  tps: 7720.64401
+  dps: 7270.87083
+  tps: 7740.76315
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7199.99138
-  tps: 7725.38568
+  dps: 7275.40603
+  tps: 7745.50323
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7172.06305
-  tps: 7714.3404
+  dps: 7248.23576
+  tps: 7684.52923
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7172.06305
-  tps: 7714.3404
+  dps: 7248.23576
+  tps: 7684.52923
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7370.20081
-  tps: 7941.06613
+  dps: 7424.33687
+  tps: 7851.63038
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 7247.67333
-  tps: 7798.75403
+  dps: 7300.55221
+  tps: 7718.07729
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7172.06305
-  tps: 7713.96933
+  dps: 7248.23576
+  tps: 7684.15661
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 7225.52366
-  tps: 7773.61113
+  dps: 7277.13677
+  tps: 7683.244
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7094.44813
-  tps: 7629.44512
+  dps: 7178.39973
+  tps: 7694.31768
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7094.44813
-  tps: 7629.44512
+  dps: 7178.39973
+  tps: 7694.31768
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7209.57429
-  tps: 7757.50946
+  dps: 7235.9807
+  tps: 7730.48941
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofHope-45703"
  value: {
-  dps: 7094.44813
-  tps: 7629.36061
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 7132.06761
-  tps: 7618.49483
+  dps: 7184.5675
+  tps: 7649.93769
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7174.5526
-  tps: 7756.32247
+  dps: 7276.429
+  tps: 7783.79465
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StormshroudArmor"
  value: {
-  dps: 5850.58778
-  tps: 6149.16505
+  dps: 5897.65877
+  tps: 6200.16496
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7199.99138
-  tps: 7725.38568
+  dps: 7275.40603
+  tps: 7745.50323
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7195.49344
-  tps: 7720.64401
+  dps: 7270.87083
+  tps: 7740.76315
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7187.62205
-  tps: 7712.34609
+  dps: 7269.31344
+  tps: 7733.04931
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7094.44813
-  tps: 7629.361
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7094.44813
-  tps: 7628.75913
+  dps: 7178.39973
+  tps: 7693.68095
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartHarness"
  value: {
-  dps: 5657.22638
-  tps: 6054.22674
+  dps: 5681.82114
+  tps: 6079.67944
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartRegalia"
  value: {
-  dps: 4977.36339
-  tps: 5371.93723
+  dps: 4986.64255
+  tps: 5339.82067
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7180.87256
-  tps: 7695.88811
+  dps: 7244.92536
+  tps: 7758.28204
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7340.73435
-  tps: 7985.96371
+  dps: 7340.29981
+  tps: 7818.12861
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7336.16214
-  tps: 7921.0474
+  dps: 7373.89143
+  tps: 7919.53172
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7172.06305
-  tps: 7714.3404
+  dps: 7248.23576
+  tps: 7684.52923
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7172.06305
-  tps: 7714.3404
+  dps: 7248.23576
+  tps: 7684.52923
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7087.1636
-  tps: 7630.91778
+  dps: 7156.69428
+  tps: 7622.67732
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7172.06305
-  tps: 7714.3404
+  dps: 7248.23576
+  tps: 7684.52923
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7172.06305
-  tps: 7714.3404
+  dps: 7248.23576
+  tps: 7684.52923
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6046.8682
-  tps: 6468.20329
+  dps: 6103.39403
+  tps: 6460.26519
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6030.60565
-  tps: 6528.67696
+  dps: 6075.42727
+  tps: 6536.97615
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 7217.33892
-  tps: 7764.02291
+  dps: 7268.78877
+  tps: 7673.42767
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7094.44813
-  tps: 7629.36186
+  dps: 7178.39973
+  tps: 7694.2673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 7253.31382
-  tps: 7805.25774
+  dps: 7303.87669
+  tps: 7728.31813
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 7423.54111
-  tps: 7950.45604
+  dps: 7478.2949
+  tps: 7972.01637
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6877.159
-  tps: 7776.10646
+  dps: 6969.43037
+  tps: 7875.38448
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6877.159
-  tps: 7338.04504
+  dps: 6969.43037
+  tps: 7419.56032
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7593.70366
-  tps: 7194.32792
+  dps: 7766.11121
+  tps: 7390.23399
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4259.9461
-  tps: 5060.44331
+  dps: 4310.20155
+  tps: 5139.50551
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4259.9461
-  tps: 4513.67947
+  dps: 4310.20155
+  tps: 4577.41179
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4432.88591
-  tps: 4138.07475
+  dps: 4408.24623
+  tps: 4164.6356
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6195.92654
-  tps: 6664.51303
+  dps: 6276.88294
+  tps: 6784.62167
  }
 }

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -84,6 +84,8 @@ type FeralDruid struct {
 	maxRipTicks    int32
 	berserkUsed    bool
 	bleedAura      *core.Aura
+
+	rotationAction *core.PendingAction
 }
 
 func (cat *FeralDruid) GetDruid() *druid.Druid {

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -100,7 +100,6 @@ func (cat *FeralDruid) MissChance() float64 {
 func (cat *FeralDruid) Initialize() {
 	cat.Druid.Initialize()
 	cat.RegisterFeralCatSpells()
-	cat.DelayDPSCooldownsForArmorDebuffs(time.Second * 10)
 }
 
 func (cat *FeralDruid) Reset(sim *core.Simulation) {

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -63,6 +63,9 @@ func NewFeralDruid(character core.Character, options *proto.Player) *FeralDruid 
 		},
 		AutoSwingMelee: true,
 	})
+	cat.ReplaceBearMHFunc = func(sim *core.Simulation, mhSwingSpell *core.Spell) *core.Spell {
+		return cat.checkReplaceMaul(sim)
+	}
 
 	return cat
 }

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -206,7 +206,7 @@ func (cat *FeralDruid) doTigersFury(sim *core.Simulation) {
 		cat.TigersFury.Cast(sim, nil)
 		// Kick gcd loop, also need to account for any gcd 'left'
 		// otherwise it breaks gcd logic
-		cat.WaitUntil(sim, sim.CurrentTime+gcdTimeToRdy)
+		cat.WaitUntil(sim, sim.CurrentTime+gcdTimeToRdy+cat.latency)
 	}
 }
 

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -273,9 +273,7 @@ func (druid *Druid) registerBearFormSpell() {
 			druid.GainHealth(sim, healthFrac*druid.MaxHealth()-druid.CurrentHealth(), healthMetrics)
 
 			if !druid.Env.MeasuringStats {
-				druid.AutoAttacks.ReplaceMHSwing = func(sim *core.Simulation, mhSwingSpell *core.Spell) *core.Spell {
-					return druid.TryMaul(sim, mhSwingSpell)
-				}
+				druid.AutoAttacks.ReplaceMHSwing = druid.ReplaceBearMHFunc
 				druid.AutoAttacks.EnableAutoSwing(sim)
 
 				druid.manageCooldownsEnabled()

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -81,7 +81,6 @@ func (druid *Druid) registerCatFormSpell() {
 		hotwDep = druid.NewDynamicMultiplyStat(stats.AttackPower, 1.0+0.02*float64(druid.Talents.HeartOfTheWild))
 	}
 
-	regWeapon := druid.WeaponFromMainHand(druid.MeleeCritMultiplier(Humanoid))
 	clawWeapon := core.Weapon{
 		BaseDamageMin:              43,
 		BaseDamageMax:              66,
@@ -136,7 +135,7 @@ func (druid *Druid) registerCatFormSpell() {
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			druid.form = Humanoid
-			druid.AutoAttacks.MH = regWeapon
+			druid.AutoAttacks.MH = druid.WeaponFromMainHand(druid.MeleeCritMultiplier(Humanoid))
 
 			druid.PseudoStats.ThreatMultiplier /= 0.71
 			druid.PseudoStats.SpiritRegenMultiplier /= AnimalSpiritRegenSuppression
@@ -232,7 +231,6 @@ func (druid *Druid) registerBearFormSpell() {
 
 	potpdtm := 1 - 0.04*float64(druid.Talents.ProtectorOfThePack)
 
-	regWeapon := druid.WeaponFromMainHand(druid.MeleeCritMultiplier(Humanoid))
 	clawWeapon := core.Weapon{
 		BaseDamageMin:              109,
 		BaseDamageMax:              165,
@@ -286,7 +284,7 @@ func (druid *Druid) registerBearFormSpell() {
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			druid.form = Humanoid
-			druid.AutoAttacks.MH = regWeapon
+			druid.AutoAttacks.MH = druid.WeaponFromMainHand(druid.MeleeCritMultiplier(Humanoid))
 
 			druid.PseudoStats.ThreatMultiplier /= 29. / 14.
 			druid.PseudoStats.DamageDealtMultiplier /= 1.0 + 0.02*float64(druid.Talents.MasterShapeshifter)

--- a/sim/druid/maul.go
+++ b/sim/druid/maul.go
@@ -85,27 +85,23 @@ func (druid *Druid) QueueMaul(sim *core.Simulation) {
 	druid.MaulQueueAura.Activate(sim)
 }
 
-func (druid *Druid) DequeueMaul(sim *core.Simulation) {
-	druid.MaulQueueAura.Deactivate(sim)
-}
-
 // Returns true if the regular melee swing should be used, false otherwise.
-func (druid *Druid) TryMaul(sim *core.Simulation, mhSwingSpell *core.Spell) *core.Spell {
+func (druid *Druid) MaulReplaceMH(sim *core.Simulation, mhSwingSpell *core.Spell) *core.Spell {
 	if !druid.MaulQueueAura.IsActive() {
 		return nil
 	}
 
 	if druid.CurrentRage() < druid.Maul.DefaultCast.Cost {
-		druid.DequeueMaul(sim)
+		druid.MaulQueueAura.Deactivate(sim)
 		return nil
 	} else if druid.CurrentRage() < druid.MaulRageThreshold {
 		if mhSwingSpell == druid.AutoAttacks.MHAuto {
-			druid.DequeueMaul(sim)
+			druid.MaulQueueAura.Deactivate(sim)
 			return nil
 		}
 	}
 
-	druid.DequeueMaul(sim)
+	druid.MaulQueueAura.Deactivate(sim)
 	return druid.Maul
 }
 

--- a/sim/druid/talents.go
+++ b/sim/druid/talents.go
@@ -249,7 +249,9 @@ func (druid *Druid) applyRendAndTear(aura core.Aura) core.Aura {
 }
 
 func (druid *Druid) applyOmenOfClarity() {
-	if !druid.Talents.OmenOfClarity {
+	// Feral 2p needs clearcasting aura
+	// Interaction here between boomkin set and feral is probably incorrect, but kinda irrelevant
+	if !druid.Talents.OmenOfClarity && !druid.HasSetBonus(ItemSetNightsongBattlegear, 2) {
 		return
 	}
 
@@ -321,6 +323,10 @@ func (druid *Druid) applyOmenOfClarity() {
 			}
 		},
 	})
+
+	if !druid.Talents.OmenOfClarity {
+		return
+	}
 
 	druid.RegisterAura(core.Aura{
 		Label:    "Omen of Clarity",

--- a/sim/druid/tank/tank.go
+++ b/sim/druid/tank/tank.go
@@ -71,6 +71,7 @@ func NewFeralTankDruid(character core.Character, options *proto.Player) *FeralTa
 			return bear.TryMaul(sim, mhSwingSpell)
 		},
 	})
+	bear.ReplaceBearMHFunc = bear.TryMaul
 
 	return bear
 }


### PR DESCRIPTION
 - tweak maul function to be replaceable from rotation, doesnt cause any huge change for feral but makes it a bit cleaner to see what function triggers maul
 - dynamically decide to ignore putting rake up if shred is dpe is higher
 - ignore delaying glove cd
 - changed feral logic to instead use custom pending actions to avoid destroying gcd