### PR TITLE
Add builder + finisher combat rotation options

### DIFF
--- a/proto/rogue.proto
+++ b/proto/rogue.proto
@@ -144,8 +144,6 @@ message Rogue {
 			Never = 0;
 			Once = 1;
 			Maintain = 2;
-			Build = 3;
-			Fill = 4;
 			FrequencyUnknown = 5;
 		}
 		Frequency expose_armor_frequency = 1;
@@ -160,6 +158,12 @@ message Rogue {
 			CombatPriorityUnknown = 2;
 		}
 		CombatPriority combat_finisher_priority = 4;
+
+		enum CombatBuilder {
+			SinisterStrike = 0;
+			Backstab = 1;
+		}
+		CombatBuilder combat_builder = 25;
 
 		enum AssassinationPriority {
 			EnvenomRupture = 0;

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -46,766 +46,766 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 6362.05402
-  tps: 4517.05836
+  dps: 6359.72742
+  tps: 4515.40647
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6482.358
-  tps: 4602.47418
+  dps: 6479.33693
+  tps: 4600.32922
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6547.10577
-  tps: 4648.4451
+  dps: 6541.74942
+  tps: 4644.64208
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6347.91854
-  tps: 55850.02699
+  dps: 6343.51712
+  tps: 57141.58873
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6347.91854
-  tps: 55850.02699
+  dps: 6343.51712
+  tps: 57141.58873
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6508.06568
-  tps: 4620.72663
+  dps: 6503.42735
+  tps: 4617.43342
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50035"
  value: {
-  dps: 6829.51419
-  tps: 4848.95508
+  dps: 6840.27623
+  tps: 4856.59613
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50692"
  value: {
-  dps: 6941.8432
-  tps: 4928.70867
+  dps: 6951.81289
+  tps: 4935.78715
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5030.21507
-  tps: 3571.4527
+  dps: 5049.3517
+  tps: 3585.03971
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6004.62008
-  tps: 4263.28026
+  dps: 6021.89159
+  tps: 4275.54303
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6482.358
-  tps: 4510.4247
+  dps: 6479.33693
+  tps: 4508.32264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6631.97875
-  tps: 4708.70491
+  dps: 6626.88875
+  tps: 4705.09101
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6631.97875
-  tps: 4708.70491
+  dps: 6626.88875
+  tps: 4705.09101
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6624.81548
-  tps: 4703.61899
+  dps: 6619.86163
+  tps: 4700.10176
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
   hps: 64
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6476.22969
-  tps: 4598.12308
+  dps: 6472.47055
+  tps: 4595.45409
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6510.0042
-  tps: 4622.10298
+  dps: 6505.83602
+  tps: 4619.14358
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6496.13135
-  tps: 4612.25326
+  dps: 6493.13423
+  tps: 4610.1253
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6829.60087
-  tps: 4849.01662
+  dps: 6821.89229
+  tps: 4843.54353
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6453.73571
-  tps: 4582.15235
+  dps: 6451.45739
+  tps: 4580.53475
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6762.4038
-  tps: 4801.3067
+  dps: 6762.36949
+  tps: 4801.28234
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6806.50608
-  tps: 4832.61931
+  dps: 6826.06088
+  tps: 4846.50322
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6511.35274
-  tps: 4623.06044
+  dps: 6506.23479
+  tps: 4619.4267
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6557.57407
-  tps: 4655.87759
+  dps: 6563.53363
+  tps: 4660.10888
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6526.82196
-  tps: 4634.04359
+  dps: 6547.56406
+  tps: 4648.77048
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6482.358
-  tps: 4602.47418
+  dps: 6479.33693
+  tps: 4600.32922
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6482.358
-  tps: 4602.47418
+  dps: 6479.33693
+  tps: 4600.32922
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6508.06568
-  tps: 4620.72663
+  dps: 6503.42735
+  tps: 4617.43342
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6503.62114
-  tps: 4617.57101
+  dps: 6499.19846
+  tps: 4614.4309
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6486.09525
-  tps: 4605.12763
+  dps: 6487.10679
+  tps: 4605.84582
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6482.358
-  tps: 4602.47418
+  dps: 6479.33693
+  tps: 4600.32922
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6510.96443
-  tps: 4622.78475
+  dps: 6507.34754
+  tps: 4620.21675
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6461.18626
-  tps: 4587.44225
+  dps: 6457.43441
+  tps: 4584.77843
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6345.67928
-  tps: 4505.43229
+  dps: 6347.32249
+  tps: 4506.59897
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6437.21636
-  tps: 4570.42362
+  dps: 6431.65196
+  tps: 4566.47289
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6482.358
-  tps: 4602.47418
+  dps: 6479.33693
+  tps: 4600.32922
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6482.358
-  tps: 4602.47418
+  dps: 6479.33693
+  tps: 4600.32922
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6589.93946
-  tps: 4678.85702
+  dps: 6585.53995
+  tps: 4675.73336
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Gladiator'sVestments"
  value: {
-  dps: 6436.11792
-  tps: 4569.64372
+  dps: 6420.20295
+  tps: 4558.34409
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6486.37804
-  tps: 4605.32841
+  dps: 6481.56284
+  tps: 4601.90961
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-49982"
  value: {
-  dps: 6631.97875
-  tps: 4708.70491
+  dps: 6626.88875
+  tps: 4705.09101
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-50641"
  value: {
-  dps: 6631.97875
-  tps: 4708.70491
+  dps: 6626.88875
+  tps: 4705.09101
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6508.06568
-  tps: 4620.72663
+  dps: 6503.42735
+  tps: 4617.43342
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6503.62114
-  tps: 4617.57101
+  dps: 6499.19846
+  tps: 4614.4309
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6530.23233
-  tps: 4636.46495
+  dps: 6525.88331
+  tps: 4633.37715
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6482.358
-  tps: 4602.47418
+  dps: 6479.33693
+  tps: 4600.32922
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6514.58482
-  tps: 4625.35522
+  dps: 6510.9859
+  tps: 4622.79999
   hps: 9.14161
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6563.74796
-  tps: 4660.26105
+  dps: 6564.42389
+  tps: 4660.74096
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6399.20442
-  tps: 4543.43514
+  dps: 6394.19121
+  tps: 4539.87576
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6508.14647
-  tps: 4620.78399
+  dps: 6505.13766
+  tps: 4618.64774
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6514.21434
-  tps: 4625.09218
+  dps: 6511.20842
+  tps: 4622.95798
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6482.358
-  tps: 4602.47418
+  dps: 6479.33693
+  tps: 4600.32922
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6482.358
-  tps: 4602.47418
+  dps: 6479.33693
+  tps: 4600.32922
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6495.54913
-  tps: 4611.83988
+  dps: 6488.83639
+  tps: 4607.07384
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6514.026
-  tps: 4624.95846
+  dps: 6507.15653
+  tps: 4620.08114
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6631.97875
-  tps: 4708.70491
+  dps: 6626.88875
+  tps: 4705.09101
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6482.358
-  tps: 4602.47418
+  dps: 6479.33693
+  tps: 4600.32922
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 6673.97963
-  tps: 4738.52554
+  dps: 6677.94077
+  tps: 4741.33795
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6631.97875
-  tps: 4708.70491
+  dps: 6626.88875
+  tps: 4705.09101
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Slayer'sArmor"
  value: {
-  dps: 4958.47814
-  tps: 3520.51948
+  dps: 4976.75078
+  tps: 3533.49305
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6465.99853
-  tps: 4590.85896
+  dps: 6462.04421
+  tps: 4588.05139
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SparkofLife-37657"
  value: {
-  dps: 6414.08913
-  tps: 4554.00328
+  dps: 6454.39904
+  tps: 4582.62332
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6521.6725
-  tps: 4630.38747
+  dps: 6536.88472
+  tps: 4641.18815
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StormshroudArmor"
  value: {
-  dps: 5072.1314
-  tps: 3601.21329
+  dps: 5076.30092
+  tps: 3604.17365
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6514.21434
-  tps: 4625.09218
+  dps: 6511.20842
+  tps: 4622.95798
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6508.14647
-  tps: 4620.78399
+  dps: 6505.13766
+  tps: 4618.64774
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6497.52769
-  tps: 4613.24466
+  dps: 6494.51383
+  tps: 4611.10482
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6404.13508
-  tps: 4546.93591
+  dps: 6408.25956
+  tps: 4549.86429
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheFistsofFury"
  value: {
-  dps: 5804.89636
-  tps: 4121.47642
+  dps: 5810.32596
+  tps: 4125.33143
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5906.59859
-  tps: 4193.685
+  dps: 5897.31816
+  tps: 4187.09589
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6547.75419
-  tps: 4648.90548
+  dps: 6568.95011
+  tps: 4663.95458
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6641.67295
-  tps: 4715.5878
+  dps: 6647.80508
+  tps: 4719.94161
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6704.04922
-  tps: 4759.87495
+  dps: 6707.91594
+  tps: 4762.62032
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6482.358
-  tps: 4602.47418
+  dps: 6479.33693
+  tps: 4600.32922
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6482.358
-  tps: 4602.47418
+  dps: 6479.33693
+  tps: 4600.32922
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6407.11866
-  tps: 4549.05425
+  dps: 6419.17649
+  tps: 4557.61531
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6482.358
-  tps: 4602.47418
+  dps: 6479.33693
+  tps: 4600.32922
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6482.358
-  tps: 4602.47418
+  dps: 6479.33693
+  tps: 4600.32922
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5338.30606
-  tps: 3790.19731
+  dps: 5331.34564
+  tps: 3785.25541
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6231.43572
-  tps: 4424.31936
+  dps: 6250.55867
+  tps: 4437.89666
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6145.65046
-  tps: 4363.41183
+  dps: 6164.55856
+  tps: 4376.83657
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6348.64628
-  tps: 4507.53886
+  dps: 6344.17767
+  tps: 4504.36614
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 6603.93323
-  tps: 4688.79259
+  dps: 6611.77259
+  tps: 4694.35854
  }
 }
 dps_results: {
@@ -818,15 +818,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4919.33217
-  tps: 3492.72584
+  dps: 4914.98418
+  tps: 3489.63877
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5752.748
-  tps: 4084.45108
+  dps: 5762.90906
+  tps: 4091.66543
  }
 }
 dps_results: {
@@ -839,15 +839,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2440.68778
-  tps: 1732.88832
+  dps: 2443.84749
+  tps: 1735.13172
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2573.63663
-  tps: 1827.28201
+  dps: 2573.849
+  tps: 1827.43279
  }
 }
 dps_results: {
@@ -860,15 +860,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6631.97875
-  tps: 4708.70491
+  dps: 6626.88875
+  tps: 4705.09101
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7772.32033
-  tps: 5518.34743
+  dps: 7789.25093
+  tps: 5530.36816
  }
 }
 dps_results: {
@@ -881,15 +881,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3281.20643
-  tps: 2329.65656
+  dps: 3281.55035
+  tps: 2329.90075
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3404.09501
-  tps: 2416.90745
+  dps: 3403.98011
+  tps: 2416.82588
  }
 }
 dps_results: {
@@ -902,15 +902,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6330.85583
-  tps: 4494.90764
+  dps: 6322.28207
+  tps: 4488.82027
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7363.47678
-  tps: 5228.06851
+  dps: 7375.04899
+  tps: 5236.28478
  }
 }
 dps_results: {
@@ -923,15 +923,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3127.44545
-  tps: 2220.48627
+  dps: 3126.90416
+  tps: 2220.10195
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3221.26105
-  tps: 2287.09535
+  dps: 3215.60944
+  tps: 2283.0827
  }
 }
 dps_results: {
@@ -944,15 +944,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5686.76508
-  tps: 4037.60321
+  dps: 5677.45963
+  tps: 4030.99633
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6813.61276
-  tps: 4837.66506
+  dps: 6831.73062
+  tps: 4850.52874
  }
 }
 dps_results: {
@@ -965,15 +965,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2649.40412
-  tps: 1881.07693
+  dps: 2655.1682
+  tps: 1885.16942
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2823.89479
-  tps: 2004.9653
+  dps: 2827.98851
+  tps: 2007.87184
  }
 }
 dps_results: {
@@ -986,15 +986,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4953.82148
-  tps: 3517.21325
+  dps: 4949.69474
+  tps: 3514.28327
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5832.53335
-  tps: 4141.09868
+  dps: 5842.69442
+  tps: 4148.31304
  }
 }
 dps_results: {
@@ -1007,15 +1007,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2459.04539
-  tps: 1745.92222
+  dps: 2461.9763
+  tps: 1748.00317
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2612.38635
-  tps: 1854.79431
+  dps: 2612.5419
+  tps: 1854.90475
  }
 }
 dps_results: {
@@ -1028,15 +1028,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6677.76266
-  tps: 4741.21149
+  dps: 6672.87735
+  tps: 4737.74292
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7876.72725
-  tps: 5592.47635
+  dps: 7893.65785
+  tps: 5604.49707
  }
 }
 dps_results: {
@@ -1049,15 +1049,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3305.28306
-  tps: 2346.75097
+  dps: 3305.34218
+  tps: 2346.79294
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3453.55644
-  tps: 2452.02507
+  dps: 3453.90325
+  tps: 2452.27131
  }
 }
 dps_results: {
@@ -1070,15 +1070,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6375.01512
-  tps: 4526.26073
+  dps: 6366.05452
+  tps: 4519.89871
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7462.43321
-  tps: 5298.32758
+  dps: 7474.00542
+  tps: 5306.54385
  }
 }
 dps_results: {
@@ -1091,15 +1091,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3150.18943
-  tps: 2236.6345
+  dps: 3149.49439
+  tps: 2236.14102
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3266.87036
-  tps: 2319.47795
+  dps: 3261.09559
+  tps: 2315.37787
  }
 }
 dps_results: {
@@ -1112,15 +1112,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5726.93425
-  tps: 4066.12332
+  dps: 5717.72274
+  tps: 4059.58314
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6908.16736
-  tps: 4904.79883
+  dps: 6926.28522
+  tps: 4917.66251
  }
 }
 dps_results: {
@@ -1133,21 +1133,21 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2669.21275
-  tps: 1895.14105
+  dps: 2674.85466
+  tps: 1899.14681
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2866.59019
-  tps: 2035.27904
+  dps: 2870.84644
+  tps: 2038.30097
  }
 }
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6359.18408
-  tps: 4515.0207
+  dps: 6376.71775
+  tps: 4527.46961
  }
 }

--- a/sim/rogue/backstab.go
+++ b/sim/rogue/backstab.go
@@ -11,7 +11,7 @@ func (rogue *Rogue) registerBackstabSpell() {
 	hasGlyph := rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfBackstab)
 
 	rogue.Backstab = rogue.RegisterSpell(core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: 26863},
+		ActionID:    core.ActionID{SpellID: 48657},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
 		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | SpellFlagBuilder | SpellFlagColdBlooded,

--- a/sim/rogue/eviscerate.go
+++ b/sim/rogue/eviscerate.go
@@ -45,7 +45,7 @@ func (rogue *Rogue) registerEviscerate() {
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			comboPoints := rogue.ComboPoints()
 			flatBaseDamage := 127 + 370*float64(comboPoints)
-			// tooltip implies 3..7% AP scaling, but testing show it's fixed at 7% (3.4.0.46158)
+			// tooltip implies 3..7% AP scaling, but testing shows it's fixed at 7% (3.4.0.46158)
 			apRatio := 0.07 * float64(comboPoints)
 
 			baseDamage := flatBaseDamage +

--- a/sim/rogue/rotation_subtlety.go
+++ b/sim/rogue/rotation_subtlety.go
@@ -107,8 +107,7 @@ func (x *rotation_subtlety) setup(sim *core.Simulation, rogue *Rogue) {
 	})
 
 	// Expose armor
-	if rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Once ||
-		rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Maintain {
+	if rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Once || rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Maintain {
 		hasCastExpose := false
 		x.prios = append(x.prios, prio{
 			func(sim *core.Simulation, rogue *Rogue) PriorityAction {
@@ -182,7 +181,7 @@ func (x *rotation_subtlety) setup(sim *core.Simulation, rogue *Rogue) {
 			func(sim *core.Simulation, rogue *Rogue) PriorityAction {
 				if rogue.Shadowstep.IsReady(sim) {
 					// Can we cast Rupture now?
-					if !rogue.Rupture.CurDot().IsActive() && rogue.ComboPoints() > 4 && rogue.CurrentEnergy() >= rogue.Rupture.DefaultCast.Cost+rogue.Shadowstep.DefaultCast.Cost {
+					if !rogue.Rupture.CurDot().IsActive() && rogue.ComboPoints() >= 5 && rogue.CurrentEnergy() >= rogue.Rupture.DefaultCast.Cost+rogue.Shadowstep.DefaultCast.Cost {
 						return Cast
 					} else {
 						return Skip

--- a/ui/rogue/inputs.ts
+++ b/ui/rogue/inputs.ts
@@ -7,6 +7,7 @@ import * as InputHelpers from '../core/components/input_helpers.js';
 import {
 	Rogue_Rotation_AssassinationPriority as AssassinationPriority,
 	Rogue_Rotation_CombatPriority as CombatPriority,
+	Rogue_Rotation_CombatBuilder as CombatBuilder,
 	Rogue_Rotation_SubtletyPriority as SubtletyPriority,
 	Rogue_Rotation_Frequency as Frequency,
 	Rogue_Options_PoisonImbue as Poison,
@@ -83,6 +84,28 @@ export const RogueRotationConfig = {
 				{ name: 'Maintain', value: Frequency.Maintain },
 			],
 		}),
+		InputHelpers.makeRotationEnumInput<Spec.SpecRogue, CombatBuilder>({
+			fieldName: 'combatBuilder',
+			label: "Builder",
+			labelTooltip: 'Use Sinister Strike or Backstab as builder.',
+			values: [
+				{ name: "Sinister Strike", value: CombatBuilder.SinisterStrike },
+				{ name: "Backstab", value: CombatBuilder.Backstab },
+			],
+			showWhen: (player: Player<Spec.SpecRogue>) => player.getTalents().combatPotency > 0
+		}),
+		/*
+		InputHelpers.makeRotationEnumInput<Spec.SpecRogue, CombatPriority>({
+			fieldName: 'combatFinisherPriority',
+			label: 'Finisher Priority',
+			labelTooltip: 'The finisher that will be cast with highest priority.',
+			values: [
+				{ name: 'Rupture', value: CombatPriority.RuptureEviscerate },
+				{ name: 'Eviscerate', value: CombatPriority.EviscerateRupture },
+			],
+			showWhen: (player: Player<Spec.SpecRogue>) => player.getTalents().combatPotency > 0
+		}),
+		*/
 		InputHelpers.makeRotationEnumInput<Spec.SpecRogue, AssassinationPriority>({
 			fieldName: 'assassinationFinisherPriority',
 			label: 'Finisher Priority',
@@ -151,7 +174,7 @@ export const RogueRotationConfig = {
 		InputHelpers.makeRotationBooleanInput<Spec.SpecRogue>({
 			fieldName: "useGhostlyStrike",
 			label: 'Use Ghostly Strike',
-			labelTooltip: 'Use Ghostly Strike as a builder.',
+			labelTooltip: 'Use Ghostly Strike on cooldown. Mainly useful when using the associate glyph.',
 			showWhen: (player: Player<Spec.SpecRogue>) => player.getTalents().ghostlyStrike
 		}),
 		InputHelpers.makeRotationBooleanInput<Spec.SpecRogue>({

--- a/ui/rogue/inputs.ts
+++ b/ui/rogue/inputs.ts
@@ -94,7 +94,6 @@ export const RogueRotationConfig = {
 			],
 			showWhen: (player: Player<Spec.SpecRogue>) => player.getTalents().combatPotency > 0
 		}),
-		/*
 		InputHelpers.makeRotationEnumInput<Spec.SpecRogue, CombatPriority>({
 			fieldName: 'combatFinisherPriority',
 			label: 'Finisher Priority',
@@ -105,7 +104,6 @@ export const RogueRotationConfig = {
 			],
 			showWhen: (player: Player<Spec.SpecRogue>) => player.getTalents().combatPotency > 0
 		}),
-		*/
 		InputHelpers.makeRotationEnumInput<Spec.SpecRogue, AssassinationPriority>({
 			fieldName: 'assassinationFinisherPriority',
 			label: 'Finisher Priority',

--- a/ui/rogue/presets.ts
+++ b/ui/rogue/presets.ts
@@ -1,23 +1,17 @@
-import { Flask } from '../core/proto/common.js';
-import { Conjured } from '../core/proto/common.js';
-import { Consumes } from '../core/proto/common.js';
-
-import { EquipmentSpec } from '../core/proto/common.js';
-import { Food } from '../core/proto/common.js';
-import { Glyphs } from '../core/proto/common.js';
-import { Player } from '../core/player.js';
-import { Potions } from '../core/proto/common.js';
-import { SavedTalents } from '../core/proto/ui.js';
+import {Conjured, Consumes, EquipmentSpec, Flask, Food, Glyphs, Potions} from '../core/proto/common.js';
+import {Player} from '../core/player.js';
+import {SavedTalents} from '../core/proto/ui.js';
 
 import {
-	Rogue_Rotation as RogueRotation,
 	Rogue_Options as RogueOptions,
 	Rogue_Options_PoisonImbue as Poison,
-	RogueMajorGlyph,
-	Rogue_Rotation_Frequency,
+	Rogue_Rotation as RogueRotation,
 	Rogue_Rotation_AssassinationPriority,
+	Rogue_Rotation_CombatBuilder,
 	Rogue_Rotation_CombatPriority,
+	Rogue_Rotation_Frequency,
 	Rogue_Rotation_SubtletyPriority,
+	RogueMajorGlyph,
 } from '../core/proto/rogue.js';
 
 import * as Tooltips from '../core/constants/tooltips.js';
@@ -77,6 +71,7 @@ export const DefaultRotation = RogueRotation.create({
 	minimumComboPointsExposeArmor: 2,
 	tricksOfTheTradeFrequency: Rogue_Rotation_Frequency.Maintain,
 	assassinationFinisherPriority: Rogue_Rotation_AssassinationPriority.EnvenomRupture,
+	combatBuilder: Rogue_Rotation_CombatBuilder.SinisterStrike,
 	combatFinisherPriority: Rogue_Rotation_CombatPriority.RuptureEviscerate,
 	subtletyFinisherPriority: Rogue_Rotation_SubtletyPriority.SubtletyEviscerate,
 	minimumComboPointsPrimaryFinisher: 4,

--- a/ui/rogue/sim.ts
+++ b/ui/rogue/sim.ts
@@ -17,6 +17,7 @@ import {IndividualSimUI} from '../core/individual_sim_ui.js';
 import {
 	Rogue_Options_PoisonImbue,
 	Rogue_Rotation_AssassinationPriority as AssassinationPriority,
+	Rogue_Rotation_CombatBuilder as CombatBuilder,
 	Rogue_Rotation_CombatPriority as CombatPriority,
 	Rogue_Rotation_Frequency as Frequency,
 	Rogue_Rotation_SubtletyPriority as SubtletyPriority,
@@ -28,7 +29,7 @@ import * as OtherInputs from '../core/components/other_inputs.js';
 
 import * as RogueInputs from './inputs.js';
 import * as Presets from './presets.js';
-import {DefaultOptions} from "./presets.js";
+import {DefaultOptions} from './presets.js';
 
 export class RogueSimUI extends IndividualSimUI<Spec.SpecRogue> {
 	constructor(parentElem: HTMLElement, player: Player<Spec.SpecRogue>) {
@@ -52,7 +53,7 @@ export class RogueSimUI extends IndividualSimUI<Spec.SpecRogue> {
 								}
 							}
 							if (hasNoArmor) {
-								return 'One or more targets have no armor! Check advanced encounter settings.';
+								return 'One or more targets have no armor. Check advanced encounter settings.';
 							} else {
 								return '';
 							}
@@ -68,7 +69,45 @@ export class RogueSimUI extends IndividualSimUI<Spec.SpecRogue> {
 								(simUI.player.getGear().getEquippedItem(ItemSlot.ItemSlotMainHand)?.item.weaponType != WeaponType.WeaponTypeDagger ||
 									simUI.player.getGear().getEquippedItem(ItemSlot.ItemSlotOffHand)?.item.weaponType != WeaponType.WeaponTypeDagger)
 							) {
-								return '\'Mutilate\' talent selected, but daggers not equipped in both hands!';
+								return '"Mutilate" talent selected, but daggers not equipped in both hands.';
+							} else {
+								return '';
+							}
+						},
+					};
+				},
+				(simUI: IndividualSimUI<Spec.SpecRogue>) => {
+					return {
+						updateOn: simUI.player.changeEmitter,
+						getContent: () => {
+							if (simUI.player.getRotation().combatBuilder == CombatBuilder.Backstab &&
+								simUI.player.getGear().getEquippedItem(ItemSlot.ItemSlotMainHand)?.item.weaponType != WeaponType.WeaponTypeDagger) {
+								return 'Builder "Backstab" selected, but no dagger equipped.';
+							} else {
+								return '';
+							}
+						},
+					};
+				},
+				(simUI: IndividualSimUI<Spec.SpecRogue>) => {
+					return {
+						updateOn: simUI.player.changeEmitter,
+						getContent: () => {
+							if (simUI.player.getInFrontOfTarget() && (simUI.player.getRotation().combatBuilder == CombatBuilder.Backstab ||
+								simUI.player.getRotation().openWithGarrote)) {
+								return 'Option "In Front of Target" selected, but using Backstab or Garrote as builder or opener.';
+							} else {
+								return '';
+							}
+						},
+					};
+				},
+				(simUI: IndividualSimUI<Spec.SpecRogue>) => {
+					return {
+						updateOn: simUI.player.changeEmitter,
+						getContent: () => {
+							if (simUI.player.getRotation().useGhostlyStrike && !simUI.player.getMajorGlyphs().includes(RogueMajorGlyph.GlyphOfGhostlyStrike)) {
+								return '"Use Ghostly Strike" selected, but missing Glyph of Ghostly Strike.';
 							} else {
 								return '';
 							}
@@ -80,7 +119,7 @@ export class RogueSimUI extends IndividualSimUI<Spec.SpecRogue> {
 						updateOn: simUI.player.changeEmitter,
 						getContent: () => {
 							if (simUI.player.getRotation().useFeint && !simUI.player.getMajorGlyphs().includes(RogueMajorGlyph.GlyphOfFeint)) {
-								return '\'Use Feint\' selected, but missing Glyph of Feint!';
+								return '"Use Feint" selected, but missing Glyph of Feint.';
 							} else {
 								return '';
 							}
@@ -98,11 +137,11 @@ export class RogueSimUI extends IndividualSimUI<Spec.SpecRogue> {
 							if (typeof mhWeaponSpeed == 'undefined' || typeof ohWeaponSpeed == 'undefined' || !simUI.player.getSpecOptions().applyPoisonsManually) {
 								return '';
 							}
-							if ((mhWeaponSpeed < ohWeaponSpeed) && (ohImbue == Rogue_Options_PoisonImbue.DeadlyPoison)) {
-								return 'Deadly poison applied to slower (off hand) weapon!';
+							if (mhWeaponSpeed < ohWeaponSpeed && ohImbue == Rogue_Options_PoisonImbue.DeadlyPoison) {
+								return 'Deadly poison applied to slower (off hand) weapon.';
 							}
-							if ((ohWeaponSpeed < mhWeaponSpeed) && (mhImbue == Rogue_Options_PoisonImbue.DeadlyPoison)) {
-								return 'Deadly poison applied to slower (main hand) weapon!';
+							if (ohWeaponSpeed < mhWeaponSpeed && mhImbue == Rogue_Options_PoisonImbue.DeadlyPoison) {
+								return 'Deadly poison applied to slower (main hand) weapon.';
 							}
 							return '';
 						},
@@ -266,11 +305,13 @@ export class RogueSimUI extends IndividualSimUI<Spec.SpecRogue> {
 					rotation.assassinationFinisherPriority = Presets.DefaultRotation.assassinationFinisherPriority;
 				}
 				rotation.combatFinisherPriority = CombatPriority.CombatPriorityUnknown;
+				rotation.combatBuilder = CombatBuilder.SinisterStrike;
 				rotation.subtletyFinisherPriority = SubtletyPriority.SubtletyPriorityUnknown;
 				options.honorOfThievesCritRate = -1;
 			} else if (this.player.getTalentTree() == 1) {
 				if (rotation.combatFinisherPriority == CombatPriority.CombatPriorityUnknown) {
 					rotation.combatFinisherPriority = Presets.DefaultRotation.combatFinisherPriority;
+					rotation.combatBuilder = Presets.DefaultRotation.combatBuilder;
 				}
 				rotation.assassinationFinisherPriority = AssassinationPriority.AssassinationPriorityUnknown;
 				rotation.subtletyFinisherPriority = SubtletyPriority.SubtletyPriorityUnknown;
@@ -281,6 +322,7 @@ export class RogueSimUI extends IndividualSimUI<Spec.SpecRogue> {
 				}
 				rotation.assassinationFinisherPriority = AssassinationPriority.AssassinationPriorityUnknown;
 				rotation.combatFinisherPriority = CombatPriority.CombatPriorityUnknown;
+				rotation.combatBuilder = CombatBuilder.SinisterStrike;
 				if (options.honorOfThievesCritRate == -1) {
 					options.honorOfThievesCritRate = DefaultOptions.honorOfThievesCritRate
 				}


### PR DESCRIPTION
[rogue] combat now allows to choose Backstab as alternative builder; fixed Backstab's ActionID
[rogue] also add back the "rupture-less" rotation (with finisher priority "Eviscerate")
[rogue] when about to waste a CP, combat now allows to clip a up to 4.5s of SnD uptime
[rogue] added some additional warnings (e.g. when using "In Front of Target" with Backstab or Garrote)

"Fixes" https://github.com/wowsims/wotlk/issues/2785 and https://github.com/wowsims/wotlk/issues/2742