### PR TITLE
fix ghoul uptime

### DIFF
--- a/sim/deathknight/dps/rotation_unholy_helper.go
+++ b/sim/deathknight/dps/rotation_unholy_helper.go
@@ -84,6 +84,10 @@ func (dk *DpsDeathknight) uhShouldWaitForDnD(sim *core.Simulation, blood bool, f
 }
 
 func (dk *DpsDeathknight) uhGhoulFrenzyCheck(sim *core.Simulation, target *core.Unit) bool {
+	if !dk.Ghoul.Pet.IsEnabled() {
+		return false
+	}
+
 	// If no Ghoul Frenzy Aura or duration less then 10 seconds we try recasting
 	if !dk.GhoulFrenzyAura.IsActive() || dk.GhoulFrenzyAura.RemainingDuration(sim) < 10*time.Second {
 		// Use Ghoul Frenzy with a Blood Tap and Blood rune if all blood runes are on CD and Garg wont come off cd in less then a minute.


### PR DESCRIPTION
Fixes https://github.com/wowsims/wotlk/issues/2279

The rotation was getting stuck when ghoul was dismissed (because of ghoul uptime option).

Baseline (100% ghoul uptime):
<img width="233" alt="image" src="https://user-images.githubusercontent.com/9436142/211342012-cb2f078d-7a62-4e2d-bab3-f592fb52b163.png">

With 0% ghoul uptime:
Before:
<img width="255" alt="image" src="https://user-images.githubusercontent.com/9436142/211342073-1f2e19d2-3603-4af6-96d2-8d8ad2cddae0.png">

After:
<img width="231" alt="image" src="https://user-images.githubusercontent.com/9436142/211341894-3b3ffc2f-3e3a-455b-9a90-217e9292ff07.png">