### PR TITLE
Dk DRW rotation fixes

### DIFF
--- a/sim/deathknight/death_strike.go
+++ b/sim/deathknight/death_strike.go
@@ -108,7 +108,6 @@ func (dk *Deathknight) registerDeathStrikeSpell() {
 
 func (dk *Deathknight) registerDrwDeathStrikeSpell() {
 	bonusBaseDamage := dk.sigilOfAwarenessBonus()
-	hasGlyph := dk.HasMajorGlyph(proto.DeathknightMajorGlyph_GlyphOfDeathStrike)
 
 	dk.RuneWeapon.DeathStrike = dk.RuneWeapon.RegisterSpell(core.SpellConfig{
 		ActionID:    DeathStrikeActionID.WithTag(1),
@@ -126,9 +125,6 @@ func (dk *Deathknight) registerDrwDeathStrikeSpell() {
 				bonusBaseDamage +
 				spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower()) +
 				spell.BonusWeaponDamage()
-			if hasGlyph {
-				baseDamage *= 1 + core.MinFloat(0.25, dk.CurrentRunicPower()/100.0)
-			}
 
 			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
 		},

--- a/sim/deathknight/deathknight.go
+++ b/sim/deathknight/deathknight.go
@@ -152,7 +152,8 @@ type Deathknight struct {
 	BoneShield     *RuneSpell
 	BoneShieldAura *core.Aura
 
-	UnholyFrenzy *core.Spell
+	UnholyFrenzy     *core.Spell
+	UnholyFrenzyAura *core.Aura
 
 	IceboundFortitude     *RuneSpell
 	IceboundFortitudeAura *core.Aura

--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -46,829 +46,829 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6261.80969
-  tps: 3255.7117
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6261.80969
-  tps: 3255.7117
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6504.82628
-  tps: 3364.1621
+  dps: 6585.08072
+  tps: 3376.44717
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6439.46944
-  tps: 3353.38189
+  dps: 6524.84598
+  tps: 3373.73257
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6261.81645
-  tps: 8752.70276
+  dps: 6329.55363
+  tps: 8781.84769
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6261.81645
-  tps: 8752.70276
+  dps: 6329.55363
+  tps: 8781.84769
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6527.9284
-  tps: 3377.23187
+  dps: 6605.48253
+  tps: 3387.90898
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6314.78359
-  tps: 3271.53122
+  dps: 6404.60197
+  tps: 3287.60564
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 5436.11562
-  tps: 2817.39947
+  dps: 5480.77355
+  tps: 2809.86549
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5342.76463
-  tps: 2772.21008
+  dps: 5410.13223
+  tps: 2777.90589
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5145.85631
-  tps: 2657.39256
+  dps: 5199.28999
+  tps: 2665.58918
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6500.31027
-  tps: 3294.45025
+  dps: 6580.50841
+  tps: 3306.48057
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6638.49966
-  tps: 3439.5585
+  dps: 6717.09109
+  tps: 3450.10651
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6261.80969
-  tps: 3255.7117
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6261.80969
-  tps: 3255.7117
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6260.93794
-  tps: 3255.20023
-  hps: 44.8
+  dps: 6329.53507
+  tps: 3265.59278
+  hps: 64
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6350.48986
-  tps: 3304.3259
+  dps: 6428.24874
+  tps: 3319.02898
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6421.01194
-  tps: 3346.20142
+  dps: 6528.81144
+  tps: 3381.89021
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6470.03783
-  tps: 3350.91218
+  dps: 6546.27122
+  tps: 3360.79613
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 6328.27344
-  tps: 3282.2202
+  dps: 6380.97957
+  tps: 3285.943
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 5519.35539
-  tps: 2846.8575
+  dps: 5545.23849
+  tps: 2830.59671
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 6589.84919
-  tps: 3411.15172
+  dps: 6669.67876
+  tps: 3421.62071
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6795.43758
-  tps: 3515.30202
+  dps: 6875.69414
+  tps: 3525.54282
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6326.20288
-  tps: 3290.76076
+  dps: 6403.96718
+  tps: 3306.02846
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6649.53656
-  tps: 3485.93734
+  dps: 6760.57313
+  tps: 3507.18574
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6728.33192
-  tps: 3529.49289
+  dps: 6803.09651
+  tps: 3534.4658
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6275.48565
-  tps: 3263.18816
+  dps: 6344.25775
+  tps: 3273.60648
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6531.90592
-  tps: 3379.21264
+  dps: 6610.47783
+  tps: 3390.51465
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6413.05515
-  tps: 3329.83429
+  dps: 6458.73708
+  tps: 3333.2693
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6403.14186
-  tps: 3343.49203
+  dps: 6481.82028
+  tps: 3351.32324
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6500.31027
-  tps: 3361.68393
+  dps: 6580.50841
+  tps: 3373.95976
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6500.31027
-  tps: 3361.68393
+  dps: 6580.50841
+  tps: 3373.95976
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6527.9284
-  tps: 3377.23187
+  dps: 6605.48253
+  tps: 3387.90898
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6520.77774
-  tps: 3373.1961
+  dps: 6597.84172
+  tps: 3383.59809
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6345.65679
-  tps: 3289.46437
+  dps: 6364.57729
+  tps: 3276.80757
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6261.80969
-  tps: 3255.7117
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6500.31027
-  tps: 3361.68393
+  dps: 6580.50841
+  tps: 3373.95976
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6399.66865
-  tps: 3333.13055
+  dps: 6485.31773
+  tps: 3355.7997
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6341.55889
-  tps: 3299.20747
+  dps: 6418.1505
+  tps: 3313.3483
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6261.80969
-  tps: 3255.7117
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6261.80969
-  tps: 3255.7117
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6326.91886
-  tps: 3291.41189
+  dps: 6401.0869
+  tps: 3303.51069
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6500.31027
-  tps: 3361.68393
+  dps: 6580.50841
+  tps: 3373.95976
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6500.31027
-  tps: 3361.68393
+  dps: 6580.50841
+  tps: 3373.95976
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 6597.89576
-  tps: 3415.48431
+  dps: 6678.1646
+  tps: 3425.98582
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6450.98675
-  tps: 3360.40821
+  dps: 6521.05936
+  tps: 3370.62437
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6260.93794
-  tps: 3255.20023
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6260.93794
-  tps: 3255.20023
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6260.93794
-  tps: 3255.20023
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6364.06611
-  tps: 3308.78148
+  dps: 6443.58732
+  tps: 3328.75175
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 6569.04783
-  tps: 3400.71828
+  dps: 6648.66231
+  tps: 3410.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6261.80969
-  tps: 3255.7117
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6527.9284
-  tps: 3377.23187
+  dps: 6605.48253
+  tps: 3387.90898
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6520.77774
-  tps: 3373.1961
+  dps: 6597.84172
+  tps: 3383.59809
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6409.672
-  tps: 3339.79785
+  dps: 6503.62349
+  tps: 3364.90648
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6500.31027
-  tps: 3361.68393
+  dps: 6580.50841
+  tps: 3373.95976
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6526.00984
-  tps: 3375.80235
-  hps: 12.40192
+  dps: 6606.52458
+  tps: 3388.13011
+  hps: 12.70546
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6260.93794
-  tps: 3255.20023
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6261.80969
-  tps: 3255.7117
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6367.43849
-  tps: 3332.77293
+  dps: 6490.82537
+  tps: 3348.87774
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6393.40576
-  tps: 3321.55897
+  dps: 6472.04562
+  tps: 3334.0507
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6270.35116
-  tps: 3260.36889
+  dps: 6339.06151
+  tps: 3270.77812
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6520.86658
-  tps: 3372.96427
+  dps: 6601.32102
+  tps: 3385.28213
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6525.70336
-  tps: 3375.61847
+  dps: 6606.2181
+  tps: 3387.94622
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6300.87078
-  tps: 3277.15975
+  dps: 6369.06113
+  tps: 3287.10721
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6305.90319
-  tps: 3279.923
+  dps: 6374.15344
+  tps: 3289.87901
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6500.31027
-  tps: 3361.68393
+  dps: 6580.50841
+  tps: 3373.95976
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6500.31027
-  tps: 3361.68393
+  dps: 6580.50841
+  tps: 3373.95976
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6261.80969
-  tps: 3255.7117
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6335.41769
-  tps: 3299.55128
+  dps: 6413.12708
+  tps: 3314.92885
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6343.73822
-  tps: 3304.5436
+  dps: 6421.73362
+  tps: 3320.09277
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6629.20186
-  tps: 3434.54398
+  dps: 6707.1708
+  tps: 3444.74059
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 6607.28343
-  tps: 3420.53899
+  dps: 6688.06474
+  tps: 3431.07845
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6500.31027
-  tps: 3361.68393
+  dps: 6580.50841
+  tps: 3373.95976
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6260.93794
-  tps: 3255.20023
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 6566.84804
-  tps: 3399.44702
+  dps: 6646.23822
+  tps: 3409.65429
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6009.43088
-  tps: 3109.58918
+  dps: 6014.34985
+  tps: 3083.13886
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 5490.07888
-  tps: 2825.38098
+  dps: 5556.06481
+  tps: 2836.48105
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 6849.64851
-  tps: 3588.03596
+  dps: 6948.10289
+  tps: 3611.37442
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 5781.85198
-  tps: 2983.04914
+  dps: 5811.31311
+  tps: 2966.96048
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6271.42306
-  tps: 3260.48517
+  dps: 6343.10513
+  tps: 3272.79207
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8582.73972
-  tps: 4539.9589
+  dps: 8641.41398
+  tps: 4537.2958
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6261.80969
-  tps: 3255.7117
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 6549.61632
-  tps: 3389.4888
+  dps: 6627.24957
+  tps: 3399.79514
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 6839.86832
-  tps: 3543.81896
+  dps: 6923.34452
+  tps: 3554.28812
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 6733.68498
-  tps: 3490.0911
+  dps: 6817.03067
+  tps: 3498.84481
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6260.93794
-  tps: 3255.20023
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6260.93794
-  tps: 3255.20023
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6260.93794
-  tps: 3255.20023
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6341.55889
-  tps: 3299.20747
+  dps: 6421.34393
+  tps: 3315.26435
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofHope-45703"
  value: {
-  dps: 6261.80969
-  tps: 3255.7117
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofLife-37657"
  value: {
-  dps: 6318.64997
-  tps: 3281.4644
+  dps: 6366.07942
+  tps: 3294.86072
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6407.17005
-  tps: 3314.5717
+  dps: 6509.80633
+  tps: 3350.07533
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 5092.90946
-  tps: 2640.62763
+  dps: 5133.22607
+  tps: 2623.93368
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6525.70336
-  tps: 3375.61847
+  dps: 6606.2181
+  tps: 3387.94622
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6520.86658
-  tps: 3372.96427
+  dps: 6601.32102
+  tps: 3385.28213
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6512.40222
-  tps: 3368.31942
+  dps: 6592.75112
+  tps: 3380.61998
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6260.93794
-  tps: 3255.20023
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6261.80969
-  tps: 3255.7117
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 6470.87995
-  tps: 3351.89706
+  dps: 6480.09845
+  tps: 3329.0357
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 5605.14614
-  tps: 2891.02898
+  dps: 5693.8275
+  tps: 2910.14236
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6261.80969
-  tps: 3255.7117
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5690.17079
-  tps: 2911.22839
+  dps: 5750.4276
+  tps: 2918.70165
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6508.58474
-  tps: 3392.68339
+  dps: 6615.47871
+  tps: 3393.31122
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6478.63507
-  tps: 3361.3354
+  dps: 6613.4387
+  tps: 3421.03679
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6503.45576
-  tps: 3378.7265
+  dps: 6610.45771
+  tps: 3421.25636
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6500.31027
-  tps: 3361.68393
+  dps: 6580.50841
+  tps: 3373.95976
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6500.31027
-  tps: 3361.68393
+  dps: 6580.50841
+  tps: 3373.95976
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6272.71328
-  tps: 3247.69451
+  dps: 6372.21513
+  tps: 3282.11468
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6500.31027
-  tps: 3361.68393
+  dps: 6580.50841
+  tps: 3373.95976
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6500.31027
-  tps: 3361.68393
+  dps: 6580.50841
+  tps: 3373.95976
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5347.52068
-  tps: 2769.81607
+  dps: 5393.97402
+  tps: 2770.55655
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5080.62121
-  tps: 2500.18963
+  dps: 5121.49629
+  tps: 2511.98537
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6260.93794
-  tps: 3255.20023
+  dps: 6329.53507
+  tps: 3265.59278
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 6618.01219
-  tps: 3426.31577
+  dps: 6699.3792
+  tps: 3436.8986
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 6594.6755
-  tps: 3411.97804
+  dps: 6659.72922
+  tps: 3419.7561
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13718.3236
-  tps: 7348.88846
+  dps: 13869.41686
+  tps: 7296.75188
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6570.59716
-  tps: 3419.24146
+  dps: 6638.68097
+  tps: 3424.74713
  }
 }
 dps_results: {
@@ -881,15 +881,15 @@ dps_results: {
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9028.99218
-  tps: 4871.79372
+  dps: 9226.38418
+  tps: 4868.5334
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3685.06948
-  tps: 1933.7664
+  dps: 3759.40933
+  tps: 1938.23888
  }
 }
 dps_results: {
@@ -902,15 +902,15 @@ dps_results: {
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13815.43282
-  tps: 7400.19684
+  dps: 14012.94108
+  tps: 7342.67053
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6629.20186
-  tps: 3434.54398
+  dps: 6707.1708
+  tps: 3444.74059
  }
 }
 dps_results: {
@@ -923,15 +923,15 @@ dps_results: {
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9121.53105
-  tps: 4907.53571
+  dps: 9275.63913
+  tps: 4882.29267
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3741.07445
-  tps: 1956.88026
+  dps: 3807.2534
+  tps: 1955.07645
  }
 }
 dps_results: {
@@ -944,7 +944,7 @@ dps_results: {
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6301.65409
-  tps: 3284.33516
+  dps: 6353.23085
+  tps: 3272.33254
  }
 }

--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -46,905 +46,905 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6873.31048
-  tps: 3520.23372
+  dps: 6913.45153
+  tps: 3547.15063
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6797.76752
-  tps: 3518.70844
+  dps: 6793.03392
+  tps: 3518.23431
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6599.28712
-  tps: 8196.43355
+  dps: 6633.09884
+  tps: 8191.92268
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6599.28712
-  tps: 8196.43355
+  dps: 6633.09884
+  tps: 8191.92268
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6894.7261
-  tps: 3532.10357
+  dps: 6929.49272
+  tps: 3555.86545
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6690.93604
-  tps: 3435.38241
+  dps: 6742.33173
+  tps: 3459.79259
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 5777.40346
-  tps: 2960.29122
+  dps: 5781.71313
+  tps: 2964.18996
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5648.97752
-  tps: 2894.09907
+  dps: 5667.87488
+  tps: 2905.61089
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5414.38869
-  tps: 2767.69625
+  dps: 5459.23258
+  tps: 2792.68748
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6868.56951
-  tps: 3447.31155
+  dps: 6908.68368
+  tps: 3473.6728
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7012.46944
-  tps: 3597.26173
+  dps: 7048.05912
+  tps: 3621.79201
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6708.6254
-  tps: 3462.80254
+  dps: 6745.13644
+  tps: 3487.47237
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6779.10081
-  tps: 3506.82812
+  dps: 6791.20231
+  tps: 3517.79417
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6838.98031
-  tps: 3506.84464
+  dps: 6873.02929
+  tps: 3530.38774
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 6614.21469
-  tps: 3391.56379
+  dps: 6690.95299
+  tps: 3444.0497
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 5807.82361
-  tps: 2966.03472
+  dps: 5803.53308
+  tps: 2962.7389
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 6910.76235
-  tps: 3538.64868
+  dps: 6940.21718
+  tps: 3560.04013
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7188.1881
-  tps: 3679.53304
+  dps: 7228.86062
+  tps: 3706.23863
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6674.44577
-  tps: 3444.14541
+  dps: 6720.25877
+  tps: 3473.75382
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7026.98518
-  tps: 3641.95323
+  dps: 7050.55727
+  tps: 3655.45355
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7096.31361
-  tps: 3684.55507
+  dps: 7120.84932
+  tps: 3701.32591
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6614.57182
-  tps: 3411.29468
+  dps: 6648.44442
+  tps: 3434.03498
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6897.67513
-  tps: 3533.39505
+  dps: 6934.06238
+  tps: 3558.60725
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6676.82335
-  tps: 3445.2437
+  dps: 6718.37544
+  tps: 3468.85745
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6663.76969
-  tps: 3438.46939
+  dps: 6720.46894
+  tps: 3471.20042
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6868.56951
-  tps: 3517.66485
+  dps: 6908.68368
+  tps: 3544.56408
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6868.56951
-  tps: 3517.66485
+  dps: 6908.68368
+  tps: 3544.56408
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6894.7261
-  tps: 3532.10357
+  dps: 6929.49272
+  tps: 3555.86545
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6889.94944
-  tps: 3529.6171
+  dps: 6923.36879
+  tps: 3552.44483
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6662.13161
-  tps: 3425.64201
+  dps: 6607.71311
+  tps: 3396.74572
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6868.56951
-  tps: 3517.66485
+  dps: 6908.68368
+  tps: 3544.56408
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6773.20491
-  tps: 3503.97036
+  dps: 6771.19817
+  tps: 3501.99892
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6693.81276
-  tps: 3454.34632
+  dps: 6737.58102
+  tps: 3483.45646
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6677.72381
-  tps: 3446.23325
+  dps: 6722.4518
+  tps: 3476.09698
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6868.56951
-  tps: 3517.66485
+  dps: 6908.68368
+  tps: 3544.56408
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6868.56951
-  tps: 3517.66485
+  dps: 6908.68368
+  tps: 3544.56408
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 6912.04646
-  tps: 3539.16501
+  dps: 6941.37783
+  tps: 3560.49995
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6797.60027
-  tps: 3511.1854
+  dps: 6832.17498
+  tps: 3534.59454
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6714.54212
-  tps: 3467.39249
+  dps: 6745.05478
+  tps: 3491.81866
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 6906.39558
-  tps: 3537.25232
+  dps: 6936.16818
+  tps: 3558.74856
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6894.7261
-  tps: 3532.10357
+  dps: 6929.49272
+  tps: 3555.86545
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6889.94944
-  tps: 3529.6171
+  dps: 6923.36879
+  tps: 3552.44483
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6761.34555
-  tps: 3494.69907
+  dps: 6793.3148
+  tps: 3516.32643
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6868.56951
-  tps: 3517.66485
+  dps: 6908.68368
+  tps: 3544.56408
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6895.232
-  tps: 3532.11204
+  dps: 6935.83782
+  tps: 3559.31497
   hps: 12.40192
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6752.1315
-  tps: 3479.80064
+  dps: 6789.06536
+  tps: 3501.92384
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6752.05058
-  tps: 3472.74683
+  dps: 6790.97923
+  tps: 3500.77712
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6609.17997
-  tps: 3408.37176
+  dps: 6643.02712
+  tps: 3431.09484
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6890.14985
-  tps: 3529.35804
+  dps: 6930.38635
+  tps: 3556.33773
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6895.22757
-  tps: 3532.10939
+  dps: 6935.49287
+  tps: 3559.108
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6640.3089
-  tps: 3425.24678
+  dps: 6674.303
+  tps: 3448.06927
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6645.59291
-  tps: 3428.11124
+  dps: 6679.61195
+  tps: 3450.95061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6868.56951
-  tps: 3517.66485
+  dps: 6908.68368
+  tps: 3544.56408
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6868.56951
-  tps: 3517.66485
+  dps: 6908.68368
+  tps: 3544.56408
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6648.25356
-  tps: 3433.73082
+  dps: 6680.67586
+  tps: 3458.0355
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6655.18343
-  tps: 3437.88875
+  dps: 6687.53597
+  tps: 3462.15156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7005.63497
-  tps: 3593.59484
+  dps: 7040.49084
+  tps: 3617.65696
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 6913.54459
-  tps: 3539.7674
+  dps: 6942.73193
+  tps: 3561.03641
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6868.56951
-  tps: 3517.66485
+  dps: 6908.68368
+  tps: 3544.56408
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 6906.16307
-  tps: 3537.11813
+  dps: 6935.96959
+  tps: 3558.6345
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6336.42696
-  tps: 3247.42681
+  dps: 6374.54895
+  tps: 3268.50559
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 5798.44027
-  tps: 2962.95436
+  dps: 5769.51845
+  tps: 2943.83166
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7246.57601
-  tps: 3761.53069
+  dps: 7271.55909
+  tps: 3775.83498
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6098.69872
-  tps: 3115.9813
+  dps: 6118.20907
+  tps: 3126.52847
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6610.28845
-  tps: 3408.58201
+  dps: 6643.76968
+  tps: 3431.08586
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8971.20505
-  tps: 4711.19594
+  dps: 9116.72723
+  tps: 4792.00347
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 6904.3418
-  tps: 3536.06704
+  dps: 6934.4139
+  tps: 3557.74105
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7221.96625
-  tps: 3702.43903
+  dps: 7254.23691
+  tps: 3725.52084
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7227.96736
-  tps: 3709.59944
+  dps: 7285.63804
+  tps: 3745.57441
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6696.37864
-  tps: 3455.88585
+  dps: 6740.5433
+  tps: 3485.08715
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofHope-45703"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofLife-37657"
  value: {
-  dps: 6613.15098
-  tps: 3410.89171
+  dps: 6674.75068
+  tps: 3444.1973
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6734.90425
-  tps: 3463.13969
+  dps: 6745.52949
+  tps: 3467.47228
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 5386.15379
-  tps: 2756.27085
+  dps: 5399.22173
+  tps: 2765.86015
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6895.22757
-  tps: 3532.10939
+  dps: 6935.49287
+  tps: 3559.108
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6890.14985
-  tps: 3529.35804
+  dps: 6930.38635
+  tps: 3556.33773
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6881.26382
-  tps: 3524.5432
+  dps: 6921.44996
+  tps: 3551.48976
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 6819.85451
-  tps: 3507.0854
+  dps: 6794.81122
+  tps: 3492.92775
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 5952.38095
-  tps: 3042.95723
+  dps: 5924.28018
+  tps: 3022.6334
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5957.39888
-  tps: 3022.2307
+  dps: 5963.49701
+  tps: 3021.80455
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6827.01291
-  tps: 3493.79243
+  dps: 6898.71487
+  tps: 3538.6416
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6814.1259
-  tps: 3520.06613
+  dps: 6869.63495
+  tps: 3547.27308
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6855.90496
-  tps: 3540.84674
+  dps: 6863.91829
+  tps: 3541.82563
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6868.56951
-  tps: 3517.66485
+  dps: 6908.68368
+  tps: 3544.56408
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6868.56951
-  tps: 3517.66485
+  dps: 6908.68368
+  tps: 3544.56408
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6593.67892
-  tps: 3392.97079
+  dps: 6601.20939
+  tps: 3395.05179
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6868.56951
-  tps: 3517.66485
+  dps: 6908.68368
+  tps: 3544.56408
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6868.56951
-  tps: 3517.66485
+  dps: 6908.68368
+  tps: 3544.56408
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5657.11797
-  tps: 2903.55874
+  dps: 5678.67573
+  tps: 2910.40934
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5349.36579
-  tps: 2612.52875
+  dps: 5341.4794
+  tps: 2612.33092
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6599.29492
-  tps: 3403.01307
+  dps: 6633.0954
+  tps: 3425.70457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 6915.25674
-  tps: 3540.45583
+  dps: 6944.27947
+  tps: 3561.6495
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 6942.81557
-  tps: 3565.82732
+  dps: 6981.38123
+  tps: 3585.79738
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15189.78858
-  tps: 8008.07002
+  dps: 15337.10877
+  tps: 8073.04448
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6908.47737
-  tps: 3554.86643
+  dps: 6963.99924
+  tps: 3590.23527
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8755.7169
-  tps: 3981.72242
+  dps: 8922.93771
+  tps: 4093.62641
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10123.45434
-  tps: 5341.61942
+  dps: 10179.83602
+  tps: 5355.7268
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3892.34922
-  tps: 2007.39367
+  dps: 3940.0921
+  tps: 2036.54835
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4705.72167
-  tps: 2107.77937
+  dps: 4693.08371
+  tps: 2098.35624
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15310.18993
-  tps: 8048.71599
+  dps: 15436.0179
+  tps: 8100.48164
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7005.63497
-  tps: 3593.59484
+  dps: 7040.49084
+  tps: 3617.65696
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8950.1012
-  tps: 4044.8633
+  dps: 9088.40449
+  tps: 4132.3436
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10231.27618
-  tps: 5384.65213
+  dps: 10288.6056
+  tps: 5395.74711
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3945.21018
-  tps: 2028.22238
+  dps: 3985.9476
+  tps: 2052.19838
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4826.87068
-  tps: 2143.18541
+  dps: 4787.2415
+  tps: 2118.69153
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6654.37636
-  tps: 3420.58331
+  dps: 6674.07937
+  tps: 3431.86673
  }
 }

--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -46,905 +46,905 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6585.08072
-  tps: 3376.44717
+  dps: 6873.31048
+  tps: 3520.23372
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6524.84598
-  tps: 3373.73257
+  dps: 6797.76752
+  tps: 3518.70844
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6329.55363
-  tps: 8781.84769
+  dps: 6599.28712
+  tps: 8196.43355
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6329.55363
-  tps: 8781.84769
+  dps: 6599.28712
+  tps: 8196.43355
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6605.48253
-  tps: 3387.90898
+  dps: 6894.7261
+  tps: 3532.10357
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6404.60197
-  tps: 3287.60564
+  dps: 6690.93604
+  tps: 3435.38241
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 5480.77355
-  tps: 2809.86549
+  dps: 5777.40346
+  tps: 2960.29122
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5410.13223
-  tps: 2777.90589
+  dps: 5648.97752
+  tps: 2894.09907
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5199.28999
-  tps: 2665.58918
+  dps: 5414.38869
+  tps: 2767.69625
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6580.50841
-  tps: 3306.48057
+  dps: 6868.56951
+  tps: 3447.31155
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6717.09109
-  tps: 3450.10651
+  dps: 7012.46944
+  tps: 3597.26173
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
-  hps: 64
+  dps: 6599.29492
+  tps: 3403.01307
+  hps: 42.66667
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6428.24874
-  tps: 3319.02898
+  dps: 6708.6254
+  tps: 3462.80254
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6528.81144
-  tps: 3381.89021
+  dps: 6779.10081
+  tps: 3506.82812
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6546.27122
-  tps: 3360.79613
+  dps: 6838.98031
+  tps: 3506.84464
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 6380.97957
-  tps: 3285.943
+  dps: 6614.21469
+  tps: 3391.56379
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 5545.23849
-  tps: 2830.59671
+  dps: 5807.82361
+  tps: 2966.03472
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 6669.67876
-  tps: 3421.62071
+  dps: 6910.76235
+  tps: 3538.64868
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6875.69414
-  tps: 3525.54282
+  dps: 7188.1881
+  tps: 3679.53304
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6403.96718
-  tps: 3306.02846
+  dps: 6674.44577
+  tps: 3444.14541
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6760.57313
-  tps: 3507.18574
+  dps: 7026.98518
+  tps: 3641.95323
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6803.09651
-  tps: 3534.4658
+  dps: 7096.31361
+  tps: 3684.55507
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6344.25775
-  tps: 3273.60648
+  dps: 6614.57182
+  tps: 3411.29468
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6610.47783
-  tps: 3390.51465
+  dps: 6897.67513
+  tps: 3533.39505
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6458.73708
-  tps: 3333.2693
+  dps: 6676.82335
+  tps: 3445.2437
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6481.82028
-  tps: 3351.32324
+  dps: 6663.76969
+  tps: 3438.46939
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6580.50841
-  tps: 3373.95976
+  dps: 6868.56951
+  tps: 3517.66485
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6580.50841
-  tps: 3373.95976
+  dps: 6868.56951
+  tps: 3517.66485
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6605.48253
-  tps: 3387.90898
+  dps: 6894.7261
+  tps: 3532.10357
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6597.84172
-  tps: 3383.59809
+  dps: 6889.94944
+  tps: 3529.6171
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6364.57729
-  tps: 3276.80757
+  dps: 6662.13161
+  tps: 3425.64201
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6580.50841
-  tps: 3373.95976
+  dps: 6868.56951
+  tps: 3517.66485
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6485.31773
-  tps: 3355.7997
+  dps: 6773.20491
+  tps: 3503.97036
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6418.1505
-  tps: 3313.3483
+  dps: 6693.81276
+  tps: 3454.34632
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6401.0869
-  tps: 3303.51069
+  dps: 6677.72381
+  tps: 3446.23325
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6580.50841
-  tps: 3373.95976
+  dps: 6868.56951
+  tps: 3517.66485
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6580.50841
-  tps: 3373.95976
+  dps: 6868.56951
+  tps: 3517.66485
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 6678.1646
-  tps: 3425.98582
+  dps: 6912.04646
+  tps: 3539.16501
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6521.05936
-  tps: 3370.62437
+  dps: 6797.60027
+  tps: 3511.1854
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6443.58732
-  tps: 3328.75175
+  dps: 6714.54212
+  tps: 3467.39249
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 6648.66231
-  tps: 3410.91291
+  dps: 6906.39558
+  tps: 3537.25232
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6605.48253
-  tps: 3387.90898
+  dps: 6894.7261
+  tps: 3532.10357
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6597.84172
-  tps: 3383.59809
+  dps: 6889.94944
+  tps: 3529.6171
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6503.62349
-  tps: 3364.90648
+  dps: 6761.34555
+  tps: 3494.69907
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6580.50841
-  tps: 3373.95976
+  dps: 6868.56951
+  tps: 3517.66485
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6606.52458
-  tps: 3388.13011
-  hps: 12.70546
+  dps: 6895.232
+  tps: 3532.11204
+  hps: 12.40192
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6490.82537
-  tps: 3348.87774
+  dps: 6752.1315
+  tps: 3479.80064
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6472.04562
-  tps: 3334.0507
+  dps: 6752.05058
+  tps: 3472.74683
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6339.06151
-  tps: 3270.77812
+  dps: 6609.17997
+  tps: 3408.37176
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6601.32102
-  tps: 3385.28213
+  dps: 6890.14985
+  tps: 3529.35804
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6606.2181
-  tps: 3387.94622
+  dps: 6895.22757
+  tps: 3532.10939
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6369.06113
-  tps: 3287.10721
+  dps: 6640.3089
+  tps: 3425.24678
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6374.15344
-  tps: 3289.87901
+  dps: 6645.59291
+  tps: 3428.11124
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6580.50841
-  tps: 3373.95976
+  dps: 6868.56951
+  tps: 3517.66485
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6580.50841
-  tps: 3373.95976
+  dps: 6868.56951
+  tps: 3517.66485
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6413.12708
-  tps: 3314.92885
+  dps: 6648.25356
+  tps: 3433.73082
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6421.73362
-  tps: 3320.09277
+  dps: 6655.18343
+  tps: 3437.88875
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6707.1708
-  tps: 3444.74059
+  dps: 7005.63497
+  tps: 3593.59484
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 6688.06474
-  tps: 3431.07845
+  dps: 6913.54459
+  tps: 3539.7674
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6580.50841
-  tps: 3373.95976
+  dps: 6868.56951
+  tps: 3517.66485
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 6646.23822
-  tps: 3409.65429
+  dps: 6906.16307
+  tps: 3537.11813
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6014.34985
-  tps: 3083.13886
+  dps: 6336.42696
+  tps: 3247.42681
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 5556.06481
-  tps: 2836.48105
+  dps: 5798.44027
+  tps: 2962.95436
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 6948.10289
-  tps: 3611.37442
+  dps: 7246.57601
+  tps: 3761.53069
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 5811.31311
-  tps: 2966.96048
+  dps: 6098.69872
+  tps: 3115.9813
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6343.10513
-  tps: 3272.79207
+  dps: 6610.28845
+  tps: 3408.58201
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8641.41398
-  tps: 4537.2958
+  dps: 8971.20505
+  tps: 4711.19594
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 6627.24957
-  tps: 3399.79514
+  dps: 6904.3418
+  tps: 3536.06704
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 6923.34452
-  tps: 3554.28812
+  dps: 7221.96625
+  tps: 3702.43903
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 6817.03067
-  tps: 3498.84481
+  dps: 7227.96736
+  tps: 3709.59944
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6421.34393
-  tps: 3315.26435
+  dps: 6696.37864
+  tps: 3455.88585
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofHope-45703"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofLife-37657"
  value: {
-  dps: 6366.07942
-  tps: 3294.86072
+  dps: 6613.15098
+  tps: 3410.89171
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6509.80633
-  tps: 3350.07533
+  dps: 6734.90425
+  tps: 3463.13969
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 5133.22607
-  tps: 2623.93368
+  dps: 5386.15379
+  tps: 2756.27085
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6606.2181
-  tps: 3387.94622
+  dps: 6895.22757
+  tps: 3532.10939
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6601.32102
-  tps: 3385.28213
+  dps: 6890.14985
+  tps: 3529.35804
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6592.75112
-  tps: 3380.61998
+  dps: 6881.26382
+  tps: 3524.5432
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 6480.09845
-  tps: 3329.0357
+  dps: 6819.85451
+  tps: 3507.0854
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 5693.8275
-  tps: 2910.14236
+  dps: 5952.38095
+  tps: 3042.95723
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5750.4276
-  tps: 2918.70165
+  dps: 5957.39888
+  tps: 3022.2307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6615.47871
-  tps: 3393.31122
+  dps: 6827.01291
+  tps: 3493.79243
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6613.4387
-  tps: 3421.03679
+  dps: 6814.1259
+  tps: 3520.06613
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6610.45771
-  tps: 3421.25636
+  dps: 6855.90496
+  tps: 3540.84674
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6580.50841
-  tps: 3373.95976
+  dps: 6868.56951
+  tps: 3517.66485
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6580.50841
-  tps: 3373.95976
+  dps: 6868.56951
+  tps: 3517.66485
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6372.21513
-  tps: 3282.11468
+  dps: 6593.67892
+  tps: 3392.97079
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6580.50841
-  tps: 3373.95976
+  dps: 6868.56951
+  tps: 3517.66485
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6580.50841
-  tps: 3373.95976
+  dps: 6868.56951
+  tps: 3517.66485
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5393.97402
-  tps: 2770.55655
+  dps: 5657.11797
+  tps: 2903.55874
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5121.49629
-  tps: 2511.98537
+  dps: 5349.36579
+  tps: 2612.52875
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6329.53507
-  tps: 3265.59278
+  dps: 6599.29492
+  tps: 3403.01307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 6699.3792
-  tps: 3436.8986
+  dps: 6915.25674
+  tps: 3540.45583
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 6659.72922
-  tps: 3419.7561
+  dps: 6942.81557
+  tps: 3565.82732
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13869.41686
-  tps: 7296.75188
+  dps: 15189.78858
+  tps: 8008.07002
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6638.68097
-  tps: 3424.74713
+  dps: 6908.47737
+  tps: 3554.86643
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8122.99851
-  tps: 3657.01988
+  dps: 8755.7169
+  tps: 3981.72242
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9226.38418
-  tps: 4868.5334
+  dps: 10123.45434
+  tps: 5341.61942
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3759.40933
-  tps: 1938.23888
+  dps: 3892.34922
+  tps: 2007.39367
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4346.18958
-  tps: 1917.1859
+  dps: 4705.72167
+  tps: 2107.77937
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14012.94108
-  tps: 7342.67053
+  dps: 15310.18993
+  tps: 8048.71599
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6707.1708
-  tps: 3444.74059
+  dps: 7005.63497
+  tps: 3593.59484
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8270.74634
-  tps: 3687.81698
+  dps: 8950.1012
+  tps: 4044.8633
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9275.63913
-  tps: 4882.29267
+  dps: 10231.27618
+  tps: 5384.65213
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3807.2534
-  tps: 1955.07645
+  dps: 3945.21018
+  tps: 2028.22238
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4432.13287
-  tps: 1936.19931
+  dps: 4826.87068
+  tps: 2143.18541
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6353.23085
-  tps: 3272.33254
+  dps: 6654.37636
+  tps: 3420.58331
  }
 }

--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -46,905 +46,905 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6280.44803
-  tps: 3257.19695
+  dps: 6261.80969
+  tps: 3255.7117
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6280.44803
-  tps: 3257.19695
+  dps: 6261.80969
+  tps: 3255.7117
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6523.11599
-  tps: 3364.19427
+  dps: 6504.82628
+  tps: 3364.1621
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6457.97069
-  tps: 3355.5347
+  dps: 6439.46944
+  tps: 3353.38189
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6280.44753
-  tps: 8765.93012
+  dps: 6261.81645
+  tps: 8752.70276
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6280.44753
-  tps: 8765.93012
+  dps: 6261.81645
+  tps: 8752.70276
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6548.41319
-  tps: 3378.45438
+  dps: 6527.9284
+  tps: 3377.23187
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6341.0271
-  tps: 3277.78628
+  dps: 6314.78359
+  tps: 3271.53122
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 5452.61958
-  tps: 2812.71105
+  dps: 5436.11562
+  tps: 2817.39947
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5370.69128
-  tps: 2771.30891
+  dps: 5342.76463
+  tps: 2772.21008
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5150.73318
-  tps: 2651.94049
+  dps: 5145.85631
+  tps: 2657.39256
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6518.58605
-  tps: 3294.48031
+  dps: 6500.31027
+  tps: 3294.45025
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6658.96932
-  tps: 3440.5406
+  dps: 6638.49966
+  tps: 3439.5585
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6280.44803
-  tps: 3257.19695
+  dps: 6261.80969
+  tps: 3255.7117
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6280.44803
-  tps: 3257.19695
+  dps: 6261.80969
+  tps: 3255.7117
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6279.57628
-  tps: 3256.68548
+  dps: 6260.93794
+  tps: 3255.20023
   hps: 44.8
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6374.90491
-  tps: 3308.69071
+  dps: 6350.48986
+  tps: 3304.3259
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6437.54363
-  tps: 3347.83513
+  dps: 6421.01194
+  tps: 3346.20142
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6489.89761
-  tps: 3351.8986
+  dps: 6470.03783
+  tps: 3350.91218
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 6345.40624
-  tps: 3281.7804
+  dps: 6328.27344
+  tps: 3282.2202
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 5501.18151
-  tps: 2823.14674
+  dps: 5519.35539
+  tps: 2846.8575
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 6610.90895
-  tps: 3413.00781
+  dps: 6589.84919
+  tps: 3411.15172
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6816.09252
-  tps: 3515.58606
+  dps: 6795.43758
+  tps: 3515.30202
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6346.64632
-  tps: 3293.60724
+  dps: 6326.20288
+  tps: 3290.76076
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6662.06764
-  tps: 3489.06258
+  dps: 6649.53656
+  tps: 3485.93734
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6725.47699
-  tps: 3527.63802
+  dps: 6728.33192
+  tps: 3529.49289
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6294.17256
-  tps: 3264.68043
+  dps: 6275.48565
+  tps: 3263.18816
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6552.51228
-  tps: 3380.63214
+  dps: 6531.90592
+  tps: 3379.21264
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6445.48328
-  tps: 3336.5739
+  dps: 6413.05515
+  tps: 3329.83429
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6400.86962
-  tps: 3328.66225
+  dps: 6403.14186
+  tps: 3343.49203
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6518.58605
-  tps: 3361.7146
+  dps: 6500.31027
+  tps: 3361.68393
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6518.58605
-  tps: 3361.7146
+  dps: 6500.31027
+  tps: 3361.68393
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6548.41319
-  tps: 3378.45438
+  dps: 6527.9284
+  tps: 3377.23187
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6541.1828
-  tps: 3374.50434
+  dps: 6520.77774
+  tps: 3373.1961
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6356.69854
-  tps: 3284.89859
+  dps: 6345.65679
+  tps: 3289.46437
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6280.44803
-  tps: 3257.19695
+  dps: 6261.80969
+  tps: 3255.7117
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6518.58605
-  tps: 3361.7146
+  dps: 6500.31027
+  tps: 3361.68393
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6412.97617
-  tps: 3333.69344
+  dps: 6399.66865
+  tps: 3333.13055
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6365.1548
-  tps: 3303.30626
+  dps: 6341.55889
+  tps: 3299.20747
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6280.44803
-  tps: 3257.19695
+  dps: 6261.80969
+  tps: 3255.7117
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6280.44803
-  tps: 3257.19695
+  dps: 6261.80969
+  tps: 3255.7117
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6348.28199
-  tps: 3294.6143
+  dps: 6326.91886
+  tps: 3291.41189
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6518.58605
-  tps: 3361.7146
+  dps: 6500.31027
+  tps: 3361.68393
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6518.58605
-  tps: 3361.7146
+  dps: 6500.31027
+  tps: 3361.68393
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 6619.01664
-  tps: 3417.33515
+  dps: 6597.89576
+  tps: 3415.48431
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6470.25179
-  tps: 3361.98855
+  dps: 6450.98675
+  tps: 3360.40821
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6279.57628
-  tps: 3256.68548
+  dps: 6260.93794
+  tps: 3255.20023
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6279.57628
-  tps: 3256.68548
+  dps: 6260.93794
+  tps: 3255.20023
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6279.57628
-  tps: 3256.68548
+  dps: 6260.93794
+  tps: 3255.20023
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6387.44027
-  tps: 3316.54109
+  dps: 6364.06611
+  tps: 3308.78148
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 6590.19502
-  tps: 3402.59142
+  dps: 6569.04783
+  tps: 3400.71828
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6280.44803
-  tps: 3257.19695
+  dps: 6261.80969
+  tps: 3255.7117
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6548.41319
-  tps: 3378.45438
+  dps: 6527.9284
+  tps: 3377.23187
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6541.1828
-  tps: 3374.50434
+  dps: 6520.77774
+  tps: 3373.1961
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6429.52698
-  tps: 3341.87442
+  dps: 6409.672
+  tps: 3339.79785
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6518.58605
-  tps: 3361.7146
+  dps: 6500.31027
+  tps: 3361.68393
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6544.36393
-  tps: 3375.84141
-  hps: 12.70546
+  dps: 6526.00984
+  tps: 3375.80235
+  hps: 12.40192
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6279.57628
-  tps: 3256.68548
+  dps: 6260.93794
+  tps: 3255.20023
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6280.44803
-  tps: 3257.19695
+  dps: 6261.80969
+  tps: 3255.7117
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6400.93135
-  tps: 3336.81725
+  dps: 6367.43849
+  tps: 3332.77293
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6409.54901
-  tps: 3321.3302
+  dps: 6393.40576
+  tps: 3321.55897
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6289.02093
-  tps: 3261.85868
+  dps: 6270.35116
+  tps: 3260.36889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6539.20576
-  tps: 3373.00173
+  dps: 6520.86658
+  tps: 3372.96427
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6544.05746
-  tps: 3375.65753
+  dps: 6525.70336
+  tps: 3375.61847
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6319.6395
-  tps: 3278.66384
+  dps: 6300.87078
+  tps: 3277.15975
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6324.68871
-  tps: 3281.42951
+  dps: 6305.90319
+  tps: 3279.923
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6518.58605
-  tps: 3361.7146
+  dps: 6500.31027
+  tps: 3361.68393
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6518.58605
-  tps: 3361.7146
+  dps: 6500.31027
+  tps: 3361.68393
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6280.44803
-  tps: 3257.19695
+  dps: 6261.80969
+  tps: 3255.7117
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6350.73767
-  tps: 3299.97615
+  dps: 6335.41769
+  tps: 3299.55128
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6359.16289
-  tps: 3305.03128
+  dps: 6343.73822
+  tps: 3304.5436
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6649.58965
-  tps: 3435.61734
+  dps: 6629.20186
+  tps: 3434.54398
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 6628.47562
-  tps: 3422.38372
+  dps: 6607.28343
+  tps: 3420.53899
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6518.58605
-  tps: 3361.7146
+  dps: 6500.31027
+  tps: 3361.68393
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6279.57628
-  tps: 3256.68548
+  dps: 6260.93794
+  tps: 3255.20023
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 6587.95073
-  tps: 3401.32119
+  dps: 6566.84804
+  tps: 3399.44702
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6010.811
-  tps: 3097.1858
+  dps: 6009.43088
+  tps: 3109.58918
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 5506.25545
-  tps: 2822.55518
+  dps: 5490.07888
+  tps: 2825.38098
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 6862.33216
-  tps: 3579.80762
+  dps: 6849.64851
+  tps: 3588.03596
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 5754.3331
-  tps: 2953.44478
+  dps: 5781.85198
+  tps: 2983.04914
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6290.20425
-  tps: 3262.03196
+  dps: 6271.42306
+  tps: 3260.48517
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8573.53354
-  tps: 4520.12979
+  dps: 8582.73972
+  tps: 4539.9589
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6280.44803
-  tps: 3257.19695
+  dps: 6261.80969
+  tps: 3255.7117
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 6570.37048
-  tps: 3391.37111
+  dps: 6549.61632
+  tps: 3389.4888
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 6860.60934
-  tps: 3545.27302
+  dps: 6839.86832
+  tps: 3543.81896
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 6755.0732
-  tps: 3491.56037
+  dps: 6733.68498
+  tps: 3490.0911
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6279.57628
-  tps: 3256.68548
+  dps: 6260.93794
+  tps: 3255.20023
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6279.57628
-  tps: 3256.68548
+  dps: 6260.93794
+  tps: 3255.20023
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6279.57628
-  tps: 3256.68548
+  dps: 6260.93794
+  tps: 3255.20023
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6366.13543
-  tps: 3303.89464
+  dps: 6341.55889
+  tps: 3299.20747
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofHope-45703"
  value: {
-  dps: 6280.44803
-  tps: 3257.19695
+  dps: 6261.80969
+  tps: 3255.7117
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofLife-37657"
  value: {
-  dps: 6337.52785
-  tps: 3284.32562
+  dps: 6318.64997
+  tps: 3281.4644
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6415.51319
-  tps: 3314.70008
+  dps: 6407.17005
+  tps: 3314.5717
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 5125.1461
-  tps: 2643.50938
+  dps: 5092.90946
+  tps: 2640.62763
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6544.05746
-  tps: 3375.65753
+  dps: 6525.70336
+  tps: 3375.61847
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6539.20576
-  tps: 3373.00173
+  dps: 6520.86658
+  tps: 3372.96427
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6530.71529
-  tps: 3368.35409
+  dps: 6512.40222
+  tps: 3368.31942
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6279.57628
-  tps: 3256.68548
+  dps: 6260.93794
+  tps: 3255.20023
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6280.44803
-  tps: 3257.19695
+  dps: 6261.80969
+  tps: 3255.7117
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 6485.6757
-  tps: 3352.14803
+  dps: 6470.87995
+  tps: 3351.89706
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 5642.42152
-  tps: 2898.9372
+  dps: 5605.14614
+  tps: 2891.02898
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6280.44803
-  tps: 3257.19695
+  dps: 6261.80969
+  tps: 3255.7117
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5732.23622
-  tps: 2917.43102
+  dps: 5690.17079
+  tps: 2911.22839
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6513.49248
-  tps: 3393.13283
+  dps: 6508.58474
+  tps: 3392.68339
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6483.96645
-  tps: 3360.1121
+  dps: 6478.63507
+  tps: 3361.3354
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6510.43186
-  tps: 3376.96448
+  dps: 6503.45576
+  tps: 3378.7265
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6518.58605
-  tps: 3361.7146
+  dps: 6500.31027
+  tps: 3361.68393
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6518.58605
-  tps: 3361.7146
+  dps: 6500.31027
+  tps: 3361.68393
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6298.55476
-  tps: 3255.14249
+  dps: 6272.71328
+  tps: 3247.69451
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6518.58605
-  tps: 3361.7146
+  dps: 6500.31027
+  tps: 3361.68393
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6518.58605
-  tps: 3361.7146
+  dps: 6500.31027
+  tps: 3361.68393
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5350.7124
-  tps: 2757.12013
+  dps: 5347.52068
+  tps: 2769.81607
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5104.54589
-  tps: 2505.04486
+  dps: 5080.62121
+  tps: 2500.18963
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6279.57628
-  tps: 3256.68548
+  dps: 6260.93794
+  tps: 3255.20023
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 6639.28587
-  tps: 3428.15351
+  dps: 6618.01219
+  tps: 3426.31577
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 6615.4033
-  tps: 3411.22634
+  dps: 6594.6755
+  tps: 3411.97804
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13716.03197
-  tps: 7289.01088
+  dps: 13718.3236
+  tps: 7348.88846
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6616.82543
-  tps: 3435.37333
+  dps: 6570.59716
+  tps: 3419.24146
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8137.92001
+  dps: 8122.99851
   tps: 3657.01988
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9123.34504
-  tps: 4854.36764
+  dps: 9028.99218
+  tps: 4871.79372
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3732.49388
-  tps: 1946.82191
+  dps: 3685.06948
+  tps: 1933.7664
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4356.30983
+  dps: 4346.18958
   tps: 1917.1859
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13882.43833
-  tps: 7339.91072
+  dps: 13815.43282
+  tps: 7400.19684
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6649.58965
-  tps: 3435.61734
+  dps: 6629.20186
+  tps: 3434.54398
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8286.06979
+  dps: 8270.74634
   tps: 3687.81698
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9215.0599
-  tps: 4883.07978
+  dps: 9121.53105
+  tps: 4907.53571
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3766.15509
-  tps: 1957.18355
+  dps: 3741.07445
+  tps: 1956.88026
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4442.00074
+  dps: 4432.13287
   tps: 1936.19931
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6364.03716
-  tps: 3305.19839
+  dps: 6301.65409
+  tps: 3284.33516
  }
 }

--- a/sim/deathknight/dps/dps_deathknight.go
+++ b/sim/deathknight/dps/dps_deathknight.go
@@ -320,7 +320,7 @@ func (dk *DpsDeathknight) gargoyleAPCooldownSync(actionID core.ActionID, isPotio
 			if dk.SummonGargoyle.CD.TimeToReady(sim) > majorCd.Spell.CD.Duration && !isPotion {
 				return true
 			}
-			if dk.SummonGargoyle.CD.ReadyAt() > dk.Env.Encounter.Duration {
+			if dk.SummonGargoyle.CD.ReadyAt() > sim.Duration {
 				return true
 			}
 
@@ -350,7 +350,7 @@ func (dk *DpsDeathknight) gargoyleHasteCooldownSync(actionID core.ActionID, isPo
 				if dk.SummonGargoyle.CD.TimeToReady(sim) > majorCd.Spell.CD.Duration && !isPotion {
 					return true
 				}
-				if dk.SummonGargoyle.CD.ReadyAt() > dk.Env.Encounter.Duration {
+				if dk.SummonGargoyle.CD.ReadyAt() > sim.Duration {
 					return true
 				}
 			}
@@ -479,13 +479,20 @@ func (dk *DpsDeathknight) drwCooldownSync(actionID core.ActionID, isPotion bool)
 			if sim.CurrentTime < 2*time.Second {
 				return true
 			}
+			// If the fight is long enough for Unholy Frenzy we use potion with it
+			if isPotion && dk.br.activatingDrw && sim.Duration > 200*time.Second {
+				if dk.UnholyFrenzy.IsReady(sim) || dk.UnholyFrenzyAura.IsActive() {
+					return true
+				}
+				return false
+			}
 			if dk.br.activatingDrw {
 				return true
 			}
 			if dk.DancingRuneWeapon.CD.TimeToReady(sim) > majorCd.Spell.CD.Duration && !isPotion {
 				return true
 			}
-			if dk.DancingRuneWeapon.CD.ReadyAt() > dk.Env.Encounter.Duration {
+			if dk.DancingRuneWeapon.CD.ReadyAt() > sim.Duration {
 				return true
 			}
 

--- a/sim/deathknight/dps/dps_deathknight_test.go
+++ b/sim/deathknight/dps/dps_deathknight_test.go
@@ -84,11 +84,11 @@ func TestFrost(t *testing.T) {
 	}))
 }
 
-var BloodTalents = "2305120530003303231023001351--230130305003"
+var BloodTalents = "2305120530003303231023001351--230220305003"
 var BloodDefaultGlyphs = &proto.Glyphs{
 	Major1: int32(proto.DeathknightMajorGlyph_GlyphOfDancingRuneWeapon),
 	Major2: int32(proto.DeathknightMajorGlyph_GlyphOfDeathStrike),
-	Major3: int32(proto.DeathknightMajorGlyph_GlyphOfDarkDeath),
+	Major3: int32(proto.DeathknightMajorGlyph_GlyphOfDisease),
 	// No interesting minor glyphs.
 }
 
@@ -131,6 +131,7 @@ var PlayerOptionsFrost = &proto.Player_Deathknight{
 
 var bloodRotation = &proto.Deathknight_Rotation{
 	ArmyOfTheDead:        proto.Deathknight_Rotation_PreCast,
+	DrwDiseases:          proto.Deathknight_Rotation_Pestilence,
 	UseEmpowerRuneWeapon: true,
 }
 
@@ -152,6 +153,8 @@ var unholyRotation = &proto.Deathknight_Rotation{
 var frostRotation = &proto.Deathknight_Rotation{}
 
 var deathKnightOptions = &proto.Deathknight_Options{
+	UnholyFrenzyTarget:  &proto.RaidTarget{TargetIndex: 0},
+	DrwPestiApply:       true,
 	StartingRunicPower:  0,
 	PetUptime:           1,
 	PrecastGhoulFrenzy:  false,

--- a/sim/deathknight/dps/rotation_blood.go
+++ b/sim/deathknight/dps/rotation_blood.go
@@ -60,27 +60,7 @@ func (dk *DpsDeathknight) RotationActionCallback_BloodRotation(sim *core.Simulat
 		dk.blRecastDiseasesSequence(sim)
 		return sim.CurrentTime
 	} else if dk.blDrwCheck(sim, target, 100*time.Millisecond) {
-		if dk.DancingRuneWeapon.IsReady(sim) {
-			dk.RotationSequence.Clear()
-
-			if dk.UnholyFrenzy.IsReady(sim) {
-				dk.RotationSequence.NewAction(dk.RotationActionCallback_UF)
-			}
-
-			dk.RotationSequence.NewAction(dk.RotationActionCallback_DRW_Custom)
-
-			if dk.sr.hasGod && dk.Rotation.DrwDiseases == proto.Deathknight_Rotation_Pestilence {
-				dk.RotationSequence.NewAction(dk.RotationActionCallback_Pesti_DRW)
-			} else if dk.Rotation.DrwDiseases == proto.Deathknight_Rotation_Normal {
-				dk.RotationSequence.
-					NewAction(dk.RotationActionBL_IT_Custom).
-					NewAction(dk.RotationActionBL_PS_Custom)
-			}
-
-			dk.RotationSequence.NewAction(dk.RotationAction_ResetToBloodMain)
-		} else {
-			dk.blAfterDrwSequence(sim)
-		}
+		dk.blAfterDrwSequence(sim)
 		return sim.CurrentTime
 	}
 
@@ -137,8 +117,8 @@ func (dk *DpsDeathknight) blAfterDrwSequence(sim *core.Simulation) {
 		dk.RotationSequence.NewAction(dk.RotationActionCallback_Pesti_DRW)
 	} else if dk.Rotation.DrwDiseases == proto.Deathknight_Rotation_Normal {
 		dk.RotationSequence.
-			NewAction(dk.RotationActionBL_IT_Custom).
-			NewAction(dk.RotationActionBL_PS_Custom)
+			NewAction(dk.RotationActionBL_IT_DRW).
+			NewAction(dk.RotationActionBL_PS_DRW)
 	}
 
 	dk.RotationSequence.
@@ -221,6 +201,14 @@ func (dk *DpsDeathknight) RotationActionBL_PS_DRW(sim *core.Simulation, target *
 	casted := dk.PlagueStrike.Cast(sim, target)
 	advance := dk.LastOutcome.Matches(core.OutcomeLanded)
 
+	if !casted {
+		if dk.Talents.HeartStrike {
+			dk.HeartStrike.Cast(sim, target)
+		} else {
+			dk.BloodStrike.Cast(sim, target)
+		}
+	}
+
 	dk.sr.recastedBP = casted && advance
 	s.ConditionalAdvance(casted && advance)
 	return -1
@@ -230,6 +218,15 @@ func (dk *DpsDeathknight) RotationActionBL_PS_DRW(sim *core.Simulation, target *
 func (dk *DpsDeathknight) RotationActionBL_IT_DRW(sim *core.Simulation, target *core.Unit, s *deathknight.Sequence) time.Duration {
 	casted := dk.IcyTouch.Cast(sim, target)
 	advance := dk.LastOutcome.Matches(core.OutcomeLanded)
+
+	if !casted {
+		if dk.Talents.HeartStrike {
+			dk.HeartStrike.Cast(sim, target)
+		} else {
+			dk.BloodStrike.Cast(sim, target)
+		}
+	}
+
 	dk.sr.recastedFF = casted && advance
 	s.ConditionalAdvance(casted && advance)
 	return -1

--- a/sim/deathknight/dps/rotation_blood.go
+++ b/sim/deathknight/dps/rotation_blood.go
@@ -177,6 +177,15 @@ func (dk *DpsDeathknight) RotationAction_ResetToBloodMain(sim *core.Simulation, 
 	return sim.CurrentTime
 }
 
+func (dk *DpsDeathknight) RotationActionCallback_DRW_Custom(sim *core.Simulation, target *core.Unit, s *deathknight.Sequence) time.Duration {
+	casted := dk.DancingRuneWeapon.Cast(sim, target)
+	if casted {
+		dk.br.drwSnapshot.ResetProcTrackers()
+	}
+	s.ConditionalAdvance(casted)
+	return -1
+}
+
 func (dk *DpsDeathknight) RotationActionCallback_FU(sim *core.Simulation, target *core.Unit, s *deathknight.Sequence) time.Duration {
 	casted := false
 	if dk.Inputs.FuStrike == deathknight.FuStrike_DeathStrike {

--- a/sim/deathknight/dps/rotation_blood.go
+++ b/sim/deathknight/dps/rotation_blood.go
@@ -24,12 +24,12 @@ func (dk *DpsDeathknight) setupBloodRotations() {
 		NewAction(dk.RotationActionCallback_HS).
 		NewAction(dk.RotationActionCallback_ERW).
 		NewAction(dk.RotationActionCallback_RD).
-		NewAction(dk.RotationActionCallback_DRW)
+		NewAction(dk.RotationActionCallback_DRW_Custom)
 
 	if dk.sr.hasGod && dk.Rotation.DrwDiseases == proto.Deathknight_Rotation_Pestilence {
 		dk.RotationSequence.
 			NewAction(dk.RotationActionCallback_Pesti).
-			NewAction(dk.RotationActionCallback_DS).
+			NewAction(dk.RotationActionCallback_FU).
 			NewAction(dk.RotationActionCallback_HS).
 			NewAction(dk.RotationActionCallback_HS).
 			NewAction(dk.RotationActionCallback_HS)
@@ -43,7 +43,7 @@ func (dk *DpsDeathknight) setupBloodRotations() {
 			NewAction(dk.RotationActionCallback_HS)
 	} else {
 		dk.RotationSequence.
-			NewAction(dk.RotationActionCallback_DS).
+			NewAction(dk.RotationActionCallback_FU).
 			NewAction(dk.RotationActionCallback_HS).
 			NewAction(dk.RotationActionCallback_HS).
 			NewAction(dk.RotationActionCallback_HS).
@@ -67,7 +67,7 @@ func (dk *DpsDeathknight) RotationActionCallback_BloodRotation(sim *core.Simulat
 				dk.RotationSequence.NewAction(dk.RotationActionCallback_UF)
 			}
 
-			dk.RotationSequence.NewAction(dk.RotationActionCallback_DRW)
+			dk.RotationSequence.NewAction(dk.RotationActionCallback_DRW_Custom)
 
 			if dk.sr.hasGod && dk.Rotation.DrwDiseases == proto.Deathknight_Rotation_Pestilence {
 				dk.RotationSequence.NewAction(dk.RotationActionCallback_Pesti)

--- a/sim/deathknight/dps/rotation_blood_helper.go
+++ b/sim/deathknight/dps/rotation_blood_helper.go
@@ -116,6 +116,7 @@ func (dk *DpsDeathknight) blDrwCheck(sim *core.Simulation, target *core.Unit, ca
 		if dk.GCD.IsReady(sim) {
 			if dk.DancingRuneWeapon.Cast(sim, target) {
 				dk.br.drwSnapshot.ResetProcTrackers()
+				dk.br.drwMaxDelay = -1
 			}
 		}
 		return true
@@ -148,7 +149,8 @@ func (dk *DpsDeathknight) blDrwCanCast(sim *core.Simulation, castTime time.Durat
 	if sim.GetRemainingDuration() < 20*time.Second {
 		return true
 	}
-	if !dk.sr.hasGod && dk.CurrentFrostRunes() < 1 || dk.CurrentUnholyRunes() < 1 {
+	// Make sure we can instantly put diseases up with the rune weapon
+	if !dk.sr.hasGod && (dk.CurrentFrostRunes() < 1 || dk.CurrentUnholyRunes() < 1) {
 		return false
 	}
 	if dk.sr.hasGod && dk.CurrentBloodRunes() < 1 {

--- a/sim/deathknight/dps/rotation_blood_helper.go
+++ b/sim/deathknight/dps/rotation_blood_helper.go
@@ -11,6 +11,7 @@ type BloodRotation struct {
 	dk *DpsDeathknight
 
 	drwSnapshot *core.SnapshotManager
+	drwMaxDelay time.Duration
 
 	activatingDrw bool
 }
@@ -18,6 +19,7 @@ type BloodRotation struct {
 func (br *BloodRotation) Reset(sim *core.Simulation) {
 	br.activatingDrw = false
 	br.drwSnapshot.ResetProcTrackers()
+	br.drwMaxDelay = -1
 }
 
 func (dk *DpsDeathknight) blDiseaseCheck(sim *core.Simulation, target *core.Unit, spell *deathknight.RuneSpell, costRunes bool, casts int) bool {
@@ -128,6 +130,20 @@ func (dk *DpsDeathknight) blDrwCanCast(sim *core.Simulation, castTime time.Durat
 	}
 	if !dk.CastCostPossible(sim, 60.0, 0, 0, 0) {
 		return false
+	}
+	// Setup max delay possible
+	if dk.br.drwMaxDelay == -1 {
+		drwCd := dk.DancingRuneWeapon.CD.Duration
+		timeLeft := sim.GetRemainingDuration()
+		for timeLeft > drwCd {
+			// code block
+			timeLeft = timeLeft - (drwCd + 2*time.Second)
+		}
+		dk.br.drwMaxDelay = timeLeft - 2*time.Second
+	}
+	// Cast it if holding will result in less total DRWs for the encounter
+	if sim.CurrentTime > dk.br.drwMaxDelay {
+		return true
 	}
 	// Cast it if holding will take from its duration
 	if sim.GetRemainingDuration() < 20*time.Second {

--- a/sim/deathknight/dps/rotation_blood_helper.go
+++ b/sim/deathknight/dps/rotation_blood_helper.go
@@ -113,11 +113,9 @@ func (dk *DpsDeathknight) blDrwCheck(sim *core.Simulation, target *core.Unit, ca
 		dk.br.drwSnapshot.ActivateMajorCooldowns(sim)
 		dk.br.activatingDrw = false
 
-		if dk.GCD.IsReady(sim) {
-			if dk.DancingRuneWeapon.Cast(sim, target) {
-				dk.br.drwSnapshot.ResetProcTrackers()
-				dk.br.drwMaxDelay = -1
-			}
+		if dk.DancingRuneWeapon.Cast(sim, target) {
+			dk.br.drwSnapshot.ResetProcTrackers()
+			dk.br.drwMaxDelay = -1
 		}
 		return true
 	}

--- a/sim/deathknight/dps/rotation_blood_helper.go
+++ b/sim/deathknight/dps/rotation_blood_helper.go
@@ -136,7 +136,6 @@ func (dk *DpsDeathknight) blDrwCanCast(sim *core.Simulation, castTime time.Durat
 		drwCd := dk.DancingRuneWeapon.CD.Duration
 		timeLeft := sim.GetRemainingDuration()
 		for timeLeft > drwCd {
-			// code block
 			timeLeft = timeLeft - (drwCd + 2*time.Second)
 		}
 		dk.br.drwMaxDelay = timeLeft - 2*time.Second

--- a/sim/deathknight/dps/rotation_blood_helper.go
+++ b/sim/deathknight/dps/rotation_blood_helper.go
@@ -133,7 +133,7 @@ func (dk *DpsDeathknight) blDrwCanCast(sim *core.Simulation, castTime time.Durat
 	if sim.GetRemainingDuration() < 20*time.Second {
 		return true
 	}
-	if !dk.sr.hasGod && dk.NormalCurrentFrostRunes() < 1 || dk.NormalCurrentUnholyRunes() < 1 {
+	if !dk.sr.hasGod && dk.CurrentFrostRunes() < 1 || dk.CurrentUnholyRunes() < 1 {
 		return false
 	}
 	if dk.sr.hasGod && dk.CurrentBloodRunes() < 1 {

--- a/sim/deathknight/unholy_frenzy.go
+++ b/sim/deathknight/unholy_frenzy.go
@@ -25,9 +25,6 @@ func (dk *Deathknight) registerUnholyFrenzyCD() {
 		ActionID: actionID,
 
 		Cast: core.CastConfig{
-			DefaultCast: core.Cast{
-				GCD: core.GCDDefault,
-			},
 			CD: core.Cooldown{
 				Timer:    dk.NewTimer(),
 				Duration: time.Minute * 3,

--- a/sim/deathknight/unholy_frenzy.go
+++ b/sim/deathknight/unholy_frenzy.go
@@ -18,7 +18,8 @@ func (dk *Deathknight) registerUnholyFrenzyCD() {
 		return
 	}
 	unholyFrenzyTarget := unholyFrenzyTargetAgent.GetCharacter()
-	unholyFrenzyAura := core.UnholyFrenzyAura(unholyFrenzyTarget, actionID.Tag)
+
+	dk.UnholyFrenzyAura = core.UnholyFrenzyAura(unholyFrenzyTarget, actionID.Tag)
 
 	dk.UnholyFrenzy = dk.Character.RegisterSpell(core.SpellConfig{
 		ActionID: actionID,
@@ -34,7 +35,7 @@ func (dk *Deathknight) registerUnholyFrenzyCD() {
 		},
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, _ *core.Spell) {
-			unholyFrenzyAura.Activate(sim)
+			dk.UnholyFrenzyAura.Activate(sim)
 		},
 	})
 

--- a/ui/deathknight/presets.ts
+++ b/ui/deathknight/presets.ts
@@ -269,8 +269,9 @@ export const P1_BLOOD_BIS_PRESET = {
 			]
 		  },
 		  {
-			"id": 40317,
+			"id": 40278,
 			"gems": [
+			  39996,
 			  39996
 			]
 		  },
@@ -279,7 +280,7 @@ export const P1_BLOOD_BIS_PRESET = {
 			"enchant": 3823,
 			"gems": [
 			  39996,
-			  39996
+			  40037
 			]
 		  },
 		  {


### PR DESCRIPTION
- Remove DRWs Death Strike glyph scaling
- Remove Unholy Frenzy GCD
- Change DRW snapshotting to make sure it doesn't miss out on possible casts by delaying too much
- Make potion snapshotting with DRW to try to snapshot with Unholy Frenzy if it will be available for a 2nd time