### PR TITLE
Added Pandora's Plea to snapshot manager for Shaman

### DIFF
--- a/sim/shaman/shaman.go
+++ b/sim/shaman/shaman.go
@@ -300,6 +300,7 @@ func (shaman *Shaman) setupProcTrackers() {
 	snapshotManager.AddProc(54572, "Charred Twilight Scale Proc", false)
 	snapshotManager.AddProc(54588, "Charred Twilight Scale H Proc", false)
 	snapshotManager.AddProc(47213, "Abyssal Rune Proc", false)
+	snapshotManager.AddProc(45490, "Pandora's Plea Proc", false)
 
 	//AP Trinket Procs
 	snapshotManager.AddProc(40684, "Mirror of Truth Proc", false)


### PR DESCRIPTION
Added Pandora's Plea to snapshot manager for Shaman

- Shaman sims were not waiting for Pandora's Plea to proc before popping Fire Elemental Totem
<img width="1390" alt="Screen Shot 2023-02-23 at 1 14 04 PM" src="https://user-images.githubusercontent.com/13421923/220994905-66b5432f-3847-41a8-b995-c9c8563d7ebc.png">
