### PR TITLE
ItemPicker and BulkUI render updates

### DIFF
--- a/ui/core/components/gear_picker.ts
+++ b/ui/core/components/gear_picker.ts
@@ -450,7 +450,7 @@ interface GearData {
 	changeEvent: TypedEvent<any>,
 }
 
-enum SelectorModalTabs {
+export enum SelectorModalTabs {
 	Items = 'Items',
 	Enchants = 'Enchants',
 	Gem1 = 'Gem1',
@@ -467,7 +467,7 @@ interface SelectorModalConfig {
 	gearData: GearData
 }
 
-class SelectorModal extends BaseModal {
+export class SelectorModal extends BaseModal {
 	private readonly simUI: SimUI;
 	private player: Player<any>;
 	private config: SelectorModalConfig;
@@ -619,7 +619,8 @@ class SelectorModal extends BaseModal {
 
 					const gemElem = tabAnchor.querySelector('.gem-icon') as HTMLElement;
 					const socketElem = tabAnchor.querySelector('.socket-icon') as HTMLElement;
-					socketElem.setAttribute('src', getEmptyGemSocketIconUrl(socketColor));
+					const emptySocketUrl = getEmptyGemSocketIconUrl(socketColor)
+					socketElem.setAttribute('src', emptySocketUrl);
 
 					const updateGemIcon = () => {
 						const equippedItem = gearData.getEquippedItem();
@@ -629,6 +630,8 @@ class SelectorModal extends BaseModal {
 							ActionId.fromItemId(gem.id).fill().then(filledId => {
 								gemElem.setAttribute('src', filledId.iconUrl);
 							});
+						} else {
+							gemElem.setAttribute('src', emptySocketUrl);
 						}
 					};
 
@@ -924,6 +927,12 @@ class SelectorModal extends BaseModal {
 			onRemove(TypedEvent.nextEventID());
 		});
 
+		if (label.startsWith("Enchants")) {
+			removeButton.textContent = 'Remove Enchant';
+		} else if (label.startsWith("Gem")) {
+			removeButton.textContent = 'Remove Gem';
+		}
+
 		const updateSelected = () => {
 			const newEquippedItem = gearData.getEquippedItem();
 			const newItem = equippedToItemFn(newEquippedItem);
@@ -1041,7 +1050,7 @@ class SelectorModal extends BaseModal {
 		});
 
 		const simAllButton = tabContent.getElementsByClassName('selector-modal-simall-button')[0] as HTMLButtonElement;
-		simAllButton.hidden = !this.player.sim.getShowExperimental()
+		simAllButton.hidden = !this.player.sim.getShowExperimental();
 		this.player.sim.showExperimentalChangeEmitter.on(() => {
 			simAllButton.hidden = !this.player.sim.getShowExperimental();
 		});

--- a/ui/scss/core/components/_bulk.scss
+++ b/ui/scss/core/components/_bulk.scss
@@ -91,24 +91,30 @@
 .bulk-tab {
   position: relative;
 
-  .input-root {
-    flex-direction: row;
-    align-items: center;
-    margin-top: 10px;
-    label {
-      flex: 1;
+  .selector-modal-simall-button {
+    visibility: hidden;
+  }
+
+  .bulk-settings {
+    .input-root {
+      flex-direction: row;
+      align-items: center;
+      margin-top: 10px;
+      label {
+        flex: 1;
+      }
+    }
+
+    .bulk-check-input {
+      width: 100%;
+      height: 40px;
+      padding: 5px;
+      margin-top: 15px;
+      display: flex;
     }
   }
 }
 
 .results-sim {
   margin-top: 5px;
-}
-
-.bulk-check-input {
-  width: 100%;
-  height: 40px;
-  padding: 5px;
-  margin-top: 15px;
-  display: flex;
 }


### PR DESCRIPTION
* Reuses the existing `SelectorModal` to render enchant/gem selection for bulk items
* Adds a new button to destroy the item (remove from bulk)
* Fixes bug in the existing `SelectorModal` gem tab where removing a gem would not change the gem icon to empty
* Renames the "Unequip Item" button depending on the tab: remains the same for the items tab, but is renamed to "Remove Enchant" and "Remove Gem" in the enchant and gem tabs, respectively. Before the button would always be "Unequip Item" even though it acted on the enchant or gem.