### PR TITLE
warlock: lightweave fixes

### DIFF
--- a/sim/common/wotlk/enchant_effects.go
+++ b/sim/common/wotlk/enchant_effects.go
@@ -351,18 +351,25 @@ func init() {
 			Duration: time.Second * 60,
 		}
 
+		callback := func(_ *core.Aura, sim *core.Simulation, _ *core.Spell, result *core.SpellResult) {
+			if !result.Landed() {
+				return
+			}
+
+			if icd.IsReady(sim) && sim.RandomFloat("Lightweave") < 0.35 {
+				icd.Use(sim)
+				procAura.Activate(sim)
+			}
+		}
+
 		character.GetOrRegisterAura(core.Aura{
 			Label:    "Lightweave Embroidery",
 			Duration: core.NeverExpires,
 			OnReset: func(aura *core.Aura, sim *core.Simulation) {
 				aura.Activate(sim)
 			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				if icd.IsReady(sim) && sim.RandomFloat("Lightweave") < 0.35 {
-					icd.Use(sim)
-					procAura.Activate(sim)
-				}
-			},
+			OnPeriodicDamageDealt: callback,
+			OnSpellHitDealt:       callback,
 		})
 	})
 

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -46,15 +46,15 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7036.8241
-  tps: 4255.41273
+  dps: 7037.08988
+  tps: 4255.5722
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7072.06521
-  tps: 4276.23221
+  dps: 7072.33099
+  tps: 4276.39168
  }
 }
 dps_results: {
@@ -67,22 +67,22 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6751.85265
-  tps: 10188.05008
+  dps: 6752.11843
+  tps: 10188.20954
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6751.85265
-  tps: 10188.05008
+  dps: 6752.11843
+  tps: 10188.20954
  }
 }
 dps_results: {
@@ -95,8 +95,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5733.77604
-  tps: 3477.14419
+  dps: 5732.37493
+  tps: 3476.30353
  }
 }
 dps_results: {
@@ -123,79 +123,79 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
   hps: 64
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6853.94544
-  tps: 4148.18443
+  dps: 6854.21123
+  tps: 4148.3439
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6866.984
-  tps: 4179.60742
+  dps: 6866.61367
+  tps: 4179.38522
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6983.31259
-  tps: 4228.8539
+  dps: 6983.45588
+  tps: 4228.93987
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6783.32319
-  tps: 4105.82577
+  dps: 6783.58897
+  tps: 4105.98524
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
@@ -208,15 +208,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7371.16859
-  tps: 4459.7004
+  dps: 7370.98322
+  tps: 4459.58918
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7293.55862
-  tps: 4413.04394
+  dps: 7293.58325
+  tps: 4413.05871
  }
 }
 dps_results: {
@@ -250,15 +250,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6835.62457
-  tps: 4136.36743
+  dps: 6836.00288
+  tps: 4136.59442
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
@@ -271,36 +271,36 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6851.99252
-  tps: 4146.71795
+  dps: 6852.2583
+  tps: 4146.87742
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7056.40614
-  tps: 4268.39526
+  dps: 7056.67192
+  tps: 4268.55473
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6851.55213
-  tps: 4150.81425
+  dps: 6851.67632
+  tps: 4150.88877
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6927.89703
-  tps: 4191.0616
+  dps: 6928.16281
+  tps: 4191.22107
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6983.50365
-  tps: 4225.09968
+  dps: 6983.76943
+  tps: 4225.25915
  }
 }
 dps_results: {
@@ -327,43 +327,43 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6897.73844
-  tps: 4172.23171
+  dps: 6898.00422
+  tps: 4172.39118
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 6817.11174
-  tps: 4114.0937
+  dps: 6817.64968
+  tps: 4114.41647
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7054.44465
-  tps: 4265.82247
+  dps: 7054.71043
+  tps: 4265.98194
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7094.49137
-  tps: 4289.48097
+  dps: 7094.75715
+  tps: 4289.64044
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6833.44781
-  tps: 4151.1584
+  dps: 6832.56319
+  tps: 4150.62764
  }
 }
 dps_results: {
@@ -383,8 +383,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7057.56366
-  tps: 4269.08574
+  dps: 7057.82944
+  tps: 4269.24521
  }
 }
 dps_results: {
@@ -404,8 +404,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
@@ -439,36 +439,36 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6945.56039
-  tps: 4200.92776
+  dps: 6946.08303
+  tps: 4201.24135
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6821.95068
-  tps: 4128.69285
+  dps: 6822.21647
+  tps: 4128.85232
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6957.82868
-  tps: 4209.02059
+  dps: 6958.09446
+  tps: 4209.18006
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
@@ -488,15 +488,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
@@ -516,22 +516,22 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7212.7986
-  tps: 4437.33477
+  dps: 7212.59793
+  tps: 4437.21437
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7265.85542
-  tps: 4478.55062
+  dps: 7265.65475
+  tps: 4478.43022
  }
 }
 dps_results: {
@@ -551,57 +551,57 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7052.51402
-  tps: 4268.4317
+  dps: 7052.80425
+  tps: 4268.60583
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7090.28306
-  tps: 4291.42725
+  dps: 7090.57328
+  tps: 4291.60138
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6917.88501
-  tps: 4192.97154
+  dps: 6918.21897
+  tps: 4193.17192
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SparkofLife-37657"
  value: {
-  dps: 6893.66553
-  tps: 4170.68397
+  dps: 6893.78904
+  tps: 4170.75807
  }
 }
 dps_results: {
@@ -635,15 +635,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6839.29971
-  tps: 4137.15894
+  dps: 6839.30922
+  tps: 4137.16465
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6903.53514
-  tps: 4179.92034
+  dps: 6903.68767
+  tps: 4180.01185
  }
 }
 dps_results: {
@@ -656,8 +656,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6750.08961
-  tps: 4086.01785
+  dps: 6750.35539
+  tps: 4086.17732
  }
 }
 dps_results: {
@@ -705,8 +705,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6903.46561
-  tps: 4177.02434
+  dps: 6903.3106
+  tps: 4176.93133
  }
 }
 dps_results: {
@@ -726,8 +726,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6884.4706
-  tps: 4166.64645
+  dps: 6884.73638
+  tps: 4166.80592
  }
 }
 dps_results: {
@@ -803,22 +803,22 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3509.47615
-  tps: 3453.3294
+  dps: 3509.42719
+  tps: 3453.30002
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3509.47615
-  tps: 2127.99285
+  dps: 3509.42719
+  tps: 2127.96347
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4757.71333
-  tps: 2842.82906
+  dps: 4757.78041
+  tps: 2842.86931
  }
 }
 dps_results: {

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -46,785 +46,785 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6236.23585
-  tps: 4991.76462
+  dps: 6239.61181
+  tps: 4994.31424
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6272.10398
-  tps: 5020.03731
+  dps: 6275.47994
+  tps: 5022.58693
  }
 }
 dps_results: {
  key: "TestFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6161.37677
-  tps: 4933.13345
+  dps: 6164.06783
+  tps: 4935.2863
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 5944.79887
-  tps: 10870.70554
+  dps: 5947.47599
+  tps: 10872.69609
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 5944.79887
-  tps: 10870.70554
+  dps: 5947.47599
+  tps: 10872.69609
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6242.69867
-  tps: 5001.43327
+  dps: 6244.68906
+  tps: 5003.02558
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4772.87843
-  tps: 3817.89412
+  dps: 4767.64009
+  tps: 3813.70345
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 6864.37283
-  tps: 5494.77939
+  dps: 6866.6081
+  tps: 5496.5676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6202.07361
-  tps: 4867.6444
+  dps: 6204.76467
+  tps: 4869.75419
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6366.44637
-  tps: 5097.18967
+  dps: 6368.32391
+  tps: 5098.6917
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
   hps: 64
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6111.27143
-  tps: 4897.12546
+  dps: 6114.72689
+  tps: 4899.88983
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6142.6648
-  tps: 4934.32649
+  dps: 6140.87427
+  tps: 4932.89407
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6027.09361
-  tps: 4830.9957
+  dps: 6029.24648
+  tps: 4832.56949
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Death'sChoice-47464"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5988.19201
-  tps: 4797.3425
+  dps: 5991.64168
+  tps: 4800.10223
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6195.62964
-  tps: 4960.47932
+  dps: 6197.95558
+  tps: 4962.16516
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6391.38453
-  tps: 5120.61025
+  dps: 6393.26891
+  tps: 5122.11776
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6332.97402
-  tps: 5073.64439
+  dps: 6333.68209
+  tps: 5074.21085
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6161.37677
-  tps: 4933.13345
+  dps: 6164.06783
+  tps: 4935.2863
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6270.77722
-  tps: 5022.96319
+  dps: 6272.83875
+  tps: 5024.61241
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6194.24138
-  tps: 4959.42568
+  dps: 6196.04504
+  tps: 4960.86861
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6183.58445
-  tps: 4950.9006
+  dps: 6185.62724
+  tps: 4952.53483
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 5998.87842
-  tps: 4808.89182
+  dps: 6001.4896
+  tps: 4810.98076
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6161.37677
-  tps: 4933.13345
+  dps: 6164.06783
+  tps: 4935.2863
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6090.54659
-  tps: 4887.76081
+  dps: 6088.23529
+  tps: 4885.91176
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6316.74115
-  tps: 5058.80768
+  dps: 6318.30153
+  tps: 5060.05598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6001.07809
-  tps: 4810.96485
+  dps: 6002.36728
+  tps: 4811.9962
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6125.37071
-  tps: 4904.3763
+  dps: 6128.74668
+  tps: 4906.92592
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6183.91819
-  tps: 4952.7264
+  dps: 6185.76913
+  tps: 4954.20715
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6202.07361
-  tps: 4965.20551
+  dps: 6204.76467
+  tps: 4967.35836
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6193.93424
-  tps: 4958.7911
+  dps: 6196.6253
+  tps: 4960.94395
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FrostfireGarb"
  value: {
-  dps: 5643.54409
-  tps: 4522.36044
+  dps: 5642.51999
+  tps: 4521.54117
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6090.87602
-  tps: 4878.52606
+  dps: 6092.59338
+  tps: 4879.74881
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 6120.802
-  tps: 4890.85944
+  dps: 6119.01906
+  tps: 4889.43309
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6254.16992
-  tps: 5005.90096
+  dps: 6257.54588
+  tps: 5008.45058
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6294.92916
-  tps: 5038.02902
+  dps: 6298.30512
+  tps: 5040.57864
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6131.00875
-  tps: 4921.73986
+  dps: 6132.32284
+  tps: 4922.79113
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-49982"
  value: {
-  dps: 6366.44637
-  tps: 5097.18967
+  dps: 6368.32391
+  tps: 5098.6917
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 6366.44637
-  tps: 5097.18967
+  dps: 6368.32391
+  tps: 5098.6917
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6256.71772
-  tps: 5009.66447
+  dps: 6260.09368
+  tps: 5012.2141
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6194.24138
-  tps: 4959.42568
+  dps: 6196.04504
+  tps: 4960.86861
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6183.58445
-  tps: 4950.9006
+  dps: 6185.62724
+  tps: 4952.53483
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6208.08919
-  tps: 4977.54637
+  dps: 6211.88544
+  tps: 4980.58338
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6161.37677
-  tps: 4933.13345
+  dps: 6164.06783
+  tps: 4935.2863
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 6306.9237
-  tps: 5049.60419
+  dps: 6307.26188
+  tps: 5049.87473
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KirinTorGarb"
  value: {
-  dps: 6298.4497
-  tps: 5037.46785
+  dps: 6298.66246
+  tps: 5037.63805
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6139.85445
-  tps: 4919.91433
+  dps: 6142.23747
+  tps: 4921.82075
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6035.34575
-  tps: 4834.02047
+  dps: 6037.19669
+  tps: 4835.50122
  }
 }
 dps_results: {
  key: "TestFire-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6232.06955
-  tps: 4991.99215
+  dps: 6233.8964
+  tps: 4993.45364
  }
 }
 dps_results: {
  key: "TestFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6161.37677
-  tps: 4933.13345
+  dps: 6164.06783
+  tps: 4935.2863
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6161.37677
-  tps: 4933.13345
+  dps: 6164.06783
+  tps: 4935.2863
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6161.37677
-  tps: 4933.13345
+  dps: 6164.06783
+  tps: 4935.2863
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6161.37677
-  tps: 4933.13345
+  dps: 6164.06783
+  tps: 4935.2863
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6351.24171
-  tps: 5122.49762
+  dps: 6352.15042
+  tps: 5123.22459
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6401.71306
-  tps: 5166.78098
+  dps: 6402.62178
+  tps: 5167.50795
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6331.96715
-  tps: 5069.60575
+  dps: 6334.77831
+  tps: 5071.85468
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6227.0978
-  tps: 4988.03935
+  dps: 6230.13902
+  tps: 4990.47232
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6203.2293
-  tps: 4970.52118
+  dps: 6204.9488
+  tps: 4971.74563
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6231.79508
-  tps: 4993.51902
+  dps: 6234.16412
+  tps: 4995.26311
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6138.64371
-  tps: 4927.26145
+  dps: 6139.9481
+  tps: 4928.17724
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 6025.40582
-  tps: 4827.87894
+  dps: 6028.86094
+  tps: 4830.64304
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6096.17158
-  tps: 4882.47534
+  dps: 6094.95342
+  tps: 4881.50081
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6161.37677
-  tps: 4933.13345
+  dps: 6164.06783
+  tps: 4935.2863
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6161.37677
-  tps: 4933.13345
+  dps: 6164.06783
+  tps: 4935.2863
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6161.37677
-  tps: 4933.13345
+  dps: 6164.06783
+  tps: 4935.2863
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6004.84146
-  tps: 4809.88193
+  dps: 6008.63527
+  tps: 4812.91698
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 5979.27598
-  tps: 4790.94323
+  dps: 5979.15105
+  tps: 4790.84329
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TempestRegalia"
  value: {
-  dps: 4369.59031
-  tps: 3496.03687
+  dps: 4365.41809
+  tps: 3492.69909
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 5944.39968
-  tps: 4761.72772
+  dps: 5947.77564
+  tps: 4764.27734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5083.92601
-  tps: 4083.77319
+  dps: 5086.93852
+  tps: 4086.1832
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6161.37677
-  tps: 4933.13345
+  dps: 6164.06783
+  tps: 4935.2863
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6176.72962
-  tps: 4948.14648
+  dps: 6179.04013
+  tps: 4949.99489
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6176.72962
-  tps: 4948.14648
+  dps: 6179.04013
+  tps: 4949.99489
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6202.07361
-  tps: 4965.20551
+  dps: 6204.76467
+  tps: 4967.35836
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6193.93424
-  tps: 4958.7911
+  dps: 6196.6253
+  tps: 4960.94395
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6032.12353
-  tps: 4831.68648
+  dps: 6032.12459
+  tps: 4831.68733
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6193.93424
-  tps: 4958.7911
+  dps: 6196.6253
+  tps: 4960.94395
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6202.07361
-  tps: 4965.20551
+  dps: 6204.76467
+  tps: 4967.35836
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6075.71227
-  tps: 4866.77779
+  dps: 6079.08823
+  tps: 4869.32741
  }
 }
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
-  dps: 6493.49303
-  tps: 5199.1356
+  dps: 6493.66488
+  tps: 5199.27308
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19043.27235
-  tps: 18634.48788
+  dps: 19053.25703
+  tps: 18643.43749
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1844.87739
-  tps: 1628.18747
+  dps: 1845.56799
+  tps: 1628.78678
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2499.4903
-  tps: 2112.46916
+  dps: 2499.41778
+  tps: 2112.40389
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13068.36127
-  tps: 13003.28056
+  dps: 13072.24203
+  tps: 13006.74863
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 865.39934
-  tps: 755.40828
+  dps: 865.61062
+  tps: 755.53744
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1446.57601
-  tps: 1177.09556
+  dps: 1446.77536
+  tps: 1177.26969
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8885.92673
-  tps: 9187.72709
+  dps: 8887.98246
+  tps: 9189.37167
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6356.1164
-  tps: 5090.65577
+  dps: 6359.179
+  tps: 5093.10586
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7696.49217
-  tps: 6072.57163
+  dps: 7699.3692
+  tps: 6074.87326
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4623.64782
-  tps: 5350.49535
+  dps: 4623.024
+  tps: 5349.99629
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2527.79011
-  tps: 2018.53115
+  dps: 2529.49986
+  tps: 2019.53856
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3845.55107
-  tps: 2983.41837
+  dps: 3849.36989
+  tps: 2986.47342
  }
 }
 dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6366.44637
-  tps: 5097.18967
+  dps: 6368.32391
+  tps: 5098.6917
  }
 }

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -46,785 +46,785 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 5105.68191
-  tps: 4047.17135
+  dps: 5105.22031
+  tps: 4046.76508
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 5135.02126
-  tps: 4070.96021
+  dps: 5134.55966
+  tps: 4070.55394
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 4992.37631
-  tps: 3955.99237
+  dps: 4992.42227
+  tps: 3956.03841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 4868.23237
-  tps: 10059.65088
+  dps: 4867.77076
+  tps: 10059.24461
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 4868.23237
-  tps: 10059.65088
+  dps: 4867.77076
+  tps: 10059.24461
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5008.36788
-  tps: 3968.48112
+  dps: 5008.53755
+  tps: 3968.63851
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4282.96011
-  tps: 3369.8636
+  dps: 4281.56422
+  tps: 3368.61509
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 5511.52053
-  tps: 4428.27616
+  dps: 5511.87897
+  tps: 4428.60132
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5025.38598
-  tps: 3903.70096
+  dps: 5025.43194
+  tps: 3903.74607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 5129.2338
-  tps: 4078.77585
+  dps: 5129.40998
+  tps: 4078.93931
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
   hps: 64
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 4947.86902
-  tps: 3925.98032
+  dps: 4947.55725
+  tps: 3925.7089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 4976.5225
-  tps: 3956.72869
+  dps: 4975.91018
+  tps: 3956.18521
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 4916.85843
-  tps: 3902.24074
+  dps: 4916.47174
+  tps: 3901.9019
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Death'sChoice-47464"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 4883.60578
-  tps: 3868.30538
+  dps: 4883.21909
+  tps: 3867.96653
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5013.28794
-  tps: 3974.66966
+  dps: 5013.45762
+  tps: 3974.82705
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 5338.97696
-  tps: 4277.27461
+  dps: 5337.67981
+  tps: 4276.10962
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 5263.88721
-  tps: 4207.34499
+  dps: 5262.81365
+  tps: 4206.3826
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 4992.37631
-  tps: 3955.99237
+  dps: 4992.42227
+  tps: 3956.03841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5027.55488
-  tps: 3982.62335
+  dps: 5027.60084
+  tps: 3982.66939
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5009.57141
-  tps: 3971.32478
+  dps: 5009.74109
+  tps: 3971.48217
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5006.89789
-  tps: 3968.96418
+  dps: 5007.06757
+  tps: 3969.12157
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 4946.29668
-  tps: 3926.32505
+  dps: 4947.37115
+  tps: 3927.28719
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 4992.37631
-  tps: 3955.99237
+  dps: 4992.42227
+  tps: 3956.03841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 4944.34543
-  tps: 3919.64341
+  dps: 4945.31405
+  tps: 3920.51735
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5104.56306
-  tps: 4064.81333
+  dps: 5104.2513
+  tps: 4064.54192
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 4860.5387
-  tps: 3846.497
+  dps: 4860.07709
+  tps: 3846.09073
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 5014.99665
-  tps: 3973.64214
+  dps: 5014.53504
+  tps: 3973.23587
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5040.93888
-  tps: 4008.24481
+  dps: 5040.62711
+  tps: 4007.97339
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5025.38598
-  tps: 3982.68461
+  dps: 5025.43194
+  tps: 3982.73065
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5018.78405
-  tps: 3977.34616
+  dps: 5018.83
+  tps: 3977.3922
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FrostfireGarb"
  value: {
-  dps: 4631.16757
-  tps: 3661.04433
+  dps: 4629.84093
+  tps: 3659.85582
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 4947.38613
-  tps: 3918.14731
+  dps: 4946.92452
+  tps: 3917.74103
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 5131.92772
-  tps: 4053.17777
+  dps: 5131.86461
+  tps: 4053.12097
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 5120.35159
-  tps: 4059.06578
+  dps: 5119.88998
+  tps: 4058.65951
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 5153.69176
-  tps: 4086.09858
+  dps: 5153.23015
+  tps: 4085.69231
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 4965.56651
-  tps: 3949.07129
+  dps: 4965.96904
+  tps: 3949.43085
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Heartpierce-49982"
  value: {
-  dps: 5129.2338
-  tps: 4078.77585
+  dps: 5129.40998
+  tps: 4078.93931
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Heartpierce-50641"
  value: {
-  dps: 5129.2338
-  tps: 4078.77585
+  dps: 5129.40998
+  tps: 4078.93931
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5103.51508
-  tps: 4064.07349
+  dps: 5103.05347
+  tps: 4063.66722
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5009.57141
-  tps: 3971.32478
+  dps: 5009.74109
+  tps: 3971.48217
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5006.89789
-  tps: 3968.96418
+  dps: 5007.06757
+  tps: 3969.12157
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 4985.07055
-  tps: 3949.4819
+  dps: 4985.1165
+  tps: 3949.52794
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 4992.37631
-  tps: 3955.99237
+  dps: 4992.42227
+  tps: 3956.03841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 4950.98937
-  tps: 3932.88526
+  dps: 4950.29582
+  tps: 3932.26081
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KirinTorGarb"
  value: {
-  dps: 4987.86221
-  tps: 3963.50822
+  dps: 4986.49255
+  tps: 3962.27937
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 4859.65431
-  tps: 3842.84998
+  dps: 4859.1927
+  tps: 3842.44371
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 4928.88655
-  tps: 3908.39797
+  dps: 4928.57479
+  tps: 3908.12655
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 5055.5799
-  tps: 4010.15077
+  dps: 5055.11829
+  tps: 4009.74449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 4992.37631
-  tps: 3955.99237
+  dps: 4992.42227
+  tps: 3956.03841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 4992.37631
-  tps: 3955.99237
+  dps: 4992.42227
+  tps: 3956.03841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 4992.37631
-  tps: 3955.99237
+  dps: 4992.42227
+  tps: 3956.03841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 4992.37631
-  tps: 3955.99237
+  dps: 4992.42227
+  tps: 3956.03841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 5162.84947
-  tps: 4115.86324
+  dps: 5162.09579
+  tps: 4115.18276
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 5202.86579
-  tps: 4151.35468
+  dps: 5202.11211
+  tps: 4150.67419
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5110.50409
-  tps: 4062.06352
+  dps: 5110.54542
+  tps: 4062.10561
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 4989.8147
-  tps: 3952.02331
+  dps: 4989.86066
+  tps: 3952.06935
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 5071.21779
-  tps: 4021.12567
+  dps: 5070.75618
+  tps: 4020.71939
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 5097.10716
-  tps: 4042.69006
+  dps: 5096.64555
+  tps: 4042.28379
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 4937.36836
-  tps: 3918.1665
+  dps: 4937.05659
+  tps: 3917.89509
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 4982.0276
-  tps: 3954.32714
+  dps: 4981.66626
+  tps: 3954.0012
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 4940.6807
-  tps: 3913.30373
+  dps: 4940.52483
+  tps: 3913.16834
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 4992.37631
-  tps: 3955.99237
+  dps: 4992.42227
+  tps: 3956.03841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 4992.37631
-  tps: 3955.99237
+  dps: 4992.42227
+  tps: 3956.03841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 4992.37631
-  tps: 3955.99237
+  dps: 4992.42227
+  tps: 3956.03841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 4863.80878
-  tps: 3848.67426
+  dps: 4863.34717
+  tps: 3848.26799
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 4876.26873
-  tps: 3859.57191
+  dps: 4875.80712
+  tps: 3859.16564
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TempestRegalia"
  value: {
-  dps: 4018.33752
-  tps: 3158.77832
+  dps: 4018.65591
+  tps: 3159.06487
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 4866.9663
-  tps: 3853.61652
+  dps: 4866.50469
+  tps: 3853.21024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 4190.21029
-  tps: 3318.40681
+  dps: 4189.50163
+  tps: 3317.76357
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 4992.37631
-  tps: 3955.99237
+  dps: 4992.42227
+  tps: 3956.03841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 4984.11599
-  tps: 3951.88569
+  dps: 4984.50038
+  tps: 3952.23654
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 4984.11599
-  tps: 3951.88569
+  dps: 4984.50038
+  tps: 3952.23654
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5025.38598
-  tps: 3982.68461
+  dps: 5025.43194
+  tps: 3982.73065
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5018.78405
-  tps: 3977.34616
+  dps: 5018.83
+  tps: 3977.3922
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 5025.44996
-  tps: 3983.63282
+  dps: 5025.39511
+  tps: 3983.58862
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5018.78405
-  tps: 3977.34616
+  dps: 5018.83
+  tps: 3977.3922
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5025.38598
-  tps: 3982.68461
+  dps: 5025.43194
+  tps: 3982.73065
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 4959.96647
-  tps: 3937.19352
+  dps: 4959.50486
+  tps: 3936.78724
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 5254.39273
-  tps: 4194.73201
+  dps: 5254.55343
+  tps: 4194.87935
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11692.0658
-  tps: 11348.12238
+  dps: 11841.62373
+  tps: 11479.8717
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1718.1419
-  tps: 1064.98127
+  dps: 1737.40374
+  tps: 1080.50253
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2740.53427
-  tps: 1850.12702
+  dps: 2775.2689
+  tps: 1881.38818
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5826.97281
-  tps: 5637.2375
+  dps: 5921.0762
+  tps: 5719.87872
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 988.38698
-  tps: 523.53198
+  dps: 1000.02262
+  tps: 532.09449
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1578.43149
-  tps: 1046.28063
+  dps: 1596.86516
+  tps: 1062.87093
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5142.28969
-  tps: 4699.46051
+  dps: 5142.63586
+  tps: 4699.77179
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5142.28969
-  tps: 4088.24037
+  dps: 5142.63586
+  tps: 4088.55164
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6396.71823
-  tps: 5093.12543
+  dps: 6395.87877
+  tps: 5092.36992
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3219.97393
-  tps: 3275.04146
+  dps: 3220.57463
+  tps: 3275.58671
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3219.97393
-  tps: 2514.72342
+  dps: 3220.57463
+  tps: 2515.26867
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3654.81258
-  tps: 2801.86215
+  dps: 3655.04304
+  tps: 2802.06957
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5129.2338
-  tps: 4078.77585
+  dps: 5129.40998
+  tps: 4078.93931
  }
 }

--- a/sim/mage/TestFrostFire.results
+++ b/sim/mage/TestFrostFire.results
@@ -46,743 +46,743 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostFire-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 5814.33001
-  tps: 4632.22171
+  dps: 5813.52994
+  tps: 4631.58165
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 5848.27475
-  tps: 4658.96056
+  dps: 5847.47469
+  tps: 4658.32051
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5774.5923
-  tps: 4601.04823
+  dps: 5776.88106
+  tps: 4602.87924
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 5538.58212
-  tps: 9881.76916
+  dps: 5537.78206
+  tps: 9881.12911
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 5538.58212
-  tps: 9881.76916
+  dps: 5537.78206
+  tps: 9881.12911
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5783.92398
-  tps: 4607.9072
+  dps: 5784.83416
+  tps: 4608.63534
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4692.17968
-  tps: 3738.69482
+  dps: 4691.37701
+  tps: 3738.05268
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 6576.19287
-  tps: 5240.09253
+  dps: 6580.43997
+  tps: 5243.49021
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5813.36852
-  tps: 4540.2406
+  dps: 5815.65728
+  tps: 4542.03499
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 5953.03339
-  tps: 4743.05215
+  dps: 5953.99894
+  tps: 4743.82459
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
   hps: 64
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5681.94498
-  tps: 4530.1693
+  dps: 5680.6644
+  tps: 4529.14484
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5810.62977
-  tps: 4645.69236
+  dps: 5812.30242
+  tps: 4647.03048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 5637.62813
-  tps: 4496.09008
+  dps: 5638.36257
+  tps: 4496.67763
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Death'sChoice-47464"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5587.94445
-  tps: 4454.8461
+  dps: 5587.51386
+  tps: 4454.50162
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5794.7949
-  tps: 4616.39256
+  dps: 5795.6987
+  tps: 4617.11559
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6078.5296
-  tps: 4848.59981
+  dps: 6078.98884
+  tps: 4848.96721
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6014.05714
-  tps: 4793.23914
+  dps: 6015.563
+  tps: 4794.44383
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5774.5923
-  tps: 4601.04823
+  dps: 5776.88106
+  tps: 4602.87924
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5822.47098
-  tps: 4639.13543
+  dps: 5824.50241
+  tps: 4640.76057
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5783.92453
-  tps: 4607.76507
+  dps: 5784.8347
+  tps: 4608.4932
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5781.82909
-  tps: 4605.84184
+  dps: 5782.83426
+  tps: 4606.64598
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 5715.89468
-  tps: 4558.60246
+  dps: 5719.32973
+  tps: 4561.3505
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5774.5923
-  tps: 4601.04823
+  dps: 5776.88106
+  tps: 4602.87924
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5743.89299
-  tps: 4591.66004
+  dps: 5747.35317
+  tps: 4594.42819
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5875.99035
-  tps: 4684.4591
+  dps: 5876.3913
+  tps: 4684.77986
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 5558.11125
-  tps: 4432.5401
+  dps: 5556.92324
+  tps: 4431.58969
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 5709.40989
-  tps: 4549.57434
+  dps: 5708.60982
+  tps: 4548.93429
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5754.78202
-  tps: 4587.91951
+  dps: 5753.1192
+  tps: 4586.58925
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5813.36852
-  tps: 4631.58232
+  dps: 5815.65728
+  tps: 4633.41333
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5805.61327
-  tps: 4625.4755
+  dps: 5807.90203
+  tps: 4627.30651
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FrostfireGarb"
  value: {
-  dps: 5243.31069
-  tps: 4179.31098
+  dps: 5243.34754
+  tps: 4179.34046
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5663.07604
-  tps: 4513.18453
+  dps: 5662.45834
+  tps: 4512.69037
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 5795.51534
-  tps: 4608.43667
+  dps: 5791.46572
+  tps: 4605.19698
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 5831.30238
-  tps: 4645.59113
+  dps: 5830.50231
+  tps: 4644.95108
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 5869.87595
-  tps: 4675.9762
+  dps: 5869.07589
+  tps: 4675.33614
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 5737.43899
-  tps: 4583.25665
+  dps: 5741.79712
+  tps: 4586.74316
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Heartpierce-49982"
  value: {
-  dps: 5953.03339
-  tps: 4743.05215
+  dps: 5953.99894
+  tps: 4743.82459
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 5953.03339
-  tps: 4743.05215
+  dps: 5953.99894
+  tps: 4743.82459
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5834.1144
-  tps: 4649.53736
+  dps: 5833.31433
+  tps: 4648.8973
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5783.92453
-  tps: 4607.76507
+  dps: 5784.8347
+  tps: 4608.4932
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5781.82909
-  tps: 4605.84184
+  dps: 5782.83426
+  tps: 4606.64598
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5782.78733
-  tps: 4613.10161
+  dps: 5784.81876
+  tps: 4614.72676
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5774.5923
-  tps: 4601.04823
+  dps: 5776.88106
+  tps: 4602.87924
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 5928.13381
-  tps: 4722.00537
+  dps: 5932.10832
+  tps: 4725.18498
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-KirinTorGarb"
  value: {
-  dps: 5905.05722
-  tps: 4700.72717
+  dps: 5907.3557
+  tps: 4702.56596
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5689.22764
-  tps: 4534.9999
+  dps: 5689.14987
+  tps: 4534.93768
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5626.34272
-  tps: 4485.20165
+  dps: 5624.83223
+  tps: 4483.99326
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 5760.1438
-  tps: 4591.61832
+  dps: 5761.23513
+  tps: 4592.49138
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5774.5923
-  tps: 4601.04823
+  dps: 5776.88106
+  tps: 4602.87924
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5774.5923
-  tps: 4601.04823
+  dps: 5776.88106
+  tps: 4602.87924
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5774.5923
-  tps: 4601.04823
+  dps: 5776.88106
+  tps: 4602.87924
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5774.5923
-  tps: 4601.04823
+  dps: 5776.88106
+  tps: 4602.87924
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 5976.69708
-  tps: 4801.61653
+  dps: 5979.1034
+  tps: 4803.54159
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6027.74696
-  tps: 4846.74965
+  dps: 6030.15328
+  tps: 4848.67471
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5942.7946
-  tps: 4735.61007
+  dps: 5945.21668
+  tps: 4737.54774
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5775.0965
-  tps: 4601.43483
+  dps: 5777.38526
+  tps: 4603.26584
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 5780.44965
-  tps: 4611.44143
+  dps: 5779.64958
+  tps: 4610.80138
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 5811.26432
-  tps: 4636.39307
+  dps: 5810.46426
+  tps: 4635.75301
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SouloftheDead-40382"
  value: {
-  dps: 5671.60542
-  tps: 4529.69193
+  dps: 5671.97052
+  tps: 4529.98401
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 5655.48797
-  tps: 4509.34058
+  dps: 5658.54194
+  tps: 4511.78376
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 5694.39557
-  tps: 4538.00639
+  dps: 5697.41291
+  tps: 4540.42027
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5774.5923
-  tps: 4601.04823
+  dps: 5776.88106
+  tps: 4602.87924
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5774.5923
-  tps: 4601.04823
+  dps: 5776.88106
+  tps: 4602.87924
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5774.5923
-  tps: 4601.04823
+  dps: 5776.88106
+  tps: 4602.87924
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 5604.26838
-  tps: 4467.89641
+  dps: 5603.1323
+  tps: 4466.98755
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 5574.3497
-  tps: 4443.6714
+  dps: 5573.41781
+  tps: 4442.92589
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TempestRegalia"
  value: {
-  dps: 4205.23309
-  tps: 3361.00275
+  dps: 4203.998
+  tps: 3360.01468
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 5538.14322
-  tps: 4414.66467
+  dps: 5537.34316
+  tps: 4414.02462
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 4786.71102
-  tps: 3821.6302
+  dps: 4790.22404
+  tps: 3824.44061
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5774.5923
-  tps: 4601.04823
+  dps: 5776.88106
+  tps: 4602.87924
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5803.17188
-  tps: 4626.15597
+  dps: 5804.81284
+  tps: 4627.46874
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5803.17188
-  tps: 4626.15597
+  dps: 5804.81284
+  tps: 4627.46874
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5813.36852
-  tps: 4631.58232
+  dps: 5815.65728
+  tps: 4633.41333
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5805.61327
-  tps: 4625.4755
+  dps: 5807.90203
+  tps: 4627.30651
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 5707.79505
-  tps: 4549.08141
+  dps: 5713.18475
+  tps: 4553.39317
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5805.61327
-  tps: 4625.4755
+  dps: 5807.90203
+  tps: 4627.30651
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5813.36852
-  tps: 4631.58232
+  dps: 5815.65728
+  tps: 4633.41333
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-WingedTalisman-37844"
  value: {
-  dps: 5669.08012
-  tps: 4519.41419
+  dps: 5668.28005
+  tps: 4518.77413
  }
 }
 dps_results: {
  key: "TestFrostFire-Average-Default"
  value: {
-  dps: 6048.42943
-  tps: 4819.8732
+  dps: 6049.72089
+  tps: 4820.90356
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8207.42906
-  tps: 8252.82851
+  dps: 8209.29432
+  tps: 8254.32072
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5925.50245
-  tps: 4722.31238
+  dps: 5929.15547
+  tps: 4725.23479
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7066.27052
-  tps: 5550.51737
+  dps: 7066.95388
+  tps: 5551.06406
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4641.01157
-  tps: 5362.53258
+  dps: 4639.57223
+  tps: 5361.38111
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2662.12053
-  tps: 2124.69538
+  dps: 2661.67585
+  tps: 2124.33963
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3189.04224
-  tps: 2450.28542
+  dps: 3190.47149
+  tps: 2451.42883
  }
 }
 dps_results: {
  key: "TestFrostFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5953.03339
-  tps: 4743.05215
+  dps: 5953.99894
+  tps: 4743.82459
  }
 }

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -46,1121 +46,1121 @@ character_stats_results: {
 dps_results: {
  key: "TestShadow-AllItems-AbsolutionRegalia"
  value: {
-  dps: 5199.9644
-  tps: 5002.50734
+  dps: 5190.89964
+  tps: 4992.61378
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7089.08783
-  tps: 7038.13055
+  dps: 7093.52912
+  tps: 7042.69064
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7121.85799
-  tps: 7070.40563
+  dps: 7126.53382
+  tps: 7075.20027
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AshtongueTalismanofAcumen-32490"
  value: {
-  dps: 6889.54134
-  tps: 6842.43
+  dps: 6892.70244
+  tps: 6845.7099
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6930.77504
-  tps: 6880.06374
+  dps: 6935.59074
+  tps: 6884.87945
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6786.93212
-  tps: 12982.13363
+  dps: 6790.72709
+  tps: 12987.2744
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6786.93212
-  tps: 12982.13363
+  dps: 6790.72709
+  tps: 12987.2744
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6957.83974
-  tps: 6906.39087
+  dps: 6959.328
+  tps: 6907.87913
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5852.31563
-  tps: 5681.56867
+  dps: 5857.82404
+  tps: 5685.73441
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6964.43339
-  tps: 6776.15948
+  dps: 6969.56488
+  tps: 6781.18834
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7110.63569
-  tps: 7059.21461
+  dps: 7115.31117
+  tps: 7064.0089
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
   hps: 64
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 6664.82269
-  tps: 6604.38597
+  dps: 6668.33632
+  tps: 6608.07985
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 7669.67441
-  tps: 7626.32412
+  dps: 7674.37942
+  tps: 7630.52831
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6883.37288
-  tps: 6838.36253
+  dps: 6886.83613
+  tps: 6841.98085
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6928.34897
-  tps: 6882.71583
+  dps: 6931.84867
+  tps: 6886.37862
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6849.57412
-  tps: 6798.59211
+  dps: 6855.9721
+  tps: 6805.25804
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6815.4819
-  tps: 6770.18655
+  dps: 6819.43371
+  tps: 6774.25717
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6969.35823
-  tps: 6917.8716
+  dps: 6973.55704
+  tps: 6922.18922
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7506.3558
-  tps: 7458.99304
+  dps: 7509.06511
+  tps: 7462.01186
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7428.0148
-  tps: 7378.71022
+  dps: 7427.53194
+  tps: 7378.35818
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6930.77504
-  tps: 6880.06374
+  dps: 6935.59074
+  tps: 6884.87945
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6980.65705
-  tps: 6928.61349
+  dps: 6982.80529
+  tps: 6930.76172
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6966.48047
-  tps: 6914.99167
+  dps: 6970.67928
+  tps: 6919.30929
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6953.88529
-  tps: 6902.85438
+  dps: 6957.94418
+  tps: 6906.93775
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6940.26826
-  tps: 6898.01838
+  dps: 6945.3152
+  tps: 6903.25399
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6930.77504
-  tps: 6880.06374
+  dps: 6935.59074
+  tps: 6884.87945
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6953.24749
-  tps: 6908.23465
+  dps: 6955.94421
+  tps: 6911.01704
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7096.52504
-  tps: 7047.57611
+  dps: 7099.43751
+  tps: 7050.60739
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6797.99653
-  tps: 6752.78729
+  dps: 6801.70932
+  tps: 6755.8009
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6975.99926
-  tps: 6927.17025
+  dps: 6980.32902
+  tps: 6931.61882
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7017.20768
-  tps: 6970.09981
+  dps: 7022.62028
+  tps: 6975.32697
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6964.43339
-  tps: 6913.15556
+  dps: 6969.56488
+  tps: 6918.28705
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6959.2909
-  tps: 6908.1424
+  dps: 6964.34628
+  tps: 6913.19777
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6908.5613
-  tps: 6859.29857
+  dps: 6910.9231
+  tps: 6861.43933
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GarbofFaith"
  value: {
-  dps: 6223.95563
-  tps: 6175.74335
+  dps: 6227.77779
+  tps: 6179.34887
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 6635.66198
-  tps: 6564.70138
+  dps: 6637.01769
+  tps: 6567.11335
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 6756.4213
-  tps: 6676.19214
+  dps: 6748.36404
+  tps: 6668.6184
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7107.6076
-  tps: 7056.30603
+  dps: 7112.05065
+  tps: 7060.8679
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7145.75354
-  tps: 7093.86442
+  dps: 7150.21681
+  tps: 7098.4465
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6904.1461
-  tps: 6857.71407
+  dps: 6906.20194
+  tps: 6859.82793
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-49982"
  value: {
-  dps: 7110.63569
-  tps: 7059.21461
+  dps: 7115.31117
+  tps: 7064.0089
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-50641"
  value: {
-  dps: 7110.63569
-  tps: 7059.21461
+  dps: 7115.31117
+  tps: 7064.0089
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6966.48047
-  tps: 6914.99167
+  dps: 6970.67928
+  tps: 6919.30929
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6953.88529
-  tps: 6902.85438
+  dps: 6957.94418
+  tps: 6906.93775
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6956.64842
-  tps: 6907.80823
+  dps: 6959.31208
+  tps: 6910.08141
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6930.77504
-  tps: 6880.06374
+  dps: 6935.59074
+  tps: 6884.87945
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6867.91754
-  tps: 6816.38334
+  dps: 6870.88385
+  tps: 6818.60001
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6858.91218
-  tps: 6814.06595
+  dps: 6862.19353
+  tps: 6817.4661
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7077.61321
-  tps: 7029.09681
+  dps: 7082.21718
+  tps: 7033.74974
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6930.77504
-  tps: 6880.06374
+  dps: 6935.59074
+  tps: 6884.87945
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6930.77504
-  tps: 6880.06374
+  dps: 6935.59074
+  tps: 6884.87945
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6930.77504
-  tps: 6880.06374
+  dps: 6935.59074
+  tps: 6884.87945
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6930.77504
-  tps: 6880.06374
+  dps: 6935.59074
+  tps: 6884.87945
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RegaliaofFaith"
  value: {
-  dps: 5994.27307
-  tps: 5931.73796
+  dps: 5987.5411
+  tps: 5924.63592
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7169.11512
-  tps: 7119.57477
+  dps: 7171.03912
+  tps: 7121.63785
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7218.72046
-  tps: 7168.61888
+  dps: 7220.61738
+  tps: 7170.65487
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7079.07529
-  tps: 7028.36131
+  dps: 7083.71833
+  tps: 7033.00435
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6933.98771
-  tps: 6882.37279
+  dps: 6935.13379
+  tps: 6883.51888
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationGarb"
  value: {
-  dps: 6934.60691
-  tps: 6870.15661
+  dps: 6938.1624
+  tps: 6873.82924
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationRegalia"
  value: {
-  dps: 6387.90995
-  tps: 6332.15
+  dps: 6397.43244
+  tps: 6341.64636
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7057.45035
-  tps: 7009.29663
+  dps: 7060.9345
+  tps: 7012.72447
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7091.20467
-  tps: 7043.59053
+  dps: 7093.86141
+  tps: 7046.20379
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6889.43173
-  tps: 6847.84683
+  dps: 6891.83358
+  tps: 6849.63771
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SparkofLife-37657"
  value: {
-  dps: 6882.70056
-  tps: 6832.42062
+  dps: 6887.79683
+  tps: 6837.19949
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6804.24294
-  tps: 6756.30162
+  dps: 6801.08528
+  tps: 6753.62668
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6930.77504
-  tps: 6880.06374
+  dps: 6935.59074
+  tps: 6884.87945
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6930.77504
-  tps: 6880.06374
+  dps: 6935.59074
+  tps: 6884.87945
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6930.77504
-  tps: 6880.06374
+  dps: 6935.59074
+  tps: 6884.87945
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6849.94781
-  tps: 6802.96826
+  dps: 6855.19575
+  tps: 6808.12028
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6804.08098
-  tps: 6756.81479
+  dps: 6806.10297
+  tps: 6758.65347
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6787.08367
-  tps: 6741.88195
+  dps: 6790.86285
+  tps: 6745.77993
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6930.77504
-  tps: 6880.06374
+  dps: 6935.59074
+  tps: 6884.87945
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6805.16567
-  tps: 6757.22434
+  dps: 6802.10932
+  tps: 6754.65072
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6805.16567
-  tps: 6757.22434
+  dps: 6802.10932
+  tps: 6754.65072
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6964.43339
-  tps: 6913.15556
+  dps: 6969.56488
+  tps: 6918.28705
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6959.2909
-  tps: 6908.1424
+  dps: 6964.34628
+  tps: 6913.19777
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6973.20034
-  tps: 6926.08577
+  dps: 6972.04187
+  tps: 6925.7389
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6959.2909
-  tps: 6908.1424
+  dps: 6964.34628
+  tps: 6913.19777
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6964.43339
-  tps: 6913.15556
+  dps: 6969.56488
+  tps: 6918.28705
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7364.95619
-  tps: 7309.81465
+  dps: 7367.97572
+  tps: 7312.98721
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VestmentsofAbsolution"
  value: {
-  dps: 5030.09761
-  tps: 4829.18412
+  dps: 5029.2106
+  tps: 4827.06521
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6904.6439
-  tps: 6858.91619
+  dps: 6908.17244
+  tps: 6862.56354
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRaiment"
  value: {
-  dps: 6328.77677
-  tps: 6272.38208
+  dps: 6330.37249
+  tps: 6273.37176
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRegalia"
  value: {
-  dps: 6684.03681
-  tps: 6630.32035
+  dps: 6686.51355
+  tps: 6632.53344
  }
 }
 dps_results: {
  key: "TestShadow-Average-Default"
  value: {
-  dps: 7143.79685
-  tps: 7091.92368
+  dps: 7146.40478
+  tps: 7094.7067
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7056.43559
-  tps: 8199.65743
+  dps: 7057.33655
+  tps: 8200.55839
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7056.43559
-  tps: 7005.22541
+  dps: 7057.33655
+  tps: 7006.12637
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7635.53951
-  tps: 7723.46683
+  dps: 7635.023
+  tps: 7722.95032
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3523.32831
-  tps: 4378.54472
+  dps: 3525.87961
+  tps: 4382.12012
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3523.32831
-  tps: 3416.22766
+  dps: 3525.87961
+  tps: 3419.80306
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4076.36819
-  tps: 3875.83414
+  dps: 4075.82037
+  tps: 3875.28632
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6696.02195
-  tps: 7788.36653
+  dps: 6696.13155
+  tps: 7789.04674
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6696.02195
-  tps: 6636.13872
+  dps: 6696.13155
+  tps: 6636.81894
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7421.51164
-  tps: 7512.63886
+  dps: 7422.74552
+  tps: 7513.87274
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3369.20717
-  tps: 4233.02076
+  dps: 3368.11037
+  tps: 4233.38856
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3369.20717
-  tps: 3260.63293
+  dps: 3368.11037
+  tps: 3261.00073
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3954.7751
-  tps: 3753.9252
+  dps: 3952.99787
+  tps: 3752.14797
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7077.10367
-  tps: 8227.41842
+  dps: 7080.29281
+  tps: 8231.10194
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7077.10367
-  tps: 7022.81236
+  dps: 7080.29281
+  tps: 7026.49588
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7830.91571
-  tps: 7929.40559
+  dps: 7830.20571
+  tps: 7928.69559
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3527.96399
-  tps: 4402.16216
+  dps: 3526.2242
+  tps: 4412.53753
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3527.96399
-  tps: 3419.70357
+  dps: 3526.2242
+  tps: 3420.00819
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4184.60689
-  tps: 3981.83424
+  dps: 4183.89236
+  tps: 3981.11971
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7040.87965
-  tps: 8184.20549
+  dps: 7041.47583
+  tps: 8184.80167
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7040.87965
-  tps: 6989.89174
+  dps: 7041.47583
+  tps: 6990.48793
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7637.39276
-  tps: 7725.28708
+  dps: 7636.63318
+  tps: 7724.5275
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3512.43314
-  tps: 4367.00381
+  dps: 3513.22217
+  tps: 4368.76599
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3512.43314
-  tps: 3405.50374
+  dps: 3513.22217
+  tps: 3407.26593
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4069.23913
-  tps: 3868.89609
+  dps: 4068.69131
+  tps: 3868.34827
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6669.71464
-  tps: 7756.52158
+  dps: 6672.45456
+  tps: 7759.84464
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6669.71464
-  tps: 6609.29704
+  dps: 6672.45456
+  tps: 6612.6201
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7417.96902
-  tps: 7508.99885
+  dps: 7419.2029
+  tps: 7510.23273
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3341.19828
-  tps: 4198.06979
+  dps: 3340.37928
+  tps: 4198.57946
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3341.19828
-  tps: 3233.21565
+  dps: 3340.37928
+  tps: 3233.72532
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3947.87115
-  tps: 3747.01736
+  dps: 3946.09393
+  tps: 3745.24014
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7057.16906
-  tps: 8204.3314
+  dps: 7061.19508
+  tps: 8208.846
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7057.16906
-  tps: 7002.6905
+  dps: 7061.19508
+  tps: 7007.2051
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7820.55646
-  tps: 7919.01334
+  dps: 7819.84646
+  tps: 7918.30335
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3510.50316
-  tps: 4418.57585
+  dps: 3505.00431
+  tps: 4414.98587
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3510.50316
-  tps: 3403.41066
+  dps: 3505.00431
+  tps: 3399.82068
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4174.2012
-  tps: 3971.11562
+  dps: 4173.48667
+  tps: 3970.40108
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7085.07865
-  tps: 8239.05897
+  dps: 7085.3591
+  tps: 8239.18529
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7085.07865
-  tps: 7032.61944
+  dps: 7085.3591
+  tps: 7032.74576
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7682.19073
-  tps: 7766.80222
+  dps: 7681.43115
+  tps: 7766.04264
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3641.5126
-  tps: 4515.22605
+  dps: 3641.2628
+  tps: 4515.32083
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3641.5126
-  tps: 3531.66698
+  dps: 3641.2628
+  tps: 3531.76176
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4090.20611
-  tps: 3890.08711
+  dps: 4089.65829
+  tps: 3889.53929
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6689.20805
-  tps: 7788.0552
+  dps: 6691.95503
+  tps: 7791.4155
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6689.20805
-  tps: 6632.91084
+  dps: 6691.95503
+  tps: 6636.27115
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7455.76767
-  tps: 7545.4713
+  dps: 7457.00155
+  tps: 7546.70518
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3412.85597
-  tps: 4289.1644
+  dps: 3417.11776
+  tps: 4293.8727
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3412.85597
-  tps: 3305.60534
+  dps: 3417.11776
+  tps: 3310.31364
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3969.20696
-  tps: 3768.66109
+  dps: 3967.25678
+  tps: 3766.71092
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7110.63569
-  tps: 8263.4405
+  dps: 7115.31117
+  tps: 8268.2348
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7110.63569
-  tps: 7059.21461
+  dps: 7115.31117
+  tps: 7064.0089
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7867.38093
-  tps: 7963.5635
+  dps: 7866.67093
+  tps: 7962.85351
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3522.94978
-  tps: 4388.07746
+  dps: 3541.16333
+  tps: 4407.78466
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3522.94978
-  tps: 3413.09594
+  dps: 3541.16333
+  tps: 3432.80315
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4190.5053
-  tps: 3986.16612
+  dps: 4189.79076
+  tps: 3985.45158
  }
 }
 dps_results: {
  key: "TestShadow-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7095.51683
-  tps: 7059.21461
+  dps: 7100.21679
+  tps: 7064.0089
  }
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -49,12 +49,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.41402
+  weights: 0.41114
   weights: 0
   weights: 1.46853
   weights: 0
   weights: 0
-  weights: 0.98147
+  weights: 0.97901
   weights: 0
   weights: 0
   weights: 0
@@ -91,1058 +91,1058 @@ stat_weights_results: {
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6031.19662
-  tps: 3840.03495
+  dps: 6033.56718
+  tps: 3841.45615
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6062.22013
-  tps: 3859.49952
+  dps: 6064.59068
+  tps: 3860.92072
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AshtongueTalismanofVision-32491"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6002.0512
-  tps: 3801.0473
+  dps: 6005.29177
+  tps: 3802.61794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 5779.23575
-  tps: 10566.92911
+  dps: 5781.6063
+  tps: 10568.35031
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 5779.23575
-  tps: 10566.92911
+  dps: 5781.6063
+  tps: 10568.35031
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6021.22239
-  tps: 3812.60824
+  dps: 6024.75025
+  tps: 3814.46296
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 5854.44506
-  tps: 3727.51989
+  dps: 5856.174
+  tps: 3728.55453
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 6375.14671
-  tps: 4045.16934
+  dps: 6377.49083
+  tps: 4046.25953
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 4815.09085
-  tps: 3095.10097
+  dps: 4817.81177
+  tps: 3097.0318
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5036.26723
-  tps: 3238.21551
+  dps: 5038.72401
+  tps: 3239.93663
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6037.45547
-  tps: 3747.52558
+  dps: 6040.69604
+  tps: 3749.06481
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6196.43025
-  tps: 3923.90446
+  dps: 6199.91954
+  tps: 3925.60688
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6196.43025
-  tps: 3923.90446
+  dps: 6199.91954
+  tps: 3925.60688
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6196.43025
-  tps: 3923.90446
+  dps: 6199.91954
+  tps: 3925.60688
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
   hps: 64
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5877.98943
-  tps: 3739.02709
+  dps: 5880.36623
+  tps: 3740.47318
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5909.63677
-  tps: 3781.91804
+  dps: 5912.54739
+  tps: 3783.67575
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 5837.5792
-  tps: 3717.37131
+  dps: 5839.42026
+  tps: 3718.5028
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 6126.05037
-  tps: 3883.50427
+  dps: 6129.53966
+  tps: 3885.2067
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Death'sChoice-47464"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5823.70736
-  tps: 3710.05844
+  dps: 5825.94043
+  tps: 3711.39643
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6024.3097
-  tps: 3814.99377
+  dps: 6027.7169
+  tps: 3816.63821
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6362.05771
-  tps: 4038.30914
+  dps: 6365.46186
+  tps: 4040.35297
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6296.03234
-  tps: 3998.01888
+  dps: 6298.51045
+  tps: 3999.43872
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 4677.04871
-  tps: 2982.28207
+  dps: 4679.60713
+  tps: 2983.68684
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EarthshatterGarb"
  value: {
-  dps: 5473.02019
-  tps: 3485.81226
+  dps: 5475.62039
+  tps: 3487.70524
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6002.0512
-  tps: 3801.0473
+  dps: 6005.29177
+  tps: 3802.61794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6042.86489
-  tps: 3824.75783
+  dps: 6046.14314
+  tps: 3826.45023
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6018.35631
-  tps: 3811.48101
+  dps: 6021.71858
+  tps: 3813.11676
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6016.11639
-  tps: 3810.15325
+  dps: 6019.47867
+  tps: 3811.789
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 5933.41623
-  tps: 3791.67094
+  dps: 5935.64771
+  tps: 3792.72367
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6002.0512
-  tps: 3801.0473
+  dps: 6005.29177
+  tps: 3802.61794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5895.93917
-  tps: 3769.10385
+  dps: 5898.81699
+  tps: 3771.05822
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6055.96996
-  tps: 3851.2581
+  dps: 6058.2911
+  tps: 3852.66522
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 5810.11065
-  tps: 3700.0702
+  dps: 5811.68446
+  tps: 3701.0713
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 5935.30577
-  tps: 3779.87172
+  dps: 5937.67633
+  tps: 3781.29292
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5992.43483
-  tps: 3812.74689
+  dps: 5994.6139
+  tps: 3814.0345
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6037.45547
-  tps: 3823.12296
+  dps: 6040.69604
+  tps: 3824.6936
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6030.37461
-  tps: 3818.70782
+  dps: 6033.61519
+  tps: 3820.27846
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 5005.66505
-  tps: 3189.82431
+  dps: 5007.14668
+  tps: 3190.52023
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 6383.96951
-  tps: 4028.56289
+  dps: 6387.365
+  tps: 4030.79964
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 6139.3762
-  tps: 3891.73045
+  dps: 6142.86548
+  tps: 3893.43288
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5866.20796
-  tps: 3736.5188
+  dps: 5868.57851
+  tps: 3737.94
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 4614.06801
-  tps: 2959.06403
+  dps: 4616.62676
+  tps: 2960.93482
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Gladiator'sWartide"
  value: {
-  dps: 5491.2717
-  tps: 3516.85079
+  dps: 5492.89605
+  tps: 3517.94832
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6046.70837
-  tps: 3849.76723
+  dps: 6049.07893
+  tps: 3851.18843
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6081.96236
-  tps: 3871.88607
+  dps: 6084.33292
+  tps: 3873.30727
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 5910.25113
-  tps: 3778.28569
+  dps: 5912.28097
+  tps: 3779.42594
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 6090.49714
-  tps: 3861.69916
+  dps: 6093.98643
+  tps: 3863.40159
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-49982"
  value: {
-  dps: 6196.43025
-  tps: 3923.90446
+  dps: 6199.91954
+  tps: 3925.60688
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-50641"
  value: {
-  dps: 6196.43025
-  tps: 3923.90446
+  dps: 6199.91954
+  tps: 3925.60688
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6018.35631
-  tps: 3811.48101
+  dps: 6021.71858
+  tps: 3813.11676
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6016.11639
-  tps: 3810.15325
+  dps: 6019.47867
+  tps: 3811.789
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6026.126
-  tps: 3818.39503
+  dps: 6028.67468
+  tps: 3819.668
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6002.0512
-  tps: 3801.0473
+  dps: 6005.29177
+  tps: 3802.61794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5858.15492
-  tps: 3728.30148
+  dps: 5860.33399
+  tps: 3729.5891
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 5972.78456
-  tps: 3802.91009
+  dps: 5974.96306
+  tps: 3804.14783
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6002.0512
-  tps: 3801.0473
+  dps: 6005.29177
+  tps: 3802.61794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6002.0512
-  tps: 3801.0473
+  dps: 6005.29177
+  tps: 3802.61794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6002.0512
-  tps: 3801.0473
+  dps: 6005.29177
+  tps: 3802.61794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6002.0512
-  tps: 3801.0473
+  dps: 6005.29177
+  tps: 3802.61794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6188.84663
-  tps: 4022.46288
+  dps: 6190.88488
+  tps: 4022.98237
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6237.93568
-  tps: 4062.13378
+  dps: 6239.97393
+  tps: 4062.65326
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6178.79009
-  tps: 3912.61369
+  dps: 6182.1492
+  tps: 3914.24688
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 6155.55755
-  tps: 3901.71939
+  dps: 6159.04684
+  tps: 3903.42182
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6002.20069
-  tps: 3799.10706
+  dps: 6005.46604
+  tps: 3800.76104
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 6085.4849
-  tps: 3858.5821
+  dps: 6088.97419
+  tps: 3860.28453
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6196.43025
-  tps: 3923.90446
+  dps: 6199.91954
+  tps: 3925.60688
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkycallTotem-33506"
  value: {
-  dps: 6102.0533
-  tps: 3873.49216
+  dps: 6104.25701
+  tps: 3874.58443
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterHarness"
  value: {
-  dps: 3934.01621
-  tps: 2538.02273
+  dps: 3936.57351
+  tps: 2539.47783
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterRegalia"
  value: {
-  dps: 4668.84334
-  tps: 2982.04802
+  dps: 4669.97812
+  tps: 2982.79484
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6030.6007
-  tps: 3842.75157
+  dps: 6032.77603
+  tps: 3843.94399
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6051.37694
-  tps: 3853.41199
+  dps: 6053.59264
+  tps: 3854.60687
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SouloftheDead-40382"
  value: {
-  dps: 5891.97639
-  tps: 3751.20177
+  dps: 5895.05933
+  tps: 3753.05879
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SparkofLife-37657"
  value: {
-  dps: 5905.8433
-  tps: 3758.55286
+  dps: 5909.63131
+  tps: 3760.87737
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 5956.30046
-  tps: 3780.66856
+  dps: 5960.18649
+  tps: 3782.73999
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 6059.42126
-  tps: 3842.37335
+  dps: 6062.91055
+  tps: 3844.07578
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StormshroudArmor"
  value: {
-  dps: 4600.0046
-  tps: 2956.19912
+  dps: 4602.87859
+  tps: 2958.2623
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6002.0512
-  tps: 3801.0473
+  dps: 6005.29177
+  tps: 3802.61794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6002.0512
-  tps: 3801.0473
+  dps: 6005.29177
+  tps: 3802.61794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6002.0512
-  tps: 3801.0473
+  dps: 6005.29177
+  tps: 3802.61794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 5824.95201
-  tps: 3705.41551
+  dps: 5827.48642
+  tps: 3706.89437
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheFistsofFury"
  value: {
-  dps: 5460.08082
-  tps: 3471.68699
+  dps: 5462.67844
+  tps: 3473.39982
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 5778.77807
-  tps: 3681.66409
+  dps: 5781.14863
+  tps: 3683.08529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 4928.41441
-  tps: 3147.90001
+  dps: 4931.37468
+  tps: 3150.17271
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Thrall'sRegalia"
  value: {
-  dps: 5875.6632
-  tps: 3750.67088
+  dps: 5879.07707
+  tps: 3752.43607
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6002.0512
-  tps: 3801.0473
+  dps: 6005.29177
+  tps: 3802.61794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TidefuryRaiment"
  value: {
-  dps: 4473.90034
-  tps: 2878.59905
+  dps: 4475.81877
+  tps: 2879.96823
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5983.15049
-  tps: 3789.62778
+  dps: 5986.63978
+  tps: 3791.3302
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5983.15049
-  tps: 3789.62778
+  dps: 5986.63978
+  tps: 3791.3302
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6037.45547
-  tps: 3823.12296
+  dps: 6040.69604
+  tps: 3824.6936
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6030.37461
-  tps: 3818.70782
+  dps: 6033.61519
+  tps: 3820.27846
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 5946.97236
-  tps: 3789.24152
+  dps: 5949.44417
+  tps: 3790.32475
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 6340.50307
-  tps: 4023.34973
+  dps: 6345.18301
+  tps: 4026.12864
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 6059.42126
-  tps: 3842.37335
+  dps: 6062.91055
+  tps: 3844.07578
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemoftheElementalPlane-40708"
  value: {
-  dps: 6139.58606
-  tps: 3897.49217
+  dps: 6142.88119
+  tps: 3899.65132
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6030.37461
-  tps: 3818.70782
+  dps: 6033.61519
+  tps: 3820.27846
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6037.45547
-  tps: 3823.12296
+  dps: 6040.69604
+  tps: 3824.6936
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 4595.30654
-  tps: 2958.2512
+  dps: 4597.94369
+  tps: 2960.06789
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6430.58168
-  tps: 4069.13181
+  dps: 6434.36164
+  tps: 4071.14836
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WingedTalisman-37844"
  value: {
-  dps: 5885.24421
-  tps: 3748.72994
+  dps: 5887.61477
+  tps: 3750.15114
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 4878.90963
-  tps: 3112.96426
+  dps: 4880.84259
+  tps: 3113.97984
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WorldbreakerGarb"
  value: {
-  dps: 5943.98631
-  tps: 3842.83919
+  dps: 5944.31417
+  tps: 3842.94886
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 6172.69075
-  tps: 3912.29591
+  dps: 6176.18004
+  tps: 3913.99834
  }
 }
 dps_results: {
  key: "TestElemental-Average-Default"
  value: {
-  dps: 6277.58227
-  tps: 3985.65893
+  dps: 6279.87863
+  tps: 3986.93304
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11056.74548
-  tps: 8411.83275
+  dps: 11058.97057
+  tps: 8413.5782
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6177.28697
-  tps: 3915.58834
+  dps: 6180.78515
+  tps: 3917.67549
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7141.22198
-  tps: 4529.32405
+  dps: 7140.81177
+  tps: 4529.16201
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3950.41494
-  tps: 2962.86701
+  dps: 3953.70493
+  tps: 2964.98391
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3121.43679
-  tps: 2024.38311
+  dps: 3123.00371
+  tps: 2025.08906
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5376.58057
-  tps: 3391.85196
+  dps: 5378.5808
+  tps: 3393.07612
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13630.33932
-  tps: 8292.89569
+  dps: 13631.326
+  tps: 8293.8774
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6807.51281
-  tps: 3920.93605
+  dps: 6808.57963
+  tps: 3922.76399
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8442.44802
-  tps: 4459.69266
+  dps: 8443.8975
+  tps: 4460.25216
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6228.60829
-  tps: 2924.764
+  dps: 6229.3835
+  tps: 2925.15189
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3584.56398
-  tps: 1970.31845
+  dps: 3587.38504
+  tps: 1972.22158
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6459.29218
-  tps: 3309.29698
+  dps: 6460.53098
+  tps: 3309.86199
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10887.99507
-  tps: 8296.91059
+  dps: 10889.58419
+  tps: 8298.0008
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6196.43025
-  tps: 3923.90446
+  dps: 6199.91954
+  tps: 3925.60688
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7034.68615
-  tps: 4457.68286
+  dps: 7034.5702
+  tps: 4457.38545
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3976.63918
-  tps: 2991.31393
+  dps: 3978.53337
+  tps: 2992.63598
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3115.71522
-  tps: 2014.33439
+  dps: 3117.57765
+  tps: 2015.46604
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5287.80577
-  tps: 3332.75998
+  dps: 5288.75374
+  tps: 3332.99419
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13413.14506
-  tps: 8287.05597
+  dps: 13416.59294
+  tps: 8289.22368
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6763.36174
-  tps: 3929.82061
+  dps: 6764.98181
+  tps: 3930.8026
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8268.92743
-  tps: 4407.10433
+  dps: 8268.88745
+  tps: 4406.68608
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6024.68996
-  tps: 2912.4752
+  dps: 6025.15209
+  tps: 2912.70974
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3533.04908
-  tps: 1963.36633
+  dps: 3535.57969
+  tps: 1964.99284
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6290.97363
-  tps: 3245.50177
+  dps: 6292.46923
+  tps: 3246.08012
  }
 }
 dps_results: {
  key: "TestElemental-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6196.43025
-  tps: 3923.90446
+  dps: 6199.91954
+  tps: 3925.60688
  }
 }

--- a/sim/warlock/TestAffliction.results
+++ b/sim/warlock/TestAffliction.results
@@ -46,315 +46,315 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 7387.6182
-  tps: 6663.03877
+  dps: 7362.97906
+  tps: 6637.09798
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7210.66149
-  tps: 6479.76505
+  dps: 7195.78936
+  tps: 6465.17404
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7226.62322
-  tps: 6495.72677
+  dps: 7210.4086
+  tps: 6479.79328
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7242.11884
-  tps: 6507.94426
+  dps: 7256.86194
+  tps: 6524.34179
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7332.3362
-  tps: 6601.43975
+  dps: 7316.04295
+  tps: 6585.42763
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 7640.14662
-  tps: 6887.8101
+  dps: 7611.93715
+  tps: 6858.8512
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DeathbringerGarb"
  value: {
-  dps: 7062.46639
-  tps: 6342.20039
+  dps: 7042.72163
+  tps: 6322.39125
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7228.74069
-  tps: 6497.84424
+  dps: 7211.75882
+  tps: 6481.1435
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7210.66149
-  tps: 6479.76505
+  dps: 7195.78936
+  tps: 6465.17404
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7242.11884
-  tps: 6507.94426
+  dps: 7256.86194
+  tps: 6524.34179
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7226.62322
-  tps: 6495.72677
+  dps: 7210.4086
+  tps: 6479.79328
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7221.05207
-  tps: 6490.15562
+  dps: 7205.3226
+  tps: 6474.70727
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7210.66149
-  tps: 6479.76505
+  dps: 7195.78936
+  tps: 6465.17404
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7242.11884
-  tps: 6507.94426
+  dps: 7256.86194
+  tps: 6524.34179
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7239.94308
-  tps: 6506.43768
+  dps: 7245.68831
+  tps: 6513.2113
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 7077.14383
-  tps: 6378.74
+  dps: 7038.8115
+  tps: 6337.90527
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 7007.23929
-  tps: 6225.47054
+  dps: 6977.72369
+  tps: 6193.64455
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7226.62322
-  tps: 6495.72677
+  dps: 7210.4086
+  tps: 6479.79328
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7221.05207
-  tps: 6490.15562
+  dps: 7205.3226
+  tps: 6474.70727
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7210.05585
-  tps: 6476.50163
+  dps: 7192.93382
+  tps: 6458.91899
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7210.66149
-  tps: 6479.76505
+  dps: 7195.78936
+  tps: 6465.17404
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MaleficRaiment"
  value: {
-  dps: 5394.39165
-  tps: 4758.12125
+  dps: 5379.87755
+  tps: 4745.68976
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7210.66149
-  tps: 6479.76505
+  dps: 7195.78936
+  tps: 6465.17404
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7210.66149
-  tps: 6479.76505
+  dps: 7195.78936
+  tps: 6465.17404
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PlagueheartGarb"
  value: {
-  dps: 6665.19599
-  tps: 5975.66334
+  dps: 6625.37564
+  tps: 5933.32635
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7210.66149
-  tps: 6479.76505
+  dps: 7195.78936
+  tps: 6465.17404
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7210.66149
-  tps: 6479.76505
+  dps: 7195.78936
+  tps: 6465.17404
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7314.93792
-  tps: 6584.04147
+  dps: 7300.10798
+  tps: 6569.49265
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7200.84556
-  tps: 6466.91958
+  dps: 7209.55028
+  tps: 6478.42477
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7210.66149
-  tps: 6479.76505
+  dps: 7195.78936
+  tps: 6465.17404
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7210.66149
-  tps: 6479.76505
+  dps: 7195.78936
+  tps: 6465.17404
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7210.66149
-  tps: 6479.76505
+  dps: 7195.78936
+  tps: 6465.17404
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7210.66149
-  tps: 6479.76505
+  dps: 7195.78936
+  tps: 6465.17404
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7242.11884
-  tps: 6507.94426
+  dps: 7256.86194
+  tps: 6524.34179
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7239.94308
-  tps: 6506.43768
+  dps: 7245.68831
+  tps: 6513.2113
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7239.94308
-  tps: 6506.43768
+  dps: 7245.68831
+  tps: 6513.2113
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7242.11884
-  tps: 6507.94426
+  dps: 7256.86194
+  tps: 6524.34179
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 7417.9626
-  tps: 6682.88897
+  dps: 7404.01948
+  tps: 6668.06277
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7355.20168
-  tps: 8492.17681
+  dps: 7349.07043
+  tps: 8485.11826
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7355.20168
-  tps: 6622.3349
+  dps: 7349.07043
+  tps: 6619.62106
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7846.25662
-  tps: 7062.80433
+  dps: 7830.53298
+  tps: 7044.39412
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4307.48501
-  tps: 6195.82608
+  dps: 4299.91108
+  tps: 6193.73924
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4307.48501
-  tps: 4060.00148
+  dps: 4299.91108
+  tps: 4052.79279
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P1-Affliction Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4138.8881
-  tps: 3798.84956
+  dps: 4130.0353
+  tps: 3795.6814
  }
 }
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7295.94737
-  tps: 6601.43975
+  dps: 7279.63441
+  tps: 6585.42763
  }
 }

--- a/sim/warlock/TestDemonology.results
+++ b/sim/warlock/TestDemonology.results
@@ -46,315 +46,315 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 7433.60297
-  tps: 6190.52229
+  dps: 7425.00943
+  tps: 6180.25852
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7325.58315
-  tps: 6088.70327
+  dps: 7312.01135
+  tps: 6074.61179
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7338.91463
-  tps: 6102.67314
+  dps: 7318.19363
+  tps: 6081.90972
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7361.48565
-  tps: 6120.25686
+  dps: 7348.83626
+  tps: 6106.17723
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7462.62787
-  tps: 6226.38639
+  dps: 7440.76974
+  tps: 6204.48583
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 7646.86574
-  tps: 6391.19634
+  dps: 7638.86234
+  tps: 6378.96941
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DeathbringerGarb"
  value: {
-  dps: 7072.7589
-  tps: 5866.62817
+  dps: 7065.96136
+  tps: 5859.55776
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7338.91463
-  tps: 6102.67314
+  dps: 7318.19363
+  tps: 6081.90972
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7325.58315
-  tps: 6088.70327
+  dps: 7312.01135
+  tps: 6074.61179
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7361.48565
-  tps: 6120.25686
+  dps: 7348.83626
+  tps: 6106.17723
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7338.91463
-  tps: 6102.67314
+  dps: 7318.19363
+  tps: 6081.90972
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7335.5823
-  tps: 6099.34081
+  dps: 7314.8258
+  tps: 6078.54188
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7323.74617
-  tps: 6087.50469
+  dps: 7302.24495
+  tps: 6065.96104
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7361.48565
-  tps: 6120.25686
+  dps: 7348.83626
+  tps: 6106.17723
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7353.65865
-  tps: 6113.66301
+  dps: 7341.2171
+  tps: 6100.05665
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 7012.62591
-  tps: 5807.54681
+  dps: 7019.66742
+  tps: 5813.43759
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 7104.11867
-  tps: 5782.86192
+  dps: 7088.76009
+  tps: 5765.90866
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7338.91463
-  tps: 6102.67314
+  dps: 7318.19363
+  tps: 6081.90972
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7335.5823
-  tps: 6099.34081
+  dps: 7314.8258
+  tps: 6078.54188
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7326.51467
-  tps: 6089.74409
+  dps: 7328.77904
+  tps: 6089.4185
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7323.74617
-  tps: 6087.50469
+  dps: 7302.24495
+  tps: 6065.96104
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MaleficRaiment"
  value: {
-  dps: 5561.87011
-  tps: 4508.32709
+  dps: 5555.27394
+  tps: 4497.99466
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7323.74617
-  tps: 6087.50469
+  dps: 7302.24495
+  tps: 6065.96104
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7323.74617
-  tps: 6087.50469
+  dps: 7302.24495
+  tps: 6065.96104
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PlagueheartGarb"
  value: {
-  dps: 6730.74155
-  tps: 5552.91018
+  dps: 6742.70603
+  tps: 5562.52835
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7324.3147
-  tps: 6087.58458
+  dps: 7310.74502
+  tps: 6073.49483
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7325.58315
-  tps: 6088.70327
+  dps: 7312.01135
+  tps: 6074.61179
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7446.09426
-  tps: 6209.85277
+  dps: 7423.38568
+  tps: 6187.10177
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7318.85768
-  tps: 6081.77199
+  dps: 7317.98787
+  tps: 6079.09702
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7323.74617
-  tps: 6087.50469
+  dps: 7302.24495
+  tps: 6065.96104
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7323.74617
-  tps: 6087.50469
+  dps: 7302.24495
+  tps: 6065.96104
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7323.74617
-  tps: 6087.50469
+  dps: 7302.24495
+  tps: 6065.96104
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7323.74617
-  tps: 6087.50469
+  dps: 7302.24495
+  tps: 6065.96104
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7361.48565
-  tps: 6120.25686
+  dps: 7348.83626
+  tps: 6106.17723
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7353.65865
-  tps: 6113.66301
+  dps: 7341.2171
+  tps: 6100.05665
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7353.65865
-  tps: 6113.66301
+  dps: 7341.2171
+  tps: 6100.05665
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7361.48565
-  tps: 6120.25686
+  dps: 7348.83626
+  tps: 6106.17723
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 7523.42834
-  tps: 6279.5938
+  dps: 7519.30403
+  tps: 6273.10901
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9840.26056
-  tps: 10587.00059
+  dps: 9852.42481
+  tps: 10614.11874
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7471.88044
-  tps: 6236.94605
+  dps: 7474.78042
+  tps: 6238.7091
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-FullBuffs-ShortSingleTarget"
  value: {
   dps: 8558.44047
-  tps: 7131.66749
+  tps: 7129.06469
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-NoBuffs-LongMultiTarget"
  value: {
   dps: 5961.51659
-  tps: 8039.79836
+  tps: 8037.74502
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-NoBuffs-LongSingleTarget"
  value: {
   dps: 4193.07101
-  tps: 3834.54183
+  tps: 3832.54183
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P1-Demonology Warlock-NoBuffs-ShortSingleTarget"
  value: {
   dps: 4401.53562
-  tps: 3961.95453
+  tps: 3959.4212
  }
 }
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7339.98313
-  tps: 6227.11485
+  dps: 7316.92343
+  tps: 6205.31562
  }
 }

--- a/sim/warlock/TestDestruction.results
+++ b/sim/warlock/TestDestruction.results
@@ -46,315 +46,315 @@ character_stats_results: {
 dps_results: {
  key: "TestDestruction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 6765.44717
-  tps: 5644.30285
+  dps: 6752.58757
+  tps: 5629.80475
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6747.94118
-  tps: 5601.68362
+  dps: 6732.40748
+  tps: 5586.85497
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6766.39737
-  tps: 5618.32566
+  dps: 6749.19111
+  tps: 5601.99171
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6786.73598
-  tps: 5634.5142
+  dps: 6770.1433
+  tps: 5618.48615
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6935.99545
-  tps: 5770.96394
+  dps: 6918.16753
+  tps: 5754.07049
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 7114.41215
-  tps: 5900.50419
+  dps: 7132.8234
+  tps: 5916.39759
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DeathbringerGarb"
  value: {
-  dps: 6602.54015
-  tps: 5486.30015
+  dps: 6582.71448
+  tps: 5468.04731
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6769.50736
-  tps: 5621.12466
+  dps: 6752.14141
+  tps: 5604.64699
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6747.94118
-  tps: 5601.68362
+  dps: 6732.40748
+  tps: 5586.85497
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6786.73598
-  tps: 5634.5142
+  dps: 6770.1433
+  tps: 5618.48615
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6766.39737
-  tps: 5618.32566
+  dps: 6749.19111
+  tps: 5601.99171
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6763.09343
-  tps: 5615.35212
+  dps: 6745.92929
+  tps: 5599.05607
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6747.94118
-  tps: 5601.68362
+  dps: 6732.40748
+  tps: 5586.85497
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6786.73598
-  tps: 5634.5142
+  dps: 6770.1433
+  tps: 5618.48615
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6779.15101
-  tps: 5628.04971
+  dps: 6762.44296
+  tps: 5611.91265
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 6568.63665
-  tps: 5468.74853
+  dps: 6559.1944
+  tps: 5458.58187
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 6608.95157
-  tps: 5449.84932
+  dps: 6615.13548
+  tps: 5452.04264
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6766.39737
-  tps: 5618.32566
+  dps: 6749.19111
+  tps: 5601.99171
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6763.09343
-  tps: 5615.35212
+  dps: 6745.92929
+  tps: 5599.05607
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6762.55342
-  tps: 5609.0392
+  dps: 6757.90777
+  tps: 5607.16756
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6747.94118
-  tps: 5601.68362
+  dps: 6732.40748
+  tps: 5586.85497
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MaleficRaiment"
  value: {
-  dps: 5146.78315
-  tps: 4274.46337
+  dps: 5169.0578
+  tps: 4297.11447
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6747.94118
-  tps: 5601.68362
+  dps: 6732.40748
+  tps: 5586.85497
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6747.94118
-  tps: 5601.68362
+  dps: 6732.40748
+  tps: 5586.85497
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PlagueheartGarb"
  value: {
-  dps: 6179.86979
-  tps: 5136.43778
+  dps: 6172.6021
+  tps: 5127.80496
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6747.94118
-  tps: 5601.68362
+  dps: 6732.40748
+  tps: 5586.85497
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6747.94118
-  tps: 5601.68362
+  dps: 6732.40748
+  tps: 5586.85497
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6915.96028
-  tps: 5752.90081
+  dps: 6899.95545
+  tps: 5737.64814
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6744.34093
-  tps: 5596.68593
+  dps: 6736.83983
+  tps: 5588.8004
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6747.94118
-  tps: 5601.68362
+  dps: 6732.40748
+  tps: 5586.85497
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6747.94118
-  tps: 5601.68362
+  dps: 6732.40748
+  tps: 5586.85497
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6747.94118
-  tps: 5601.68362
+  dps: 6732.40748
+  tps: 5586.85497
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6747.94118
-  tps: 5601.68362
+  dps: 6732.40748
+  tps: 5586.85497
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6786.73598
-  tps: 5634.5142
+  dps: 6770.1433
+  tps: 5618.48615
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6779.15101
-  tps: 5628.04971
+  dps: 6762.44296
+  tps: 5611.91265
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6779.15101
-  tps: 5628.04971
+  dps: 6762.44296
+  tps: 5611.91265
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6786.73598
-  tps: 5634.5142
+  dps: 6770.1433
+  tps: 5618.48615
  }
 }
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 7008.0959
-  tps: 5836.19692
+  dps: 7009.30212
+  tps: 5835.53968
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P1-Destruction Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6955.00358
-  tps: 7904.49782
+  dps: 6940.35611
+  tps: 7887.42078
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P1-Destruction Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6955.00358
-  tps: 5790.28416
+  dps: 6940.35611
+  tps: 5770.85665
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P1-Destruction Warlock-FullBuffs-ShortSingleTarget"
  value: {
   dps: 8018.99122
-  tps: 6620.15015
+  tps: 6617.85856
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P1-Destruction Warlock-NoBuffs-LongMultiTarget"
  value: {
   dps: 3677.74443
-  tps: 5423.60177
+  tps: 5421.65511
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P1-Destruction Warlock-NoBuffs-LongSingleTarget"
  value: {
   dps: 3677.74443
-  tps: 3283.15915
+  tps: 3281.21248
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P1-Destruction Warlock-NoBuffs-ShortSingleTarget"
  value: {
   dps: 4014.68436
-  tps: 3353.06727
+  tps: 3350.53394
  }
 }
 dps_results: {
  key: "TestDestruction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6935.99545
-  tps: 5770.96394
+  dps: 6918.16753
+  tps: 5754.07049
  }
 }

--- a/sim/warlock/corruption.go
+++ b/sim/warlock/corruption.go
@@ -66,7 +66,7 @@ func (warlock *Warlock) registerCorruptionSpell() {
 		},
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			result := spell.CalcAndDealOutcome(sim, target, spell.OutcomeMagicHit)
+			result := spell.CalcOutcome(sim, target, spell.OutcomeMagicHit)
 			if result.Landed() {
 				spell.SpellMetrics[target.UnitIndex].Hits--
 				spell.Dot(target).Apply(sim)

--- a/sim/warlock/curses.go
+++ b/sim/warlock/curses.go
@@ -29,7 +29,7 @@ func (warlock *Warlock) registerCurseOfElementsSpell() {
 		FlatThreatBonus:  156,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			result := spell.CalcAndDealOutcome(sim, target, spell.OutcomeMagicHit)
+			result := spell.CalcOutcome(sim, target, spell.OutcomeMagicHit)
 			if result.Landed() {
 				warlock.CurseOfElementsAuras.Get(target).Activate(sim)
 			}
@@ -65,7 +65,7 @@ func (warlock *Warlock) registerCurseOfWeaknessSpell() {
 		FlatThreatBonus:  142,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			result := spell.CalcAndDealOutcome(sim, target, spell.OutcomeMagicHit)
+			result := spell.CalcOutcome(sim, target, spell.OutcomeMagicHit)
 			if result.Landed() {
 				warlock.CurseOfWeaknessAuras.Get(target).Activate(sim)
 			}
@@ -104,7 +104,7 @@ func (warlock *Warlock) registerCurseOfTonguesSpell() {
 		FlatThreatBonus:  100,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			result := spell.CalcAndDealOutcome(sim, target, spell.OutcomeMagicHit)
+			result := spell.CalcOutcome(sim, target, spell.OutcomeMagicHit)
 			if result.Landed() {
 				warlock.CurseOfTonguesAuras.Get(target).Activate(sim)
 			}
@@ -159,7 +159,7 @@ func (warlock *Warlock) registerCurseOfAgonySpell() {
 		},
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			result := spell.CalcAndDealOutcome(sim, target, spell.OutcomeMagicHit)
+			result := spell.CalcOutcome(sim, target, spell.OutcomeMagicHit)
 			if result.Landed() {
 				warlock.CurseOfDoom.Dot(target).Cancel(sim)
 				spell.Dot(target).Apply(sim)
@@ -209,7 +209,7 @@ func (warlock *Warlock) registerCurseOfDoomSpell() {
 		},
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			result := spell.CalcAndDealOutcome(sim, target, spell.OutcomeMagicHit)
+			result := spell.CalcOutcome(sim, target, spell.OutcomeMagicHit)
 			if result.Landed() {
 				warlock.CurseOfAgony.Dot(target).Cancel(sim)
 				spell.Dot(target).Apply(sim)

--- a/sim/warlock/drain_soul.go
+++ b/sim/warlock/drain_soul.go
@@ -73,7 +73,7 @@ func (warlock *Warlock) registerDrainSoulSpell() {
 		},
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			result := spell.CalcAndDealOutcome(sim, target, spell.OutcomeMagicHit)
+			result := spell.CalcOutcome(sim, target, spell.OutcomeMagicHit)
 			if result.Landed() {
 				dot := spell.Dot(target)
 				dot.Apply(sim)

--- a/sim/warlock/unstable_affliction.go
+++ b/sim/warlock/unstable_affliction.go
@@ -61,7 +61,9 @@ func (warlock *Warlock) registerUnstableAfflictionSpell() {
 		},
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			result := spell.CalcAndDealOutcome(sim, target, spell.OutcomeMagicHit)
+			// this is a non-standard way of dealing with dot effects, but get's rid of the 0 damage tick
+			// that can proc on-damage effects; same with corruption, curses, ds
+			result := spell.CalcOutcome(sim, target, spell.OutcomeMagicHit)
 			if result.Landed() {
 				spell.Dot(target).Apply(sim)
 			}


### PR DESCRIPTION
The first 0 damage tick could proc on-damage effects like tailoring cloak enchant.