### PR TITLE
update haste rating to percent coefficient

### DIFF
--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -46,905 +46,905 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6907.47083
-  tps: 3554.34223
+  dps: 6877.6624
+  tps: 3533.56842
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6819.09853
-  tps: 3540.95687
+  dps: 6809.21504
+  tps: 3528.75464
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6626.96174
-  tps: 8229.48985
+  dps: 6595.38345
+  tps: 8236.05906
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6626.96174
-  tps: 8229.48985
+  dps: 6595.38345
+  tps: 8236.05906
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6923.65393
-  tps: 3563.32207
+  dps: 6892.06718
+  tps: 3541.23413
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6699.46012
-  tps: 3445.32285
+  dps: 6726.10199
+  tps: 3456.46405
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 5791.07079
-  tps: 2977.81642
+  dps: 5795.56545
+  tps: 2976.91676
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5716.63772
-  tps: 2951.13812
+  dps: 5702.98542
+  tps: 2934.67081
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5453.22326
-  tps: 2802.36636
+  dps: 5428.76215
+  tps: 2783.65476
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6902.66311
-  tps: 3480.71645
+  dps: 6872.8779
+  tps: 3460.37167
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7041.62255
-  tps: 3628.8648
+  dps: 7008.58218
+  tps: 3605.83896
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6723.28016
-  tps: 3484.01822
+  dps: 6709.38478
+  tps: 3474.82921
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6779.31996
-  tps: 3520.4503
+  dps: 6783.51681
+  tps: 3516.25978
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6866.54103
-  tps: 3537.50127
+  dps: 6834.39439
+  tps: 3515.21714
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 6694.31319
-  tps: 3453.49589
+  dps: 6697.68909
+  tps: 3448.55627
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 5851.18112
-  tps: 3000.14678
+  dps: 5811.69538
+  tps: 2976.33514
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 6939.71054
-  tps: 3569.76748
+  dps: 6907.8069
+  tps: 3547.81152
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7219.99898
-  tps: 3713.52279
+  dps: 7189.2367
+  tps: 3691.05217
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6703.51465
-  tps: 3473.75061
+  dps: 6677.86342
+  tps: 3456.8448
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7079.96161
-  tps: 3679.75833
+  dps: 7085.28794
+  tps: 3679.38151
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7075.88435
-  tps: 3685.02021
+  dps: 7103.01058
+  tps: 3697.11655
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6642.43391
-  tps: 3441.15898
+  dps: 6610.79047
+  tps: 3418.57986
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6925.03801
-  tps: 3564.01517
+  dps: 6896.68868
+  tps: 3543.87293
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6711.46527
-  tps: 3463.52203
+  dps: 6735.84009
+  tps: 3476.44725
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6760.9022
-  tps: 3495.00031
+  dps: 6741.94734
+  tps: 3480.95551
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6902.66311
-  tps: 3551.75148
+  dps: 6872.8779
+  tps: 3530.9915
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6902.66311
-  tps: 3551.75148
+  dps: 6872.8779
+  tps: 3530.9915
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6923.65393
-  tps: 3563.32207
+  dps: 6892.06718
+  tps: 3541.23413
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6918.20488
-  tps: 3560.14468
+  dps: 6886.69702
+  tps: 3538.11431
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6693.73092
-  tps: 3453.80317
+  dps: 6713.74054
+  tps: 3465.26264
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6902.66311
-  tps: 3551.75148
+  dps: 6872.8779
+  tps: 3530.9915
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6766.02745
-  tps: 3512.44797
+  dps: 6756.06681
+  tps: 3501.60269
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6712.04199
-  tps: 3477.77276
+  dps: 6700.57452
+  tps: 3469.63173
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6694.78293
-  tps: 3468.92431
+  dps: 6680.08413
+  tps: 3458.17545
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6902.66311
-  tps: 3551.75148
+  dps: 6872.8779
+  tps: 3530.9915
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6902.66311
-  tps: 3551.75148
+  dps: 6872.8779
+  tps: 3530.9915
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 6940.87844
-  tps: 3570.22568
+  dps: 6909.05671
+  tps: 3548.31347
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6826.05291
-  tps: 3541.91776
+  dps: 6793.28312
+  tps: 3518.70851
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6723.27805
-  tps: 3485.56223
+  dps: 6733.89439
+  tps: 3488.7375
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 6935.70776
-  tps: 3568.48231
+  dps: 6903.53063
+  tps: 3546.43651
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6923.65393
-  tps: 3563.32207
+  dps: 6892.06718
+  tps: 3541.23413
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6918.20488
-  tps: 3560.14468
+  dps: 6886.69702
+  tps: 3538.11431
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6788.6108
-  tps: 3523.90527
+  dps: 6756.59769
+  tps: 3501.10393
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6902.66311
-  tps: 3551.75148
+  dps: 6872.8779
+  tps: 3530.9915
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6930.0866
-  tps: 3566.55311
-  hps: 12.48865
+  dps: 6900.17712
+  tps: 3545.72437
+  hps: 12.79219
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6748.91116
-  tps: 3480.88995
+  dps: 6809.46483
+  tps: 3514.56734
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6780.96944
-  tps: 3505.17255
+  dps: 6751.53476
+  tps: 3486.28804
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6636.97183
-  tps: 3438.21401
+  dps: 6605.35595
+  tps: 3415.65146
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6924.54728
-  tps: 3563.54427
+  dps: 6894.65635
+  tps: 3542.72134
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6929.6965
-  tps: 3566.31905
+  dps: 6899.78069
+  tps: 3545.48131
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6668.50626
-  tps: 3455.2163
+  dps: 6636.73122
+  tps: 3432.55809
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6673.85911
-  tps: 3458.10237
+  dps: 6642.05705
+  tps: 3435.42792
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6902.66311
-  tps: 3551.75148
+  dps: 6872.8779
+  tps: 3530.9915
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6902.66311
-  tps: 3551.75148
+  dps: 6872.8779
+  tps: 3530.9915
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6683.31385
-  tps: 3464.99298
+  dps: 6666.66875
+  tps: 3449.64667
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6690.27713
-  tps: 3469.17095
+  dps: 6673.60644
+  tps: 3453.80928
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7034.83645
-  tps: 3625.0119
+  dps: 7001.96098
+  tps: 3602.18761
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 6942.24099
-  tps: 3570.76024
+  dps: 6910.51483
+  tps: 3548.89909
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6902.66311
-  tps: 3551.75148
+  dps: 6872.8779
+  tps: 3530.9915
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 6935.49983
-  tps: 3568.36845
+  dps: 6903.3073
+  tps: 3546.30804
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6413.38483
-  tps: 3303.50174
+  dps: 6437.06871
+  tps: 3314.10042
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 5788.04314
-  tps: 2962.91455
+  dps: 5819.807
+  tps: 2980.21965
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7297.3234
-  tps: 3802.42966
+  dps: 7263.65468
+  tps: 3776.30814
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6124.17552
-  tps: 3140.11122
+  dps: 6123.35011
+  tps: 3138.56498
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6637.41952
-  tps: 3438.09279
+  dps: 6605.96933
+  tps: 3415.59982
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 9187.30596
-  tps: 4843.56955
+  dps: 9097.128
+  tps: 4781.99564
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 6933.87104
-  tps: 3567.47651
+  dps: 6901.55785
+  tps: 3545.30175
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7242.83298
-  tps: 3731.97298
+  dps: 7208.30567
+  tps: 3707.36721
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7253.35874
-  tps: 3740.70954
+  dps: 7207.25386
+  tps: 3710.4828
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6713.59616
-  tps: 3478.70527
+  dps: 6703.90639
+  tps: 3471.63085
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofHope-45703"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofLife-37657"
  value: {
-  dps: 6713.68339
-  tps: 3482.011
+  dps: 6705.28365
+  tps: 3463.98037
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6839.2718
-  tps: 3540.42463
+  dps: 6851.07703
+  tps: 3542.17883
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 5382.30047
-  tps: 2763.52018
+  dps: 5358.68757
+  tps: 2753.83192
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6929.6965
-  tps: 3566.31905
+  dps: 6899.78069
+  tps: 3545.48131
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6924.54728
-  tps: 3563.54427
+  dps: 6894.65635
+  tps: 3542.72134
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6915.53615
-  tps: 3558.68842
+  dps: 6885.68876
+  tps: 3537.89141
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 6797.7946
-  tps: 3501.60008
+  dps: 6807.4657
+  tps: 3507.15441
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 5974.38891
-  tps: 3063.6147
+  dps: 5961.02233
+  tps: 3055.64719
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6046.98292
-  tps: 3079.93035
+  dps: 6040.38538
+  tps: 3070.12617
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6914.99992
-  tps: 3554.86042
+  dps: 6941.93415
+  tps: 3561.73161
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6919.69621
-  tps: 3590.62631
+  dps: 6898.76596
+  tps: 3578.53017
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6907.66052
-  tps: 3583.8314
+  dps: 6909.75852
+  tps: 3583.9017
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6902.66311
-  tps: 3551.75148
+  dps: 6872.8779
+  tps: 3530.9915
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6902.66311
-  tps: 3551.75148
+  dps: 6872.8779
+  tps: 3530.9915
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6636.48514
-  tps: 3422.41839
+  dps: 6628.7094
+  tps: 3412.20932
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6902.66311
-  tps: 3551.75148
+  dps: 6872.8779
+  tps: 3530.9915
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6902.66311
-  tps: 3551.75148
+  dps: 6872.8779
+  tps: 3530.9915
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5706.84841
-  tps: 2944.17414
+  dps: 5670.55737
+  tps: 2915.88179
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5371.23936
-  tps: 2641.53241
+  dps: 5374.33634
+  tps: 2636.52156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6626.958
-  tps: 3432.81489
+  dps: 6595.39267
+  tps: 3410.28272
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 6943.79819
-  tps: 3571.37116
+  dps: 6912.18124
+  tps: 3549.56836
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 7002.06832
-  tps: 3607.16508
+  dps: 7003.09814
+  tps: 3603.86157
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15286.59386
-  tps: 8051.27715
+  dps: 15331.97352
+  tps: 8086.11118
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6963.10518
-  tps: 3599.83758
+  dps: 6934.95961
+  tps: 3576.5628
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8898.48074
-  tps: 4084.3458
+  dps: 9026.07095
+  tps: 4125.15657
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10211.89767
-  tps: 5394.60173
+  dps: 10229.62283
+  tps: 5396.00033
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3941.40975
-  tps: 2043.78735
+  dps: 3907.52938
+  tps: 2017.30867
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4723.97968
-  tps: 2140.39158
+  dps: 4689.68245
+  tps: 2116.74064
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15437.81026
-  tps: 8111.83829
+  dps: 15470.00988
+  tps: 8137.22857
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7034.83645
-  tps: 3625.0119
+  dps: 7001.96098
+  tps: 3602.18761
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9064.37189
-  tps: 4143.47432
+  dps: 9146.40714
+  tps: 4160.6007
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10311.93577
-  tps: 5434.23819
+  dps: 10320.78625
+  tps: 5426.599
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3970.19456
-  tps: 2052.20863
+  dps: 3949.16563
+  tps: 2036.60019
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4787.52847
-  tps: 2159.69946
+  dps: 4779.93093
+  tps: 2152.75375
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6683.31897
-  tps: 3445.04499
+  dps: 6690.37033
+  tps: 3446.31026
  }
 }

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -46,905 +46,905 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7827.62905
-  tps: 4579.34106
+  dps: 7845.53091
+  tps: 4585.52163
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7813.80965
-  tps: 4583.37241
+  dps: 7838.44396
+  tps: 4595.1143
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7599.24599
-  tps: 8421.33551
+  dps: 7616.13447
+  tps: 8429.42841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7599.24599
-  tps: 8421.33551
+  dps: 7616.13447
+  tps: 8429.42841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7844.81022
-  tps: 4589.64976
+  dps: 7858.60735
+  tps: 4593.36749
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7602.92299
-  tps: 4447.73997
+  dps: 7591.79432
+  tps: 4436.64629
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6590.95426
-  tps: 3853.41664
+  dps: 6599.54444
+  tps: 3856.25622
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6483.80798
-  tps: 3793.3213
+  dps: 6497.04926
+  tps: 3798.48209
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6209.46867
-  tps: 3629.47412
+  dps: 6221.59945
+  tps: 3633.86971
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7821.65281
-  tps: 4484.24021
+  dps: 7839.54363
+  tps: 4490.29068
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8026.5892
-  tps: 4698.71715
+  dps: 8040.75742
+  tps: 4702.65753
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
   hps: 64
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7698.20835
-  tps: 4514.23257
+  dps: 7723.58194
+  tps: 4525.39751
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7752.52191
-  tps: 4546.29528
+  dps: 7778.44784
+  tps: 4558.603
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7831.93534
-  tps: 4584.81958
+  dps: 7846.89332
+  tps: 4589.34952
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7491.01828
-  tps: 4383.19254
+  dps: 7476.62869
+  tps: 4370.1321
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 6579.28953
-  tps: 3841.86096
+  dps: 6613.1422
+  tps: 3859.85198
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7511.4019
-  tps: 4389.60477
+  dps: 7526.3362
+  tps: 4394.0048
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8211.25816
-  tps: 4805.65885
+  dps: 8227.11823
+  tps: 4810.4601
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7687.26715
-  tps: 4507.66785
+  dps: 7703.18263
+  tps: 4513.15792
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8001.93842
-  tps: 4691.02143
+  dps: 8024.91134
+  tps: 4700.77971
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8126.2756
-  tps: 4767.29194
+  dps: 8116.59024
+  tps: 4755.95097
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7618.40811
-  tps: 4466.35242
+  dps: 7635.41001
+  tps: 4472.49435
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7846.64702
-  tps: 4590.75184
+  dps: 7863.90397
+  tps: 4596.54547
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7775.70118
-  tps: 4557.28322
+  dps: 7752.44253
+  tps: 4538.38102
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7735.42514
-  tps: 4533.79232
+  dps: 7786.01619
+  tps: 4557.74735
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7821.65281
-  tps: 4575.75531
+  dps: 7839.54363
+  tps: 4581.92926
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7821.65281
-  tps: 4575.75531
+  dps: 7839.54363
+  tps: 4581.92926
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7844.81022
-  tps: 4589.64976
+  dps: 7858.60735
+  tps: 4593.36749
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7840.14822
-  tps: 4586.85256
+  dps: 7855.33715
+  tps: 4591.40538
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7670.78182
-  tps: 4492.6281
+  dps: 7718.48062
+  tps: 4515.65352
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7821.65281
-  tps: 4575.75531
+  dps: 7839.54363
+  tps: 4581.92926
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7777.67601
-  tps: 4562.207
+  dps: 7744.26285
+  tps: 4537.24204
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7684.98145
-  tps: 4506.29643
+  dps: 7707.29345
+  tps: 4515.62442
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7670.08284
-  tps: 4497.35726
+  dps: 7694.67766
+  tps: 4508.05494
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7821.65281
-  tps: 4575.75531
+  dps: 7839.54363
+  tps: 4581.92926
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7821.65281
-  tps: 4575.75531
+  dps: 7839.54363
+  tps: 4581.92926
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7512.05397
-  tps: 4389.99601
+  dps: 7526.9883
+  tps: 4394.39606
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7837.0691
-  tps: 4597.54902
+  dps: 7854.40285
+  tps: 4603.89005
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7734.76974
-  tps: 4536.57069
+  dps: 7727.74166
+  tps: 4529.03649
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7510.09025
-  tps: 4388.81778
+  dps: 7525.02095
+  tps: 4393.21565
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7844.81022
-  tps: 4589.64976
+  dps: 7858.60735
+  tps: 4593.36749
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7840.14822
-  tps: 4586.85256
+  dps: 7855.33715
+  tps: 4591.40538
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7791.26951
-  tps: 4570.06926
+  dps: 7809.34967
+  tps: 4576.85815
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7821.65281
-  tps: 4575.75531
+  dps: 7839.54363
+  tps: 4581.92926
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7852.48336
-  tps: 4594.25364
+  dps: 7870.67677
+  tps: 4600.60915
   hps: 12.97738
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7784.94986
-  tps: 4560.03183
+  dps: 7785.35594
+  tps: 4554.66085
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7720.6095
-  tps: 4527.67326
+  dps: 7746.17755
+  tps: 4538.95488
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7611.58026
-  tps: 4462.25571
+  dps: 7628.57097
+  tps: 4468.39093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7846.68139
-  tps: 4590.77246
+  dps: 7864.61579
+  tps: 4596.97256
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7852.57047
-  tps: 4594.30591
+  dps: 7870.51512
+  tps: 4600.51215
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7650.99968
-  tps: 4485.90736
+  dps: 7668.05505
+  tps: 4492.08137
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7657.69096
-  tps: 4489.92213
+  dps: 7674.75731
+  tps: 4496.10273
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7821.65281
-  tps: 4575.75531
+  dps: 7839.54363
+  tps: 4581.92926
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7821.65281
-  tps: 4575.75531
+  dps: 7839.54363
+  tps: 4581.92926
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7608.62471
-  tps: 4460.93873
+  dps: 7665.37037
+  tps: 4491.13092
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7610.2553
-  tps: 4461.91709
+  dps: 7667.34888
+  tps: 4492.31803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8021.73479
-  tps: 4695.8045
+  dps: 8037.27291
+  tps: 4700.56683
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7512.81472
-  tps: 4390.45246
+  dps: 7527.74908
+  tps: 4394.85253
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7821.65281
-  tps: 4575.75531
+  dps: 7839.54363
+  tps: 4581.92926
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7509.86964
-  tps: 4388.68541
+  dps: 7524.80073
+  tps: 4393.08352
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7287.13309
-  tps: 4265.86671
+  dps: 7169.6258
+  tps: 4191.43269
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 6483.94684
-  tps: 3785.5199
+  dps: 6499.21631
+  tps: 3793.15647
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8227.90178
-  tps: 4824.47784
+  dps: 8215.88761
+  tps: 4814.88831
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6909.51852
-  tps: 4035.47223
+  dps: 6872.09271
+  tps: 4010.29985
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7618.04086
-  tps: 4466.13207
+  dps: 7635.06965
+  tps: 4472.29014
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8021.73479
-  tps: 4695.8045
+  dps: 8037.27291
+  tps: 4700.56683
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7520.14615
-  tps: 4394.85132
+  dps: 7538.82609
+  tps: 4401.49874
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7916.82468
-  tps: 4627.177
+  dps: 7932.97229
+  tps: 4632.12449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7948.95903
-  tps: 4648.02915
+  dps: 7964.99725
+  tps: 4652.99494
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7686.80129
-  tps: 4507.38833
+  dps: 7709.61039
+  tps: 4517.01458
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofHope-45703"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 7638.0995
-  tps: 4477.45191
+  dps: 7684.30335
+  tps: 4499.15371
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7753.72696
-  tps: 4547.25227
+  dps: 7761.71717
+  tps: 4547.32223
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StormshroudArmor"
  value: {
-  dps: 6167.7786
-  tps: 3605.7778
+  dps: 6148.11944
+  tps: 3591.89885
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7852.57047
-  tps: 4594.30591
+  dps: 7870.51512
+  tps: 4600.51215
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7846.68139
-  tps: 4590.77246
+  dps: 7864.61579
+  tps: 4596.97256
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7836.3755
-  tps: 4584.58893
+  dps: 7854.29196
+  tps: 4590.77826
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7520.39737
-  tps: 4399.77065
+  dps: 7556.51707
+  tps: 4418.56881
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6612.23812
-  tps: 3860.00089
+  dps: 6615.65414
+  tps: 3860.58271
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7080.14631
-  tps: 4133.082
+  dps: 7052.07912
+  tps: 4111.08873
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7849.3072
-  tps: 4591.4355
+  dps: 7863.85974
+  tps: 4595.80784
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7816.92355
-  tps: 4585.78757
+  dps: 7755.81809
+  tps: 4544.78709
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7800.04476
-  tps: 4574.79614
+  dps: 7795.36731
+  tps: 4569.22783
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7821.65281
-  tps: 4575.75531
+  dps: 7839.54363
+  tps: 4581.92926
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7821.65281
-  tps: 4575.75531
+  dps: 7839.54363
+  tps: 4581.92926
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7687.01815
-  tps: 4505.2102
+  dps: 7623.9503
+  tps: 4461.71145
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7821.65281
-  tps: 4575.75531
+  dps: 7839.54363
+  tps: 4581.92926
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7821.65281
-  tps: 4575.75531
+  dps: 7839.54363
+  tps: 4581.92926
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6490.38376
-  tps: 3797.66696
+  dps: 6461.48014
+  tps: 3776.81253
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7495.31914
-  tps: 4378.59044
+  dps: 7487.72092
+  tps: 4369.7272
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7599.06255
-  tps: 4454.74509
+  dps: 7616.03272
+  tps: 4460.86798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7513.68414
-  tps: 4390.97411
+  dps: 7528.61855
+  tps: 4395.37421
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 8006.05278
-  tps: 4687.19136
+  dps: 8014.31497
+  tps: 4687.69337
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15934.84984
-  tps: 9448.79618
+  dps: 15533.11899
+  tps: 9204.60578
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8020.72253
-  tps: 4700.36924
+  dps: 7977.6465
+  tps: 4670.4214
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8797.25944
-  tps: 4980.32961
+  dps: 8809.85417
+  tps: 4973.87182
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9843.53765
-  tps: 5834.80959
+  dps: 10094.50844
+  tps: 5982.34843
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4786.2103
-  tps: 2800.08553
+  dps: 4771.87161
+  tps: 2789.50587
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4998.87588
-  tps: 2832.25789
+  dps: 4963.86158
+  tps: 2805.63028
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15923.16548
-  tps: 9437.43484
+  dps: 15894.8181
+  tps: 9415.79734
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8021.73479
-  tps: 4695.8045
+  dps: 8037.27291
+  tps: 4700.56683
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8905.85275
-  tps: 5031.89006
+  dps: 8876.90063
+  tps: 4999.47319
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9938.93236
-  tps: 5888.14091
+  dps: 10117.96339
+  tps: 5992.52738
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4793.53352
-  tps: 2800.32424
+  dps: 4770.2989
+  tps: 2784.58285
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5026.8489
-  tps: 2840.74408
+  dps: 4990.71397
+  tps: 2813.5794
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7754.25764
-  tps: 4543.40573
+  dps: 7799.38303
+  tps: 4566.22711
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -46,1016 +46,1016 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7391.85909
-  tps: 4772.04708
-  hps: 375.09127
+  dps: 7448.67614
+  tps: 4763.54016
+  hps: 378.13162
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7391.85909
-  tps: 4772.04708
-  hps: 388.864
+  dps: 7448.67614
+  tps: 4763.54016
+  hps: 392.09559
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7914.04742
-  tps: 5051.42345
-  hps: 275.37679
+  dps: 7974.3748
+  tps: 5042.68827
+  hps: 276.99095
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7586.05878
-  tps: 4925.14298
-  hps: 268.77177
+  dps: 7665.55562
+  tps: 4937.17469
+  hps: 270.35651
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7392.04745
-  tps: 18825.69272
-  hps: 270.35651
+  dps: 7448.87825
+  tps: 18816.8002
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7392.04745
-  tps: 18825.69272
-  hps: 270.35651
+  dps: 7448.87825
+  tps: 18816.8002
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7936.59507
-  tps: 5073.22081
-  hps: 270.35651
+  dps: 7997.62305
+  tps: 5064.49882
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7686.81093
-  tps: 4878.28324
+  dps: 7774.15814
+  tps: 4891.22424
   hps: 261.90935
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6545.29813
-  tps: 4204.94049
-  hps: 237.29211
+  dps: 6582.55704
+  tps: 4193.17397
+  hps: 236.15674
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6348.4264
-  tps: 4103.09332
-  hps: 227.34058
+  dps: 6405.42462
+  tps: 4110.15743
+  hps: 227.0709
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6132.95433
-  tps: 3919.93809
-  hps: 224.52313
+  dps: 6177.60675
+  tps: 3934.35432
+  hps: 225.325
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7914.04742
-  tps: 4950.39498
-  hps: 270.35651
+  dps: 7974.3748
+  tps: 4941.83451
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8005.48594
-  tps: 5138.94577
-  hps: 270.35651
+  dps: 8065.99178
+  tps: 5129.83417
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7391.97091
-  tps: 4772.20497
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7391.97091
-  tps: 4772.20497
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7391.97757
-  tps: 4772.2151
-  hps: 370.126
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 371.92041
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7496.35881
-  tps: 4871.23097
-  hps: 270.35651
+  dps: 7546.39366
+  tps: 4857.85163
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7518.25939
-  tps: 4882.2427
-  hps: 268.77177
+  dps: 7597.90797
+  tps: 4897.33238
+  hps: 270.03956
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7749.48905
-  tps: 4964.58457
-  hps: 270.35651
+  dps: 7809.33781
+  tps: 4955.95555
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7595.325
-  tps: 4903.0251
-  hps: 280.98599
+  dps: 7634.77465
+  tps: 4885.52896
+  hps: 280.31936
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 6683.42407
-  tps: 4268.46692
-  hps: 294.96503
+  dps: 6729.65831
+  tps: 4260.8846
+  hps: 297.44373
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8238.3096
-  tps: 5289.19066
-  hps: 270.35651
+  dps: 8298.8311
+  tps: 5279.98884
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7475.98484
-  tps: 4853.11048
-  hps: 270.35651
+  dps: 7531.36855
+  tps: 4841.21723
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7707.29598
-  tps: 5112.92943
-  hps: 269.72261
+  dps: 7744.54506
+  tps: 5075.52309
+  hps: 270.03956
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7745.40742
-  tps: 5152.55234
-  hps: 270.9904
+  dps: 7797.46609
+  tps: 5137.10112
+  hps: 271.30735
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7391.97757
-  tps: 4772.2151
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7939.77363
-  tps: 5076.00405
-  hps: 270.35651
+  dps: 8001.27895
+  tps: 5067.24019
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7599.68294
-  tps: 4872.76475
-  hps: 267.82092
+  dps: 7693.15736
+  tps: 4883.12889
+  hps: 269.08872
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7587.68343
-  tps: 4875.85223
-  hps: 267.82092
+  dps: 7687.05277
+  tps: 4886.29971
+  hps: 268.45482
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7914.04742
-  tps: 5051.42345
-  hps: 275.37679
+  dps: 7974.3748
+  tps: 5042.68827
+  hps: 276.99095
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7914.04742
-  tps: 5051.42345
-  hps: 270.35651
+  dps: 7974.3748
+  tps: 5042.68827
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7936.59507
-  tps: 5073.22081
-  hps: 270.35651
+  dps: 7997.62305
+  tps: 5064.49882
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7929.87336
-  tps: 5067.99996
-  hps: 270.35651
+  dps: 7993.75711
+  tps: 5061.2395
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7544.22147
-  tps: 4817.62738
-  hps: 269.08872
+  dps: 7606.27096
+  tps: 4788.64783
+  hps: 268.45482
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7391.97091
-  tps: 4772.20497
-  hps: 287.7706
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 289.45742
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7914.04742
-  tps: 5051.42345
-  hps: 270.35651
+  dps: 7974.3748
+  tps: 5042.68827
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7562.7642
-  tps: 4928.44529
-  hps: 269.40566
+  dps: 7607.74452
+  tps: 4909.15717
+  hps: 270.67346
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7482.83443
-  tps: 4859.55513
-  hps: 270.35651
+  dps: 7536.52222
+  tps: 4849.68473
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7391.97091
-  tps: 4772.20497
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7391.97091
-  tps: 4772.20497
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7462.9673
-  tps: 4839.98551
-  hps: 270.35651
+  dps: 7517.89563
+  tps: 4832.14348
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7914.04742
-  tps: 5051.42345
-  hps: 270.35651
+  dps: 7974.3748
+  tps: 5042.68827
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7914.04742
-  tps: 5051.42345
-  hps: 270.35651
+  dps: 7974.3748
+  tps: 5042.68827
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 8007.61699
-  tps: 5138.00003
-  hps: 270.35651
+  dps: 8068.69657
+  tps: 5128.94817
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7654.65734
-  tps: 4982.4268
-  hps: 270.35651
+  dps: 7711.20349
+  tps: 4973.54798
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7391.97757
-  tps: 4772.2151
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7391.97757
-  tps: 4772.2151
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7391.97757
-  tps: 4772.2151
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7496.35448
-  tps: 4864.90786
-  hps: 266.23619
+  dps: 7590.54124
+  tps: 4892.42288
+  hps: 270.9904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7955.78156
-  tps: 5096.90732
-  hps: 270.35651
+  dps: 8017.61793
+  tps: 5087.83561
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7391.97091
-  tps: 4772.20497
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7936.59507
-  tps: 5073.22081
-  hps: 270.35651
+  dps: 7997.62305
+  tps: 5064.49882
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7929.87336
-  tps: 5067.99996
-  hps: 270.35651
+  dps: 7993.75711
+  tps: 5061.2395
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7555.47303
-  tps: 4906.34078
-  hps: 270.35651
+  dps: 7612.45053
+  tps: 4897.8987
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7914.04742
-  tps: 5051.42345
-  hps: 270.35651
+  dps: 7974.3748
+  tps: 5042.68827
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7948.58683
-  tps: 5079.06393
-  hps: 283.14135
+  dps: 8008.88721
+  tps: 5070.29189
+  hps: 284.80992
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7391.97757
-  tps: 4772.2151
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7391.97091
-  tps: 4772.20497
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7482.96994
-  tps: 4867.56962
-  hps: 270.35651
+  dps: 7539.06269
+  tps: 4862.16039
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7391.97091
-  tps: 4772.20497
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7941.94684
-  tps: 5073.74026
-  hps: 270.35651
+  dps: 8002.25932
+  tps: 5064.98513
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7948.51141
-  tps: 5078.99127
-  hps: 270.35651
+  dps: 8008.82039
+  tps: 5070.23145
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7391.97091
-  tps: 4772.20497
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7391.97091
-  tps: 4772.20497
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7914.04742
-  tps: 5051.42345
-  hps: 274.43549
+  dps: 7974.3748
+  tps: 5042.68827
+  hps: 276.04413
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7914.04742
-  tps: 5051.42345
-  hps: 275.37679
+  dps: 7974.3748
+  tps: 5042.68827
+  hps: 276.99095
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7391.97091
-  tps: 4772.20497
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7456.90034
-  tps: 4835.44097
-  hps: 270.35651
+  dps: 7554.36033
+  tps: 4852.59544
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7466.85367
-  tps: 4843.75221
-  hps: 270.35651
+  dps: 7564.11073
+  tps: 4860.70775
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7990.43673
-  tps: 5124.5448
-  hps: 270.35651
+  dps: 8051.61482
+  tps: 5115.62771
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 8027.66062
-  tps: 5153.69781
-  hps: 270.35651
+  dps: 8088.62527
+  tps: 5144.48871
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7914.04742
-  tps: 5051.42345
-  hps: 270.35651
+  dps: 7974.3748
+  tps: 5042.68827
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7391.97757
-  tps: 4772.2151
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7949.98011
-  tps: 5092.41992
-  hps: 270.35651
+  dps: 8011.79772
+  tps: 5083.442
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7213.92138
-  tps: 4645.79434
-  hps: 258.97492
+  dps: 7286.02355
+  tps: 4644.33987
+  hps: 258.0478
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6642.75181
-  tps: 4234.44988
-  hps: 274.34825
+  dps: 6687.5157
+  tps: 4227.18759
+  hps: 273.37423
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8001.54948
-  tps: 5310.73649
-  hps: 296.4724
+  dps: 8030.81878
+  tps: 5290.60354
+  hps: 296.82576
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7231.50826
-  tps: 4752.59933
-  hps: 315.14377
+  dps: 7274.61801
+  tps: 4740.13626
+  hps: 315.89501
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7391.97757
-  tps: 4772.2151
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7990.43673
-  tps: 5124.5448
-  hps: 270.35651
+  dps: 8051.61482
+  tps: 5115.62771
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7391.97091
-  tps: 4772.20497
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7919.65134
-  tps: 5069.99647
-  hps: 270.35651
+  dps: 7978.64419
+  tps: 5061.04464
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7904.53545
-  tps: 5057.26862
-  hps: 270.35651
+  dps: 7966.20608
+  tps: 5049.0254
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7904.53545
-  tps: 5057.26862
-  hps: 270.35651
+  dps: 7966.20608
+  tps: 5049.0254
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7391.97757
-  tps: 4772.2151
-  hps: 306.126
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 307.92041
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7391.97091
-  tps: 4772.20497
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7391.97091
-  tps: 4772.20497
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7485.99606
-  tps: 4862.80752
-  hps: 270.35651
+  dps: 7538.63065
+  tps: 4850.92406
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofHope-45703"
  value: {
-  dps: 7391.97091
-  tps: 4772.20497
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 7489.40157
-  tps: 4831.41244
-  hps: 270.9904
+  dps: 7560.51602
+  tps: 4814.51448
+  hps: 270.35651
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7620.81915
-  tps: 4904.94498
-  hps: 269.08872
+  dps: 7662.05573
+  tps: 4880.65974
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StormshroudArmor"
  value: {
-  dps: 6071.25658
-  tps: 3915.03999
-  hps: 207.55745
+  dps: 6093.81645
+  tps: 3896.68203
+  hps: 206.56554
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7948.51141
-  tps: 5078.99127
-  hps: 270.35651
+  dps: 8008.82039
+  tps: 5070.23145
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7941.94684
-  tps: 5073.74026
-  hps: 270.35651
+  dps: 8002.25932
+  tps: 5064.98513
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7930.45884
-  tps: 5064.55098
-  hps: 270.35651
+  dps: 7990.77746
+  tps: 5055.80407
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7391.97757
-  tps: 4772.2151
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7391.97091
-  tps: 4772.20497
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7763.50813
-  tps: 5057.15398
-  hps: 278.79435
+  dps: 7841.93961
+  tps: 5078.6331
+  hps: 280.78101
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6744.69741
-  tps: 4292.50214
-  hps: 293.46397
+  dps: 6776.8903
+  tps: 4282.02998
+  hps: 291.03291
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7391.97091
-  tps: 4772.20497
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7340.17487
-  tps: 4667.45105
-  hps: 257.12542
+  dps: 7410.84738
+  tps: 4650.78201
+  hps: 255.59126
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7962.56502
-  tps: 5074.51307
-  hps: 269.72261
+  dps: 8061.26605
+  tps: 5069.75923
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7600.53259
-  tps: 4938.09644
-  hps: 267.82092
+  dps: 7668.27562
+  tps: 4943.63604
+  hps: 268.45482
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7594.25121
-  tps: 4937.21096
-  hps: 269.08872
+  dps: 7659.99672
+  tps: 4924.70454
+  hps: 266.23619
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7914.04742
-  tps: 5051.42345
-  hps: 270.35651
+  dps: 7974.3748
+  tps: 5042.68827
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7914.04742
-  tps: 5051.42345
-  hps: 270.35651
+  dps: 7974.3748
+  tps: 5042.68827
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7456.65322
-  tps: 4780.95267
-  hps: 265.60229
+  dps: 7545.86177
+  tps: 4786.82589
+  hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7914.04742
-  tps: 5051.42345
-  hps: 270.35651
+  dps: 7974.3748
+  tps: 5042.68827
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7914.04742
-  tps: 5051.42345
-  hps: 270.35651
+  dps: 7974.3748
+  tps: 5042.68827
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6386.15357
-  tps: 4133.23518
-  hps: 231.17249
+  dps: 6404.85956
+  tps: 4113.87262
+  hps: 232.00305
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7675.66714
-  tps: 4900.85151
-  hps: 269.71728
+  dps: 7761.75594
+  tps: 4902.7599
+  hps: 273.59085
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7391.97757
-  tps: 4772.2151
-  hps: 270.35651
+  dps: 7448.72195
+  tps: 4763.58855
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 8050.56763
-  tps: 5171.63812
-  hps: 270.35651
+  dps: 8111.40094
+  tps: 5162.24932
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 7980.13823
-  tps: 5131.42618
-  hps: 269.08496
+  dps: 8058.92066
+  tps: 5129.81837
+  hps: 269.03323
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 34835.03336
-  tps: 37360.87351
-  hps: 268.93257
+  dps: 34977.65981
+  tps: 37395.08835
+  hps: 268.6158
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7812.92459
-  tps: 5088.31229
-  hps: 266.08169
+  dps: 7888.73542
+  tps: 5097.53775
+  hps: 271.46668
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11178.65619
-  tps: 5572.70984
-  hps: 237.57294
+  dps: 11429.99028
+  tps: 5610.50593
+  hps: 240.74058
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 20876.89121
-  tps: 23064.17726
-  hps: 159.47414
+  dps: 20956.42732
+  tps: 23099.93584
+  hps: 160.81266
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3850.91307
-  tps: 2767.13033
-  hps: 159.47414
+  dps: 3874.44448
+  tps: 2771.09103
+  hps: 159.85658
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4940.5913
-  tps: 2860.73572
-  hps: 141.49984
+  dps: 4943.80026
+  tps: 2812.17326
+  hps: 136.71944
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 35185.68446
-  tps: 37596.28611
-  hps: 270.35651
+  dps: 35372.02967
+  tps: 37686.02234
+  hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7990.43673
-  tps: 5124.5448
-  hps: 270.35651
+  dps: 8051.61482
+  tps: 5115.62771
+  hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11564.29968
-  tps: 5635.13392
-  hps: 237.71088
+  dps: 11823.39058
+  tps: 5677.54689
+  hps: 240.88036
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 21141.61904
-  tps: 23250.38656
-  hps: 158.64407
+  dps: 21170.7466
+  tps: 23288.55815
+  hps: 160.94049
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3936.07284
-  tps: 2785.93865
-  hps: 160.36638
+  dps: 3961.30661
+  tps: 2789.35248
+  hps: 161.32322
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5112.52386
-  tps: 2897.9847
-  hps: 141.61232
+  dps: 5123.58196
+  tps: 2847.61797
+  hps: 136.82812
  }
 }
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7612.32881
-  tps: 4941.63481
-  hps: 269.40566
+  dps: 7706.21225
+  tps: 4956.09593
+  hps: 268.45482
  }
 }

--- a/sim/deathknight/ghoul_pet.go
+++ b/sim/deathknight/ghoul_pet.go
@@ -47,6 +47,7 @@ func (dk *Deathknight) NewArmyGhoulPet(index int) *GhoulPet {
 	}
 
 	ghoulPet.PseudoStats.DamageTakenMultiplier *= 0.1
+	ghoulPet.PseudoStats.MeleeHasteRatingPerHastePercent = dk.PseudoStats.MeleeHasteRatingPerHastePercent
 
 	dk.SetupGhoul(ghoulPet)
 
@@ -104,6 +105,7 @@ func (dk *Deathknight) NewGhoulPet(permanent bool) *GhoulPet {
 
 	// NightOfTheDead
 	ghoulPet.PseudoStats.DamageTakenMultiplier *= (1.0 - float64(dk.Talents.NightOfTheDead)*0.45)
+	ghoulPet.PseudoStats.MeleeHasteRatingPerHastePercent = dk.PseudoStats.MeleeHasteRatingPerHastePercent
 
 	dk.SetupGhoul(ghoulPet)
 


### PR DESCRIPTION
Naked human 0 haste (blood presence): Pet has 2.0 attack speed on pet sheet
Geared human 350 haste (blood presence): Pet has 1.76 attack speed

Matches:
```
2/((1+350/(32.79/1.3)/100)) = 1.75629351901
```

Geared human 350 haste (blood presence) + Mark of norgannon (+491 haste): Pet has 1.50 attack speed

Matches:
```
2/((1+(350+491)/(32.79/1.3)/100)) = 1.49989707934
```

Then to test for AotD ghouls:

Looking at my logs from https://classic.warcraftlogs.com/reports/v49X1ZjtY8yQBW23/#boss=0&difficulty=0&type=damage&by=ability&source=3.2&view=events

my army ghouls consistently seem to have ~1.5s swing speeds

Which matches (0.15 from unholy presence):
```
2/((1+350/(32.79/1.3)/100)*(1+0.15)) = 1.52721175566
```

otherwise, if it was using the other coefficient:
```
2/((1+350/(32.79)/100)*(1+0.15)) = 1.57139947524
```

I made a quick script to go through a bunch of the events to see average swing time for these logs and I got `1.531` which suggests it was using `32.79/1.3` instead of `32.79` as the coefficient. 

