### PR TITLE
Add a workflow for automatic publish of binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      ref:
+        description: 'Commit Reference'
+        default: 'master'
+        required: true
+      tag:
+        description: 'Version Tag'
+        default: 'latest'
+        required: true
+        
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18.x
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Protoc Go plugin
+        run: go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+        with:
+          ref: ${{ github.event.inputs.ref }}
+          
+      - name: Test
+        run: |
+          make test
+
+      - name: Build 🔧
+        run: |
+          make clean && VERSION=${{ github.event.inputs.tag }} make release
+          
+      - uses: ncipollo/release-action@v1
+        with:
+          commit: ${{ github.event.inputs.ref }}
+          tag: ${{ github.event.inputs.tag }}
+          generateReleaseNotes: true
+          makeLatest: true
+          artifactErrorsFailBuild: true
+          artifacts: |
+            wowsimcli-amd64-linux
+            wowsimwotlk-amd64-darwin.zip
+            wowsimwotlk-amd64-linux.zip
+            wowsimwotlk-windows.exe.zip
+            

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           node-version: '14'
 
-      - name: Checkout 🛎️
+      - name: Checkout
         uses: actions/checkout@v2.3.1
         with:
           ref: ${{ github.event.inputs.ref }}
@@ -51,7 +51,8 @@ jobs:
         run: |
           make clean && VERSION=${{ github.event.inputs.tag }} make release
           
-      - uses: ncipollo/release-action@v1
+      - name: Release
+        uses: ncipollo/release-action@v1
         with:
           commit: ${{ github.event.inputs.ref }}
           tag: ${{ github.event.inputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ on:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/changelog_test.txt
+++ b/changelog_test.txt
@@ -1,2 +1,0 @@
-testing if changelog works
-adding more changes


### PR DESCRIPTION
## Releasing binary from github
Starting a new release is done from the github actions menu:

**Actions -> Release -> Run workflow**

---

### Inputs
- **Commit Reference** is a reference to the commit that the release should be based one. It can be a branch name a SHA or anything that git uses to reference commits
- **Version Tag** is the tag to create for the release. Should follow standard convention we use already `vX.X.X`

---

![image](https://user-images.githubusercontent.com/5707996/212310795-b26887f1-82ea-44cb-83e0-a0188d2d3da3.png)
![image](https://user-images.githubusercontent.com/5707996/212311505-cfe27400-7d9d-4c4c-9eec-e024d89d32f2.png)
