### PR TITLE
Remove some uses of ModifyCast and fix warlock bugs

### DIFF
--- a/sim/paladin/exorcism.go
+++ b/sim/paladin/exorcism.go
@@ -28,13 +28,11 @@ func (paladin *Paladin) registerExorcismSpell() {
 				Duration: time.Second * 15,
 			},
 			ModifyCast: func(sim *core.Simulation, spell *core.Spell, cast *core.Cast) {
-				if paladin.ArtOfWarInstantCast.IsActive() {
-					paladin.ArtOfWarInstantCast.Deactivate(sim)
-					cast.CastTime = 0
-					return
-				}
 				if paladin.CurrentMana() >= cast.Cost {
-					paladin.AutoAttacks.StopMeleeUntil(sim, sim.CurrentTime+cast.CastTime, false)
+					castTime := time.Duration(float64(cast.CastTime) * spell.CastTimeMultiplier)
+					if castTime > 0 {
+						paladin.AutoAttacks.StopMeleeUntil(sim, sim.CurrentTime+castTime, false)
+					}
 				}
 			},
 		},
@@ -52,14 +50,14 @@ func (paladin *Paladin) registerExorcismSpell() {
 				.15*spell.SpellPower() +
 				.15*spell.MeleeAttackPower()
 
-			isDemonOrUndead := target.MobType == proto.MobType_MobTypeDemon || target.MobType == proto.MobType_MobTypeUndead
-			if isDemonOrUndead {
-				spell.BonusCritRating += 100 * core.CritRatingPerCritChance
-			}
+			bonusCrit := core.TernaryFloat64(
+				target.MobType == proto.MobType_MobTypeDemon || target.MobType == proto.MobType_MobTypeUndead,
+				100 * core.CritRatingPerCritChance,
+				0)
+
+			spell.BonusCritRating += bonusCrit
 			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
-			if isDemonOrUndead {
-				spell.BonusCritRating -= 100 * core.CritRatingPerCritChance
-			}
+			spell.BonusCritRating -= bonusCrit
 		},
 	})
 }

--- a/sim/paladin/talents.go
+++ b/sim/paladin/talents.go
@@ -416,10 +416,22 @@ func (paladin *Paladin) applyArtOfWar() {
 		return
 	}
 
+	castTimeReduction := 0.5 * float64(paladin.Talents.TheArtOfWar)
 	paladin.ArtOfWarInstantCast = paladin.RegisterAura(core.Aura{
 		Label:    "Art Of War",
 		ActionID: core.ActionID{SpellID: 53488},
 		Duration: time.Second * 15,
+		OnGain: func(aura *core.Aura, sim *core.Simulation) {
+			paladin.Exorcism.CastTimeMultiplier -= castTimeReduction
+		},
+		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
+			paladin.Exorcism.CastTimeMultiplier += castTimeReduction
+		},
+		OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
+			if spell == paladin.Exorcism {
+				aura.Deactivate(sim)
+			}
+		},
 	})
 
 	paladin.RegisterAura(core.Aura{

--- a/sim/warlock/TestAffliction.results
+++ b/sim/warlock/TestAffliction.results
@@ -46,315 +46,315 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 7368.59451
-  tps: 6640.7569
+  dps: 7326.57854
+  tps: 6593.52858
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7193.03323
-  tps: 6461.14319
+  dps: 7188.50775
+  tps: 6450.53391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7205.91374
-  tps: 6474.0237
+  dps: 7199.50367
+  tps: 6461.52982
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7248.05897
-  tps: 6513.86209
+  dps: 7238.11889
+  tps: 6499.17495
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7311.15785
-  tps: 6579.26781
+  dps: 7305.10243
+  tps: 6567.12859
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 7660.82091
-  tps: 6911.02713
+  dps: 7636.96965
+  tps: 6887.67518
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DeathbringerGarb"
  value: {
-  dps: 7009.10157
-  tps: 6286.76891
+  dps: 6982.37131
+  tps: 6260.95596
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7208.40026
-  tps: 6476.51022
+  dps: 7201.91862
+  tps: 6463.94477
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7193.03323
-  tps: 6461.14319
+  dps: 7188.50775
+  tps: 6450.53391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7248.05897
-  tps: 6513.86209
+  dps: 7238.11889
+  tps: 6499.17495
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7205.91374
-  tps: 6474.0237
+  dps: 7199.50367
+  tps: 6461.52982
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7202.01837
-  tps: 6470.12833
+  dps: 7197.0133
+  tps: 6459.03946
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7193.03323
-  tps: 6461.14319
+  dps: 7188.50775
+  tps: 6450.53391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7248.05897
-  tps: 6513.86209
+  dps: 7238.11889
+  tps: 6499.17495
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7237.72501
-  tps: 6503.95496
+  dps: 7230.69145
+  tps: 6492.41447
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 7056.49434
-  tps: 6357.26257
+  dps: 6977.68505
+  tps: 6272.7475
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 6975.17435
-  tps: 6192.38335
+  dps: 6921.89804
+  tps: 6134.12047
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7205.91374
-  tps: 6474.0237
+  dps: 7199.50367
+  tps: 6461.52982
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7202.01837
-  tps: 6470.12833
+  dps: 7197.0133
+  tps: 6459.03946
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7212.80508
-  tps: 6479.86174
+  dps: 7195.22303
+  tps: 6456.47338
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7193.03323
-  tps: 6461.14319
+  dps: 7188.50775
+  tps: 6450.53391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MaleficRaiment"
  value: {
-  dps: 5389.70755
-  tps: 4757.46061
+  dps: 5392.69331
+  tps: 4760.9016
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7193.03323
-  tps: 6461.14319
+  dps: 7188.50775
+  tps: 6450.53391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7193.03323
-  tps: 6461.14319
+  dps: 7188.50775
+  tps: 6450.53391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PlagueheartGarb"
  value: {
-  dps: 6651.89777
-  tps: 5963.94005
+  dps: 6616.01959
+  tps: 5920.89029
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7193.03323
-  tps: 6461.14319
+  dps: 7188.50775
+  tps: 6450.53391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7193.03323
-  tps: 6461.14319
+  dps: 7188.50775
+  tps: 6450.53391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7297.11809
-  tps: 6565.22805
+  dps: 7293.11688
+  tps: 6555.14304
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7210.50969
-  tps: 6477.51299
+  dps: 7185.84765
+  tps: 6446.82511
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7193.03323
-  tps: 6461.14319
+  dps: 7188.50775
+  tps: 6450.53391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7193.03323
-  tps: 6461.14319
+  dps: 7188.50775
+  tps: 6450.53391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7193.03323
-  tps: 6461.14319
+  dps: 7188.50775
+  tps: 6450.53391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7193.03323
-  tps: 6461.14319
+  dps: 7188.50775
+  tps: 6450.53391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7248.05897
-  tps: 6513.86209
+  dps: 7238.11889
+  tps: 6499.17495
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7237.72501
-  tps: 6503.95496
+  dps: 7230.69145
+  tps: 6492.41447
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7237.72501
-  tps: 6503.95496
+  dps: 7230.69145
+  tps: 6492.41447
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7248.05897
-  tps: 6513.86209
+  dps: 7238.11889
+  tps: 6499.17495
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 7404.49498
-  tps: 6668.41422
+  dps: 7378.05416
+  tps: 6640.5536
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7366.18544
-  tps: 8509.71556
+  dps: 7302.12956
+  tps: 8407.62056
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7366.18544
-  tps: 6634.04174
+  dps: 7302.12956
+  tps: 6566.51869
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7779.14108
-  tps: 6989.34516
+  dps: 7759.80441
+  tps: 6978.8374
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4290.35965
-  tps: 6177.21645
+  dps: 4266.46917
+  tps: 6140.60547
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4290.35965
-  tps: 4041.57863
+  dps: 4266.46917
+  tps: 4015.28413
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4095.83138
-  tps: 3752.94489
+  dps: 4076.72752
+  tps: 3728.92926
  }
 }
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7274.81262
-  tps: 6579.26781
+  dps: 7268.72706
+  tps: 6567.12859
  }
 }

--- a/sim/warlock/TestDemonology.results
+++ b/sim/warlock/TestDemonology.results
@@ -46,315 +46,315 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 7409.83362
-  tps: 6166.87432
+  dps: 7314.75488
+  tps: 6071.77642
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7293.69789
-  tps: 6057.06087
+  dps: 7223.70546
+  tps: 5984.65403
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7308.90778
-  tps: 6072.8978
+  dps: 7231.39435
+  tps: 5992.88828
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7328.50857
-  tps: 6087.46295
+  dps: 7254.74041
+  tps: 6012.03352
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7430.31387
-  tps: 6194.30389
+  dps: 7350.82033
+  tps: 6112.31426
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 7646.61679
-  tps: 6391.78858
+  dps: 7538.17602
+  tps: 6279.6952
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DeathbringerGarb"
  value: {
-  dps: 7080.38678
-  tps: 5874.06419
+  dps: 7007.00126
+  tps: 5798.83394
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7308.90778
-  tps: 6072.8978
+  dps: 7231.39435
+  tps: 5992.88828
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7293.69789
-  tps: 6057.06087
+  dps: 7223.70546
+  tps: 5984.65403
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7328.50857
-  tps: 6087.46295
+  dps: 7254.74041
+  tps: 6012.03352
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7308.90778
-  tps: 6072.8978
+  dps: 7231.39435
+  tps: 5992.88828
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7304.51572
-  tps: 6068.50574
+  dps: 7229.00135
+  tps: 5990.49528
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7292.50507
-  tps: 6056.49508
+  dps: 7219.09781
+  tps: 5980.59174
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7328.50857
-  tps: 6087.46295
+  dps: 7254.74041
+  tps: 6012.03352
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7320.718
-  tps: 6080.90528
+  dps: 7246.93427
+  tps: 6005.08654
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 7015.66068
-  tps: 5810.9278
+  dps: 6936.92951
+  tps: 5731.45837
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 7096.64227
-  tps: 5775.83391
+  dps: 7022.94666
+  tps: 5703.00401
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7308.90778
-  tps: 6072.8978
+  dps: 7231.39435
+  tps: 5992.88828
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7304.51572
-  tps: 6068.50574
+  dps: 7229.00135
+  tps: 5990.49528
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7299.53391
-  tps: 6062.86419
+  dps: 7244.06229
+  tps: 6006.11656
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7292.50507
-  tps: 6056.49508
+  dps: 7219.09781
+  tps: 5980.59174
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MaleficRaiment"
  value: {
-  dps: 5556.75573
-  tps: 4503.07037
+  dps: 5507.19836
+  tps: 4450.32419
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7292.50507
-  tps: 6056.49508
+  dps: 7219.09781
+  tps: 5980.59174
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7292.50507
-  tps: 6056.49508
+  dps: 7219.09781
+  tps: 5980.59174
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PlagueheartGarb"
  value: {
-  dps: 6707.81767
-  tps: 5531.42185
+  dps: 6648.05361
+  tps: 5466.58483
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7292.43494
-  tps: 6055.94797
+  dps: 7222.48014
+  tps: 5983.56871
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7293.69789
-  tps: 6057.06087
+  dps: 7223.70546
+  tps: 5984.65403
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7412.43491
-  tps: 6176.42493
+  dps: 7337.41711
+  tps: 6098.91103
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7292.41579
-  tps: 6055.76578
+  dps: 7227.44687
+  tps: 5989.63179
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7292.50507
-  tps: 6056.49508
+  dps: 7219.09781
+  tps: 5980.59174
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7292.50507
-  tps: 6056.49508
+  dps: 7219.09781
+  tps: 5980.59174
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7292.50507
-  tps: 6056.49508
+  dps: 7219.09781
+  tps: 5980.59174
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7292.50507
-  tps: 6056.49508
+  dps: 7219.09781
+  tps: 5980.59174
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7328.50857
-  tps: 6087.46295
+  dps: 7254.74041
+  tps: 6012.03352
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7320.718
-  tps: 6080.90528
+  dps: 7246.93427
+  tps: 6005.08654
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7320.718
-  tps: 6080.90528
+  dps: 7246.93427
+  tps: 6005.08654
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7328.50857
-  tps: 6087.46295
+  dps: 7254.74041
+  tps: 6012.03352
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 7506.12356
-  tps: 6262.32167
+  dps: 7409.17223
+  tps: 6164.61889
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9489.27892
-  tps: 10258.36466
+  dps: 9415.39619
+  tps: 10160.18827
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7456.08656
-  tps: 6220.79088
+  dps: 7360.99999
+  tps: 6122.9493
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8529.364
-  tps: 7101.84759
+  dps: 8436.24714
+  tps: 7008.28087
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5944.123
-  tps: 8021.93058
+  dps: 5870.17543
+  tps: 7906.04109
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4177.59526
-  tps: 3818.95886
+  dps: 4116.1664
+  tps: 3756.42714
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4375.61179
-  tps: 3935.44095
+  dps: 4275.20048
+  tps: 3835.28107
  }
 }
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7307.54694
-  tps: 6195.02948
+  dps: 7224.397
+  tps: 6113.15062
  }
 }

--- a/sim/warlock/TestDemonology.results
+++ b/sim/warlock/TestDemonology.results
@@ -46,315 +46,315 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 7314.75488
-  tps: 6071.77642
+  dps: 7071.17912
+  tps: 5836.74396
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7223.70546
-  tps: 5984.65403
+  dps: 6971.90322
+  tps: 5743.92466
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7231.39435
-  tps: 5992.88828
+  dps: 6980.29021
+  tps: 5752.80828
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7254.74041
-  tps: 6012.03352
+  dps: 7004.94287
+  tps: 5772.97978
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7350.82033
-  tps: 6112.31426
+  dps: 7092.7403
+  tps: 5865.25837
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 7538.17602
-  tps: 6279.6952
+  dps: 7248.87716
+  tps: 6002.76602
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DeathbringerGarb"
  value: {
-  dps: 7007.00126
-  tps: 5798.83394
+  dps: 6762.08138
+  tps: 5566.08033
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7231.39435
-  tps: 5992.88828
+  dps: 6980.29021
+  tps: 5752.80828
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7223.70546
-  tps: 5984.65403
+  dps: 6971.90322
+  tps: 5743.92466
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7254.74041
-  tps: 6012.03352
+  dps: 7004.94287
+  tps: 5772.97978
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7231.39435
-  tps: 5992.88828
+  dps: 6980.29021
+  tps: 5752.80828
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7229.00135
-  tps: 5990.49528
+  dps: 6977.92457
+  tps: 5750.44265
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7219.09781
-  tps: 5980.59174
+  dps: 6964.85118
+  tps: 5737.36925
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7254.74041
-  tps: 6012.03352
+  dps: 7004.94287
+  tps: 5772.97978
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7246.93427
-  tps: 6005.08654
+  dps: 7004.15352
+  tps: 5772.88102
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 6936.92951
-  tps: 5731.45837
+  dps: 6683.40399
+  tps: 5487.38765
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 7022.94666
-  tps: 5703.00401
+  dps: 6759.99822
+  tps: 5449.7903
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7231.39435
-  tps: 5992.88828
+  dps: 6980.29021
+  tps: 5752.80828
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7229.00135
-  tps: 5990.49528
+  dps: 6977.92457
+  tps: 5750.44265
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7244.06229
-  tps: 6006.11656
+  dps: 6976.4231
+  tps: 5747.70851
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7219.09781
-  tps: 5980.59174
+  dps: 6964.85118
+  tps: 5737.36925
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MaleficRaiment"
  value: {
-  dps: 5507.19836
-  tps: 4450.32419
+  dps: 5318.6992
+  tps: 4269.87695
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7219.09781
-  tps: 5980.59174
+  dps: 6964.85118
+  tps: 5737.36925
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7219.09781
-  tps: 5980.59174
+  dps: 6964.85118
+  tps: 5737.36925
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PlagueheartGarb"
  value: {
-  dps: 6648.05361
-  tps: 5466.58483
+  dps: 6426.4263
+  tps: 5254.69927
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7222.48014
-  tps: 5983.56871
+  dps: 6970.69167
+  tps: 5742.86171
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7223.70546
-  tps: 5984.65403
+  dps: 6971.90322
+  tps: 5743.92466
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7337.41711
-  tps: 6098.91103
+  dps: 7075.91176
+  tps: 5848.42983
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7227.44687
-  tps: 5989.63179
+  dps: 6967.34828
+  tps: 5738.69633
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7219.09781
-  tps: 5980.59174
+  dps: 6964.85118
+  tps: 5737.36925
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7219.09781
-  tps: 5980.59174
+  dps: 6964.85118
+  tps: 5737.36925
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7219.09781
-  tps: 5980.59174
+  dps: 6964.85118
+  tps: 5737.36925
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7219.09781
-  tps: 5980.59174
+  dps: 6964.85118
+  tps: 5737.36925
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7254.74041
-  tps: 6012.03352
+  dps: 7004.94287
+  tps: 5772.97978
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7246.93427
-  tps: 6005.08654
+  dps: 7004.15352
+  tps: 5772.88102
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7246.93427
-  tps: 6005.08654
+  dps: 7004.15352
+  tps: 5772.88102
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7254.74041
-  tps: 6012.03352
+  dps: 7004.94287
+  tps: 5772.97978
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 7409.17223
-  tps: 6164.61889
+  dps: 7152.28883
+  tps: 5917.06878
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9415.39619
-  tps: 10160.18827
+  dps: 9171.41423
+  tps: 10143.80781
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7360.99999
-  tps: 6122.9493
+  dps: 7129.87052
+  tps: 5900.87191
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8436.24714
-  tps: 7008.28087
+  dps: 8311.52384
+  tps: 6883.38305
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5870.17543
-  tps: 7906.04109
+  dps: 5787.77448
+  tps: 8006.64563
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4116.1664
-  tps: 3756.42714
+  dps: 4005.65582
+  tps: 3653.46359
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4275.20048
-  tps: 3835.28107
+  dps: 4147.54903
+  tps: 3707.08522
  }
 }
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7224.397
-  tps: 6113.15062
+  dps: 6964.89736
+  tps: 5865.11376
  }
 }

--- a/sim/warlock/chaos_bolt.go
+++ b/sim/warlock/chaos_bolt.go
@@ -27,10 +27,6 @@ func (warlock *Warlock) registerChaosBoltSpell() {
 				GCD:      core.GCDDefault,
 				CastTime: time.Millisecond*2500 - (time.Millisecond * 100 * time.Duration(warlock.Talents.Bane)),
 			},
-			ModifyCast: func(_ *core.Simulation, _ *core.Spell, cast *core.Cast) {
-				cast.GCD = time.Duration(float64(cast.GCD) * warlock.backdraftModifier())
-				cast.CastTime = time.Duration(float64(cast.CastTime) * warlock.backdraftModifier())
-			},
 			CD: core.Cooldown{
 				Timer:    warlock.NewTimer(),
 				Duration: time.Second * (12 - 2*core.TernaryDuration(warlock.HasMajorGlyph(proto.WarlockMajorGlyph_GlyphOfChaosBolt), 1, 0)),

--- a/sim/warlock/immolate.go
+++ b/sim/warlock/immolate.go
@@ -25,10 +25,6 @@ func (warlock *Warlock) registerImmolateSpell() {
 				GCD:      core.GCDDefault,
 				CastTime: time.Millisecond * (2000 - 100*time.Duration(warlock.Talents.Bane)),
 			},
-			ModifyCast: func(_ *core.Simulation, _ *core.Spell, cast *core.Cast) {
-				cast.GCD = time.Duration(float64(cast.GCD) * warlock.backdraftModifier())
-				cast.CastTime = time.Duration(float64(cast.CastTime) * warlock.backdraftModifier())
-			},
 		},
 
 		BonusCritRating: 0 +

--- a/sim/warlock/incinerate.go
+++ b/sim/warlock/incinerate.go
@@ -9,7 +9,6 @@ import (
 
 func (warlock *Warlock) registerIncinerateSpell() {
 	spellCoeff := 0.713 * (1 + 0.04*float64(warlock.Talents.ShadowAndFlame))
-	mcCastMod := (1.0 - 0.1*float64(warlock.Talents.MoltenCore))
 
 	warlock.Incinerate = warlock.RegisterSpell(core.SpellConfig{
 		ActionID:     core.ActionID{SpellID: 47838},
@@ -25,14 +24,6 @@ func (warlock *Warlock) registerIncinerateSpell() {
 			DefaultCast: core.Cast{
 				GCD:      core.GCDDefault,
 				CastTime: time.Millisecond * time.Duration(2500-50*warlock.Talents.Emberstorm),
-			},
-			ModifyCast: func(_ *core.Simulation, _ *core.Spell, cast *core.Cast) {
-				totalMod := warlock.backdraftModifier()
-				if warlock.MoltenCoreAura.IsActive() {
-					totalMod *= mcCastMod
-				}
-				cast.GCD = time.Duration(float64(cast.GCD) * totalMod)
-				cast.CastTime = time.Duration(float64(cast.CastTime) * totalMod)
 			},
 		},
 

--- a/sim/warlock/shadowbolt.go
+++ b/sim/warlock/shadowbolt.go
@@ -33,13 +33,6 @@ func (warlock *Warlock) registerShadowBoltSpell() {
 				GCD:      core.GCDDefault,
 				CastTime: time.Millisecond * (3000 - 100*time.Duration(warlock.Talents.Bane)),
 			},
-			ModifyCast: func(_ *core.Simulation, _ *core.Spell, cast *core.Cast) {
-				cast.GCD = time.Duration(float64(cast.GCD) * warlock.backdraftModifier())
-				cast.CastTime = time.Duration(float64(cast.CastTime) * warlock.backdraftModifier())
-				if warlock.Talents.Nightfall > 0 {
-					warlock.applyNightfall(cast)
-				}
-			},
 		},
 
 		BonusCritRating: 0 +

--- a/sim/warlock/soul_fire.go
+++ b/sim/warlock/soul_fire.go
@@ -7,8 +7,6 @@ import (
 )
 
 func (warlock *Warlock) registerSoulFireSpell() {
-	decimationMod := 1.0 - 0.2*float64(warlock.Talents.Decimation)
-
 	warlock.SoulFire = warlock.RegisterSpell(core.SpellConfig{
 		ActionID:     core.ActionID{SpellID: 47825},
 		SpellSchool:  core.SpellSchoolFire,
@@ -23,15 +21,6 @@ func (warlock *Warlock) registerSoulFireSpell() {
 			DefaultCast: core.Cast{
 				GCD:      core.GCDDefault,
 				CastTime: time.Millisecond * time.Duration(6000-400*warlock.Talents.Bane),
-			},
-			ModifyCast: func(_ *core.Simulation, _ *core.Spell, cast *core.Cast) {
-				totalMod := warlock.backdraftModifier()
-				if warlock.DecimationAura.IsActive() {
-					totalMod *= decimationMod
-				}
-
-				cast.GCD = time.Duration(float64(cast.GCD) * totalMod)
-				cast.CastTime = time.Duration(float64(cast.CastTime) * totalMod)
 			},
 		},
 

--- a/sim/warlock/talents.go
+++ b/sim/warlock/talents.go
@@ -170,10 +170,23 @@ func (warlock *Warlock) setupEmpoweredImp() {
 }
 
 func (warlock *Warlock) setupDecimation() {
+	decimationMod := 0.2*float64(warlock.Talents.Decimation)
 	warlock.DecimationAura = warlock.RegisterAura(core.Aura{
 		Label:    "Decimation Proc Aura",
 		ActionID: core.ActionID{SpellID: 63167},
 		Duration: time.Second * 10,
+		OnGain: func(aura *core.Aura, sim *core.Simulation) {
+			warlock.SoulFire.CastTimeMultiplier -= decimationMod
+		},
+		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
+			warlock.SoulFire.CastTimeMultiplier += decimationMod
+		},
+		OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
+			// TODO: Decimation wasn't being deactivated anywhere
+			//if spell == warlock.SoulFire {
+			//	aura.Deactivate(sim)
+			//}
+		},
 	})
 
 	decimation := warlock.RegisterAura(core.Aura{
@@ -305,9 +318,14 @@ func (warlock *Warlock) setupNightfall() {
 		Label:    "Nightfall Shadow Trance",
 		ActionID: core.ActionID{SpellID: 17941},
 		Duration: time.Second * 10,
+		OnGain: func(aura *core.Aura, sim *core.Simulation) {
+			warlock.ShadowBolt.CastTimeMultiplier -= 1
+		},
+		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
+			warlock.ShadowBolt.CastTimeMultiplier += 1
+		},
 		OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
-			// Check for an instant cast shadowbolt to disable aura
-			if spell == warlock.ShadowBolt && spell.CurCast.CastTime == 0 {
+			if spell == warlock.ShadowBolt {
 				aura.Deactivate(sim)
 			}
 		},
@@ -329,13 +347,8 @@ func (warlock *Warlock) setupNightfall() {
 	})
 }
 
-func (warlock *Warlock) applyNightfall(cast *core.Cast) {
-	if warlock.NightfallProcAura.IsActive() {
-		cast.CastTime = 0
-	}
-}
-
 func (warlock *Warlock) setupMoltenCore() {
+	incinerateCastTimeReduction := 0.1 * float64(warlock.Talents.MoltenCore)
 	moltenCoreDamageBonus := 1 + 0.06*float64(warlock.Talents.MoltenCore)
 	moltenCoreCritBonus := 5 * float64(warlock.Talents.MoltenCore) * core.CritRatingPerCritChance
 
@@ -346,13 +359,20 @@ func (warlock *Warlock) setupMoltenCore() {
 		MaxStacks: 3,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			warlock.Incinerate.DamageMultiplier *= moltenCoreDamageBonus
+			warlock.Incinerate.CastTimeMultiplier -= incinerateCastTimeReduction
 			warlock.SoulFire.DamageMultiplier *= moltenCoreDamageBonus
 			warlock.SoulFire.BonusCritRating += moltenCoreCritBonus
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			warlock.Incinerate.DamageMultiplier /= moltenCoreDamageBonus
+			warlock.Incinerate.CastTimeMultiplier += incinerateCastTimeReduction
 			warlock.SoulFire.DamageMultiplier /= moltenCoreDamageBonus
 			warlock.SoulFire.BonusCritRating -= moltenCoreCritBonus
+		},
+		OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
+			if spell == warlock.Incinerate || spell == warlock.SoulFire {
+				aura.RemoveStack(sim)
+			}
 		},
 	})
 
@@ -375,15 +395,41 @@ func (warlock *Warlock) setupMoltenCore() {
 }
 
 func (warlock *Warlock) setupBackdraft() {
+	castTimeModifier := 0.1 * float64(warlock.Talents.Backdraft)
+	var affectedSpells []*core.Spell
+
 	warlock.BackdraftAura = warlock.RegisterAura(core.Aura{
 		Label:     "Backdraft Proc Aura",
 		ActionID:  core.ActionID{SpellID: 54277},
 		Duration:  time.Second * 15,
 		MaxStacks: 3,
+		OnInit: func(aura *core.Aura, sim *core.Simulation) {
+			affectedSpells = core.FilterSlice([]*core.Spell{
+				warlock.Incinerate,
+				warlock.SoulFire,
+				warlock.ShadowBolt,
+				warlock.ChaosBolt,
+				warlock.Immolate,
+			}, func(spell *core.Spell) bool { return spell != nil })
+		},
+		OnGain: func(aura *core.Aura, sim *core.Simulation) {
+			for _, destroSpell := range affectedSpells {
+				destroSpell.CastTimeMultiplier -= castTimeModifier
+				destroSpell.DefaultCast.GCD = time.Duration(float64(destroSpell.DefaultCast.GCD) * (1 - castTimeModifier))
+			}
+		},
+		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
+			for _, destroSpell := range affectedSpells {
+				destroSpell.CastTimeMultiplier += castTimeModifier
+				destroSpell.DefaultCast.GCD = time.Duration(float64(destroSpell.DefaultCast.GCD) / (1 - castTimeModifier))
+			}
+		},
 		OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
-			if spell == warlock.Incinerate || spell == warlock.SoulFire || spell == warlock.ShadowBolt ||
-				spell == warlock.ChaosBolt || spell == warlock.Immolate {
-				aura.RemoveStack(sim)
+			for _, destroSpell := range affectedSpells {
+				if spell == destroSpell {
+					aura.RemoveStack(sim)
+					return
+				}
 			}
 		},
 	})

--- a/sim/warlock/talents.go
+++ b/sim/warlock/talents.go
@@ -182,10 +182,9 @@ func (warlock *Warlock) setupDecimation() {
 			warlock.SoulFire.CastTimeMultiplier += decimationMod
 		},
 		OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
-			// TODO: Decimation wasn't being deactivated anywhere
-			//if spell == warlock.SoulFire {
-			//	aura.Deactivate(sim)
-			//}
+			if spell == warlock.SoulFire {
+				aura.Deactivate(sim)
+			}
 		},
 	})
 


### PR DESCRIPTION
Bugs fixed:
 - Molten Core talent was incorrectly reducing Incinerate GCD in addition to cast time.
 - Decimation talent was incorrectly reducing Soul Fire GCD in addition to cast time.
 - Molten Core and Decimation auras were never being consumed.