### PR TITLE
Stop Feint from casting at near maximum energy

### DIFF
--- a/sim/rogue/feint.go
+++ b/sim/rogue/feint.go
@@ -41,6 +41,11 @@ func (rogue *Rogue) registerFeintSpell() {
 			Spell:    rogue.Feint,
 			Priority: core.CooldownPriorityDefault,
 			Type:     core.CooldownTypeDPS,
+			//don't feint if you're gonna waste energy by using the gcd
+			ShouldActivate: func(sim *core.Simulation, character *core.Character) bool {
+				thresh := 55.0 //55 simmed best with standard settings for now 3/12/2023, will refine with the rotational refinements. 55 was definitely best for combat, didn't make a difference for muti
+				return rogue.CurrentEnergy() <= thresh
+			},
 		})
 	}
 }


### PR DESCRIPTION
It was a major dps loss, most notably for Combat. Simply stops attempting to cast Feint if over 55 energy.