### PR TITLE
Update tank stat display for final totals

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -125,6 +125,8 @@ enum PseudoStat {
 	PseudoStatOffHandDps = 1;
 	PseudoStatRangedDps = 2;
 	PseudoStatBlockValueMultiplier = 3;
+	PseudoStatDodge = 4;
+	PseudoStatParry = 5;
 }
 
 message UnitStats {

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -561,6 +561,10 @@ func (character *Character) GetPseudoStatsProto() []float64 {
 	vals[proto.PseudoStat_PseudoStatOffHandDps] = character.WeaponFromOffHand(0).DPS()
 	vals[proto.PseudoStat_PseudoStatRangedDps] = character.WeaponFromRanged(0).DPS()
 	vals[proto.PseudoStat_PseudoStatBlockValueMultiplier] = character.PseudoStats.BlockValueMultiplier
+	// Base values are modified by Enemy attackTables, but we display for LVL 80 enemy as paperdoll default
+	vals[proto.PseudoStat_PseudoStatDodge] = character.PseudoStats.BaseDodge + character.GetDiminishedDodgeChance()
+	vals[proto.PseudoStat_PseudoStatParry] = character.PseudoStats.BaseParry + character.GetDiminishedParryChance()
+	//vals[proto.PseudoStat_PseudoStatMiss] = 0.05 + character.GetDiminishedMissChance() + character.PseudoStats.ReducedPhysicalHitTakenChance
 	return vals
 }
 

--- a/ui/core/components/character_stats.ts
+++ b/ui/core/components/character_stats.ts
@@ -177,13 +177,19 @@ export class CharacterStats extends Component {
 		} else if (stat == Stat.StatExpertise) {
 			displayStr += ` (${(Math.floor(rawValue / Mechanics.EXPERTISE_PER_QUARTER_PERCENT_REDUCTION) / 4).toFixed(2)}%)`;
 		} else if (stat == Stat.StatDefense) {
-			displayStr += ` (${(Mechanics.CHARACTER_LEVEL * 5 + rawValue / Mechanics.DEFENSE_RATING_PER_DEFENSE).toFixed(1)})`;
+			displayStr += ` (${(Mechanics.CHARACTER_LEVEL * 5 + Math.floor(rawValue / Mechanics.DEFENSE_RATING_PER_DEFENSE)).toFixed(0)})`;
 		} else if (stat == Stat.StatBlock) {
-			displayStr += ` (${(rawValue / Mechanics.BLOCK_RATING_PER_BLOCK_CHANCE).toFixed(2)}%)`;
+			// TODO: Figure out how to display these differently for the components than the final value
+			//displayStr += ` (${(rawValue / Mechanics.BLOCK_RATING_PER_BLOCK_CHANCE).toFixed(2)}%)`;
+			displayStr += ` (${((rawValue / Mechanics.BLOCK_RATING_PER_BLOCK_CHANCE) + (Mechanics.MISS_DODGE_PARRY_BLOCK_CRIT_CHANCE_PER_DEFENSE * Math.floor(stats.getStat(Stat.StatDefense) / Mechanics.DEFENSE_RATING_PER_DEFENSE)) + 5.00).toFixed(2)}%)`;
 		} else if (stat == Stat.StatDodge) {
-			displayStr += ` (${(rawValue / Mechanics.DODGE_RATING_PER_DODGE_CHANCE).toFixed(2)}%)`;
+			//displayStr += ` (${(rawValue / Mechanics.DODGE_RATING_PER_DODGE_CHANCE).toFixed(2)}%)`;
+			displayStr += ` (${(stats.getPseudoStat(PseudoStat.PseudoStatDodge)*100).toFixed(2)}%)`;
 		} else if (stat == Stat.StatParry) {
-			displayStr += ` (${(rawValue / Mechanics.PARRY_RATING_PER_PARRY_CHANCE).toFixed(2)}%)`;
+			//displayStr += ` (${(rawValue / Mechanics.PARRY_RATING_PER_PARRY_CHANCE).toFixed(2)}%)`;
+			displayStr += ` (${(stats.getPseudoStat(PseudoStat.PseudoStatParry)*100).toFixed(2)}%)`;
+		} else if (stat == Stat.StatResilience) {
+			displayStr += ` (${(rawValue / Mechanics.RESILIENCE_RATING_PER_CRIT_REDUCTION_CHANCE).toFixed(2)}%)`;
 		}
 
 		return displayStr;

--- a/ui/core/proto_utils/names.ts
+++ b/ui/core/proto_utils/names.ts
@@ -193,6 +193,8 @@ export const pseudoStatNames: Record<PseudoStat, string> = {
 	[PseudoStat.PseudoStatOffHandDps]: 'Off Hand DPS',
 	[PseudoStat.PseudoStatRangedDps]: 'Ranged DPS',
 	[PseudoStat.PseudoStatBlockValueMultiplier]: 'Block Value Multiplier',
+	[PseudoStat.PseudoStatDodge]: 'Dodge Chance',
+	[PseudoStat.PseudoStatParry]: 'Parry Chance',
 };
 
 export function getClassStatName(stat: Stat, playerClass: Class): string {


### PR DESCRIPTION
Updated stat displays to improve the final values shown, but the subtotals displayed in tooltips still have issues.

- Dodge shown uses the post-DR total dodge chance. Ideally the components would still show direct rating conversion and a line item would be included for defense contribution.
- Parry shown uses the post-DR total parry chance. Ideally the components would still show direct rating conversion and a line item would be included for defense contribution.
- Block shown uses the total block chance. Ideally a line item would be included for defense contribution.
- Resilience now shows crit reduction percentage. Ideally this would be a meta-stat for Crit % showing contributions from both Defense and Resilience, since that is the only context we care about Resilience.
- Defense now applies a Floor function. Ideally the components would not apply a Floor, so that you can tell how close to the next point you are at a glance.

Fixes #2242 but leaves loose ends as mentioned above.