### PR TITLE
improve frost sub UH opener

### DIFF
--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -46,940 +46,940 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7899.30582
-  tps: 4613.01824
+  dps: 7921.78885
+  tps: 4626.90952
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7897.64049
-  tps: 4626.75663
+  dps: 7897.85826
+  tps: 4626.80136
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7665.8822
-  tps: 8480.02823
+  dps: 7687.51205
+  tps: 8503.67393
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7665.8822
-  tps: 8480.02823
+  dps: 7687.51205
+  tps: 8503.67393
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7917.76454
-  tps: 4624.09347
+  dps: 7938.17373
+  tps: 4636.74046
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7708.96339
-  tps: 4502.896
+  dps: 7705.15833
+  tps: 4501.34202
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6632.22124
-  tps: 3873.82666
+  dps: 6650.01036
+  tps: 3884.53532
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6522.41494
-  tps: 3812.16687
+  dps: 6520.16385
+  tps: 3810.56735
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6252.57221
-  tps: 3651.26832
+  dps: 6249.49628
+  tps: 3649.39412
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7893.29446
-  tps: 4517.22319
+  dps: 7915.75956
+  tps: 4530.82611
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8094.77091
-  tps: 4730.2973
+  dps: 8118.39618
+  tps: 4744.87392
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8094.77091
-  tps: 4730.2973
+  dps: 8118.39618
+  tps: 4744.87392
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8101.40368
-  tps: 4734.27695
+  dps: 8122.76645
+  tps: 4747.49609
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7764.81505
-  tps: 4546.27847
+  dps: 7790.37257
+  tps: 4561.92502
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7835.31823
-  tps: 4589.2167
+  dps: 7835.60551
+  tps: 4589.30313
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7903.48003
-  tps: 4618.74308
+  dps: 7926.41806
+  tps: 4632.88673
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7532.13259
-  tps: 4402.34346
+  dps: 7550.9042
+  tps: 4413.16813
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 6646.75178
-  tps: 3877.63384
+  dps: 6624.87894
+  tps: 3865.09661
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7572.74093
-  tps: 4417.0793
+  dps: 7597.94306
+  tps: 4432.60205
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8290.56471
-  tps: 4843.47982
+  dps: 8314.96298
+  tps: 4858.54777
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7752.87423
-  tps: 4539.11398
+  dps: 7779.09522
+  tps: 4555.15861
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8151.81202
-  tps: 4772.29318
+  dps: 8133.85758
+  tps: 4762.16304
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8208.51227
-  tps: 4806.93151
+  dps: 8207.84179
+  tps: 4806.88223
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7685.31546
-  tps: 4498.57872
+  dps: 7707.01554
+  tps: 4511.9108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7921.11901
-  tps: 4626.10615
+  dps: 7942.08719
+  tps: 4639.08853
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7866.75867
-  tps: 4603.2843
+  dps: 7865.43692
+  tps: 4603.84432
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7853.23511
-  tps: 4594.73689
+  dps: 7850.09638
+  tps: 4592.4643
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7893.29446
-  tps: 4609.41142
+  dps: 7915.75956
+  tps: 4623.29195
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7893.29446
-  tps: 4609.41142
+  dps: 7915.75956
+  tps: 4623.29195
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7917.76454
-  tps: 4624.09347
+  dps: 7938.17373
+  tps: 4636.74046
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7911.54034
-  tps: 4620.35895
+  dps: 7934.08092
+  tps: 4634.28477
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7742.95171
-  tps: 4525.96311
+  dps: 7738.39784
+  tps: 4523.76247
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7893.29446
-  tps: 4609.41142
+  dps: 7915.75956
+  tps: 4623.29195
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7814.29763
-  tps: 4576.09626
+  dps: 7835.13344
+  tps: 4588.63802
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7750.57424
-  tps: 4537.73399
+  dps: 7776.55428
+  tps: 4553.63404
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7733.81225
-  tps: 4527.67679
+  dps: 7757.67818
+  tps: 4542.30839
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7893.29446
-  tps: 4609.41142
+  dps: 7915.75956
+  tps: 4623.29195
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7893.29446
-  tps: 4609.41142
+  dps: 7915.75956
+  tps: 4623.29195
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7573.55439
-  tps: 4417.56738
+  dps: 7598.79042
+  tps: 4433.11047
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7904.98561
-  tps: 4630.38081
+  dps: 7927.28665
+  tps: 4644.07347
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7751.8318
-  tps: 4538.42669
+  dps: 7766.30437
+  tps: 4547.24881
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7570.87411
-  tps: 4415.95922
+  dps: 7595.98464
+  tps: 4431.427
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7917.76454
-  tps: 4624.09347
+  dps: 7938.17373
+  tps: 4636.74046
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7911.54034
-  tps: 4620.35895
+  dps: 7934.08092
+  tps: 4634.28477
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7867.92366
-  tps: 4608.14364
+  dps: 7891.16762
+  tps: 4622.40205
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7893.29446
-  tps: 4609.41142
+  dps: 7915.75956
+  tps: 4623.29195
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7924.30694
-  tps: 4628.01891
+  dps: 7946.86849
+  tps: 4641.95731
   hps: 12.97738
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7858.36923
-  tps: 4598.4002
+  dps: 7835.86353
+  tps: 4585.40186
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7732.6053
-  tps: 4526.95262
+  dps: 7751.76896
+  tps: 4538.76285
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7678.44651
-  tps: 4494.45735
+  dps: 7700.12567
+  tps: 4507.77688
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7918.44811
-  tps: 4624.50361
+  dps: 7940.99129
+  tps: 4638.43099
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7924.36662
-  tps: 4628.05472
+  dps: 7946.92817
+  tps: 4641.99312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7718.10324
-  tps: 4518.25138
+  dps: 7739.90314
+  tps: 4531.64336
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7724.8348
-  tps: 4522.29033
+  dps: 7746.65521
+  tps: 4535.6946
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7893.29446
-  tps: 4609.41142
+  dps: 7915.75956
+  tps: 4623.29195
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7893.29446
-  tps: 4609.41142
+  dps: 7915.75956
+  tps: 4623.29195
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7679.71881
-  tps: 4494.98529
+  dps: 7697.36252
+  tps: 4505.89177
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7681.46689
-  tps: 4496.03414
+  dps: 7699.14535
+  tps: 4506.96147
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8094.77091
-  tps: 4730.2973
+  dps: 8118.39618
+  tps: 4744.87392
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7574.50342
-  tps: 4418.1368
+  dps: 7599.779
+  tps: 4433.70362
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7893.29446
-  tps: 4609.41142
+  dps: 7915.75956
+  tps: 4623.29195
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7570.625
-  tps: 4415.80975
+  dps: 7595.72671
+  tps: 4431.27224
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7300.83727
-  tps: 4267.29546
+  dps: 7313.15116
+  tps: 4274.41409
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 6568.63068
-  tps: 3832.85873
+  dps: 6562.76303
+  tps: 3829.44583
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8315.07064
-  tps: 4870.5572
+  dps: 8307.83538
+  tps: 4866.38335
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6985.17137
-  tps: 4074.52859
+  dps: 6992.63513
+  tps: 4079.12436
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7679.2986
-  tps: 4494.9686
+  dps: 7700.85765
+  tps: 4508.21607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8094.77091
-  tps: 4730.2973
+  dps: 8118.39618
+  tps: 4744.87392
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7568.67364
-  tps: 4414.63893
+  dps: 7593.70626
+  tps: 4430.05997
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7576.82507
-  tps: 4419.52979
+  dps: 7602.37666
+  tps: 4435.26221
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7568.67364
-  tps: 4414.63893
+  dps: 7593.70626
+  tps: 4430.05997
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7982.21089
-  tps: 4655.60503
+  dps: 8008.95319
+  tps: 4672.09774
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7568.67364
-  tps: 4414.63893
+  dps: 7593.70626
+  tps: 4430.05997
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 8020.44717
-  tps: 4677.86695
+  dps: 8047.12598
+  tps: 4694.32593
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7568.67364
-  tps: 4414.63893
+  dps: 7593.70626
+  tps: 4430.05997
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7754.21186
-  tps: 4539.91656
+  dps: 7780.19189
+  tps: 4555.81661
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 7775.70498
-  tps: 4549.30219
+  dps: 7764.56082
+  tps: 4543.11278
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7878.49665
-  tps: 4615.02321
+  dps: 7862.15163
+  tps: 4605.45659
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StormshroudArmor"
  value: {
-  dps: 6245.30273
-  tps: 3649.22608
+  dps: 6239.41134
+  tps: 3645.40168
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7924.36662
-  tps: 4628.05472
+  dps: 7946.92817
+  tps: 4641.99312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7918.44811
-  tps: 4624.50361
+  dps: 7940.99129
+  tps: 4638.43099
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7908.09072
-  tps: 4618.28918
+  dps: 7930.60175
+  tps: 4632.19727
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7566.93373
-  tps: 4423.0283
+  dps: 7585.86608
+  tps: 4434.24411
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6626.30414
-  tps: 3867.9248
+  dps: 6614.81222
+  tps: 3860.21905
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7148.66592
-  tps: 4167.21719
+  dps: 7152.5723
+  tps: 4170.38976
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7868.8985
-  tps: 4593.475
+  dps: 7883.4663
+  tps: 4601.9829
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7854.65559
-  tps: 4599.56207
+  dps: 7863.08905
+  tps: 4604.88562
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7883.53436
-  tps: 4616.58467
+  dps: 7858.39735
+  tps: 4600.7727
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7893.29446
-  tps: 4609.41142
+  dps: 7915.75956
+  tps: 4623.29195
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7893.29446
-  tps: 4609.41142
+  dps: 7915.75956
+  tps: 4623.29195
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7717.11061
-  tps: 4514.48252
+  dps: 7728.31375
+  tps: 4521.21476
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7893.29446
-  tps: 4609.41142
+  dps: 7915.75956
+  tps: 4623.29195
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7893.29446
-  tps: 4609.41142
+  dps: 7915.75956
+  tps: 4623.29195
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6512.99512
-  tps: 3806.59809
+  dps: 6513.611
+  tps: 3807.10024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7570.05308
-  tps: 4414.23787
+  dps: 7561.58413
+  tps: 4409.15818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7665.85344
-  tps: 4486.90151
+  dps: 7687.49426
+  tps: 4500.19803
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7575.58804
-  tps: 4418.78757
+  dps: 7600.90882
+  tps: 4434.38151
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 8101.7783
-  tps: 4735.10572
+  dps: 8103.00046
+  tps: 4735.85461
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15869.29079
-  tps: 9399.75697
+  dps: 15942.5985
+  tps: 9444.11485
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8086.14816
-  tps: 4729.276
+  dps: 8084.74197
+  tps: 4728.45455
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9160.32174
-  tps: 5212.58158
+  dps: 9202.4198
+  tps: 5236.2006
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10141.83245
-  tps: 6007.78824
+  dps: 10176.55042
+  tps: 6028.77043
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4844.94985
-  tps: 2829.86744
+  dps: 4840.73142
+  tps: 2826.94213
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5179.26106
-  tps: 2952.55446
+  dps: 5164.78993
+  tps: 2944.81799
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15772.4721
-  tps: 9337.98292
+  dps: 15827.89951
+  tps: 9372.02235
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8094.77091
-  tps: 4730.2973
+  dps: 8118.39618
+  tps: 4744.87392
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9233.2668
-  tps: 5242.50398
+  dps: 9260.7207
+  tps: 5257.0836
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10132.84642
-  tps: 5999.37634
+  dps: 10232.48469
+  tps: 6059.06048
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4862.74646
-  tps: 2836.30637
+  dps: 4869.53987
+  tps: 2840.24335
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5233.75923
-  tps: 2978.59875
+  dps: 5206.8456
+  tps: 2964.02745
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7843.98955
-  tps: 4591.48051
+  dps: 7857.66894
+  tps: 4599.72051
  }
 }

--- a/sim/deathknight/dps/rotation_frost_sub_blood.go
+++ b/sim/deathknight/dps/rotation_frost_sub_blood.go
@@ -340,7 +340,7 @@ func (dk *DpsDeathknight) setupFrostSubBloodERWOpener() {
 		NewAction(dk.RotationActionCallback_UA_Frost).
 		NewAction(dk.RotationActionCallback_BT).
 		NewAction(dk.RotationActionCallback_FrostSubBlood_Obli).
-		NewAction(dk.RotationActionCallback_FS).
+		NewAction(dk.RotationActionCallback_Frost_FS_HB).
 		NewAction(dk.RotationActionCallback_FrostSubBlood_Sequence_Pesti).
 		NewAction(dk.RotationActionCallback_ERW).
 		NewAction(dk.RotationActionCallback_FrostSubBlood_Obli).

--- a/sim/deathknight/dps/rotation_frost_sub_unholy.go
+++ b/sim/deathknight/dps/rotation_frost_sub_unholy.go
@@ -18,11 +18,11 @@ func (dk *DpsDeathknight) setupFrostSubUnholyERWOpener() {
 		NewAction(dk.RotationActionCallback_UA_Frost).
 		NewAction(dk.RotationActionCallback_FrostSubUnholy_Obli).
 		NewAction(dk.RotationActionCallback_Pesti).
-		NewAction(dk.RotationActionCallback_FS).
 		NewAction(dk.RotationActionCallback_ERW).
-		NewAction(dk.RotationActionCallback_FrostSubUnholy_Obli).
+		NewAction(dk.RotationActionCallback_FS).
 		NewAction(dk.RotationActionCallback_FrostSubUnholy_Obli).
 		NewAction(dk.RotationActionCallback_FrostSubUnholy_FS_HB).
+		NewAction(dk.RotationActionCallback_FrostSubUnholy_Obli).
 		NewAction(dk.RotationActionCallback_FrostSubUnholy_Obli).
 		NewAction(dk.RotationAction_CancelBT).
 		NewAction(dk.RotationActionCallback_RD).

--- a/sim/deathknight/dps/rotation_frost_sub_unholy.go
+++ b/sim/deathknight/dps/rotation_frost_sub_unholy.go
@@ -7,7 +7,6 @@ import (
 	"github.com/wowsims/wotlk/sim/deathknight"
 )
 
-// frosst's opener
 func (dk *DpsDeathknight) setupFrostSubUnholyERWOpener() {
 	dk.setupUnbreakableArmorCooldowns()
 


### PR DESCRIPTION
- ERWs before frost strike which causes rune grace to start sooner
- Frost strike after first oblit to not overcap RP

+25 dps on 180s fight (50k iterations)
<img width="277" alt="image" src="https://user-images.githubusercontent.com/9436142/221902238-f073d227-75f5-4bfe-a4aa-6951ade3fbdb.png">
