### PR TITLE
fix: cast raise dead if available outside opener

### DIFF
--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -46,829 +46,829 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7740.87879
-  tps: 4574.10799
+  dps: 7839.87982
+  tps: 4587.54763
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7743.6254
-  tps: 4583.54879
+  dps: 7799.07322
+  tps: 4574.90158
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7519.05706
-  tps: 8153.57712
+  dps: 7609.13605
+  tps: 8144.2097
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7519.05706
-  tps: 8153.57712
+  dps: 7609.13605
+  tps: 8144.2097
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7757.05183
-  tps: 4583.81182
+  dps: 7854.14481
+  tps: 4596.10662
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7514.35148
-  tps: 4439.86479
+  dps: 7580.14631
+  tps: 4433.23404
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6488.3854
-  tps: 3834.48148
+  dps: 6552.53476
+  tps: 3830.07723
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6357.47421
-  tps: 3758.13609
+  dps: 6460.24118
+  tps: 3779.33642
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6132.14232
-  tps: 3623.50847
+  dps: 6180.49895
+  tps: 3611.66435
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7734.91221
-  tps: 4479.11749
+  dps: 7833.89389
+  tps: 4492.27695
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7938.23314
-  tps: 4692.5206
+  dps: 8036.20647
+  tps: 4705.34362
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
   hps: 64
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7634.25108
-  tps: 4517.92586
+  dps: 7715.02414
+  tps: 4525.06498
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7675.80117
-  tps: 4542.75387
+  dps: 7748.00675
+  tps: 4544.18364
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7744.59344
-  tps: 4578.13551
+  dps: 7842.60718
+  tps: 4592.05269
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7390.44693
-  tps: 4368.51315
+  dps: 7441.75407
+  tps: 4352.77965
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 6514.98951
-  tps: 3846.85562
+  dps: 6545.15808
+  tps: 3821.92697
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7415.7966
-  tps: 4379.05868
+  dps: 7520.40772
+  tps: 4395.86437
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8120.0294
-  tps: 4799.20005
+  dps: 8221.98852
+  tps: 4812.988
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7615.69016
-  tps: 4506.78931
+  dps: 7695.38927
+  tps: 4513.28406
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7921.21186
-  tps: 4684.53002
+  dps: 8026.47801
+  tps: 4705.55783
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8011.39418
-  tps: 4740.4033
+  dps: 8101.72583
+  tps: 4753.07021
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7538.29345
-  tps: 4460.35128
+  dps: 7628.32816
+  tps: 4473.04739
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7759.09257
-  tps: 4585.03626
+  dps: 7855.85275
+  tps: 4597.13139
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7641.19626
-  tps: 4519.99808
+  dps: 7718.7135
+  tps: 4523.41883
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7696.57521
-  tps: 4552.58784
+  dps: 7721.8832
+  tps: 4525.14513
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7734.91221
-  tps: 4570.52805
+  dps: 7833.89389
+  tps: 4583.95607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7734.91221
-  tps: 4570.52805
+  dps: 7833.89389
+  tps: 4583.95607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7757.05183
-  tps: 4583.81182
+  dps: 7854.14481
+  tps: 4596.10662
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7752.52585
-  tps: 4581.09623
+  dps: 7850.87394
+  tps: 4594.1441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7585.48229
-  tps: 4483.58594
+  dps: 7666.82912
+  tps: 4491.24052
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7734.91221
-  tps: 4570.52805
+  dps: 7833.89389
+  tps: 4583.95607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7669.10729
-  tps: 4538.70899
+  dps: 7729.04083
+  tps: 4533.40524
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7620.08661
-  tps: 4509.42718
+  dps: 7700.32408
+  tps: 4516.24495
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7603.45681
-  tps: 4499.4493
+  dps: 7688.11166
+  tps: 4508.9175
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7734.91221
-  tps: 4570.52805
+  dps: 7833.89389
+  tps: 4583.95607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7734.91221
-  tps: 4570.52805
+  dps: 7833.89389
+  tps: 4583.95607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7416.47216
-  tps: 4379.46402
+  dps: 7521.08327
+  tps: 4396.2697
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7756.39437
-  tps: 4591.21183
+  dps: 7847.23018
+  tps: 4604.38861
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7633.48759
-  tps: 4517.36044
+  dps: 7733.94539
+  tps: 4535.64276
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7414.4748
-  tps: 4378.2656
+  dps: 7519.08591
+  tps: 4395.07128
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7757.05183
-  tps: 4583.81182
+  dps: 7854.14481
+  tps: 4596.10662
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7752.52585
-  tps: 4581.09623
+  dps: 7850.87394
+  tps: 4594.1441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7711.54759
-  tps: 4564.30377
+  dps: 7802.25602
+  tps: 4577.40411
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7734.91221
-  tps: 4570.52805
+  dps: 7833.89389
+  tps: 4583.95607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7765.79618
-  tps: 4589.05843
+  dps: 7864.7761
+  tps: 4602.4854
   hps: 12.97738
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7693.75513
-  tps: 4549.10128
+  dps: 7777.73005
+  tps: 4555.93456
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7646.40857
-  tps: 4525.22036
+  dps: 7742.23501
+  tps: 4541.39151
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7531.47837
-  tps: 4456.26224
+  dps: 7621.49013
+  tps: 4468.94458
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7759.88428
-  tps: 4585.51129
+  dps: 7858.95256
+  tps: 4598.99128
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7765.76006
-  tps: 4589.03675
+  dps: 7864.84872
+  tps: 4602.52897
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7570.8241
-  tps: 4479.86967
+  dps: 7660.96834
+  tps: 4492.6315
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7577.50287
-  tps: 4483.87694
+  dps: 7667.66961
+  tps: 4496.65226
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7734.91221
-  tps: 4570.52805
+  dps: 7833.89389
+  tps: 4583.95607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7734.91221
-  tps: 4570.52805
+  dps: 7833.89389
+  tps: 4583.95607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7523.27778
-  tps: 4451.36892
+  dps: 7620.04261
+  tps: 4467.63076
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7524.37931
-  tps: 4452.02984
+  dps: 7621.0234
+  tps: 4468.21923
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7932.09615
-  tps: 4688.83841
+  dps: 8032.62167
+  tps: 4703.19274
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7417.26031
-  tps: 4379.9369
+  dps: 7521.87142
+  tps: 4396.74259
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7734.91221
-  tps: 4570.52805
+  dps: 7833.89389
+  tps: 4583.95607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7414.24205
-  tps: 4378.12595
+  dps: 7518.85316
+  tps: 4394.93163
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7144.53177
-  tps: 4223.77037
+  dps: 7269.82518
+  tps: 4254.63812
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 6423.13897
-  tps: 3792.74006
+  dps: 6470.30502
+  tps: 3777.22049
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8098.8236
-  tps: 4793.26892
+  dps: 8176.11621
+  tps: 4792.50875
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6790.98432
-  tps: 4009.42326
+  dps: 6900.64446
+  tps: 4029.65492
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7537.90306
-  tps: 4460.11705
+  dps: 7627.94091
+  tps: 4472.81504
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7932.09615
-  tps: 4688.83841
+  dps: 8032.62167
+  tps: 4703.19274
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7427.043
-  tps: 4385.80652
+  dps: 7532.16676
+  tps: 4402.91979
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7819.00103
-  tps: 4617.73078
+  dps: 7930.8044
+  tps: 4636.48101
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7849.37436
-  tps: 4637.74637
+  dps: 7960.09905
+  tps: 4655.6158
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7623.45203
-  tps: 4511.44643
+  dps: 7702.45347
+  tps: 4517.52258
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofHope-45703"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 7579.18365
-  tps: 4483.57789
+  dps: 7624.43529
+  tps: 4468.69788
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7651.02356
-  tps: 4527.74551
+  dps: 7752.06252
+  tps: 4545.63691
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StormshroudArmor"
  value: {
-  dps: 6056.02999
-  tps: 3577.77381
+  dps: 6120.82034
+  tps: 3578.02562
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7765.76006
-  tps: 4589.03675
+  dps: 7864.84872
+  tps: 4602.52897
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7759.88428
-  tps: 4585.51129
+  dps: 7858.95256
+  tps: 4598.99128
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7749.60166
-  tps: 4579.34172
+  dps: 7848.63428
+  tps: 4592.80031
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7444.40383
-  tps: 4399.86588
+  dps: 7511.49713
+  tps: 4394.06959
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6516.71338
-  tps: 3848.24245
+  dps: 6601.97779
+  tps: 3852.66119
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6952.94812
-  tps: 4101.20931
+  dps: 7055.37448
+  tps: 4118.04746
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7751.79308
-  tps: 4579.73231
+  dps: 7855.90761
+  tps: 4595.39198
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7703.9281
-  tps: 4560.08635
+  dps: 7730.08665
+  tps: 4534.21858
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7726.51179
-  tps: 4573.18812
+  dps: 7791.7348
+  tps: 4570.61523
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7734.91221
-  tps: 4570.52805
+  dps: 7833.89389
+  tps: 4583.95607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7734.91221
-  tps: 4570.52805
+  dps: 7833.89389
+  tps: 4583.95607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7577.15051
-  tps: 4481.50648
+  dps: 7630.95496
+  tps: 4471.59834
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7734.91221
-  tps: 4570.52805
+  dps: 7833.89389
+  tps: 4583.95607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7734.91221
-  tps: 4570.52805
+  dps: 7833.89389
+  tps: 4583.95607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6367.7407
-  tps: 3764.71861
+  dps: 6430.80109
+  tps: 3762.21567
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7389.09314
-  tps: 4362.04277
+  dps: 7476.81069
+  tps: 4367.12812
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7518.98406
-  tps: 4448.76565
+  dps: 7608.95375
+  tps: 4461.42275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7418.16105
-  tps: 4380.47735
+  dps: 7522.77217
+  tps: 4397.28304
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 7918.8574
-  tps: 4681.13233
+  dps: 7995.23618
+  tps: 4680.57063
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11270.41078
-  tps: 6694.4398
+  dps: 11292.67219
+  tps: 6663.10769
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5885.23786
-  tps: 3463.75544
+  dps: 5961.41561
+  tps: 3465.06833
  }
 }
 dps_results: {
@@ -881,15 +881,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7268.93511
-  tps: 4323.29481
+  dps: 7237.92159
+  tps: 4271.90802
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3448.9796
-  tps: 2030.99128
+  dps: 3518.22301
+  tps: 2039.48365
  }
 }
 dps_results: {
@@ -902,15 +902,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11240.12486
-  tps: 6672.86873
+  dps: 11295.02806
+  tps: 6659.34513
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5879.11563
-  tps: 3456.44023
+  dps: 5930.41743
+  tps: 3441.09371
  }
 }
 dps_results: {
@@ -923,15 +923,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7281.75105
-  tps: 4328.90838
+  dps: 7298.98931
+  tps: 4304.98102
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3484.67618
-  tps: 2050.48786
+  dps: 3535.76101
+  tps: 2046.14066
  }
 }
 dps_results: {
@@ -944,7 +944,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7690.32187
-  tps: 4548.63345
+  dps: 7814.23259
+  tps: 4579.27411
  }
 }

--- a/sim/deathknight/dps/rotation_frost_helper.go
+++ b/sim/deathknight/dps/rotation_frost_helper.go
@@ -26,18 +26,22 @@ func (dk *DpsDeathknight) RotationActionCallback_FrostSubUnh_EndOfFight_Obli(sim
 func (dk *DpsDeathknight) RegularPrioPickSpell(sim *core.Simulation, target *core.Unit, untilTime time.Duration) *deathknight.RuneSpell {
 	abGcd := 1500 * time.Millisecond
 	spGcd := dk.SpellGCD()
+	canCastAbility := sim.CurrentTime+abGcd <= untilTime
+	canCastSpell := sim.CurrentTime+spGcd <= untilTime
 
 	km := dk.KM()
 	rime := dk.Rime()
-	if sim.CurrentTime+abGcd <= untilTime && dk.FrostStrike.CanCast(sim) && km {
+	if canCastSpell && dk.RaiseDead.CanCast(sim) && sim.GetRemainingDuration() >= time.Second*20 { // Based on Raised dead doing 30-40k versus Frost Strike's 8-10k
+		return dk.RaiseDead
+	} else if canCastAbility && dk.FrostStrike.CanCast(sim) && km {
 		return dk.FrostStrike
-	} else if sim.CurrentTime+abGcd <= untilTime && dk.FrostStrike.CanCast(sim) && dk.CurrentRunicPower() >= 100.0 {
+	} else if canCastAbility && dk.FrostStrike.CanCast(sim) && dk.CurrentRunicPower() >= 100.0 {
 		return dk.FrostStrike
-	} else if sim.CurrentTime+spGcd <= untilTime && dk.HowlingBlast.CanCast(sim) && rime {
+	} else if canCastSpell && dk.HowlingBlast.CanCast(sim) && rime {
 		return dk.HowlingBlast
-	} else if sim.CurrentTime+abGcd <= untilTime && dk.FrostStrike.CanCast(sim) {
+	} else if canCastAbility && dk.FrostStrike.CanCast(sim) {
 		return dk.FrostStrike
-	} else if sim.CurrentTime+spGcd <= untilTime && dk.HornOfWinter.CanCast(sim) {
+	} else if canCastSpell && dk.HornOfWinter.CanCast(sim) {
 		return dk.HornOfWinter
 	} else {
 		return nil

--- a/sim/deathknight/dps/rotation_frost_helper.go
+++ b/sim/deathknight/dps/rotation_frost_helper.go
@@ -31,7 +31,7 @@ func (dk *DpsDeathknight) RegularPrioPickSpell(sim *core.Simulation, target *cor
 
 	km := dk.KM()
 	rime := dk.Rime()
-	if canCastSpell && dk.RaiseDead.CanCast(sim) && sim.GetRemainingDuration() >= time.Second*20 { // Based on Raised dead doing 30-40k versus Frost Strike's 8-10k
+	if canCastSpell && dk.RaiseDead.CanCast(sim) && sim.GetRemainingDuration() >= time.Second*30 {
 		return dk.RaiseDead
 	} else if canCastAbility && dk.FrostStrike.CanCast(sim) && km {
 		return dk.FrostStrike


### PR DESCRIPTION
Will now cast raise dead outside the opener if it's available

Report from blight club: https://discord.com/channels/894792866658930688/1055183739283583027/1055183743448522884