### PR TITLE
allow prepull pending actions to run

### DIFF
--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -395,7 +395,7 @@ func (aa *AutoAttacks) startPull(sim *Simulation) {
 }
 
 func (aa *AutoAttacks) resetAutoSwing(sim *Simulation) {
-	if aa.autoSwingCancelled || (!aa.AutoSwingMelee && !aa.AutoSwingRanged) {
+	if aa.autoSwingCancelled || (!aa.AutoSwingMelee && !aa.AutoSwingRanged) || sim.CurrentTime < 0 {
 		return
 	}
 

--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -440,8 +440,8 @@ func (aa *AutoAttacks) CancelAutoSwing(sim *Simulation) {
 	if aa.autoSwingAction != nil {
 		aa.autoSwingAction.Cancel(sim)
 		aa.autoSwingAction = nil
-		aa.autoSwingCancelled = true
 	}
+	aa.autoSwingCancelled = true
 }
 
 // Renables the auto swing action for the iteration

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -379,6 +379,10 @@ func (character *Character) initialize(agent Agent) {
 	character.gcdAction = &PendingAction{
 		Priority: ActionPriorityGCD,
 		OnAction: func(sim *Simulation) {
+			if sim.CurrentTime < 0 {
+				return
+			}
+
 			character.TryUseCooldowns(sim)
 			if character.GCD.IsReady(sim) {
 				agent.OnGCDReady(sim)

--- a/sim/core/pet.go
+++ b/sim/core/pet.go
@@ -163,7 +163,16 @@ func (pet *Pet) Enable(sim *Simulation, petAgent PetAgent) {
 	pet.manaBar.reset()
 
 	pet.SetGCDTimer(sim, MaxDuration(0, sim.CurrentTime))
-	pet.AutoAttacks.EnableAutoSwing(sim)
+	if sim.CurrentTime >= 0 {
+		pet.AutoAttacks.EnableAutoSwing(sim)
+	} else {
+		sim.AddPendingAction(&PendingAction{
+			NextActionAt: 0,
+			OnAction: func(sim *Simulation) {
+				pet.AutoAttacks.EnableAutoSwing(sim)
+			},
+		})
+	}
 
 	pet.enabled = true
 

--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -344,12 +344,6 @@ func (sim *Simulation) runPendingActions(max time.Duration) {
 		}
 		pa.OnAction(sim)
 	}
-
-	for _, pa := range sim.pendingActions {
-		if pa.CleanUp != nil {
-			pa.CleanUp(sim)
-		}
-	}
 }
 
 // RunOnce is the main event loop. It will run the simulation for number of seconds.
@@ -383,6 +377,13 @@ func (sim *Simulation) runOnce() {
 	// during the doneIteration phase will return the Duration value, which is
 	// intuitive.
 	sim.CurrentTime = sim.Duration
+
+	for _, pa := range sim.pendingActions {
+		if pa.CleanUp != nil {
+			pa.CleanUp(sim)
+		}
+	}
+
 	sim.Raid.doneIteration(sim)
 	sim.Encounter.doneIteration(sim)
 

--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -334,6 +334,7 @@ func (sim *Simulation) runPendingActions(max time.Duration) {
 			if pa.NextActionAt < max {
 				sim.advance(pa.NextActionAt - sim.CurrentTime)
 			} else {
+				sim.pendingActions = append(sim.pendingActions, pa)
 				break
 			}
 		}
@@ -362,6 +363,7 @@ func (sim *Simulation) runOnce() {
 		}
 
 		if sim.CurrentTime < 0 {
+			sim.runPendingActions(0)
 			sim.advance(0 - sim.CurrentTime)
 		}
 	}

--- a/sim/deathknight/army_of_the_dead.go
+++ b/sim/deathknight/army_of_the_dead.go
@@ -13,7 +13,9 @@ func (dk *Deathknight) registerArmyOfTheDeadCD() {
 		ActionID: core.ActionID{SpellID: 42650},
 		Duration: time.Millisecond * 500 * 8,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			dk.AutoAttacks.CancelAutoSwing(sim)
+			if sim.CurrentTime >= 0 {
+				dk.AutoAttacks.CancelAutoSwing(sim)
+			}
 			dk.CancelGCDTimer(sim)
 
 			ghoulIndex = 0

--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -46,933 +46,933 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7037.7793
-  tps: 3555.75291
+  dps: 6947.38326
+  tps: 3566.70415
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6922.20288
-  tps: 3530.88449
+  dps: 6858.94094
+  tps: 3557.3495
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6751.94356
-  tps: 8196.65546
+  dps: 6670.8035
+  tps: 8212.51835
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6751.94356
-  tps: 8196.65546
+  dps: 6670.8035
+  tps: 8212.51835
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7058.95699
-  tps: 3567.11264
+  dps: 6968.67432
+  tps: 3578.54829
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6882.10514
-  tps: 3479.93289
+  dps: 6761.43915
+  tps: 3469.92829
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 5853.33535
-  tps: 2961.59302
+  dps: 5765.78552
+  tps: 2958.1124
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5767.20006
-  tps: 2921.10083
+  dps: 5689.32365
+  tps: 2925.72159
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5548.06858
-  tps: 2804.14361
+  dps: 5463.85323
+  tps: 2804.94455
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7032.93473
-  tps: 3482.09622
+  dps: 6942.55634
+  tps: 3492.825
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7177.73505
-  tps: 3632.9803
+  dps: 7088.25888
+  tps: 3644.72933
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6857.82272
-  tps: 3493.79043
+  dps: 6784.57133
+  tps: 3511.37244
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6905.14485
-  tps: 3522.34764
+  dps: 6844.47153
+  tps: 3551.16056
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6998.9542
-  tps: 3540.88179
+  dps: 6912.68548
+  tps: 3553.72426
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 6794.86898
-  tps: 3456.15317
+  dps: 6741.04475
+  tps: 3474.65938
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 5919.6896
-  tps: 2990.15347
+  dps: 5839.86555
+  tps: 2989.20732
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7072.74261
-  tps: 3572.32415
+  dps: 6984.16632
+  tps: 3584.81578
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7359.21636
-  tps: 3717.21525
+  dps: 7267.09334
+  tps: 3728.2443
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6834.20646
-  tps: 3481.95829
+  dps: 6754.00574
+  tps: 3494.30834
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7159.07034
-  tps: 3651.32368
+  dps: 7088.01851
+  tps: 3677.63559
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7220.61221
-  tps: 3693.79835
+  dps: 7147.3243
+  tps: 3719.86076
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6767.53972
-  tps: 3444.30668
+  dps: 6686.34711
+  tps: 3456.33345
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7063.95184
-  tps: 3569.70682
+  dps: 6972.91718
+  tps: 3580.7894
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6876.91804
-  tps: 3491.38939
+  dps: 6751.71692
+  tps: 3478.73442
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6898.80848
-  tps: 3506.00132
+  dps: 6772.09566
+  tps: 3495.46494
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7032.93473
-  tps: 3553.15941
+  dps: 6942.55634
+  tps: 3564.10714
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7032.93473
-  tps: 3553.15941
+  dps: 6942.55634
+  tps: 3564.10714
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7058.95699
-  tps: 3567.11264
+  dps: 6968.67432
+  tps: 3578.54829
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7051.48995
-  tps: 3563.16642
+  dps: 6963.44746
+  tps: 3575.76393
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6810.81726
-  tps: 3446.04274
+  dps: 6685.31661
+  tps: 3439.20014
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7032.93473
-  tps: 3553.15941
+  dps: 6942.55634
+  tps: 3564.10714
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6896.65458
-  tps: 3515.78435
+  dps: 6811.43957
+  tps: 3532.4297
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6846.9287
-  tps: 3488.00531
+  dps: 6775.01303
+  tps: 3505.85041
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6832.29577
-  tps: 3479.68793
+  dps: 6753.34292
+  tps: 3494.23138
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7032.93473
-  tps: 3553.15941
+  dps: 6942.55634
+  tps: 3564.10714
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7032.93473
-  tps: 3553.15941
+  dps: 6942.55634
+  tps: 3564.10714
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7074.0651
-  tps: 3572.77182
+  dps: 6985.27766
+  tps: 3585.24575
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6951.75302
-  tps: 3545.13206
+  dps: 6870.76593
+  tps: 3557.42485
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6866.18985
-  tps: 3501.10315
+  dps: 6770.295
+  tps: 3507.1223
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7068.7205
-  tps: 3571.11969
+  dps: 6980.27637
+  tps: 3583.62428
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7058.95699
-  tps: 3567.11264
+  dps: 6968.67432
+  tps: 3578.54829
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7051.48995
-  tps: 3563.16642
+  dps: 6963.44746
+  tps: 3575.76393
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6914.40654
-  tps: 3527.14467
+  dps: 6833.11992
+  tps: 3539.34766
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7032.93473
-  tps: 3553.15941
+  dps: 6942.55634
+  tps: 3564.10714
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7060.26017
-  tps: 3567.79338
-  hps: 12.70546
+  dps: 6969.66121
+  tps: 3578.688
+  hps: 12.79219
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6882.0962
-  tps: 3492.40496
+  dps: 6832.45588
+  tps: 3529.91377
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6907.37639
-  tps: 3505.78807
+  dps: 6816.18627
+  tps: 3516.17133
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6762.03289
-  tps: 3441.35644
+  dps: 6680.85777
+  tps: 3453.37813
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7054.98662
-  tps: 3564.96473
+  dps: 6964.52789
+  tps: 3575.9284
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7060.1753
-  tps: 3567.74245
+  dps: 6969.69766
+  tps: 3578.70987
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6793.82569
-  tps: 3458.38912
+  dps: 6712.54958
+  tps: 3470.44019
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6799.2224
-  tps: 3461.28035
+  dps: 6717.92914
+  tps: 3473.3364
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7032.93473
-  tps: 3553.15941
+  dps: 6942.55634
+  tps: 3564.10714
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7032.93473
-  tps: 3553.15941
+  dps: 6942.55634
+  tps: 3564.10714
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6805.90235
-  tps: 3469.50496
+  dps: 6711.10988
+  tps: 3472.13095
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6812.9896
-  tps: 3473.75731
+  dps: 6718.24708
+  tps: 3476.41327
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7168.78975
-  tps: 3628.4731
+  dps: 7081.91192
+  tps: 3641.50303
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7075.60801
-  tps: 3573.29411
+  dps: 6986.57423
+  tps: 3585.74737
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7032.93473
-  tps: 3553.15941
+  dps: 6942.55634
+  tps: 3564.10714
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7068.42726
-  tps: 3571.00264
+  dps: 6980.08768
+  tps: 3583.51579
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6429.15262
-  tps: 3257.84523
+  dps: 6397.32118
+  tps: 3291.05613
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 5896.56287
-  tps: 2977.16761
+  dps: 5813.55308
+  tps: 2974.32751
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7375.02306
-  tps: 3793.41057
+  dps: 7351.49892
+  tps: 3829.1359
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6235.74386
-  tps: 3152.14262
+  dps: 6146.57441
+  tps: 3150.2564
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6763.33714
-  tps: 3441.23213
+  dps: 6681.38297
+  tps: 3453.28163
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 9194.93512
-  tps: 4774.9337
+  dps: 9147.60038
+  tps: 4813.10725
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7066.13015
-  tps: 3570.08578
+  dps: 6978.60962
+  tps: 3582.66596
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7103.83176
-  tps: 3589.51896
+  dps: 7006.72855
+  tps: 3597.76782
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7066.13015
-  tps: 3570.08578
+  dps: 6978.60962
+  tps: 3582.66596
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7380.31136
-  tps: 3735.61885
+  dps: 7290.59937
+  tps: 3747.02107
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7066.13015
-  tps: 3570.08578
+  dps: 6978.60962
+  tps: 3582.66596
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7377.6707
-  tps: 3737.28386
+  dps: 7302.62591
+  tps: 3757.38216
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7066.13015
-  tps: 3570.08578
+  dps: 6978.60962
+  tps: 3582.66596
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6849.94647
-  tps: 3489.81597
+  dps: 6778.44076
+  tps: 3507.90705
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofHope-45703"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofLife-37657"
  value: {
-  dps: 6815.87532
-  tps: 3472.0752
+  dps: 6694.98123
+  tps: 3461.64334
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6963.09058
-  tps: 3535.41817
+  dps: 6830.93502
+  tps: 3526.57513
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 5470.61896
-  tps: 2768.92851
+  dps: 5389.36985
+  tps: 2766.21744
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7060.1753
-  tps: 3567.74245
+  dps: 6969.69766
+  tps: 3578.70987
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7054.98662
-  tps: 3564.96473
+  dps: 6964.52789
+  tps: 3575.9284
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7045.90643
-  tps: 3560.10372
+  dps: 6955.48078
+  tps: 3571.06082
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 6952.09256
-  tps: 3536.94609
+  dps: 6860.46601
+  tps: 3535.73295
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6058.50039
-  tps: 3060.3195
+  dps: 6003.90706
+  tps: 3077.45085
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6158.73189
-  tps: 3081.25183
+  dps: 6051.66902
+  tps: 3076.35501
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7015.67775
-  tps: 3535.58537
+  dps: 6949.61149
+  tps: 3563.22699
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6960.16398
-  tps: 3548.49121
+  dps: 6908.83994
+  tps: 3582.00685
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7013.87538
-  tps: 3579.56428
+  dps: 6916.69136
+  tps: 3586.88826
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7032.93473
-  tps: 3553.15941
+  dps: 6942.55634
+  tps: 3564.10714
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7032.93473
-  tps: 3553.15941
+  dps: 6942.55634
+  tps: 3564.10714
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6730.81312
-  tps: 3413.51135
+  dps: 6656.82581
+  tps: 3434.70604
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7032.93473
-  tps: 3553.15941
+  dps: 6942.55634
+  tps: 3564.10714
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7032.93473
-  tps: 3553.15941
+  dps: 6942.55634
+  tps: 3564.10714
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5765.6789
-  tps: 2923.58242
+  dps: 5672.71251
+  tps: 2915.48936
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5490.82739
-  tps: 2633.42052
+  dps: 5386.21179
+  tps: 2645.60936
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6751.93702
-  tps: 3435.94768
+  dps: 6670.79397
+  tps: 3447.96005
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7077.37133
-  tps: 3573.89101
+  dps: 6988.05602
+  tps: 3586.32066
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 7114.6664
-  tps: 3604.19736
+  dps: 7011.53061
+  tps: 3607.01141
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15449.50604
-  tps: 8086.2273
+  dps: 15394.91702
+  tps: 8119.76243
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7104.21046
-  tps: 3608.27668
+  dps: 7036.53592
+  tps: 3629.60591
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9525.01208
-  tps: 4080.12082
+  dps: 9014.41219
+  tps: 4108.04429
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10254.33892
-  tps: 5396.91621
+  dps: 10248.75925
+  tps: 5399.58634
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3962.98665
-  tps: 2036.33459
+  dps: 3938.35289
+  tps: 2038.69995
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4893.8587
-  tps: 2149.39944
+  dps: 4678.75259
+  tps: 2107.02331
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15608.09517
-  tps: 8157.11363
+  dps: 15521.30793
+  tps: 8165.65022
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7168.78975
-  tps: 3628.4731
+  dps: 7081.91192
+  tps: 3641.50303
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9654.96398
-  tps: 4108.67159
+  dps: 9133.73519
+  tps: 4142.91734
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10351.47621
-  tps: 5427.02412
+  dps: 10340.34015
+  tps: 5434.0365
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4002.83017
-  tps: 2051.51688
+  dps: 3973.53206
+  tps: 2051.36151
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4983.44564
-  tps: 2180.61989
+  dps: 4783.54354
+  tps: 2151.45082
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6845.99551
-  tps: 3475.74494
+  dps: 6696.83463
+  tps: 3449.51951
  }
 }

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -46,112 +46,112 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7799.55174
+  dps: 7799.54326
   tps: 4557.91258
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7781.91718
+  dps: 7781.90996
   tps: 4560.26182
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7570.76202
+  dps: 7570.75481
   tps: 8385.13338
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7570.76202
+  dps: 7570.75481
   tps: 8385.13338
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7813.25271
+  dps: 7813.24422
   tps: 4566.13316
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7629.20193
+  dps: 7629.19709
   tps: 4458.44354
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6597.49283
-  tps: 3855.44383
+  dps: 6599.25394
+  tps: 3856.59023
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6468.25595
-  tps: 3781.60597
+  dps: 6465.06894
+  tps: 3779.62216
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6191.24058
-  tps: 3615.96323
+  dps: 6198.80733
+  tps: 3620.433
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7793.59861
+  dps: 7793.59013
   tps: 4463.25389
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7993.21924
+  dps: 7993.21076
   tps: 4674.11308
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
   hps: 42.66667
  }
@@ -159,287 +159,287 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7675.91023
+  dps: 7675.90302
   tps: 4496.7848
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7751.78453
+  dps: 7751.77732
   tps: 4542.61139
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7799.86015
+  dps: 7799.85196
   tps: 4561.11081
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7490.9629
+  dps: 7490.98079
   tps: 4379.43979
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 6596.17026
+  dps: 6596.09429
   tps: 3848.86271
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7480.59638
+  dps: 7480.58789
   tps: 4366.53936
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8175.1549
+  dps: 8175.14603
   tps: 4779.2569
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7659.08522
+  dps: 7659.07801
   tps: 4486.68979
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8060.65982
+  dps: 8060.65721
   tps: 4721.32542
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8139.46282
+  dps: 8139.36928
   tps: 4769.78238
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7590.06462
+  dps: 7590.0574
   tps: 4445.27743
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7816.19462
+  dps: 7816.18614
   tps: 4567.89831
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7766.51792
+  dps: 7766.32996
   tps: 4546.22053
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7754.25763
+  dps: 7754.06967
   tps: 4539.07712
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7793.59861
+  dps: 7793.59013
   tps: 4554.34071
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7793.59861
+  dps: 7793.59013
   tps: 4554.34071
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7813.25271
+  dps: 7813.24422
   tps: 4566.13316
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7810.53379
+  dps: 7810.5253
   tps: 4564.50181
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7677.7554
+  dps: 7677.75794
   tps: 4491.7471
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7793.59861
+  dps: 7793.59013
   tps: 4554.34071
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7703.34351
+  dps: 7703.33629
   tps: 4513.06093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7662.15257
+  dps: 7662.14535
   tps: 4488.5302
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7643.2734
+  dps: 7643.26619
   tps: 4477.2027
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7793.59861
+  dps: 7793.59013
   tps: 4554.34071
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7793.59861
+  dps: 7793.59013
   tps: 4554.34071
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7481.2458
+  dps: 7481.23732
   tps: 4366.92902
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7807.77936
+  dps: 7807.77215
   tps: 4575.90628
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7693.16036
+  dps: 7693.15315
   tps: 4507.54877
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7479.30408
+  dps: 7479.29559
   tps: 4365.76398
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7813.25271
+  dps: 7813.24422
   tps: 4566.13316
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7810.53379
+  dps: 7810.5253
   tps: 4564.50181
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7762.15272
+  dps: 7762.14551
   tps: 4548.53029
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7793.59861
+  dps: 7793.59013
   tps: 4554.34071
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7824.54351
+  dps: 7824.53503
   tps: 4572.90765
   hps: 12.97738
  }
@@ -447,532 +447,532 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7792.32103
+  dps: 7792.27088
   tps: 4557.58933
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7625.47253
+  dps: 7625.46532
   tps: 4466.52218
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7583.265
+  dps: 7583.25779
   tps: 4441.19766
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7818.52892
+  dps: 7818.52043
   tps: 4569.29889
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7824.39487
+  dps: 7824.38638
   tps: 4572.81846
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7622.52145
+  dps: 7622.51424
   tps: 4464.75153
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7629.18507
+  dps: 7629.17786
   tps: 4468.7497
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7793.59861
+  dps: 7793.59013
   tps: 4554.34071
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7793.59861
+  dps: 7793.59013
   tps: 4554.34071
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7593.27709
+  dps: 7593.26988
   tps: 4447.17707
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7595.07479
+  dps: 7595.06757
   tps: 4448.25569
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7989.11638
+  dps: 7989.1079
   tps: 4671.65137
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7482.00347
+  dps: 7481.99498
   tps: 4367.38362
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7793.59861
+  dps: 7793.59013
   tps: 4554.34071
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7479.08278
+  dps: 7479.07429
   tps: 4365.6312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7230.40257
+  dps: 7230.46699
   tps: 4227.73748
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 6490.80907
+  dps: 6490.7966
   tps: 3787.73379
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8198.64962
+  dps: 8198.57034
   tps: 4803.545
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6891.9336
+  dps: 6891.85614
   tps: 4022.21128
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7583.44246
+  dps: 7583.43525
   tps: 4441.30414
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7989.11638
+  dps: 7989.1079
   tps: 4671.65137
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7477.34925
+  dps: 7477.34076
   tps: 4364.59109
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7490.75389
+  dps: 7490.74541
   tps: 4372.63387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7477.34925
+  dps: 7477.34076
   tps: 4364.59109
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7885.11927
+  dps: 7885.11078
   tps: 4603.37144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7477.34925
+  dps: 7477.34076
   tps: 4364.59109
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7916.56681
+  dps: 7916.55809
   tps: 4623.89251
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7477.34925
+  dps: 7477.34076
   tps: 4364.59109
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7663.55995
+  dps: 7663.55273
   tps: 4489.37463
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofHope-45703"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 7703.79693
+  dps: 7703.78972
   tps: 4510.93824
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7748.48491
+  dps: 7748.47494
   tps: 4540.11713
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StormshroudArmor"
  value: {
-  dps: 6155.0676
-  tps: 3596.81876
+  dps: 6155.74214
+  tps: 3597.40264
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7824.39487
+  dps: 7824.38638
   tps: 4572.81846
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7818.52892
+  dps: 7818.52043
   tps: 4569.29889
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7808.2635
+  dps: 7808.25501
   tps: 4563.13964
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7551.14872
+  dps: 7551.18198
   tps: 4414.86667
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6663.57663
+  dps: 6663.56366
   tps: 3887.47413
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7132.43141
+  dps: 7132.24296
   tps: 4158.63046
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7895.48772
+  dps: 7895.47755
   tps: 4614.43662
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7777.31646
+  dps: 7777.35305
   tps: 4558.18102
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7782.64878
+  dps: 7782.64668
   tps: 4560.92925
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7793.59861
+  dps: 7793.59013
   tps: 4554.34071
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7793.59861
+  dps: 7793.59013
   tps: 4554.34071
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7646.97586
+  dps: 7646.87527
   tps: 4475.30875
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7793.59861
+  dps: 7793.59013
   tps: 4554.34071
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7793.59861
+  dps: 7793.59013
   tps: 4554.34071
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6450.45747
-  tps: 3770.99267
+  dps: 6448.89658
+  tps: 3770.21657
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7495.57543
+  dps: 7495.44034
   tps: 4374.83977
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7570.79904
+  dps: 7570.79183
   tps: 4433.71808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7482.86937
+  dps: 7482.86088
   tps: 4367.90316
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 8015.57798
+  dps: 8015.58186
   tps: 4688.4151
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15781.57547
+  dps: 15781.56404
   tps: 9352.4683
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7972.4836
+  dps: 7972.47216
   tps: 4666.73594
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8832.65874
+  dps: 8832.60157
   tps: 4988.47306
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10103.38602
+  dps: 10103.31831
   tps: 5987.71686
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4760.32769
+  dps: 4760.25998
   tps: 2782.77969
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4966.32606
+  dps: 4965.98753
   tps: 2806.61806
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16018.3157
+  dps: 16018.30722
   tps: 9490.18326
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7989.11638
+  dps: 7989.1079
   tps: 4671.65137
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8905.68235
+  dps: 8905.63992
   tps: 5018.09735
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10190.90995
+  dps: 10190.8388
   tps: 6036.68475
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4780.15103
+  dps: 4780.07988
   tps: 2790.33156
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5028.54715
+  dps: 5028.19138
   tps: 2836.39403
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7710.66622
-  tps: 4512.35482
+  dps: 7710.21237
+  tps: 4512.06595
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -46,599 +46,599 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7505.31314
-  tps: 4807.75383
+  dps: 7506.39239
+  tps: 4808.28911
   hps: 369.79592
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7505.31314
-  tps: 4807.75383
+  dps: 7506.39239
+  tps: 4808.28911
   hps: 383.53906
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8020.66105
-  tps: 5078.51022
+  dps: 8022.19954
+  tps: 5079.4617
   hps: 271.50279
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7717.62538
-  tps: 4969.25365
+  dps: 7720.31694
+  tps: 4971.19333
   hps: 267.82092
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7505.32519
-  tps: 18984.45751
+  dps: 7506.40444
+  tps: 18984.9928
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7505.32519
-  tps: 18984.45751
+  dps: 7506.40444
+  tps: 18984.9928
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8042.03369
-  tps: 5098.68715
+  dps: 8043.24477
+  tps: 5099.34603
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7823.2948
-  tps: 4920.49608
+  dps: 7821.62415
+  tps: 4920.72186
   hps: 261.90935
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6577.82217
-  tps: 4195.36396
+  dps: 6579.87747
+  tps: 4197.44003
   hps: 237.29211
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6407.36635
-  tps: 4107.96734
+  dps: 6403.77012
+  tps: 4104.5235
   hps: 226.26186
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6195.2753
-  tps: 3932.89776
+  dps: 6195.6523
+  tps: 3934.60833
   hps: 223.72126
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8020.66105
-  tps: 4976.94002
+  dps: 8022.19954
+  tps: 4977.87247
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8110.96698
-  tps: 5164.5555
+  dps: 8112.23807
+  tps: 5165.25391
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 364.3839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7602.6622
-  tps: 4901.34853
+  dps: 7603.53112
+  tps: 4901.6839
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7669.60998
-  tps: 4935.98528
+  dps: 7669.31073
+  tps: 4938.14212
   hps: 269.08872
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7853.14312
-  tps: 4989.22306
+  dps: 7854.33578
+  tps: 4989.89922
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7644.76101
-  tps: 4898.66604
+  dps: 7644.59365
+  tps: 4899.25255
   hps: 277.98614
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 6725.70819
-  tps: 4276.75102
+  dps: 6728.30315
+  tps: 4279.12447
   hps: 295.31913
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8346.42819
-  tps: 5319.08266
+  dps: 8347.60309
+  tps: 5319.74695
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7583.93707
-  tps: 4884.26034
+  dps: 7584.51727
+  tps: 4884.29836
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7851.70937
-  tps: 5146.67731
+  dps: 7850.95245
+  tps: 5145.55048
   hps: 270.35651
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7874.74363
-  tps: 5189.95179
+  dps: 7873.66892
+  tps: 5189.25999
   hps: 270.35651
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8045.53666
-  tps: 5102.27825
+  dps: 8046.74774
+  tps: 5102.93712
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7743.12029
-  tps: 4909.73492
+  dps: 7742.08849
+  tps: 4909.70278
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7714.68696
-  tps: 4892.60488
+  dps: 7714.73412
+  tps: 4892.99976
   hps: 268.45482
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8020.66105
-  tps: 5078.51022
+  dps: 8022.19954
+  tps: 5079.4617
   hps: 271.50279
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8020.66105
-  tps: 5078.51022
+  dps: 8022.19954
+  tps: 5079.4617
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8042.03369
-  tps: 5098.68715
+  dps: 8043.24477
+  tps: 5099.34603
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8038.23762
-  tps: 5094.89644
+  dps: 8039.41168
+  tps: 5095.55637
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7673.37814
-  tps: 4840.80605
+  dps: 7671.18896
+  tps: 4840.5481
   hps: 266.87008
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 282.3728
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8020.66105
-  tps: 5078.51022
+  dps: 8022.19954
+  tps: 5079.4617
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7670.29378
-  tps: 4950.34175
+  dps: 7669.24873
+  tps: 4949.23721
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7589.19936
-  tps: 4889.85732
+  dps: 7590.06828
+  tps: 4890.1927
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7571.49907
-  tps: 4873.44714
+  dps: 7572.56357
+  tps: 4873.93897
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8020.66105
-  tps: 5078.51022
+  dps: 8022.19954
+  tps: 5079.4617
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8020.66105
-  tps: 5078.51022
+  dps: 8022.19954
+  tps: 5079.4617
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 8114.24437
-  tps: 5163.50978
+  dps: 8115.47968
+  tps: 5164.21201
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7769.91387
-  tps: 5019.57213
+  dps: 7771.02833
+  tps: 5020.13251
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7634.01907
-  tps: 4912.03787
+  dps: 7634.50113
+  tps: 4912.0869
   hps: 266.87008
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 8062.34237
-  tps: 5122.8442
+  dps: 8063.55135
+  tps: 5123.52437
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8042.03369
-  tps: 5098.68715
+  dps: 8043.24477
+  tps: 5099.34603
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8038.23762
-  tps: 5094.89644
+  dps: 8039.41168
+  tps: 5095.55637
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7671.6996
-  tps: 4944.29114
+  dps: 7672.85342
+  tps: 4944.88197
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8020.66105
-  tps: 5078.51022
+  dps: 8022.19954
+  tps: 5079.4617
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8055.42961
-  tps: 5106.33368
+  dps: 8056.97496
+  tps: 5107.29035
   hps: 279.33797
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7590.48746
-  tps: 4900.73927
+  dps: 7591.42754
+  tps: 4901.09781
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8048.71428
-  tps: 5100.95834
+  dps: 8050.25833
+  tps: 5101.91402
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8055.31504
-  tps: 5106.24024
+  dps: 8056.86039
+  tps: 5107.19692
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8020.66105
-  tps: 5078.51022
+  dps: 8022.19954
+  tps: 5079.4617
   hps: 270.57473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8020.66105
-  tps: 5078.51022
+  dps: 8022.19954
+  tps: 5079.4617
   hps: 271.50279
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7556.82025
-  tps: 4849.37352
+  dps: 7557.5525
+  tps: 4849.82491
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7566.5205
-  tps: 4857.44098
+  dps: 7567.25275
+  tps: 4857.89236
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8097.20937
-  tps: 5150.23887
+  dps: 8098.44122
+  tps: 5150.9384
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 8134.11853
-  tps: 5178.99251
+  dps: 8135.35789
+  tps: 5179.69789
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8020.66105
-  tps: 5078.51022
+  dps: 8022.19954
+  tps: 5079.4617
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 8056.64789
-  tps: 5118.43482
+  dps: 8057.8575
+  tps: 5119.11565
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7286.46222
+  dps: 7286.12342
   tps: 4642.50889
   hps: 255.57548
  }
@@ -646,159 +646,159 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6679.013
-  tps: 4230.98203
+  dps: 6678.71536
+  tps: 4231.66706
   hps: 270.45218
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8073.15383
-  tps: 5348.53855
+  dps: 8073.95239
+  tps: 5349.62309
   hps: 296.11903
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7288.53613
-  tps: 4765.78356
+  dps: 7288.07244
+  tps: 4764.45356
   hps: 314.01692
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8097.20937
-  tps: 5150.23887
+  dps: 8098.44122
+  tps: 5150.9384
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 8012.03438
-  tps: 5083.88432
+  dps: 8013.2489
+  tps: 5084.57035
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 8022.50889
-  tps: 5094.15918
+  dps: 8023.54293
+  tps: 5094.66473
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 8012.03438
-  tps: 5083.88432
+  dps: 8013.2489
+  tps: 5084.57035
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8012.03438
-  tps: 5083.88432
+  dps: 8013.2489
+  tps: 5084.57035
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 8012.03438
-  tps: 5083.88432
+  dps: 8013.2489
+  tps: 5084.57035
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 8012.03438
-  tps: 5083.88432
+  dps: 8013.2489
+  tps: 5084.57035
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 8012.03438
-  tps: 5083.88432
+  dps: 8013.2489
+  tps: 5084.57035
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 300.3839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7592.61828
-  tps: 4893.03672
+  dps: 7593.48719
+  tps: 4893.3721
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofHope-45703"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 7628.71416
-  tps: 4859.20902
+  dps: 7627.59161
+  tps: 4857.76693
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7749.76654
+  dps: 7749.78503
   tps: 4935.24376
   hps: 269.08872
  }
@@ -806,95 +806,95 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-StormshroudArmor"
  value: {
-  dps: 6104.28251
-  tps: 3907.65544
+  dps: 6105.41612
+  tps: 3910.41657
   hps: 208.30139
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8055.31504
-  tps: 5106.24024
+  dps: 8056.86039
+  tps: 5107.19692
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8048.71428
-  tps: 5100.95834
+  dps: 8050.25833
+  tps: 5101.91402
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8037.16295
-  tps: 5091.715
+  dps: 8038.70471
+  tps: 5092.66895
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7834.74504
-  tps: 5080.11854
+  dps: 7834.74561
+  tps: 5080.5092
   hps: 277.1388
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6770.67521
-  tps: 4269.72041
+  dps: 6770.35818
+  tps: 4269.83951
   hps: 289.64373
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7462.06759
-  tps: 4684.81328
+  dps: 7462.06526
+  tps: 4684.14122
   hps: 254.05709
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8137.6039
-  tps: 5122.32301
+  dps: 8137.31102
+  tps: 5121.95361
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7681.99623
+  dps: 7682.04347
   tps: 4942.98552
   hps: 267.82092
  }
@@ -902,7 +902,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7684.18335
+  dps: 7684.05207
   tps: 4946.31898
   hps: 266.23619
  }
@@ -910,111 +910,111 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8020.66105
-  tps: 5078.51022
+  dps: 8022.19954
+  tps: 5079.4617
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8020.66105
-  tps: 5078.51022
+  dps: 8022.19954
+  tps: 5079.4617
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7603.43981
-  tps: 4821.37753
+  dps: 7604.01152
+  tps: 4821.03545
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8020.66105
-  tps: 5078.51022
+  dps: 8022.19954
+  tps: 5079.4617
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8020.66105
-  tps: 5078.51022
+  dps: 8022.19954
+  tps: 5079.4617
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6461.37425
-  tps: 4159.22928
+  dps: 6461.01708
+  tps: 4158.00957
   hps: 231.7262
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7822.13043
-  tps: 4932.53954
+  dps: 7824.17365
+  tps: 4934.90361
   hps: 270.61481
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7505.22877
-  tps: 4807.68591
+  dps: 7506.30803
+  tps: 4808.2212
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 8156.83186
-  tps: 5196.68705
+  dps: 8158.07584
+  tps: 5197.39604
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 8109.82711
-  tps: 5159.97387
+  dps: 8109.74167
+  tps: 5159.91725
   hps: 267.47585
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 34864.30262
-  tps: 37322.64979
+  dps: 34865.13959
+  tps: 37322.09347
   hps: 267.34875
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7922.2478
-  tps: 5126.92075
+  dps: 7921.60617
+  tps: 5126.97626
   hps: 266.71522
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11407.93221
-  tps: 5607.11113
+  dps: 11400.21517
+  tps: 5599.47846
   hps: 231.23766
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 20910.7413
+  dps: 20910.55074
   tps: 23044.88485
   hps: 159.66536
  }
@@ -1022,47 +1022,47 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3895.17982
-  tps: 2773.63947
+  dps: 3894.32804
+  tps: 2773.18053
   hps: 158.70928
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4984.11207
-  tps: 2820.92885
+  dps: 4983.33755
+  tps: 2820.30088
   hps: 131.93904
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 35415.96393
-  tps: 37796.68648
+  dps: 35416.39533
+  tps: 37795.97727
   hps: 265.60229
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8097.20937
-  tps: 5150.23887
+  dps: 8098.44122
+  tps: 5150.9384
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11800.16286
-  tps: 5660.95524
+  dps: 11793.26459
+  tps: 5654.04825
   hps: 231.37192
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 21050.75355
+  dps: 21050.59852
   tps: 23101.07676
   hps: 159.40954
  }
@@ -1070,24 +1070,24 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3985.48769
-  tps: 2795.98318
+  dps: 3985.02426
+  tps: 2795.85475
   hps: 159.02681
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5153.74342
-  tps: 2853.88592
+  dps: 5152.95644
+  tps: 2853.25762
   hps: 132.04392
  }
 }
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7762.51774
-  tps: 4982.0427
+  dps: 7760.07281
+  tps: 4977.64846
   hps: 263.7006
  }
 }

--- a/sim/warlock/TestAffliction.results
+++ b/sim/warlock/TestAffliction.results
@@ -46,302 +46,302 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 7381.80071
-  tps: 6655.79116
+  dps: 7387.6182
+  tps: 6663.03877
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7207.33419
-  tps: 6476.69537
+  dps: 7210.66149
+  tps: 6479.76505
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7223.2473
-  tps: 6492.60848
+  dps: 7226.62322
+  tps: 6495.72677
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7244.99854
-  tps: 6511.512
+  dps: 7242.11884
+  tps: 6507.94426
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7328.86779
-  tps: 6598.22897
+  dps: 7332.3362
+  tps: 6601.43975
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 7641.31676
-  tps: 6888.93029
+  dps: 7640.14662
+  tps: 6887.8101
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DeathbringerGarb"
  value: {
-  dps: 7066.78294
-  tps: 6347.54106
+  dps: 7062.46639
+  tps: 6342.20039
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7225.34059
-  tps: 6494.70178
+  dps: 7228.74069
+  tps: 6497.84424
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7207.33419
-  tps: 6476.69537
+  dps: 7210.66149
+  tps: 6479.76505
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7244.99854
-  tps: 6511.512
+  dps: 7242.11884
+  tps: 6507.94426
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7223.2473
-  tps: 6492.60848
+  dps: 7226.62322
+  tps: 6495.72677
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7217.71146
-  tps: 6487.07264
+  dps: 7221.05207
+  tps: 6490.15562
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7207.33419
-  tps: 6476.69537
+  dps: 7210.66149
+  tps: 6479.76505
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7244.99854
-  tps: 6511.512
+  dps: 7242.11884
+  tps: 6507.94426
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7237.5598
-  tps: 6505.15118
+  dps: 7239.94308
+  tps: 6506.43768
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 7072.49322
-  tps: 6374.27807
+  dps: 7077.14383
+  tps: 6378.74
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 7009.89108
-  tps: 6227.84673
+  dps: 7007.23929
+  tps: 6225.47054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7223.2473
-  tps: 6492.60848
+  dps: 7226.62322
+  tps: 6495.72677
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7217.71146
-  tps: 6487.07264
+  dps: 7221.05207
+  tps: 6490.15562
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7208.10836
-  tps: 6474.56808
+  dps: 7210.05585
+  tps: 6476.50163
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7207.33419
-  tps: 6476.69537
+  dps: 7210.66149
+  tps: 6479.76505
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MaleficRaiment"
  value: {
-  dps: 5393.52926
-  tps: 4757.06124
+  dps: 5394.39165
+  tps: 4758.12125
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7207.33419
-  tps: 6476.69537
+  dps: 7210.66149
+  tps: 6479.76505
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7207.33419
-  tps: 6476.69537
+  dps: 7210.66149
+  tps: 6479.76505
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PlagueheartGarb"
  value: {
-  dps: 6658.05294
-  tps: 5967.77292
+  dps: 6665.19599
+  tps: 5975.66334
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7207.33419
-  tps: 6476.69537
+  dps: 7210.66149
+  tps: 6479.76505
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7207.33419
-  tps: 6476.69537
+  dps: 7210.66149
+  tps: 6479.76505
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7311.5225
-  tps: 6580.88368
+  dps: 7314.93792
+  tps: 6584.04147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7194.96905
-  tps: 6460.55273
+  dps: 7200.84556
+  tps: 6466.91958
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7207.33419
-  tps: 6476.69537
+  dps: 7210.66149
+  tps: 6479.76505
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7207.33419
-  tps: 6476.69537
+  dps: 7210.66149
+  tps: 6479.76505
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7207.33419
-  tps: 6476.69537
+  dps: 7210.66149
+  tps: 6479.76505
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7207.33419
-  tps: 6476.69537
+  dps: 7210.66149
+  tps: 6479.76505
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7244.99854
-  tps: 6511.512
+  dps: 7242.11884
+  tps: 6507.94426
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7237.5598
-  tps: 6505.15118
+  dps: 7239.94308
+  tps: 6506.43768
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7237.5598
-  tps: 6505.15118
+  dps: 7239.94308
+  tps: 6506.43768
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7244.99854
-  tps: 6511.512
+  dps: 7242.11884
+  tps: 6507.94426
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 7417.14498
-  tps: 6682.0311
+  dps: 7417.9626
+  tps: 6682.88897
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7346.80206
-  tps: 8484.92928
+  dps: 7355.20168
+  tps: 8492.17681
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7346.80206
-  tps: 6614.54659
+  dps: 7355.20168
+  tps: 6622.3349
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7836.96583
-  tps: 7053.51355
+  dps: 7846.25662
+  tps: 7062.80433
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4307.09988
-  tps: 6190.46114
+  dps: 4307.48501
+  tps: 6195.82608
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4307.09988
-  tps: 4059.66776
+  dps: 4307.48501
+  tps: 4060.00148
  }
 }
 dps_results: {
@@ -354,7 +354,7 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7292.49374
-  tps: 6598.22897
+  dps: 7295.94737
+  tps: 6601.43975
  }
 }

--- a/sim/warlock/TestAffliction.results
+++ b/sim/warlock/TestAffliction.results
@@ -46,315 +46,315 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 7388.73649
-  tps: 6663.55034
+  dps: 7381.80071
+  tps: 6655.79116
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7203.22993
-  tps: 6470.07298
+  dps: 7207.33419
+  tps: 6476.69537
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7218.76765
-  tps: 6485.6107
+  dps: 7223.2473
+  tps: 6492.60848
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7248.14967
-  tps: 6512.73639
+  dps: 7244.99854
+  tps: 6511.512
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7323.80331
-  tps: 6590.64636
+  dps: 7328.86779
+  tps: 6598.22897
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 7643.67315
-  tps: 6890.45042
+  dps: 7641.31676
+  tps: 6888.93029
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DeathbringerGarb"
  value: {
-  dps: 7060.50803
-  tps: 6342.24285
+  dps: 7066.78294
+  tps: 6347.54106
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7220.96656
-  tps: 6487.80961
+  dps: 7225.34059
+  tps: 6494.70178
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7203.22993
-  tps: 6470.07298
+  dps: 7207.33419
+  tps: 6476.69537
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7248.14967
-  tps: 6512.73639
+  dps: 7244.99854
+  tps: 6511.512
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7218.76765
-  tps: 6485.6107
+  dps: 7223.2473
+  tps: 6492.60848
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7214.02631
-  tps: 6480.86936
+  dps: 7217.71146
+  tps: 6487.07264
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7203.22993
-  tps: 6470.07298
+  dps: 7207.33419
+  tps: 6476.69537
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7248.14967
-  tps: 6512.73639
+  dps: 7244.99854
+  tps: 6511.512
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7239.9529
-  tps: 6504.99337
+  dps: 7237.5598
+  tps: 6505.15118
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 7064.34676
-  tps: 6364.36139
+  dps: 7072.49322
+  tps: 6374.27807
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 6995.37104
-  tps: 6213.78278
+  dps: 7009.89108
+  tps: 6227.84673
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7218.76765
-  tps: 6485.6107
+  dps: 7223.2473
+  tps: 6492.60848
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7214.02631
-  tps: 6480.86936
+  dps: 7217.71146
+  tps: 6487.07264
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7210.28978
-  tps: 6475.34524
+  dps: 7208.10836
+  tps: 6474.56808
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7203.22993
-  tps: 6470.07298
+  dps: 7207.33419
+  tps: 6476.69537
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MaleficRaiment"
  value: {
-  dps: 5386.9016
-  tps: 4751.36616
+  dps: 5393.52926
+  tps: 4757.06124
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7203.22993
-  tps: 6470.07298
+  dps: 7207.33419
+  tps: 6476.69537
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7203.22993
-  tps: 6470.07298
+  dps: 7207.33419
+  tps: 6476.69537
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PlagueheartGarb"
  value: {
-  dps: 6654.80459
-  tps: 5965.17575
+  dps: 6658.05294
+  tps: 5967.77292
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7203.22993
-  tps: 6470.07298
+  dps: 7207.33419
+  tps: 6476.69537
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7203.22993
-  tps: 6470.07298
+  dps: 7207.33419
+  tps: 6476.69537
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7306.86719
-  tps: 6573.71024
+  dps: 7311.5225
+  tps: 6580.88368
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7195.71104
-  tps: 6460.23712
+  dps: 7194.96905
+  tps: 6460.55273
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7203.22993
-  tps: 6470.07298
+  dps: 7207.33419
+  tps: 6476.69537
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7203.22993
-  tps: 6470.07298
+  dps: 7207.33419
+  tps: 6476.69537
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7203.22993
-  tps: 6470.07298
+  dps: 7207.33419
+  tps: 6476.69537
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7203.22993
-  tps: 6470.07298
+  dps: 7207.33419
+  tps: 6476.69537
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7248.14967
-  tps: 6512.73639
+  dps: 7244.99854
+  tps: 6511.512
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7239.9529
-  tps: 6504.99337
+  dps: 7237.5598
+  tps: 6505.15118
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7239.9529
-  tps: 6504.99337
+  dps: 7237.5598
+  tps: 6505.15118
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7248.14967
-  tps: 6512.73639
+  dps: 7244.99854
+  tps: 6511.512
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 7416.21738
-  tps: 6681.23304
+  dps: 7417.14498
+  tps: 6682.0311
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7359.43512
-  tps: 8496.11147
+  dps: 7346.80206
+  tps: 8484.92928
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7359.43512
-  tps: 6626.96527
+  dps: 7346.80206
+  tps: 6614.54659
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7831.76249
-  tps: 7049.36064
+  dps: 7836.96583
+  tps: 7053.51355
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4307.90878
-  tps: 6191.60845
+  dps: 4307.09988
+  tps: 6190.46114
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4307.90878
-  tps: 4060.8
+  dps: 4307.09988
+  tps: 4059.66776
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4137.01217
-  tps: 3797.65141
+  dps: 4138.8881
+  tps: 3798.84956
  }
 }
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7287.4541
-  tps: 6590.64636
+  dps: 7292.49374
+  tps: 6598.22897
  }
 }

--- a/sim/warlock/TestDemonology.results
+++ b/sim/warlock/TestDemonology.results
@@ -46,36 +46,36 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 7410.18442
-  tps: 6168.80801
+  dps: 7432.41727
+  tps: 6189.33659
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7323.84039
-  tps: 6087.19354
+  dps: 7324.3886
+  tps: 6087.50872
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7337.17186
-  tps: 6101.16341
+  dps: 7337.72007
+  tps: 6101.47859
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7359.74289
-  tps: 6118.74714
+  dps: 7360.29109
+  tps: 6119.0623
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7460.84949
-  tps: 6224.84104
+  dps: 7461.39776
+  tps: 6225.15627
  }
 }
 dps_results: {
@@ -95,57 +95,57 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7337.17186
-  tps: 6101.16341
+  dps: 7337.72007
+  tps: 6101.47859
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7323.84039
-  tps: 6087.19354
+  dps: 7324.3886
+  tps: 6087.50872
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7359.74289
-  tps: 6118.74714
+  dps: 7360.29109
+  tps: 6119.0623
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7337.17186
-  tps: 6101.16341
+  dps: 7337.72007
+  tps: 6101.47859
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7333.83953
-  tps: 6097.83109
+  dps: 7334.38774
+  tps: 6098.14626
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7322.00341
-  tps: 6085.99496
+  dps: 7322.55162
+  tps: 6086.31014
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7359.74289
-  tps: 6118.74714
+  dps: 7360.29109
+  tps: 6119.0623
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7351.91589
-  tps: 6112.1533
+  dps: 7352.4641
+  tps: 6112.46846
  }
 }
 dps_results: {
@@ -165,29 +165,29 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7337.17186
-  tps: 6101.16341
+  dps: 7337.72007
+  tps: 6101.47859
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7333.83953
-  tps: 6097.83109
+  dps: 7334.38774
+  tps: 6098.14626
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7324.77191
-  tps: 6088.23437
+  dps: 7325.32012
+  tps: 6088.54953
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7322.00341
-  tps: 6085.99496
+  dps: 7322.55162
+  tps: 6086.31014
  }
 }
 dps_results: {
@@ -200,161 +200,161 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7322.00341
-  tps: 6085.99496
+  dps: 7322.55162
+  tps: 6086.31014
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7322.00341
-  tps: 6085.99496
+  dps: 7322.55162
+  tps: 6086.31014
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PlagueheartGarb"
  value: {
-  dps: 6729.00114
-  tps: 5551.40809
+  dps: 6729.59141
+  tps: 5551.76004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7322.57193
-  tps: 6086.07486
+  dps: 7323.12014
+  tps: 6086.39003
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7323.84039
-  tps: 6087.19354
+  dps: 7324.3886
+  tps: 6087.50872
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7444.31588
-  tps: 6208.30743
+  dps: 7444.86414
+  tps: 6208.62266
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7317.11494
-  tps: 6080.26228
+  dps: 7317.66313
+  tps: 6080.57743
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7322.00341
-  tps: 6085.99496
+  dps: 7322.55162
+  tps: 6086.31014
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7322.00341
-  tps: 6085.99496
+  dps: 7322.55162
+  tps: 6086.31014
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7322.00341
-  tps: 6085.99496
+  dps: 7322.55162
+  tps: 6086.31014
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7322.00341
-  tps: 6085.99496
+  dps: 7322.55162
+  tps: 6086.31014
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7359.74289
-  tps: 6118.74714
+  dps: 7360.29109
+  tps: 6119.0623
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7351.91589
-  tps: 6112.1533
+  dps: 7352.4641
+  tps: 6112.46846
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7351.91589
-  tps: 6112.1533
+  dps: 7352.4641
+  tps: 6112.46846
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7359.74289
-  tps: 6118.74714
+  dps: 7360.29109
+  tps: 6119.0623
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 7521.63832
-  tps: 6278.04451
+  dps: 7522.23561
+  tps: 6278.40106
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9502.02157
-  tps: 10272.33483
+  dps: 9503.80428
+  tps: 10273.73476
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7470.10205
-  tps: 6235.40069
+  dps: 7470.65033
+  tps: 6235.71593
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8545.15551
-  tps: 7120.69799
+  dps: 8549.91833
+  tps: 7123.67819
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5960.34203
-  tps: 8039.01555
+  dps: 5960.83575
+  tps: 8039.19912
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4192.63047
-  tps: 3834.22845
+  dps: 4192.73371
+  tps: 3834.26587
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4398.0346
-  tps: 3959.39544
+  dps: 4399.09585
+  tps: 3959.84409
  }
 }
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7338.21363
-  tps: 6225.56335
+  dps: 7338.75302
+  tps: 6225.88474
  }
 }

--- a/sim/warlock/TestDemonology.results
+++ b/sim/warlock/TestDemonology.results
@@ -46,36 +46,36 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 7432.41727
-  tps: 6189.33659
+  dps: 7433.60297
+  tps: 6190.52229
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7324.3886
-  tps: 6087.50872
+  dps: 7325.58315
+  tps: 6088.70327
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7337.72007
-  tps: 6101.47859
+  dps: 7338.91463
+  tps: 6102.67314
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7360.29109
-  tps: 6119.0623
+  dps: 7361.48565
+  tps: 6120.25686
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7461.39776
-  tps: 6225.15627
+  dps: 7462.62787
+  tps: 6226.38639
  }
 }
 dps_results: {
@@ -95,57 +95,57 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7337.72007
-  tps: 6101.47859
+  dps: 7338.91463
+  tps: 6102.67314
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7324.3886
-  tps: 6087.50872
+  dps: 7325.58315
+  tps: 6088.70327
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7360.29109
-  tps: 6119.0623
+  dps: 7361.48565
+  tps: 6120.25686
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7337.72007
-  tps: 6101.47859
+  dps: 7338.91463
+  tps: 6102.67314
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7334.38774
-  tps: 6098.14626
+  dps: 7335.5823
+  tps: 6099.34081
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7322.55162
-  tps: 6086.31014
+  dps: 7323.74617
+  tps: 6087.50469
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7360.29109
-  tps: 6119.0623
+  dps: 7361.48565
+  tps: 6120.25686
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7352.4641
-  tps: 6112.46846
+  dps: 7353.65865
+  tps: 6113.66301
  }
 }
 dps_results: {
@@ -165,29 +165,29 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7337.72007
-  tps: 6101.47859
+  dps: 7338.91463
+  tps: 6102.67314
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7334.38774
-  tps: 6098.14626
+  dps: 7335.5823
+  tps: 6099.34081
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7325.32012
-  tps: 6088.54953
+  dps: 7326.51467
+  tps: 6089.74409
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7322.55162
-  tps: 6086.31014
+  dps: 7323.74617
+  tps: 6087.50469
  }
 }
 dps_results: {
@@ -200,161 +200,161 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7322.55162
-  tps: 6086.31014
+  dps: 7323.74617
+  tps: 6087.50469
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7322.55162
-  tps: 6086.31014
+  dps: 7323.74617
+  tps: 6087.50469
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PlagueheartGarb"
  value: {
-  dps: 6729.59141
-  tps: 5551.76004
+  dps: 6730.74155
+  tps: 5552.91018
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7323.12014
-  tps: 6086.39003
+  dps: 7324.3147
+  tps: 6087.58458
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7324.3886
-  tps: 6087.50872
+  dps: 7325.58315
+  tps: 6088.70327
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7444.86414
-  tps: 6208.62266
+  dps: 7446.09426
+  tps: 6209.85277
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7317.66313
-  tps: 6080.57743
+  dps: 7318.85768
+  tps: 6081.77199
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7322.55162
-  tps: 6086.31014
+  dps: 7323.74617
+  tps: 6087.50469
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7322.55162
-  tps: 6086.31014
+  dps: 7323.74617
+  tps: 6087.50469
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7322.55162
-  tps: 6086.31014
+  dps: 7323.74617
+  tps: 6087.50469
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7322.55162
-  tps: 6086.31014
+  dps: 7323.74617
+  tps: 6087.50469
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7360.29109
-  tps: 6119.0623
+  dps: 7361.48565
+  tps: 6120.25686
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7352.4641
-  tps: 6112.46846
+  dps: 7353.65865
+  tps: 6113.66301
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7352.4641
-  tps: 6112.46846
+  dps: 7353.65865
+  tps: 6113.66301
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7360.29109
-  tps: 6119.0623
+  dps: 7361.48565
+  tps: 6120.25686
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 7522.23561
-  tps: 6278.40106
+  dps: 7523.42834
+  tps: 6279.5938
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9503.80428
-  tps: 10273.73476
+  dps: 9506.01342
+  tps: 10275.9439
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7470.65033
-  tps: 6235.71593
+  dps: 7471.88044
+  tps: 6236.94605
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8549.91833
-  tps: 7123.67819
+  dps: 8558.44047
+  tps: 7131.66749
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5960.83575
-  tps: 8039.19912
+  dps: 5961.51659
+  tps: 8039.79836
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4192.73371
-  tps: 3834.26587
+  dps: 4193.07101
+  tps: 3834.54183
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4399.09585
-  tps: 3959.84409
+  dps: 4401.53562
+  tps: 3961.95453
  }
 }
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7338.75302
-  tps: 6225.88474
+  dps: 7339.98313
+  tps: 6227.11485
  }
 }

--- a/sim/warlock/TestDestruction.results
+++ b/sim/warlock/TestDestruction.results
@@ -46,315 +46,315 @@ character_stats_results: {
 dps_results: {
  key: "TestDestruction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 6749.62934
-  tps: 5626.68945
+  dps: 6769.09333
+  tps: 5647.53243
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6735.94111
-  tps: 5593.05547
+  dps: 6747.94118
+  tps: 5601.68362
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6753.3374
-  tps: 5608.74526
+  dps: 6766.39737
+  tps: 5618.32566
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6774.78245
-  tps: 5625.69744
+  dps: 6786.73598
+  tps: 5634.5142
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6922.09691
-  tps: 5760.62881
+  dps: 6935.99545
+  tps: 5770.96394
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 7103.24124
-  tps: 5889.88547
+  dps: 7109.22351
+  tps: 5894.52773
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DeathbringerGarb"
  value: {
-  dps: 6599.20224
-  tps: 5483.92186
+  dps: 6602.54015
+  tps: 5486.30015
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6757.67893
-  tps: 5612.65263
+  dps: 6769.50736
+  tps: 5621.12466
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6735.94111
-  tps: 5593.05547
+  dps: 6747.94118
+  tps: 5601.68362
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6774.78245
-  tps: 5625.69744
+  dps: 6786.73598
+  tps: 5634.5142
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6753.3374
-  tps: 5608.74526
+  dps: 6766.39737
+  tps: 5618.32566
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6749.9079
-  tps: 5605.65871
+  dps: 6763.09343
+  tps: 5615.35212
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6735.94111
-  tps: 5593.05547
+  dps: 6747.94118
+  tps: 5601.68362
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6774.78245
-  tps: 5625.69744
+  dps: 6786.73598
+  tps: 5634.5142
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6768.18789
-  tps: 5620.14365
+  dps: 6779.15101
+  tps: 5628.04971
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 6556.53507
-  tps: 5455.24925
+  dps: 6566.74366
+  tps: 5467.10281
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 6631.27281
-  tps: 5457.81223
+  dps: 6608.95157
+  tps: 5449.84932
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6753.3374
-  tps: 5608.74526
+  dps: 6766.39737
+  tps: 5618.32566
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6749.9079
-  tps: 5605.65871
+  dps: 6763.09343
+  tps: 5615.35212
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6770.86035
-  tps: 5621.35058
+  dps: 6762.55342
+  tps: 5609.0392
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6735.94111
-  tps: 5593.05547
+  dps: 6747.94118
+  tps: 5601.68362
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MaleficRaiment"
  value: {
-  dps: 5171.77675
-  tps: 4299.46206
+  dps: 5151.35519
+  tps: 4279.3337
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6735.94111
-  tps: 5593.05547
+  dps: 6747.94118
+  tps: 5601.68362
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6735.94111
-  tps: 5593.05547
+  dps: 6747.94118
+  tps: 5601.68362
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PlagueheartGarb"
  value: {
-  dps: 6184.50294
-  tps: 5142.61975
+  dps: 6178.41051
+  tps: 5135.23277
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6735.94111
-  tps: 5593.05547
+  dps: 6747.94118
+  tps: 5601.68362
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6735.94111
-  tps: 5593.05547
+  dps: 6747.94118
+  tps: 5601.68362
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6903.21281
-  tps: 5743.59999
+  dps: 6915.96028
+  tps: 5752.90081
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6741.26608
-  tps: 5596.44474
+  dps: 6744.34093
+  tps: 5596.68593
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6735.94111
-  tps: 5593.05547
+  dps: 6747.94118
+  tps: 5601.68362
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6735.94111
-  tps: 5593.05547
+  dps: 6747.94118
+  tps: 5601.68362
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6735.94111
-  tps: 5593.05547
+  dps: 6747.94118
+  tps: 5601.68362
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6735.94111
-  tps: 5593.05547
+  dps: 6747.94118
+  tps: 5601.68362
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6774.78245
-  tps: 5625.69744
+  dps: 6786.73598
+  tps: 5634.5142
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6768.18789
-  tps: 5620.14365
+  dps: 6779.15101
+  tps: 5628.04971
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6768.18789
-  tps: 5620.14365
+  dps: 6779.15101
+  tps: 5628.04971
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6774.78245
-  tps: 5625.69744
+  dps: 6786.73598
+  tps: 5634.5142
  }
 }
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 7015.42761
-  tps: 5843.12765
+  dps: 7008.57731
+  tps: 5836.73468
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P1-Destruction Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6929.36706
-  tps: 7885.33311
+  dps: 6955.00358
+  tps: 7904.49782
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P1-Destruction Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6929.36706
-  tps: 5766.43764
+  dps: 6955.00358
+  tps: 5790.28416
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P1-Destruction Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8007.20382
-  tps: 6610.37644
+  dps: 8018.99122
+  tps: 6620.15015
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P1-Destruction Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3684.2011
-  tps: 5425.97565
+  dps: 3677.10794
+  tps: 5422.13545
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P1-Destruction Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3684.2011
-  tps: 3287.18262
+  dps: 3677.10794
+  tps: 3282.35864
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P1-Destruction Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4008.88269
-  tps: 3347.8294
+  dps: 4014.68436
+  tps: 3353.06727
  }
 }
 dps_results: {
  key: "TestDestruction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6922.09691
-  tps: 5760.62881
+  dps: 6935.99545
+  tps: 5770.96394
  }
 }

--- a/sim/warlock/TestDestruction.results
+++ b/sim/warlock/TestDestruction.results
@@ -46,8 +46,8 @@ character_stats_results: {
 dps_results: {
  key: "TestDestruction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 6769.09333
-  tps: 5647.53243
+  dps: 6765.44717
+  tps: 5644.30285
  }
 }
 dps_results: {
@@ -81,8 +81,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 7109.22351
-  tps: 5894.52773
+  dps: 7114.41215
+  tps: 5900.50419
  }
 }
 dps_results: {
@@ -151,8 +151,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 6566.74366
-  tps: 5467.10281
+  dps: 6568.63665
+  tps: 5468.74853
  }
 }
 dps_results: {
@@ -193,8 +193,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-MaleficRaiment"
  value: {
-  dps: 5151.35519
-  tps: 4279.3337
+  dps: 5146.78315
+  tps: 4274.46337
  }
 }
 dps_results: {
@@ -214,8 +214,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-PlagueheartGarb"
  value: {
-  dps: 6178.41051
-  tps: 5135.23277
+  dps: 6179.86979
+  tps: 5136.43778
  }
 }
 dps_results: {
@@ -305,8 +305,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 7008.57731
-  tps: 5836.73468
+  dps: 7008.0959
+  tps: 5836.19692
  }
 }
 dps_results: {
@@ -333,15 +333,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Settings-Orc-P1-Destruction Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3677.10794
-  tps: 5422.13545
+  dps: 3677.74443
+  tps: 5423.60177
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P1-Destruction Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3677.10794
-  tps: 3282.35864
+  dps: 3677.74443
+  tps: 3283.15915
  }
 }
 dps_results: {

--- a/sim/warlock/warlock.go
+++ b/sim/warlock/warlock.go
@@ -148,7 +148,7 @@ func (warlock *Warlock) Initialize() {
 			precastSpell.Cast(sim, warlock.CurrentTarget)
 		})
 		if warlock.GlyphOfLifeTapAura != nil || warlock.SpiritsoftheDamnedAura != nil {
-			warlock.RegisterPrepullAction(precastSpellAt-core.GCDDefault, func(sim *core.Simulation) {
+			warlock.RegisterPrepullAction(precastSpellAt-warlock.SpellGCD(), func(sim *core.Simulation) {
 				warlock.LifeTap.Cast(sim, nil)
 			})
 		}


### PR DESCRIPTION
Previously AotD ghouls would only be spawned after 0s since PendingActions were only run after the clock was set to 0. This change runs pending actions in the pre-pull steps as well to ensure pre-pull actions that spawn pending actions are correctly called