### PR TITLE
Vigo/mutilate fix

### DIFF
--- a/sim/core/dot.go
+++ b/sim/core/dot.go
@@ -30,7 +30,7 @@ type DotConfig struct {
 type Dot struct {
 	Spell *Spell
 
-	// Embed Aura so we can use IsActive/Refresh/etc directly.
+	// Embed Aura, so we can use IsActive/Refresh/etc directly.
 	*Aura
 
 	NumberOfTicks int32         // number of ticks over the whole duration
@@ -55,7 +55,7 @@ type Dot struct {
 	lastTickTime time.Duration
 }
 
-// TickPeriod is how fast the snapshotted dot ticks.
+// TickPeriod is how fast the snapshot dot ticks.
 func (dot *Dot) TickPeriod() time.Duration {
 	return dot.tickPeriod
 }
@@ -72,7 +72,7 @@ func (dot *Dot) NumTicksRemaining(sim *Simulation) int {
 
 // Roll over = gets carried over with everlasting refresh and doesn't get applied if triggered when the spell is already up.
 // - Example: critical strike rating, internal % damage modifiers: buffs or debuffs on player
-// Nevermelting Ice, Shadow Mastery (ISB), Trick of the Trades, Deaths Embrace, Thadius Polarity, Hera Spores, Crit on weapons from swapping
+// Nevermelting Ice, Shadow Mastery (ISB), Trick of the Trades, Deaths Embrace, Thaddius Polarity, Hera Spores, Crit on weapons from swapping
 
 // Snapshot = calculation happens at refresh and application (stays up even if buff falls of, until new refresh or application)
 // - Example: Spell power, Haste rating
@@ -83,8 +83,8 @@ func (dot *Dot) NumTicksRemaining(sim *Simulation) int {
 // Haunt, Curse of Shadow, Shadow Embrace
 
 // Rollover is used to reset the duration of a dot from an external spell (not casting the dot itself)
-// This keeps the snapshotted crit and %dmg modifiers.
-// However sp and haste are recalculated.
+// This keeps the snapshot crit and %dmg modifiers.
+// However, sp and haste are recalculated.
 func (dot *Dot) Rollover(sim *Simulation) {
 	dot.TakeSnapshot(sim, true)
 

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -102,15 +102,15 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50035"
  value: {
-  dps: 5872.95633
-  tps: 4169.79899
+  dps: 5794.16901
+  tps: 4113.85999
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50692"
  value: {
-  dps: 5955.53292
-  tps: 4228.42837
+  dps: 5868.32686
+  tps: 4166.51207
  }
 }
 dps_results: {
@@ -678,8 +678,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-TheFistsofFury"
  value: {
-  dps: 5100.49059
-  tps: 3621.34832
+  dps: 4991.98319
+  tps: 3544.30807
  }
 }
 dps_results: {

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -46,1073 +46,1073 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7546.42172
-  tps: 5357.95942
+  dps: 7448.83287
+  tps: 5288.67134
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7741.27364
-  tps: 5496.30428
+  dps: 7646.65833
+  tps: 5429.12741
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7515.12114
-  tps: 34929.2012
+  dps: 7422.49556
+  tps: 34397.73584
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7515.12114
-  tps: 34929.2012
+  dps: 7422.49556
+  tps: 34397.73584
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7745.86575
-  tps: 5499.56468
+  dps: 7650.55705
+  tps: 5431.89551
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50035"
  value: {
-  dps: 5794.16901
-  tps: 4113.85999
+  dps: 5794.83443
+  tps: 4114.33244
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50692"
  value: {
-  dps: 5868.32686
-  tps: 4166.51207
+  dps: 5868.81783
+  tps: 4166.86066
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5846.71398
-  tps: 4151.16693
+  dps: 5799.07092
+  tps: 4117.34035
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 7038.19628
-  tps: 4997.11936
+  dps: 6981.37646
+  tps: 4956.77728
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5375.27727
+  dps: 7590.29787
+  tps: 5281.32926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7871.28365
-  tps: 5588.61139
+  dps: 7774.21843
+  tps: 5519.69509
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7675.19447
-  tps: 5449.38808
+  dps: 7588.34644
+  tps: 5387.72597
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7699.78178
-  tps: 5466.84506
+  dps: 7620.21704
+  tps: 5410.3541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7695.45726
-  tps: 5463.77465
+  dps: 7585.13491
+  tps: 5385.44579
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8084.19096
-  tps: 5739.77558
+  dps: 7993.78378
+  tps: 5675.58648
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7646.08215
-  tps: 5428.71832
+  dps: 7536.50297
+  tps: 5350.91711
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7943.51546
-  tps: 5639.89598
+  dps: 7861.22984
+  tps: 5581.47318
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8024.65265
-  tps: 5697.50338
+  dps: 7911.20246
+  tps: 5616.95374
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7754.03696
-  tps: 5505.36624
+  dps: 7656.8012
+  tps: 5436.32885
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7760.60861
-  tps: 5510.03211
+  dps: 7668.23891
+  tps: 5444.44963
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7729.93735
-  tps: 5488.25552
+  dps: 7640.04972
+  tps: 5424.4353
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7745.86575
-  tps: 5499.56468
+  dps: 7650.55705
+  tps: 5431.89551
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7734.06947
-  tps: 5491.18932
+  dps: 7645.59098
+  tps: 5428.3696
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7621.72791
-  tps: 5411.42682
+  dps: 7515.74689
+  tps: 5336.18029
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7683.72253
-  tps: 5455.44299
+  dps: 7594.788
+  tps: 5392.29948
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7645.19208
-  tps: 5428.08638
+  dps: 7562.74848
+  tps: 5369.55142
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7513.16621
-  tps: 5334.34801
+  dps: 7421.89641
+  tps: 5269.54645
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7595.71808
-  tps: 5392.95984
+  dps: 7525.97994
+  tps: 5343.44576
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7798.03636
-  tps: 5536.60581
+  dps: 7702.53211
+  tps: 5468.7978
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7606.06932
-  tps: 5400.30921
+  dps: 7498.06822
+  tps: 5323.62844
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7647.64131
-  tps: 5429.82533
+  dps: 7572.70483
+  tps: 5376.62043
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-49982"
  value: {
-  dps: 7884.03961
-  tps: 5597.66812
+  dps: 7761.60532
+  tps: 5510.73978
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-50641"
  value: {
-  dps: 7884.03961
-  tps: 5597.66812
+  dps: 7761.60532
+  tps: 5510.73978
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7745.86575
-  tps: 5499.56468
+  dps: 7650.55705
+  tps: 5431.89551
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7734.06947
-  tps: 5491.18932
+  dps: 7645.59098
+  tps: 5428.3696
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7686.00075
-  tps: 5457.06054
+  dps: 7592.53403
+  tps: 5390.69916
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7757.24208
-  tps: 5507.64187
+  dps: 7630.40626
+  tps: 5417.58845
   hps: 9.14161
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7788.85938
-  tps: 5530.09016
+  dps: 7683.43824
+  tps: 5455.24115
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7540.7054
-  tps: 5353.90084
+  dps: 7455.23528
+  tps: 5293.21705
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7755.81473
-  tps: 5506.62846
+  dps: 7620.35584
+  tps: 5410.45265
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7762.99009
-  tps: 5511.72296
+  dps: 7627.42831
+  tps: 5415.4741
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7721.89847
-  tps: 5482.54791
+  dps: 7624.97767
+  tps: 5413.73414
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7748.40067
-  tps: 5501.36448
+  dps: 7650.21309
+  tps: 5431.65129
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7884.03961
-  tps: 5597.66812
+  dps: 7761.60532
+  tps: 5510.73978
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7885.5423
-  tps: 5598.73503
+  dps: 7787.26234
+  tps: 5528.95626
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 5794.10704
-  tps: 4113.816
+  dps: 5719.03636
+  tps: 4060.51582
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7653.51472
-  tps: 5433.99545
+  dps: 7565.55505
+  tps: 5371.54408
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 7614.68495
-  tps: 5406.42631
+  dps: 7556.35277
+  tps: 5365.01047
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7673.66364
-  tps: 5448.30118
+  dps: 7563.0495
+  tps: 5369.76514
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StormshroudArmor"
  value: {
-  dps: 6155.20223
-  tps: 4370.19358
+  dps: 6053.68041
+  tps: 4298.11309
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7762.99009
-  tps: 5511.72296
+  dps: 7627.42831
+  tps: 5415.4741
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7755.81473
-  tps: 5506.62846
+  dps: 7620.35584
+  tps: 5410.45265
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7743.25784
-  tps: 5497.71307
+  dps: 7607.97903
+  tps: 5401.66511
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 7452.47118
-  tps: 5291.25454
+  dps: 7365.69472
+  tps: 5229.64325
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheFistsofFury"
  value: {
-  dps: 4991.98319
-  tps: 3544.30807
+  dps: 4991.69544
+  tps: 3544.10376
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7803.63143
-  tps: 5540.57832
+  dps: 7672.38129
+  tps: 5447.39071
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7972.37753
-  tps: 5660.38805
+  dps: 7882.45671
+  tps: 5596.54427
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8042.88297
-  tps: 5710.44691
+  dps: 7955.44865
+  tps: 5648.36854
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7574.66571
-  tps: 5378.01266
+  dps: 7459.75606
+  tps: 5296.4268
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6224.90573
-  tps: 4419.68307
+  dps: 6164.46072
+  tps: 4376.76711
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 7268.73862
-  tps: 5160.80442
+  dps: 7157.21494
+  tps: 5081.62261
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 7881.24271
-  tps: 5595.68232
+  dps: 7773.30418
+  tps: 5519.04597
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28351.85946
-  tps: 20129.82022
+  dps: 28361.14643
+  tps: 20136.41396
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7884.03961
-  tps: 5597.66812
+  dps: 7761.60532
+  tps: 5510.73978
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9086.90129
-  tps: 6451.69992
+  dps: 8908.16218
+  tps: 6324.79515
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15287.19957
-  tps: 10853.91169
+  dps: 15371.20282
+  tps: 10913.554
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3793.99118
-  tps: 2693.73374
+  dps: 3749.75237
+  tps: 2662.32418
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3867.02962
-  tps: 2745.59103
+  dps: 3815.50047
+  tps: 2709.00534
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21480.25706
-  tps: 15250.98251
+  dps: 21534.87875
+  tps: 15289.76391
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5137.62635
-  tps: 3647.71471
+  dps: 5063.93231
+  tps: 3595.39194
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5940.32452
-  tps: 4217.63041
+  dps: 5850.70964
+  tps: 4154.00385
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12907.79258
-  tps: 9164.53273
+  dps: 12930.61595
+  tps: 9180.73732
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2485.91196
-  tps: 1764.99749
+  dps: 2455.7035
+  tps: 1743.54948
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2617.29392
-  tps: 1858.27868
+  dps: 2581.42308
+  tps: 1832.81039
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27126.18212
-  tps: 19259.5893
+  dps: 27131.91561
+  tps: 19263.66008
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7436.57789
-  tps: 5279.9703
+  dps: 7339.08333
+  tps: 5210.74917
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8550.59789
-  tps: 6070.9245
+  dps: 8383.90693
+  tps: 5952.57392
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14671.11988
-  tps: 10416.49512
+  dps: 14728.80828
+  tps: 10457.45388
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3579.03851
-  tps: 2541.11734
+  dps: 3539.55267
+  tps: 2513.0824
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3629.81891
-  tps: 2577.17143
+  dps: 3577.29864
+  tps: 2539.88203
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18041.57363
-  tps: 12809.51728
+  dps: 18047.87407
+  tps: 12813.99059
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3807.21635
-  tps: 2703.12361
+  dps: 3806.24152
+  tps: 2702.43148
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4639.48337
-  tps: 3294.03319
+  dps: 4635.57465
+  tps: 3291.258
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9349.69715
-  tps: 6638.28498
+  dps: 9352.08794
+  tps: 6639.98244
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1675.36562
-  tps: 1189.50959
+  dps: 1678.54219
+  tps: 1191.76496
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1772.82431
-  tps: 1258.70526
+  dps: 1774.22659
+  tps: 1259.70088
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28444.57411
-  tps: 20195.64761
+  dps: 28474.88576
+  tps: 20217.16889
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7919.44856
-  tps: 5622.80848
+  dps: 7797.6117
+  tps: 5536.30431
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9183.75687
-  tps: 6520.46738
+  dps: 9008.24352
+  tps: 6395.8529
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15358.3642
-  tps: 10904.43859
+  dps: 15452.69366
+  tps: 10971.4125
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3812.92427
-  tps: 2707.17623
+  dps: 3766.09546
+  tps: 2673.92778
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3912.27097
-  tps: 2777.71239
+  dps: 3857.36279
+  tps: 2738.72758
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21599.51535
-  tps: 15335.6559
+  dps: 21649.15041
+  tps: 15370.89679
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5162.96811
-  tps: 3665.70736
+  dps: 5087.98341
+  tps: 3612.46822
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6007.97051
-  tps: 4265.65906
+  dps: 5920.21343
+  tps: 4203.35153
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12999.22811
-  tps: 9229.45196
+  dps: 13004.29574
+  tps: 9233.04998
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2499.50205
-  tps: 1774.64646
+  dps: 2467.7296
+  tps: 1752.08801
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2650.53548
-  tps: 1881.88019
+  dps: 2612.48554
+  tps: 1854.86473
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27268.01557
-  tps: 19360.29106
+  dps: 27305.68158
+  tps: 19387.03392
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7469.62635
-  tps: 5303.43471
+  dps: 7371.2184
+  tps: 5233.56507
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8641.61502
-  tps: 6135.54666
+  dps: 8477.44985
+  tps: 6018.9894
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14737.395
-  tps: 10463.55045
+  dps: 14816.41755
+  tps: 10519.65646
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3596.73552
-  tps: 2553.68222
+  dps: 3558.35416
+  tps: 2526.43145
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3671.65788
-  tps: 2606.87709
+  dps: 3615.36306
+  tps: 2566.90777
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18136.30525
-  tps: 12876.77673
+  dps: 18144.68646
+  tps: 12882.72739
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3825.17553
-  tps: 2715.87463
+  dps: 3824.19332
+  tps: 2715.17726
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4693.67805
-  tps: 3332.51142
+  dps: 4689.7131
+  tps: 3329.6963
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9414.12829
-  tps: 6684.03109
+  dps: 9415.80913
+  tps: 6685.22448
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1683.30887
-  tps: 1195.1493
+  dps: 1686.52541
+  tps: 1197.43304
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1793.78216
-  tps: 1273.58534
+  dps: 1795.38098
+  tps: 1274.7205
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7403.53866
-  tps: 5256.51245
+  dps: 7284.93475
+  tps: 5172.30367
  }
 }

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -46,892 +46,892 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 6327.5169
-  tps: 4492.537
+  dps: 6327.20158
+  tps: 4492.31312
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6446.91163
-  tps: 4577.30726
+  dps: 6447.10663
+  tps: 4577.44571
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6508.49808
-  tps: 4621.03364
+  dps: 6508.18915
+  tps: 4620.8143
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6311.68427
-  tps: 52189.11729
+  dps: 6311.36894
+  tps: 52188.89341
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6311.68427
-  tps: 52189.11729
+  dps: 6311.36894
+  tps: 52188.89341
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6471.18331
-  tps: 4594.54015
+  dps: 6471.61055
+  tps: 4594.84349
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50035"
  value: {
-  dps: 6775.3268
-  tps: 4810.48203
+  dps: 6777.09215
+  tps: 4811.73543
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50692"
  value: {
-  dps: 6888.63287
-  tps: 4890.92934
+  dps: 6890.33634
+  tps: 4892.1388
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5010.19887
-  tps: 3557.24119
+  dps: 5010.1028
+  tps: 3557.17299
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BonescytheBattlegear"
  value: {
-  dps: 5983.51774
-  tps: 4248.2976
+  dps: 5983.77091
+  tps: 4248.47735
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6446.91163
-  tps: 4485.76111
+  dps: 6447.10663
+  tps: 4485.8968
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6593.14262
-  tps: 4681.13126
+  dps: 6593.47436
+  tps: 4681.3668
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6593.14262
-  tps: 4681.13126
+  dps: 6593.47436
+  tps: 4681.3668
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6587.07972
-  tps: 4676.8266
+  dps: 6587.50697
+  tps: 4677.12995
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
   hps: 64
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6439.83718
-  tps: 4572.2844
+  dps: 6439.59631
+  tps: 4572.11338
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6472.81066
-  tps: 4595.69557
+  dps: 6472.6593
+  tps: 4595.5881
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6462.13017
-  tps: 4588.11242
+  dps: 6462.32134
+  tps: 4588.24815
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6786.87732
-  tps: 4818.6829
+  dps: 6787.25847
+  tps: 4818.95352
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6418.76926
-  tps: 4557.32617
+  dps: 6418.51473
+  tps: 4557.14546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6734.87001
-  tps: 4781.75771
+  dps: 6735.17106
+  tps: 4781.97145
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6781.84806
-  tps: 4815.11213
+  dps: 6781.22324
+  tps: 4814.6685
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6473.96697
-  tps: 4596.51655
+  dps: 6474.39422
+  tps: 4596.8199
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6518.1156
-  tps: 4627.86208
+  dps: 6518.73776
+  tps: 4628.30381
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6505.78364
-  tps: 4619.10639
+  dps: 6506.14815
+  tps: 4619.36519
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6446.91163
-  tps: 4577.30726
+  dps: 6447.10663
+  tps: 4577.44571
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6446.91163
-  tps: 4577.30726
+  dps: 6447.10663
+  tps: 4577.44571
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6471.18331
-  tps: 4594.54015
+  dps: 6471.61055
+  tps: 4594.84349
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6467.00596
-  tps: 4591.57423
+  dps: 6467.37173
+  tps: 4591.83393
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6438.84099
-  tps: 4571.57711
+  dps: 6439.2489
+  tps: 4571.86672
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6446.91163
-  tps: 4577.30726
+  dps: 6447.10663
+  tps: 4577.44571
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6471.9972
-  tps: 4595.11801
+  dps: 6471.83734
+  tps: 4595.00451
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6425.1039
-  tps: 4561.82377
+  dps: 6424.93134
+  tps: 4561.70125
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6315.20156
-  tps: 4483.79311
+  dps: 6315.06028
+  tps: 4483.6928
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6399.36646
-  tps: 4543.55018
+  dps: 6399.23488
+  tps: 4543.45676
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6446.91163
-  tps: 4577.30726
+  dps: 6447.10663
+  tps: 4577.44571
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6446.91163
-  tps: 4577.30726
+  dps: 6447.10663
+  tps: 4577.44571
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6552.82022
-  tps: 4652.50236
+  dps: 6552.4873
+  tps: 4652.26598
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Gladiator'sVestments"
  value: {
-  dps: 6379.60123
-  tps: 4529.51687
+  dps: 6380.22596
+  tps: 4529.96043
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6448.40497
-  tps: 4578.36753
+  dps: 6448.2454
+  tps: 4578.25424
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-49982"
  value: {
-  dps: 6593.14262
-  tps: 4681.13126
+  dps: 6593.47436
+  tps: 4681.3668
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-50641"
  value: {
-  dps: 6593.14262
-  tps: 4681.13126
+  dps: 6593.47436
+  tps: 4681.3668
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6471.18331
-  tps: 4594.54015
+  dps: 6471.61055
+  tps: 4594.84349
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6467.00596
-  tps: 4591.57423
+  dps: 6467.37173
+  tps: 4591.83393
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6492.41571
-  tps: 4609.61515
+  dps: 6492.10119
+  tps: 4609.39185
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6446.91163
-  tps: 4577.30726
+  dps: 6447.10663
+  tps: 4577.44571
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6478.96321
-  tps: 4600.06388
+  dps: 6479.05243
+  tps: 4600.12722
   hps: 9.14161
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6526.46696
-  tps: 4633.79154
+  dps: 6526.66426
+  tps: 4633.93163
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6361.02035
-  tps: 4516.32445
+  dps: 6360.84095
+  tps: 4516.19708
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6472.60749
-  tps: 4595.55132
+  dps: 6472.80268
+  tps: 4595.6899
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6478.65357
-  tps: 4599.84404
+  dps: 6478.8488
+  tps: 4599.98265
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6446.91163
-  tps: 4577.30726
+  dps: 6447.10663
+  tps: 4577.44571
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6446.91163
-  tps: 4577.30726
+  dps: 6447.10663
+  tps: 4577.44571
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6459.88472
-  tps: 4586.51815
+  dps: 6459.51143
+  tps: 4586.25311
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6478.63698
-  tps: 4599.83226
+  dps: 6478.26369
+  tps: 4599.56722
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6593.14262
-  tps: 4681.13126
+  dps: 6593.47436
+  tps: 4681.3668
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6446.91163
-  tps: 4577.30726
+  dps: 6447.10663
+  tps: 4577.44571
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 6617.18951
-  tps: 4698.20455
+  dps: 6617.66204
+  tps: 4698.54005
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6593.14262
-  tps: 4681.13126
+  dps: 6593.47436
+  tps: 4681.3668
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Slayer'sArmor"
  value: {
-  dps: 4934.4961
-  tps: 3503.49223
+  dps: 4934.21898
+  tps: 3503.29548
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6428.80645
-  tps: 4564.45258
+  dps: 6428.58266
+  tps: 4564.29369
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SparkofLife-37657"
  value: {
-  dps: 6401.38548
-  tps: 4544.98369
+  dps: 6401.56503
+  tps: 4545.11117
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6504.64597
-  tps: 4618.29864
+  dps: 6504.14713
+  tps: 4617.94446
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StormshroudArmor"
  value: {
-  dps: 5044.43453
-  tps: 3581.54852
+  dps: 5045.14782
+  tps: 3582.05495
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6478.65357
-  tps: 4599.84404
+  dps: 6478.8488
+  tps: 4599.98265
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6472.60749
-  tps: 4595.55132
+  dps: 6472.80268
+  tps: 4595.6899
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6462.02684
-  tps: 4588.03906
+  dps: 6462.22195
+  tps: 4588.17759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6379.03162
-  tps: 4529.11245
+  dps: 6378.70871
+  tps: 4528.88319
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheFistsofFury"
  value: {
-  dps: 5770.76474
-  tps: 4097.24297
+  dps: 5771.33075
+  tps: 4097.64483
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5870.0151
-  tps: 4167.71072
+  dps: 5870.83737
+  tps: 4168.29454
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6518.51847
-  tps: 4628.14811
+  dps: 6519.40605
+  tps: 4628.7783
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6639.50791
-  tps: 4714.05062
+  dps: 6639.73953
+  tps: 4714.21507
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6651.01116
-  tps: 4722.21793
+  dps: 6650.68651
+  tps: 4721.98742
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6446.91163
-  tps: 4577.30726
+  dps: 6447.10663
+  tps: 4577.44571
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6446.91163
-  tps: 4577.30726
+  dps: 6447.10663
+  tps: 4577.44571
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6364.60741
-  tps: 4518.87126
+  dps: 6364.23908
+  tps: 4518.60975
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6446.91163
-  tps: 4577.30726
+  dps: 6447.10663
+  tps: 4577.44571
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6446.91163
-  tps: 4577.30726
+  dps: 6447.10663
+  tps: 4577.44571
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5313.82113
-  tps: 3772.813
+  dps: 5313.82954
+  tps: 3772.81897
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6203.78644
-  tps: 4404.68837
+  dps: 6204.53997
+  tps: 4405.22338
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6128.62927
-  tps: 4351.32678
+  dps: 6129.08899
+  tps: 4351.65318
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6312.4609
-  tps: 4481.84724
+  dps: 6312.14558
+  tps: 4481.62336
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 6575.11664
-  tps: 4668.33282
+  dps: 6575.58862
+  tps: 4668.66792
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18991.27045
-  tps: 13483.80202
+  dps: 18991.40439
+  tps: 13483.89711
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4880.40471
-  tps: 3465.08735
+  dps: 4880.65357
+  tps: 3465.26404
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5728.81142
-  tps: 4067.45611
+  dps: 5727.60155
+  tps: 4066.5971
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11525.41975
-  tps: 8183.04802
+  dps: 11534.75688
+  tps: 8189.67738
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2418.78987
-  tps: 1717.34081
+  dps: 2418.90872
+  tps: 1717.42519
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2554.13725
-  tps: 1813.43745
+  dps: 2554.29998
+  tps: 1813.55298
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20560.15466
-  tps: 14597.70981
+  dps: 20614.56969
+  tps: 14636.34448
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6593.14262
-  tps: 4681.13126
+  dps: 6593.47436
+  tps: 4681.3668
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7758.72195
-  tps: 5508.69258
+  dps: 7757.23895
+  tps: 5507.63966
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11941.88372
-  tps: 8478.73744
+  dps: 11991.47207
+  tps: 8513.94517
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3255.95035
-  tps: 2311.72475
+  dps: 3256.02007
+  tps: 2311.77425
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3385.70997
-  tps: 2403.85408
+  dps: 3385.80103
+  tps: 2403.91873
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19714.44222
-  tps: 13997.25397
+  dps: 19743.78724
+  tps: 14018.08894
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6288.75302
-  tps: 4465.01464
+  dps: 6290.59597
+  tps: 4466.32314
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7339.30007
-  tps: 5210.90305
+  dps: 7339.70096
+  tps: 5211.18768
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11492.09177
-  tps: 8159.38516
+  dps: 11517.31317
+  tps: 8177.29235
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3102.61931
-  tps: 2202.85971
+  dps: 3103.8753
+  tps: 2203.75146
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3199.53852
-  tps: 2271.67235
+  dps: 3202.5563
+  tps: 2273.81497
  }
 }
 dps_results: {
@@ -979,127 +979,127 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19131.51554
-  tps: 13583.37603
+  dps: 19131.7997
+  tps: 13583.57779
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4913.61851
-  tps: 3488.66914
+  dps: 4913.90168
+  tps: 3488.87019
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5805.9521
-  tps: 4122.22599
+  dps: 5804.74883
+  tps: 4121.37167
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11617.22779
-  tps: 8248.23173
+  dps: 11627.83525
+  tps: 8255.76303
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2436.90762
-  tps: 1730.20441
+  dps: 2437.04979
+  tps: 1730.30535
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2590.97264
-  tps: 1839.59057
+  dps: 2591.12739
+  tps: 1839.70045
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20711.36122
-  tps: 14705.06647
+  dps: 20767.06156
+  tps: 14744.61371
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6637.2518
-  tps: 4712.44878
+  dps: 6637.61103
+  tps: 4712.70383
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7860.24542
-  tps: 5580.77425
+  dps: 7858.95708
+  tps: 5579.85953
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12036.95195
-  tps: 8546.23588
+  dps: 12087.93924
+  tps: 8582.43686
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3279.83471
-  tps: 2328.68265
+  dps: 3279.92332
+  tps: 2328.74556
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3433.53807
-  tps: 2437.81203
+  dps: 3433.72363
+  tps: 2437.94377
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19859.46816
-  tps: 14100.2224
+  dps: 19890.6181
+  tps: 14122.33885
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6330.88035
-  tps: 4494.92505
+  dps: 6332.7969
+  tps: 4496.2858
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7435.20725
-  tps: 5278.99715
+  dps: 7435.93212
+  tps: 5279.5118
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11583.88681
-  tps: 8224.55963
+  dps: 11611.15426
+  tps: 8243.91952
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3125.18976
-  tps: 2218.88473
+  dps: 3126.414
+  tps: 2219.75394
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3243.2049
-  tps: 2302.67548
+  dps: 3246.27011
+  tps: 2304.85178
  }
 }
 dps_results: {
@@ -1147,7 +1147,7 @@ dps_results: {
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6351.13966
-  tps: 4509.30916
+  dps: 6352.48338
+  tps: 4510.2632
  }
 }

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -46,766 +46,766 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 6329.91742
-  tps: 4494.24137
+  dps: 6327.5169
+  tps: 4492.537
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6446.91163
+  tps: 4577.30726
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6511.50672
-  tps: 4623.16977
+  dps: 6508.49808
+  tps: 4621.03364
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6314.46194
-  tps: 50548.14429
+  dps: 6311.68427
+  tps: 52189.11729
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6314.46194
-  tps: 50548.14429
+  dps: 6311.68427
+  tps: 52189.11729
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6472.61146
-  tps: 4595.55414
+  dps: 6471.18331
+  tps: 4594.54015
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50035"
  value: {
-  dps: 6787.61687
-  tps: 4819.20798
+  dps: 6775.3268
+  tps: 4810.48203
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50692"
  value: {
-  dps: 6900.27569
-  tps: 4899.19574
+  dps: 6888.63287
+  tps: 4890.92934
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5013.23343
-  tps: 3559.39573
+  dps: 5010.19887
+  tps: 3557.24119
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BonescytheBattlegear"
  value: {
-  dps: 5987.48762
-  tps: 4251.11621
+  dps: 5983.51774
+  tps: 4248.2976
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4487.07638
+  dps: 6446.91163
+  tps: 4485.76111
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6594.09049
-  tps: 4681.80425
+  dps: 6593.14262
+  tps: 4681.13126
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6594.09049
-  tps: 4681.80425
+  dps: 6593.14262
+  tps: 4681.13126
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6588.49942
-  tps: 4677.83459
+  dps: 6587.07972
+  tps: 4676.8266
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
   hps: 64
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6441.47318
-  tps: 4573.44596
+  dps: 6439.83718
+  tps: 4572.2844
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6475.19432
-  tps: 4597.38797
+  dps: 6472.81066
+  tps: 4595.69557
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6463.54539
-  tps: 4589.11723
+  dps: 6462.13017
+  tps: 4588.11242
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6789.74039
-  tps: 4820.71568
+  dps: 6786.87732
+  tps: 4818.6829
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6421.20052
-  tps: 4559.05237
+  dps: 6418.76926
+  tps: 4557.32617
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6730.66394
-  tps: 4778.7714
+  dps: 6734.87001
+  tps: 4781.75771
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6785.74497
-  tps: 4817.87893
+  dps: 6781.84806
+  tps: 4815.11213
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6475.28838
-  tps: 4597.45475
+  dps: 6473.96697
+  tps: 4596.51655
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6524.02283
-  tps: 4632.05621
+  dps: 6518.1156
+  tps: 4627.86208
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6507.82493
-  tps: 4620.5557
+  dps: 6505.78364
+  tps: 4619.10639
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6446.91163
+  tps: 4577.30726
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6446.91163
+  tps: 4577.30726
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6472.61146
-  tps: 4595.55414
+  dps: 6471.18331
+  tps: 4594.54015
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6467.73183
-  tps: 4592.0896
+  dps: 6467.00596
+  tps: 4591.57423
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6438.03813
-  tps: 4571.00708
+  dps: 6438.84099
+  tps: 4571.57711
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6446.91163
+  tps: 4577.30726
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6475.55405
-  tps: 4597.64338
+  dps: 6471.9972
+  tps: 4595.11801
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6426.67408
-  tps: 4562.9386
+  dps: 6425.1039
+  tps: 4561.82377
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6316.73217
-  tps: 4484.87984
+  dps: 6315.20156
+  tps: 4483.79311
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6401.32645
-  tps: 4544.94178
+  dps: 6399.36646
+  tps: 4543.55018
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6446.91163
+  tps: 4577.30726
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6446.91163
+  tps: 4577.30726
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6554.83305
-  tps: 4653.93146
+  dps: 6552.82022
+  tps: 4652.50236
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Gladiator'sVestments"
  value: {
-  dps: 6383.89595
-  tps: 4532.56612
+  dps: 6379.60123
+  tps: 4529.51687
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6450.87518
-  tps: 4580.12138
+  dps: 6448.40497
+  tps: 4578.36753
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-49982"
  value: {
-  dps: 6594.09049
-  tps: 4681.80425
+  dps: 6593.14262
+  tps: 4681.13126
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-50641"
  value: {
-  dps: 6594.09049
-  tps: 4681.80425
+  dps: 6593.14262
+  tps: 4681.13126
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6472.61146
-  tps: 4595.55414
+  dps: 6471.18331
+  tps: 4594.54015
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6467.73183
-  tps: 4592.0896
+  dps: 6467.00596
+  tps: 4591.57423
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6494.54497
-  tps: 4611.12693
+  dps: 6492.41571
+  tps: 4609.61515
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6446.91163
+  tps: 4577.30726
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6480.43332
-  tps: 4601.10766
+  dps: 6478.96321
+  tps: 4600.06388
   hps: 9.14161
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6529.01959
-  tps: 4635.60391
+  dps: 6526.46696
+  tps: 4633.79154
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6362.87821
-  tps: 4517.64353
+  dps: 6361.02035
+  tps: 4516.32445
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6474.49693
-  tps: 4596.89282
+  dps: 6472.60749
+  tps: 4595.55132
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6480.54282
-  tps: 4601.1854
+  dps: 6478.65357
+  tps: 4599.84404
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6446.91163
+  tps: 4577.30726
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6446.91163
+  tps: 4577.30726
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6463.33386
-  tps: 4588.96704
+  dps: 6459.88472
+  tps: 4586.51815
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6482.18753
-  tps: 4602.35315
+  dps: 6478.63698
+  tps: 4599.83226
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6594.09049
-  tps: 4681.80425
+  dps: 6593.14262
+  tps: 4681.13126
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6446.91163
+  tps: 4577.30726
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 6630.64948
-  tps: 4707.76113
+  dps: 6617.18951
+  tps: 4698.20455
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6594.09049
-  tps: 4681.80425
+  dps: 6593.14262
+  tps: 4681.13126
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Slayer'sArmor"
  value: {
-  dps: 4940.09874
-  tps: 3507.4701
+  dps: 4934.4961
+  tps: 3503.49223
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6430.39774
-  tps: 4565.58239
+  dps: 6428.80645
+  tps: 4564.45258
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SparkofLife-37657"
  value: {
-  dps: 6403.48938
-  tps: 4546.47746
+  dps: 6401.38548
+  tps: 4544.98369
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6506.97127
-  tps: 4619.9496
+  dps: 6504.64597
+  tps: 4618.29864
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StormshroudArmor"
  value: {
-  dps: 5045.60186
-  tps: 3582.37732
+  dps: 5044.43453
+  tps: 3581.54852
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6480.54282
-  tps: 4601.1854
+  dps: 6478.65357
+  tps: 4599.84404
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6474.49693
-  tps: 4596.89282
+  dps: 6472.60749
+  tps: 4595.55132
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6463.91664
-  tps: 4589.38081
+  dps: 6462.02684
+  tps: 4588.03906
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6379.41416
-  tps: 4529.38405
+  dps: 6379.03162
+  tps: 4529.11245
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheFistsofFury"
  value: {
-  dps: 5772.43194
-  tps: 4098.42668
+  dps: 5770.76474
+  tps: 4097.24297
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5873.20567
-  tps: 4169.97602
+  dps: 5870.0151
+  tps: 4167.71072
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6528.45168
-  tps: 4635.20069
+  dps: 6518.51847
+  tps: 4628.14811
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6634.2276
-  tps: 4710.30159
+  dps: 6639.50791
+  tps: 4714.05062
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6652.01379
-  tps: 4722.92979
+  dps: 6651.01116
+  tps: 4722.21793
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6446.91163
+  tps: 4577.30726
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6446.91163
+  tps: 4577.30726
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6369.83293
-  tps: 4522.58138
+  dps: 6364.60741
+  tps: 4518.87126
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6446.91163
+  tps: 4577.30726
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6446.91163
+  tps: 4577.30726
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5320.27285
-  tps: 3777.39373
+  dps: 5313.82113
+  tps: 3772.813
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6212.87279
-  tps: 4411.13968
+  dps: 6203.78644
+  tps: 4404.68837
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6129.01862
-  tps: 4351.60322
+  dps: 6128.62927
+  tps: 4351.32678
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6312.4609
+  tps: 4481.84724
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 6575.59092
-  tps: 4668.66955
+  dps: 6575.11664
+  tps: 4668.33282
  }
 }
 dps_results: {
@@ -818,15 +818,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4882.06439
-  tps: 3466.26572
+  dps: 4880.40471
+  tps: 3465.08735
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5723.96887
-  tps: 4064.0179
+  dps: 5728.81142
+  tps: 4067.45611
  }
 }
 dps_results: {
@@ -839,15 +839,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2421.70886
-  tps: 1719.41329
+  dps: 2418.78987
+  tps: 1717.34081
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2553.01751
-  tps: 1812.64243
+  dps: 2554.13725
+  tps: 1813.43745
  }
 }
 dps_results: {
@@ -860,15 +860,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6594.09049
-  tps: 4681.80425
+  dps: 6593.14262
+  tps: 4681.13126
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7754.08617
-  tps: 5505.40118
+  dps: 7758.72195
+  tps: 5508.69258
  }
 }
 dps_results: {
@@ -881,15 +881,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3257.93289
-  tps: 2313.13235
+  dps: 3255.95035
+  tps: 2311.72475
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3385.03976
-  tps: 2403.37823
+  dps: 3385.70997
+  tps: 2403.85408
  }
 }
 dps_results: {
@@ -902,15 +902,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6292.31969
-  tps: 4467.54698
+  dps: 6288.75302
+  tps: 4465.01464
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7334.49698
-  tps: 5207.49286
+  dps: 7339.30007
+  tps: 5210.90305
  }
 }
 dps_results: {
@@ -923,15 +923,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3104.81383
-  tps: 2204.41782
+  dps: 3102.61931
+  tps: 2202.85971
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3200.06663
-  tps: 2272.0473
+  dps: 3199.53852
+  tps: 2271.67235
  }
 }
 dps_results: {
@@ -944,15 +944,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5645.50776
-  tps: 4008.31051
+  dps: 5645.1173
+  tps: 4008.03328
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6778.63142
-  tps: 4812.82831
+  dps: 6781.72491
+  tps: 4815.02468
  }
 }
 dps_results: {
@@ -965,15 +965,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2631.24941
-  tps: 1868.18708
+  dps: 2629.99047
+  tps: 1867.29323
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2803.16527
-  tps: 1990.24734
+  dps: 2805.03308
+  tps: 1991.57349
  }
 }
 dps_results: {
@@ -986,15 +986,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4915.37692
-  tps: 3489.91761
+  dps: 4913.61851
+  tps: 3488.66914
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5801.10955
-  tps: 4118.78778
+  dps: 5805.9521
+  tps: 4122.22599
  }
 }
 dps_results: {
@@ -1007,15 +1007,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2439.87391
-  tps: 1732.31048
+  dps: 2436.90762
+  tps: 1730.20441
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2589.8529
-  tps: 1838.79556
+  dps: 2590.97264
+  tps: 1839.59057
  }
 }
 dps_results: {
@@ -1028,15 +1028,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6638.734
-  tps: 4713.50114
+  dps: 6637.2518
+  tps: 4712.44878
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7855.60965
-  tps: 5577.48285
+  dps: 7860.24542
+  tps: 5580.77425
  }
 }
 dps_results: {
@@ -1049,15 +1049,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3281.87607
-  tps: 2330.13201
+  dps: 3279.83471
+  tps: 2328.68265
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3432.86787
-  tps: 2437.33619
+  dps: 3433.53807
+  tps: 2437.81203
  }
 }
 dps_results: {
@@ -1070,15 +1070,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6334.98616
-  tps: 4497.84017
+  dps: 6330.88035
+  tps: 4494.92505
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7430.40416
-  tps: 5275.58695
+  dps: 7435.20725
+  tps: 5278.99715
  }
 }
 dps_results: {
@@ -1091,15 +1091,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3127.40735
-  tps: 2220.45922
+  dps: 3125.18976
+  tps: 2218.88473
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3243.73301
-  tps: 2303.05044
+  dps: 3243.2049
+  tps: 2302.67548
  }
 }
 dps_results: {
@@ -1112,15 +1112,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5684.24805
-  tps: 4035.81611
+  dps: 5683.7737
+  tps: 4035.47933
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6870.62619
-  tps: 4878.14459
+  dps: 6873.71968
+  tps: 4880.34097
  }
 }
 dps_results: {
@@ -1133,21 +1133,21 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2650.97581
-  tps: 1882.19283
+  dps: 2649.71276
+  tps: 1881.29606
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2843.70961
-  tps: 2019.03382
+  dps: 2845.57743
+  tps: 2020.35997
  }
 }
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6348.53495
-  tps: 4507.45981
+  dps: 6351.13966
+  tps: 4509.30916
  }
 }

--- a/sim/rogue/TestSubtlety.results
+++ b/sim/rogue/TestSubtlety.results
@@ -81,15 +81,15 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 8034.73651
-  tps: 72791.40175
+  dps: 8035.29044
+  tps: 74729.97734
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 8034.73651
-  tps: 72791.40175
+  dps: 8035.29044
+  tps: 74729.97734
  }
 }
 dps_results: {
@@ -776,8 +776,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15943.468
-  tps: 11318.4378
+  dps: 31169.71376
+  tps: 22130.49677
  }
 }
 dps_results: {
@@ -797,8 +797,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8800.94176
-  tps: 6246.29678
+  dps: 19171.32445
+  tps: 13611.64036
  }
 }
 dps_results: {
@@ -818,8 +818,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15751.56164
-  tps: 11179.26868
+  dps: 30902.69424
+  tps: 21940.91291
  }
 }
 dps_results: {
@@ -839,8 +839,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8220.44804
-  tps: 5833.6891
+  dps: 18961.89284
+  tps: 13462.94392
  }
 }
 dps_results: {

--- a/sim/rogue/TestSubtlety.results
+++ b/sim/rogue/TestSubtlety.results
@@ -46,821 +46,821 @@ character_stats_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 8057.21939
-  tps: 5715.66998
+  dps: 8057.36562
+  tps: 5715.7738
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8279.39663
-  tps: 5876.9513
+  dps: 8279.69255
+  tps: 5877.16141
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 8035.29044
-  tps: 74729.97734
+  dps: 8035.49818
+  tps: 74730.12483
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 8035.29044
-  tps: 74729.97734
+  dps: 8035.49818
+  tps: 74730.12483
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8322.66915
-  tps: 5907.11621
+  dps: 8322.88244
+  tps: 5907.26765
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlackBruise-50035"
  value: {
-  dps: 8269.70688
-  tps: 5867.81469
+  dps: 8269.62115
+  tps: 5867.75382
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlackBruise-50692"
  value: {
-  dps: 8367.03522
-  tps: 5936.9149
+  dps: 8366.89474
+  tps: 5936.81516
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6004.9972
-  tps: 4261.54925
+  dps: 6005.17912
+  tps: 4261.67841
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BonescytheBattlegear"
  value: {
-  dps: 7096.67356
-  tps: 5034.49752
+  dps: 7096.7796
+  tps: 5034.57281
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5745.9772
+  dps: 8261.76312
+  tps: 5745.96178
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8474.7267
-  tps: 6015.02042
+  dps: 8474.93999
+  tps: 6015.17185
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
   hps: 64
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 8188.19601
-  tps: 5810.51642
+  dps: 8188.02111
+  tps: 5810.39223
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 8236.93665
-  tps: 5845.16946
+  dps: 8237.2577
+  tps: 5845.3974
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 8210.75638
-  tps: 5825.58294
+  dps: 8211.34643
+  tps: 5826.00187
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8628.05413
-  tps: 6123.43669
+  dps: 8629.27676
+  tps: 6124.30476
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 8189.61325
-  tps: 5812.72332
+  dps: 8190.07852
+  tps: 5813.05366
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8522.36927
-  tps: 6048.56226
+  dps: 8523.07486
+  tps: 6049.06323
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8588.26711
-  tps: 6095.53018
+  dps: 8589.24175
+  tps: 6096.22218
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Defender'sCode-40257"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8324.84588
-  tps: 5908.55335
+  dps: 8324.89704
+  tps: 5908.58968
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 8235.61787
-  tps: 5842.38255
+  dps: 8235.88133
+  tps: 5842.5696
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 8224.47681
-  tps: 5838.08183
+  dps: 8224.64072
+  tps: 5838.1982
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8322.66915
-  tps: 5907.11621
+  dps: 8322.88244
+  tps: 5907.26765
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8316.7563
-  tps: 5901.96802
+  dps: 8316.91955
+  tps: 5902.08392
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 8199.97947
-  tps: 5820.16151
+  dps: 8199.99716
+  tps: 5820.17408
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 8253.32978
-  tps: 5858.0357
+  dps: 8253.46401
+  tps: 5858.131
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 8185.34284
-  tps: 5808.07243
+  dps: 8185.47363
+  tps: 5808.16529
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForgeEmber-37660"
  value: {
-  dps: 8153.36839
-  tps: 5786.97246
+  dps: 8153.57674
+  tps: 5787.12039
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8297.66033
-  tps: 5886.63855
+  dps: 8297.83394
+  tps: 5886.76181
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FuturesightRune-38763"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7483.70635
-  tps: 5310.20459
+  dps: 7483.84854
+  tps: 5310.30554
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 8227.09304
-  tps: 5838.57527
+  dps: 8227.37204
+  tps: 5838.77336
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Heartpierce-49982"
  value: {
-  dps: 8454.04731
-  tps: 5999.56218
+  dps: 8454.06774
+  tps: 5999.57668
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Heartpierce-50641"
  value: {
-  dps: 8454.04731
-  tps: 5999.56218
+  dps: 8454.06774
+  tps: 5999.57668
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8322.66915
-  tps: 5907.11621
+  dps: 8322.88244
+  tps: 5907.26765
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8316.7563
-  tps: 5901.96802
+  dps: 8316.91955
+  tps: 5902.08392
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8237.69813
-  tps: 5844.1346
+  dps: 8237.90827
+  tps: 5844.28379
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8297.8089
-  tps: 5888.80865
+  dps: 8297.78735
+  tps: 5888.79335
   hps: 10.24843
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8284.53878
-  tps: 5880.84899
+  dps: 8284.91227
+  tps: 5881.11417
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 8084.68807
-  tps: 5738.44283
+  dps: 8085.00956
+  tps: 5738.67109
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8290.94726
-  tps: 5883.93882
+  dps: 8290.92559
+  tps: 5883.92344
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8297.8089
-  tps: 5888.80865
+  dps: 8297.78735
+  tps: 5888.79335
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 8212.0707
-  tps: 5830.1024
+  dps: 8212.12797
+  tps: 5830.14307
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 8232.5585
-  tps: 5844.64874
+  dps: 8232.61577
+  tps: 5844.6894
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8454.04731
-  tps: 5999.56218
+  dps: 8454.06774
+  tps: 5999.57668
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7813.99831
-  tps: 5546.46972
+  dps: 7813.84533
+  tps: 5546.3611
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Slayer'sArmor"
  value: {
-  dps: 5459.79046
-  tps: 3874.32853
+  dps: 5459.85722
+  tps: 3874.37594
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SouloftheDead-40382"
  value: {
-  dps: 8181.83328
-  tps: 5805.58063
+  dps: 8181.9152
+  tps: 5805.6388
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SparkofLife-37657"
  value: {
-  dps: 8130.60358
-  tps: 5770.44507
+  dps: 8131.0433
+  tps: 5770.75727
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 8274.59129
-  tps: 5870.46695
+  dps: 8274.77948
+  tps: 5870.60057
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-StormshroudArmor"
  value: {
-  dps: 6182.9608
-  tps: 4387.20152
+  dps: 6183.09079
+  tps: 4387.29381
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8297.8089
-  tps: 5888.80865
+  dps: 8297.78735
+  tps: 5888.79335
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8290.94726
-  tps: 5883.93882
+  dps: 8290.92559
+  tps: 5883.92344
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8278.93939
-  tps: 5875.41662
+  dps: 8278.91752
+  tps: 5875.40109
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 7601.15689
-  tps: 5394.04978
+  dps: 7600.75076
+  tps: 5393.76142
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TheFistsofFury"
  value: {
-  dps: 7154.48183
-  tps: 5077.7134
+  dps: 7154.67026
+  tps: 5077.84718
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8333.75862
-  tps: 5913.93035
+  dps: 8334.3629
+  tps: 5914.35939
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 8515.70985
-  tps: 6045.25607
+  dps: 8515.69418
+  tps: 6045.24495
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8569.87177
-  tps: 6084.12676
+  dps: 8570.48789
+  tps: 6084.56421
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 8125.48008
-  tps: 5764.01109
+  dps: 8125.92317
+  tps: 5764.32568
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6344.5897
-  tps: 4504.58018
+  dps: 6344.76232
+  tps: 4504.70274
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 7367.83492
-  tps: 5228.52305
+  dps: 7367.92421
+  tps: 5228.58645
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-WingedTalisman-37844"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-Average-Default"
  value: {
-  dps: 8502.84674
-  tps: 6034.39867
+  dps: 8502.90599
+  tps: 6034.44073
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31169.71376
-  tps: 22130.49677
+  dps: 31218.16635
+  tps: 22164.89811
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8454.04731
-  tps: 5999.56218
+  dps: 8454.06774
+  tps: 5999.57668
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9819.30433
-  tps: 6955.28461
+  dps: 9821.35525
+  tps: 6956.74076
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 19171.32445
-  tps: 13611.64036
+  dps: 19204.58632
+  tps: 13635.25629
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4193.89089
-  tps: 2975.15135
+  dps: 4194.03777
+  tps: 2975.25563
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4409.11313
-  tps: 3117.90465
+  dps: 4411.5374
+  tps: 3119.62587
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30902.69424
-  tps: 21940.91291
+  dps: 30990.84554
+  tps: 22003.50033
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8460.24996
-  tps: 6004.14242
+  dps: 8460.63724
+  tps: 6004.41739
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9910.6172
-  tps: 7022.7359
+  dps: 9912.79565
+  tps: 7024.28261
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 18961.89284
-  tps: 13462.94392
+  dps: 18986.91332
+  tps: 13480.70846
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4187.31084
-  tps: 2970.74131
+  dps: 4187.52126
+  tps: 2970.89071
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4410.7093
-  tps: 3125.04097
+  dps: 4412.80719
+  tps: 3126.53048
  }
 }
 dps_results: {
  key: "TestSubtlety-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3217.74551
-  tps: 2284.59931
+  dps: 3217.60828
+  tps: 2284.50188
  }
 }

--- a/sim/rogue/backstab.go
+++ b/sim/rogue/backstab.go
@@ -54,12 +54,10 @@ func (rogue *Rogue) registerBackstabSpell() {
 
 			if result.Landed() {
 				rogue.AddComboPoints(sim, 1, spell.ComboPointMetrics())
-				// FIXME: Extension of a Rupture Dot can occur up to 3 times
-				ruptureDot := rogue.Rupture.Dot(target)
-				if hasGlyph && ruptureDot.IsActive() {
-					ruptureDot.NumberOfTicks += 1
-					ruptureDot.RecomputeAuraDuration()
-					ruptureDot.UpdateExpires(ruptureDot.ExpiresAt() + ruptureDot.TickLength)
+				if dot := rogue.Rupture.Dot(target); hasGlyph && dot.IsActive() && dot.NumberOfTicks < dot.MaxStacks+3 {
+					dot.NumberOfTicks += 1
+					dot.RecomputeAuraDuration()
+					dot.UpdateExpires(dot.ExpiresAt() + dot.TickLength)
 				}
 			} else {
 				spell.IssueRefund(sim)

--- a/sim/rogue/fan_of_knives.go
+++ b/sim/rogue/fan_of_knives.go
@@ -13,10 +13,10 @@ func (rogue *Rogue) makeFanOfKnivesWeaponHitSpell(isMH bool) *core.Spell {
 	var procMask core.ProcMask
 	var weaponMultiplier float64
 	if isMH {
-		weaponMultiplier = core.TernaryFloat64(rogue.Equip[proto.ItemSlot_ItemSlotMainHand].WeaponType == proto.WeaponType_WeaponTypeDagger, 1.05, 0.7)
+		weaponMultiplier = core.TernaryFloat64(rogue.HasDagger(core.MainHand), 1.05, 0.7)
 		procMask = core.ProcMaskMeleeMHSpecial
 	} else {
-		weaponMultiplier = core.TernaryFloat64(rogue.Equip[proto.ItemSlot_ItemSlotOffHand].WeaponType == proto.WeaponType_WeaponTypeDagger, 1.05, 0.7)
+		weaponMultiplier = core.TernaryFloat64(rogue.HasDagger(core.OffHand), 1.05, 0.7)
 		weaponMultiplier *= rogue.dwsMultiplier()
 		procMask = core.ProcMaskMeleeOHSpecial
 	}

--- a/sim/rogue/generic_rotation.go
+++ b/sim/rogue/generic_rotation.go
@@ -1,0 +1,505 @@
+package rogue
+
+import (
+	"math"
+	"time"
+
+	"github.com/wowsims/wotlk/sim/core"
+	"github.com/wowsims/wotlk/sim/core/proto"
+)
+
+type rogueRotationItem struct {
+	ExpiresAt            time.Duration
+	MinimumBuildDuration time.Duration
+	MaximumBuildDuration time.Duration
+	PrioIndex            int
+}
+
+type roguePriorityItem struct {
+	Aura               *core.Aura
+	CastCount          int32
+	EnergyCost         float64
+	PoolAmount         float64
+	GetDuration        func(*Rogue, int32) time.Duration
+	GetSpell           func(*Rogue, int32) *core.Spell
+	IsFiller           bool
+	MaximumComboPoints int32
+	MaxCasts           int32
+	MinimumComboPoints int32
+}
+
+type shouldCastRotationItemResult int32
+
+const (
+	ShouldNotCast shouldCastRotationItemResult = iota
+	ShouldBuild
+	ShouldCast
+	ShouldWait
+)
+
+type generic_rotation struct {
+	priorityItems []roguePriorityItem
+	rotationItems []rogueRotationItem
+}
+
+func (x *generic_rotation) setup(sim *core.Simulation, rogue *Rogue) {
+	rogue.Builder = rogue.SinisterStrike
+	rogue.BuilderPoints = 1
+
+	if rogue.CanMutilate() {
+		rogue.Builder = rogue.Mutilate
+		rogue.BuilderPoints = 2
+	}
+
+	if rogue.Talents.Hemorrhage {
+		rogue.Builder = rogue.Hemorrhage
+		rogue.BuilderPoints = 1
+	}
+
+	if rogue.Talents.SlaughterFromTheShadows > 0 && !rogue.Rotation.HemoWithDagger && !rogue.PseudoStats.InFrontOfTarget && rogue.HasDagger(core.MainHand) {
+		rogue.Builder = rogue.Backstab
+		rogue.BuilderPoints = 1
+	}
+
+	isMultiTarget := sim.GetNumTargets() >= 3
+
+	// Slice and Dice
+	x.priorityItems = x.priorityItems[:0]
+
+	sliceAndDice := roguePriorityItem{
+		MinimumComboPoints: 1,
+		MaximumComboPoints: 5,
+		Aura:               rogue.SliceAndDiceAura,
+		EnergyCost:         rogue.SliceAndDice.DefaultCast.Cost,
+		GetDuration: func(rogue *Rogue, cp int32) time.Duration {
+			return rogue.sliceAndDiceDurations[cp]
+		},
+		GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
+			return rogue.SliceAndDice
+		},
+	}
+	if isMultiTarget {
+		if rogue.Rotation.MultiTargetSliceFrequency != proto.Rogue_Rotation_Never {
+			sliceAndDice.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsMultiTargetSlice)
+			if rogue.Rotation.MultiTargetSliceFrequency == proto.Rogue_Rotation_Once {
+				sliceAndDice.MaxCasts = 1
+			}
+			x.priorityItems = append(x.priorityItems, sliceAndDice)
+		}
+	} else {
+		x.priorityItems = append(x.priorityItems, sliceAndDice)
+	}
+
+	// Expose Armor
+	if rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Maintain ||
+		rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Once {
+		minPoints := int32(1)
+		maxCasts := int32(0)
+		if rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Once {
+			minPoints = rogue.Rotation.MinimumComboPointsExposeArmor
+			maxCasts = 1
+		}
+		x.priorityItems = append(x.priorityItems, roguePriorityItem{
+			MaxCasts:           maxCasts,
+			MaximumComboPoints: 5,
+			MinimumComboPoints: minPoints,
+			Aura:               rogue.ExposeArmorAuras.Get(rogue.CurrentTarget),
+			EnergyCost:         rogue.ExposeArmor.DefaultCast.Cost,
+			GetDuration: func(rogue *Rogue, cp int32) time.Duration {
+				return rogue.exposeArmorDurations[cp]
+			},
+			GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
+				return rogue.ExposeArmor
+			},
+		})
+	}
+
+	// Hunger for Blood
+	if rogue.Talents.HungerForBlood {
+		x.priorityItems = append(x.priorityItems, roguePriorityItem{
+			MaximumComboPoints: 0,
+			Aura:               rogue.HungerForBloodAura,
+			EnergyCost:         rogue.HungerForBlood.DefaultCast.Cost,
+			GetDuration: func(rogue *Rogue, cp int32) time.Duration {
+				return rogue.HungerForBloodAura.Duration
+			},
+			GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
+				return rogue.HungerForBlood
+			},
+		})
+	}
+
+	// Dummy priority to enable CDs
+	x.priorityItems = append(x.priorityItems, roguePriorityItem{
+		MaxCasts:           1,
+		MaximumComboPoints: 0,
+		GetDuration: func(rogue *Rogue, cp int32) time.Duration {
+			return 0
+		},
+		GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
+			if rogue.allMCDsDisabled {
+				for _, mcd := range rogue.GetMajorCooldowns() {
+					mcd.Enable()
+				}
+				rogue.allMCDsDisabled = false
+			}
+			return nil
+		},
+	})
+
+	// Rupture
+	rupture := roguePriorityItem{
+		MinimumComboPoints: 3,
+		MaximumComboPoints: 5,
+		Aura:               rogue.Rupture.CurDot().Aura,
+		EnergyCost:         rogue.Rupture.DefaultCast.Cost,
+		GetDuration: func(rogue *Rogue, cp int32) time.Duration {
+			return rogue.RuptureDuration(cp)
+		},
+		GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
+			return rogue.Rupture
+		},
+	}
+
+	// Eviscerate
+	eviscerate := roguePriorityItem{
+		MinimumComboPoints: 1,
+		MaximumComboPoints: 5,
+		EnergyCost:         rogue.Eviscerate.DefaultCast.Cost,
+		GetDuration: func(rogue *Rogue, cp int32) time.Duration {
+			return 0
+		},
+		GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
+			return rogue.Eviscerate
+		},
+	}
+
+	if isMultiTarget {
+		x.priorityItems = append(x.priorityItems, roguePriorityItem{
+			MaximumComboPoints: 0,
+			EnergyCost:         rogue.FanOfKnives.DefaultCast.Cost,
+			GetSpell: func(rogue *Rogue, i int32) *core.Spell {
+				return rogue.FanOfKnives
+			},
+		})
+
+	} else if rogue.Talents.MasterPoisoner > 0 || rogue.Talents.CutToTheChase > 0 {
+		// Envenom
+		envenom := roguePriorityItem{
+			MinimumComboPoints: 1,
+			MaximumComboPoints: 5,
+			Aura:               rogue.EnvenomAura,
+			EnergyCost:         rogue.Envenom.DefaultCast.Cost,
+			GetDuration: func(rogue *Rogue, cp int32) time.Duration {
+				return rogue.EnvenomAura.Duration
+			},
+			GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
+				return rogue.Envenom
+			},
+		}
+		switch rogue.Rotation.AssassinationFinisherPriority {
+		case proto.Rogue_Rotation_EnvenomRupture:
+			envenom.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
+			x.priorityItems = append(x.priorityItems, envenom)
+			rupture.MinimumComboPoints = rogue.Rotation.MinimumComboPointsSecondaryFinisher
+			rupture.IsFiller = true
+			if rupture.MinimumComboPoints > 0 && rupture.MinimumComboPoints <= 5 {
+				x.priorityItems = append(x.priorityItems, rupture)
+			}
+		case proto.Rogue_Rotation_RuptureEnvenom:
+			rupture.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
+			x.priorityItems = append(x.priorityItems, rupture)
+			envenom.MinimumComboPoints = rogue.Rotation.MinimumComboPointsSecondaryFinisher
+			envenom.IsFiller = true
+			if envenom.MinimumComboPoints > 0 && envenom.MinimumComboPoints <= 5 {
+				x.priorityItems = append(x.priorityItems, envenom)
+			}
+		}
+		eviscerate.IsFiller = true
+		eviscerate.MinimumComboPoints = 1
+		x.priorityItems = append(x.priorityItems, eviscerate)
+	} else {
+		if rogue.PrimaryTalentTree == CombatTree {
+			switch rogue.Rotation.CombatFinisherPriority {
+			case proto.Rogue_Rotation_RuptureEviscerate:
+				rupture.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
+				x.priorityItems = append(x.priorityItems, rupture)
+				eviscerate.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsSecondaryFinisher)
+				eviscerate.IsFiller = true
+				x.priorityItems = append(x.priorityItems, eviscerate)
+			case proto.Rogue_Rotation_EviscerateRupture:
+				eviscerate.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
+				x.priorityItems = append(x.priorityItems, eviscerate)
+				rupture.MinimumComboPoints = rogue.Rotation.MinimumComboPointsSecondaryFinisher
+				rupture.IsFiller = true
+				if rupture.MinimumComboPoints > 0 && rupture.MinimumComboPoints <= 5 {
+					x.priorityItems = append(x.priorityItems, rupture)
+				}
+			}
+		} else {
+			switch rogue.Rotation.SubtletyFinisherPriority {
+			case proto.Rogue_Rotation_SubtletyEviscerate:
+				rupture.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
+				x.priorityItems = append(x.priorityItems, rupture)
+				eviscerate.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsSecondaryFinisher)
+				eviscerate.IsFiller = true
+				x.priorityItems = append(x.priorityItems, eviscerate)
+			case proto.Rogue_Rotation_SubtletyEnvenom:
+				eviscerate.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
+				x.priorityItems = append(x.priorityItems, eviscerate)
+				rupture.MinimumComboPoints = rogue.Rotation.MinimumComboPointsSecondaryFinisher
+				rupture.IsFiller = true
+				if rupture.MinimumComboPoints > 0 && rupture.MinimumComboPoints <= 5 {
+					x.priorityItems = append(x.priorityItems, rupture)
+				}
+			}
+		}
+	}
+	x.rotationItems = x.planRotation(sim, rogue)
+}
+
+func (x *generic_rotation) run(sim *core.Simulation, rogue *Rogue) {
+	if rogue.KillingSpreeAura.IsActive() {
+		rogue.DoNothing()
+		return
+	}
+
+	if len(x.rotationItems) < 1 {
+		panic("Rotation is empty")
+	}
+	eps := rogue.getExpectedEnergyPerSecond()
+	shouldCast := x.shouldCastNextRotationItem(sim, rogue, eps)
+	item := x.rotationItems[0]
+	prio := x.priorityItems[item.PrioIndex]
+
+	switch shouldCast {
+	case ShouldNotCast:
+		x.rotationItems = x.rotationItems[1:]
+		x.run(sim, rogue)
+	case ShouldBuild:
+		spell := rogue.Builder
+		if spell == nil || spell.Cast(sim, rogue.CurrentTarget) {
+			if rogue.GCD.IsReady(sim) {
+				x.run(sim, rogue)
+			}
+		} else {
+			panic("Unexpected builder cast failure")
+		}
+	case ShouldCast:
+		spell := prio.GetSpell(rogue, rogue.ComboPoints())
+		if spell == nil || spell.Cast(sim, rogue.CurrentTarget) {
+			x.priorityItems[item.PrioIndex].CastCount += 1
+			x.rotationItems = x.planRotation(sim, rogue)
+			if rogue.GCD.IsReady(sim) {
+				x.run(sim, rogue)
+			}
+		} else {
+			panic("Unexpected cast failure")
+		}
+	case ShouldWait:
+		desiredEnergy := 100.0
+		if rogue.ComboPoints() == 5 {
+			desiredEnergy = prio.EnergyCost
+		} else {
+			if rogue.CurrentEnergy() < prio.EnergyCost && rogue.ComboPoints() >= prio.MinimumComboPoints {
+				desiredEnergy = prio.EnergyCost
+			} else if rogue.ComboPoints() < 5 {
+				desiredEnergy = rogue.Builder.DefaultCast.Cost
+			}
+		}
+		cdAvailableTime := time.Second * 10
+		if sim.CurrentTime > cdAvailableTime {
+			cdAvailableTime = core.NeverExpires
+		}
+		nextExpiration := cdAvailableTime
+		for _, otherItem := range x.rotationItems {
+			if otherItem.ExpiresAt < nextExpiration {
+				nextExpiration = otherItem.ExpiresAt
+			}
+		}
+		neededEnergy := desiredEnergy - rogue.CurrentEnergy()
+		energyAvailableTime := time.Second*time.Duration(neededEnergy/eps) + 1*time.Second
+		energyAt := sim.CurrentTime + energyAvailableTime
+		if energyAt < nextExpiration {
+			rogue.WaitForEnergy(sim, desiredEnergy)
+		} else if nextExpiration > sim.CurrentTime {
+			rogue.WaitUntil(sim, nextExpiration)
+		} else {
+			rogue.DoNothing()
+		}
+	}
+}
+
+func (x *generic_rotation) energyToBuild(rogue *Rogue, points int32) float64 {
+	costPerBuilder := rogue.Builder.DefaultCast.Cost
+
+	buildersNeeded := math.Ceil(float64(points) / float64(rogue.BuilderPoints))
+	return buildersNeeded * costPerBuilder
+}
+
+func (x *generic_rotation) timeToBuild(_ *core.Simulation, rogue *Rogue, points int32, builderPoints int32, eps float64, finisherCost float64) time.Duration {
+	energyNeeded := x.energyToBuild(rogue, points) + finisherCost
+	secondsNeeded := energyNeeded / eps
+	globalsNeeded := math.Ceil(float64(points)/float64(builderPoints)) + 1
+	// Return greater of the time it takes to use the globals and the time it takes to build the energy
+	return core.MaxDuration(time.Second*time.Duration(secondsNeeded), time.Second*time.Duration(globalsNeeded))
+}
+
+func (x *generic_rotation) shouldCastNextRotationItem(sim *core.Simulation, rogue *Rogue, eps float64) shouldCastRotationItemResult {
+	if len(x.rotationItems) == 0 {
+		panic("Empty rotation")
+	}
+	currentEnergy := rogue.CurrentEnergy()
+	comboPoints := rogue.ComboPoints()
+	currentTime := sim.CurrentTime
+	item := x.rotationItems[0]
+	prio := x.priorityItems[item.PrioIndex]
+	tte := item.ExpiresAt - currentTime
+	clippingThreshold := time.Second * 2
+	timeUntilNextGCD := rogue.GCD.TimeToReady(sim)
+
+	// Check to see if a higher prio item will expire
+	if len(x.rotationItems) >= 2 {
+		timeElapsed := time.Second * 1
+		for _, nextItem := range x.rotationItems[1:] {
+			if nextItem.ExpiresAt <= currentTime+timeElapsed {
+				return ShouldNotCast
+			}
+			timeElapsed += nextItem.MinimumBuildDuration
+		}
+	}
+
+	// Expires before next GCD
+	if tte <= timeUntilNextGCD {
+		if comboPoints >= prio.MinimumComboPoints && currentEnergy >= (prio.EnergyCost+prio.PoolAmount) {
+			return ShouldCast
+		} else if comboPoints < prio.MinimumComboPoints && currentEnergy >= rogue.Builder.DefaultCast.Cost {
+			return ShouldBuild
+		} else {
+			return ShouldWait
+		}
+	}
+	if comboPoints >= prio.MaximumComboPoints { // Don't need CP
+		// Cast
+		if tte <= clippingThreshold && currentEnergy >= (prio.EnergyCost+prio.PoolAmount) {
+			return ShouldCast
+		}
+		// Pool energy
+		if tte <= clippingThreshold && currentEnergy < (prio.EnergyCost+prio.PoolAmount) {
+			return ShouldWait
+		}
+		// We have time to squeeze in another spell
+		if tte > item.MinimumBuildDuration {
+			// Find the first lower prio item that can be cast and use it
+			for lpi, lowerPrio := range x.priorityItems[item.PrioIndex+1:] {
+				if comboPoints > lowerPrio.MinimumComboPoints && currentEnergy > lowerPrio.EnergyCost && lowerPrio.MaxCasts == 0 {
+					x.rotationItems = append([]rogueRotationItem{
+						{ExpiresAt: currentTime, PrioIndex: lpi + item.PrioIndex + 1},
+					}, x.rotationItems...)
+					return ShouldCast
+				}
+			}
+		}
+		// Overcap CP with builder
+		if x.timeToBuild(sim, rogue, 1, rogue.BuilderPoints, eps, prio.EnergyCost+prio.PoolAmount) <= tte && currentEnergy >= rogue.Builder.DefaultCast.Cost {
+			return ShouldBuild
+		}
+	} else if comboPoints < prio.MinimumComboPoints { // Need CP
+		if currentEnergy >= rogue.Builder.DefaultCast.Cost {
+			return ShouldBuild
+		} else {
+			return ShouldWait
+		}
+	} else { // Between MinimumComboPoints and MaximumComboPoints
+		if currentEnergy >= prio.EnergyCost+prio.PoolAmount && tte <= timeUntilNextGCD {
+			return ShouldCast
+		}
+		ttb := x.timeToBuild(sim, rogue, 1, 2, eps, prio.EnergyCost+prio.PoolAmount-currentEnergy)
+		if currentEnergy >= rogue.Builder.DefaultCast.Cost && tte > ttb {
+			return ShouldBuild
+		}
+	}
+	return ShouldWait
+}
+
+func (x *generic_rotation) planRotation(sim *core.Simulation, rogue *Rogue) []rogueRotationItem {
+	var rotationItems []rogueRotationItem
+	eps := rogue.getExpectedEnergyPerSecond()
+	for pi, prio := range x.priorityItems {
+		if prio.MaxCasts > 0 && prio.CastCount >= prio.MaxCasts {
+			continue
+		}
+		maxCP := prio.MaximumComboPoints
+		for maxCP > 0 && prio.GetDuration(rogue, maxCP)+sim.CurrentTime > sim.Duration {
+			maxCP--
+		}
+		var expiresAt time.Duration
+		if prio.Aura != nil {
+			expiresAt = prio.Aura.ExpiresAt()
+		} else if prio.MaxCasts == 1 {
+			expiresAt = sim.CurrentTime // TODO looks fishy, repeated expiresAt = sim.CurrentTime
+		} else {
+			expiresAt = sim.CurrentTime
+		}
+		minimumBuildDuration := x.timeToBuild(sim, rogue, prio.MinimumComboPoints, rogue.BuilderPoints, eps, prio.EnergyCost)
+		maximumBuildDuration := x.timeToBuild(sim, rogue, maxCP, rogue.BuilderPoints, eps, prio.EnergyCost)
+		rotationItems = append(rotationItems, rogueRotationItem{
+			ExpiresAt:            expiresAt,
+			MaximumBuildDuration: maximumBuildDuration,
+			MinimumBuildDuration: minimumBuildDuration,
+			PrioIndex:            pi,
+		})
+	}
+
+	currentTime := sim.CurrentTime
+	comboPoints := rogue.ComboPoints()
+	currentEnergy := rogue.CurrentEnergy()
+
+	var prioStack []rogueRotationItem
+	for _, item := range rotationItems {
+		if item.ExpiresAt >= sim.Duration {
+			continue
+		}
+		prio := x.priorityItems[item.PrioIndex]
+		maxBuildAt := item.ExpiresAt - item.MaximumBuildDuration
+		if prio.Aura == nil {
+			timeValueOfResources := time.Duration((float64(comboPoints)*rogue.Builder.DefaultCast.Cost/float64(rogue.BuilderPoints) + currentEnergy) / eps)
+			maxBuildAt = currentTime - item.MaximumBuildDuration - timeValueOfResources
+		}
+		if currentTime < maxBuildAt {
+			// Put it on the to cast stack
+			prioStack = append(prioStack, item)
+			if prio.MinimumComboPoints > 0 {
+				comboPoints = 0
+			}
+			currentTime += item.MaximumBuildDuration
+		} else {
+			cpUsed := core.MaxInt32(0, prio.MinimumComboPoints-comboPoints)
+			energyUsed := core.MaxFloat(0, prio.EnergyCost-currentEnergy)
+			minBuildTime := x.timeToBuild(sim, rogue, cpUsed, rogue.BuilderPoints, eps, energyUsed)
+			if currentTime+minBuildTime <= item.ExpiresAt || !prio.IsFiller {
+				prioStack = append(prioStack, item)
+				currentTime = core.MaxDuration(item.ExpiresAt, currentTime+minBuildTime)
+				currentEnergy = 0
+				if prio.MinimumComboPoints > 0 {
+					comboPoints = 0
+				}
+			} else if len(prioStack) < 1 || (prio.Aura != nil && !prio.Aura.IsActive() && !prio.IsFiller) || prio.MaxCasts == 1 {
+				// Plan to cast it as soon as possible
+				prioStack = append(prioStack, item)
+				currentTime += item.MinimumBuildDuration
+				currentEnergy = 0
+				if prio.MinimumComboPoints > 0 {
+					comboPoints = 0
+				}
+			}
+		}
+	}
+
+	// Reverse
+	for i, j := 0, len(prioStack)-1; i < j; i, j = i+1, j-1 {
+		prioStack[i], prioStack[j] = prioStack[j], prioStack[i]
+	}
+
+	return prioStack
+}

--- a/sim/rogue/ghostly_strike.go
+++ b/sim/rogue/ghostly_strike.go
@@ -15,7 +15,6 @@ func (rogue *Rogue) registerGhostlyStrikeSpell() {
 	hasGlyph := rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfGhostlyStrike)
 
 	actionID := core.ActionID{SpellID: 14278}
-	daggerMH := rogue.Equip[proto.ItemSlot_ItemSlotMainHand].WeaponType == proto.WeaponType_WeaponTypeDagger
 
 	rogue.GhostlyStrike = rogue.RegisterSpell(core.SpellConfig{
 		ActionID:    actionID,
@@ -41,7 +40,7 @@ func (rogue *Rogue) registerGhostlyStrikeSpell() {
 		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0) +
 			[]float64{0, 2, 4, 6}[rogue.Talents.TurnTheTables]*core.CritRatingPerCritChance,
 
-		DamageMultiplier: (core.TernaryFloat64(daggerMH, 1.8, 1.25) + core.TernaryFloat64(hasGlyph, 0.4, 0)) * (1 + 0.02*float64(rogue.Talents.FindWeakness)),
+		DamageMultiplier: core.TernaryFloat64(rogue.HasDagger(core.MainHand), 1.8, 1.25) * core.TernaryFloat64(hasGlyph, 1.4, 1) * (1 + 0.02*float64(rogue.Talents.FindWeakness)),
 		CritMultiplier:   rogue.MeleeCritMultiplier(true),
 		ThreatMultiplier: 1,
 

--- a/sim/rogue/hemorrhage.go
+++ b/sim/rogue/hemorrhage.go
@@ -51,7 +51,6 @@ func (rogue *Rogue) registerHemorrhageSpell() {
 		})
 	}
 
-	daggerMH := rogue.Equip[proto.ItemSlot_ItemSlotMainHand].WeaponType == proto.WeaponType_WeaponTypeDagger
 	rogue.Hemorrhage = rogue.RegisterSpell(core.SpellConfig{
 		ActionID:    actionID,
 		SpellSchool: core.SpellSchoolPhysical,
@@ -72,7 +71,7 @@ func (rogue *Rogue) registerHemorrhageSpell() {
 		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0) +
 			[]float64{0, 2, 4, 6}[rogue.Talents.TurnTheTables]*core.CritRatingPerCritChance,
 
-		DamageMultiplier: core.TernaryFloat64(daggerMH, 1.6, 1.1) * (1 +
+		DamageMultiplier: core.TernaryFloat64(rogue.HasDagger(core.MainHand), 1.6, 1.1) * (1 +
 			0.02*float64(rogue.Talents.FindWeakness) +
 			core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0)) *
 			(1 + 0.02*float64(rogue.Talents.SinisterCalling)),

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -7,9 +7,6 @@ import (
 	"github.com/wowsims/wotlk/sim/core/proto"
 )
 
-var MHOutcome = core.OutcomeHit
-var OHOutcome = core.OutcomeHit
-
 var MutilateSpellID int32 = 48666
 
 func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
@@ -24,7 +21,7 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 		ActionID:    actionID,
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    procMask,
-		Flags:       core.SpellFlagMeleeMetrics | SpellFlagColdBlooded,
+		Flags:       core.SpellFlagMeleeMetrics | SpellFlagBuilder | SpellFlagColdBlooded,
 
 		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0) +
 			[]float64{0, 2, 4, 6}[rogue.Talents.TurnTheTables]*core.CritRatingPerCritChance +
@@ -51,13 +48,7 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 				baseDamage *= 1.2
 			}
 
-			result := spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialCritOnly)
-
-			if isMH {
-				MHOutcome = result.Outcome
-			} else {
-				OHOutcome = result.Outcome
-			}
+			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialCritOnly)
 		},
 	})
 }
@@ -70,7 +61,7 @@ func (rogue *Rogue) registerMutilateSpell() {
 		ActionID:    core.ActionID{SpellID: MutilateSpellID},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
-		Flags:       core.SpellFlagMeleeMetrics | SpellFlagBuilder,
+		Flags:       core.SpellFlagMeleeMetrics,
 
 		EnergyCost: core.EnergyCostOptions{
 			Cost:   rogue.costModifier(60 - core.TernaryFloat64(rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfMutilate), 5, 0)),
@@ -91,9 +82,6 @@ func (rogue *Rogue) registerMutilateSpell() {
 				rogue.AddComboPoints(sim, 2, spell.ComboPointMetrics())
 				ohHitSpell.Cast(sim, target)
 				mhHitSpell.Cast(sim, target)
-				if MHOutcome == core.OutcomeCrit || OHOutcome == core.OutcomeCrit {
-					result.Outcome = core.OutcomeCrit
-				}
 			} else {
 				spell.IssueRefund(sim)
 			}

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -29,10 +29,6 @@ const (
 	SpellFlagBuilder     = core.SpellFlagAgentReserved2
 	SpellFlagFinisher    = core.SpellFlagAgentReserved3
 	SpellFlagColdBlooded = core.SpellFlagAgentReserved4
-
-	AssassinationTree = 0
-	CombatTree        = 1
-	SubtletyTree      = 2
 )
 
 var TalentTreeSizes = [3]int{27, 28, 28}
@@ -57,8 +53,6 @@ type Rogue struct {
 
 	maxEnergy float64
 
-	BuilderPoints    int32
-	Builder          *core.Spell
 	Backstab         *core.Spell
 	BladeFlurry      *core.Spell
 	DeadlyPoison     *core.Spell

--- a/sim/rogue/rotation.go
+++ b/sim/rogue/rotation.go
@@ -1,531 +1,61 @@
 package rogue
 
 import (
-	"math"
-	"time"
-
 	"github.com/wowsims/wotlk/sim/core"
-	"github.com/wowsims/wotlk/sim/core/proto"
 )
 
+type rotation interface {
+	setup(sim *core.Simulation, rogue *Rogue)
+	run(sim *core.Simulation, rogue *Rogue)
+}
+
+type PriorityAction int32
+
+const (
+	Skip PriorityAction = iota
+	Build
+	Cast
+	Wait
+)
+
+type GetAction func(*core.Simulation, *Rogue) PriorityAction
+type DoAction func(*core.Simulation, *Rogue) bool
+
+type prio struct {
+	check GetAction
+	cast  DoAction
+	cost  float64
+}
+
 func (rogue *Rogue) OnEnergyGain(sim *core.Simulation) {
-	if rogue.Talents.Mutilate && sim.GetNumTargets() <= 3 {
-		rogue.OnCanAct(sim)
-		return
-	}
-	if rogue.KillingSpreeAura.IsActive() {
-		rogue.DoNothing()
-		return
-	}
 	rogue.TryUseCooldowns(sim)
-	if rogue.GCD.IsReady(sim) {
-		if rogue.Talents.HonorAmongThieves > 0 {
-			rogue.doSubtletyRotation(sim)
-		} else {
-			rogue.rotation(sim)
-		}
+
+	if !rogue.GCD.IsReady(sim) {
+		return
 	}
+
+	rogue.rotation.run(sim, rogue)
 }
 
 func (rogue *Rogue) OnGCDReady(sim *core.Simulation) {
-	if rogue.Talents.Mutilate && sim.GetNumTargets() <= 3 {
-		rogue.OnCanAct(sim)
-		return
-	}
-	if rogue.Talents.HonorAmongThieves > 0 && sim.GetNumTargets() <= 3 {
-		rogue.OnCanActSubtlety(sim)
-		return
-	}
-	if rogue.KillingSpreeAura.IsActive() {
-		rogue.DoNothing()
-		return
-	}
 	rogue.TryUseCooldowns(sim)
+
 	if rogue.IsWaitingForEnergy() {
 		rogue.DoNothing()
 		return
 	}
-	if rogue.GCD.IsReady(sim) {
-		rogue.rotation(sim)
-	}
+
+	rogue.rotation.run(sim, rogue)
 }
 
-type rogueRotationItem struct {
-	ExpiresAt            time.Duration
-	MinimumBuildDuration time.Duration
-	MaximumBuildDuration time.Duration
-	PrioIndex            int
-}
-
-type roguePriorityItem struct {
-	Aura               *core.Aura
-	CastCount          int32
-	EnergyCost         float64
-	PoolAmount         float64
-	GetDuration        func(*Rogue, int32) time.Duration
-	GetSpell           func(*Rogue, int32) *core.Spell
-	IsFiller           bool
-	MaximumComboPoints int32
-	MaxCasts           int32
-	MinimumComboPoints int32
-}
-
-type shouldCastRotationItemResult int32
-
-const (
-	ShouldNotCast shouldCastRotationItemResult = iota
-	ShouldBuild
-	ShouldCast
-	ShouldWait
-)
-
-func (rogue *Rogue) energyToBuild(points int32) float64 {
-	costPerBuilder := rogue.Builder.DefaultCast.Cost
-
-	buildersNeeded := math.Ceil(float64(points) / float64(rogue.BuilderPoints))
-	return buildersNeeded * costPerBuilder
-}
-
-func (rogue *Rogue) timeToBuild(_ *core.Simulation, points int32, builderPoints int32, eps float64, finisherCost float64) time.Duration {
-	energyNeeded := rogue.energyToBuild(points) + finisherCost
-	secondsNeeded := energyNeeded / eps
-	globalsNeeded := math.Ceil(float64(points)/float64(builderPoints)) + 1
-	// Return greater of the time it takes to use the globals and the time it takes to build the energy
-	return core.MaxDuration(time.Second*time.Duration(secondsNeeded), time.Second*time.Duration(globalsNeeded))
-}
-
-func (rogue *Rogue) shouldCastNextRotationItem(sim *core.Simulation, eps float64) shouldCastRotationItemResult {
-	if len(rogue.rotationItems) == 0 {
-		panic("Empty rotation")
+func (rogue *Rogue) setupRotation(sim *core.Simulation) {
+	switch {
+	case rogue.CanMutilate() && rogue.Env.GetNumTargets() <= 3:
+		rogue.rotation = &assassination_rotation{}
+	case rogue.Talents.HonorAmongThieves > 0 && rogue.Env.GetNumTargets() <= 3:
+		rogue.rotation = &subtlety_rotation{}
+	default:
+		rogue.rotation = &combat_rotation{}
 	}
-	currentEnergy := rogue.CurrentEnergy()
-	comboPoints := rogue.ComboPoints()
-	currentTime := sim.CurrentTime
-	item := rogue.rotationItems[0]
-	prio := rogue.priorityItems[item.PrioIndex]
-	tte := item.ExpiresAt - currentTime
-	clippingThreshold := time.Second * 2
-	timeUntilNextGCD := rogue.GCD.TimeToReady(sim)
-
-	// Check to see if a higher prio item will expire
-	if len(rogue.rotationItems) >= 2 {
-		timeElapsed := time.Second * 1
-		for _, nextItem := range rogue.rotationItems[1:] {
-			if nextItem.ExpiresAt <= currentTime+timeElapsed {
-				return ShouldNotCast
-			}
-			timeElapsed += nextItem.MinimumBuildDuration
-		}
-	}
-
-	// Expires before next GCD
-	if tte <= timeUntilNextGCD {
-		if comboPoints >= prio.MinimumComboPoints && currentEnergy >= (prio.EnergyCost+prio.PoolAmount) {
-			return ShouldCast
-		} else if comboPoints < prio.MinimumComboPoints && currentEnergy >= rogue.Builder.DefaultCast.Cost {
-			return ShouldBuild
-		} else {
-			return ShouldWait
-		}
-	}
-	if comboPoints >= prio.MaximumComboPoints { // Don't need CP
-		// Cast
-		if tte <= clippingThreshold && currentEnergy >= (prio.EnergyCost+prio.PoolAmount) {
-			return ShouldCast
-		}
-		// Pool energy
-		if tte <= clippingThreshold && currentEnergy < (prio.EnergyCost+prio.PoolAmount) {
-			return ShouldWait
-		}
-		// We have time to squeeze in another spell
-		if tte > item.MinimumBuildDuration {
-			// Find the first lower prio item that can be cast and use it
-			for lpi, lowerPrio := range rogue.priorityItems[item.PrioIndex+1:] {
-				if comboPoints > lowerPrio.MinimumComboPoints && currentEnergy > lowerPrio.EnergyCost && lowerPrio.MaxCasts == 0 {
-					rogue.rotationItems = append([]rogueRotationItem{
-						{ExpiresAt: currentTime, PrioIndex: lpi + item.PrioIndex + 1},
-					}, rogue.rotationItems...)
-					return ShouldCast
-				}
-			}
-		}
-		// Overcap CP with builder
-		if rogue.timeToBuild(sim, 1, rogue.BuilderPoints, eps, prio.EnergyCost+prio.PoolAmount) <= tte && currentEnergy >= rogue.Builder.DefaultCast.Cost {
-			return ShouldBuild
-		}
-	} else if comboPoints < prio.MinimumComboPoints { // Need CP
-		if currentEnergy >= rogue.Builder.DefaultCast.Cost {
-			return ShouldBuild
-		} else {
-			return ShouldWait
-		}
-	} else { // Between MinimumComboPoints and MaximumComboPoints
-		if currentEnergy >= prio.EnergyCost+prio.PoolAmount && tte <= timeUntilNextGCD {
-			return ShouldCast
-		}
-		ttb := rogue.timeToBuild(sim, 1, 2, eps, prio.EnergyCost+prio.PoolAmount-currentEnergy)
-		if currentEnergy >= rogue.Builder.DefaultCast.Cost && tte > ttb {
-			return ShouldBuild
-		}
-	}
-	return ShouldWait
-}
-
-func (rogue *Rogue) planRotation(sim *core.Simulation) []rogueRotationItem {
-	var rotationItems []rogueRotationItem
-	eps := rogue.getExpectedEnergyPerSecond()
-	for pi, prio := range rogue.priorityItems {
-		if prio.MaxCasts > 0 && prio.CastCount >= prio.MaxCasts {
-			continue
-		}
-		maxCP := prio.MaximumComboPoints
-		for maxCP > 0 && prio.GetDuration(rogue, maxCP)+sim.CurrentTime > sim.Duration {
-			maxCP--
-		}
-		var expiresAt time.Duration
-		if prio.Aura != nil {
-			expiresAt = prio.Aura.ExpiresAt()
-		} else if prio.MaxCasts == 1 {
-			expiresAt = sim.CurrentTime // TODO looks fishy, repeated expiresAt = sim.CurrentTime
-		} else {
-			expiresAt = sim.CurrentTime
-		}
-		minimumBuildDuration := rogue.timeToBuild(sim, prio.MinimumComboPoints, rogue.BuilderPoints, eps, prio.EnergyCost)
-		maximumBuildDuration := rogue.timeToBuild(sim, maxCP, rogue.BuilderPoints, eps, prio.EnergyCost)
-		rotationItems = append(rotationItems, rogueRotationItem{
-			ExpiresAt:            expiresAt,
-			MaximumBuildDuration: maximumBuildDuration,
-			MinimumBuildDuration: minimumBuildDuration,
-			PrioIndex:            pi,
-		})
-	}
-
-	currentTime := sim.CurrentTime
-	comboPoints := rogue.ComboPoints()
-	currentEnergy := rogue.CurrentEnergy()
-
-	var prioStack []rogueRotationItem
-	for _, item := range rotationItems {
-		if item.ExpiresAt >= sim.Duration {
-			continue
-		}
-		prio := rogue.priorityItems[item.PrioIndex]
-		maxBuildAt := item.ExpiresAt - item.MaximumBuildDuration
-		if prio.Aura == nil {
-			timeValueOfResources := time.Duration((float64(comboPoints)*rogue.Builder.DefaultCast.Cost/float64(rogue.BuilderPoints) + currentEnergy) / eps)
-			maxBuildAt = currentTime - item.MaximumBuildDuration - timeValueOfResources
-		}
-		if currentTime < maxBuildAt {
-			// Put it on the to cast stack
-			prioStack = append(prioStack, item)
-			if prio.MinimumComboPoints > 0 {
-				comboPoints = 0
-			}
-			currentTime += item.MaximumBuildDuration
-		} else {
-			cpUsed := core.MaxInt32(0, prio.MinimumComboPoints-comboPoints)
-			energyUsed := core.MaxFloat(0, prio.EnergyCost-currentEnergy)
-			minBuildTime := rogue.timeToBuild(sim, cpUsed, rogue.BuilderPoints, eps, energyUsed)
-			if currentTime+minBuildTime <= item.ExpiresAt || !prio.IsFiller {
-				prioStack = append(prioStack, item)
-				currentTime = core.MaxDuration(item.ExpiresAt, currentTime+minBuildTime)
-				currentEnergy = 0
-				if prio.MinimumComboPoints > 0 {
-					comboPoints = 0
-				}
-			} else if len(prioStack) < 1 || (prio.Aura != nil && !prio.Aura.IsActive() && !prio.IsFiller) || prio.MaxCasts == 1 {
-				// Plan to cast it as soon as possible
-				prioStack = append(prioStack, item)
-				currentTime += item.MinimumBuildDuration
-				currentEnergy = 0
-				if prio.MinimumComboPoints > 0 {
-					comboPoints = 0
-				}
-			}
-		}
-	}
-
-	// Reverse
-	for i, j := 0, len(prioStack)-1; i < j; i, j = i+1, j-1 {
-		prioStack[i], prioStack[j] = prioStack[j], prioStack[i]
-	}
-
-	return prioStack
-}
-
-func (rogue *Rogue) setPriorityItems(sim *core.Simulation) {
-	rogue.Builder = rogue.SinisterStrike
-	rogue.BuilderPoints = 1
-	if rogue.PrimaryTalentTree == AssassinTree {
-		if rogue.CanMutilate() {
-			rogue.Builder = rogue.Mutilate
-			rogue.BuilderPoints = 2
-		}
-		rogue.setupAssassinationRotation(sim)
-	}
-	if rogue.PrimaryTalentTree == SubtletyTree {
-		rogue.setSubtletyBuilder(sim)
-		rogue.setupSubtletyRotation(sim)
-	}
-	isMultiTarget := sim.GetNumTargets() >= 3
-	// Slice and Dice
-	rogue.priorityItems = rogue.priorityItems[:0]
-
-	sliceAndDice := roguePriorityItem{
-		MinimumComboPoints: 1,
-		MaximumComboPoints: 5,
-		Aura:               rogue.SliceAndDiceAura,
-		EnergyCost:         rogue.SliceAndDice.DefaultCast.Cost,
-		GetDuration: func(rogue *Rogue, cp int32) time.Duration {
-			return rogue.sliceAndDiceDurations[cp]
-		},
-		GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
-			return rogue.SliceAndDice
-		},
-	}
-	if isMultiTarget {
-		if rogue.Rotation.MultiTargetSliceFrequency != proto.Rogue_Rotation_Never {
-			sliceAndDice.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsMultiTargetSlice)
-			if rogue.Rotation.MultiTargetSliceFrequency == proto.Rogue_Rotation_Once {
-				sliceAndDice.MaxCasts = 1
-			}
-			rogue.priorityItems = append(rogue.priorityItems, sliceAndDice)
-		}
-	} else {
-		rogue.priorityItems = append(rogue.priorityItems, sliceAndDice)
-	}
-
-	// Expose Armor
-	if rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Maintain ||
-		rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Once {
-		minPoints := int32(1)
-		maxCasts := int32(0)
-		if rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Once {
-			minPoints = rogue.Rotation.MinimumComboPointsExposeArmor
-			maxCasts = 1
-		}
-		rogue.priorityItems = append(rogue.priorityItems, roguePriorityItem{
-			MaxCasts:           maxCasts,
-			MaximumComboPoints: 5,
-			MinimumComboPoints: minPoints,
-			Aura:               rogue.ExposeArmorAuras.Get(rogue.CurrentTarget),
-			EnergyCost:         rogue.ExposeArmor.DefaultCast.Cost,
-			GetDuration: func(rogue *Rogue, cp int32) time.Duration {
-				return rogue.exposeArmorDurations[cp]
-			},
-			GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
-				return rogue.ExposeArmor
-			},
-		})
-	}
-
-	// Hunger for Blood
-	if rogue.Talents.HungerForBlood {
-		rogue.priorityItems = append(rogue.priorityItems, roguePriorityItem{
-			MaximumComboPoints: 0,
-			Aura:               rogue.HungerForBloodAura,
-			EnergyCost:         rogue.HungerForBlood.DefaultCast.Cost,
-			GetDuration: func(rogue *Rogue, cp int32) time.Duration {
-				return rogue.HungerForBloodAura.Duration
-			},
-			GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
-				return rogue.HungerForBlood
-			},
-		})
-	}
-
-	// Dummy priority to enable CDs
-	rogue.priorityItems = append(rogue.priorityItems, roguePriorityItem{
-		MaxCasts:           1,
-		MaximumComboPoints: 0,
-		GetDuration: func(rogue *Rogue, cp int32) time.Duration {
-			return 0
-		},
-		GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
-			if rogue.allMCDsDisabled {
-				for _, mcd := range rogue.GetMajorCooldowns() {
-					mcd.Enable()
-				}
-				rogue.allMCDsDisabled = false
-			}
-			return nil
-		},
-	})
-
-	// Rupture
-	rupture := roguePriorityItem{
-		MinimumComboPoints: 3,
-		MaximumComboPoints: 5,
-		Aura:               rogue.Rupture.CurDot().Aura,
-		EnergyCost:         rogue.Rupture.DefaultCast.Cost,
-		GetDuration: func(rogue *Rogue, cp int32) time.Duration {
-			return rogue.RuptureDuration(cp)
-		},
-		GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
-			return rogue.Rupture
-		},
-	}
-
-	// Eviscerate
-	eviscerate := roguePriorityItem{
-		MinimumComboPoints: 1,
-		MaximumComboPoints: 5,
-		EnergyCost:         rogue.Eviscerate.DefaultCast.Cost,
-		GetDuration: func(rogue *Rogue, cp int32) time.Duration {
-			return 0
-		},
-		GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
-			return rogue.Eviscerate
-		},
-	}
-
-	if isMultiTarget {
-		rogue.priorityItems = append(rogue.priorityItems, roguePriorityItem{
-			MaximumComboPoints: 0,
-			EnergyCost:         rogue.FanOfKnives.DefaultCast.Cost,
-			GetSpell: func(rogue *Rogue, i int32) *core.Spell {
-				return rogue.FanOfKnives
-			},
-		})
-
-	} else if rogue.Talents.MasterPoisoner > 0 || rogue.Talents.CutToTheChase > 0 {
-		// Envenom
-		envenom := roguePriorityItem{
-			MinimumComboPoints: 1,
-			MaximumComboPoints: 5,
-			Aura:               rogue.EnvenomAura,
-			EnergyCost:         rogue.Envenom.DefaultCast.Cost,
-			GetDuration: func(rogue *Rogue, cp int32) time.Duration {
-				return rogue.EnvenomAura.Duration
-			},
-			GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
-				return rogue.Envenom
-			},
-		}
-		switch rogue.Rotation.AssassinationFinisherPriority {
-		case proto.Rogue_Rotation_EnvenomRupture:
-			envenom.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
-			rogue.priorityItems = append(rogue.priorityItems, envenom)
-			rupture.MinimumComboPoints = rogue.Rotation.MinimumComboPointsSecondaryFinisher
-			rupture.IsFiller = true
-			if rupture.MinimumComboPoints > 0 && rupture.MinimumComboPoints <= 5 {
-				rogue.priorityItems = append(rogue.priorityItems, rupture)
-			}
-		case proto.Rogue_Rotation_RuptureEnvenom:
-			rupture.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
-			rogue.priorityItems = append(rogue.priorityItems, rupture)
-			envenom.MinimumComboPoints = rogue.Rotation.MinimumComboPointsSecondaryFinisher
-			envenom.IsFiller = true
-			if envenom.MinimumComboPoints > 0 && envenom.MinimumComboPoints <= 5 {
-				rogue.priorityItems = append(rogue.priorityItems, envenom)
-			}
-		}
-		eviscerate.IsFiller = true
-		eviscerate.MinimumComboPoints = 1
-		rogue.priorityItems = append(rogue.priorityItems, eviscerate)
-	} else {
-		if rogue.PrimaryTalentTree == CombatTree {
-			switch rogue.Rotation.CombatFinisherPriority {
-			case proto.Rogue_Rotation_RuptureEviscerate:
-				rupture.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
-				rogue.priorityItems = append(rogue.priorityItems, rupture)
-				eviscerate.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsSecondaryFinisher)
-				eviscerate.IsFiller = true
-				rogue.priorityItems = append(rogue.priorityItems, eviscerate)
-			case proto.Rogue_Rotation_EviscerateRupture:
-				eviscerate.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
-				rogue.priorityItems = append(rogue.priorityItems, eviscerate)
-				rupture.MinimumComboPoints = rogue.Rotation.MinimumComboPointsSecondaryFinisher
-				rupture.IsFiller = true
-				if rupture.MinimumComboPoints > 0 && rupture.MinimumComboPoints <= 5 {
-					rogue.priorityItems = append(rogue.priorityItems, rupture)
-				}
-			}
-		} else {
-			switch rogue.Rotation.SubtletyFinisherPriority {
-			case proto.Rogue_Rotation_SubtletyEviscerate:
-				rupture.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
-				rogue.priorityItems = append(rogue.priorityItems, rupture)
-				eviscerate.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsSecondaryFinisher)
-				eviscerate.IsFiller = true
-				rogue.priorityItems = append(rogue.priorityItems, eviscerate)
-			case proto.Rogue_Rotation_SubtletyEnvenom:
-				eviscerate.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
-				rogue.priorityItems = append(rogue.priorityItems, eviscerate)
-				rupture.MinimumComboPoints = rogue.Rotation.MinimumComboPointsSecondaryFinisher
-				rupture.IsFiller = true
-				if rupture.MinimumComboPoints > 0 && rupture.MinimumComboPoints <= 5 {
-					rogue.priorityItems = append(rogue.priorityItems, rupture)
-				}
-			}
-		}
-	}
-	rogue.rotationItems = rogue.planRotation(sim)
-}
-
-func (rogue *Rogue) rotation(sim *core.Simulation) {
-	if len(rogue.rotationItems) < 1 {
-		panic("Rotation is empty")
-	}
-	eps := rogue.getExpectedEnergyPerSecond()
-	shouldCast := rogue.shouldCastNextRotationItem(sim, eps)
-	item := rogue.rotationItems[0]
-	prio := rogue.priorityItems[item.PrioIndex]
-
-	switch shouldCast {
-	case ShouldNotCast:
-		rogue.rotationItems = rogue.rotationItems[1:]
-		rogue.rotation(sim)
-	case ShouldBuild:
-		spell := rogue.Builder
-		if spell == nil || spell.Cast(sim, rogue.CurrentTarget) {
-			if rogue.GCD.IsReady(sim) {
-				rogue.rotation(sim)
-			}
-		} else {
-			panic("Unexpected builder cast failure")
-		}
-	case ShouldCast:
-		spell := prio.GetSpell(rogue, rogue.ComboPoints())
-		if spell == nil || spell.Cast(sim, rogue.CurrentTarget) {
-			rogue.priorityItems[item.PrioIndex].CastCount += 1
-			rogue.rotationItems = rogue.planRotation(sim)
-			if rogue.GCD.IsReady(sim) {
-				rogue.rotation(sim)
-			}
-		} else {
-			panic("Unexpected cast failure")
-		}
-	case ShouldWait:
-		desiredEnergy := 100.0
-		if rogue.ComboPoints() == 5 {
-			desiredEnergy = prio.EnergyCost
-		} else {
-			if rogue.CurrentEnergy() < prio.EnergyCost && rogue.ComboPoints() >= prio.MinimumComboPoints {
-				desiredEnergy = prio.EnergyCost
-			} else if rogue.ComboPoints() < 5 {
-				desiredEnergy = rogue.Builder.DefaultCast.Cost
-			}
-		}
-		cdAvailableTime := time.Second * 10
-		if sim.CurrentTime > cdAvailableTime {
-			cdAvailableTime = core.NeverExpires
-		}
-		nextExpiration := cdAvailableTime
-		for _, otherItem := range rogue.rotationItems {
-			if otherItem.ExpiresAt < nextExpiration {
-				nextExpiration = otherItem.ExpiresAt
-			}
-		}
-		neededEnergy := desiredEnergy - rogue.CurrentEnergy()
-		energyAvailableTime := time.Second*time.Duration(neededEnergy/eps) + 1*time.Second
-		energyAt := sim.CurrentTime + energyAvailableTime
-		if energyAt < nextExpiration {
-			rogue.WaitForEnergy(sim, desiredEnergy)
-		} else if nextExpiration > sim.CurrentTime {
-			rogue.WaitUntil(sim, nextExpiration)
-		} else {
-			rogue.DoNothing()
-		}
-	}
+	rogue.rotation.setup(sim, rogue)
 }

--- a/sim/rogue/rotation.go
+++ b/sim/rogue/rotation.go
@@ -16,14 +16,12 @@ const (
 	Build
 	Cast
 	Wait
+	Once
 )
 
-type GetAction func(*core.Simulation, *Rogue) PriorityAction
-type DoAction func(*core.Simulation, *Rogue) bool
-
 type prio struct {
-	check GetAction
-	cast  DoAction
+	check func(sim *core.Simulation, rogue *Rogue) PriorityAction
+	cast  func(sim *core.Simulation, rogue *Rogue) bool
 	cost  float64
 }
 
@@ -55,7 +53,7 @@ func (rogue *Rogue) setupRotation(sim *core.Simulation) {
 	case rogue.Talents.HonorAmongThieves > 0 && rogue.Env.GetNumTargets() <= 3:
 		rogue.rotation = &subtlety_rotation{}
 	default:
-		rogue.rotation = &combat_rotation{}
+		rogue.rotation = &generic_rotation{}
 	}
 	rogue.rotation.setup(sim, rogue)
 }

--- a/sim/rogue/subtlety_rotation.go
+++ b/sim/rogue/subtlety_rotation.go
@@ -1,62 +1,25 @@
 package rogue
 
 import (
+	"log"
 	"time"
 
 	"github.com/wowsims/wotlk/sim/core"
 	"github.com/wowsims/wotlk/sim/core/proto"
 )
 
-type subtletyPrio struct {
-	check GetAction
-	cast  DoAction
-	cost  float64
+type subtlety_rotation struct {
+	prios []prio
 }
 
-func (rogue *Rogue) setSubtletyBuilder(sim *core.Simulation) {
-	mhDagger := rogue.Equip[proto.ItemSlot_ItemSlotMainHand].WeaponType == proto.WeaponType_WeaponTypeDagger
-	// Garrote
-	if !rogue.Garrote.CurDot().Aura.IsActive() && rogue.ShadowDanceAura.IsActive() && !rogue.PseudoStats.InFrontOfTarget {
-		rogue.Builder = rogue.Garrote
-		rogue.BuilderPoints = 1
-		return
-	}
-	// Ambush
-	if rogue.ShadowDanceAura.IsActive() && mhDagger && !rogue.PseudoStats.InFrontOfTarget {
-		rogue.Builder = rogue.Ambush
-		rogue.BuilderPoints = 2
-		return
-	}
-	// Backstab
-	if mhDagger && !rogue.Rotation.HemoWithDagger && !rogue.PseudoStats.InFrontOfTarget {
-		rogue.Builder = rogue.Backstab
-		rogue.BuilderPoints = 1
-		return
-	}
-	// Ghostly Strike
-	if rogue.Talents.GhostlyStrike && rogue.Rotation.UseGhostlyStrike && rogue.GhostlyStrike.IsReady(sim) {
-		rogue.Builder = rogue.GhostlyStrike
-		rogue.BuilderPoints = 1
-		return
-	}
-	// Hemorrhage
-	if rogue.Talents.Hemorrhage {
-		rogue.Builder = rogue.Hemorrhage
-		rogue.BuilderPoints = 1
-	} else
-	// Sinister Strike
-	{
-		rogue.Builder = rogue.SinisterStrike
-		rogue.BuilderPoints = 1
-	}
-}
+func (x *subtlety_rotation) setup(sim *core.Simulation, rogue *Rogue) {
+	x.setSubtletyBuilder(sim, rogue)
 
-func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
-	rogue.subtletyPrios = rogue.subtletyPrios[:0]
+	x.prios = x.prios[:0]
 
 	if rogue.Rotation.OpenWithPremeditation && rogue.Talents.Premeditation {
 		hasCastPremeditation := false
-		rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
+		x.prios = append(x.prios, prio{
 			func(s *core.Simulation, r *Rogue) PriorityAction {
 				if hasCastPremeditation {
 					return Skip
@@ -79,7 +42,7 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 
 	if rogue.Rotation.OpenWithShadowstep && rogue.Talents.Shadowstep {
 		hasCastShadowstep := false
-		rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
+		x.prios = append(x.prios, prio{
 			func(s *core.Simulation, r *Rogue) PriorityAction {
 				if hasCastShadowstep {
 					return Skip
@@ -103,7 +66,7 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 	// Garrote
 	if rogue.Rotation.OpenWithGarrote {
 		hasCastGarrote := false
-		rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
+		x.prios = append(x.prios, prio{
 			func(sim *core.Simulation, rogue *Rogue) PriorityAction {
 				if hasCastGarrote {
 					return Skip
@@ -125,7 +88,7 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 	}
 
 	// Slice and Dice
-	rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
+	x.prios = append(x.prios, prio{
 		func(sim *core.Simulation, rogue *Rogue) PriorityAction {
 			if rogue.SliceAndDiceAura.IsActive() {
 				return Skip
@@ -155,7 +118,7 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 	if rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Once ||
 		rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Maintain {
 		hasCastExpose := false
-		rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
+		x.prios = append(x.prios, prio{
 			func(sim *core.Simulation, rogue *Rogue) PriorityAction {
 				if hasCastExpose && rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Once {
 					return Skip
@@ -208,7 +171,7 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 	}
 
 	// Enable CDS
-	rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
+	x.prios = append(x.prios, prio{
 		func(sim *core.Simulation, rogue *Rogue) PriorityAction {
 			if rogue.allMCDsDisabled {
 				for _, mcd := range rogue.GetMajorCooldowns() {
@@ -226,7 +189,7 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 
 	//Shadowstep
 	if rogue.Talents.Shadowstep {
-		rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
+		x.prios = append(x.prios, prio{
 			func(sim *core.Simulation, rogue *Rogue) PriorityAction {
 				if rogue.Shadowstep.IsReady(sim) {
 					// Can we cast Rupture now?
@@ -248,7 +211,7 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 	const ruptureMinDuration = time.Second * 8 // heuristically, 3-4 Rupture ticks are better DPE than Eviscerate or Envenom
 
 	// Rupture
-	rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
+	x.prios = append(x.prios, prio{
 		func(sim *core.Simulation, rogue *Rogue) PriorityAction {
 			if rogue.Rupture.CurDot().IsActive() || sim.GetRemainingDuration() < ruptureMinDuration {
 				return Skip
@@ -270,7 +233,7 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 
 	//Envenom
 	if rogue.Rotation.SubtletyFinisherPriority == proto.Rogue_Rotation_SubtletyEnvenom {
-		rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
+		x.prios = append(x.prios, prio{
 			func(sim *core.Simulation, rogue *Rogue) PriorityAction {
 				if !rogue.DeadlyPoison.CurDot().Aura.IsActive() {
 					return Skip
@@ -294,7 +257,7 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 	}
 
 	// Eviscerate
-	rogue.subtletyPrios = append(rogue.subtletyPrios, subtletyPrio{
+	x.prios = append(x.prios, prio{
 		func(sim *core.Simulation, rogue *Rogue) PriorityAction {
 			// end of combat handling - prefer Eviscerate over Builder, heuristically
 			if sim.GetRemainingDuration().Seconds() < rogue.getExpectedSecondsPerComboPoint() && rogue.ComboPoints() >= 2 && rogue.CurrentEnergy() >= rogue.Eviscerate.DefaultCast.Cost {
@@ -315,10 +278,14 @@ func (rogue *Rogue) setupSubtletyRotation(sim *core.Simulation) {
 	})
 }
 
-func (rogue *Rogue) doSubtletyRotation(sim *core.Simulation) {
+func (x *subtlety_rotation) run(sim *core.Simulation, rogue *Rogue) {
+	if !rogue.GCD.IsReady(sim) {
+		log.Panic("gcd not ready")
+	}
+
 	prioIndex := 0
-	for prioIndex < len(rogue.subtletyPrios) {
-		prio := rogue.subtletyPrios[prioIndex]
+	for prioIndex < len(x.prios) {
+		prio := x.prios[prioIndex]
 		switch prio.check(sim, rogue) {
 		case Skip:
 			prioIndex += 1
@@ -331,7 +298,7 @@ func (rogue *Rogue) doSubtletyRotation(sim *core.Simulation) {
 			}
 
 			if rogue.GCD.IsReady(sim) {
-				rogue.setSubtletyBuilder(sim)
+				x.setSubtletyBuilder(sim, rogue)
 				if !rogue.Builder.Cast(sim, rogue.CurrentTarget) {
 					rogue.WaitForEnergy(sim, rogue.Builder.DefaultCast.Cost)
 					return
@@ -356,8 +323,39 @@ func (rogue *Rogue) doSubtletyRotation(sim *core.Simulation) {
 	rogue.DoNothing()
 }
 
-func (rogue *Rogue) OnCanActSubtlety(sim *core.Simulation) {
-	if rogue.GCD.IsReady(sim) {
-		rogue.doSubtletyRotation(sim)
+func (x *subtlety_rotation) setSubtletyBuilder(sim *core.Simulation, rogue *Rogue) {
+	// Garrote
+	if !rogue.Garrote.CurDot().Aura.IsActive() && rogue.ShadowDanceAura.IsActive() && !rogue.PseudoStats.InFrontOfTarget {
+		rogue.Builder = rogue.Garrote
+		rogue.BuilderPoints = 1
+		return
 	}
+	// Ambush
+	if rogue.ShadowDanceAura.IsActive() && !rogue.PseudoStats.InFrontOfTarget && rogue.HasDagger(core.MainHand) {
+		rogue.Builder = rogue.Ambush
+		rogue.BuilderPoints = 2
+		return
+	}
+	// Backstab
+	if !rogue.Rotation.HemoWithDagger && !rogue.PseudoStats.InFrontOfTarget && rogue.HasDagger(core.MainHand) {
+		rogue.Builder = rogue.Backstab
+		rogue.BuilderPoints = 1
+		return
+	}
+	// Ghostly Strike
+	if rogue.Talents.GhostlyStrike && rogue.Rotation.UseGhostlyStrike && rogue.GhostlyStrike.IsReady(sim) {
+		rogue.Builder = rogue.GhostlyStrike
+		rogue.BuilderPoints = 1
+		return
+	}
+	// Hemorrhage
+	if rogue.Talents.Hemorrhage {
+		rogue.Builder = rogue.Hemorrhage
+		rogue.BuilderPoints = 1
+		return
+	}
+
+	// Sinister Strike
+	rogue.Builder = rogue.SinisterStrike
+	rogue.BuilderPoints = 1
 }

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -266,6 +266,11 @@ func (rogue *Rogue) applySealFate() {
 	procChance := 0.2 * float64(rogue.Talents.SealFate)
 	cpMetrics := rogue.NewComboPointMetrics(core.ActionID{SpellID: 14195})
 
+	icd := core.Cooldown{
+		Timer:    rogue.NewTimer(),
+		Duration: 500 * time.Millisecond,
+	}
+
 	rogue.RegisterAura(core.Aura{
 		Label:    "Seal Fate",
 		Duration: core.NeverExpires,
@@ -281,8 +286,9 @@ func (rogue *Rogue) applySealFate() {
 				return
 			}
 
-			if sim.Proc(procChance, "Seal Fate") {
+			if icd.IsReady(sim) && sim.Proc(procChance, "Seal Fate") {
 				rogue.AddComboPoints(sim, 1, cpMetrics)
+				icd.Use(sim)
 			}
 		},
 	})

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -528,14 +528,14 @@ func (rogue *Rogue) registerAdrenalineRushCD() {
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			rogue.ResetEnergyTick(sim)
 			rogue.ApplyEnergyTickMultiplier(1.0)
-			if r, ok := rogue.rotation.(*combat_rotation); ok {
+			if r, ok := rogue.rotation.(*generic_rotation); ok {
 				r.planRotation(sim, rogue)
 			}
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			rogue.ResetEnergyTick(sim)
 			rogue.ApplyEnergyTickMultiplier(-1.0)
-			if r, ok := rogue.rotation.(*combat_rotation); ok {
+			if r, ok := rogue.rotation.(*generic_rotation); ok {
 				r.planRotation(sim, rogue)
 			}
 		},

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -528,12 +528,16 @@ func (rogue *Rogue) registerAdrenalineRushCD() {
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			rogue.ResetEnergyTick(sim)
 			rogue.ApplyEnergyTickMultiplier(1.0)
-			rogue.rotationItems = rogue.planRotation(sim)
+			if r, ok := rogue.rotation.(*combat_rotation); ok {
+				r.planRotation(sim, rogue)
+			}
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			rogue.ResetEnergyTick(sim)
 			rogue.ApplyEnergyTickMultiplier(-1.0)
-			rogue.rotationItems = rogue.planRotation(sim)
+			if r, ok := rogue.rotation.(*combat_rotation); ok {
+				r.planRotation(sim, rogue)
+			}
 		},
 	})
 


### PR DESCRIPTION
[rogue] The Mutilate "parent" spell triggered Focused Attacks whenever any of the damage spells crit, returning up to 6 instead of only 4 energy. Each damage spell now counts as a builder for Seal Fate, which has gained an ICD so Mutilate doesn't grant up to 4 CPs

[rogue] Seal Fate now has a proper ICD (500 ms, as used in-game as well)

[rogue] Deadly Poison now properly snapshots BaseDamage and AttackerMultiplier on each refresh. The DPS difference is negligible, as expected
