### PR TITLE
Mutilate Fix (and only that!)

### DIFF
--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -46,1073 +46,1073 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7546.42172
-  tps: 5357.95942
+  dps: 7448.83287
+  tps: 5288.67134
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7741.27364
-  tps: 5496.30428
+  dps: 7646.65833
+  tps: 5429.12741
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7515.12114
-  tps: 34929.2012
+  dps: 7422.49556
+  tps: 34397.73584
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7515.12114
-  tps: 34929.2012
+  dps: 7422.49556
+  tps: 34397.73584
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7745.86575
-  tps: 5499.56468
+  dps: 7650.55705
+  tps: 5431.89551
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50035"
  value: {
-  dps: 5872.95633
-  tps: 4169.79899
+  dps: 5873.6918
+  tps: 4170.32118
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50692"
  value: {
-  dps: 5955.53292
-  tps: 4228.42837
+  dps: 5956.05754
+  tps: 4228.80085
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5846.71398
-  tps: 4151.16693
+  dps: 5799.07092
+  tps: 4117.34035
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 7038.19628
-  tps: 4997.11936
+  dps: 6981.37646
+  tps: 4956.77728
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5375.27727
+  dps: 7590.29787
+  tps: 5281.32926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7871.28365
-  tps: 5588.61139
+  dps: 7774.21843
+  tps: 5519.69509
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7675.19447
-  tps: 5449.38808
+  dps: 7588.34644
+  tps: 5387.72597
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7699.78178
-  tps: 5466.84506
+  dps: 7620.21704
+  tps: 5410.3541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7695.45726
-  tps: 5463.77465
+  dps: 7585.13491
+  tps: 5385.44579
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8084.19096
-  tps: 5739.77558
+  dps: 7993.78378
+  tps: 5675.58648
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7646.08215
-  tps: 5428.71832
+  dps: 7536.50297
+  tps: 5350.91711
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7943.51546
-  tps: 5639.89598
+  dps: 7861.22984
+  tps: 5581.47318
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8024.65265
-  tps: 5697.50338
+  dps: 7911.20246
+  tps: 5616.95374
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7754.03696
-  tps: 5505.36624
+  dps: 7656.8012
+  tps: 5436.32885
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7760.60861
-  tps: 5510.03211
+  dps: 7668.23891
+  tps: 5444.44963
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7729.93735
-  tps: 5488.25552
+  dps: 7640.04972
+  tps: 5424.4353
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7745.86575
-  tps: 5499.56468
+  dps: 7650.55705
+  tps: 5431.89551
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7734.06947
-  tps: 5491.18932
+  dps: 7645.59098
+  tps: 5428.3696
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7621.72791
-  tps: 5411.42682
+  dps: 7515.74689
+  tps: 5336.18029
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7683.72253
-  tps: 5455.44299
+  dps: 7594.788
+  tps: 5392.29948
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7645.19208
-  tps: 5428.08638
+  dps: 7562.74848
+  tps: 5369.55142
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7513.16621
-  tps: 5334.34801
+  dps: 7421.89641
+  tps: 5269.54645
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7595.71808
-  tps: 5392.95984
+  dps: 7525.97994
+  tps: 5343.44576
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7798.03636
-  tps: 5536.60581
+  dps: 7702.53211
+  tps: 5468.7978
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7606.06932
-  tps: 5400.30921
+  dps: 7498.06822
+  tps: 5323.62844
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7647.64131
-  tps: 5429.82533
+  dps: 7572.70483
+  tps: 5376.62043
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-49982"
  value: {
-  dps: 7884.03961
-  tps: 5597.66812
+  dps: 7761.60532
+  tps: 5510.73978
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-50641"
  value: {
-  dps: 7884.03961
-  tps: 5597.66812
+  dps: 7761.60532
+  tps: 5510.73978
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7745.86575
-  tps: 5499.56468
+  dps: 7650.55705
+  tps: 5431.89551
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7734.06947
-  tps: 5491.18932
+  dps: 7645.59098
+  tps: 5428.3696
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7686.00075
-  tps: 5457.06054
+  dps: 7592.53403
+  tps: 5390.69916
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7757.24208
-  tps: 5507.64187
+  dps: 7630.40626
+  tps: 5417.58845
   hps: 9.14161
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7788.85938
-  tps: 5530.09016
+  dps: 7683.43824
+  tps: 5455.24115
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7540.7054
-  tps: 5353.90084
+  dps: 7455.23528
+  tps: 5293.21705
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7755.81473
-  tps: 5506.62846
+  dps: 7620.35584
+  tps: 5410.45265
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7762.99009
-  tps: 5511.72296
+  dps: 7627.42831
+  tps: 5415.4741
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7721.89847
-  tps: 5482.54791
+  dps: 7624.97767
+  tps: 5413.73414
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7748.40067
-  tps: 5501.36448
+  dps: 7650.21309
+  tps: 5431.65129
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7884.03961
-  tps: 5597.66812
+  dps: 7761.60532
+  tps: 5510.73978
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7885.5423
-  tps: 5598.73503
+  dps: 7787.26234
+  tps: 5528.95626
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 5794.10704
-  tps: 4113.816
+  dps: 5719.03636
+  tps: 4060.51582
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7653.51472
-  tps: 5433.99545
+  dps: 7565.55505
+  tps: 5371.54408
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 7614.68495
-  tps: 5406.42631
+  dps: 7556.35277
+  tps: 5365.01047
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7673.66364
-  tps: 5448.30118
+  dps: 7563.0495
+  tps: 5369.76514
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StormshroudArmor"
  value: {
-  dps: 6155.20223
-  tps: 4370.19358
+  dps: 6053.68041
+  tps: 4298.11309
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7762.99009
-  tps: 5511.72296
+  dps: 7627.42831
+  tps: 5415.4741
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7755.81473
-  tps: 5506.62846
+  dps: 7620.35584
+  tps: 5410.45265
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7743.25784
-  tps: 5497.71307
+  dps: 7607.97903
+  tps: 5401.66511
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 7452.47118
-  tps: 5291.25454
+  dps: 7365.69472
+  tps: 5229.64325
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheFistsofFury"
  value: {
-  dps: 5100.49059
-  tps: 3621.34832
+  dps: 5100.8384
+  tps: 3621.59526
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7803.63143
-  tps: 5540.57832
+  dps: 7672.38129
+  tps: 5447.39071
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7972.37753
-  tps: 5660.38805
+  dps: 7882.45671
+  tps: 5596.54427
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8042.88297
-  tps: 5710.44691
+  dps: 7955.44865
+  tps: 5648.36854
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7574.66571
-  tps: 5378.01266
+  dps: 7459.75606
+  tps: 5296.4268
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7725.31944
-  tps: 5484.9768
+  dps: 7590.29787
+  tps: 5389.11149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6224.90573
-  tps: 4419.68307
+  dps: 6164.46072
+  tps: 4376.76711
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 7268.73862
-  tps: 5160.80442
+  dps: 7157.21494
+  tps: 5081.62261
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7514.05379
-  tps: 5334.97819
+  dps: 7421.95128
+  tps: 5269.58541
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 7881.24271
-  tps: 5595.68232
+  dps: 7773.30418
+  tps: 5519.04597
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28351.85946
-  tps: 20129.82022
+  dps: 28361.14643
+  tps: 20136.41396
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7884.03961
-  tps: 5597.66812
+  dps: 7761.60532
+  tps: 5510.73978
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9086.90129
-  tps: 6451.69992
+  dps: 8908.16218
+  tps: 6324.79515
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15287.19957
-  tps: 10853.91169
+  dps: 15371.20282
+  tps: 10913.554
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3793.99118
-  tps: 2693.73374
+  dps: 3749.75237
+  tps: 2662.32418
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3867.02962
-  tps: 2745.59103
+  dps: 3815.50047
+  tps: 2709.00534
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21480.25706
-  tps: 15250.98251
+  dps: 21534.87875
+  tps: 15289.76391
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5137.62635
-  tps: 3647.71471
+  dps: 5063.93231
+  tps: 3595.39194
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5940.32452
-  tps: 4217.63041
+  dps: 5850.70964
+  tps: 4154.00385
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12907.79258
-  tps: 9164.53273
+  dps: 12930.61595
+  tps: 9180.73732
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2485.91196
-  tps: 1764.99749
+  dps: 2455.7035
+  tps: 1743.54948
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2617.29392
-  tps: 1858.27868
+  dps: 2581.42308
+  tps: 1832.81039
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27126.18212
-  tps: 19259.5893
+  dps: 27131.91561
+  tps: 19263.66008
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7436.57789
-  tps: 5279.9703
+  dps: 7339.08333
+  tps: 5210.74917
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8550.59789
-  tps: 6070.9245
+  dps: 8383.90693
+  tps: 5952.57392
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14671.11988
-  tps: 10416.49512
+  dps: 14728.80828
+  tps: 10457.45388
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3579.03851
-  tps: 2541.11734
+  dps: 3539.55267
+  tps: 2513.0824
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3629.81891
-  tps: 2577.17143
+  dps: 3577.29864
+  tps: 2539.88203
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18041.57363
-  tps: 12809.51728
+  dps: 18047.87407
+  tps: 12813.99059
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3807.21635
-  tps: 2703.12361
+  dps: 3806.24152
+  tps: 2702.43148
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4639.48337
-  tps: 3294.03319
+  dps: 4635.57465
+  tps: 3291.258
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9349.69715
-  tps: 6638.28498
+  dps: 9352.08794
+  tps: 6639.98244
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1675.36562
-  tps: 1189.50959
+  dps: 1678.54219
+  tps: 1191.76496
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1772.82431
-  tps: 1258.70526
+  dps: 1774.22659
+  tps: 1259.70088
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28444.57411
-  tps: 20195.64761
+  dps: 28474.88576
+  tps: 20217.16889
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7919.44856
-  tps: 5622.80848
+  dps: 7797.6117
+  tps: 5536.30431
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9183.75687
-  tps: 6520.46738
+  dps: 9008.24352
+  tps: 6395.8529
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15358.3642
-  tps: 10904.43859
+  dps: 15452.69366
+  tps: 10971.4125
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3812.92427
-  tps: 2707.17623
+  dps: 3766.09546
+  tps: 2673.92778
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3912.27097
-  tps: 2777.71239
+  dps: 3857.36279
+  tps: 2738.72758
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21599.51535
-  tps: 15335.6559
+  dps: 21649.15041
+  tps: 15370.89679
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5162.96811
-  tps: 3665.70736
+  dps: 5087.98341
+  tps: 3612.46822
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6007.97051
-  tps: 4265.65906
+  dps: 5920.21343
+  tps: 4203.35153
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12999.22811
-  tps: 9229.45196
+  dps: 13004.29574
+  tps: 9233.04998
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2499.50205
-  tps: 1774.64646
+  dps: 2467.7296
+  tps: 1752.08801
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2650.53548
-  tps: 1881.88019
+  dps: 2612.48554
+  tps: 1854.86473
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27268.01557
-  tps: 19360.29106
+  dps: 27305.68158
+  tps: 19387.03392
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7469.62635
-  tps: 5303.43471
+  dps: 7371.2184
+  tps: 5233.56507
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8641.61502
-  tps: 6135.54666
+  dps: 8477.44985
+  tps: 6018.9894
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14737.395
-  tps: 10463.55045
+  dps: 14816.41755
+  tps: 10519.65646
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3596.73552
-  tps: 2553.68222
+  dps: 3558.35416
+  tps: 2526.43145
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3671.65788
-  tps: 2606.87709
+  dps: 3615.36306
+  tps: 2566.90777
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18136.30525
-  tps: 12876.77673
+  dps: 18144.68646
+  tps: 12882.72739
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3825.17553
-  tps: 2715.87463
+  dps: 3824.19332
+  tps: 2715.17726
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4693.67805
-  tps: 3332.51142
+  dps: 4689.7131
+  tps: 3329.6963
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9414.12829
-  tps: 6684.03109
+  dps: 9415.80913
+  tps: 6685.22448
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1683.30887
-  tps: 1195.1493
+  dps: 1686.52541
+  tps: 1197.43304
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1793.78216
-  tps: 1273.58534
+  dps: 1795.38098
+  tps: 1274.7205
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7403.53866
-  tps: 5256.51245
+  dps: 7284.93475
+  tps: 5172.30367
  }
 }

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -46,892 +46,892 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 6329.91742
-  tps: 4494.24137
+  dps: 6329.71453
+  tps: 4494.09732
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6449.25308
+  tps: 4578.96969
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6511.50672
-  tps: 4623.16977
+  dps: 6511.33641
+  tps: 4623.04885
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6314.46194
-  tps: 50548.14429
+  dps: 6314.25904
+  tps: 50548.00024
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6314.46194
-  tps: 50548.14429
+  dps: 6314.25904
+  tps: 50548.00024
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6472.61146
-  tps: 4595.55414
+  dps: 6473.20605
+  tps: 4595.9763
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50035"
  value: {
-  dps: 6787.61687
-  tps: 4819.20798
+  dps: 6789.21033
+  tps: 4820.33933
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50692"
  value: {
-  dps: 6900.27569
-  tps: 4899.19574
+  dps: 6901.80807
+  tps: 4900.28373
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5013.23343
-  tps: 3559.39573
+  dps: 5013.37718
+  tps: 3559.4978
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BonescytheBattlegear"
  value: {
-  dps: 5987.48762
-  tps: 4251.11621
+  dps: 5987.892
+  tps: 4251.40332
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4487.07638
+  dps: 6449.25308
+  tps: 4487.39029
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6594.09049
-  tps: 4681.80425
+  dps: 6594.67912
+  tps: 4682.22218
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6594.09049
-  tps: 4681.80425
+  dps: 6594.67912
+  tps: 4682.22218
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6588.49942
-  tps: 4677.83459
+  dps: 6589.09402
+  tps: 4678.25675
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
   hps: 64
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6441.47318
-  tps: 4573.44596
+  dps: 6441.55307
+  tps: 4573.50268
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6475.19432
-  tps: 4597.38797
+  dps: 6475.41879
+  tps: 4597.54734
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6463.54539
-  tps: 4589.11723
+  dps: 6463.85708
+  tps: 4589.33852
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6789.74039
-  tps: 4820.71568
+  dps: 6790.4313
+  tps: 4821.20622
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6421.20052
-  tps: 4559.05237
+  dps: 6421.23943
+  tps: 4559.07999
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6730.66394
-  tps: 4778.7714
+  dps: 6731.20564
+  tps: 4779.15601
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6785.74497
-  tps: 4817.87893
+  dps: 6785.16751
+  tps: 4817.46893
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6475.28838
-  tps: 4597.45475
+  dps: 6475.88298
+  tps: 4597.87692
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6524.02283
-  tps: 4632.05621
+  dps: 6524.47688
+  tps: 4632.37859
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6507.82493
-  tps: 4620.5557
+  dps: 6507.84514
+  tps: 4620.57005
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6449.25308
+  tps: 4578.96969
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6449.25308
+  tps: 4578.96969
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6472.61146
-  tps: 4595.55414
+  dps: 6473.20605
+  tps: 4595.9763
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6467.73183
-  tps: 4592.0896
+  dps: 6468.35375
+  tps: 4592.53116
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6438.03813
-  tps: 4571.00708
+  dps: 6438.06377
+  tps: 4571.02527
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6449.25308
+  tps: 4578.96969
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6475.55405
-  tps: 4597.64338
+  dps: 6475.74023
+  tps: 4597.77556
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6426.67408
-  tps: 4562.9386
+  dps: 6426.82228
+  tps: 4563.04382
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6316.73217
-  tps: 4484.87984
+  dps: 6316.67736
+  tps: 4484.84093
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6401.32645
-  tps: 4544.94178
+  dps: 6401.42683
+  tps: 4545.01305
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6449.25308
+  tps: 4578.96969
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6449.25308
+  tps: 4578.96969
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6554.83305
-  tps: 4653.93146
+  dps: 6554.62283
+  tps: 4653.78221
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Gladiator'sVestments"
  value: {
-  dps: 6383.89595
-  tps: 4532.56612
+  dps: 6384.42691
+  tps: 4532.9431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6450.87518
-  tps: 4580.12138
+  dps: 6451.02608
+  tps: 4580.22852
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-49982"
  value: {
-  dps: 6594.09049
-  tps: 4681.80425
+  dps: 6594.67912
+  tps: 4682.22218
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-50641"
  value: {
-  dps: 6594.09049
-  tps: 4681.80425
+  dps: 6594.67912
+  tps: 4682.22218
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6472.61146
-  tps: 4595.55414
+  dps: 6473.20605
+  tps: 4595.9763
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6467.73183
-  tps: 4592.0896
+  dps: 6468.35375
+  tps: 4592.53116
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6494.54497
-  tps: 4611.12693
+  dps: 6494.34763
+  tps: 4610.98682
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6449.25308
+  tps: 4578.96969
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6480.43332
-  tps: 4601.10766
+  dps: 6480.71016
+  tps: 4601.30421
   hps: 9.14161
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6529.01959
-  tps: 4635.60391
+  dps: 6529.14201
+  tps: 4635.69083
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6362.87821
-  tps: 4517.64353
+  dps: 6362.79759
+  tps: 4517.58629
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6474.49693
-  tps: 4596.89282
+  dps: 6474.94936
+  tps: 4597.21405
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6480.54282
-  tps: 4601.1854
+  dps: 6480.99555
+  tps: 4601.50684
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6449.25308
+  tps: 4578.96969
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6449.25308
+  tps: 4578.96969
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6463.33386
-  tps: 4588.96704
+  dps: 6463.10784
+  tps: 4588.80657
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6482.18753
-  tps: 4602.35315
+  dps: 6481.96152
+  tps: 4602.19268
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6594.09049
-  tps: 4681.80425
+  dps: 6594.67912
+  tps: 4682.22218
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6449.25308
+  tps: 4578.96969
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 6630.64948
-  tps: 4707.76113
+  dps: 6631.34434
+  tps: 4708.25448
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6594.09049
-  tps: 4681.80425
+  dps: 6594.67912
+  tps: 4682.22218
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Slayer'sArmor"
  value: {
-  dps: 4940.09874
-  tps: 3507.4701
+  dps: 4939.74985
+  tps: 3507.2224
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6430.39774
-  tps: 4565.58239
+  dps: 6430.49471
+  tps: 4565.65124
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SparkofLife-37657"
  value: {
-  dps: 6403.48938
-  tps: 4546.47746
+  dps: 6403.46617
+  tps: 4546.46098
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6506.97127
-  tps: 4619.9496
+  dps: 6506.48187
+  tps: 4619.60213
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StormshroudArmor"
  value: {
-  dps: 5045.60186
-  tps: 3582.37732
+  dps: 5046.08304
+  tps: 3582.71896
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6480.54282
-  tps: 4601.1854
+  dps: 6480.99555
+  tps: 4601.50684
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6474.49693
-  tps: 4596.89282
+  dps: 6474.94936
+  tps: 4597.21405
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6463.91664
-  tps: 4589.38081
+  dps: 6464.36854
+  tps: 4589.70166
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6379.41416
-  tps: 4529.38405
+  dps: 6379.18145
+  tps: 4529.21883
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheFistsofFury"
  value: {
-  dps: 5772.43194
-  tps: 4098.42668
+  dps: 5772.88045
+  tps: 4098.74512
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5873.20567
-  tps: 4169.97602
+  dps: 5874.0482
+  tps: 4170.57422
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6528.45168
-  tps: 4635.20069
+  dps: 6529.6204
+  tps: 4636.03049
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6634.2276
-  tps: 4710.30159
+  dps: 6634.47279
+  tps: 4710.47568
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6652.01379
-  tps: 4722.92979
+  dps: 6651.82679
+  tps: 4722.79702
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6449.25308
+  tps: 4578.96969
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6449.25308
+  tps: 4578.96969
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6369.83293
-  tps: 4522.58138
+  dps: 6369.3563
+  tps: 4522.24298
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6449.25308
+  tps: 4578.96969
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6448.80193
-  tps: 4578.64937
+  dps: 6449.25308
+  tps: 4578.96969
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5320.27285
-  tps: 3777.39373
+  dps: 5320.50285
+  tps: 3777.55702
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6212.87279
-  tps: 4411.13968
+  dps: 6213.50734
+  tps: 4411.59021
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6129.01862
-  tps: 4351.60322
+  dps: 6129.17384
+  tps: 4351.71343
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6314.47992
-  tps: 4483.28075
+  dps: 6314.27703
+  tps: 4483.13669
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 6575.59092
-  tps: 4668.66955
+  dps: 6576.05277
+  tps: 4668.99747
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18991.27045
-  tps: 13483.80202
+  dps: 18991.40439
+  tps: 13483.89711
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4882.06439
-  tps: 3466.26572
+  dps: 4882.26732
+  tps: 3466.4098
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5723.96887
-  tps: 4064.0179
+  dps: 5722.43506
+  tps: 4062.92889
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11525.41975
-  tps: 8183.04802
+  dps: 11534.75688
+  tps: 8189.67738
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2421.70886
-  tps: 1719.41329
+  dps: 2421.77391
+  tps: 1719.45947
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2553.01751
-  tps: 1812.64243
+  dps: 2553.17757
+  tps: 1812.75607
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20560.15466
-  tps: 14597.70981
+  dps: 20614.56969
+  tps: 14636.34448
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6594.09049
-  tps: 4681.80425
+  dps: 6594.67912
+  tps: 4682.22218
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7754.08617
-  tps: 5505.40118
+  dps: 7752.3221
+  tps: 5504.14869
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11941.88372
-  tps: 8478.73744
+  dps: 11991.47207
+  tps: 8513.94517
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3257.93289
-  tps: 2313.13235
+  dps: 3257.97922
+  tps: 2313.16524
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3385.03976
-  tps: 2403.37823
+  dps: 3385.17885
+  tps: 2403.47698
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19714.44222
-  tps: 13997.25397
+  dps: 19743.78724
+  tps: 14018.08894
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6292.31969
-  tps: 4467.54698
+  dps: 6294.18911
+  tps: 4468.87427
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7334.49698
-  tps: 5207.49286
+  dps: 7334.52048
+  tps: 5207.50954
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11492.09177
-  tps: 8159.38516
+  dps: 11517.31317
+  tps: 8177.29235
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3104.81383
-  tps: 2204.41782
+  dps: 3105.94186
+  tps: 2205.21872
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3200.06663
-  tps: 2272.0473
+  dps: 3203.04439
+  tps: 2274.16152
  }
 }
 dps_results: {
@@ -979,127 +979,127 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19131.51554
-  tps: 13583.37603
+  dps: 19131.7997
+  tps: 13583.57779
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4915.37692
-  tps: 3489.91761
+  dps: 4915.60536
+  tps: 3490.07981
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5801.10955
-  tps: 4118.78778
+  dps: 5799.58233
+  tps: 4117.70346
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11617.22779
-  tps: 8248.23173
+  dps: 11627.83525
+  tps: 8255.76303
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2439.87391
-  tps: 1732.31048
+  dps: 2439.96313
+  tps: 1732.37382
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2589.8529
-  tps: 1838.79556
+  dps: 2590.00498
+  tps: 1838.90354
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20711.36122
-  tps: 14705.06647
+  dps: 20767.06156
+  tps: 14744.61371
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6638.734
-  tps: 4713.50114
+  dps: 6639.35343
+  tps: 4713.94093
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7855.60965
-  tps: 5577.48285
+  dps: 7854.04023
+  tps: 5576.36856
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12036.95195
-  tps: 8546.23588
+  dps: 12087.93924
+  tps: 8582.43686
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3281.87607
-  tps: 2330.13201
+  dps: 3281.92498
+  tps: 2330.16674
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3432.86787
-  tps: 2437.33619
+  dps: 3433.10144
+  tps: 2437.50202
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19859.46816
-  tps: 14100.2224
+  dps: 19890.6181
+  tps: 14122.33885
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6334.98616
-  tps: 4497.84017
+  dps: 6336.94017
+  tps: 4499.22752
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7430.40416
-  tps: 5275.58695
+  dps: 7430.75164
+  tps: 5275.83366
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11583.88681
-  tps: 8224.55963
+  dps: 11611.15426
+  tps: 8243.91952
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3127.40735
-  tps: 2220.45922
+  dps: 3128.47872
+  tps: 2221.21989
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3243.73301
-  tps: 2303.05044
+  dps: 3246.75821
+  tps: 2305.19833
  }
 }
 dps_results: {
@@ -1147,7 +1147,7 @@ dps_results: {
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6348.53495
-  tps: 4507.45981
+  dps: 6349.16494
+  tps: 4507.90711
  }
 }

--- a/sim/rogue/TestSubtlety.results
+++ b/sim/rogue/TestSubtlety.results
@@ -46,821 +46,821 @@ character_stats_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 8057.21939
-  tps: 5715.66998
+  dps: 8057.36562
+  tps: 5715.7738
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8279.39663
-  tps: 5876.9513
+  dps: 8279.69255
+  tps: 5877.16141
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 8034.73651
-  tps: 72791.40175
+  dps: 8034.94424
+  tps: 72791.54924
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 8034.73651
-  tps: 72791.40175
+  dps: 8034.94424
+  tps: 72791.54924
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8322.66915
-  tps: 5907.11621
+  dps: 8322.88244
+  tps: 5907.26765
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlackBruise-50035"
  value: {
-  dps: 8269.70688
-  tps: 5867.81469
+  dps: 8269.62115
+  tps: 5867.75382
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlackBruise-50692"
  value: {
-  dps: 8367.03522
-  tps: 5936.9149
+  dps: 8366.89474
+  tps: 5936.81516
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6004.9972
-  tps: 4261.54925
+  dps: 6005.17912
+  tps: 4261.67841
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BonescytheBattlegear"
  value: {
-  dps: 7096.67356
-  tps: 5034.49752
+  dps: 7096.7796
+  tps: 5034.57281
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5745.9772
+  dps: 8261.76312
+  tps: 5745.96178
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8474.7267
-  tps: 6015.02042
+  dps: 8474.93999
+  tps: 6015.17185
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
   hps: 64
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 8188.19601
-  tps: 5810.51642
+  dps: 8188.02111
+  tps: 5810.39223
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 8236.93665
-  tps: 5845.16946
+  dps: 8237.2577
+  tps: 5845.3974
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 8210.75638
-  tps: 5825.58294
+  dps: 8211.34643
+  tps: 5826.00187
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8628.05413
-  tps: 6123.43669
+  dps: 8629.27676
+  tps: 6124.30476
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 8189.61325
-  tps: 5812.72332
+  dps: 8190.07852
+  tps: 5813.05366
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8522.36927
-  tps: 6048.56226
+  dps: 8523.07486
+  tps: 6049.06323
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8588.26711
-  tps: 6095.53018
+  dps: 8589.24175
+  tps: 6096.22218
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Defender'sCode-40257"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8324.84588
-  tps: 5908.55335
+  dps: 8324.89704
+  tps: 5908.58968
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 8235.61787
-  tps: 5842.38255
+  dps: 8235.88133
+  tps: 5842.5696
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 8224.47681
-  tps: 5838.08183
+  dps: 8224.64072
+  tps: 5838.1982
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8322.66915
-  tps: 5907.11621
+  dps: 8322.88244
+  tps: 5907.26765
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8316.7563
-  tps: 5901.96802
+  dps: 8316.91955
+  tps: 5902.08392
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 8199.97947
-  tps: 5820.16151
+  dps: 8199.99716
+  tps: 5820.17408
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 8253.32978
-  tps: 5858.0357
+  dps: 8253.46401
+  tps: 5858.131
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 8185.34284
-  tps: 5808.07243
+  dps: 8185.47363
+  tps: 5808.16529
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForgeEmber-37660"
  value: {
-  dps: 8153.36839
-  tps: 5786.97246
+  dps: 8153.57674
+  tps: 5787.12039
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8297.66033
-  tps: 5886.63855
+  dps: 8297.83394
+  tps: 5886.76181
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FuturesightRune-38763"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7483.70635
-  tps: 5310.20459
+  dps: 7483.84854
+  tps: 5310.30554
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 8227.09304
-  tps: 5838.57527
+  dps: 8227.37204
+  tps: 5838.77336
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Heartpierce-49982"
  value: {
-  dps: 8454.04731
-  tps: 5999.56218
+  dps: 8454.06774
+  tps: 5999.57668
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Heartpierce-50641"
  value: {
-  dps: 8454.04731
-  tps: 5999.56218
+  dps: 8454.06774
+  tps: 5999.57668
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8322.66915
-  tps: 5907.11621
+  dps: 8322.88244
+  tps: 5907.26765
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8316.7563
-  tps: 5901.96802
+  dps: 8316.91955
+  tps: 5902.08392
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8237.69813
-  tps: 5844.1346
+  dps: 8237.90827
+  tps: 5844.28379
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8297.8089
-  tps: 5888.80865
+  dps: 8297.78735
+  tps: 5888.79335
   hps: 10.24843
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8284.53878
-  tps: 5880.84899
+  dps: 8284.91227
+  tps: 5881.11417
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 8084.68807
-  tps: 5738.44283
+  dps: 8085.00956
+  tps: 5738.67109
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8290.94726
-  tps: 5883.93882
+  dps: 8290.92559
+  tps: 5883.92344
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8297.8089
-  tps: 5888.80865
+  dps: 8297.78735
+  tps: 5888.79335
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 8212.0707
-  tps: 5830.1024
+  dps: 8212.12797
+  tps: 5830.14307
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 8232.5585
-  tps: 5844.64874
+  dps: 8232.61577
+  tps: 5844.6894
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8454.04731
-  tps: 5999.56218
+  dps: 8454.06774
+  tps: 5999.57668
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7813.99831
-  tps: 5546.46972
+  dps: 7813.84533
+  tps: 5546.3611
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Slayer'sArmor"
  value: {
-  dps: 5459.79046
-  tps: 3874.32853
+  dps: 5459.85722
+  tps: 3874.37594
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SouloftheDead-40382"
  value: {
-  dps: 8181.83328
-  tps: 5805.58063
+  dps: 8181.9152
+  tps: 5805.6388
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SparkofLife-37657"
  value: {
-  dps: 8130.60358
-  tps: 5770.44507
+  dps: 8131.0433
+  tps: 5770.75727
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 8274.59129
-  tps: 5870.46695
+  dps: 8274.77948
+  tps: 5870.60057
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-StormshroudArmor"
  value: {
-  dps: 6182.9608
-  tps: 4387.20152
+  dps: 6183.09079
+  tps: 4387.29381
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8297.8089
-  tps: 5888.80865
+  dps: 8297.78735
+  tps: 5888.79335
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8290.94726
-  tps: 5883.93882
+  dps: 8290.92559
+  tps: 5883.92344
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8278.93939
-  tps: 5875.41662
+  dps: 8278.91752
+  tps: 5875.40109
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 7601.15689
-  tps: 5394.04978
+  dps: 7600.75076
+  tps: 5393.76142
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TheFistsofFury"
  value: {
-  dps: 7154.48183
-  tps: 5077.7134
+  dps: 7154.67026
+  tps: 5077.84718
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8333.75862
-  tps: 5913.93035
+  dps: 8334.3629
+  tps: 5914.35939
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 8515.70985
-  tps: 6045.25607
+  dps: 8515.69418
+  tps: 6045.24495
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8569.87177
-  tps: 6084.12676
+  dps: 8570.48789
+  tps: 6084.56421
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 8125.48008
-  tps: 5764.01109
+  dps: 8125.92317
+  tps: 5764.32568
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8261.78529
-  tps: 5863.24204
+  dps: 8261.76312
+  tps: 5863.2263
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6344.5897
-  tps: 4504.58018
+  dps: 6344.76232
+  tps: 4504.70274
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 7367.83492
-  tps: 5228.52305
+  dps: 7367.92421
+  tps: 5228.58645
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-WingedTalisman-37844"
  value: {
-  dps: 8035.74514
-  tps: 5700.80753
+  dps: 8035.95288
+  tps: 5700.95502
  }
 }
 dps_results: {
  key: "TestSubtlety-Average-Default"
  value: {
-  dps: 8502.84674
-  tps: 6034.39867
+  dps: 8502.90599
+  tps: 6034.44073
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15943.468
-  tps: 11318.4378
+  dps: 16082.10667
+  tps: 11416.87126
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8454.04731
-  tps: 5999.56218
+  dps: 8454.06774
+  tps: 5999.57668
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9819.30433
-  tps: 6955.28461
+  dps: 9821.35525
+  tps: 6956.74076
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8800.94176
-  tps: 6246.29678
+  dps: 8893.80872
+  tps: 6312.23233
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4193.89089
-  tps: 2975.15135
+  dps: 4194.03777
+  tps: 2975.25563
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4409.11313
-  tps: 3117.90465
+  dps: 4411.5374
+  tps: 3119.62587
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15751.56164
-  tps: 11179.26868
+  dps: 15890.74333
+  tps: 11278.08768
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8460.24996
-  tps: 6004.14242
+  dps: 8460.63724
+  tps: 6004.41739
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9910.6172
-  tps: 7022.7359
+  dps: 9912.79565
+  tps: 7024.28261
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8220.44804
-  tps: 5833.6891
+  dps: 8313.5236
+  tps: 5899.77275
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4187.31084
-  tps: 2970.74131
+  dps: 4187.52126
+  tps: 2970.89071
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4410.7093
-  tps: 3125.04097
+  dps: 4412.80719
+  tps: 3126.53048
  }
 }
 dps_results: {
  key: "TestSubtlety-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3217.74551
-  tps: 2284.59931
+  dps: 3217.60828
+  tps: 2284.50188
  }
 }

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -7,9 +7,6 @@ import (
 	"github.com/wowsims/wotlk/sim/core/proto"
 )
 
-var MHOutcome = core.OutcomeHit
-var OHOutcome = core.OutcomeHit
-
 var MutilateSpellID int32 = 48666
 
 func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
@@ -24,7 +21,7 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 		ActionID:    actionID,
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    procMask,
-		Flags:       core.SpellFlagMeleeMetrics | SpellFlagColdBlooded,
+		Flags:       core.SpellFlagMeleeMetrics | SpellFlagBuilder | SpellFlagColdBlooded,
 
 		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0) +
 			[]float64{0, 2, 4, 6}[rogue.Talents.TurnTheTables]*core.CritRatingPerCritChance +
@@ -51,13 +48,7 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 				baseDamage *= 1.2
 			}
 
-			result := spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialCritOnly)
-
-			if isMH {
-				MHOutcome = result.Outcome
-			} else {
-				OHOutcome = result.Outcome
-			}
+			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialCritOnly)
 		},
 	})
 }
@@ -70,7 +61,7 @@ func (rogue *Rogue) registerMutilateSpell() {
 		ActionID:    core.ActionID{SpellID: MutilateSpellID},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
-		Flags:       core.SpellFlagMeleeMetrics | SpellFlagBuilder,
+		Flags:       core.SpellFlagMeleeMetrics,
 
 		EnergyCost: core.EnergyCostOptions{
 			Cost:   rogue.costModifier(60 - core.TernaryFloat64(rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfMutilate), 5, 0)),
@@ -91,9 +82,6 @@ func (rogue *Rogue) registerMutilateSpell() {
 				rogue.AddComboPoints(sim, 2, spell.ComboPointMetrics())
 				ohHitSpell.Cast(sim, target)
 				mhHitSpell.Cast(sim, target)
-				if MHOutcome == core.OutcomeCrit || OHOutcome == core.OutcomeCrit {
-					result.Outcome = core.OutcomeCrit
-				}
 			} else {
 				spell.IssueRefund(sim)
 			}

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -266,6 +266,11 @@ func (rogue *Rogue) applySealFate() {
 	procChance := 0.2 * float64(rogue.Talents.SealFate)
 	cpMetrics := rogue.NewComboPointMetrics(core.ActionID{SpellID: 14195})
 
+	icd := core.Cooldown{
+		Timer:    rogue.NewTimer(),
+		Duration: 500 * time.Millisecond,
+	}
+
 	rogue.RegisterAura(core.Aura{
 		Label:    "Seal Fate",
 		Duration: core.NeverExpires,
@@ -281,8 +286,9 @@ func (rogue *Rogue) applySealFate() {
 				return
 			}
 
-			if sim.Proc(procChance, "Seal Fate") {
+			if icd.IsReady(sim) && sim.Proc(procChance, "Seal Fate") {
 				rogue.AddComboPoints(sim, 1, cpMetrics)
+				icd.Use(sim)
 			}
 		},
 	})


### PR DESCRIPTION
[rogue] The Mutilate "parent" spell triggered Focused Attacks whenever any of the damage spells crit, returning up to 6 instead of only 4 energy. Each damage spell now counts as a builder for Seal Fate, which has gained an ICD so Mutilate doesn't grant up to 4 CPs

[rogue] Seal Fate now has a proper ICD (500 ms, as used in-game as well) 

[rogue] Deadly Poison now properly snapshots BaseDamage and AttackerMutliplier on each refresh. The DPS difference is negligible, as expected