### PR TITLE
desync rotation improvements

### DIFF
--- a/sim/deathknight/dps/dps_deathknight.go
+++ b/sim/deathknight/dps/dps_deathknight.go
@@ -146,12 +146,10 @@ func (dk *DpsDeathknight) SetupRotations() {
 	if dk.CustomRotation == nil || dk.Rotation.FrostRotationType == proto.Deathknight_Rotation_SingleTarget {
 		dk.Rotation.FrostRotationType = proto.Deathknight_Rotation_SingleTarget
 		if (dk.Talents.BloodOfTheNorth == 3) && (dk.Talents.Epidemic == 0) {
-			if dk.Rotation.UseEmpowerRuneWeapon {
-				if dk.Rotation.DesyncRotation {
-					dk.setupFrostSubBloodDesyncERWOpener()
-				} else {
-					dk.setupFrostSubBloodERWOpener()
-				}
+			if dk.Rotation.DesyncRotation {
+				dk.setupFrostSubBloodDesyncERWOpener()
+			} else if dk.Rotation.UseEmpowerRuneWeapon {
+				dk.setupFrostSubBloodERWOpener()
 			} else {
 				dk.setupFrostSubBloodNoERWOpener()
 			}

--- a/sim/deathknight/dps/dps_deathknight.go
+++ b/sim/deathknight/dps/dps_deathknight.go
@@ -147,7 +147,7 @@ func (dk *DpsDeathknight) SetupRotations() {
 		dk.Rotation.FrostRotationType = proto.Deathknight_Rotation_SingleTarget
 		if (dk.Talents.BloodOfTheNorth == 3) && (dk.Talents.Epidemic == 0) {
 			if dk.Rotation.DesyncRotation {
-				dk.setupFrostSubBloodDesyncERWOpener()
+				dk.setupFrostSubBloodDesyncOpener()
 			} else if dk.Rotation.UseEmpowerRuneWeapon {
 				dk.setupFrostSubBloodERWOpener()
 			} else {

--- a/sim/deathknight/dps/rotation_frost_sub_blood_desync.go
+++ b/sim/deathknight/dps/rotation_frost_sub_blood_desync.go
@@ -70,6 +70,7 @@ func (dk *DpsDeathknight) RotationActionCallback_FrostSubBlood_Desync_UA(sim *co
 		dk.BloodTap.Cast(sim, target)
 		return sim.CurrentTime + waitFor
 	} else if dk.UnbreakableArmor.IsReady(sim) && runeGrace >= waitFor {
+		dk.castAllMajorCooldowns(sim)
 		dk.UnbreakableArmor.Cast(sim, target)
 	}
 

--- a/sim/deathknight/dps/rotation_frost_sub_blood_desync.go
+++ b/sim/deathknight/dps/rotation_frost_sub_blood_desync.go
@@ -27,9 +27,8 @@ func (dk *DpsDeathknight) setupFrostSubBloodDesyncERWOpener() {
 // We need to keep the B2 and F1 runes in sync and immediately use them for obliterate
 // otherwise if an unholy rune comes up then we can't continue the Desync rotation without
 // re-casting IT + PS
-func (dk *DpsDeathknight) canFitBeforeFirstOblit(sim *core.Simulation, gcd time.Duration) bool {
-	ob := core.MaxDuration(dk.RuneReadyAt(sim, 1), dk.RuneReadyAt(sim, 2))
-	return sim.CurrentTime+gcd < ob
+func (dk *DpsDeathknight) firstOblitAt(sim *core.Simulation) time.Duration {
+	return core.MaxDuration(dk.RuneReadyAt(sim, 1), dk.RuneReadyAt(sim, 2))
 }
 
 func (dk *DpsDeathknight) RotationActionCallback_FrostSubBlood_Desync_Obli(sim *core.Simulation, target *core.Unit, s *deathknight.Sequence) time.Duration {
@@ -108,17 +107,9 @@ func (dk *DpsDeathknight) RotationActionCallback_FrostSubBlood_Desync_Sequence2(
 }
 
 func (dk *DpsDeathknight) desync_Filler(sim *core.Simulation, target *core.Unit) {
-	canFitAb := dk.canFitBeforeFirstOblit(sim, dk.GetModifiedGCD())
-	canFitSpell := dk.canFitBeforeFirstOblit(sim, dk.SpellGCD())
-
-	if canFitAb && dk.KM() && dk.FrostStrike.CanCast(sim) {
-		dk.FrostStrike.Cast(sim, target)
-	} else if canFitSpell && dk.Rime() {
-		dk.HowlingBlast.Cast(sim, target)
-	} else if canFitAb && dk.FrostStrike.CanCast(sim) {
-		dk.FrostStrike.Cast(sim, target)
-	} else if canFitSpell {
-		dk.HornOfWinter.Cast(sim, target)
+	spell := dk.RegularPrioPickSpell(sim, target, dk.firstOblitAt(sim))
+	if spell != nil {
+		spell.Cast(sim, target)
 	}
 }
 

--- a/sim/deathknight/dps/rotation_frost_sub_blood_desync.go
+++ b/sim/deathknight/dps/rotation_frost_sub_blood_desync.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wowsims/wotlk/sim/deathknight"
 )
 
-func (dk *DpsDeathknight) setupFrostSubBloodDesyncERWOpener() {
+func (dk *DpsDeathknight) setupFrostSubBloodDesyncOpener() {
 	dk.setupUnbreakableArmorCooldowns()
 
 	dk.RotationSequence.


### PR DESCRIPTION
- Allows doing desync rotation without ERW
- Use same filler logic as normal sub-blood
- Cast major cooldowns on UA (speed pot, racials, etc.)