### PR TITLE
Fix issues with nested modals and raid sim close button

### DIFF
--- a/ui/core/components/gear_picker.ts
+++ b/ui/core/components/gear_picker.ts
@@ -677,7 +677,7 @@ class SelectorModal extends BaseModal {
 
 			const filtersButton = tabContent.getElementsByClassName('selector-modal-filters-button')[0] as HTMLElement;
 			if (FiltersMenu.anyFiltersForSlot(slot)) {
-				filtersButton.addEventListener('click', () => new FiltersMenu(this.simUI.rootElem, this.player, slot));
+				filtersButton.addEventListener('click', () => new FiltersMenu(this.body, this.player, slot));
 			} else {
 				filtersButton.style.display = 'none';
 			}

--- a/ui/scss/core/components/_close_button.scss
+++ b/ui/scss/core/components/_close_button.scss
@@ -1,7 +1,7 @@
 .close-button {
 	white-space: nowrap;
 	line-height: 1.5;
-	z-index: 1;
+	z-index: 2;
 	order: 1;
 
 	&> i {

--- a/ui/scss/sims/raid/index.scss
+++ b/ui/scss/sims/raid/index.scss
@@ -1,20 +1,4 @@
 @import "../../core/individual_sim_ui/index";
 @import "./sim";
-
-@import "../balance_druid/sim";
-@import "../elemental_shaman/sim";
-@import "../enhancement_shaman/sim";
-@import "../feral_druid/sim";
-@import "../feral_tank_druid/sim";
-@import "../hunter/sim";
-@import "../mage/sim";
-@import "../protection_paladin/sim";
-@import "../protection_warrior/sim";
-@import "../retribution_paladin/sim";
-@import "../rogue/sim";
-@import "../shadow_priest/sim";
-@import "../smite_priest/sim";
-@import "../warlock/sim";
-@import "../warrior/sim";
-
+@import "../index";
 @import "./raid_sim_ui";


### PR DESCRIPTION
re https://github.com/wowsims/wotlk/issues/2570

Nested modals in the raid sim player editor were mostly not functional - especially after closing a modal within the editor. Bootstrap doesn't handle this natively, so we have to do some extra work to make them play nicely. We stop the propagation of the modal events to parents to avoid triggering handlers on those parent modals, which was particularly problematic when closing modals as closing one would close them all. Then we also adjust the backdrop, as by default Bootstrap appends the backdrop to the `<body>` and provides no way to change this.