### PR TITLE
DK Rotations Setup

### DIFF
--- a/sim/deathknight/dps/dps_deathknight.go
+++ b/sim/deathknight/dps/dps_deathknight.go
@@ -100,9 +100,9 @@ func (dk *DpsDeathknight) FrostPointsInUnholy() int32 {
 }
 
 func (dk *DpsDeathknight) SetupRotations() {
-	if dk.Rotation.AutoRotation {
-		bl, fr, uh := deathknight.PointsInTalents(dk.Talents)
+	bl, fr, uh := deathknight.PointsInTalents(dk.Talents)
 
+	if dk.Rotation.AutoRotation {
 		if uh > fr && uh > bl {
 			// Unholy
 			dk.Rotation.BtGhoulFrenzy = false
@@ -159,28 +159,34 @@ func (dk *DpsDeathknight) SetupRotations() {
 
 	dk.CustomRotation = dk.makeCustomRotation()
 	if dk.CustomRotation == nil || dk.Rotation.FrostRotationType == proto.Deathknight_Rotation_SingleTarget {
-
 		dk.Rotation.FrostRotationType = proto.Deathknight_Rotation_SingleTarget
-		if (dk.Talents.BloodOfTheNorth == 3) && (dk.Talents.Epidemic == 0) {
-			if dk.Rotation.DesyncRotation {
-				dk.setupFrostSubBloodDesyncOpener()
-			} else if dk.Rotation.UseEmpowerRuneWeapon {
-				dk.setupFrostSubBloodERWOpener()
-			} else {
-				dk.setupFrostSubBloodNoERWOpener()
+		if fr > uh && fr > bl {
+			// AotD as major CD doesnt work well with frost
+			if dk.Inputs.ArmyOfTheDeadType == proto.Deathknight_Rotation_AsMajorCd {
+				dk.Inputs.ArmyOfTheDeadType = proto.Deathknight_Rotation_PreCast
+				dk.Rotation.HoldErwArmy = false
 			}
-		} else if (dk.Talents.BloodOfTheNorth == 3) && (dk.Talents.Epidemic == 2) {
-			dk.Rotation.FrostRotationType = proto.Deathknight_Rotation_SingleTarget
-			if dk.Rotation.UseEmpowerRuneWeapon {
-				dk.setupFrostSubUnholyERWOpener()
+			if bl > uh {
+				if dk.Rotation.DesyncRotation {
+					dk.setupFrostSubBloodDesyncOpener()
+				} else if dk.Rotation.UseEmpowerRuneWeapon {
+					dk.setupFrostSubBloodERWOpener()
+				} else {
+					dk.setupFrostSubBloodNoERWOpener()
+				}
 			} else {
-				// TODO you can't unh sub without ERW in the opener...yet
-				dk.Rotation.UseEmpowerRuneWeapon = true
-				dk.setupFrostSubUnholyERWOpener()
+				dk.Rotation.FrostRotationType = proto.Deathknight_Rotation_SingleTarget
+				if dk.Rotation.UseEmpowerRuneWeapon {
+					dk.setupFrostSubUnholyERWOpener()
+				} else {
+					// TODO you can't unh sub without ERW in the opener...yet
+					dk.Rotation.UseEmpowerRuneWeapon = true
+					dk.setupFrostSubUnholyERWOpener()
+				}
 			}
-		} else if dk.Talents.SummonGargoyle {
+		} else if uh > fr && uh > bl {
 			dk.setupUnholyRotations()
-		} else if dk.Talents.BloodGorged > 0 {
+		} else if bl > fr && bl > uh {
 			if dk.Inputs.ArmyOfTheDeadType == proto.Deathknight_Rotation_AsMajorCd {
 				dk.Inputs.ArmyOfTheDeadType = proto.Deathknight_Rotation_PreCast
 				dk.Rotation.HoldErwArmy = false

--- a/sim/deathknight/rotation.go
+++ b/sim/deathknight/rotation.go
@@ -205,7 +205,9 @@ func (dk *Deathknight) RotationActionCallback_UP(sim *core.Simulation, target *c
 }
 
 func (dk *Deathknight) RotationActionCallback_RD(sim *core.Simulation, target *core.Unit, s *Sequence) time.Duration {
-	dk.RaiseDead.Cast(sim, target)
+	if !dk.Talents.MasterOfGhouls {
+		dk.RaiseDead.Cast(sim, target)
+	}
 
 	s.Advance()
 	return -1

--- a/ui/deathknight/inputs.ts
+++ b/ui/deathknight/inputs.ts
@@ -358,7 +358,7 @@ export const FrostCustomRotation = InputHelpers.makeCustomRotationInput<Spec.Spe
 export const EnableWeaponSwap = InputHelpers.makeRotationBooleanInput<Spec.SpecDeathknight>({
 	fieldName: 'enableWeaponSwap',
 	label: 'Enable Weapon Swapping',
-	showWhen: (player: Player<Spec.SpecDeathknight>) =>  player.getRotation().useGargoyle,
+	showWhen: (player: Player<Spec.SpecDeathknight>) => player.getTalents().summonGargoyle && player.getRotation().useGargoyle,
 })
 
 export const WeaponSwapInputs = InputHelpers.MakeItemSwapInput<Spec.SpecDeathknight>({
@@ -369,7 +369,7 @@ export const WeaponSwapInputs = InputHelpers.MakeItemSwapInput<Spec.SpecDeathkni
 		//ItemSlot.ItemSlotRanged, Not support yet
 	],
 	labelTooltip: '<b>Berserking</b> will be equipped when FC has procced and Berserking is not active.<br><br><b>Black Magic</b> will be prioed to swap during gargoyle or if gargoyle will be on CD for full BM Icd.',
-	showWhen: (player: Player<Spec.SpecDeathknight>) => player.getRotation().useGargoyle && player.getRotation().enableWeaponSwap,
+	showWhen: (player: Player<Spec.SpecDeathknight>) => player.getTalents().summonGargoyle && player.getRotation().useGargoyle && player.getRotation().enableWeaponSwap,
 })
 
 export const DeathKnightRotationConfig = {


### PR DESCRIPTION
Change the rotation checks to work with total talents spent in spec instead of a specific talent