### PR TITLE
Desync sub-blood: improve ERW logic for when there's no UA up

### DIFF
--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -74,15 +74,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7605.73529
-  tps: 8139.57941
+  dps: 7605.68062
+  tps: 8426.45421
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7605.73529
-  tps: 8139.57941
+  dps: 7605.68062
+  tps: 8426.45421
  }
 }
 dps_results: {

--- a/sim/deathknight/dps/rotation_frost_sub_blood.go
+++ b/sim/deathknight/dps/rotation_frost_sub_blood.go
@@ -320,6 +320,7 @@ func (dk *DpsDeathknight) RotationActionCallback_FrostSubBlood_Obli_Check(sim *c
 
 func (dk *DpsDeathknight) RotationActionCallback_FrostSubBlood_SequenceRotation(sim *core.Simulation, target *core.Unit, s *deathknight.Sequence) time.Duration {
 	s.Clear().
+		NewAction(dk.RotationActionCallback_FrostSubBlood_ERW_Check).
 		NewAction(dk.RotationActionCallback_FrostSubBlood_FS_Dump)
 
 	if dk.UnbreakableArmor != nil {
@@ -441,4 +442,27 @@ func (dk *DpsDeathknight) RotationActionCallback_FrostSubBlood_Sequence_Pesti(si
 			return core.TernaryDuration(casted, -1, waitUntil)
 		}
 	}
+}
+
+func (dk *DpsDeathknight) RotationActionCallback_FrostSubBlood_ERW_Check(sim *core.Simulation, target *core.Unit, s *deathknight.Sequence) time.Duration {
+	/*
+		This ERW should only ever happen from the desync rotation when it falls back to this normal sub blood rotation
+	*/
+	bothDeath := dk.RuneIsDeath(0) && dk.RuneIsDeath(1)
+	noMoreUAs := sim.Duration-dk.UnbreakableArmor.ReadyAt() < 5*time.Second
+	numRunes := dk.CurrentDeathRunes() + dk.CurrentBloodRunes() + dk.CurrentUnholyRunes() + dk.CurrentFrostRunes()
+
+	if sim.IsExecutePhase35() && dk.Rotation.UseEmpowerRuneWeapon && dk.EmpowerRuneWeapon.IsReady(sim) && numRunes <= 2 && bothDeath && (dk.UnbreakableArmorAura.IsActive() || noMoreUAs) {
+		dk.castAllMajorCooldowns(sim)
+
+		s.Clear().
+			NewAction(dk.RotationActionCallback_ERW).
+			NewAction(dk.RotationActionCallback_Obli).
+			NewAction(dk.RotationActionCallback_Obli).
+			NewAction(dk.RotationActionCallback_Obli).
+			NewAction(dk.RotationActionCallback_FrostSubBlood_SequenceRotation)
+	} else {
+		s.Advance()
+	}
+	return sim.CurrentTime
 }


### PR DESCRIPTION
- Uses ERW even when there's no UA if there won't be a future UA
- Falls back to normal sub-blood if runes get synced again