### PR TITLE
fix master demonologist crit logic

### DIFF
--- a/sim/warlock/chaos_bolt.go
+++ b/sim/warlock/chaos_bolt.go
@@ -34,7 +34,6 @@ func (warlock *Warlock) registerChaosBoltSpell() {
 		},
 
 		BonusCritRating: 0 +
-			warlock.masterDemonologistFireCrit +
 			core.TernaryFloat64(warlock.Talents.Devastation, 1, 0)*5*core.CritRatingPerCritChance,
 		DamageMultiplierAdditive: 1 +
 			warlock.GrandFirestoneBonus() +

--- a/sim/warlock/conflagrate.go
+++ b/sim/warlock/conflagrate.go
@@ -42,7 +42,6 @@ func (warlock *Warlock) registerConflagrateSpell() {
 		},
 
 		BonusCritRating: 0 +
-			warlock.masterDemonologistFireCrit +
 			core.TernaryFloat64(warlock.Talents.Devastation, 5*core.CritRatingPerCritChance, 0) +
 			5*float64(warlock.Talents.FireAndBrimstone)*core.CritRatingPerCritChance,
 		DamageMultiplierAdditive: 1 +

--- a/sim/warlock/corruption.go
+++ b/sim/warlock/corruption.go
@@ -27,7 +27,6 @@ func (warlock *Warlock) registerCorruptionSpell() {
 		},
 
 		BonusCritRating: 0 +
-			warlock.masterDemonologistShadowCrit +
 			3*float64(warlock.Talents.Malediction)*core.CritRatingPerCritChance +
 			core.TernaryFloat64(warlock.HasSetBonus(ItemSetDarkCovensRegalia, 2), 5*core.CritRatingPerCritChance, 0),
 		DamageMultiplierAdditive: 1 +

--- a/sim/warlock/haunt.go
+++ b/sim/warlock/haunt.go
@@ -50,8 +50,6 @@ func (warlock *Warlock) registerHauntSpell() {
 			},
 		},
 
-		BonusCritRating: 0 +
-			warlock.masterDemonologistShadowCrit,
 		DamageMultiplierAdditive: 1 +
 			warlock.GrandFirestoneBonus() +
 			0.03*float64(warlock.Talents.ShadowMastery),

--- a/sim/warlock/immolate.go
+++ b/sim/warlock/immolate.go
@@ -32,7 +32,6 @@ func (warlock *Warlock) registerImmolateSpell() {
 		},
 
 		BonusCritRating: 0 +
-			warlock.masterDemonologistFireCrit +
 			core.TernaryFloat64(warlock.Talents.Devastation, 5*core.CritRatingPerCritChance, 0),
 		DamageMultiplierAdditive: 1 +
 			warlock.GrandFirestoneBonus() +

--- a/sim/warlock/incinerate.go
+++ b/sim/warlock/incinerate.go
@@ -28,7 +28,6 @@ func (warlock *Warlock) registerIncinerateSpell() {
 		},
 
 		BonusCritRating: 0 +
-			warlock.masterDemonologistFireCrit +
 			core.TernaryFloat64(warlock.Talents.Devastation, 5*core.CritRatingPerCritChance, 0) +
 			core.TernaryFloat64(warlock.HasSetBonus(ItemSetDeathbringerGarb, 4), 5*core.CritRatingPerCritChance, 0) +
 			core.TernaryFloat64(warlock.HasSetBonus(ItemSetDarkCovensRegalia, 2), 5*core.CritRatingPerCritChance, 0),

--- a/sim/warlock/pet_abilities.go
+++ b/sim/warlock/pet_abilities.go
@@ -71,7 +71,6 @@ func (wp *WarlockPet) newFirebolt() *core.Spell {
 			},
 		},
 
-		BonusCritRating: wp.owner.masterDemonologistFireCrit,
 		DamageMultiplier: (1 + 0.1*float64(wp.owner.Talents.ImprovedImp)) *
 			(1 + 0.2*core.TernaryFloat64(wp.owner.HasMajorGlyph(proto.WarlockMajorGlyph_GlyphOfImp), 1, 0)),
 		CritMultiplier:   2,
@@ -144,7 +143,6 @@ func (wp *WarlockPet) newLashOfPain() *core.Spell {
 			},
 		},
 
-		BonusCritRating:  wp.owner.masterDemonologistShadowCrit,
 		DamageMultiplier: 1,
 		CritMultiplier:   1.5,
 		ThreatMultiplier: 1,

--- a/sim/warlock/seed.go
+++ b/sim/warlock/seed.go
@@ -15,7 +15,6 @@ func (warlock *Warlock) registerSeedSpell() {
 		ProcMask:    core.ProcMaskSpellDamage,
 
 		BonusCritRating: 0 +
-			warlock.masterDemonologistShadowCrit +
 			float64(warlock.Talents.ImprovedCorruption)*core.CritRatingPerCritChance,
 		DamageMultiplierAdditive: 1 +
 			warlock.GrandFirestoneBonus() +

--- a/sim/warlock/shadowbolt.go
+++ b/sim/warlock/shadowbolt.go
@@ -37,7 +37,6 @@ func (warlock *Warlock) registerShadowBoltSpell() {
 		},
 
 		BonusCritRating: 0 +
-			warlock.masterDemonologistShadowCrit +
 			core.TernaryFloat64(warlock.Talents.Devastation, 5*core.CritRatingPerCritChance, 0) +
 			core.TernaryFloat64(warlock.HasSetBonus(ItemSetDeathbringerGarb, 4), 5*core.CritRatingPerCritChance, 0) +
 			core.TernaryFloat64(warlock.HasSetBonus(ItemSetDarkCovensRegalia, 2), 5*core.CritRatingPerCritChance, 0),

--- a/sim/warlock/shadowburn.go
+++ b/sim/warlock/shadowburn.go
@@ -44,7 +44,6 @@ func (warlock *Warlock) registerShadowBurnSpell() {
 		},
 
 		BonusCritRating: 0 +
-			warlock.masterDemonologistShadowCrit +
 			core.TernaryFloat64(warlock.Talents.Devastation, 5*core.CritRatingPerCritChance, 0),
 		DamageMultiplierAdditive: 1 +
 			warlock.GrandFirestoneBonus() +

--- a/sim/warlock/soul_fire.go
+++ b/sim/warlock/soul_fire.go
@@ -25,7 +25,6 @@ func (warlock *Warlock) registerSoulFireSpell() {
 		},
 
 		BonusCritRating: 0 +
-			warlock.masterDemonologistFireCrit +
 			core.TernaryFloat64(warlock.Talents.Devastation, 5*core.CritRatingPerCritChance, 0) +
 			core.TernaryFloat64(warlock.HasSetBonus(ItemSetDarkCovensRegalia, 2), 5*core.CritRatingPerCritChance, 0),
 		DamageMultiplierAdditive: 1 +

--- a/sim/warlock/unstable_affliction.go
+++ b/sim/warlock/unstable_affliction.go
@@ -28,7 +28,6 @@ func (warlock *Warlock) registerUnstableAfflictionSpell() {
 		},
 
 		BonusCritRating: 0 +
-			warlock.masterDemonologistShadowCrit +
 			3*core.CritRatingPerCritChance*float64(warlock.Talents.Malediction),
 		DamageMultiplierAdditive: 1 +
 			warlock.GrandSpellstoneBonus() +

--- a/sim/warlock/warlock.go
+++ b/sim/warlock/warlock.go
@@ -75,9 +75,7 @@ type Warlock struct {
 	PreviousTime   time.Duration
 	SpellsRotation []SpellRotation
 
-	petStmBonusSP                float64
-	masterDemonologistFireCrit   float64
-	masterDemonologistShadowCrit float64
+	petStmBonusSP float64
 
 	CritDebuffCategory *core.ExclusiveCategory
 }


### PR DESCRIPTION
Fixes https://github.com/wowsims/wotlk/issues/2817

Imp Before:
<img width="1129" alt="image" src="https://user-images.githubusercontent.com/9436142/227593688-f6556105-41b8-4faf-9d7e-e5261a536dc8.png">

Imp After:
<img width="1117" alt="image" src="https://user-images.githubusercontent.com/9436142/227593725-8fc6264e-ef21-4edc-b81e-8a335b8f2209.png">


Succubus Before:
<img width="1132" alt="image" src="https://user-images.githubusercontent.com/9436142/227593778-80dfa0e6-066d-4583-8f37-c74a227a1c22.png">

Succubus After:
<img width="1139" alt="image" src="https://user-images.githubusercontent.com/9436142/227593815-d7ba9fbd-3c41-4c6f-b34b-46464e56de2a.png">

Notice how now the bonus 5% crit is being applied to fire (imp) and shadow (succubus) as expected. Before, the `warlock.masterDemonologistShadowCrit` was not being applied because spells were registered before the pets were created