### PR TITLE
Subtlety rotation improvements, plus related fixes

### DIFF
--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -46,877 +46,877 @@ character_stats_results: {
 dps_results: {
  key: "TestMM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 7626.26794
-  tps: 6725.49161
+  dps: 7673.84938
+  tps: 6773.3213
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 6997.13124
-  tps: 6075.9563
+  dps: 7013.69995
+  tps: 6093.5854
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7039.78033
-  tps: 6108.95916
+  dps: 7066.47956
+  tps: 6141.73611
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7121.39356
-  tps: 6194.23205
+  dps: 7132.49577
+  tps: 6206.07493
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6944.2288
-  tps: 15324.71967
+  dps: 6962.65117
+  tps: 15385.91878
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6944.2288
-  tps: 15324.71967
+  dps: 6962.65117
+  tps: 15385.91878
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7055.49833
-  tps: 6125.67828
+  dps: 7091.21392
+  tps: 6166.13217
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6989.11999
-  tps: 6075.87625
+  dps: 7031.5161
+  tps: 6113.44186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 6603.47618
-  tps: 5686.12553
+  dps: 6559.94015
+  tps: 5652.14425
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6071.12737
-  tps: 5274.72946
+  dps: 6095.52421
+  tps: 5294.83011
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5817.6836
-  tps: 5036.24268
+  dps: 5889.96292
+  tps: 5104.14948
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7039.78033
-  tps: 5987.91669
+  dps: 7066.47956
+  tps: 6020.04306
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7427.83852
-  tps: 6496.37585
+  dps: 7453.43712
+  tps: 6527.44078
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7439.53775
-  tps: 6507.84365
+  dps: 7469.44808
+  tps: 6543.343
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7201.97511
-  tps: 6272.2182
+  dps: 7238.93227
+  tps: 6313.93962
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
   hps: 64
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 6579.80556
-  tps: 5681.7886
+  dps: 6630.88576
+  tps: 5729.36887
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7063.21344
-  tps: 6143.30986
+  dps: 7074.74363
+  tps: 6159.94182
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7113.63957
-  tps: 6193.72915
+  dps: 7120.75752
+  tps: 6204.63732
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7146.21632
-  tps: 6216.87572
+  dps: 7186.04328
+  tps: 6260.6369
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7361.63266
-  tps: 6418.2625
+  dps: 7403.24045
+  tps: 6462.76531
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7030.26177
-  tps: 6110.93493
+  dps: 7041.81148
+  tps: 6127.78186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7325.02122
-  tps: 6395.04827
+  dps: 7344.76898
+  tps: 6417.29773
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7371.9331
-  tps: 6440.14929
+  dps: 7397.07935
+  tps: 6469.1357
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7059.38795
-  tps: 6129.639
+  dps: 7093.1065
+  tps: 6168.11384
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7107.71148
-  tps: 6199.87523
+  dps: 7079.4504
+  tps: 6158.82312
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7080.57393
-  tps: 6169.61698
+  dps: 7090.74299
+  tps: 6175.72938
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7039.78033
-  tps: 6108.95916
+  dps: 7066.47956
+  tps: 6141.73611
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7047.37663
-  tps: 6115.77762
+  dps: 7074.39373
+  tps: 6148.88311
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7055.44483
-  tps: 6125.68792
+  dps: 7090.82606
+  tps: 6165.83341
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7057.20838
-  tps: 6126.88508
+  dps: 7086.46327
+  tps: 6161.71582
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7053.06325
-  tps: 6141.58094
+  dps: 7051.28101
+  tps: 6136.54567
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7039.78033
-  tps: 6108.95916
+  dps: 7066.47956
+  tps: 6141.73611
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7118.62916
-  tps: 6198.71006
+  dps: 7126.7469
+  tps: 6211.48391
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7049.09086
-  tps: 6129.21678
+  dps: 7064.38087
+  tps: 6149.15621
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6974.23494
-  tps: 6055.23767
+  dps: 6992.62987
+  tps: 6074.56576
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7019.54971
-  tps: 6099.91885
+  dps: 7039.44832
+  tps: 6123.26559
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7039.78033
-  tps: 6108.95916
+  dps: 7066.47956
+  tps: 6141.73611
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7039.78033
-  tps: 6108.95916
+  dps: 7066.47956
+  tps: 6141.73611
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7133.39578
-  tps: 6199.31761
+  dps: 7152.14246
+  tps: 6218.96681
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 7173.35352
-  tps: 6302.2461
+  dps: 7214.3372
+  tps: 6340.04381
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7087.35888
-  tps: 6167.49583
+  dps: 7087.05985
+  tps: 6170.79678
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5473.69762
-  tps: 4706.02625
+  dps: 5502.7033
+  tps: 4734.07122
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-49982"
  value: {
-  dps: 7273.25537
-  tps: 6336.24095
+  dps: 7306.45737
+  tps: 6375.05156
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-50641"
  value: {
-  dps: 7274.49307
-  tps: 6337.36422
+  dps: 7307.70148
+  tps: 6376.18188
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7055.44483
-  tps: 6125.68792
+  dps: 7090.82606
+  tps: 6165.83341
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7057.20838
-  tps: 6126.88508
+  dps: 7086.46327
+  tps: 6161.71582
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7098.48008
-  tps: 6173.75439
+  dps: 7119.1279
+  tps: 6195.29964
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7055.34542
-  tps: 6130.46215
+  dps: 7082.12203
+  tps: 6163.23303
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7065.07634
-  tps: 6131.8818
+  dps: 7089.95732
+  tps: 6162.8635
   hps: 11.22172
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7097.30128
-  tps: 6188.70402
+  dps: 7126.8388
+  tps: 6215.501
  }
 }
 dps_results: {
  key: "TestMM-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7117.16479
-  tps: 6201.17737
+  dps: 7136.73978
+  tps: 6221.83578
  }
 }
 dps_results: {
  key: "TestMM-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7060.32732
-  tps: 6127.55975
+  dps: 7087.11874
+  tps: 6160.44079
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7065.16191
-  tps: 6131.93636
+  dps: 7091.97502
+  tps: 6164.84188
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7039.78033
-  tps: 6108.95916
+  dps: 7066.47956
+  tps: 6141.73611
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7039.78033
-  tps: 6108.95916
+  dps: 7066.47956
+  tps: 6141.73611
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7215.70242
-  tps: 6284.00906
+  dps: 7248.60611
+  tps: 6322.49177
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7040.31939
-  tps: 6109.2083
+  dps: 7067.20431
+  tps: 6142.1459
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 6959.76357
-  tps: 6075.71851
+  dps: 6991.88387
+  tps: 6104.78066
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7453.3054
-  tps: 6520.90211
+  dps: 7484.2837
+  tps: 6558.94318
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6945.06075
-  tps: 6034.01151
+  dps: 6963.36812
+  tps: 6053.14438
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6945.06075
-  tps: 6034.60637
+  dps: 6963.36812
+  tps: 6053.70493
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7055.13643
-  tps: 6135.33011
+  dps: 7065.68646
+  tps: 6150.42639
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SparkofLife-37657"
  value: {
-  dps: 6997.39507
-  tps: 6088.04608
+  dps: 7011.98156
+  tps: 6096.56976
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7041.16059
-  tps: 6115.15369
+  dps: 7060.39076
+  tps: 6135.28365
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StormshroudArmor"
  value: {
-  dps: 5682.49224
-  tps: 4903.20043
+  dps: 5706.82051
+  tps: 4924.49332
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7065.16191
-  tps: 6131.93636
+  dps: 7091.97502
+  tps: 6164.84188
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7060.32732
-  tps: 6127.55975
+  dps: 7087.11874
+  tps: 6160.44079
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7051.8668
-  tps: 6119.90069
+  dps: 7078.62026
+  tps: 6152.73886
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7003.40492
-  tps: 6081.2137
+  dps: 7021.88883
+  tps: 6100.61044
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheFistsofFury"
  value: {
-  dps: 6878.4886
-  tps: 5965.48278
+  dps: 6875.48798
+  tps: 5962.2936
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7014.10086
-  tps: 6098.64768
+  dps: 7004.13652
+  tps: 6088.46159
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7082.31639
-  tps: 6155.4015
+  dps: 7118.42182
+  tps: 6190.79439
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6944.35012
-  tps: 6028.07331
+  dps: 6962.58456
+  tps: 6047.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6944.35012
-  tps: 6028.07331
+  dps: 6962.58456
+  tps: 6047.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7039.78033
-  tps: 6108.95916
+  dps: 7066.47956
+  tps: 6141.73611
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7039.78033
-  tps: 6108.95916
+  dps: 7066.47956
+  tps: 6141.73611
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7015.47671
-  tps: 6104.22839
+  dps: 7032.75647
+  tps: 6110.5663
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7039.78033
-  tps: 6108.95916
+  dps: 7066.47956
+  tps: 6141.73611
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7039.78033
-  tps: 6108.95916
+  dps: 7066.47956
+  tps: 6141.73611
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6013.92939
-  tps: 5219.55035
+  dps: 6013.64556
+  tps: 5211.8911
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6912.70754
-  tps: 6001.93862
+  dps: 6903.42295
+  tps: 6001.75089
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 7096.1157
-  tps: 6190.52287
+  dps: 7092.56109
+  tps: 6171.47805
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6944.09811
-  tps: 6027.82129
+  dps: 6962.34284
+  tps: 6046.95014
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7694.89848
-  tps: 6776.62209
+  dps: 7725.80399
+  tps: 6795.5931
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 7901.12112
-  tps: 6987.0243
+  dps: 7914.67291
+  tps: 6998.33541
  }
 }
 dps_results: {
  key: "TestMM-Average-Default"
  value: {
-  dps: 7218.80925
-  tps: 6297.62223
+  dps: 7233.39867
+  tps: 6309.81869
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-P1-MM-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7183.25893
-  tps: 7381.89234
+  dps: 7215.57291
+  tps: 7423.69761
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-P1-MM-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7183.25893
-  tps: 6302.16713
+  dps: 7215.57291
+  tps: 6339.23866
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-P1-MM-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8207.90377
-  tps: 7198.70674
+  dps: 8180.4132
+  tps: 7168.43161
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-P1-MM-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3544.37197
-  tps: 4792.25511
+  dps: 3547.94603
+  tps: 4799.65753
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-P1-MM-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3544.37197
-  tps: 3277.1598
+  dps: 3547.94603
+  tps: 3282.02919
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-P1-MM-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4324.48817
-  tps: 3969.3733
+  dps: 4267.45181
+  tps: 3906.1549
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-P1-MM-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7215.70242
-  tps: 7363.88169
+  dps: 7248.60611
+  tps: 7407.07275
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-P1-MM-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7215.70242
-  tps: 6284.00906
+  dps: 7248.60611
+  tps: 6322.49177
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-P1-MM-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8294.49
-  tps: 7225.66525
+  dps: 8248.33922
+  tps: 7171.80939
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-P1-MM-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3552.22017
-  tps: 4789.95847
+  dps: 3561.29834
+  tps: 4794.64235
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-P1-MM-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3552.22017
-  tps: 3269.16606
+  dps: 3561.29834
+  tps: 3276.15954
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-P1-MM-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4344.01306
-  tps: 3969.45975
+  dps: 4291.90506
+  tps: 3910.88471
  }
 }
 dps_results: {
  key: "TestMM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7199.7256
-  tps: 6335.57688
+  dps: 7182.42519
+  tps: 6314.69988
  }
 }

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -46,1059 +46,1059 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7450.50008
-  tps: 5289.85506
+  dps: 7438.95101
+  tps: 5281.65521
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7621.73252
-  tps: 5411.43009
+  dps: 7619.31054
+  tps: 5409.71049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7640.0346
-  tps: 5424.42457
+  dps: 7635.739
+  tps: 5421.37469
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7411.33228
-  tps: 78706.94118
+  dps: 7400.60485
+  tps: 79709.36853
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7411.33228
-  tps: 78706.94118
+  dps: 7400.60485
+  tps: 79709.36853
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7643.94197
-  tps: 5427.1988
+  dps: 7647.85961
+  tps: 5429.98032
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5736.42588
-  tps: 4072.86237
+  dps: 5749.43996
+  tps: 4082.10237
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6905.98387
-  tps: 4903.24855
+  dps: 6916.00969
+  tps: 4910.36688
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7621.73252
-  tps: 5303.20149
+  dps: 7619.31054
+  tps: 5301.51628
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7766.97742
-  tps: 5514.55397
+  dps: 7771.13809
+  tps: 5517.50805
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
   hps: 64
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7578.51466
-  tps: 5380.74541
+  dps: 7593.53516
+  tps: 5391.40997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7633.04777
-  tps: 5419.46392
+  dps: 7613.75336
+  tps: 5405.76489
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7611.44552
-  tps: 5404.12632
+  dps: 7587.6571
+  tps: 5387.23654
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8008.41306
-  tps: 5685.97327
+  dps: 7993.59589
+  tps: 5675.45309
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7568.79619
-  tps: 5373.84529
+  dps: 7525.83877
+  tps: 5343.34553
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7834.37753
-  tps: 5562.40805
+  dps: 7822.90171
+  tps: 5554.26021
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7933.33111
-  tps: 5632.66509
+  dps: 7927.4251
+  tps: 5628.47182
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7650.01531
-  tps: 5431.51087
+  dps: 7656.59342
+  tps: 5436.18133
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7641.59066
-  tps: 5425.52937
+  dps: 7644.15567
+  tps: 5427.35052
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7600.39105
-  tps: 5396.27765
+  dps: 7621.66487
+  tps: 5411.38206
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7621.73252
-  tps: 5411.43009
+  dps: 7619.31054
+  tps: 5409.71049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7621.73252
-  tps: 5411.43009
+  dps: 7619.31054
+  tps: 5409.71049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7643.94197
-  tps: 5427.1988
+  dps: 7647.85961
+  tps: 5429.98032
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7633.20561
-  tps: 5419.57598
+  dps: 7648.47294
+  tps: 5430.41579
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7527.14814
-  tps: 5344.27518
+  dps: 7542.07653
+  tps: 5354.87434
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7621.73252
-  tps: 5411.43009
+  dps: 7619.31054
+  tps: 5409.71049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7605.65804
-  tps: 5400.01721
+  dps: 7595.4059
+  tps: 5392.73819
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7569.78706
-  tps: 5374.54881
+  dps: 7560.35193
+  tps: 5367.84987
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7544.29821
-  tps: 5356.45173
+  dps: 7521.65196
+  tps: 5340.37289
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7621.73252
-  tps: 5411.43009
+  dps: 7619.31054
+  tps: 5409.71049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7621.73252
-  tps: 5411.43009
+  dps: 7619.31054
+  tps: 5409.71049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7692.62374
-  tps: 5461.76285
+  dps: 7680.62232
+  tps: 5453.24185
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7434.57853
-  tps: 5278.55075
+  dps: 7453.2048
+  tps: 5291.77541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7606.21238
-  tps: 5400.41079
+  dps: 7590.23283
+  tps: 5389.06531
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-49982"
  value: {
-  dps: 7772.12467
-  tps: 5518.20852
+  dps: 7779.29011
+  tps: 5523.29598
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-50641"
  value: {
-  dps: 7772.12467
-  tps: 5518.20852
+  dps: 7779.29011
+  tps: 5523.29598
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7643.94197
-  tps: 5427.1988
+  dps: 7647.85961
+  tps: 5429.98032
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7633.20561
-  tps: 5419.57598
+  dps: 7648.47294
+  tps: 5430.41579
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7596.48055
-  tps: 5393.50119
+  dps: 7584.98846
+  tps: 5385.3418
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7621.73252
-  tps: 5411.43009
+  dps: 7619.31054
+  tps: 5409.71049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7653.14299
-  tps: 5433.73152
+  dps: 7655.71156
+  tps: 5435.5552
   hps: 9.14161
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7683.00817
-  tps: 5454.9358
+  dps: 7675.47404
+  tps: 5449.58657
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7448.02593
-  tps: 5288.09841
+  dps: 7447.88011
+  tps: 5287.99488
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7651.91693
-  tps: 5432.86102
+  dps: 7649.4976
+  tps: 5431.14329
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7659.01915
-  tps: 5437.90359
+  dps: 7656.60043
+  tps: 5436.18631
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7621.73252
-  tps: 5411.43009
+  dps: 7619.31054
+  tps: 5409.71049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7621.73252
-  tps: 5411.43009
+  dps: 7619.31054
+  tps: 5409.71049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7614.24878
-  tps: 5406.11664
+  dps: 7612.08217
+  tps: 5404.57834
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7639.79267
-  tps: 5424.25279
+  dps: 7637.61633
+  tps: 5422.7076
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7772.12467
-  tps: 5518.20852
+  dps: 7779.29011
+  tps: 5523.29598
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7621.73252
-  tps: 5411.43009
+  dps: 7619.31054
+  tps: 5409.71049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7953.55987
-  tps: 5647.02751
+  dps: 7956.12056
+  tps: 5648.84559
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 5669.11509
-  tps: 4025.07172
+  dps: 5664.92262
+  tps: 4022.09506
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7571.13719
-  tps: 5375.5074
+  dps: 7565.05963
+  tps: 5371.19234
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 7496.36522
-  tps: 5322.4193
+  dps: 7514.90607
+  tps: 5335.58331
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7615.9625
-  tps: 5407.33338
+  dps: 7593.70792
+  tps: 5391.53262
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StormshroudArmor"
  value: {
-  dps: 6041.331
-  tps: 4289.34501
+  dps: 6042.36733
+  tps: 4290.0808
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7659.01915
-  tps: 5437.90359
+  dps: 7656.60043
+  tps: 5436.18631
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7651.91693
-  tps: 5432.86102
+  dps: 7649.4976
+  tps: 5431.14329
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7639.48806
-  tps: 5424.03652
+  dps: 7637.06763
+  tps: 5422.31802
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 7330.77211
-  tps: 5204.8482
+  dps: 7324.95629
+  tps: 5200.71897
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheFistsofFury"
  value: {
-  dps: 5019.85456
-  tps: 3564.09673
+  dps: 5016.65875
+  tps: 3561.82771
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7666.37947
-  tps: 5443.12942
+  dps: 7696.97726
+  tps: 5464.85385
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7780.71865
-  tps: 5524.31024
+  dps: 7782.81429
+  tps: 5525.79815
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7815.47584
-  tps: 5548.98784
+  dps: 7810.73463
+  tps: 5545.62159
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7621.73252
-  tps: 5411.43009
+  dps: 7619.31054
+  tps: 5409.71049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7621.73252
-  tps: 5411.43009
+  dps: 7619.31054
+  tps: 5409.71049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7477.25297
-  tps: 5308.84961
+  dps: 7480.11788
+  tps: 5310.88369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7621.73252
-  tps: 5411.43009
+  dps: 7619.31054
+  tps: 5409.71049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7621.73252
-  tps: 5411.43009
+  dps: 7619.31054
+  tps: 5409.71049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6105.86364
-  tps: 4335.16318
+  dps: 6125.65359
+  tps: 4349.21405
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 7102.78446
-  tps: 5042.97697
+  dps: 7106.79941
+  tps: 5045.82758
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7412.28246
-  tps: 5262.72055
+  dps: 7400.81686
+  tps: 5254.57997
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 7761.11867
-  tps: 5510.39425
+  dps: 7764.81567
+  tps: 5513.01912
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25612.30905
-  tps: 18184.73943
+  dps: 25704.52751
+  tps: 18250.21453
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7772.12467
-  tps: 5518.20852
+  dps: 7779.29011
+  tps: 5523.29598
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8843.8125
-  tps: 6279.10688
+  dps: 8881.02869
+  tps: 6305.53037
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15184.77867
-  tps: 10781.19285
+  dps: 15085.5854
+  tps: 10710.76563
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3717.2526
-  tps: 2639.24935
+  dps: 3719.10716
+  tps: 2640.56608
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3752.87267
-  tps: 2664.5396
+  dps: 3778.83555
+  tps: 2682.97324
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15971.6642
-  tps: 11339.88158
+  dps: 15987.58546
+  tps: 11351.18567
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3833.41425
-  tps: 2721.72412
+  dps: 3831.83974
+  tps: 2720.60621
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4638.91612
-  tps: 3293.63045
+  dps: 4636.39611
+  tps: 3291.84124
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9211.6454
-  tps: 6540.26824
+  dps: 9222.83087
+  tps: 6548.20992
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1691.70334
-  tps: 1201.10937
+  dps: 1685.17486
+  tps: 1196.47415
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1767.02582
-  tps: 1254.58833
+  dps: 1756.7653
+  tps: 1247.30336
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25612.30905
-  tps: 18184.73943
+  dps: 25704.52751
+  tps: 18250.21453
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7772.12467
-  tps: 5518.20852
+  dps: 7779.29011
+  tps: 5523.29598
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8843.8125
-  tps: 6279.10688
+  dps: 8881.02869
+  tps: 6305.53037
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15184.77867
-  tps: 10781.19285
+  dps: 15085.5854
+  tps: 10710.76563
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3717.2526
-  tps: 2639.24935
+  dps: 3719.10716
+  tps: 2640.56608
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3752.87267
-  tps: 2664.5396
+  dps: 3778.83555
+  tps: 2682.97324
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19744.773
-  tps: 14018.78883
+  dps: 19766.05867
+  tps: 14033.90166
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5062.61665
-  tps: 3594.45782
+  dps: 5063.06854
+  tps: 3594.77866
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5753.97466
-  tps: 4085.32201
+  dps: 5774.293
+  tps: 4099.74803
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12759.6379
-  tps: 9059.34291
+  dps: 12767.16461
+  tps: 9064.68687
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2445.73136
-  tps: 1736.46926
+  dps: 2448.74192
+  tps: 1738.60676
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2535.73272
-  tps: 1800.37023
+  dps: 2561.83158
+  tps: 1818.90042
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25760.65619
-  tps: 18290.06589
+  dps: 25855.00889
+  tps: 18357.05631
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7817.84797
-  tps: 5550.67206
+  dps: 7809.37141
+  tps: 5544.6537
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8943.5609
-  tps: 6349.92824
+  dps: 8967.92294
+  tps: 6367.22528
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15232.38009
-  tps: 10814.98986
+  dps: 15160.48355
+  tps: 10763.94332
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3742.27053
-  tps: 2657.01207
+  dps: 3743.80779
+  tps: 2658.10353
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3797.04042
-  tps: 2695.8987
+  dps: 3823.16521
+  tps: 2714.4473
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16048.41596
-  tps: 11394.37533
+  dps: 16057.3132
+  tps: 11400.69237
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3857.94683
-  tps: 2739.14225
+  dps: 3856.28705
+  tps: 2737.9638
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4690.25112
-  tps: 3330.0783
+  dps: 4686.68801
+  tps: 3327.54849
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9267.15989
-  tps: 6579.68352
+  dps: 9284.43526
+  tps: 6591.94904
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1703.55895
-  tps: 1209.52685
+  dps: 1696.93802
+  tps: 1204.82599
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1786.50096
-  tps: 1268.41568
+  dps: 1776.13563
+  tps: 1261.0563
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25760.65619
-  tps: 18290.06589
+  dps: 25855.00889
+  tps: 18357.05631
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7817.84797
-  tps: 5550.67206
+  dps: 7809.37141
+  tps: 5544.6537
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8943.5609
-  tps: 6349.92824
+  dps: 8967.92294
+  tps: 6367.22528
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15232.38009
-  tps: 10814.98986
+  dps: 15160.48355
+  tps: 10763.94332
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3742.27053
-  tps: 2657.01207
+  dps: 3743.80779
+  tps: 2658.10353
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3797.04042
-  tps: 2695.8987
+  dps: 3823.16521
+  tps: 2714.4473
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19845.25659
-  tps: 14090.13218
+  dps: 19873.4399
+  tps: 14110.14233
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5093.51048
-  tps: 3616.39244
+  dps: 5089.11546
+  tps: 3613.27198
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5817.96602
-  tps: 4130.75587
+  dps: 5831.97194
+  tps: 4140.70008
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12850.37682
-  tps: 9123.76755
+  dps: 12836.40028
+  tps: 9113.8442
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2462.15198
-  tps: 1748.12791
+  dps: 2466.025
+  tps: 1750.87775
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2565.34781
-  tps: 1821.39695
+  dps: 2591.40895
+  tps: 1839.90036
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7256.22352
-  tps: 5151.9187
+  dps: 7286.2564
+  tps: 5173.24204
  }
 }

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -46,1094 +46,1094 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 6266.73262
-  tps: 4449.38016
+  dps: 6301.49714
+  tps: 4474.06297
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6378.25638
-  tps: 4528.56203
+  dps: 6416.79964
+  tps: 4555.92775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6450.38946
-  tps: 4579.77652
+  dps: 6484.87275
+  tps: 4604.25965
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6251.93356
-  tps: 48411.18653
+  dps: 6287.87416
+  tps: 48846.24925
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6251.93356
-  tps: 48411.18653
+  dps: 6287.87416
+  tps: 48846.24925
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6402.1316
-  tps: 4545.51344
+  dps: 6442.22107
+  tps: 4573.97696
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4954.49873
-  tps: 3517.6941
+  dps: 5005.55717
+  tps: 3553.94559
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BonescytheBattlegear"
  value: {
-  dps: 5921.50444
-  tps: 4204.26815
+  dps: 5972.17504
+  tps: 4240.24428
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6378.25638
-  tps: 4437.99079
+  dps: 6416.79964
+  tps: 4464.80919
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6522.82727
-  tps: 4631.20736
+  dps: 6562.66634
+  tps: 4659.4931
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6522.82727
-  tps: 4631.20736
+  dps: 6562.66634
+  tps: 4659.4931
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6516.5398
-  tps: 4626.74326
+  dps: 6557.4461
+  tps: 4655.78673
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
   hps: 64
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6380.03313
-  tps: 4529.82352
+  dps: 6415.95472
+  tps: 4555.32785
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6413.37716
-  tps: 4553.49779
+  dps: 6449.69381
+  tps: 4579.28261
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6391.34018
-  tps: 4537.85153
+  dps: 6431.244
+  tps: 4566.18324
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6706.10306
-  tps: 4761.33317
+  dps: 6749.82452
+  tps: 4792.37541
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6355.67913
-  tps: 4512.53218
+  dps: 6394.65418
+  tps: 4540.20446
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6642.7531
-  tps: 4716.3547
+  dps: 6693.24947
+  tps: 4752.20712
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6696.25758
-  tps: 4754.34288
+  dps: 6763.32034
+  tps: 4801.95744
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6405.90823
-  tps: 4548.19484
+  dps: 6445.88802
+  tps: 4576.5805
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6476.68686
-  tps: 4598.44767
+  dps: 6528.5236
+  tps: 4635.25175
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6431.52883
-  tps: 4566.38547
+  dps: 6498.11667
+  tps: 4613.66283
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6378.25638
-  tps: 4528.56203
+  dps: 6416.79964
+  tps: 4555.92775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6378.25638
-  tps: 4528.56203
+  dps: 6416.79964
+  tps: 4555.92775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6402.1316
-  tps: 4545.51344
+  dps: 6442.22107
+  tps: 4573.97696
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6397.72085
-  tps: 4542.38181
+  dps: 6436.29978
+  tps: 4569.77284
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6391.12226
-  tps: 4537.69681
+  dps: 6458.57861
+  tps: 4585.59081
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6378.25638
-  tps: 4528.56203
+  dps: 6416.79964
+  tps: 4555.92775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6414.30394
-  tps: 4554.1558
+  dps: 6451.39505
+  tps: 4580.49049
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6364.68288
-  tps: 4518.92484
+  dps: 6401.41612
+  tps: 4545.00544
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6338.44695
-  tps: 4500.29733
+  dps: 6376.35078
+  tps: 4527.20905
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6378.25638
-  tps: 4528.56203
+  dps: 6416.79964
+  tps: 4555.92775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6378.25638
-  tps: 4528.56203
+  dps: 6416.79964
+  tps: 4555.92775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6490.99971
-  tps: 4608.60979
+  dps: 6528.13737
+  tps: 4634.97754
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Gladiator'sVestments"
  value: {
-  dps: 6325.06768
-  tps: 4490.79805
+  dps: 6392.36108
+  tps: 4538.57637
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6388.30013
-  tps: 4535.69309
+  dps: 6424.9469
+  tps: 4561.7123
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-49982"
  value: {
-  dps: 6522.82727
-  tps: 4631.20736
+  dps: 6562.66634
+  tps: 4659.4931
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-50641"
  value: {
-  dps: 6522.82727
-  tps: 4631.20736
+  dps: 6562.66634
+  tps: 4659.4931
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6402.1316
-  tps: 4545.51344
+  dps: 6442.22107
+  tps: 4573.97696
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6397.72085
-  tps: 4542.38181
+  dps: 6436.29978
+  tps: 4569.77284
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6428.48243
-  tps: 4564.22253
+  dps: 6469.55759
+  tps: 4593.38589
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6378.25638
-  tps: 4528.56203
+  dps: 6416.79964
+  tps: 4555.92775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6409.49135
-  tps: 4550.73886
+  dps: 6448.82679
+  tps: 4578.66702
   hps: 9.14161
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6484.7655
-  tps: 4604.18351
+  dps: 6515.97158
+  tps: 4626.33982
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6301.60448
-  tps: 4474.13918
+  dps: 6333.91651
+  tps: 4497.08072
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6403.73008
-  tps: 4546.64836
+  dps: 6442.46175
+  tps: 4574.14784
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6409.72389
-  tps: 4550.90396
+  dps: 6448.49989
+  tps: 4578.43492
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6378.25638
-  tps: 4528.56203
+  dps: 6416.79964
+  tps: 4555.92775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6378.25638
-  tps: 4528.56203
+  dps: 6416.79964
+  tps: 4555.92775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6399.80475
-  tps: 4543.86137
+  dps: 6434.46191
+  tps: 4568.46795
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6418.58025
-  tps: 4557.19198
+  dps: 6453.18664
+  tps: 4581.76251
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6522.82727
-  tps: 4631.20736
+  dps: 6562.66634
+  tps: 4659.4931
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6378.25638
-  tps: 4528.56203
+  dps: 6416.79964
+  tps: 4555.92775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 6550.98108
-  tps: 4651.19657
+  dps: 6604.07048
+  tps: 4688.89004
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6522.82727
-  tps: 4631.20736
+  dps: 6562.66634
+  tps: 4659.4931
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Slayer'sArmor"
  value: {
-  dps: 4887.80785
-  tps: 3470.34357
+  dps: 4933.58105
+  tps: 3502.84255
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6369.76836
-  tps: 4522.53553
+  dps: 6405.67857
+  tps: 4548.03178
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SparkofLife-37657"
  value: {
-  dps: 6349.23683
-  tps: 4507.95815
+  dps: 6392.51253
+  tps: 4538.6839
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6442.05048
-  tps: 4573.85584
+  dps: 6481.41391
+  tps: 4601.80388
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StormshroudArmor"
  value: {
-  dps: 5015.76604
-  tps: 3561.19388
+  dps: 5054.41702
+  tps: 3588.63609
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6409.72389
-  tps: 4550.90396
+  dps: 6448.49989
+  tps: 4578.43492
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6403.73008
-  tps: 4546.64836
+  dps: 6442.46175
+  tps: 4574.14784
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6393.24091
-  tps: 4539.20105
+  dps: 6431.895
+  tps: 4566.64545
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6325.95045
-  tps: 4491.42482
+  dps: 6370.43316
+  tps: 4523.00755
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheFistsofFury"
  value: {
-  dps: 5719.6596
-  tps: 4060.95832
+  dps: 5774.94134
+  tps: 4100.20835
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5812.2848
-  tps: 4126.72221
+  dps: 5879.32356
+  tps: 4174.31973
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6475.47468
-  tps: 4597.58702
+  dps: 6504.99896
+  tps: 4618.54926
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6522.80889
-  tps: 4631.19431
+  dps: 6608.97272
+  tps: 4692.37063
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6557.7301
-  tps: 4655.98837
+  dps: 6629.84705
+  tps: 4707.1914
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6378.25638
-  tps: 4528.56203
+  dps: 6416.79964
+  tps: 4555.92775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6378.25638
-  tps: 4528.56203
+  dps: 6416.79964
+  tps: 4555.92775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6311.63874
-  tps: 4481.26351
+  dps: 6372.28785
+  tps: 4524.32437
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6378.25638
-  tps: 4528.56203
+  dps: 6416.79964
+  tps: 4555.92775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6378.25638
-  tps: 4528.56203
+  dps: 6416.79964
+  tps: 4555.92775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5261.08853
-  tps: 3735.37286
+  dps: 5294.68082
+  tps: 3759.22338
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6129.89115
-  tps: 4352.22271
+  dps: 6174.50975
+  tps: 4383.90192
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6095.08964
-  tps: 4327.51364
+  dps: 6128.66973
+  tps: 4351.35551
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6252.93473
-  tps: 4439.58366
+  dps: 6288.33983
+  tps: 4464.72128
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 6507.04757
-  tps: 4620.00378
+  dps: 6559.66104
+  tps: 4657.35934
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14135.92316
-  tps: 10036.50545
+  dps: 14253.58511
+  tps: 10120.04543
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5580.73467
-  tps: 3962.32162
+  dps: 5617.27291
+  tps: 3988.26377
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6384.05622
-  tps: 4532.67992
+  dps: 6713.67434
+  tps: 4766.70878
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8679.74892
-  tps: 6162.62173
+  dps: 8763.71883
+  tps: 6222.24037
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2620.77498
-  tps: 1860.75023
+  dps: 2628.19679
+  tps: 1866.01972
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2689.59637
-  tps: 1909.61342
+  dps: 2744.43344
+  tps: 1948.54774
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18983.45956
-  tps: 13478.25629
+  dps: 19183.71622
+  tps: 13620.43852
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6522.82727
-  tps: 4631.20736
+  dps: 6562.66634
+  tps: 4659.4931
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7305.08034
-  tps: 5186.60704
+  dps: 7646.68842
+  tps: 5429.14878
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12025.07873
-  tps: 8537.8059
+  dps: 12193.99641
+  tps: 8657.73745
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3244.73437
-  tps: 2303.7614
+  dps: 3252.77832
+  tps: 2309.47261
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3258.6316
-  tps: 2313.62844
+  dps: 3316.1622
+  tps: 2354.47516
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18983.45956
-  tps: 13478.25629
+  dps: 19183.71622
+  tps: 13620.43852
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6522.82727
-  tps: 4631.20736
+  dps: 6562.66634
+  tps: 4659.4931
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7305.08034
-  tps: 5186.60704
+  dps: 7646.68842
+  tps: 5429.14878
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12025.07873
-  tps: 8537.8059
+  dps: 12193.99641
+  tps: 8657.73745
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3244.73437
-  tps: 2303.7614
+  dps: 3252.77832
+  tps: 2309.47261
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3258.6316
-  tps: 2313.62844
+  dps: 3316.1622
+  tps: 2354.47516
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17491.96226
-  tps: 12419.29321
+  dps: 17635.29765
+  tps: 12521.06133
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4833.15108
-  tps: 3431.53726
+  dps: 4859.57133
+  tps: 3450.29565
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5399.06206
-  tps: 3833.33406
+  dps: 5646.80533
+  tps: 4009.23178
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11487.38264
-  tps: 8156.04167
+  dps: 11596.12526
+  tps: 8233.24893
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2415.31981
-  tps: 1714.87706
+  dps: 2417.42272
+  tps: 1716.37013
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2462.40327
-  tps: 1748.30632
+  dps: 2495.78756
+  tps: 1772.00917
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14251.27166
-  tps: 10118.40288
+  dps: 14371.17354
+  tps: 10203.53321
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5617.52055
-  tps: 3988.43959
+  dps: 5656.0763
+  tps: 4015.81417
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6469.59886
-  tps: 4593.41519
+  dps: 6800.91895
+  tps: 4828.65246
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8756.52356
-  tps: 6217.13173
+  dps: 8843.47696
+  tps: 6278.86864
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2640.1818
-  tps: 1874.52908
+  dps: 2647.91976
+  tps: 1880.02303
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2727.4766
-  tps: 1936.50838
+  dps: 2785.16584
+  tps: 1977.46775
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19124.81181
-  tps: 13578.61638
+  dps: 19326.30966
+  tps: 13721.67986
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6565.07563
-  tps: 4661.2037
+  dps: 6607.73594
+  tps: 4691.49252
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7402.28686
-  tps: 5255.62367
+  dps: 7746.17951
+  tps: 5499.78745
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12123.21708
-  tps: 8607.48413
+  dps: 12293.49122
+  tps: 8728.37876
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3268.65124
-  tps: 2320.74238
+  dps: 3277.27108
+  tps: 2326.86246
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3305.25202
-  tps: 2346.72893
+  dps: 3366.22489
+  tps: 2390.01968
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19124.81181
-  tps: 13578.61638
+  dps: 19326.30966
+  tps: 13721.67986
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6565.07563
-  tps: 4661.2037
+  dps: 6607.73594
+  tps: 4691.49252
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7402.28686
-  tps: 5255.62367
+  dps: 7746.17951
+  tps: 5499.78745
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12123.21708
-  tps: 8607.48413
+  dps: 12293.49122
+  tps: 8728.37876
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3268.65124
-  tps: 2320.74238
+  dps: 3277.27108
+  tps: 2326.86246
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3305.25202
-  tps: 2346.72893
+  dps: 3366.22489
+  tps: 2390.01968
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17623.71714
-  tps: 12512.83917
+  dps: 17767.71463
+  tps: 12615.07739
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4864.52581
-  tps: 3453.81332
+  dps: 4892.98954
+  tps: 3474.02258
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5470.69955
-  tps: 3884.19668
+  dps: 5720.30144
+  tps: 4061.41403
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11583.36399
-  tps: 8224.18843
+  dps: 11692.59386
+  tps: 8301.74164
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2433.04111
-  tps: 1727.45919
+  dps: 2435.45664
+  tps: 1729.17421
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2497.0241
-  tps: 1772.88711
+  dps: 2532.91505
+  tps: 1798.36968
  }
 }
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6265.28218
-  tps: 4448.35035
+  dps: 6345.69704
+  tps: 4505.4449
  }
 }

--- a/sim/rogue/TestSubtlety.results
+++ b/sim/rogue/TestSubtlety.results
@@ -1,0 +1,852 @@
+character_stats_results: {
+ key: "TestSubtlety-CharacterStats-Default"
+ value: {
+  final_stats: 394.9
+  final_stats: 2528.735
+  final_stats: 1650.55
+  final_stats: 194.7
+  final_stats: 237.6
+  final_stats: 280
+  final_stats: 109
+  final_stats: 384
+  final_stats: 995.777
+  final_stats: 288
+  final_stats: 0
+  final_stats: 7547.53835
+  final_stats: 384
+  final_stats: 2621.52933
+  final_stats: 288
+  final_stats: 304.91
+  final_stats: 214
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 11629.97
+  final_stats: 3491.4
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 20029.5
+  final_stats: 75
+  final_stats: 75
+  final_stats: 75
+  final_stats: 75
+  final_stats: 130
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-Althor'sAbacus-50359"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-Althor'sAbacus-50366"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-AshtongueTalismanofLethality-32492"
+ value: {
+  dps: 8743.49716
+  tps: 6196.48171
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-AustereEarthsiegeDiamond"
+ value: {
+  dps: 8932.72923
+  tps: 6329.3057
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-Bandit'sInsignia-40371"
+ value: {
+  dps: 8916.38507
+  tps: 6319.05427
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-BaubleofTrueBlood-50354"
+ value: {
+  dps: 8697.89219
+  tps: 72337.37342
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-BaubleofTrueBlood-50726"
+ value: {
+  dps: 8697.89219
+  tps: 72337.37342
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-BeamingEarthsiegeDiamond"
+ value: {
+  dps: 8957.63434
+  tps: 6347.02169
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-BlessedRegaliaofUndeadCleansing"
+ value: {
+  dps: 6692.82732
+  tps: 4743.98025
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-BonescytheBattlegear"
+ value: {
+  dps: 7763.03407
+  tps: 5505.28045
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-BracingEarthsiegeDiamond"
+ value: {
+  dps: 8932.72923
+  tps: 6202.71959
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-ChaoticSkyflareDiamond"
+ value: {
+  dps: 9131.50355
+  tps: 6470.16578
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-CorpseTongueCoin-50349"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-CorpseTongueCoin-50352"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-CorrodedSkeletonKey-50356"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+  hps: 64
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-DarkmoonCard:Berserker!-42989"
+ value: {
+  dps: 8839.98633
+  tps: 6264.9613
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-DarkmoonCard:Death-42990"
+ value: {
+  dps: 8872.80854
+  tps: 6288.25161
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-DarkmoonCard:Greatness-44255"
+ value: {
+  dps: 8906.94755
+  tps: 6312.52758
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-Death'sChoice-47464"
+ value: {
+  dps: 9305.02429
+  tps: 6594.34217
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-DeathKnight'sAnguish-38212"
+ value: {
+  dps: 8808.92707
+  tps: 6242.97894
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-Deathbringer'sWill-50362"
+ value: {
+  dps: 9218.42726
+  tps: 6533.03352
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-Deathbringer'sWill-50363"
+ value: {
+  dps: 9299.88523
+  tps: 6590.93851
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-Defender'sCode-40257"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-DestructiveSkyflareDiamond"
+ value: {
+  dps: 8970.61848
+  tps: 6356.22697
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-DislodgedForeignObject-50348"
+ value: {
+  dps: 8876.56784
+  tps: 6290.75608
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-DislodgedForeignObject-50353"
+ value: {
+  dps: 8852.43828
+  tps: 6273.51264
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-EffulgentSkyflareDiamond"
+ value: {
+  dps: 8932.72923
+  tps: 6329.3057
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-EmberSkyflareDiamond"
+ value: {
+  dps: 8932.72923
+  tps: 6329.3057
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-EnigmaticSkyflareDiamond"
+ value: {
+  dps: 8957.63434
+  tps: 6347.02169
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-EnigmaticStarflareDiamond"
+ value: {
+  dps: 8952.24212
+  tps: 6343.15986
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-EphemeralSnowflake-50260"
+ value: {
+  dps: 8828.80857
+  tps: 6256.90057
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-EssenceofGossamer-37220"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-EternalEarthsiegeDiamond"
+ value: {
+  dps: 8932.72923
+  tps: 6329.3057
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-ExtractofNecromanticPower-40373"
+ value: {
+  dps: 8873.58986
+  tps: 6288.8198
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-EyeoftheBroodmother-45308"
+ value: {
+  dps: 8818.9098
+  tps: 6249.99696
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-Figurine-SapphireOwl-42413"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-ForethoughtTalisman-40258"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-ForgeEmber-37660"
+ value: {
+  dps: 8791.4025
+  tps: 6230.4945
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-ForlornSkyflareDiamond"
+ value: {
+  dps: 8932.72923
+  tps: 6329.3057
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-ForlornStarflareDiamond"
+ value: {
+  dps: 8932.72923
+  tps: 6329.3057
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-FuryoftheFiveFlights-40431"
+ value: {
+  dps: 8966.59263
+  tps: 6354.57019
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-FuturesightRune-38763"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-Gladiator'sVestments"
+ value: {
+  dps: 8175.52939
+  tps: 5797.02686
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-GlowingTwilightScale-54573"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-GlowingTwilightScale-54589"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-GnomishLightningGenerator-41121"
+ value: {
+  dps: 8846.72932
+  tps: 6269.73536
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-Heartpierce-49982"
+ value: {
+  dps: 9143.9427
+  tps: 6478.93216
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-Heartpierce-50641"
+ value: {
+  dps: 9143.9427
+  tps: 6478.93216
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-IllustrationoftheDragonSoul-40432"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-ImpassiveSkyflareDiamond"
+ value: {
+  dps: 8957.63434
+  tps: 6347.02169
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-ImpassiveStarflareDiamond"
+ value: {
+  dps: 8952.24212
+  tps: 6343.15986
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-IncisorFragment-37723"
+ value: {
+  dps: 8916.62811
+  tps: 6319.2693
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-InsightfulEarthsiegeDiamond"
+ value: {
+  dps: 8932.72923
+  tps: 6329.3057
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-InvigoratingEarthsiegeDiamond"
+ value: {
+  dps: 8969.82073
+  tps: 6355.59266
+  hps: 10.24843
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-Lavanthor'sTalisman-37872"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-MajesticDragonFigurine-40430"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-MeteoriteWhetstone-37390"
+ value: {
+  dps: 8924.35861
+  tps: 6324.71036
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-NevermeltingIceCrystal-50259"
+ value: {
+  dps: 8749.07445
+  tps: 6200.42813
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-OfferingofSacrifice-37638"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-PersistentEarthshatterDiamond"
+ value: {
+  dps: 8962.75569
+  tps: 6350.58562
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-PersistentEarthsiegeDiamond"
+ value: {
+  dps: 8969.82073
+  tps: 6355.59266
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54571"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54591"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-PowerfulEarthshatterDiamond"
+ value: {
+  dps: 8932.72923
+  tps: 6329.3057
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-PowerfulEarthsiegeDiamond"
+ value: {
+  dps: 8932.72923
+  tps: 6329.3057
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-PurifiedShardoftheGods"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-ReignoftheDead-47316"
+ value: {
+  dps: 8830.9729
+  tps: 6258.60376
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-ReignoftheDead-47477"
+ value: {
+  dps: 8848.06228
+  tps: 6270.73721
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-RelentlessEarthsiegeDiamond"
+ value: {
+  dps: 9143.9427
+  tps: 6478.93216
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-RevitalizingSkyflareDiamond"
+ value: {
+  dps: 8932.72923
+  tps: 6329.3057
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-RuneofRepulsion-40372"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-SealofthePantheon-36993"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-Shadowblade'sBattlegear"
+ value: {
+  dps: 8589.49214
+  tps: 6089.58768
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-ShinyShardoftheGods"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-Sindragosa'sFlawlessFang-50361"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-Slayer'sArmor"
+ value: {
+  dps: 6144.63326
+  tps: 4356.81543
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-SliverofPureIce-50339"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-SliverofPureIce-50346"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-SouloftheDead-40382"
+ value: {
+  dps: 8824.68999
+  tps: 6254.10089
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-SparkofLife-37657"
+ value: {
+  dps: 8809.49124
+  tps: 6243.18147
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-SphereofRedDragon'sBlood-37166"
+ value: {
+  dps: 8879.09446
+  tps: 6293.34733
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-StormshroudArmor"
+ value: {
+  dps: 6781.20459
+  tps: 4810.21374
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-SwiftSkyflareDiamond"
+ value: {
+  dps: 8969.82073
+  tps: 6355.59266
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-SwiftStarflareDiamond"
+ value: {
+  dps: 8962.75569
+  tps: 6350.58562
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-SwiftWindfireDiamond"
+ value: {
+  dps: 8950.39185
+  tps: 6341.8233
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-TalismanofTrollDivinity-37734"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-TearsoftheVanquished-47215"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-TerrorbladeBattlegear"
+ value: {
+  dps: 8227.90829
+  tps: 5830.0838
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-TheFistsofFury"
+ value: {
+  dps: 7892.32261
+  tps: 5590.92964
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-TheGeneral'sHeart-45507"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-ThunderingSkyflareDiamond"
+ value: {
+  dps: 9028.74683
+  tps: 6397.39499
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-TinyAbominationinaJar-50351"
+ value: {
+  dps: 9004.75768
+  tps: 6382.47153
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-TinyAbominationinaJar-50706"
+ value: {
+  dps: 9034.16962
+  tps: 6403.33872
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-TirelessSkyflareDiamond"
+ value: {
+  dps: 8932.72923
+  tps: 6329.3057
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-TirelessStarflareDiamond"
+ value: {
+  dps: 8932.72923
+  tps: 6329.3057
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-TomeofArcanePhenomena-36972"
+ value: {
+  dps: 8783.26645
+  tps: 6224.53436
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-TrenchantEarthshatterDiamond"
+ value: {
+  dps: 8932.72923
+  tps: 6329.3057
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-TrenchantEarthsiegeDiamond"
+ value: {
+  dps: 8932.72923
+  tps: 6329.3057
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-UndeadSlayer'sBlessedArmor"
+ value: {
+  dps: 7055.78411
+  tps: 5003.45433
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-VanCleef'sBattlegear"
+ value: {
+  dps: 8022.29312
+  tps: 5689.00271
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-WingedTalisman-37844"
+ value: {
+  dps: 8697.02021
+  tps: 6163.49734
+ }
+}
+dps_results: {
+ key: "TestSubtlety-Average-Default"
+ value: {
+  dps: 9153.25201
+  tps: 6491.53655
+ }
+}
+dps_results: {
+ key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-LongMultiTarget"
+ value: {
+  dps: 16127.98446
+  tps: 11445.29839
+ }
+}
+dps_results: {
+ key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-LongSingleTarget"
+ value: {
+  dps: 9143.9427
+  tps: 6478.93216
+ }
+}
+dps_results: {
+ key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-ShortSingleTarget"
+ value: {
+  dps: 10328.63916
+  tps: 7303.01995
+ }
+}
+dps_results: {
+ key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-LongMultiTarget"
+ value: {
+  dps: 10408.79068
+  tps: 7385.65747
+ }
+}
+dps_results: {
+ key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-LongSingleTarget"
+ value: {
+  dps: 4858.83304
+  tps: 3444.64725
+ }
+}
+dps_results: {
+ key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-ShortSingleTarget"
+ value: {
+  dps: 4994.7006
+  tps: 3525.94199
+ }
+}
+dps_results: {
+ key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-LongMultiTarget"
+ value: {
+  dps: 16033.15187
+  tps: 11378.06294
+ }
+}
+dps_results: {
+ key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-LongSingleTarget"
+ value: {
+  dps: 9165.06989
+  tps: 6500.63712
+ }
+}
+dps_results: {
+ key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-ShortSingleTarget"
+ value: {
+  dps: 10267.2809
+  tps: 7251.32134
+ }
+}
+dps_results: {
+ key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-LongMultiTarget"
+ value: {
+  dps: 9849.85452
+  tps: 6989.0554
+ }
+}
+dps_results: {
+ key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-LongSingleTarget"
+ value: {
+  dps: 4873.06858
+  tps: 3455.50164
+ }
+}
+dps_results: {
+ key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-ShortSingleTarget"
+ value: {
+  dps: 4984.68934
+  tps: 3530.03568
+ }
+}
+dps_results: {
+ key: "TestSubtlety-SwitchInFrontOfTarget-Default"
+ value: {
+  dps: 2710.75852
+  tps: 1924.63855
+ }
+}

--- a/sim/rogue/hemorrhage.go
+++ b/sim/rogue/hemorrhage.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (rogue *Rogue) registerHemorrhageSpell() {
-	actionID := core.ActionID{SpellID: 26864}
+	actionID := core.ActionID{SpellID: 48660}
 	bonusDamage := 75.0
 	if rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfHemorrhage) {
 		bonusDamage *= 1.4

--- a/sim/rogue/master_of_subtlety.go
+++ b/sim/rogue/master_of_subtlety.go
@@ -32,6 +32,38 @@ func (rogue *Rogue) registerMasterOfSubtletyCD() {
 		},
 	})
 
+	const garroteMinDuration = time.Second * 9 // heuristically, 3 Garrote ticks are better DPE than regular builders
+
+	garrote := func(sim *core.Simulation, rogue *Rogue) (bool, int32) {
+		if !rogue.Rotation.OpenWithGarrote || rogue.PseudoStats.InFrontOfTarget {
+			return false, 0
+		}
+
+		if !rogue.GCD.IsReady(sim) || rogue.CurrentEnergy() < rogue.Garrote.DefaultCast.Cost {
+			return true, 0
+		}
+
+		if rogue.Garrote.Dot(rogue.CurrentTarget).IsActive() || sim.GetRemainingDuration() <= garroteMinDuration {
+			return true, 0
+		}
+
+		if rogue.Talents.Initiative == 0 {
+			return true, 1
+		}
+		return true, 2
+	}
+
+	premed := func(sim *core.Simulation, rogue *Rogue) (bool, int32) {
+		if rogue.Premeditation == nil {
+			return false, 0
+		}
+
+		if !rogue.Premeditation.IsReady(sim) {
+			return true, 0
+		}
+		return true, 2
+	}
+
 	rogue.MasterOfSubtlety = rogue.RegisterSpell(core.SpellConfig{
 		ActionID: MasterOfSubtletyID,
 		Cast: core.CastConfig{
@@ -44,25 +76,45 @@ func (rogue *Rogue) registerMasterOfSubtletyCD() {
 				Duration: time.Second * time.Duration(180-30*rogue.Talents.Elusiveness),
 			},
 		},
-		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
+		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			rogue.MasterOfSubtletyAura.Activate(sim)
+
+			_, premedCPs := premed(sim, rogue)
+			_, garroteCPs := garrote(sim, rogue)
+
+			if premedCPs > 0 && rogue.ComboPoints()+premedCPs+garroteCPs <= 5 {
+				rogue.Premeditation.Cast(sim, target)
+			}
+
+			if garroteCPs > 0 {
+				rogue.Garrote.Cast(sim, target)
+			}
 		},
 	})
 
 	rogue.AddMajorCooldown(core.MajorCooldown{
 		Spell: rogue.MasterOfSubtlety,
 		Type:  core.CooldownTypeDPS,
-		ShouldActivate: func(s *core.Simulation, c *core.Character) bool {
+		ShouldActivate: func(sim *core.Simulation, character *core.Character) bool {
 			if rogue.MasterOfSubtletyAura.IsActive() {
 				return false // possible after preparation
 			}
-			if s.GetRemainingDuration() < time.Second*10 {
+
+			if sim.GetRemainingDuration() < garroteMinDuration {
 				return true // getting the buff up under non-ideal circumstances is fine at end of combat
 			}
-			if rogue.Premeditation != nil && !rogue.Premeditation.IsReady(s) {
+
+			wantPremed, premedCPs := premed(sim, rogue)
+			if wantPremed && premedCPs == 0 {
 				return false // essentially sync with premed if possible
 			}
-			return rogue.ComboPoints() <= 1 && rogue.CurrentEnergy() >= 40 // this covers any opener w/ talents, for now
+
+			wantGarrote, garroteCPs := garrote(sim, rogue)
+			if wantGarrote && garroteCPs == 0 {
+				return false
+			}
+
+			return rogue.ComboPoints()+garroteCPs+premedCPs <= 5+1 // heuristically, "<= 5" is too strict (since omitting premed is fine)
 		},
 	})
 }

--- a/sim/rogue/overkill.go
+++ b/sim/rogue/overkill.go
@@ -39,8 +39,9 @@ func (rogue *Rogue) registerOverkillCD() {
 	rogue.AddMajorCooldown(core.MajorCooldown{
 		Spell: rogue.Overkill,
 		Type:  core.CooldownTypeDPS,
-		ShouldActivate: func(s *core.Simulation, c *core.Character) bool {
-			return rogue.CurrentEnergy() < 50
+
+		ShouldActivate: func(sim *core.Simulation, c *core.Character) bool {
+			return !rogue.OverkillAura.IsActive() && rogue.CurrentEnergy() < 50
 		},
 	})
 

--- a/sim/rogue/premeditation.go
+++ b/sim/rogue/premeditation.go
@@ -38,8 +38,7 @@ func (rogue *Rogue) registerPremeditation() {
 		Type:     core.CooldownTypeDPS,
 		Priority: core.CooldownPriorityLow,
 		ShouldActivate: func(sim *core.Simulation, character *core.Character) bool {
-			// guarding by Master of Subtlety is slightly hacky, but working
-			return rogue.ComboPoints() <= 2 && (rogue.MasterOfSubtletyAura.IsActive() || rogue.ShadowDanceAura.IsActive())
+			return rogue.ComboPoints() <= 2 && rogue.ShadowDanceAura.IsActive()
 		},
 	})
 }

--- a/sim/rogue/premeditation.go
+++ b/sim/rogue/premeditation.go
@@ -38,8 +38,8 @@ func (rogue *Rogue) registerPremeditation() {
 		Type:     core.CooldownTypeDPS,
 		Priority: core.CooldownPriorityLow,
 		ShouldActivate: func(sim *core.Simulation, character *core.Character) bool {
-			thresh := 2
-			return rogue.ComboPoints() <= int32(thresh) && rogue.ShadowDanceAura.IsActive()
+			// guarding by Master of Subtlety is slightly hacky, but working
+			return rogue.ComboPoints() <= 2 && (rogue.MasterOfSubtletyAura.IsActive() || rogue.ShadowDanceAura.IsActive())
 		},
 	})
 }

--- a/sim/rogue/preparation.go
+++ b/sim/rogue/preparation.go
@@ -42,7 +42,7 @@ func (rogue *Rogue) registerPreparationCD() {
 		Type:     core.CooldownTypeDPS,
 		Priority: core.CooldownPriorityDefault,
 		ShouldActivate: func(sim *core.Simulation, character *core.Character) bool {
-			return !rogue.MasterOfSubtlety.CD.IsReady(sim)
+			return rogue.MasterOfSubtlety != nil && !rogue.MasterOfSubtlety.CD.IsReady(sim)
 		},
 	})
 }

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -185,7 +185,7 @@ func (rogue *Rogue) Initialize() {
 	rogue.registerEnvenom()
 
 	rogue.finishingMoveEffectApplier = rogue.makeFinishingMoveEffectApplier()
-	rogue.DelayDPSCooldownsForArmorDebuffs(time.Second * 14)
+	rogue.DelayDPSCooldownsForArmorDebuffs(time.Second * 10)
 }
 
 func (rogue *Rogue) getExpectedEnergyPerSecond() float64 {
@@ -213,6 +213,7 @@ func (rogue *Rogue) Reset(sim *core.Simulation) {
 	}
 	rogue.allMCDsDisabled = true
 	rogue.lastDeadlyPoisonProcMask = core.ProcMaskEmpty
+
 	// Vanish triggered effects (Overkill and Master of Subtlety) prepull activation
 	if rogue.Rotation.OpenWithGarrote || rogue.Options.StartingOverkillDuration > 0 {
 		length := rogue.Options.StartingOverkillDuration

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -214,22 +214,22 @@ func (rogue *Rogue) Reset(sim *core.Simulation) {
 	rogue.allMCDsDisabled = true
 	rogue.lastDeadlyPoisonProcMask = core.ProcMaskEmpty
 
-	// Vanish triggered effects (Overkill and Master of Subtlety) prepull activation
+	// Stealth triggered effects (Overkill and Master of Subtlety) pre-pull activation
 	if rogue.Rotation.OpenWithGarrote || rogue.Options.StartingOverkillDuration > 0 {
-		length := rogue.Options.StartingOverkillDuration
+		dur := time.Duration(rogue.Options.StartingOverkillDuration) * time.Second
 		if rogue.OverkillAura != nil {
-			if rogue.Rotation.OpenWithGarrote {
-				length = 20
+			if maxDur := rogue.OverkillAura.Duration; rogue.Rotation.OpenWithGarrote || dur > maxDur {
+				dur = maxDur
 			}
 			rogue.OverkillAura.Activate(sim)
-			rogue.OverkillAura.UpdateExpires(sim.CurrentTime + time.Second*time.Duration(length))
+			rogue.OverkillAura.UpdateExpires(sim.CurrentTime + dur)
 		}
 		if rogue.MasterOfSubtletyAura != nil {
-			if rogue.Rotation.OpenWithGarrote {
-				length = 6
+			if maxDur := rogue.MasterOfSubtletyAura.Duration; rogue.Rotation.OpenWithGarrote || dur > maxDur {
+				dur = maxDur
 			}
 			rogue.MasterOfSubtletyAura.Activate(sim)
-			rogue.MasterOfSubtletyAura.UpdateExpires(sim.CurrentTime + time.Second*time.Duration(length))
+			rogue.MasterOfSubtletyAura.UpdateExpires(sim.CurrentTime + dur)
 		}
 	}
 	rogue.setPriorityItems(sim)

--- a/sim/rogue/rogue_test.go
+++ b/sim/rogue/rogue_test.go
@@ -68,6 +68,31 @@ func TestAssassination(t *testing.T) {
 	}))
 }
 
+func TestSubtlety(t *testing.T) {
+	core.RunTestSuite(t, t.Name(), core.FullCharacterTestSuiteGenerator(core.CharacterSuiteConfig{
+		Class:       proto.Class_ClassRogue,
+		Race:        proto.Race_RaceBloodElf,
+		OtherRaces:  []proto.Race{proto.Race_RaceOrc},
+		GearSet:     core.GearSetCombo{Label: "P2 Subtlety", GearSet: SubtletyP2Gear},
+		Talents:     SubtletyTalents,
+		Glyphs:      SubtletyGlyphs,
+		Consumes:    FullConsumes,
+		SpecOptions: core.SpecOptionsCombo{Label: "Subtlety", SpecOptions: PlayerOptionsSubtletyID},
+		ItemFilter: core.ItemFilter{
+			ArmorType: proto.ArmorType_ArmorTypeLeather,
+			RangedWeaponTypes: []proto.RangedWeaponType{
+				proto.RangedWeaponType_RangedWeaponTypeBow,
+				proto.RangedWeaponType_RangedWeaponTypeCrossbow,
+				proto.RangedWeaponType_RangedWeaponTypeGun,
+			},
+			WeaponTypes: []proto.WeaponType{
+				proto.WeaponType_WeaponTypeDagger,
+				proto.WeaponType_WeaponTypeFist,
+			},
+		},
+	}))
+}
+
 type AttackType int
 
 const (
@@ -178,6 +203,7 @@ var CombatNoLethalityTalents = "00532000023-0252051050035010223100501251"
 var CombatNoPotWTalents = "00532000523-0252051050035010223100501201"
 var CombatNoLethalityNoPotWTalents = "00532000023-0252051050035010223100501201"
 var AssassinationTalents = "005303005352100520103331051-005005003-502"
+var SubtletyTalents = "30532000235--512003203032012135011503113"
 var CombatGlyphs = &proto.Glyphs{
 	Major1: int32(proto.RogueMajorGlyph_GlyphOfKillingSpree),
 	Major2: int32(proto.RogueMajorGlyph_GlyphOfTricksOfTheTrade),
@@ -187,6 +213,11 @@ var AssassinationGlyphs = &proto.Glyphs{
 	Major1: int32(proto.RogueMajorGlyph_GlyphOfMutilate),
 	Major2: int32(proto.RogueMajorGlyph_GlyphOfTricksOfTheTrade),
 	Major3: int32(proto.RogueMajorGlyph_GlyphOfHungerForBlood),
+}
+var SubtletyGlyphs = &proto.Glyphs{
+	Major1: int32(proto.RogueMajorGlyph_GlyphOfHemorrhage),
+	Major2: int32(proto.RogueMajorGlyph_GlyphOfEviscerate),
+	Major3: int32(proto.RogueMajorGlyph_GlyphOfRupture),
 }
 
 var PlayerOptionsCombatDI = &proto.Player_Rogue{
@@ -260,6 +291,13 @@ var PlayerOptionsAssassinationII = &proto.Player_Rogue{
 	},
 }
 
+var PlayerOptionsSubtletyID = &proto.Player_Rogue{
+	Rogue: &proto.Rogue{
+		Options:  InstantDeadly,
+		Rotation: subtletyRotation,
+	},
+}
+
 var basicRotation = &proto.Rogue_Rotation{
 	ExposeArmorFrequency:                proto.Rogue_Rotation_Never,
 	TricksOfTheTradeFrequency:           proto.Rogue_Rotation_Maintain,
@@ -270,6 +308,16 @@ var basicRotation = &proto.Rogue_Rotation{
 	MinimumComboPointsSecondaryFinisher: 2,
 	MultiTargetSliceFrequency:           proto.Rogue_Rotation_Once,
 	MinimumComboPointsMultiTargetSlice:  4,
+}
+
+var subtletyRotation = &proto.Rogue_Rotation{
+	ExposeArmorFrequency:                proto.Rogue_Rotation_Never,
+	TricksOfTheTradeFrequency:           proto.Rogue_Rotation_Never,
+	SubtletyFinisherPriority:            proto.Rogue_Rotation_SubtletyEviscerate,
+	MinimumComboPointsPrimaryFinisher:   5,
+	MinimumComboPointsSecondaryFinisher: 5,
+	OpenWithGarrote:                     true,
+	OpenWithPremeditation:               true,
 }
 
 var DeadlyInstant = &proto.Rogue_Options{
@@ -646,5 +694,123 @@ var MutilateP1Gear = core.EquipmentSpecFromJsonString(`{"items": [
 	},
 	{
 		"id": 28772
+	}
+]}`)
+var SubtletyP2Gear = core.EquipmentSpecFromJsonString(`{"items": [
+	{
+	  "id": 46125,
+	  "enchant": 3817,
+	  "gems": [
+		41398,
+		42143
+	  ]
+	},
+	{
+	  "id": 45517,
+	  "gems": [
+		49110
+	  ]
+	},
+	{
+	  "id": 46127,
+	  "enchant": 3808,
+	  "gems": [
+		39997
+	  ]
+	},
+	{
+	  "id": 45461,
+	  "enchant": 3605,
+	  "gems": [
+		40044
+	  ]
+	},
+	{
+	  "id": 46123,
+	  "enchant": 3832,
+	  "gems": [
+		39997,
+		40044
+	  ]
+	},
+	{
+	  "id": 45611,
+	  "enchant": 3845,
+	  "gems": [
+		40044,
+		0
+	  ]
+	},
+	{
+	  "id": 46124,
+	  "enchant": 3604,
+	  "gems": [
+		39997,
+		0
+	  ]
+	},
+	{
+	  "id": 46095,
+	  "enchant": 3599,
+	  "gems": [
+		42143,
+		42143,
+		39997
+	  ]
+	},
+	{
+	  "id": 45536,
+	  "enchant": 3823,
+	  "gems": [
+		40044,
+		39997,
+		40023
+	  ]
+	},
+	{
+	  "id": 45564,
+	  "enchant": 3606,
+	  "gems": [
+		40023,
+		40003
+	  ]
+	},
+	{
+	  "id": 45608,
+	  "gems": [
+		39997
+	  ]
+	},
+	{
+	  "id": 46048,
+	  "gems": [
+		39997
+	  ]
+	},
+	{
+	  "id": 45609
+	},
+	{
+	  "id": 45931
+	},
+	{
+	  "id": 45132,
+	  "enchant": 3789,
+	  "gems": [
+		40044
+	  ]
+	},
+	{
+	  "id": 45484,
+	  "enchant": 3789,
+	  "gems": [
+		39997
+	  ]
+	},
+	{
+	  "id": 45296,
+	  "gems": [
+		39997
+	  ]
 	}
 ]}`)

--- a/sim/rogue/subtlety_rotation.go
+++ b/sim/rogue/subtlety_rotation.go
@@ -241,10 +241,12 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 		})
 	}
 
+	const ruptureMinDuration = time.Second * 10 // heuristically, 5 Rupture ticks are better DPE than other finishers
+
 	// Rupture
 	rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
 		func(sim *core.Simulation, rogue *Rogue) PriorityAction {
-			if rogue.Rupture.CurDot().IsActive() || sim.GetRemainingDuration() < time.Second*22 {
+			if rogue.Rupture.CurDot().IsActive() || sim.GetRemainingDuration() < ruptureMinDuration {
 				return Skip
 			}
 			if rogue.ComboPoints() > 4 && rogue.CurrentEnergy() >= rogue.Rupture.DefaultCast.Cost {

--- a/sim/rogue/subtlety_rotation.go
+++ b/sim/rogue/subtlety_rotation.go
@@ -52,7 +52,7 @@ func (rogue *Rogue) setSubtletyBuilder(sim *core.Simulation) {
 }
 
 func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
-	rogue.subtletyPrios = make([]subtletyPrio, 0)
+	rogue.subtletyPrios = rogue.subtletyPrios[:0]
 
 	if rogue.Rotation.OpenWithPremeditation && rogue.Talents.Premeditation {
 		hasCastPremeditation := false
@@ -104,7 +104,7 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 	if rogue.Rotation.OpenWithGarrote {
 		hasCastGarrote := false
 		rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
-			func(s *core.Simulation, r *Rogue) PriorityAction {
+			func(sim *core.Simulation, rogue *Rogue) PriorityAction {
 				if hasCastGarrote {
 					return Skip
 				}
@@ -113,7 +113,7 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 				}
 				return Wait
 			},
-			func(s *core.Simulation, r *Rogue) bool {
+			func(sim *core.Simulation, rogue *Rogue) bool {
 				casted := rogue.Garrote.Cast(sim, rogue.CurrentTarget)
 				if casted {
 					hasCastGarrote = true
@@ -126,7 +126,7 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 
 	// Slice and Dice
 	rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
-		func(s *core.Simulation, r *Rogue) PriorityAction {
+		func(sim *core.Simulation, rogue *Rogue) PriorityAction {
 			if rogue.SliceAndDiceAura.IsActive() {
 				return Skip
 			}
@@ -141,8 +141,8 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 			}
 			return Wait
 		},
-		func(s *core.Simulation, r *Rogue) bool {
-			return rogue.SliceAndDice.Cast(s, r.CurrentTarget)
+		func(sim *core.Simulation, rogue *Rogue) bool {
+			return rogue.SliceAndDice.Cast(sim, rogue.CurrentTarget)
 		},
 		rogue.SliceAndDice.DefaultCast.Cost,
 	})
@@ -152,7 +152,7 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 		rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Maintain {
 		hasCastExpose := false
 		rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
-			func(s *core.Simulation, r *Rogue) PriorityAction {
+			func(sim *core.Simulation, rogue *Rogue) PriorityAction {
 				if hasCastExpose && rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Once {
 					return Skip
 				}
@@ -192,8 +192,8 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 					}
 				}
 			},
-			func(s *core.Simulation, r *Rogue) bool {
-				casted := r.ExposeArmor.Cast(sim, r.CurrentTarget)
+			func(sim *core.Simulation, rogue *Rogue) bool {
+				casted := rogue.ExposeArmor.Cast(sim, rogue.CurrentTarget)
 				if casted {
 					hasCastExpose = true
 				}
@@ -205,16 +205,16 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 
 	// Enable CDS
 	rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
-		func(s *core.Simulation, r *Rogue) PriorityAction {
-			if r.allMCDsDisabled {
-				for _, mcd := range r.GetMajorCooldowns() {
+		func(sim *core.Simulation, rogue *Rogue) PriorityAction {
+			if rogue.allMCDsDisabled {
+				for _, mcd := range rogue.GetMajorCooldowns() {
 					mcd.Enable()
 				}
-				r.allMCDsDisabled = false
+				rogue.allMCDsDisabled = false
 			}
 			return Skip
 		},
-		func(s *core.Simulation, r *Rogue) bool {
+		func(_ *core.Simulation, _ *Rogue) bool {
 			return false
 		},
 		0,
@@ -223,10 +223,10 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 	//Shadowstep
 	if rogue.Talents.Shadowstep {
 		rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
-			func(s *core.Simulation, r *Rogue) PriorityAction {
-				if r.Shadowstep.IsReady(s) {
+			func(sim *core.Simulation, rogue *Rogue) PriorityAction {
+				if rogue.Shadowstep.IsReady(sim) {
 					// Can we cast Rupture now?
-					if !r.Rupture.CurDot().IsActive() && rogue.ComboPoints() > 4 && rogue.CurrentEnergy() >= rogue.Rupture.DefaultCast.Cost+rogue.Shadowstep.DefaultCast.Cost {
+					if !rogue.Rupture.CurDot().IsActive() && rogue.ComboPoints() > 4 && rogue.CurrentEnergy() >= rogue.Rupture.DefaultCast.Cost+rogue.Shadowstep.DefaultCast.Cost {
 						return Cast
 					} else {
 						return Skip
@@ -234,8 +234,8 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 				}
 				return Skip
 			},
-			func(s *core.Simulation, r *Rogue) bool {
-				return r.Shadowstep.Cast(s, r.CurrentTarget)
+			func(sim *core.Simulation, rogue *Rogue) bool {
+				return rogue.Shadowstep.Cast(sim, rogue.CurrentTarget)
 			},
 			rogue.Shadowstep.DefaultCast.Cost,
 		})
@@ -243,8 +243,8 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 
 	// Rupture
 	rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
-		func(s *core.Simulation, r *Rogue) PriorityAction {
-			if r.Rupture.CurDot().IsActive() || s.GetRemainingDuration() < time.Second*22 {
+		func(sim *core.Simulation, rogue *Rogue) PriorityAction {
+			if rogue.Rupture.CurDot().IsActive() || sim.GetRemainingDuration() < time.Second*22 {
 				return Skip
 			}
 			if rogue.ComboPoints() > 4 && rogue.CurrentEnergy() >= rogue.Rupture.DefaultCast.Cost {
@@ -261,8 +261,8 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 			}
 			return Wait
 		},
-		func(s *core.Simulation, r *Rogue) bool {
-			return r.Rupture.Cast(s, r.CurrentTarget)
+		func(sim *core.Simulation, rogue *Rogue) bool {
+			return rogue.Rupture.Cast(sim, rogue.CurrentTarget)
 		},
 		rogue.Rupture.DefaultCast.Cost,
 	})
@@ -270,12 +270,12 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 	//Envenom
 	if rogue.Rotation.SubtletyFinisherPriority == proto.Rogue_Rotation_SubtletyEnvenom {
 		rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
-			func(s *core.Simulation, r *Rogue) PriorityAction {
+			func(sim *core.Simulation, rogue *Rogue) PriorityAction {
 				minimumCP := int32(5)
-				if !r.DeadlyPoison.Dot(r.CurrentTarget).Aura.IsActive() {
+				if !rogue.DeadlyPoison.Dot(rogue.CurrentTarget).Aura.IsActive() {
 					return Skip
 				}
-				if r.EnvenomAura.IsActive() {
+				if rogue.EnvenomAura.IsActive() {
 					return Skip
 				}
 				if rogue.ComboPoints() >= minimumCP && rogue.CurrentEnergy() >= rogue.Envenom.DefaultCast.Cost {
@@ -292,7 +292,7 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 				}
 				return Wait
 			},
-			func(s *core.Simulation, r *Rogue) bool {
+			func(sim *core.Simulation, rogue *Rogue) bool {
 				return rogue.Envenom.Cast(sim, rogue.CurrentTarget)
 			},
 			rogue.Envenom.DefaultCast.Cost,
@@ -301,18 +301,18 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 
 	// Eviscerate
 	rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
-		func(s *core.Simulation, r *Rogue) PriorityAction {
-			energyNeeded := r.Eviscerate.DefaultCast.Cost
+		func(sim *core.Simulation, rogue *Rogue) PriorityAction {
+			energyNeeded := rogue.Eviscerate.DefaultCast.Cost
 			minimumCP := int32(5)
-			if r.ComboPoints() >= minimumCP && r.CurrentEnergy() >= energyNeeded {
+			if rogue.ComboPoints() >= minimumCP && rogue.CurrentEnergy() >= energyNeeded {
 				return Cast
 			}
-			if r.ComboPoints() < minimumCP && r.CurrentEnergy() >= r.Builder.DefaultCast.Cost+r.Eviscerate.DefaultCast.Cost {
+			if rogue.ComboPoints() < minimumCP && rogue.CurrentEnergy() >= rogue.Builder.DefaultCast.Cost+rogue.Eviscerate.DefaultCast.Cost {
 				return Build
 			}
 			return Wait
 		},
-		func(s *core.Simulation, r *Rogue) bool {
+		func(sim *core.Simulation, rogue *Rogue) bool {
 			return rogue.Eviscerate.Cast(sim, rogue.CurrentTarget)
 		},
 		rogue.Eviscerate.DefaultCast.Cost,
@@ -327,6 +327,13 @@ func (rogue *Rogue) doSubtletyRotation(sim *core.Simulation) {
 		case Skip:
 			prioIndex += 1
 		case Build:
+			if rogue.HonorAmongThieves != nil && rogue.ComboPoints() == 4 && rogue.CurrentEnergy() <= rogue.maxEnergy-20 {
+				// just wait for HaT proc - if it happens, a finisher will follow and often cost effectively 0 energy,
+				// so we add another GCD worth of energy headroom
+				rogue.WaitUntil(sim, sim.CurrentTime+time.Second)
+				return
+			}
+
 			if rogue.GCD.IsReady(sim) {
 				rogue.setSubtletyBuilder(sim)
 				if !rogue.Builder.Cast(sim, rogue.CurrentTarget) {

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -598,7 +598,9 @@ func (rogue *Rogue) registerKillingSpreeCD() {
 }
 
 func (rogue *Rogue) registerHonorAmongThieves() {
-	// When anyone in your group critically hits with a damage or healing spell or ability, you have a [33%/66%/100%] cahnce to gain a combo point on your current target. This effect cannot occur more than once per second.
+	// When anyone in your group critically hits with a damage or healing spell or ability,
+	// you have a [33%/66%/100%] chance to gain a combo point on your current target.
+	// This effect cannot occur more than once per second.
 	if rogue.Talents.HonorAmongThieves == 0 {
 		return
 	}
@@ -618,7 +620,7 @@ func (rogue *Rogue) registerHonorAmongThieves() {
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			core.StartPeriodicAction(sim, core.PeriodicActionOptions{
 				Period: time.Second,
-				OnAction: func(s *core.Simulation) {
+				OnAction: func(sim *core.Simulation) {
 					if sim.Proc(procChance, "Honor Among Thieves") {
 						rogue.AddComboPoints(sim, 1, comboMetrics)
 					}


### PR DESCRIPTION
[core] fix - DelayDPSCooldownsForArmorDebuffs() was using timings to delay cooldowns, so ShouldActivate() callbacks were ignored for automatic CDs

[rogue] cleanup - using "sim" and "rogue" for rotation callbacks, so they don't accidentally capture the enclosing vars; re-use priority items 

[rogue] delay building at 4 CP, so HAT-generated CPs don't get wasted 

[rogue] fix - prevent Vanish (Overkill) while Overkill is active

[rogue] validate StartingOverkillDuration

[rogue] added subtlety tests

[rogue] support Garrote after Vanish (Master of Subtlety), staple Vanish + Premediation + Garrote into one major cooldown, essentially

[rogue] Garrote and Rupture use heuristically determined minimum durations (could be determined via pre-simming in the general case, for non-subtlety as well)
