### PR TITLE
Allow usage of Ambush while in Shadow Dance

### DIFF
--- a/sim/rogue/subtlety_rotation.go
+++ b/sim/rogue/subtlety_rotation.go
@@ -21,7 +21,7 @@ func (rogue *Rogue) setSubtletyBuilder() {
 		rogue.BuilderPoints = 1
 	} else
 	// Ambush
-	if rogue.ShadowDanceAura.IsActive() && !mhDagger {
+	if rogue.ShadowDanceAura.IsActive() && mhDagger {
 		rogue.Builder = rogue.Ambush
 		rogue.BuilderPoints = 2
 	} else


### PR DESCRIPTION
Fix an issue in the subtlety rotation where Ambush was not able to be used during Shadow Dance when a dagger was equipped