### PR TITLE
prioritize HB rime over FS

### DIFF
--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -46,905 +46,905 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7835.74454
-  tps: 4584.66373
+  dps: 7836.22067
+  tps: 4584.55783
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7829.88526
-  tps: 4593.72008
+  dps: 7814.50463
+  tps: 4582.91008
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7602.88788
-  tps: 8423.64824
+  dps: 7607.28963
+  tps: 8425.09912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7602.88788
-  tps: 8423.64824
+  dps: 7607.28963
+  tps: 8425.09912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7848.43487
-  tps: 4592.27793
+  dps: 7850.55603
+  tps: 4593.15905
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7588.76345
-  tps: 4438.97424
+  dps: 7612.60203
+  tps: 4453.07399
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6528.40937
-  tps: 3815.07246
+  dps: 6562.29504
+  tps: 3836.30842
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6424.55351
-  tps: 3758.3953
+  dps: 6450.63028
+  tps: 3773.39728
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6182.30181
-  tps: 3613.52294
+  dps: 6186.01117
+  tps: 3615.948
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7829.76993
-  tps: 4489.45739
+  dps: 7830.23646
+  tps: 4489.34796
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8030.46787
-  tps: 4701.49773
+  dps: 8033.00586
+  tps: 4702.62895
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
   hps: 64
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7706.02457
-  tps: 4519.29405
+  dps: 7714.68505
+  tps: 4524.00951
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7764.65992
-  tps: 4554.41991
+  dps: 7753.49902
+  tps: 4546.73556
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7835.70167
-  tps: 4587.51392
+  dps: 7837.71874
+  tps: 4588.35149
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7455.30244
-  tps: 4361.6008
+  dps: 7473.8282
+  tps: 4373.10199
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 6557.53862
-  tps: 3828.38794
+  dps: 6571.5758
+  tps: 3837.18506
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7509.9389
-  tps: 4389.18035
+  dps: 7515.95083
+  tps: 4392.39593
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8215.23646
-  tps: 4808.52433
+  dps: 8219.25512
+  tps: 4810.3476
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7688.06142
-  tps: 4508.51616
+  dps: 7700.94236
+  tps: 4515.76389
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8041.95429
-  tps: 4715.77044
+  dps: 8038.10134
+  tps: 4712.46294
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8127.17842
-  tps: 4768.46681
+  dps: 8126.7821
+  tps: 4767.45983
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7622.20308
-  tps: 4469.00115
+  dps: 7626.64821
+  tps: 4471.1874
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7852.1108
-  tps: 4594.48349
+  dps: 7854.07548
+  tps: 4595.27072
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7717.27192
-  tps: 4522.74207
+  dps: 7757.35406
+  tps: 4546.43826
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7710.10018
-  tps: 4517.7806
+  dps: 7715.47815
+  tps: 4521.83637
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7829.76993
-  tps: 4581.07896
+  dps: 7830.23646
+  tps: 4580.96731
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7829.76993
-  tps: 4581.07896
+  dps: 7830.23646
+  tps: 4580.96731
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7848.43487
-  tps: 4592.27793
+  dps: 7850.55603
+  tps: 4593.15905
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7844.83961
-  tps: 4590.12078
+  dps: 7845.59286
+  tps: 4590.18115
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7659.35653
-  tps: 4486.92793
+  dps: 7674.24134
+  tps: 4494.96955
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7829.76993
-  tps: 4581.07896
+  dps: 7830.23646
+  tps: 4580.96731
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7753.37928
-  tps: 4548.05085
+  dps: 7755.74338
+  tps: 4548.41656
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7692.52539
-  tps: 4511.19454
+  dps: 7700.79876
+  tps: 4515.67773
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7679.66357
-  tps: 4503.47745
+  dps: 7686.32282
+  tps: 4506.99217
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7829.76993
-  tps: 4581.07896
+  dps: 7830.23646
+  tps: 4580.96731
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7829.76993
-  tps: 4581.07896
+  dps: 7830.23646
+  tps: 4580.96731
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7510.58819
-  tps: 4389.56992
+  dps: 7516.6029
+  tps: 4392.78717
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7840.78229
-  tps: 4600.14868
+  dps: 7845.61477
+  tps: 4602.56734
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7709.41903
-  tps: 4520.99404
+  dps: 7705.65732
+  tps: 4518.00286
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7508.63242
-  tps: 4388.39646
+  dps: 7514.63917
+  tps: 4391.60894
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7848.43487
-  tps: 4592.27793
+  dps: 7850.55603
+  tps: 4593.15905
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7844.83961
-  tps: 4590.12078
+  dps: 7845.59286
+  tps: 4590.18115
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7795.13933
-  tps: 4572.76291
+  dps: 7798.53948
+  tps: 4574.32217
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7829.76993
-  tps: 4581.07896
+  dps: 7830.23646
+  tps: 4580.96731
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7860.72972
-  tps: 4599.65484
+  dps: 7861.42891
+  tps: 4599.68278
   hps: 12.97738
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7773.44407
-  tps: 4553.27952
+  dps: 7755.42954
+  tps: 4542.50992
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7735.35001
-  tps: 4536.88931
+  dps: 7738.67542
+  tps: 4538.40373
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7615.38075
-  tps: 4464.90775
+  dps: 7619.81292
+  tps: 4467.08623
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7854.79974
-  tps: 4596.09685
+  dps: 7855.30535
+  tps: 4596.00865
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7860.68911
-  tps: 4599.63047
+  dps: 7861.20392
+  tps: 4599.54779
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7654.76834
-  tps: 4488.54031
+  dps: 7659.27535
+  tps: 4490.76369
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7661.45423
-  tps: 4492.55184
+  dps: 7665.97394
+  tps: 4494.78284
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7829.76993
-  tps: 4581.07896
+  dps: 7830.23646
+  tps: 4580.96731
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7829.76993
-  tps: 4581.07896
+  dps: 7830.23646
+  tps: 4580.96731
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7606.70525
-  tps: 4459.77838
+  dps: 7610.10412
+  tps: 4460.41942
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7607.70263
-  tps: 4460.3768
+  dps: 7611.81696
+  tps: 4461.44712
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8025.30663
-  tps: 4698.40099
+  dps: 8027.72621
+  tps: 4699.46116
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7511.3457
-  tps: 4390.02443
+  dps: 7517.36364
+  tps: 4393.24362
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7829.76993
-  tps: 4581.07896
+  dps: 7830.23646
+  tps: 4580.96731
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7508.4128
-  tps: 4388.26469
+  dps: 7514.41857
+  tps: 4391.47658
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7235.18912
-  tps: 4234.36762
+  dps: 7281.96279
+  tps: 4262.17342
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 6488.85729
-  tps: 3788.85114
+  dps: 6488.24523
+  tps: 3788.87795
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8187.93885
-  tps: 4799.91835
+  dps: 8235.69835
+  tps: 4828.64591
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6875.68858
-  tps: 4015.0649
+  dps: 6899.89868
+  tps: 4029.80102
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7621.66346
-  tps: 4468.67738
+  dps: 7626.0223
+  tps: 4470.81186
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8025.30663
-  tps: 4698.40099
+  dps: 8027.72621
+  tps: 4699.46116
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7518.64613
-  tps: 4394.40469
+  dps: 7525.5469
+  tps: 4398.15358
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7915.28505
-  tps: 4626.7505
+  dps: 7921.74234
+  tps: 4630.19917
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7947.10952
-  tps: 4647.40872
+  dps: 7954.00207
+  tps: 4651.12388
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7694.88935
-  tps: 4512.61292
+  dps: 7702.81202
+  tps: 4516.88569
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofHope-45703"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 7633.77873
-  tps: 4474.23886
+  dps: 7664.45207
+  tps: 4492.89956
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7782.51096
-  tps: 4564.37254
+  dps: 7748.52673
+  tps: 4543.54577
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StormshroudArmor"
  value: {
-  dps: 6101.70304
-  tps: 3566.28778
+  dps: 6153.19536
+  tps: 3596.17595
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7860.68911
-  tps: 4599.63047
+  dps: 7861.20392
+  tps: 4599.54779
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7854.79974
-  tps: 4596.09685
+  dps: 7855.30535
+  tps: 4596.00865
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7844.49335
-  tps: 4589.91302
+  dps: 7844.98287
+  tps: 4589.81516
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7488.68128
-  tps: 4380.73862
+  dps: 7494.70569
+  tps: 4384.4163
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6557.23084
-  tps: 3826.28894
+  dps: 6565.99966
+  tps: 3831.50483
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7033.56203
-  tps: 4105.18091
+  dps: 7084.72454
+  tps: 4136.14519
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7847.57769
-  tps: 4590.60863
+  dps: 7876.44346
+  tps: 4607.41744
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7743.2238
-  tps: 4541.48853
+  dps: 7792.08305
+  tps: 4570.34917
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7788.52972
-  tps: 4568.85713
+  dps: 7795.32193
+  tps: 4572.16546
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7829.76993
-  tps: 4581.07896
+  dps: 7830.23646
+  tps: 4580.96731
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7829.76993
-  tps: 4581.07896
+  dps: 7830.23646
+  tps: 4580.96731
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7600.48351
-  tps: 4453.71414
+  dps: 7660.46897
+  tps: 4488.79221
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7829.76993
-  tps: 4581.07896
+  dps: 7830.23646
+  tps: 4580.96731
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7829.76993
-  tps: 4581.07896
+  dps: 7830.23646
+  tps: 4580.96731
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6453.24621
-  tps: 3775.47161
+  dps: 6463.04531
+  tps: 3780.89662
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7481.02654
-  tps: 4369.79261
+  dps: 7473.43319
+  tps: 4364.80784
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7602.87314
-  tps: 4457.40319
+  dps: 7607.28154
+  tps: 4459.5674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7512.21141
-  tps: 4390.54386
+  dps: 7518.23306
+  tps: 4393.76527
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 7987.46305
-  tps: 4675.92242
+  dps: 7992.45386
+  tps: 4679.01053
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15469.53954
-  tps: 9170.25454
+  dps: 15920.54829
+  tps: 9439.89851
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7993.35872
-  tps: 4684.47461
+  dps: 8006.50513
+  tps: 4691.61242
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8766.80496
-  tps: 4963.59297
+  dps: 8799.59234
+  tps: 4982.15535
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9768.68687
-  tps: 5789.34707
+  dps: 9854.52963
+  tps: 5841.42911
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4770.29624
-  tps: 2790.44738
+  dps: 4784.82793
+  tps: 2799.06515
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4957.31382
-  tps: 2809.14241
+  dps: 4987.76002
+  tps: 2826.40624
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15504.20465
-  tps: 9185.32272
+  dps: 15978.35594
+  tps: 9470.27137
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8025.30663
-  tps: 4698.40099
+  dps: 8027.72621
+  tps: 4699.46116
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8905.96567
-  tps: 5033.77059
+  dps: 8933.88766
+  tps: 5051.53307
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9824.48336
-  tps: 5819.13827
+  dps: 9961.93588
+  tps: 5902.08082
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4789.338
-  tps: 2797.76966
+  dps: 4795.4982
+  tps: 2801.59757
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5010.7519
-  tps: 2831.76476
+  dps: 5029.59856
+  tps: 2842.42115
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7733.11694
-  tps: 4530.52723
+  dps: 7769.72213
+  tps: 4553.06904
  }
 }

--- a/sim/deathknight/dps/rotation_frost.go
+++ b/sim/deathknight/dps/rotation_frost.go
@@ -168,7 +168,7 @@ func (dk *DpsDeathknight) RotationActionCallback_UA_Frost(sim *core.Simulation, 
 }
 
 func (dk *DpsDeathknight) RotationActionCallback_Frost_FS_HB(sim *core.Simulation, target *core.Unit, s *deathknight.Sequence) time.Duration {
-	if dk.Rime() && !dk.KM() {
+	if dk.Rime() {
 		dk.HowlingBlast.Cast(sim, target)
 	} else {
 		dk.FrostStrike.Cast(sim, target)

--- a/sim/deathknight/dps/rotation_frost_helper.go
+++ b/sim/deathknight/dps/rotation_frost_helper.go
@@ -33,12 +33,12 @@ func (dk *DpsDeathknight) RegularPrioPickSpell(sim *core.Simulation, target *cor
 	rime := dk.Rime()
 	if canCastSpell && dk.RaiseDead.CanCast(sim) && sim.GetRemainingDuration() >= time.Second*30 {
 		return dk.RaiseDead
+	} else if canCastSpell && dk.HowlingBlast.CanCast(sim) && rime && dk.CurrentRunicPower() <= 100 {
+		return dk.HowlingBlast
 	} else if canCastAbility && dk.FrostStrike.CanCast(sim) && km {
 		return dk.FrostStrike
 	} else if canCastAbility && dk.FrostStrike.CanCast(sim) && dk.CurrentRunicPower() >= 100.0 {
 		return dk.FrostStrike
-	} else if canCastSpell && dk.HowlingBlast.CanCast(sim) && rime {
-		return dk.HowlingBlast
 	} else if canCastAbility && dk.FrostStrike.CanCast(sim) {
 		return dk.FrostStrike
 	} else if canCastSpell && dk.HornOfWinter.CanCast(sim) {

--- a/sim/deathknight/dps/rotation_frost_helper.go
+++ b/sim/deathknight/dps/rotation_frost_helper.go
@@ -33,7 +33,7 @@ func (dk *DpsDeathknight) RegularPrioPickSpell(sim *core.Simulation, target *cor
 	rime := dk.Rime()
 	if canCastSpell && dk.RaiseDead.CanCast(sim) && sim.GetRemainingDuration() >= time.Second*30 {
 		return dk.RaiseDead
-	} else if canCastSpell && dk.HowlingBlast.CanCast(sim) && rime && dk.CurrentRunicPower() <= 100 {
+	} else if canCastSpell && dk.HowlingBlast.CanCast(sim) && rime {
 		return dk.HowlingBlast
 	} else if canCastAbility && dk.FrostStrike.CanCast(sim) && km {
 		return dk.FrostStrike


### PR DESCRIPTION
The AP scaling on HB is better + reduced GCD probably why this performs better than prioritizing FS

P1 Before:
<img width="252" alt="image" src="https://user-images.githubusercontent.com/9436142/212497112-2c3f2816-835d-4369-8ed8-a7a576c72fa6.png">

P1 After:
<img width="248" alt="image" src="https://user-images.githubusercontent.com/9436142/212497396-4260bd7a-92e2-48ee-88bd-ff051ab12789.png">

P2 Before:
<img width="248" alt="image" src="https://user-images.githubusercontent.com/9436142/212497169-903e78c4-772a-4118-a12a-0a4b0d907ada.png">

P2 After:
<img width="263" alt="image" src="https://user-images.githubusercontent.com/9436142/212497383-73355d47-483e-4bf7-bee2-980ecee69c58.png">