### PR TITLE
DK Bcb scaling & imp unh presence updates

### DIFF
--- a/sim/deathknight/diseases.go
+++ b/sim/deathknight/diseases.go
@@ -34,6 +34,20 @@ func (dk *Deathknight) dkCountActiveDiseases(target *core.Unit) float64 {
 	return float64(count)
 }
 
+func (dk *Deathknight) dkCountActiveDiseasesBcb(target *core.Unit) float64 {
+	count := 0
+	if dk.FrostFeverSpell.Dot(target).IsActive() {
+		count++
+	}
+	if dk.BloodPlagueSpell.Dot(target).IsActive() {
+		count++
+	}
+	if dk.EbonPlagueOrCryptFeverAura[target.Index].IsActive() || target.GetAura("EbonPlaguebringer-1").IsActive() {
+		count++
+	}
+	return float64(count)
+}
+
 // diseaseMultiplier calculates the bonus based on if you have DarkrunedBattlegear 4p.
 //
 //	This function is slow so should only be used during initialization.

--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -46,871 +46,871 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7069.95487
-  tps: 3633.19014
+  dps: 7118.02856
+  tps: 3662.03435
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6938.63036
-  tps: 3593.50749
+  dps: 6984.77233
+  tps: 3621.19267
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6790.83993
-  tps: 8375.88421
+  dps: 6836.00468
+  tps: 8402.98306
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6790.83993
-  tps: 8375.88421
+  dps: 6836.00468
+  tps: 8402.98306
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7089.57045
-  tps: 3643.55623
+  dps: 7137.60657
+  tps: 3672.3779
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6826.14402
-  tps: 3508.69661
+  dps: 6871.79403
+  tps: 3536.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 5826.55303
-  tps: 2992.97884
+  dps: 5865.47772
+  tps: 3016.33365
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5737.12198
-  tps: 2958.00809
+  dps: 5774.89948
+  tps: 2980.67458
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5460.21924
-  tps: 2807.64696
+  dps: 5496.53096
+  tps: 2829.43399
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7065.04045
-  tps: 3557.93428
+  dps: 7113.07656
+  tps: 3586.17951
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8289.11185
-  tps: 4327.90447
+  dps: 8351.05394
+  tps: 4365.06972
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8370.72027
-  tps: 4378.63702
+  dps: 8433.98254
+  tps: 4416.59438
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7212.69572
-  tps: 3711.77825
+  dps: 7260.73183
+  tps: 3740.59991
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6886.53895
-  tps: 3565.42242
+  dps: 6931.7037
+  tps: 3592.52127
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6908.0212
-  tps: 3577.68055
+  dps: 6953.11621
+  tps: 3604.73755
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7034.19223
-  tps: 3619.545
+  dps: 7080.98939
+  tps: 3647.6233
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 6742.68509
-  tps: 3479.86096
+  dps: 6788.94156
+  tps: 3507.61485
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 5933.8832
-  tps: 3050.16006
+  dps: 5974.70548
+  tps: 3074.65342
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7106.77201
-  tps: 3651.33824
+  dps: 7154.85852
+  tps: 3680.19015
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7395.58068
-  tps: 3798.05981
+  dps: 7444.86332
+  tps: 3827.62939
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6865.86459
-  tps: 3554.90016
+  dps: 6911.03088
+  tps: 3581.99993
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7194.14015
-  tps: 3730.22661
+  dps: 7243.13319
+  tps: 3759.62244
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7291.46474
-  tps: 3794.91635
+  dps: 7340.59828
+  tps: 3824.39648
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6806.66157
-  tps: 3522.28107
+  dps: 6851.94513
+  tps: 3549.45121
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7092.25481
-  tps: 3645.16685
+  dps: 7140.29092
+  tps: 3673.98852
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6890.44727
-  tps: 3552.57151
+  dps: 6937.83756
+  tps: 3581.00568
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6834.51687
-  tps: 3520.45446
+  dps: 6881.78048
+  tps: 3548.81263
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7065.04045
-  tps: 3630.54518
+  dps: 7113.07656
+  tps: 3659.36685
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7065.04045
-  tps: 3630.54518
+  dps: 7113.07656
+  tps: 3659.36685
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7089.57045
-  tps: 3643.55623
+  dps: 7137.60657
+  tps: 3672.3779
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7084.67876
-  tps: 3641.424
+  dps: 7132.71488
+  tps: 3670.24566
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6766.53794
-  tps: 3478.03526
+  dps: 6813.03053
+  tps: 3505.93081
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7065.04045
-  tps: 3630.54518
+  dps: 7113.07656
+  tps: 3659.36685
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6920.91113
-  tps: 3583.35741
+  dps: 6966.28871
+  tps: 3610.58396
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6879.73331
-  tps: 3562.28407
+  dps: 6924.8996
+  tps: 3589.38384
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6862.86849
-  tps: 3553.20469
+  dps: 6908.03478
+  tps: 3580.30447
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7065.04045
-  tps: 3630.54518
+  dps: 7113.07656
+  tps: 3659.36685
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7065.04045
-  tps: 3630.54518
+  dps: 7113.07656
+  tps: 3659.36685
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7107.93187
-  tps: 3651.78746
+  dps: 7156.02718
+  tps: 3680.64464
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6994.42459
-  tps: 3625.25087
+  dps: 7041.12856
+  tps: 3653.27325
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6881.33926
-  tps: 3564.53403
+  dps: 6926.73227
+  tps: 3591.76984
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7102.71587
-  tps: 3650.09642
+  dps: 7150.77766
+  tps: 3678.9335
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7089.57045
-  tps: 3643.55623
+  dps: 7137.60657
+  tps: 3672.3779
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7084.67876
-  tps: 3641.424
+  dps: 7132.71488
+  tps: 3670.24566
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6956.11004
-  tps: 3606.8239
+  dps: 7002.67733
+  tps: 3634.76428
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7065.04045
-  tps: 3630.54518
+  dps: 7113.07656
+  tps: 3659.36685
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7093.01543
-  tps: 3645.5941
+  dps: 7141.27039
+  tps: 3674.54708
   hps: 12.6621
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6864.21188
-  tps: 3536.06544
+  dps: 6910.77413
+  tps: 3564.00279
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6955.93693
-  tps: 3590.00832
+  dps: 7001.11927
+  tps: 3617.11773
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6801.07312
-  tps: 3519.27143
+  dps: 6846.31475
+  tps: 3546.41641
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7087.41027
-  tps: 3642.5847
+  dps: 7135.61747
+  tps: 3671.50901
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7092.67376
-  tps: 3645.41752
+  dps: 7140.92121
+  tps: 3674.36599
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6833.33708
-  tps: 3536.64708
+  dps: 6878.8208
+  tps: 3563.93731
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6838.81376
-  tps: 3539.59653
+  dps: 6884.33857
+  tps: 3566.91141
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7065.04045
-  tps: 3630.54518
+  dps: 7113.07656
+  tps: 3659.36685
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7065.04045
-  tps: 3630.54518
+  dps: 7113.07656
+  tps: 3659.36685
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6826.43682
-  tps: 3536.11421
+  dps: 6871.53519
+  tps: 3563.17324
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6833.62867
-  tps: 3540.42932
+  dps: 6878.72704
+  tps: 3567.48835
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7206.35612
-  tps: 3708.92238
+  dps: 7254.39869
+  tps: 3737.74793
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7109.28505
-  tps: 3652.31155
+  dps: 7157.39061
+  tps: 3681.17489
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7065.04045
-  tps: 3630.54518
+  dps: 7113.07656
+  tps: 3659.36685
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7102.51853
-  tps: 3649.98273
+  dps: 7150.57815
+  tps: 3678.8185
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6456.39427
-  tps: 3317.71519
+  dps: 6500.32842
+  tps: 3344.07568
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 5866.12749
-  tps: 3008.15444
+  dps: 5906.71269
+  tps: 3032.50556
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7376.33176
-  tps: 3844.96021
+  dps: 7424.37338
+  tps: 3873.78519
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6200.60171
-  tps: 3180.42084
+  dps: 6243.53158
+  tps: 3206.17876
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6801.61173
-  tps: 3519.1534
+  dps: 6846.85877
+  tps: 3546.30162
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 9237.44401
-  tps: 4851.70948
+  dps: 9307.34878
+  tps: 4893.65235
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7100.97269
-  tps: 3649.09213
+  dps: 7149.01526
+  tps: 3677.91767
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7128.45729
-  tps: 3664.19756
+  dps: 7176.50223
+  tps: 3693.02453
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7100.97269
-  tps: 3649.09213
+  dps: 7149.01526
+  tps: 3677.91767
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7415.57283
-  tps: 3816.42955
+  dps: 7465.94783
+  tps: 3846.65456
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7100.97269
-  tps: 3649.09213
+  dps: 7149.01526
+  tps: 3677.91767
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7432.81208
-  tps: 3828.71763
+  dps: 7483.35466
+  tps: 3859.04318
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7100.97269
-  tps: 3649.09213
+  dps: 7149.01526
+  tps: 3677.91767
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6880.54692
-  tps: 3562.611
+  dps: 6925.71321
+  tps: 3589.71077
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofLife-37657"
  value: {
-  dps: 6771.12894
-  tps: 3494.88701
+  dps: 6817.13087
+  tps: 3522.48817
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6970.60202
-  tps: 3595.92898
+  dps: 7017.67387
+  tps: 3624.17209
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 5439.71109
-  tps: 2798.92145
+  dps: 5475.07761
+  tps: 2820.14136
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7092.67376
-  tps: 3645.41752
+  dps: 7140.92121
+  tps: 3674.36599
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7087.41027
-  tps: 3642.5847
+  dps: 7135.61747
+  tps: 3671.50901
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7078.19917
-  tps: 3637.62725
+  dps: 7126.33592
+  tps: 3666.5093
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 6925.14542
-  tps: 3570.34939
+  dps: 6971.56099
+  tps: 3598.19874
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6062.02374
-  tps: 3110.29853
+  dps: 6103.11438
+  tps: 3134.95291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6017.11554
-  tps: 3042.54639
+  dps: 6062.57564
+  tps: 3069.82245
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7055.09637
-  tps: 3612.4928
+  dps: 7103.72201
+  tps: 3641.66819
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7033.01474
-  tps: 3640.83116
+  dps: 7085.66795
+  tps: 3672.42309
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7037.021
-  tps: 3646.17041
+  dps: 7090.51889
+  tps: 3678.26914
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7065.04045
-  tps: 3630.54518
+  dps: 7113.07656
+  tps: 3659.36685
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7065.04045
-  tps: 3630.54518
+  dps: 7113.07656
+  tps: 3659.36685
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6784.87561
-  tps: 3492.38264
+  dps: 6830.98486
+  tps: 3520.04819
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7065.04045
-  tps: 3630.54518
+  dps: 7113.07656
+  tps: 3659.36685
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7065.04045
-  tps: 3630.54518
+  dps: 7113.07656
+  tps: 3659.36685
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5722.63774
-  tps: 2948.96245
+  dps: 5760.32555
+  tps: 2971.57514
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5347.00526
-  tps: 2609.1919
+  dps: 5382.91616
+  tps: 2630.73844
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6790.82764
-  tps: 3513.75376
+  dps: 6835.99239
+  tps: 3540.85261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7110.83153
-  tps: 3652.91052
+  dps: 7158.94881
+  tps: 3681.78088
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 7099.17127
-  tps: 3652.55555
+  dps: 7146.14367
+  tps: 3680.73899
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19431.71291
-  tps: 10264.25538
+  dps: 19479.27339
+  tps: 10292.79166
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7107.50428
-  tps: 3662.88173
+  dps: 7155.18232
+  tps: 3691.48855
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9156.54894
-  tps: 4172.34173
+  dps: 9217.72882
+  tps: 4209.04966
  }
 }
 dps_results: {
@@ -937,22 +937,22 @@ dps_results: {
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19623.27301
-  tps: 10352.92503
+  dps: 19670.99878
+  tps: 10381.56049
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7206.35612
-  tps: 3708.92238
+  dps: 7254.39869
+  tps: 3737.74793
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9311.22304
-  tps: 4229.24386
+  dps: 9373.72879
+  tps: 4266.74731
  }
 }
 dps_results: {
@@ -979,7 +979,7 @@ dps_results: {
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6762.52875
-  tps: 3482.06723
+  dps: 6803.79146
+  tps: 3506.82486
  }
 }

--- a/sim/deathknight/dps/TestFrostUH.results
+++ b/sim/deathknight/dps/TestFrostUH.results
@@ -46,871 +46,871 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7918.59399
-  tps: 5628.4519
+  dps: 7971.39817
+  tps: 5667.31578
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7855.25704
-  tps: 5608.77052
+  dps: 7905.67742
+  tps: 5645.87992
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7630.84443
-  tps: 11925.60747
+  dps: 7680.05218
+  tps: 11961.82438
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7630.84443
-  tps: 11925.60747
+  dps: 7680.05218
+  tps: 11961.82438
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7941.58889
-  tps: 5645.37615
+  dps: 7994.39307
+  tps: 5684.24003
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7767.87919
-  tps: 5521.86711
+  dps: 7819.11522
+  tps: 5559.57683
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6519.2568
-  tps: 4632.7464
+  dps: 6563.2095
+  tps: 4665.09559
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6424.11481
-  tps: 4572.8073
+  dps: 6466.87933
+  tps: 4604.28198
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6281.0439
-  tps: 4466.45927
+  dps: 6322.71398
+  tps: 4497.12845
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7918.59399
-  tps: 5515.88287
+  dps: 7971.39817
+  tps: 5553.96947
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8098.94761
-  tps: 5761.19217
+  dps: 8151.7518
+  tps: 5800.05605
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8098.94761
-  tps: 5761.19217
+  dps: 8151.7518
+  tps: 5800.05605
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8104.43886
-  tps: 5765.23373
+  dps: 8157.24305
+  tps: 5804.09761
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
   hps: 43.73333
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7757.5611
-  tps: 5536.86631
+  dps: 7806.76885
+  tps: 5573.08321
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7821.52498
-  tps: 5583.94372
+  dps: 7870.73273
+  tps: 5620.16063
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7893.9272
-  tps: 5616.51283
+  dps: 7945.12333
+  tps: 5654.19318
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7549.64139
-  tps: 5364.95764
+  dps: 7601.37266
+  tps: 5403.03186
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkrunedPlate"
  value: {
-  dps: 6628.55439
-  tps: 4702.75683
+  dps: 6674.42269
+  tps: 4736.51589
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7517.61006
-  tps: 5333.32773
+  dps: 7570.45673
+  tps: 5372.22288
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8304.562
-  tps: 5904.23679
+  dps: 8358.99922
+  tps: 5944.30258
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7749.92449
-  tps: 5531.24577
+  dps: 7799.13224
+  tps: 5567.46267
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8142.95189
-  tps: 5809.17499
+  dps: 8196.25755
+  tps: 5848.40796
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8272.71193
-  tps: 5905.01222
+  dps: 8326.96292
+  tps: 5944.94095
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7946.15728
-  tps: 5648.73849
+  dps: 7998.96146
+  tps: 5687.60237
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7809.3235
-  tps: 5563.0726
+  dps: 7862.15448
+  tps: 5601.9562
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7801.95786
-  tps: 5557.19265
+  dps: 7854.9154
+  tps: 5596.1694
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7918.59399
-  tps: 5628.4519
+  dps: 7971.39817
+  tps: 5667.31578
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7918.59399
-  tps: 5628.4519
+  dps: 7971.39817
+  tps: 5667.31578
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7941.58889
-  tps: 5645.37615
+  dps: 7994.39307
+  tps: 5684.24003
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7936.89263
-  tps: 5641.9197
+  dps: 7989.69681
+  tps: 5680.78358
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7776.03582
-  tps: 5536.80347
+  dps: 7826.68182
+  tps: 5574.07893
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7918.59399
-  tps: 5628.4519
+  dps: 7971.39817
+  tps: 5667.31578
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7806.17562
-  tps: 5572.64659
+  dps: 7855.38337
+  tps: 5608.8635
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7743.49067
-  tps: 5526.51047
+  dps: 7792.69842
+  tps: 5562.72738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7720.78154
-  tps: 5509.79655
+  dps: 7769.98929
+  tps: 5546.01345
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7918.59399
-  tps: 5628.4519
+  dps: 7971.39817
+  tps: 5667.31578
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7918.59399
-  tps: 5628.4519
+  dps: 7971.39817
+  tps: 5667.31578
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7518.47188
-  tps: 5333.96203
+  dps: 7571.32705
+  tps: 5372.86344
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7878.33151
-  tps: 5625.75333
+  dps: 7929.54892
+  tps: 5663.44934
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7754.09443
-  tps: 5534.31484
+  dps: 7803.30218
+  tps: 5570.53174
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7515.75183
-  tps: 5331.96008
+  dps: 7568.57624
+  tps: 5370.83884
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7941.58889
-  tps: 5645.37615
+  dps: 7994.39307
+  tps: 5684.24003
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7936.89263
-  tps: 5641.9197
+  dps: 7989.69681
+  tps: 5680.78358
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7832.87792
-  tps: 5592.29949
+  dps: 7883.95002
+  tps: 5629.88856
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7918.59399
-  tps: 5628.4519
+  dps: 7971.39817
+  tps: 5667.31578
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7950.64163
-  tps: 5652.03897
+  dps: 8003.70514
+  tps: 5691.09371
   hps: 12.85179
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7886.96688
-  tps: 5624.3612
+  dps: 7938.17925
+  tps: 5662.05351
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7720.1928
-  tps: 5509.36324
+  dps: 7769.40055
+  tps: 5545.58015
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7944.67616
-  tps: 5647.64838
+  dps: 7997.69734
+  tps: 5686.67197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7950.81314
-  tps: 5652.1652
+  dps: 8003.88538
+  tps: 5691.22637
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7918.59399
-  tps: 5628.4519
+  dps: 7971.39817
+  tps: 5667.31578
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7918.59399
-  tps: 5628.4519
+  dps: 7971.39817
+  tps: 5667.31578
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7649.21817
-  tps: 5457.12591
+  dps: 7698.42592
+  tps: 5493.34282
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7651.11056
-  tps: 5458.51871
+  dps: 7700.31831
+  tps: 5494.73561
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8098.94761
-  tps: 5761.19217
+  dps: 8151.7518
+  tps: 5800.05605
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7519.47734
-  tps: 5334.70205
+  dps: 7572.34243
+  tps: 5373.61076
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7918.59399
-  tps: 5628.4519
+  dps: 7971.39817
+  tps: 5667.31578
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7515.47437
-  tps: 5331.75587
+  dps: 7568.29649
+  tps: 5370.63295
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7126.16186
-  tps: 5066.82797
+  dps: 7172.65982
+  tps: 5101.05046
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ScourgebornePlate"
  value: {
-  dps: 6350.66301
-  tps: 4501.75276
+  dps: 6394.11175
+  tps: 4533.73103
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8359.98106
-  tps: 5960.73587
+  dps: 8414.19603
+  tps: 6000.63809
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6972.57965
-  tps: 4944.85339
+  dps: 7020.7682
+  tps: 4980.32016
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8098.94761
-  tps: 5761.19217
+  dps: 8151.7518
+  tps: 5800.05605
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7513.30095
-  tps: 5330.15623
+  dps: 7566.10513
+  tps: 5369.02011
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7523.55646
-  tps: 5337.70428
+  dps: 7576.36064
+  tps: 5376.56816
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7513.30095
-  tps: 5330.15623
+  dps: 7566.10513
+  tps: 5369.02011
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7957.86115
-  tps: 5643.53991
+  dps: 8014.14777
+  tps: 5684.96686
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7513.30095
-  tps: 5330.15623
+  dps: 7566.10513
+  tps: 5369.02011
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7996.51074
-  tps: 5670.67381
+  dps: 8053.08548
+  tps: 5712.31283
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7513.30095
-  tps: 5330.15623
+  dps: 7566.10513
+  tps: 5369.02011
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7746.27869
-  tps: 5528.56246
+  dps: 7795.48644
+  tps: 5564.77936
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SparkofLife-37657"
  value: {
-  dps: 7718.48061
-  tps: 5503.20525
+  dps: 7769.18136
+  tps: 5540.521
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7718.55019
-  tps: 5507.60719
+  dps: 7769.31285
+  tps: 5544.96851
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-StormshroudArmor"
  value: {
-  dps: 6171.36678
-  tps: 4390.17832
+  dps: 6211.11764
+  tps: 4419.43495
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7950.81314
-  tps: 5652.1652
+  dps: 8003.88538
+  tps: 5691.22637
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7944.67616
-  tps: 5647.64838
+  dps: 7997.69734
+  tps: 5686.67197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7933.93644
-  tps: 5639.74395
+  dps: 7986.86827
+  tps: 5678.70178
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7618.26638
-  tps: 5420.05
+  dps: 7670.09111
+  tps: 5458.193
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6382.291
-  tps: 4522.26133
+  dps: 6425.70732
+  tps: 4554.21575
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7154.66791
-  tps: 5073.9284
+  dps: 7202.40291
+  tps: 5109.06136
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8031.37013
-  tps: 5704.29196
+  dps: 8086.26198
+  tps: 5744.69236
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7858.53603
-  tps: 5609.47124
+  dps: 7915.67005
+  tps: 5651.52188
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7862.73799
-  tps: 5613.45598
+  dps: 7920.32799
+  tps: 5655.84222
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7918.59399
-  tps: 5628.4519
+  dps: 7971.39817
+  tps: 5667.31578
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7918.59399
-  tps: 5628.4519
+  dps: 7971.39817
+  tps: 5667.31578
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7650.86674
-  tps: 5450.81858
+  dps: 7701.16257
+  tps: 5487.83632
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7918.59399
-  tps: 5628.4519
+  dps: 7971.39817
+  tps: 5667.31578
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7918.59399
-  tps: 5628.4519
+  dps: 7971.39817
+  tps: 5667.31578
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6522.30667
-  tps: 4644.35843
+  dps: 6565.38284
+  tps: 4676.06249
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7622.43778
-  tps: 5405.82853
+  dps: 7674.20363
+  tps: 5443.92819
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7630.73347
-  tps: 5443.52117
+  dps: 7679.94122
+  tps: 5479.73808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7520.62643
-  tps: 5335.54778
+  dps: 7573.50286
+  tps: 5374.46483
  }
 }
 dps_results: {
  key: "TestFrostUH-Average-Default"
  value: {
-  dps: 8053.0157
-  tps: 5725.41694
+  dps: 8105.27115
+  tps: 5763.87695
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18871.88516
-  tps: 13696.45259
+  dps: 18925.63845
+  tps: 13736.01501
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8073.22207
-  tps: 5748.47207
+  dps: 8126.92592
+  tps: 5787.9981
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9556.98349
-  tps: 6564.92265
+  dps: 9624.44924
+  tps: 6614.57744
  }
 }
 dps_results: {
@@ -937,22 +937,22 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21643.54309
-  tps: 15709.82512
+  dps: 21710.33969
+  tps: 15758.98742
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9763.43594
-  tps: 6962.14796
+  dps: 9830.4223
+  tps: 7011.44992
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11743.16908
-  tps: 8098.74941
+  dps: 11827.41255
+  tps: 8160.7526
  }
 }
 dps_results: {
@@ -979,22 +979,22 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18711.49992
-  tps: 13571.93701
+  dps: 18764.32366
+  tps: 13610.81528
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8098.94761
-  tps: 5761.19217
+  dps: 8151.7518
+  tps: 5800.05605
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9569.70194
-  tps: 6551.2959
+  dps: 9636.38653
+  tps: 6600.37575
  }
 }
 dps_results: {
@@ -1021,22 +1021,22 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21950.19996
-  tps: 15923.27622
+  dps: 22016.22026
+  tps: 15971.86716
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9826.55714
-  tps: 7001.48615
+  dps: 9892.94469
+  tps: 7050.34739
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11819.04001
-  tps: 8125.97204
+  dps: 11903.39518
+  tps: 8188.05745
  }
 }
 dps_results: {
@@ -1063,7 +1063,7 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7231.26138
-  tps: 5138.60167
+  dps: 7273.05085
+  tps: 5169.35871
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -46,976 +46,976 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7510.26396
-  tps: 4805.29641
+  dps: 7510.31715
+  tps: 4805.3496
   hps: 373.66539
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7510.26396
-  tps: 4805.29641
+  dps: 7510.31715
+  tps: 4805.3496
   hps: 387.62555
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8036.37111
-  tps: 5084.21442
+  dps: 8036.42933
+  tps: 5084.27264
   hps: 272.47129
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7733.5504
-  tps: 4982.36569
+  dps: 7733.60507
+  tps: 4982.42037
   hps: 266.87008
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7510.3115
-  tps: 21145.25092
+  dps: 7510.36469
+  tps: 21145.3041
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7510.3115
-  tps: 21145.25092
+  dps: 7510.36469
+  tps: 21145.3041
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8061.67483
-  tps: 5108.99586
+  dps: 8061.73305
+  tps: 5109.05408
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7794.22969
-  tps: 4908.08818
+  dps: 7794.28653
+  tps: 4908.14502
   hps: 261.60049
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6588.23894
-  tps: 4198.57985
+  dps: 6588.29118
+  tps: 4198.63209
   hps: 238.14364
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6432.60599
-  tps: 4124.89975
+  dps: 6432.65709
+  tps: 4124.95085
   hps: 227.87994
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6209.73046
-  tps: 3947.38442
+  dps: 6209.78005
+  tps: 3947.43401
   hps: 226.39416
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8036.37111
-  tps: 4982.53013
+  dps: 8036.42933
+  tps: 4982.58719
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8116.73956
-  tps: 5160.52955
+  dps: 8116.79777
+  tps: 5160.58777
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8116.73956
-  tps: 5160.52955
+  dps: 8116.79777
+  tps: 5160.58777
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8130.72331
-  tps: 5175.07588
+  dps: 8130.78152
+  tps: 5175.13409
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 366.89607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7603.00581
-  tps: 4894.82467
+  dps: 7603.059
+  tps: 4894.87786
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7668.71166
-  tps: 4946.87741
+  dps: 7668.76485
+  tps: 4946.9306
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7872.3045
-  tps: 4999.36834
+  dps: 7872.36106
+  tps: 4999.4249
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7654.86205
-  tps: 4904.36459
+  dps: 7654.91988
+  tps: 4904.42243
   hps: 280.31936
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 6713.89276
-  tps: 4262.16307
+  dps: 6713.94751
+  tps: 4262.21783
   hps: 297.44373
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8365.77928
-  tps: 5328.12433
+  dps: 8365.84081
+  tps: 5328.18586
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7592.99574
-  tps: 4883.90971
+  dps: 7593.04893
+  tps: 4883.9629
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7844.27505
-  tps: 5146.36102
+  dps: 7844.36451
+  tps: 5146.45047
   hps: 273.20904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7876.97349
-  tps: 5191.1674
+  dps: 7877.03063
+  tps: 5191.22454
   hps: 272.57514
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8064.76113
-  tps: 5111.04618
+  dps: 8064.81935
+  tps: 5111.1044
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7744.2643
-  tps: 4913.24682
+  dps: 7744.31749
+  tps: 4913.3
   hps: 268.77177
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7734.80117
-  tps: 4913.41182
+  dps: 7734.85435
+  tps: 4913.46501
   hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8036.37111
-  tps: 5084.21442
+  dps: 8036.42933
+  tps: 5084.27264
   hps: 272.47129
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8036.37111
-  tps: 5084.21442
+  dps: 8036.42933
+  tps: 5084.27264
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8061.67483
-  tps: 5108.99586
+  dps: 8061.73305
+  tps: 5109.05408
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8057.72525
-  tps: 5104.99592
+  dps: 8057.78347
+  tps: 5105.05414
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7657.2059
-  tps: 4835.43828
+  dps: 7657.25909
+  tps: 4835.49147
   hps: 268.77177
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 284.73434
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8036.37111
-  tps: 5084.21442
+  dps: 8036.42933
+  tps: 5084.27264
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7666.57468
-  tps: 4943.01323
+  dps: 7666.62787
+  tps: 4943.06642
   hps: 266.23619
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7595.21681
-  tps: 4886.61266
+  dps: 7595.27
+  tps: 4886.66585
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7574.97302
-  tps: 4867.35389
+  dps: 7575.02621
+  tps: 4867.40708
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8036.37111
-  tps: 5084.21442
+  dps: 8036.42933
+  tps: 5084.27264
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8036.37111
-  tps: 5084.21442
+  dps: 8036.42933
+  tps: 5084.27264
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 8133.76988
-  tps: 5173.93269
+  dps: 8133.8281
+  tps: 5173.99091
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7774.97088
-  tps: 5017.24999
+  dps: 7775.02421
+  tps: 5017.30332
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7616.76428
-  tps: 4899.99298
+  dps: 7616.81747
+  tps: 4900.04617
   hps: 268.77177
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 8081.78659
-  tps: 5132.91331
+  dps: 8081.8448
+  tps: 5132.97153
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8061.67483
-  tps: 5108.99586
+  dps: 8061.73305
+  tps: 5109.05408
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8057.72525
-  tps: 5104.99592
+  dps: 8057.78347
+  tps: 5105.05414
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7676.36662
-  tps: 4941.60026
+  dps: 7676.42097
+  tps: 4941.65461
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8036.37111
-  tps: 5084.21442
+  dps: 8036.42933
+  tps: 5084.27264
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8071.15991
-  tps: 5112.06574
+  dps: 8071.21917
+  tps: 5112.125
   hps: 280.37265
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7600.13885
-  tps: 4905.77305
+  dps: 7600.19203
+  tps: 4905.82623
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8064.44072
-  tps: 5106.68509
+  dps: 8064.49921
+  tps: 5106.74357
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8071.04534
-  tps: 5111.9723
+  dps: 8071.10389
+  tps: 5112.03085
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8036.37111
-  tps: 5084.21442
+  dps: 8036.42933
+  tps: 5084.27264
   hps: 271.53992
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8036.37111
-  tps: 5084.21442
+  dps: 8036.42933
+  tps: 5084.27264
   hps: 272.47129
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7601.56327
-  tps: 4873.89744
+  dps: 7601.61646
+  tps: 4873.95063
   hps: 267.82092
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7611.35842
-  tps: 4882.02906
+  dps: 7611.41161
+  tps: 4882.08225
   hps: 267.82092
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8116.73956
-  tps: 5160.52955
+  dps: 8116.79777
+  tps: 5160.58777
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 8153.6386
-  tps: 5189.56969
+  dps: 8153.69682
+  tps: 5189.62791
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8036.37111
-  tps: 5084.21442
+  dps: 8036.42933
+  tps: 5084.27264
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 8076.10372
-  tps: 5128.45299
+  dps: 8076.16194
+  tps: 5128.51121
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7275.28667
-  tps: 4641.09073
+  dps: 7275.34111
+  tps: 4641.14517
   hps: 259.28396
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6665.23267
-  tps: 4211.66093
+  dps: 6665.2867
+  tps: 4211.71497
   hps: 269.15349
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8068.40929
-  tps: 5328.1087
+  dps: 8068.472
+  tps: 5328.17141
   hps: 295.4123
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7304.64664
-  tps: 4766.53435
+  dps: 7304.70454
+  tps: 4766.59226
   hps: 313.6413
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8116.73956
-  tps: 5160.52955
+  dps: 8116.79777
+  tps: 5160.58777
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 8031.58792
-  tps: 5093.51383
+  dps: 8031.64614
+  tps: 5093.57205
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 8038.91431
-  tps: 5101.32054
+  dps: 8038.97253
+  tps: 5101.37876
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 8031.58792
-  tps: 5093.51383
+  dps: 8031.64614
+  tps: 5093.57205
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8031.58792
-  tps: 5093.51383
+  dps: 8031.64614
+  tps: 5093.57205
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 8031.58792
-  tps: 5093.51383
+  dps: 8031.64614
+  tps: 5093.57205
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 8031.58792
-  tps: 5093.51383
+  dps: 8031.64614
+  tps: 5093.57205
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 8031.58792
-  tps: 5093.51383
+  dps: 8031.64614
+  tps: 5093.57205
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 302.89607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7595.69704
-  tps: 4887.50431
+  dps: 7595.75023
+  tps: 4887.5575
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 7615.55357
-  tps: 4849.58352
+  dps: 7615.60676
+  tps: 4849.63671
   hps: 268.77177
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7741.30434
-  tps: 4936.1357
+  dps: 7741.35753
+  tps: 4936.18889
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StormshroudArmor"
  value: {
-  dps: 6121.4013
-  tps: 3928.11475
+  dps: 6121.45099
+  tps: 3928.16445
   hps: 206.31756
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8071.04534
-  tps: 5111.9723
+  dps: 8071.10389
+  tps: 5112.03085
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8064.44072
-  tps: 5106.68509
+  dps: 8064.49921
+  tps: 5106.74357
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8052.88265
-  tps: 5097.43246
+  dps: 8052.94102
+  tps: 5097.49083
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7848.65588
-  tps: 5087.77587
+  dps: 7848.71401
+  tps: 5087.83401
   hps: 277.1388
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6782.06076
-  tps: 4276.99527
+  dps: 6782.11587
+  tps: 4277.05037
   hps: 289.99102
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7469.48708
-  tps: 4696.40406
+  dps: 7469.54073
+  tps: 4696.45772
   hps: 254.97759
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8139.25202
-  tps: 5129.3162
+  dps: 8139.31024
+  tps: 5129.37442
   hps: 266.87008
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7691.41758
-  tps: 4957.74393
+  dps: 7691.47077
+  tps: 4957.79712
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7710.40893
-  tps: 4971.52603
+  dps: 7710.46212
+  tps: 4971.57922
   hps: 270.03956
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8036.37111
-  tps: 5084.21442
+  dps: 8036.42933
+  tps: 5084.27264
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8036.37111
-  tps: 5084.21442
+  dps: 8036.42933
+  tps: 5084.27264
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7583.3926
-  tps: 4816.26136
+  dps: 7583.44579
+  tps: 4816.31455
   hps: 267.18703
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8036.37111
-  tps: 5084.21442
+  dps: 8036.42933
+  tps: 5084.27264
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8036.37111
-  tps: 5084.21442
+  dps: 8036.42933
+  tps: 5084.27264
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6427.86642
-  tps: 4127.40151
+  dps: 6427.91792
+  tps: 4127.45302
   hps: 233.66417
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7805.63567
-  tps: 4921.44082
+  dps: 7805.69333
+  tps: 4921.49849
   hps: 265.35557
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7510.40583
-  tps: 4805.39305
+  dps: 7510.45902
+  tps: 4805.44624
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 8176.3457
-  tps: 5207.44055
+  dps: 8176.40392
+  tps: 5207.49877
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 8112.11056
-  tps: 5166.83012
+  dps: 8112.17886
+  tps: 5166.89842
   hps: 267.59817
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 35628.01023
-  tps: 38385.96169
+  dps: 35628.0684
+  tps: 38386.01985
   hps: 264.49787
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7945.07456
-  tps: 5141.43022
+  dps: 7945.13272
+  tps: 5141.48839
   hps: 266.71522
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11408.79657
-  tps: 5601.26795
+  dps: 11409.08739
+  tps: 5601.55876
   hps: 229.65384
  }
 }
@@ -1046,24 +1046,24 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 45395.49064
-  tps: 49122.6343
+  dps: 45395.56525
+  tps: 49122.70891
   hps: 329.80311
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10321.89229
-  tps: 6805.56573
+  dps: 10321.9669
+  tps: 6805.64033
   hps: 332.16166
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14532.62173
-  tps: 7410.1543
+  dps: 14532.99475
+  tps: 7410.52732
   hps: 275.1635
  }
 }
@@ -1094,24 +1094,24 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 35828.23049
-  tps: 38494.60799
+  dps: 35828.28871
+  tps: 38494.6662
   hps: 265.91924
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8116.73956
-  tps: 5160.52955
+  dps: 8116.79777
+  tps: 5160.58777
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11800.40176
-  tps: 5659.21053
+  dps: 11800.69285
+  tps: 5659.50162
   hps: 229.78718
  }
 }
@@ -1142,24 +1142,24 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 45645.48784
-  tps: 49236.70341
+  dps: 45645.5625
+  tps: 49236.77807
   hps: 331.53052
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10503.77447
-  tps: 6813.86535
+  dps: 10503.84913
+  tps: 6813.94002
   hps: 331.53052
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14923.47841
-  tps: 7413.70792
+  dps: 14923.85171
+  tps: 7414.08123
   hps: 275.29225
  }
 }
@@ -1190,8 +1190,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7762.20261
-  tps: 4990.46044
+  dps: 7762.26083
+  tps: 4990.51866
   hps: 264.65145
  }
 }

--- a/sim/deathknight/dps/rotation_unholy_helper.go
+++ b/sim/deathknight/dps/rotation_unholy_helper.go
@@ -246,7 +246,11 @@ func (dk *DpsDeathknight) uhSpreadDiseases(sim *core.Simulation, target *core.Un
 
 // Simpler but somehow more effective for overall dps dnd check
 func (dk *DpsDeathknight) uhShouldWaitForDnD(sim *core.Simulation, blood bool, frost bool, unholy bool) bool {
-	return !(!(dk.DeathAndDecay.CD.IsReady(sim) || dk.DeathAndDecay.CD.TimeToReady(sim) <= 4*time.Second) || ((!blood || dk.CurrentBloodRunes() > 1) && (!frost || dk.CurrentFrostRunes() > 1) && (!unholy || dk.CurrentUnholyRunes() > 1)))
+	if dk.Talents.ImprovedUnholyPresence > 0 {
+		return dk.DeathAndDecay.IsReady(sim) || ((!blood || dk.CurrentBloodRunes() > 1) && (!frost || dk.CurrentFrostRunes() > 1) && (!unholy || dk.CurrentUnholyRunes() > 1))
+	} else {
+		return !(!(dk.DeathAndDecay.CD.IsReady(sim) || dk.DeathAndDecay.CD.TimeToReady(sim) <= 4*time.Second) || ((!blood || dk.CurrentBloodRunes() > 1) && (!frost || dk.CurrentFrostRunes() > 1) && (!unholy || dk.CurrentUnholyRunes() > 1)))
+	}
 }
 
 func (dk *DpsDeathknight) uhGhoulFrenzyCheck(sim *core.Simulation, target *core.Unit) bool {

--- a/sim/deathknight/talents_unholy.go
+++ b/sim/deathknight/talents_unholy.go
@@ -172,7 +172,7 @@ func (dk *Deathknight) bloodCakedBladeHit(isMh bool) *core.Spell {
 					spell.Unit.OHWeaponDamage(sim, spell.MeleeAttackPower()) +
 					spell.BonusWeaponDamage()
 			}
-			baseDamage *= 0.25 + 0.125*dk.dkCountActiveDiseases(target)
+			baseDamage *= 0.25 + 0.125*dk.dkCountActiveDiseasesBcb(target)
 
 			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialNoCrit)
 		},


### PR DESCRIPTION
- Fix bcb scaling to work with external CF/EF as it does on live
- Stop rune holding for Dnd when improved unholy presence is talented