### PR TITLE
feral: add in defaut stat weight for mh dps

### DIFF
--- a/ui/feral_druid/sim.ts
+++ b/ui/feral_druid/sim.ts
@@ -71,7 +71,7 @@ export class FeralDruidSimUI extends IndividualSimUI<Spec.SpecFeralDruid> {
 					[Stat.StatArmorPenetration]: 2.08,
 					[Stat.StatExpertise]: 2.44,
 				}, {
-					[PseudoStat.PseudoStatMainHandDps]: 0.0,
+					[PseudoStat.PseudoStatMainHandDps]: 16.5,
 				}),
 				// Default consumes settings.
 				consumes: Presets.DefaultConsumes,


### PR DESCRIPTION
 - this is semi rough, idea based on fap ((dps - 54.8) * 14) * 1.2

Signed-off-by: jarves <jarveson@gmail.com>