### PR TITLE
warlock: fix pets being intermixed on 'Automatic'

### DIFF
--- a/sim/warlock/pet.go
+++ b/sim/warlock/pet.go
@@ -22,20 +22,6 @@ type WarlockPet struct {
 const PetExpertiseScale = 1.53
 
 func (warlock *Warlock) NewWarlockPet() *WarlockPet {
-
-	summonChoice := warlock.Options.Summon
-	preset := warlock.Rotation.Preset
-
-	if preset == proto.Warlock_Rotation_Automatic {
-		if warlock.Talents.Haunt {
-			summonChoice = proto.Warlock_Options_Felhunter
-		} else if warlock.Talents.Metamorphosis {
-			summonChoice = proto.Warlock_Options_Felguard
-		} else if warlock.Talents.ChaosBolt {
-			summonChoice = proto.Warlock_Options_Imp
-		}
-	}
-
 	var cfg struct {
 		Name          string
 		PowerModifier float64
@@ -43,7 +29,7 @@ func (warlock *Warlock) NewWarlockPet() *WarlockPet {
 		AutoAttacks   core.AutoAttackOptions
 	}
 
-	switch summonChoice {
+	switch warlock.Options.Summon {
 	// TODO: revisit base damage once blizzard fixes JamminL/wotlk-classic-bugs#328
 	case proto.Warlock_Options_Felguard:
 		cfg.Name = "Felguard"
@@ -147,7 +133,7 @@ func (warlock *Warlock) NewWarlockPet() *WarlockPet {
 	wp.AddStatDependency(stats.Strength, stats.AttackPower, 2)
 	wp.AddStat(stats.AttackPower, -20)
 
-	if summonChoice == proto.Warlock_Options_Imp {
+	if warlock.Options.Summon == proto.Warlock_Options_Imp {
 		// imp has a slightly different agi crit scaling coef for some reason
 		wp.AddStatDependency(stats.Agility, stats.MeleeCrit, core.CritRatingPerCritChance*1/51.0204)
 	} else {
@@ -166,11 +152,11 @@ func (warlock *Warlock) NewWarlockPet() *WarlockPet {
 
 	wp.PseudoStats.DamageDealtMultiplier *= 1.0 + 0.04*float64(warlock.Talents.UnholyPower)
 
-	if summonChoice != proto.Warlock_Options_Imp { // imps generally don't meele
+	if warlock.Options.Summon != proto.Warlock_Options_Imp { // imps generally don't meele
 		wp.EnableAutoAttacks(wp, cfg.AutoAttacks)
 	}
 
-	if summonChoice == proto.Warlock_Options_Felguard {
+	if warlock.Options.Summon == proto.Warlock_Options_Felguard {
 		if wp.owner.HasMajorGlyph(proto.WarlockMajorGlyph_GlyphOfFelguard) {
 			wp.MultiplyStat(stats.AttackPower, 1.2)
 		}


### PR DESCRIPTION
When automatic mode was selected, and a pet that is not the typical pet for that spec what would happen is some parts of the code would swap that pet out for the 'typical' choice while others would not, leading to weird situations like imp meeleing.

We remove that code entirely since it serves no purpose anymore, should also remove the UI options at some point since this was it's last use.