### PR TITLE
remove panic message

### DIFF
--- a/sim/deathknight/dps/dps_deathknight.go
+++ b/sim/deathknight/dps/dps_deathknight.go
@@ -173,7 +173,8 @@ func (dk *DpsDeathknight) SetupRotations() {
 			if dk.Rotation.UseEmpowerRuneWeapon {
 				dk.setupFrostSubUnholyERWOpener()
 			} else {
-				panic("you can't unh sub without ERW in the opener...yet")
+				// TODO you can't unh sub without ERW in the opener...yet
+				dk.Rotation.UseEmpowerRuneWeapon = true
 				dk.setupFrostSubUnholyERWOpener()
 			}
 		} else if dk.Talents.SummonGargoyle {

--- a/sim/deathknight/scourge_strike.go
+++ b/sim/deathknight/scourge_strike.go
@@ -65,9 +65,7 @@ func (dk *Deathknight) registerScourgeStrikeSpell() {
 		},
 
 		BonusCritRating: (dk.subversionCritBonus() + dk.viciousStrikesCritChanceBonus() + dk.scourgeborneBattlegearCritBonus()) * core.CritRatingPerCritChance,
-		DamageMultiplier: .7 *
-			[]float64{1.0, 1.07, 1.13, 1.2}[dk.Talents.Outbreak] *
-			dk.scourgelordsBattlegearDamageBonus(dk.ScourgeStrike),
+
 		CritMultiplier:   dk.bonusCritMultiplier(dk.Talents.ViciousStrikes),
 		ThreatMultiplier: 1,
 
@@ -106,4 +104,6 @@ func (dk *Deathknight) registerScourgeStrikeSpell() {
 	}, func(sim *core.Simulation) bool {
 		return dk.Talents.ScourgeStrike && dk.CastCostPossible(sim, 0.0, 0, 1, 1) && dk.ScourgeStrike.IsReady(sim)
 	}, nil)
+	dk.ScourgeStrike.DamageMultiplier = .7 * []float64{1.0, 1.07, 1.13, 1.2}[dk.Talents.Outbreak] *
+		dk.scourgelordsBattlegearDamageBonus(dk.ScourgeStrike)
 }


### PR DESCRIPTION
Automatically activete ERW when using Blood sub Unholy rotation instead of panicing when not active

Fixes #1950 