### PR TITLE
Vigo/rogue cleanup

### DIFF
--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -170,7 +170,7 @@ func applyDebuffEffects(target *Unit, targetIdx int, debuffs *proto.Debuffs, rai
 	}
 
 	if debuffs.HeartOfTheCrusader && targetIdx == 0 {
-		MakePermanent(HeartoftheCrusaderDebuff(target, 3))
+		MakePermanent(HeartOfTheCrusaderDebuff(target, 3))
 	}
 
 	if debuffs.HuntersMark > 0 && targetIdx == 0 {
@@ -914,7 +914,7 @@ func MasterPoisonerDebuff(target *Unit, points float64) *Aura {
 	return minorCritDebuffAura(target, "Master Poisoner", ActionID{SpellID: 58410}, time.Second*20, points*CritRatingPerCritChance)
 }
 
-func HeartoftheCrusaderDebuff(target *Unit, points float64) *Aura {
+func HeartOfTheCrusaderDebuff(target *Unit, points float64) *Aura {
 	return minorCritDebuffAura(target, "Heart of the Crusader", ActionID{SpellID: 20337}, time.Second*20, points*CritRatingPerCritChance)
 }
 

--- a/sim/paladin/talents.go
+++ b/sim/paladin/talents.go
@@ -405,7 +405,7 @@ func (paladin *Paladin) applyHeartOfTheCrusader() {
 			if !spell.Flags.Matches(SpellFlagSecondaryJudgement) {
 				return
 			}
-			debuffAura := core.HeartoftheCrusaderDebuff(result.Target, float64(paladin.Talents.HeartOfTheCrusader))
+			debuffAura := core.HeartOfTheCrusaderDebuff(result.Target, float64(paladin.Talents.HeartOfTheCrusader))
 			debuffAura.Activate(sim)
 		},
 	})

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -46,619 +46,619 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7438.95101
-  tps: 5281.65521
+  dps: 7454.34291
+  tps: 5292.58347
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7619.31054
-  tps: 5409.71049
+  dps: 7616.10249
+  tps: 5407.43277
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7635.739
-  tps: 5421.37469
+  dps: 7645.72224
+  tps: 5428.46279
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7400.60485
-  tps: 79709.36853
+  dps: 7414.94004
+  tps: 79760.44979
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7400.60485
-  tps: 79709.36853
+  dps: 7414.94004
+  tps: 79760.44979
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7647.85961
-  tps: 5429.98032
+  dps: 7663.15639
+  tps: 5440.84104
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5749.43996
-  tps: 4082.10237
+  dps: 5763.15447
+  tps: 4091.83967
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6916.00969
-  tps: 4910.36688
+  dps: 6923.5563
+  tps: 4915.72497
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7619.31054
-  tps: 5301.51628
+  dps: 7616.10249
+  tps: 5299.28411
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7771.13809
-  tps: 5517.50805
+  dps: 7787.04891
+  tps: 5528.80473
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
   hps: 64
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7593.53516
-  tps: 5391.40997
+  dps: 7613.10031
+  tps: 5405.30122
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7613.75336
-  tps: 5405.76489
+  dps: 7624.47082
+  tps: 5413.37428
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7587.6571
-  tps: 5387.23654
+  dps: 7601.60783
+  tps: 5397.14156
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7993.59589
-  tps: 5675.45309
+  dps: 8001.72943
+  tps: 5681.22789
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7525.83877
-  tps: 5343.34553
+  dps: 7548.19621
+  tps: 5359.21931
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7822.90171
-  tps: 5554.26021
+  dps: 7849.90645
+  tps: 5573.43358
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7927.4251
-  tps: 5628.47182
+  dps: 7935.77771
+  tps: 5634.40218
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7656.59342
-  tps: 5436.18133
+  dps: 7675.43505
+  tps: 5449.55889
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7644.15567
-  tps: 5427.35052
+  dps: 7658.54293
+  tps: 5437.56548
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7621.66487
-  tps: 5411.38206
+  dps: 7654.28961
+  tps: 5434.54563
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7619.31054
-  tps: 5409.71049
+  dps: 7616.10249
+  tps: 5407.43277
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7619.31054
-  tps: 5409.71049
+  dps: 7616.10249
+  tps: 5407.43277
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7647.85961
-  tps: 5429.98032
+  dps: 7663.15639
+  tps: 5440.84104
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7648.47294
-  tps: 5430.41579
+  dps: 7672.21256
+  tps: 5447.27092
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7542.07653
-  tps: 5354.87434
+  dps: 7572.39454
+  tps: 5376.40013
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7619.31054
-  tps: 5409.71049
+  dps: 7616.10249
+  tps: 5407.43277
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7595.4059
-  tps: 5392.73819
+  dps: 7610.23706
+  tps: 5403.26831
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7560.35193
-  tps: 5367.84987
+  dps: 7574.13069
+  tps: 5377.63279
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7521.65196
-  tps: 5340.37289
+  dps: 7536.66378
+  tps: 5351.03128
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7619.31054
-  tps: 5409.71049
+  dps: 7616.10249
+  tps: 5407.43277
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7619.31054
-  tps: 5409.71049
+  dps: 7616.10249
+  tps: 5407.43277
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7680.62232
-  tps: 5453.24185
+  dps: 7696.76746
+  tps: 5464.7049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7453.2048
-  tps: 5291.77541
+  dps: 7461.1976
+  tps: 5297.4503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7590.23283
-  tps: 5389.06531
+  dps: 7601.65307
+  tps: 5397.17368
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-49982"
  value: {
-  dps: 7779.29011
-  tps: 5523.29598
+  dps: 7799.50062
+  tps: 5537.64544
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-50641"
  value: {
-  dps: 7779.29011
-  tps: 5523.29598
+  dps: 7799.50062
+  tps: 5537.64544
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7647.85961
-  tps: 5429.98032
+  dps: 7663.15639
+  tps: 5440.84104
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7648.47294
-  tps: 5430.41579
+  dps: 7672.21256
+  tps: 5447.27092
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7584.98846
-  tps: 5385.3418
+  dps: 7601.25562
+  tps: 5396.89149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7619.31054
-  tps: 5409.71049
+  dps: 7616.10249
+  tps: 5407.43277
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7655.71156
-  tps: 5435.5552
+  dps: 7650.36635
+  tps: 5431.76011
   hps: 9.14161
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7675.47404
-  tps: 5449.58657
+  dps: 7711.46269
+  tps: 5475.13851
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7447.88011
-  tps: 5287.99488
+  dps: 7447.11376
+  tps: 5287.45077
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7649.4976
-  tps: 5431.14329
+  dps: 7646.27619
+  tps: 5428.85609
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7656.60043
-  tps: 5436.18631
+  dps: 7653.37588
+  tps: 5433.89688
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7619.31054
-  tps: 5409.71049
+  dps: 7616.10249
+  tps: 5407.43277
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7619.31054
-  tps: 5409.71049
+  dps: 7616.10249
+  tps: 5407.43277
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7612.08217
-  tps: 5404.57834
+  dps: 7621.90797
+  tps: 5411.55466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7637.61633
-  tps: 5422.7076
+  dps: 7647.25714
+  tps: 5429.55257
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7779.29011
-  tps: 5523.29598
+  dps: 7799.50062
+  tps: 5537.64544
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7619.31054
-  tps: 5409.71049
+  dps: 7616.10249
+  tps: 5407.43277
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7956.12056
-  tps: 5648.84559
+  dps: 7953.25049
+  tps: 5646.80785
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 5664.92262
-  tps: 4022.09506
+  dps: 5681.9101
+  tps: 4034.15617
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7565.05963
-  tps: 5371.19234
+  dps: 7577.63896
+  tps: 5380.12366
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 7514.90607
-  tps: 5335.58331
+  dps: 7532.45624
+  tps: 5348.04393
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7593.70792
-  tps: 5391.53262
+  dps: 7616.97094
+  tps: 5408.04937
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StormshroudArmor"
  value: {
-  dps: 6042.36733
-  tps: 4290.0808
+  dps: 6045.90435
+  tps: 4292.59209
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7656.60043
-  tps: 5436.18631
+  dps: 7653.37588
+  tps: 5433.89688
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7649.4976
-  tps: 5431.14329
+  dps: 7646.27619
+  tps: 5428.85609
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7637.06763
-  tps: 5422.31802
+  dps: 7633.85172
+  tps: 5420.03472
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 7324.95629
-  tps: 5200.71897
+  dps: 7337.6352
+  tps: 5209.721
  }
 }
 dps_results: {
@@ -671,434 +671,434 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7696.97726
-  tps: 5464.85385
+  dps: 7703.36772
+  tps: 5469.39108
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7782.81429
-  tps: 5525.79815
+  dps: 7777.95269
+  tps: 5522.34641
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7810.73463
-  tps: 5545.62159
+  dps: 7842.33817
+  tps: 5568.0601
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7619.31054
-  tps: 5409.71049
+  dps: 7616.10249
+  tps: 5407.43277
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7619.31054
-  tps: 5409.71049
+  dps: 7616.10249
+  tps: 5407.43277
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7480.11788
-  tps: 5310.88369
+  dps: 7495.22884
+  tps: 5321.61248
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7619.31054
-  tps: 5409.71049
+  dps: 7616.10249
+  tps: 5407.43277
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7619.31054
-  tps: 5409.71049
+  dps: 7616.10249
+  tps: 5407.43277
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6125.65359
-  tps: 4349.21405
+  dps: 6127.31233
+  tps: 4350.39175
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 7106.79941
-  tps: 5045.82758
+  dps: 7115.59179
+  tps: 5052.07017
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7400.81686
-  tps: 5254.57997
+  dps: 7416.42707
+  tps: 5265.66322
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 7764.81567
-  tps: 5513.01912
+  dps: 7774.54884
+  tps: 5519.92967
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28034.79439
-  tps: 19904.70402
+  dps: 28239.22705
+  tps: 20049.8512
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7779.29011
-  tps: 5523.29598
+  dps: 7799.50062
+  tps: 5537.64544
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8881.02869
-  tps: 6305.53037
+  dps: 8916.96848
+  tps: 6331.04762
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15085.5854
-  tps: 10710.76563
+  dps: 15356.23303
+  tps: 10902.92545
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3719.10716
-  tps: 2640.56608
+  dps: 3737.07283
+  tps: 2653.32171
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3778.83555
-  tps: 2682.97324
+  dps: 3801.88548
+  tps: 2699.33869
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21280.48805
-  tps: 15109.14652
+  dps: 21422.78683
+  tps: 15210.17865
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5063.06854
-  tps: 3594.77866
+  dps: 5076.82408
+  tps: 3604.5451
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5774.293
-  tps: 4099.74803
+  dps: 5802.32109
+  tps: 4119.64798
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12767.16461
-  tps: 9064.68687
+  dps: 12887.96247
+  tps: 9150.45335
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2448.74192
-  tps: 1738.60676
+  dps: 2457.80703
+  tps: 1745.04299
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2561.83158
-  tps: 1818.90042
+  dps: 2582.62431
+  tps: 1833.66326
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26897.30994
-  tps: 19097.09006
+  dps: 27083.20454
+  tps: 19229.07522
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7346.84694
-  tps: 5216.26133
+  dps: 7355.97088
+  tps: 5222.73932
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8333.81936
-  tps: 5917.01174
+  dps: 8364.84891
+  tps: 5939.04272
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14462.35679
-  tps: 10268.27332
+  dps: 14799.70942
+  tps: 10507.79369
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3518.84965
-  tps: 2498.38325
+  dps: 3533.25036
+  tps: 2508.60776
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3557.40874
-  tps: 2525.7602
+  dps: 3578.49359
+  tps: 2540.73045
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17837.16923
-  tps: 12664.39015
+  dps: 18062.64557
+  tps: 12824.47835
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3831.83974
-  tps: 2720.60621
+  dps: 3840.10811
+  tps: 2726.47676
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4636.39611
-  tps: 3291.84124
+  dps: 4653.17002
+  tps: 3303.75071
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9222.83087
-  tps: 6548.20992
+  dps: 9348.32237
+  tps: 6637.30888
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1685.17486
-  tps: 1196.47415
+  dps: 1692.55582
+  tps: 1201.71464
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1756.7653
-  tps: 1247.30336
+  dps: 1773.40088
+  tps: 1259.11462
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28177.25885
-  tps: 20005.85378
+  dps: 28429.20106
+  tps: 20184.73276
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7809.37141
-  tps: 5544.6537
+  dps: 7828.47102
+  tps: 5558.21442
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8967.92294
-  tps: 6367.22528
+  dps: 9005.09915
+  tps: 6393.6204
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15160.48355
-  tps: 10763.94332
+  dps: 15466.26237
+  tps: 10981.04629
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3743.80779
-  tps: 2658.10353
+  dps: 3757.72165
+  tps: 2667.98237
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3823.16521
-  tps: 2714.4473
+  dps: 3843.79128
+  tps: 2729.09181
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21394.07471
-  tps: 15189.79304
+  dps: 21556.10585
+  tps: 15304.83515
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5089.11546
-  tps: 3613.27198
+  dps: 5103.89425
+  tps: 3623.76492
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5831.97194
-  tps: 4140.70008
+  dps: 5862.14674
+  tps: 4162.12419
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12836.40028
-  tps: 9113.8442
+  dps: 12971.39131
+  tps: 9209.68783
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2466.025
-  tps: 1750.87775
+  dps: 2473.56161
+  tps: 1756.22874
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2591.40895
-  tps: 1839.90036
+  dps: 2611.21276
+  tps: 1853.96106
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27022.07891
-  tps: 19185.67603
+  dps: 27244.77983
+  tps: 19343.79368
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7377.2903
-  tps: 5237.87611
+  dps: 7382.8693
+  tps: 5241.8372
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8413.16833
-  tps: 5973.34951
+  dps: 8445.4107
+  tps: 5996.24159
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14545.56817
-  tps: 10327.3534
+  dps: 14901.82222
+  tps: 10580.29377
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3542.06786
-  tps: 2514.86818
+  dps: 3553.58065
+  tps: 2523.04226
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3599.70057
-  tps: 2555.7874
+  dps: 3616.74328
+  tps: 2567.88773
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17926.71283
-  tps: 12727.96611
+  dps: 18153.46458
+  tps: 12888.95985
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3856.28705
-  tps: 2737.9638
+  dps: 3864.63678
+  tps: 2743.89211
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4686.68801
-  tps: 3327.54849
+  dps: 4704.08184
+  tps: 3339.89811
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9284.43526
-  tps: 6591.94904
+  dps: 9415.38504
+  tps: 6684.92338
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1696.93802
-  tps: 1204.82599
+  dps: 1704.48718
+  tps: 1210.1859
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1776.13563
-  tps: 1261.0563
+  dps: 1793.39282
+  tps: 1273.3089
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7286.2564
-  tps: 5173.24204
+  dps: 7304.13485
+  tps: 5185.93574
  }
 }

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -804,127 +804,127 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17837.16923
-  tps: 12664.39015
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
- value: {
-  dps: 3831.83974
-  tps: 2720.60621
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
- value: {
-  dps: 4636.39611
-  tps: 3291.84124
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
- value: {
-  dps: 9222.83087
-  tps: 6548.20992
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
- value: {
-  dps: 1685.17486
-  tps: 1196.47415
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
- value: {
-  dps: 1756.7653
-  tps: 1247.30336
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
- value: {
-  dps: 28034.79439
-  tps: 19904.70402
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
- value: {
-  dps: 7779.29011
-  tps: 5523.29598
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
- value: {
-  dps: 8881.02869
-  tps: 6305.53037
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
- value: {
-  dps: 15085.5854
-  tps: 10710.76563
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
- value: {
-  dps: 3719.10716
-  tps: 2640.56608
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
- value: {
-  dps: 3778.83555
-  tps: 2682.97324
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
- value: {
   dps: 21280.48805
   tps: 15109.14652
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
   dps: 5063.06854
   tps: 3594.77866
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
   dps: 5774.293
   tps: 4099.74803
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
+ key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
   dps: 12767.16461
   tps: 9064.68687
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
   dps: 2448.74192
   tps: 1738.60676
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
   dps: 2561.83158
   tps: 1818.90042
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
+ value: {
+  dps: 26897.30994
+  tps: 19097.09006
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
+ value: {
+  dps: 7346.84694
+  tps: 5216.26133
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
+ value: {
+  dps: 8333.81936
+  tps: 5917.01174
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
+ value: {
+  dps: 14462.35679
+  tps: 10268.27332
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
+ value: {
+  dps: 3518.84965
+  tps: 2498.38325
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
+ value: {
+  dps: 3557.40874
+  tps: 2525.7602
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
+ value: {
+  dps: 17837.16923
+  tps: 12664.39015
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
+ value: {
+  dps: 3831.83974
+  tps: 2720.60621
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
+ value: {
+  dps: 4636.39611
+  tps: 3291.84124
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
+ value: {
+  dps: 9222.83087
+  tps: 6548.20992
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
+ value: {
+  dps: 1685.17486
+  tps: 1196.47415
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
+ value: {
+  dps: 1756.7653
+  tps: 1247.30336
  }
 }
 dps_results: {
@@ -972,127 +972,127 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17926.71283
-  tps: 12727.96611
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
- value: {
-  dps: 3856.28705
-  tps: 2737.9638
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
- value: {
-  dps: 4686.68801
-  tps: 3327.54849
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
- value: {
-  dps: 9284.43526
-  tps: 6591.94904
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
- value: {
-  dps: 1696.93802
-  tps: 1204.82599
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
- value: {
-  dps: 1776.13563
-  tps: 1261.0563
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
- value: {
-  dps: 28177.25885
-  tps: 20005.85378
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
- value: {
-  dps: 7809.37141
-  tps: 5544.6537
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
- value: {
-  dps: 8967.92294
-  tps: 6367.22528
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
- value: {
-  dps: 15160.48355
-  tps: 10763.94332
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
- value: {
-  dps: 3743.80779
-  tps: 2658.10353
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
- value: {
-  dps: 3823.16521
-  tps: 2714.4473
- }
-}
-dps_results: {
- key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
- value: {
   dps: 21394.07471
   tps: 15189.79304
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
   dps: 5089.11546
   tps: 3613.27198
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
   dps: 5831.97194
   tps: 4140.70008
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
+ key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
   dps: 12836.40028
   tps: 9113.8442
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
   dps: 2466.025
   tps: 1750.87775
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
   dps: 2591.40895
   tps: 1839.90036
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
+ value: {
+  dps: 27022.07891
+  tps: 19185.67603
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
+ value: {
+  dps: 7377.2903
+  tps: 5237.87611
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
+ value: {
+  dps: 8413.16833
+  tps: 5973.34951
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
+ value: {
+  dps: 14545.56817
+  tps: 10327.3534
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
+ value: {
+  dps: 3542.06786
+  tps: 2514.86818
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
+ value: {
+  dps: 3599.70057
+  tps: 2555.7874
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
+ value: {
+  dps: 17926.71283
+  tps: 12727.96611
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
+ value: {
+  dps: 3856.28705
+  tps: 2737.9638
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
+ value: {
+  dps: 4686.68801
+  tps: 3327.54849
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
+ value: {
+  dps: 9284.43526
+  tps: 6591.94904
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
+ value: {
+  dps: 1696.93802
+  tps: 1204.82599
+ }
+}
+dps_results: {
+ key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
+ value: {
+  dps: 1776.13563
+  tps: 1261.0563
  }
 }
 dps_results: {

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -797,43 +797,43 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15286.18964
-  tps: 10853.19465
+  dps: 18998.41027
+  tps: 13488.87129
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5617.27291
-  tps: 3988.26377
+  dps: 4859.57133
+  tps: 3450.29565
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6713.67434
-  tps: 4766.70878
+  dps: 5646.80533
+  tps: 4009.23178
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8763.71883
-  tps: 6222.24037
+  dps: 11596.12526
+  tps: 8233.24893
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2628.19679
-  tps: 1866.01972
+  dps: 2417.42272
+  tps: 1716.37013
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2744.43344
-  tps: 1948.54774
+  dps: 2495.78756
+  tps: 1772.00917
  }
 }
 dps_results: {
@@ -881,127 +881,127 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20680.59608
-  tps: 14683.22322
+  dps: 19871.11957
+  tps: 14108.49489
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6562.66634
-  tps: 4659.4931
+  dps: 6255.58168
+  tps: 4441.46299
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7646.68842
-  tps: 5429.14878
+  dps: 7240.51184
+  tps: 5140.76341
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12193.99641
-  tps: 8657.73745
+  dps: 11644.69027
+  tps: 8267.73009
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3252.77832
-  tps: 2309.47261
+  dps: 3092.88775
+  tps: 2195.9503
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3316.1622
-  tps: 2354.47516
+  dps: 3127.39904
+  tps: 2220.45332
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18998.41027
-  tps: 13488.87129
+  dps: 15286.18964
+  tps: 10853.19465
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4859.57133
-  tps: 3450.29565
+  dps: 5617.27291
+  tps: 3988.26377
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5646.80533
-  tps: 4009.23178
+  dps: 6713.67434
+  tps: 4766.70878
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11596.12526
-  tps: 8233.24893
+  dps: 8763.71883
+  tps: 6222.24037
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2417.42272
-  tps: 1716.37013
+  dps: 2628.19679
+  tps: 1866.01972
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2495.78756
-  tps: 1772.00917
+  dps: 2744.43344
+  tps: 1948.54774
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15411.35565
-  tps: 10942.06251
+  dps: 19138.97186
+  tps: 13588.67002
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5656.0763
-  tps: 4015.81417
+  dps: 4892.98954
+  tps: 3474.02258
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6800.91895
-  tps: 4828.65246
+  dps: 5720.30144
+  tps: 4061.41403
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8843.47696
-  tps: 6278.86864
+  dps: 11692.59386
+  tps: 8301.74164
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2647.91976
-  tps: 1880.02303
+  dps: 2435.45664
+  tps: 1729.17421
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2785.16584
-  tps: 1977.46775
+  dps: 2532.91505
+  tps: 1798.36968
  }
 }
 dps_results: {
@@ -1049,85 +1049,85 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20832.17856
-  tps: 14790.84678
+  dps: 20017.12245
+  tps: 14212.15694
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6607.73594
-  tps: 4691.49252
+  dps: 6298.67518
+  tps: 4472.05938
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7746.17951
-  tps: 5499.78745
+  dps: 7334.84405
+  tps: 5207.73927
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12293.49122
-  tps: 8728.37876
+  dps: 11740.45892
+  tps: 8335.72583
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3277.27108
-  tps: 2326.86246
+  dps: 3115.91108
+  tps: 2212.29687
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3366.22489
-  tps: 2390.01968
+  dps: 3174.04386
+  tps: 2253.57114
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19138.97186
-  tps: 13588.67002
+  dps: 15411.35565
+  tps: 10942.06251
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4892.98954
-  tps: 3474.02258
+  dps: 5656.0763
+  tps: 4015.81417
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5720.30144
-  tps: 4061.41403
+  dps: 6800.91895
+  tps: 4828.65246
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11692.59386
-  tps: 8301.74164
+  dps: 8843.47696
+  tps: 6278.86864
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2435.45664
-  tps: 1729.17421
+  dps: 2647.91976
+  tps: 1880.02303
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2532.91505
-  tps: 1798.36968
+  dps: 2785.16584
+  tps: 1977.46775
  }
 }
 dps_results: {

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -102,15 +102,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50035"
  value: {
-  dps: 6785.27542
-  tps: 4817.54555
+  dps: 6775.08263
+  tps: 4810.30866
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50692"
  value: {
-  dps: 6894.74754
-  tps: 4895.27076
+  dps: 6885.90816
+  tps: 4888.99479
  }
 }
 dps_results: {

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -46,1094 +46,1094 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 6301.49714
-  tps: 4474.06297
+  dps: 6301.1469
+  tps: 4473.8143
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6416.79964
-  tps: 4555.92775
+  dps: 6413.73993
+  tps: 4553.75535
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6484.87275
-  tps: 4604.25965
+  dps: 6479.77006
+  tps: 4600.63675
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6287.87416
-  tps: 48846.24925
+  dps: 6283.63169
+  tps: 48863.2896
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6287.87416
-  tps: 48846.24925
+  dps: 6283.63169
+  tps: 48863.2896
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6442.22107
-  tps: 4573.97696
+  dps: 6438.93606
+  tps: 4571.64461
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5005.55717
-  tps: 3553.94559
+  dps: 4976.0121
+  tps: 3532.96859
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BonescytheBattlegear"
  value: {
-  dps: 5972.17504
-  tps: 4240.24428
+  dps: 5971.82245
+  tps: 4239.99394
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6416.79964
-  tps: 4464.80919
+  dps: 6413.73993
+  tps: 4462.68024
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6562.66634
-  tps: 4659.4931
+  dps: 6559.51552
+  tps: 4657.25602
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6562.66634
-  tps: 4659.4931
+  dps: 6559.51552
+  tps: 4657.25602
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6557.4461
-  tps: 4655.78673
+  dps: 6554.03464
+  tps: 4653.36459
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
   hps: 64
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6415.95472
-  tps: 4555.32785
+  dps: 6414.32391
+  tps: 4554.16998
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6449.69381
-  tps: 4579.28261
+  dps: 6445.249
+  tps: 4576.12679
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6431.244
-  tps: 4566.18324
+  dps: 6425.77225
+  tps: 4562.29829
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6749.82452
-  tps: 4792.37541
+  dps: 6748.59499
+  tps: 4791.50244
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6394.65418
-  tps: 4540.20446
+  dps: 6391.81937
+  tps: 4538.19175
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6693.24947
-  tps: 4752.20712
+  dps: 6695.90307
+  tps: 4754.09118
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6763.32034
-  tps: 4801.95744
+  dps: 6752.47427
+  tps: 4794.25673
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6445.88802
-  tps: 4576.5805
+  dps: 6442.21598
+  tps: 4573.97334
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6528.5236
-  tps: 4635.25175
+  dps: 6515.86015
+  tps: 4626.2607
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6498.11667
-  tps: 4613.66283
+  dps: 6503.64411
+  tps: 4617.58732
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6416.79964
-  tps: 4555.92775
+  dps: 6413.73993
+  tps: 4553.75535
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6416.79964
-  tps: 4555.92775
+  dps: 6413.73993
+  tps: 4553.75535
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6442.22107
-  tps: 4573.97696
+  dps: 6438.93606
+  tps: 4571.64461
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6436.29978
-  tps: 4569.77284
+  dps: 6433.9124
+  tps: 4568.0778
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6458.57861
-  tps: 4585.59081
+  dps: 6457.80176
+  tps: 4585.03925
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6416.79964
-  tps: 4555.92775
+  dps: 6413.73993
+  tps: 4553.75535
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6451.39505
-  tps: 4580.49049
+  dps: 6445.92321
+  tps: 4576.60548
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6401.41612
-  tps: 4545.00544
+  dps: 6399.21754
+  tps: 4543.44445
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6376.35078
-  tps: 4527.20905
+  dps: 6373.54044
+  tps: 4525.21371
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6416.79964
-  tps: 4555.92775
+  dps: 6413.73993
+  tps: 4553.75535
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6416.79964
-  tps: 4555.92775
+  dps: 6413.73993
+  tps: 4553.75535
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6528.13737
-  tps: 4634.97754
+  dps: 6524.14814
+  tps: 4632.14518
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Gladiator'sVestments"
  value: {
-  dps: 6392.36108
-  tps: 4538.57637
+  dps: 6390.0973
+  tps: 4536.96908
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6424.9469
-  tps: 4561.7123
+  dps: 6422.72217
+  tps: 4560.13274
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-49982"
  value: {
-  dps: 6562.66634
-  tps: 4659.4931
+  dps: 6559.51552
+  tps: 4657.25602
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-50641"
  value: {
-  dps: 6562.66634
-  tps: 4659.4931
+  dps: 6559.51552
+  tps: 4657.25602
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6442.22107
-  tps: 4573.97696
+  dps: 6438.93606
+  tps: 4571.64461
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6436.29978
-  tps: 4569.77284
+  dps: 6433.9124
+  tps: 4568.0778
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6469.55759
-  tps: 4593.38589
+  dps: 6465.506
+  tps: 4590.50926
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6416.79964
-  tps: 4555.92775
+  dps: 6413.73993
+  tps: 4553.75535
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6448.82679
-  tps: 4578.66702
+  dps: 6445.38059
+  tps: 4576.22022
   hps: 9.14161
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6515.97158
-  tps: 4626.33982
+  dps: 6510.15367
+  tps: 4622.2091
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6333.91651
-  tps: 4497.08072
+  dps: 6332.7364
+  tps: 4496.24285
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6442.46175
-  tps: 4574.14784
+  dps: 6439.37276
+  tps: 4571.95466
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6448.49989
-  tps: 4578.43492
+  dps: 6445.40402
+  tps: 4576.23685
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6416.79964
-  tps: 4555.92775
+  dps: 6413.73993
+  tps: 4553.75535
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6416.79964
-  tps: 4555.92775
+  dps: 6413.73993
+  tps: 4553.75535
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6434.46191
-  tps: 4568.46795
+  dps: 6430.42642
+  tps: 4565.60276
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6453.18664
-  tps: 4581.76251
+  dps: 6448.92688
+  tps: 4578.73809
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6562.66634
-  tps: 4659.4931
+  dps: 6559.51552
+  tps: 4657.25602
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6416.79964
-  tps: 4555.92775
+  dps: 6413.73993
+  tps: 4553.75535
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 6604.07048
-  tps: 4688.89004
+  dps: 6627.31895
+  tps: 4705.39646
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6562.66634
-  tps: 4659.4931
+  dps: 6559.51552
+  tps: 4657.25602
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Slayer'sArmor"
  value: {
-  dps: 4933.58105
-  tps: 3502.84255
+  dps: 4929.24643
+  tps: 3499.76497
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6405.67857
-  tps: 4548.03178
+  dps: 6403.66224
+  tps: 4546.60019
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SparkofLife-37657"
  value: {
-  dps: 6392.51253
-  tps: 4538.6839
+  dps: 6390.22357
+  tps: 4537.05873
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6481.41391
-  tps: 4601.80388
+  dps: 6480.39084
+  tps: 4601.0775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StormshroudArmor"
  value: {
-  dps: 5054.41702
-  tps: 3588.63609
+  dps: 5056.24381
+  tps: 3589.93311
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6448.49989
-  tps: 4578.43492
+  dps: 6445.40402
+  tps: 4576.23685
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6442.46175
-  tps: 4574.14784
+  dps: 6439.37276
+  tps: 4571.95466
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6431.895
-  tps: 4566.64545
+  dps: 6428.81807
+  tps: 4564.46083
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6370.43316
-  tps: 4523.00755
+  dps: 6349.13791
+  tps: 4507.88792
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheFistsofFury"
  value: {
-  dps: 5774.94134
-  tps: 4100.20835
+  dps: 5751.72151
+  tps: 4083.72227
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5879.32356
-  tps: 4174.31973
+  dps: 5850.52553
+  tps: 4153.87312
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6504.99896
-  tps: 4618.54926
+  dps: 6495.33248
+  tps: 4611.68606
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6608.97272
-  tps: 4692.37063
+  dps: 6588.66284
+  tps: 4677.95061
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6629.84705
-  tps: 4707.1914
+  dps: 6620.1541
+  tps: 4700.30941
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6416.79964
-  tps: 4555.92775
+  dps: 6413.73993
+  tps: 4553.75535
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6416.79964
-  tps: 4555.92775
+  dps: 6413.73993
+  tps: 4553.75535
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6372.28785
-  tps: 4524.32437
+  dps: 6371.09197
+  tps: 4523.4753
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6416.79964
-  tps: 4555.92775
+  dps: 6413.73993
+  tps: 4553.75535
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6416.79964
-  tps: 4555.92775
+  dps: 6413.73993
+  tps: 4553.75535
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5294.68082
-  tps: 3759.22338
+  dps: 5278.0854
+  tps: 3747.44063
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6174.50975
-  tps: 4383.90192
+  dps: 6188.15304
+  tps: 4393.58866
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6128.66973
-  tps: 4351.35551
+  dps: 6108.72571
+  tps: 4337.19525
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6288.33983
-  tps: 4464.72128
+  dps: 6284.61395
+  tps: 4462.0759
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 6559.66104
-  tps: 4657.35934
+  dps: 6553.80759
+  tps: 4653.20339
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18998.41027
-  tps: 13488.87129
+  dps: 18853.4312
+  tps: 13385.93615
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4859.57133
-  tps: 3450.29565
+  dps: 4854.33217
+  tps: 3446.57584
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5646.80533
-  tps: 4009.23178
+  dps: 5672.21317
+  tps: 4027.27135
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11596.12526
-  tps: 8233.24893
+  dps: 11476.58
+  tps: 8148.3718
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2417.42272
-  tps: 1716.37013
+  dps: 2418.37317
+  tps: 1717.04495
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2495.78756
-  tps: 1772.00917
+  dps: 2509.70357
+  tps: 1781.88953
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20680.59608
-  tps: 14683.22322
+  dps: 20419.98353
+  tps: 14498.18831
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6562.66634
-  tps: 4659.4931
+  dps: 6559.51552
+  tps: 4657.25602
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7646.68842
-  tps: 5429.14878
+  dps: 7669.26138
+  tps: 5445.17558
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12193.99641
-  tps: 8657.73745
+  dps: 11995.56276
+  tps: 8516.84956
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3252.77832
-  tps: 2309.47261
+  dps: 3252.2649
+  tps: 2309.10808
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3316.1622
-  tps: 2354.47516
+  dps: 3336.59103
+  tps: 2368.97963
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19871.11957
-  tps: 14108.49489
+  dps: 19729.63078
+  tps: 14008.03785
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6255.58168
-  tps: 4441.46299
+  dps: 6251.46857
+  tps: 4438.54269
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7240.51184
-  tps: 5140.76341
+  dps: 7258.6951
+  tps: 5153.67352
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11644.69027
-  tps: 8267.73009
+  dps: 11466.07715
+  tps: 8140.91477
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3092.88775
-  tps: 2195.9503
+  dps: 3093.69328
+  tps: 2196.52223
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3127.39904
-  tps: 2220.45332
+  dps: 3144.05931
+  tps: 2232.28211
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15286.18964
-  tps: 10853.19465
+  dps: 15181.32916
+  tps: 10778.74371
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5617.27291
-  tps: 3988.26377
+  dps: 5608.62932
+  tps: 3982.12682
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6713.67434
-  tps: 4766.70878
+  dps: 6727.49646
+  tps: 4776.52249
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8763.71883
-  tps: 6222.24037
+  dps: 8672.24133
+  tps: 6157.29134
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2628.19679
-  tps: 1866.01972
+  dps: 2627.8475
+  tps: 1865.77173
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2744.43344
-  tps: 1948.54774
+  dps: 2759.1577
+  tps: 1959.00197
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19138.97186
-  tps: 13588.67002
+  dps: 18992.81256
+  tps: 13484.89692
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4892.98954
-  tps: 3474.02258
+  dps: 4887.76127
+  tps: 3470.3105
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5720.30144
-  tps: 4061.41403
+  dps: 5745.97937
+  tps: 4079.64535
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11692.59386
-  tps: 8301.74164
+  dps: 11572.13761
+  tps: 8216.21771
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2435.45664
-  tps: 1729.17421
+  dps: 2436.26934
+  tps: 1729.75123
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2532.91505
-  tps: 1798.36968
+  dps: 2546.09058
+  tps: 1807.72431
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20832.17856
-  tps: 14790.84678
+  dps: 20569.08145
+  tps: 14604.04783
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6607.73594
-  tps: 4691.49252
+  dps: 6604.39953
+  tps: 4689.12367
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7746.17951
-  tps: 5499.78745
+  dps: 7769.07466
+  tps: 5516.04301
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12293.49122
-  tps: 8728.37876
+  dps: 12094.3449
+  tps: 8586.98488
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3277.27108
-  tps: 2326.86246
+  dps: 3276.36835
+  tps: 2326.22153
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3366.22489
-  tps: 2390.01968
+  dps: 3385.73311
+  tps: 2403.87051
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20017.12245
-  tps: 14212.15694
+  dps: 19873.88906
+  tps: 14110.46123
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6298.67518
-  tps: 4472.05938
+  dps: 6294.60741
+  tps: 4469.17126
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7334.84405
-  tps: 5207.73927
+  dps: 7353.27475
+  tps: 5220.82507
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11740.45892
-  tps: 8335.72583
+  dps: 11561.21231
+  tps: 8208.46074
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3115.91108
-  tps: 2212.29687
+  dps: 3116.40783
+  tps: 2212.64956
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3174.04386
-  tps: 2253.57114
+  dps: 3189.74603
+  tps: 2264.71968
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15411.35565
-  tps: 10942.06251
+  dps: 15305.65715
+  tps: 10867.01657
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5656.0763
-  tps: 4015.81417
+  dps: 5647.60594
+  tps: 4009.80022
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6800.91895
-  tps: 4828.65246
+  dps: 6814.9732
+  tps: 4838.63097
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8843.47696
-  tps: 6278.86864
+  dps: 8752.34308
+  tps: 6214.16358
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2647.91976
-  tps: 1880.02303
+  dps: 2647.50711
+  tps: 1879.73005
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2785.16584
-  tps: 1977.46775
+  dps: 2799.19559
+  tps: 1987.42887
  }
 }
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6345.69704
-  tps: 4505.4449
+  dps: 6324.07092
+  tps: 4490.09035
  }
 }

--- a/sim/rogue/TestSubtlety.results
+++ b/sim/rogue/TestSubtlety.results
@@ -46,807 +46,807 @@ character_stats_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 8250.99171
-  tps: 5853.7794
+  dps: 8786.15872
+  tps: 6234.569
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8432.85379
-  tps: 5984.34064
+  dps: 8954.10766
+  tps: 6352.67178
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8400.51531
-  tps: 5961.03601
+  dps: 8968.74735
+  tps: 6361.22395
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 8212.82977
-  tps: 71764.04775
+  dps: 8739.908
+  tps: 72193.53945
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 8212.82977
-  tps: 71764.04775
+  dps: 8739.908
+  tps: 72193.53945
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8461.45396
-  tps: 6003.8843
+  dps: 8980.03389
+  tps: 6371.0794
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6244.19782
-  tps: 4429.39265
+  dps: 6632.25859
+  tps: 4706.93755
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BonescytheBattlegear"
  value: {
-  dps: 7260.57081
-  tps: 5149.18136
+  dps: 7748.58463
+  tps: 5497.98701
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8432.85379
-  tps: 5864.65383
+  dps: 8954.10766
+  tps: 6225.61835
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8623.68114
-  tps: 6118.96735
+  dps: 9146.86385
+  tps: 6489.42757
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
   hps: 64
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 8334.49082
-  tps: 5914.33253
+  dps: 8874.4423
+  tps: 6296.37242
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 8369.92574
-  tps: 5938.59136
+  dps: 8936.20792
+  tps: 6339.95473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 8401.09672
-  tps: 5960.789
+  dps: 8945.57075
+  tps: 6347.2805
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8792.70183
-  tps: 6237.10126
+  dps: 9357.25903
+  tps: 6638.61213
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 8306.94294
-  tps: 5892.58962
+  dps: 8847.7376
+  tps: 6278.29001
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8672.23676
-  tps: 6150.14953
+  dps: 9278.72427
+  tps: 6583.24756
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8765.03979
-  tps: 6220.27448
+  dps: 9328.98994
+  tps: 6620.26947
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Defender'sCode-40257"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8467.00649
-  tps: 6007.8266
+  dps: 8988.13662
+  tps: 6376.83234
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 8401.87857
-  tps: 5962.01715
+  dps: 8946.85867
+  tps: 6347.08574
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 8343.12477
-  tps: 5919.9585
+  dps: 8949.73882
+  tps: 6350.22777
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8432.85379
-  tps: 5984.34064
+  dps: 8954.10766
+  tps: 6352.67178
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8432.85379
-  tps: 5984.34064
+  dps: 8954.10766
+  tps: 6352.67178
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8461.45396
-  tps: 6003.8843
+  dps: 8980.03389
+  tps: 6371.0794
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8457.27878
-  tps: 6000.91993
+  dps: 8976.22401
+  tps: 6368.37439
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 8302.83187
-  tps: 5890.04983
+  dps: 8850.11874
+  tps: 6278.2988
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8432.85379
-  tps: 5984.34064
+  dps: 8954.10766
+  tps: 6352.67178
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 8375.44769
-  tps: 5941.48601
+  dps: 8926.71
+  tps: 6333.30242
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 8324.71362
-  tps: 5906.56481
+  dps: 8862.95406
+  tps: 6288.26995
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForgeEmber-37660"
  value: {
-  dps: 8292.91816
-  tps: 5883.21462
+  dps: 8837.33983
+  tps: 6270.9076
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8432.85379
-  tps: 5984.34064
+  dps: 8954.10766
+  tps: 6352.67178
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8432.85379
-  tps: 5984.34064
+  dps: 8954.10766
+  tps: 6352.67178
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8476.99225
-  tps: 6013.72302
+  dps: 9022.49382
+  tps: 6402.65927
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FuturesightRune-38763"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7680.97544
-  tps: 5450.36224
+  dps: 8150.93551
+  tps: 5782.53749
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 8347.7142
-  tps: 5922.05276
+  dps: 8900.25329
+  tps: 6315.1564
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Heartpierce-49982"
  value: {
-  dps: 8636.48811
-  tps: 6128.05138
+  dps: 9158.87754
+  tps: 6497.83172
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Heartpierce-50641"
  value: {
-  dps: 8636.48811
-  tps: 6128.05138
+  dps: 9158.87754
+  tps: 6497.83172
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8461.45396
-  tps: 6003.8843
+  dps: 8980.03389
+  tps: 6371.0794
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8457.27878
-  tps: 6000.91993
+  dps: 8976.22401
+  tps: 6368.37439
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8421.66061
-  tps: 5974.50874
+  dps: 8958.30221
+  tps: 6357.13056
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8432.85379
-  tps: 5984.34064
+  dps: 8954.10766
+  tps: 6352.67178
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8469.12279
-  tps: 6010.08073
+  dps: 8992.61278
+  tps: 6379.99324
   hps: 10.24843
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8383.17942
-  tps: 5947.11528
+  dps: 8982.16448
+  tps: 6372.80161
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 8247.32584
-  tps: 5850.73715
+  dps: 8777.06104
+  tps: 6227.59553
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8462.21441
-  tps: 6005.17785
+  dps: 8985.27847
+  tps: 6374.78915
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8469.12279
-  tps: 6010.08073
+  dps: 8992.61278
+  tps: 6379.99324
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8432.85379
-  tps: 5984.34064
+  dps: 8954.10766
+  tps: 6352.67178
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8432.85379
-  tps: 5984.34064
+  dps: 8954.10766
+  tps: 6352.67178
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 8378.10215
-  tps: 5946.25513
+  dps: 8917.21917
+  tps: 6326.32844
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 8394.76146
-  tps: 5958.08324
+  dps: 8937.53153
+  tps: 6340.75021
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8636.48811
-  tps: 6128.05138
+  dps: 9158.87754
+  tps: 6497.83172
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8432.85379
-  tps: 5984.34064
+  dps: 8954.10766
+  tps: 6352.67178
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 8093.32797
-  tps: 5740.21876
+  dps: 8560.96459
+  tps: 6071.88182
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Slayer'sArmor"
  value: {
-  dps: 5748.24651
-  tps: 4077.8564
+  dps: 6122.53715
+  tps: 4340.86233
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SouloftheDead-40382"
  value: {
-  dps: 8328.96692
-  tps: 5909.58465
+  dps: 8866.05463
+  tps: 6290.47136
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SparkofLife-37657"
  value: {
-  dps: 8233.65766
-  tps: 5841.79262
+  dps: 8840.4488
+  tps: 6273.94116
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 8361.00513
-  tps: 5935.10227
+  dps: 8968.08701
+  tps: 6359.622
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-StormshroudArmor"
  value: {
-  dps: 6395.24695
-  tps: 4537.77218
+  dps: 6778.7239
+  tps: 4807.58047
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8469.12279
-  tps: 6010.08073
+  dps: 8992.61278
+  tps: 6379.99324
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8462.21441
-  tps: 6005.17785
+  dps: 8985.27847
+  tps: 6374.78915
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8450.12474
-  tps: 5996.59782
+  dps: 8972.44343
+  tps: 6365.682
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 7769.35852
-  tps: 5509.57742
+  dps: 8243.16155
+  tps: 5849.07942
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TheFistsofFury"
  value: {
-  dps: 7415.41729
-  tps: 5262.86884
+  dps: 7819.41884
+  tps: 5545.36262
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8489.60559
-  tps: 6022.76125
+  dps: 9030.69286
+  tps: 6409.56229
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 8479.31667
-  tps: 6014.17693
+  dps: 9092.65046
+  tps: 6451.19027
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8544.83136
-  tps: 6063.38222
+  dps: 9129.30698
+  tps: 6476.42629
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8432.85379
-  tps: 5984.34064
+  dps: 8954.10766
+  tps: 6352.67178
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8432.85379
-  tps: 5984.34064
+  dps: 8954.10766
+  tps: 6352.67178
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 8241.95619
-  tps: 5848.10062
+  dps: 8817.61411
+  tps: 6254.05314
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8432.85379
-  tps: 5984.34064
+  dps: 8954.10766
+  tps: 6352.67178
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8432.85379
-  tps: 5984.34064
+  dps: 8954.10766
+  tps: 6352.67178
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6602.96114
-  tps: 4685.1941
+  dps: 7035.53194
+  tps: 4990.94427
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 7558.67032
-  tps: 5362.46914
+  dps: 8057.90294
+  tps: 5715.02679
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-WingedTalisman-37844"
  value: {
-  dps: 8213.54
-  tps: 5826.80436
+  dps: 8742.45819
+  tps: 6203.92204
  }
 }
 dps_results: {
  key: "TestSubtlety-Average-Default"
  value: {
-  dps: 8602.53054
-  tps: 6102.51483
+  dps: 9187.97399
+  tps: 6518.15133
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16614.01015
-  tps: 11793.04147
+  dps: 18582.87164
+  tps: 13190.03685
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8636.48811
-  tps: 6128.05138
+  dps: 9158.87754
+  tps: 6497.83172
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9763.40405
-  tps: 6908.59706
+  dps: 10477.82695
+  tps: 7403.36589
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9754.98407
-  tps: 6924.71979
+  dps: 11130.58622
+  tps: 7899.52585
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4488.30806
-  tps: 3183.21527
+  dps: 4801.1144
+  tps: 3406.14901
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4666.07947
-  tps: 3286.14542
+  dps: 4961.99569
+  tps: 3499.96847
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16631.04184
-  tps: 11805.09554
+  dps: 18783.92548
+  tps: 13330.4177
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8615.0961
-  tps: 6109.23849
+  dps: 9166.23234
+  tps: 6502.2035
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9770.7113
-  tps: 6907.06487
+  dps: 10445.35997
+  tps: 7381.97971
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9773.89054
-  tps: 6937.3145
+  dps: 11032.1769
+  tps: 7831.51432
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4508.21306
-  tps: 3196.57667
+  dps: 4774.48174
+  tps: 3388.18917
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4648.40105
-  tps: 3290.95706
+  dps: 4930.17167
+  tps: 3489.00063
  }
 }
 dps_results: {
  key: "TestSubtlety-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2717.85542
-  tps: 1929.67735
+  dps: 3217.70824
+  tps: 2284.57285
  }
 }

--- a/sim/rogue/TestSubtlety.results
+++ b/sim/rogue/TestSubtlety.results
@@ -102,15 +102,15 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-BlackBruise-50035"
  value: {
-  dps: 8479.17731
-  tps: 6015.36174
+  dps: 8960.1337
+  tps: 6357.19907
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlackBruise-50692"
  value: {
-  dps: 8571.95875
-  tps: 6081.24551
+  dps: 9054.4291
+  tps: 6424.15732
  }
 }
 dps_results: {

--- a/sim/rogue/ambush.go
+++ b/sim/rogue/ambush.go
@@ -12,7 +12,7 @@ func (rogue *Rogue) registerAmbushSpell() {
 		ActionID:    core.ActionID{SpellID: 48691},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
-		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | SpellFlagBuilder,
+		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | SpellFlagBuilder | SpellFlagColdBlooded,
 
 		EnergyCost: core.EnergyCostOptions{
 			Cost:   rogue.costModifier(60 - 4*float64(rogue.Talents.SlaughterFromTheShadows)),

--- a/sim/rogue/backstab.go
+++ b/sim/rogue/backstab.go
@@ -14,7 +14,7 @@ func (rogue *Rogue) registerBackstabSpell() {
 		ActionID:    core.ActionID{SpellID: 26863},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
-		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | SpellFlagBuilder,
+		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | SpellFlagBuilder | SpellFlagColdBlooded,
 
 		EnergyCost: core.EnergyCostOptions{
 			Cost:   rogue.costModifier(60 - 4*float64(rogue.Talents.SlaughterFromTheShadows)),

--- a/sim/rogue/envenom.go
+++ b/sim/rogue/envenom.go
@@ -26,7 +26,7 @@ func (rogue *Rogue) registerEnvenom() {
 		ActionID:     core.ActionID{SpellID: 57993},
 		SpellSchool:  core.SpellSchoolNature,
 		ProcMask:     core.ProcMaskMeleeMHSpecial, // not core.ProcMaskSpellDamage
-		Flags:        core.SpellFlagMeleeMetrics | rogue.finisherFlags(),
+		Flags:        core.SpellFlagMeleeMetrics | rogue.finisherFlags() | SpellFlagColdBlooded,
 		MetricSplits: 6,
 
 		EnergyCost: core.EnergyCostOptions{

--- a/sim/rogue/eviscerate.go
+++ b/sim/rogue/eviscerate.go
@@ -12,7 +12,7 @@ func (rogue *Rogue) registerEviscerate() {
 		ActionID:     core.ActionID{SpellID: 48668},
 		SpellSchool:  core.SpellSchoolPhysical,
 		ProcMask:     core.ProcMaskMeleeMHSpecial,
-		Flags:        core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | rogue.finisherFlags(),
+		Flags:        core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | rogue.finisherFlags() | SpellFlagColdBlooded,
 		MetricSplits: 6,
 
 		EnergyCost: core.EnergyCostOptions{

--- a/sim/rogue/ghostly_strike.go
+++ b/sim/rogue/ghostly_strike.go
@@ -21,7 +21,7 @@ func (rogue *Rogue) registerGhostlyStrikeSpell() {
 		ActionID:    actionID,
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
-		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | SpellFlagBuilder,
+		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | SpellFlagBuilder | SpellFlagColdBlooded,
 		EnergyCost: core.EnergyCostOptions{
 			Cost:   40.0,
 			Refund: 0.8,

--- a/sim/rogue/hemorrhage.go
+++ b/sim/rogue/hemorrhage.go
@@ -56,7 +56,7 @@ func (rogue *Rogue) registerHemorrhageSpell() {
 		ActionID:    actionID,
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
-		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | SpellFlagBuilder,
+		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | SpellFlagBuilder | SpellFlagColdBlooded,
 
 		EnergyCost: core.EnergyCostOptions{
 			Cost:   rogue.costModifier(35 - float64(rogue.Talents.SlaughterFromTheShadows)),

--- a/sim/rogue/killing_spree.go
+++ b/sim/rogue/killing_spree.go
@@ -44,7 +44,7 @@ func (rogue *Rogue) registerKillingSpreeSpell() {
 	rogue.KillingSpreeAura = rogue.RegisterAura(core.Aura{
 		Label:    "Killing Spree",
 		ActionID: core.ActionID{SpellID: 51690},
-		Duration: time.Second * 2,
+		Duration: time.Second*2 + 1,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			rogue.PseudoStats.DamageDealtMultiplier *= 1.2
 			core.StartPeriodicAction(sim, core.PeriodicActionOptions{

--- a/sim/rogue/master_of_subtlety.go
+++ b/sim/rogue/master_of_subtlety.go
@@ -43,7 +43,7 @@ func (rogue *Rogue) registerMasterOfSubtletyCD() {
 			return true, 0
 		}
 
-		if rogue.Garrote.Dot(rogue.CurrentTarget).IsActive() || sim.GetRemainingDuration() <= garroteMinDuration {
+		if rogue.Garrote.CurDot().IsActive() || sim.GetRemainingDuration() <= garroteMinDuration {
 			return true, 0
 		}
 

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -24,7 +24,7 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 		ActionID:    actionID,
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    procMask,
-		Flags:       core.SpellFlagMeleeMetrics,
+		Flags:       core.SpellFlagMeleeMetrics | SpellFlagColdBlooded,
 
 		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0) +
 			[]float64{0, 2, 4, 6}[rogue.Talents.TurnTheTables]*core.CritRatingPerCritChance +
@@ -89,8 +89,8 @@ func (rogue *Rogue) registerMutilateSpell() {
 			result := spell.CalcOutcome(sim, target, spell.OutcomeMeleeSpecialHit) // Miss/Dodge/Parry/Hit
 			if result.Landed() {
 				rogue.AddComboPoints(sim, 2, spell.ComboPointMetrics())
-				mhHitSpell.Cast(sim, target)
-				ohHitSpell.Cast(sim, target)
+				ohHitSpell.SkipCastAndApplyEffects(sim, target)
+				mhHitSpell.SkipCastAndApplyEffects(sim, target)
 				if MHOutcome == core.OutcomeCrit || OHOutcome == core.OutcomeCrit {
 					result.Outcome = core.OutcomeCrit
 				}

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -89,8 +89,8 @@ func (rogue *Rogue) registerMutilateSpell() {
 			result := spell.CalcOutcome(sim, target, spell.OutcomeMeleeSpecialHit) // Miss/Dodge/Parry/Hit
 			if result.Landed() {
 				rogue.AddComboPoints(sim, 2, spell.ComboPointMetrics())
-				ohHitSpell.SkipCastAndApplyEffects(sim, target)
-				mhHitSpell.SkipCastAndApplyEffects(sim, target)
+				ohHitSpell.Cast(sim, target)
+				mhHitSpell.Cast(sim, target)
 				if MHOutcome == core.OutcomeCrit || OHOutcome == core.OutcomeCrit {
 					result.Outcome = core.OutcomeCrit
 				}

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -89,7 +89,8 @@ type Rogue struct {
 	Rupture      *core.Spell
 	SliceAndDice *core.Spell
 
-	lastDeadlyPoisonProcMask    core.ProcMask
+	lastDeadlyPoisonProcMask core.ProcMask
+
 	deadlyPoisonProcChanceBonus float64
 	instantPoisonPPMM           core.PPMManager
 	woundPoisonPPMM             core.PPMManager
@@ -127,8 +128,8 @@ func (rogue *Rogue) GetRogue() *Rogue {
 	return rogue
 }
 
-func (rogue *Rogue) AddRaidBuffs(raidBuffs *proto.RaidBuffs)    {}
-func (rogue *Rogue) AddPartyBuffs(partyBuffs *proto.PartyBuffs) {}
+func (rogue *Rogue) AddRaidBuffs(_ *proto.RaidBuffs)   {}
+func (rogue *Rogue) AddPartyBuffs(_ *proto.PartyBuffs) {}
 
 func (rogue *Rogue) finisherFlags() core.SpellFlag {
 	flags := SpellFlagFinisher
@@ -211,7 +212,6 @@ func (rogue *Rogue) Reset(sim *core.Simulation) {
 		mcd.Disable()
 	}
 	rogue.allMCDsDisabled = true
-	rogue.lastDeadlyPoisonProcMask = core.ProcMaskEmpty
 
 	// Stealth triggered effects (Overkill and Master of Subtlety) pre-pull activation
 	if rogue.Rotation.OpenWithGarrote || rogue.Options.StartingOverkillDuration > 0 {

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -26,11 +26,12 @@ func RegisterRogue() {
 }
 
 const (
-	SpellFlagBuilder  = core.SpellFlagAgentReserved2
-	SpellFlagFinisher = core.SpellFlagAgentReserved3
-	AssassinTree      = 0
-	CombatTree        = 1
-	SubtletyTree      = 2
+	SpellFlagBuilder     = core.SpellFlagAgentReserved2
+	SpellFlagFinisher    = core.SpellFlagAgentReserved3
+	SpellFlagColdBlooded = core.SpellFlagAgentReserved4
+	AssassinTree         = 0
+	CombatTree           = 1
+	SubtletyTree         = 2
 )
 
 var TalentTreeSizes = [3]int{27, 28, 28}

--- a/sim/rogue/rogue_test.go
+++ b/sim/rogue/rogue_test.go
@@ -325,16 +325,16 @@ var DeadlyInstant = &proto.Rogue_Options{
 	OhImbue: proto.Rogue_Options_InstantPoison,
 }
 var InstantDeadly = &proto.Rogue_Options{
-	MhImbue: proto.Rogue_Options_DeadlyPoison,
-	OhImbue: proto.Rogue_Options_InstantPoison,
-}
-var InstantInstant = &proto.Rogue_Options{
-	MhImbue: proto.Rogue_Options_DeadlyPoison,
+	MhImbue: proto.Rogue_Options_InstantPoison,
 	OhImbue: proto.Rogue_Options_DeadlyPoison,
 }
-var DeadlyDeadly = &proto.Rogue_Options{
+var InstantInstant = &proto.Rogue_Options{
 	MhImbue: proto.Rogue_Options_InstantPoison,
 	OhImbue: proto.Rogue_Options_InstantPoison,
+}
+var DeadlyDeadly = &proto.Rogue_Options{
+	MhImbue: proto.Rogue_Options_DeadlyPoison,
+	OhImbue: proto.Rogue_Options_DeadlyPoison,
 }
 
 var FullConsumes = &proto.Consumes{

--- a/sim/rogue/shiv.go
+++ b/sim/rogue/shiv.go
@@ -44,11 +44,11 @@ func (rogue *Rogue) registerShivSpell() {
 
 				switch rogue.Options.OhImbue {
 				case proto.Rogue_Options_DeadlyPoison:
-					rogue.DeadlyPoison.Cast(sim, target)
+					rogue.DeadlyPoison.SkipCastAndApplyEffects(sim, target)
 				case proto.Rogue_Options_InstantPoison:
-					rogue.InstantPoison[ShivProc].Cast(sim, target)
+					rogue.InstantPoison[ShivProc].SkipCastAndApplyEffects(sim, target)
 				case proto.Rogue_Options_WoundPoison:
-					rogue.WoundPoison[ShivProc].Cast(sim, target)
+					rogue.WoundPoison[ShivProc].SkipCastAndApplyEffects(sim, target)
 				}
 			}
 		},

--- a/sim/rogue/sinister_strike.go
+++ b/sim/rogue/sinister_strike.go
@@ -14,7 +14,7 @@ func (rogue *Rogue) registerSinisterStrikeSpell() {
 		ActionID:    core.ActionID{SpellID: 48638},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
-		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | SpellFlagBuilder,
+		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | SpellFlagBuilder | SpellFlagColdBlooded,
 
 		EnergyCost: core.EnergyCostOptions{
 			Cost:   rogue.costModifier([]float64{45, 42, 40}[rogue.Talents.ImprovedSinisterStrike]),

--- a/sim/rogue/subtlety_rotation.go
+++ b/sim/rogue/subtlety_rotation.go
@@ -16,7 +16,7 @@ type subtletyPrio struct {
 func (rogue *Rogue) setSubtletyBuilder(sim *core.Simulation) {
 	mhDagger := rogue.Equip[proto.ItemSlot_ItemSlotMainHand].WeaponType == proto.WeaponType_WeaponTypeDagger
 	// Garrote
-	if !rogue.Garrote.Dot(rogue.CurrentTarget).Aura.IsActive() && rogue.ShadowDanceAura.IsActive() && !rogue.PseudoStats.InFrontOfTarget {
+	if !rogue.Garrote.CurDot().Aura.IsActive() && rogue.ShadowDanceAura.IsActive() && !rogue.PseudoStats.InFrontOfTarget {
 		rogue.Builder = rogue.Garrote
 		rogue.BuilderPoints = 1
 		return
@@ -274,7 +274,7 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 		rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
 			func(sim *core.Simulation, rogue *Rogue) PriorityAction {
 				minimumCP := int32(5)
-				if !rogue.DeadlyPoison.Dot(rogue.CurrentTarget).Aura.IsActive() {
+				if !rogue.DeadlyPoison.CurDot().Aura.IsActive() {
 					return Skip
 				}
 				if rogue.EnvenomAura.IsActive() {

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -380,25 +380,14 @@ func (rogue *Rogue) applyCombatPotency() {
 			aura.Activate(sim)
 		},
 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-			if !result.Landed() {
+			// from 3.0.3 patch notes: "Combat Potency: Now only works with auto attacks"
+			if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeOHAuto) {
 				return
 			}
 
-			// https://wotlk.wowhead.com/spell=35553/combat-potency, proc mask = 8838608.
-			if !spell.ProcMask.Matches(core.ProcMaskMeleeOH) {
-				return
+			if sim.RandomFloat("Combat Potency") < procChance {
+				rogue.AddEnergy(sim, energyBonus, energyMetrics)
 			}
-
-			// Fan of Knives OH hits do not proc combat potency
-			if spell.IsSpellAction(FanOfKnivesSpellID) {
-				return
-			}
-
-			if sim.RandomFloat("Combat Potency") > procChance {
-				return
-			}
-
-			rogue.AddEnergy(sim, energyBonus, energyMetrics)
 		},
 	})
 }

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -300,25 +300,18 @@ func (rogue *Rogue) applyInitiative() {
 
 	procChance := []float64{0, 0.33, 0.66, 1.0}[rogue.Talents.Initiative]
 	cpMetrics := rogue.NewComboPointMetrics(core.ActionID{SpellID: 13980})
-	var affectedSpells []*core.Spell
 
 	rogue.RegisterAura(core.Aura{
 		Label:    "Initiative",
 		Duration: core.NeverExpires,
-		OnInit: func(aura *core.Aura, sim *core.Simulation) {
-			affectedSpells = append(affectedSpells, rogue.Ambush)
-			affectedSpells = append(affectedSpells, rogue.Garrote)
-		},
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
 		},
 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-			for _, affectedSpell := range affectedSpells {
-				if spell == affectedSpell {
-					if result.Landed() {
-						if sim.Proc(procChance, "Initiative") {
-							rogue.AddComboPoints(sim, 1, cpMetrics)
-						}
+			if spell == rogue.Garrote || spell == rogue.Ambush {
+				if result.Landed() {
+					if sim.Proc(procChance, "Initiative") {
+						rogue.AddComboPoints(sim, 1, cpMetrics)
 					}
 				}
 			}


### PR DESCRIPTION
[rogue] some cleanup work, mostly around poisons (which all use SkipCastAndApply() instead of Cast(), have fewer redundant checks (e.g. proc mask is checked in PPMManager.Proc() already), and have correct ActionIDs)

[rogue] fix test rogue options (e.g. "DeadlyDeadly" was actually using Instant/Instant)

[rogue] fix Killing Spree's aura to fade too early (not buffing the last pair of attacks), and also fix KS offhand attacks to no longer proc Combat Potency

[rogue] Cold Blood now affects the correct set of spells (Garrote, Rupture, Shiv are no longer affected, while Fan of Knives is); also, Mutilate and Fan of Knives have both their MH and OH components crit, not just one or the other
