### PR TITLE
KM is still consumed on miss

### DIFF
--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -46,142 +46,142 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7838.82164
-  tps: 4586.50401
+  dps: 7835.74454
+  tps: 4584.66373
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7831.18356
-  tps: 4594.49906
+  dps: 7829.88526
+  tps: 4593.72008
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7605.68062
-  tps: 8426.45421
+  dps: 7602.88788
+  tps: 8423.64824
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7605.68062
-  tps: 8426.45421
+  dps: 7602.88788
+  tps: 8423.64824
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7851.51025
-  tps: 4594.11718
+  dps: 7848.43487
+  tps: 4592.27793
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7587.47842
-  tps: 4437.1165
+  dps: 7588.76345
+  tps: 4438.97424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6540.13187
-  tps: 3822.7544
+  dps: 6528.40937
+  tps: 3815.07246
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6422.92824
-  tps: 3757.54075
+  dps: 6424.55351
+  tps: 3758.3953
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6202.63721
-  tps: 3625.22005
+  dps: 6182.30181
+  tps: 3613.52294
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7832.8453
-  tps: 4491.25984
+  dps: 7829.76993
+  tps: 4489.45739
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8033.59623
-  tps: 4703.36876
+  dps: 8030.46787
+  tps: 4701.49773
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
   hps: 64
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7711.35757
-  tps: 4522.4885
+  dps: 7706.02457
+  tps: 4519.29405
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7766.93518
-  tps: 4555.78507
+  dps: 7764.65992
+  tps: 4554.41991
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7838.77106
-  tps: 4589.34973
+  dps: 7835.70167
+  tps: 4587.51392
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7451.79634
-  tps: 4359.46406
+  dps: 7455.30244
+  tps: 4361.6008
  }
 }
 dps_results: {
@@ -194,702 +194,702 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7512.92074
-  tps: 4390.96347
+  dps: 7509.9389
+  tps: 4389.18035
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8218.77108
-  tps: 4810.63892
+  dps: 8215.23646
+  tps: 4808.52433
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7690.85102
-  tps: 4510.18457
+  dps: 7688.06142
+  tps: 4508.51616
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8031.36904
-  tps: 4709.02017
+  dps: 8041.95429
+  tps: 4715.77044
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8116.13868
-  tps: 4761.8782
+  dps: 8127.17842
+  tps: 4768.46681
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7624.99155
-  tps: 4470.66889
+  dps: 7622.20308
+  tps: 4469.00115
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7855.18618
-  tps: 4596.32273
+  dps: 7852.1108
+  tps: 4594.48349
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7716.0157
-  tps: 4522.00387
+  dps: 7717.27192
+  tps: 4522.74207
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7713.76562
-  tps: 4520.16039
+  dps: 7710.10018
+  tps: 4517.7806
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7832.8453
-  tps: 4582.91821
+  dps: 7829.76993
+  tps: 4581.07896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7832.8453
-  tps: 4582.91821
+  dps: 7829.76993
+  tps: 4581.07896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7851.51025
-  tps: 4594.11718
+  dps: 7848.43487
+  tps: 4592.27793
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7847.91499
-  tps: 4591.96002
+  dps: 7844.83961
+  tps: 4590.12078
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7672.88134
-  tps: 4494.97162
+  dps: 7659.35653
+  tps: 4486.92793
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7832.8453
-  tps: 4582.91821
+  dps: 7829.76993
+  tps: 4581.07896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7757.27851
-  tps: 4550.4815
+  dps: 7753.37928
+  tps: 4548.05085
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7697.85839
-  tps: 4514.389
+  dps: 7692.52539
+  tps: 4511.19454
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7683.74391
-  tps: 4505.92031
+  dps: 7679.66357
+  tps: 4503.47745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7832.8453
-  tps: 4582.91821
+  dps: 7829.76993
+  tps: 4581.07896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7832.8453
-  tps: 4582.91821
+  dps: 7829.76993
+  tps: 4581.07896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7513.57003
-  tps: 4391.35304
+  dps: 7510.58819
+  tps: 4389.56992
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7843.62092
-  tps: 4601.84651
+  dps: 7840.78229
+  tps: 4600.14868
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7717.87722
-  tps: 4526.19349
+  dps: 7709.41903
+  tps: 4520.99404
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7511.61425
-  tps: 4390.17958
+  dps: 7508.63242
+  tps: 4388.39646
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7851.51025
-  tps: 4594.11718
+  dps: 7848.43487
+  tps: 4592.27793
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7847.91499
-  tps: 4591.96002
+  dps: 7844.83961
+  tps: 4590.12078
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7798.01532
-  tps: 4574.48315
+  dps: 7795.13933
+  tps: 4572.76291
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7832.8453
-  tps: 4582.91821
+  dps: 7829.76993
+  tps: 4581.07896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7863.81234
-  tps: 4601.49843
+  dps: 7860.72972
+  tps: 4599.65484
   hps: 12.97738
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7773.31767
-  tps: 4553.25658
+  dps: 7773.44407
+  tps: 4553.27952
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7737.75391
-  tps: 4538.32631
+  dps: 7735.35001
+  tps: 4536.88931
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7618.16725
-  tps: 4466.57431
+  dps: 7615.38075
+  tps: 4464.90775
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7857.88098
-  tps: 4597.93961
+  dps: 7854.79974
+  tps: 4596.09685
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7863.77172
-  tps: 4601.47406
+  dps: 7860.68911
+  tps: 4599.63047
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7657.56622
-  tps: 4490.21369
+  dps: 7654.76834
+  tps: 4488.54031
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7664.25403
-  tps: 4494.22638
+  dps: 7661.45423
+  tps: 4492.55184
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7832.8453
-  tps: 4582.91821
+  dps: 7829.76993
+  tps: 4581.07896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7832.8453
-  tps: 4582.91821
+  dps: 7829.76993
+  tps: 4581.07896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7607.20409
-  tps: 4460.08114
+  dps: 7606.70525
+  tps: 4459.77838
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7608.1936
-  tps: 4460.67485
+  dps: 7607.70263
+  tps: 4460.3768
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8028.43529
-  tps: 4700.2722
+  dps: 8025.30663
+  tps: 4698.40099
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7514.32753
-  tps: 4391.80754
+  dps: 7511.3457
+  tps: 4390.02443
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7832.8453
-  tps: 4582.91821
+  dps: 7829.76993
+  tps: 4581.07896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7511.39464
-  tps: 4390.04781
+  dps: 7508.4128
+  tps: 4388.26469
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7239.74852
-  tps: 4237.16788
+  dps: 7235.18912
+  tps: 4234.36762
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 6482.49617
-  tps: 3785.04699
+  dps: 6488.85729
+  tps: 3788.85114
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8189.46733
-  tps: 4800.83544
+  dps: 8187.93885
+  tps: 4799.91835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6878.24561
-  tps: 4016.5151
+  dps: 6875.68858
+  tps: 4015.0649
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7624.48557
-  tps: 4470.3653
+  dps: 7621.66346
+  tps: 4468.67738
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8028.43529
-  tps: 4700.2722
+  dps: 8025.30663
+  tps: 4698.40099
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7523.16034
-  tps: 4397.10723
+  dps: 7518.64613
+  tps: 4394.40469
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7918.39859
-  tps: 4628.61231
+  dps: 7915.28505
+  tps: 4626.7505
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7950.23557
-  tps: 4649.27801
+  dps: 7947.10952
+  tps: 4647.40872
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7700.22236
-  tps: 4515.80737
+  dps: 7694.88935
+  tps: 4512.61292
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofHope-45703"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 7626.32193
-  tps: 4469.85654
+  dps: 7633.77873
+  tps: 4474.23886
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7772.74458
-  tps: 4558.29864
+  dps: 7782.51096
+  tps: 4564.37254
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StormshroudArmor"
  value: {
-  dps: 6109.02876
-  tps: 3570.66901
+  dps: 6101.70304
+  tps: 3566.28778
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7863.77172
-  tps: 4601.47406
+  dps: 7860.68911
+  tps: 4599.63047
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7857.88098
-  tps: 4597.93961
+  dps: 7854.79974
+  tps: 4596.09685
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7847.57217
-  tps: 4591.75433
+  dps: 7844.49335
+  tps: 4589.91302
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7491.21404
-  tps: 4382.25827
+  dps: 7488.68128
+  tps: 4380.73862
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6587.39489
-  tps: 3844.04427
+  dps: 6557.23084
+  tps: 3826.28894
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7031.77399
-  tps: 4103.98017
+  dps: 7033.56203
+  tps: 4105.18091
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7846.23792
-  tps: 4589.51935
+  dps: 7847.57769
+  tps: 4590.60863
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7734.44867
-  tps: 4536.36916
+  dps: 7743.2238
+  tps: 4541.48853
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7790.48318
-  tps: 4569.68181
+  dps: 7788.52972
+  tps: 4568.85713
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7832.8453
-  tps: 4582.91821
+  dps: 7829.76993
+  tps: 4581.07896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7832.8453
-  tps: 4582.91821
+  dps: 7829.76993
+  tps: 4581.07896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7616.68633
-  tps: 4463.51395
+  dps: 7600.48351
+  tps: 4453.71414
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7832.8453
-  tps: 4582.91821
+  dps: 7829.76993
+  tps: 4581.07896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7832.8453
-  tps: 4582.91821
+  dps: 7829.76993
+  tps: 4581.07896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6458.73143
-  tps: 3778.76274
+  dps: 6453.24621
+  tps: 3775.47161
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7479.42346
-  tps: 4368.7338
+  dps: 7481.02654
+  tps: 4369.79261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7605.65603
-  tps: 4459.06758
+  dps: 7602.87314
+  tps: 4457.40319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7515.19325
-  tps: 4392.32698
+  dps: 7512.21141
+  tps: 4390.54386
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 7990.51443
-  tps: 4677.76856
+  dps: 7987.46305
+  tps: 4675.92242
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15470.82051
-  tps: 9170.99372
+  dps: 15469.53954
+  tps: 9170.25454
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7993.60628
-  tps: 4684.62315
+  dps: 7993.35872
+  tps: 4684.47461
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8768.47331
-  tps: 4964.59398
+  dps: 8766.80496
+  tps: 4963.59297
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9781.84558
-  tps: 5797.47094
+  dps: 9768.68687
+  tps: 5789.34707
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4769.31331
-  tps: 2789.82971
+  dps: 4770.29624
+  tps: 2790.44738
  }
 }
 dps_results: {
@@ -902,15 +902,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15492.03256
-  tps: 9177.96776
+  dps: 15504.20465
+  tps: 9185.32272
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8028.43529
-  tps: 4700.2722
+  dps: 8025.30663
+  tps: 4698.40099
  }
 }
 dps_results: {
@@ -923,15 +923,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9628.45551
-  tps: 5701.89517
+  dps: 9824.48336
+  tps: 5819.13827
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4791.96127
-  tps: 2799.63075
+  dps: 4789.338
+  tps: 2797.76966
  }
 }
 dps_results: {
@@ -944,7 +944,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7786.51789
-  tps: 4562.35846
+  dps: 7733.11694
+  tps: 4530.52723
  }
 }

--- a/sim/deathknight/talents_frost.go
+++ b/sim/deathknight/talents_frost.go
@@ -189,13 +189,14 @@ func (dk *Deathknight) applyKillingMachine() {
 	core.MakePermanent(dk.GetOrRegisterAura(core.Aura{
 		Label: "Killing Machine",
 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-			if !result.Landed() {
-				return
-			}
-
+			// KM is consumed even if it's a miss
 			if dk.KillingMachineAura.IsActive() && (dk.runeSpellComp(spell, dk.IcyTouch) ||
 				dk.runeSpellComp(spell, dk.FrostStrike)) {
 				dk.KillingMachineAura.Deactivate(sim)
+			}
+
+			if !result.Landed() {
+				return
 			}
 
 			if !spell.ProcMask.Matches(core.ProcMaskMeleeMHAuto) {


### PR DESCRIPTION
https://classic.warcraftlogs.com/reports/cYGVNg42mMZQ3Fbr/#fight=1&source=1


00:04.542	Apply Buff	[Killing Machine](https://www.wowhead.com/wotlk/spell=51124)Killing Machine	[Duets](https://classic.warcraftlogs.com/reports/DfJQ8vcTXB16mkKM/#) → [Duets](https://classic.warcraftlogs.com/reports/DfJQ8vcTXB16mkKM/#)	
00:10.654	Refresh Buff	[Killing Machine](https://www.wowhead.com/wotlk/spell=51124)Killing Machine	[Duets](https://classic.warcraftlogs.com/reports/DfJQ8vcTXB16mkKM/#) → [Duets](https://classic.warcraftlogs.com/reports/DfJQ8vcTXB16mkKM/#)	
00:12.754 | Duets Icy Touch Highlord's Nemesis Trainer Miss
00:12.754	[Duets](https://classic.warcraftlogs.com/reports/DfJQ8vcTXB16mkKM/#) [Icy Touch](https://www.wowhead.com/wotlk/spell=49909) [Highlord's Nemesis Trainer](https://classic.warcraftlogs.com/reports/DfJQ8vcTXB16mkKM/#) Miss
00:12.754	Remove Buff	[Killing Machine](https://www.wowhead.com/wotlk/spell=51124)Killing Machine

Also from the same report I confirmed FS + HB consume it even when missed as well