### PR TITLE
dont try to snapshot FC for nerfed gary

### DIFF
--- a/sim/deathknight/dps/dps_deathknight.go
+++ b/sim/deathknight/dps/dps_deathknight.go
@@ -206,6 +206,14 @@ func (dk *DpsDeathknight) setupProcTrackers() {
 		snapshotManager.AddProc(43573, "Tears of Bitter Anguish Proc", false)
 		snapshotManager.AddProc(45609, "Comet's Trail Proc", false)
 		snapshotManager.AddProc(45866, "Elemental Focus Stone Proc", false)
+
+		snapshotManager.AddProc(53344, "Rune Of The Fallen Crusader Proc", false)
+	} else {
+		fcEnchantId := int32(3368)
+		// Only worth snapshotting if both are on (might want to re-visit this after P2)
+		if dk.Character.GetMHWeapon().Enchant.EffectID == fcEnchantId && dk.Character.GetOHWeapon().Enchant.EffectID == fcEnchantId {
+			snapshotManager.AddProc(53344, "Rune Of The Fallen Crusader Proc", false)
+		}
 	}
 
 	snapshotManager.AddProc(42987, "DMC Greatness Strength Proc", false)

--- a/sim/deathknight/dps/dps_deathknight.go
+++ b/sim/deathknight/dps/dps_deathknight.go
@@ -198,6 +198,7 @@ func (dk *DpsDeathknight) setupProcTrackers() {
 
 		snapshotManager.AddProc(55379, "Thundering Skyflare Diamond Proc", false)
 		snapshotManager.AddProc(59626, "Black Magic Proc", false)
+		snapshotManager.AddProc(53344, "Rune Of The Fallen Crusader Proc", false)
 
 		snapshotManager.AddProc(37390, "Meteorite Whetstone Proc", false)
 		snapshotManager.AddProc(39229, "Embrace of the Spider Proc", false)
@@ -206,8 +207,6 @@ func (dk *DpsDeathknight) setupProcTrackers() {
 		snapshotManager.AddProc(45609, "Comet's Trail Proc", false)
 		snapshotManager.AddProc(45866, "Elemental Focus Stone Proc", false)
 	}
-
-	snapshotManager.AddProc(53344, "Rune Of The Fallen Crusader Proc", false)
 
 	snapshotManager.AddProc(42987, "DMC Greatness Strength Proc", false)
 

--- a/sim/deathknight/dps/rotation_unholy_helper.go
+++ b/sim/deathknight/dps/rotation_unholy_helper.go
@@ -194,7 +194,7 @@ func (dk *DpsDeathknight) uhGargoyleCheck(sim *core.Simulation, target *core.Uni
 	}
 
 	if dk.uhGargoyleCanCast(sim, castTime) {
-		if !dk.PresenceMatches(deathknight.UnholyPresence) && (!dk.Rotation.NerfedGargoyle || dk.Rotation.GargoylePresence != proto.Deathknight_Rotation_Unholy) {
+		if !dk.PresenceMatches(deathknight.UnholyPresence) && (!dk.Rotation.NerfedGargoyle || dk.Rotation.GargoylePresence == proto.Deathknight_Rotation_Unholy) {
 			if dk.CurrentUnholyRunes() == 0 {
 				if dk.BloodTap.IsReady(sim) {
 					dk.BloodTap.Cast(sim, dk.CurrentTarget)


### PR DESCRIPTION
Trying to snapshot fallen crusader on only 1 weapon with nerfed gary isn't worth it because it pushes out haste trinkets / procs further out which are not snapshotted thus getting less benefit from them

P1 Gear:
FC, Berserking Before:
<img width="235" alt="image" src="https://user-images.githubusercontent.com/9436142/211956183-5f901dbb-ba4f-4883-b8d0-484ff731a38f.png">

FC, Berserking After:
<img width="233" alt="image" src="https://user-images.githubusercontent.com/9436142/211956215-9107a171-db2f-4cfe-ab8f-8874c8c35c50.png">

P2 Gear:
FC, Berserking Before:
<img width="231" alt="image" src="https://user-images.githubusercontent.com/9436142/211959133-f1f1cc73-7ceb-4eab-a77f-91925841052b.png">


FC, Berserking After:
<img width="228" alt="image" src="https://user-images.githubusercontent.com/9436142/211959090-857f8297-94fd-40e8-bb20-8d04c31e75e6.png">
