### PR TITLE
Rogue crash fixes by adding a more stable "generic" rotation

### DIFF
--- a/sim/core/racials.go
+++ b/sim/core/racials.go
@@ -58,6 +58,14 @@ func applyRaceEffects(agent Agent) {
 			Spell:    spell,
 			Type:     CooldownTypeDPS,
 			Priority: CooldownPriorityLow,
+			ShouldActivate: func(sim *Simulation, character *Character) bool {
+				if spell.Unit.HasRunicPowerBar() {
+					return character.CurrentRunicPower() <= character.maxRunicPower-15
+				} else if spell.Unit.HasEnergyBar() {
+					return character.CurrentEnergy() <= character.maxEnergy-15
+				}
+				return true
+			},
 		})
 	case proto.Race_RaceDraenei:
 		character.PseudoStats.ReducedShadowHitTakenChance += 0.02

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -104,15 +104,15 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50035"
  value: {
-  dps: 5794.83443
-  tps: 4114.33244
+  dps: 4918.97032
+  tps: 3492.46893
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50692"
  value: {
-  dps: 5868.81783
-  tps: 4166.86066
+  dps: 4990.83279
+  tps: 3543.49128
  }
 }
 dps_results: {
@@ -568,8 +568,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7790.58277
-  tps: 5531.31376
+  dps: 7780.75381
+  tps: 5524.3352
  }
 }
 dps_results: {
@@ -687,8 +687,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-TheFistsofFury"
  value: {
-  dps: 4991.69544
-  tps: 3544.10376
+  dps: 4227.34765
+  tps: 3001.41683
  }
 }
 dps_results: {

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -582,8 +582,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 6677.94077
-  tps: 4741.33795
+  dps: 6670.11079
+  tps: 4735.77866
  }
 }
 dps_results: {

--- a/sim/rogue/TestSubtlety.results
+++ b/sim/rogue/TestSubtlety.results
@@ -74,8 +74,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8294.27788
-  tps: 5886.09208
+  dps: 8302.07578
+  tps: 5892.45012
  }
 }
 dps_results: {
@@ -125,8 +125,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-BonescytheBattlegear"
  value: {
-  dps: 7128.20117
-  tps: 5059.38962
+  dps: 7128.06098
+  tps: 5059.29009
  }
 }
 dps_results: {
@@ -175,8 +175,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 8245.43389
-  tps: 5851.88277
+  dps: 8242.12071
+  tps: 5849.53042
  }
 }
 dps_results: {
@@ -196,8 +196,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 8157.1724
-  tps: 5789.07132
+  dps: 8167.97127
+  tps: 5795.9133
  }
 }
 dps_results: {
@@ -231,15 +231,15 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 8259.93796
-  tps: 5863.38533
+  dps: 8250.90669
+  tps: 5856.60201
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 8237.14712
-  tps: 5848.37445
+  dps: 8235.6446
+  tps: 5847.30766
  }
 }
 dps_results: {
@@ -273,8 +273,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 8173.9795
-  tps: 5802.75378
+  dps: 8179.37337
+  tps: 5806.58343
  }
 }
 dps_results: {
@@ -322,8 +322,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-ForgeEmber-37660"
  value: {
-  dps: 8166.40265
-  tps: 5794.36136
+  dps: 8161.72382
+  tps: 5791.0394
  }
 }
 dps_results: {
@@ -378,8 +378,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 8237.10224
-  tps: 5845.90324
+  dps: 8242.81008
+  tps: 5849.95581
  }
 }
 dps_results: {
@@ -568,8 +568,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7901.07659
-  tps: 5607.30215
+  dps: 7903.97197
+  tps: 5608.60618
  }
 }
 dps_results: {
@@ -589,8 +589,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-Slayer'sArmor"
  value: {
-  dps: 5490.51321
-  tps: 3895.42103
+  dps: 5488.73564
+  tps: 3893.33952
  }
 }
 dps_results: {
@@ -638,8 +638,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-StormshroudArmor"
  value: {
-  dps: 6171.04692
-  tps: 4379.43616
+  dps: 6162.22026
+  tps: 4373.50418
  }
 }
 dps_results: {
@@ -680,8 +680,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 7606.71412
-  tps: 5397.43663
+  dps: 7603.41353
+  tps: 5394.73697
  }
 }
 dps_results: {
@@ -701,8 +701,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8357.93928
-  tps: 5929.49372
+  dps: 8347.34064
+  tps: 5921.96868
  }
 }
 dps_results: {
@@ -736,8 +736,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 8087.7673
-  tps: 5740.34157
+  dps: 8085.50521
+  tps: 5738.73549
  }
 }
 dps_results: {
@@ -764,8 +764,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 7369.3106
-  tps: 5231.2652
+  dps: 7369.36226
+  tps: 5231.30187
  }
 }
 dps_results: {
@@ -778,8 +778,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-Average-Default"
  value: {
-  dps: 8508.99372
-  tps: 6039.04633
+  dps: 8509.30304
+  tps: 6039.19515
  }
 }
 dps_results: {
@@ -869,7 +869,7 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7719.63138
-  tps: 5478.60469
+  dps: 7720.53051
+  tps: 5478.42353
  }
 }

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -54,8 +54,8 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 }
 
 func (rogue *Rogue) registerMutilateSpell() {
-	mhHitSpell := rogue.newMutilateHitSpell(true)
-	ohHitSpell := rogue.newMutilateHitSpell(false)
+	rogue.MutilateMH = rogue.newMutilateHitSpell(true)
+	rogue.MutilateOH = rogue.newMutilateHitSpell(false)
 
 	rogue.Mutilate = rogue.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: MutilateSpellID},
@@ -80,8 +80,8 @@ func (rogue *Rogue) registerMutilateSpell() {
 			result := spell.CalcOutcome(sim, target, spell.OutcomeMeleeSpecialHit) // Miss/Dodge/Parry/Hit
 			if result.Landed() {
 				rogue.AddComboPoints(sim, 2, spell.ComboPointMetrics())
-				ohHitSpell.Cast(sim, target)
-				mhHitSpell.Cast(sim, target)
+				rogue.MutilateOH.Cast(sim, target)
+				rogue.MutilateMH.Cast(sim, target)
 			} else {
 				spell.IssueRefund(sim)
 			}

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -66,6 +66,8 @@ type Rogue struct {
 	InstantPoison    [3]*core.Spell
 	WoundPoison      [3]*core.Spell
 	Mutilate         *core.Spell
+	MutilateMH       *core.Spell
+	MutilateOH       *core.Spell
 	Shiv             *core.Spell
 	SinisterStrike   *core.Spell
 	TricksOfTheTrade *core.Spell

--- a/sim/rogue/rotation.go
+++ b/sim/rogue/rotation.go
@@ -48,11 +48,13 @@ func (rogue *Rogue) OnGCDReady(sim *core.Simulation) {
 
 func (rogue *Rogue) setupRotation(sim *core.Simulation) {
 	switch {
-	case rogue.CanMutilate() && rogue.Env.GetNumTargets() <= 3:
+	case rogue.Env.GetNumTargets() >= 3:
+		rogue.rotation = &rotation_multi{} // rotation multi will soon be removed
+	case rogue.CanMutilate():
 		rogue.rotation = &rotation_assassination{}
-	case rogue.Talents.CombatPotency > 0 && rogue.Env.GetNumTargets() <= 3:
+	case rogue.Talents.CombatPotency > 0:
 		rogue.rotation = &rotation_combat{}
-	case rogue.Talents.HonorAmongThieves > 0 && rogue.Env.GetNumTargets() <= 3:
+	case rogue.Talents.HonorAmongThieves > 0:
 		rogue.rotation = &rotation_subtlety{}
 	default:
 		rogue.rotation = &rotation_generic{}

--- a/sim/rogue/rotation_generic.go
+++ b/sim/rogue/rotation_generic.go
@@ -1,264 +1,379 @@
 package rogue
 
 import (
-	"math"
+	"github.com/wowsims/wotlk/sim/core/stats"
+	"golang.org/x/exp/slices"
+	"log"
 	"time"
 
 	"github.com/wowsims/wotlk/sim/core"
 	"github.com/wowsims/wotlk/sim/core/proto"
 )
 
-type rogueRotationItem struct {
-	ExpiresAt            time.Duration
-	MinimumBuildDuration time.Duration
-	MaximumBuildDuration time.Duration
-	PrioIndex            int
-}
-
-type roguePriorityItem struct {
-	Aura               *core.Aura
-	CastCount          int32
-	EnergyCost         float64
-	PoolAmount         float64
-	GetDuration        func(*Rogue, int32) time.Duration
-	GetSpell           func(*Rogue, int32) *core.Spell
-	IsFiller           bool
-	MaximumComboPoints int32
-	MaxCasts           int32
-	MinimumComboPoints int32
-}
-
-type shouldCastRotationItemResult int32
-
-const (
-	ShouldNotCast shouldCastRotationItemResult = iota
-	ShouldBuild
-	ShouldCast
-	ShouldWait
-)
-
 type rotation_generic struct {
-	priorityItems []roguePriorityItem
-	rotationItems []rogueRotationItem
+	prios []prio
 
-	builder       *core.Spell
-	builderPoints int32
+	builder *core.Spell
 }
 
-func (x *rotation_generic) setup(sim *core.Simulation, rogue *Rogue) {
-	x.builder = rogue.SinisterStrike
-	x.builderPoints = 1
+func (x *rotation_generic) setup(_ *core.Simulation, rogue *Rogue) {
+	x.prios = x.prios[:0]
 
+	x.builder = rogue.SinisterStrike
+	if rogue.HasDagger(core.MainHand) && !rogue.PseudoStats.InFrontOfTarget {
+		x.builder = rogue.Backstab
+	}
 	if rogue.CanMutilate() {
 		x.builder = rogue.Mutilate
-		x.builderPoints = 2
 	}
-
 	if rogue.Talents.Hemorrhage {
 		x.builder = rogue.Hemorrhage
-		x.builderPoints = 1
 	}
 
-	if rogue.Talents.SlaughterFromTheShadows > 0 && !rogue.Rotation.HemoWithDagger && !rogue.PseudoStats.InFrontOfTarget && rogue.HasDagger(core.MainHand) {
-		x.builder = rogue.Backstab
-		x.builderPoints = 1
-	}
+	bldCost := x.builder.DefaultCast.Cost
+	sndCost := rogue.SliceAndDice.DefaultCast.Cost
+	rupCost := rogue.Rupture.DefaultCast.Cost
 
-	isMultiTarget := sim.GetNumTargets() >= 3
+	baseEps := 10 * rogue.EnergyTickMultiplier
+	maxPool := rogue.maxEnergy - 3*float64(rogue.Talents.CombatPotency) - 2*float64(rogue.Talents.FocusedAttacks)/3.0
 
-	// Slice and Dice
-	x.priorityItems = x.priorityItems[:0]
+	ruthCp := 0.2 * float64(rogue.Talents.Ruthlessness)
+	rsPerCp := float64(rogue.Talents.RelentlessStrikes)
 
-	sliceAndDice := roguePriorityItem{
-		MinimumComboPoints: 1,
-		MaximumComboPoints: 5,
-		Aura:               rogue.SliceAndDiceAura,
-		EnergyCost:         rogue.SliceAndDice.DefaultCast.Cost,
-		GetDuration: func(rogue *Rogue, cp int32) time.Duration {
-			return rogue.sliceAndDiceDurations[cp]
-		},
-		GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
-			return rogue.SliceAndDice
-		},
-	}
-	if isMultiTarget {
-		if rogue.Rotation.MultiTargetSliceFrequency != proto.Rogue_Rotation_Never {
-			sliceAndDice.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsMultiTargetSlice)
-			if rogue.Rotation.MultiTargetSliceFrequency == proto.Rogue_Rotation_Once {
-				sliceAndDice.MaxCasts = 1
+	// estimate of energy per second while nothing is cast
+	energyPerSecond := func() float64 {
+		var eps float64
+		if rogue.Talents.CombatPotency > 0 {
+			attackTable := rogue.AttackTables[rogue.CurrentTarget.UnitIndex]
+			spell := rogue.AutoAttacks.OHAuto
+
+			landChance := 1.0
+			if miss := attackTable.BaseMissChance + 0.19 - spell.PhysicalHitChance(rogue.CurrentTarget); miss > 0 {
+				landChance -= miss
 			}
-			x.priorityItems = append(x.priorityItems, sliceAndDice)
+			if dodge := attackTable.BaseDodgeChance - spell.ExpertisePercentage() - spell.Unit.PseudoStats.DodgeReduction; dodge > 0 {
+				landChance -= dodge
+			}
+			landsPerSecond := landChance * (1 / rogue.AutoAttacks.OffhandSwingSpeed().Seconds())
+			eps += landsPerSecond * 0.2 * float64(rogue.Talents.CombatPotency) * 3
 		}
-	} else {
-		x.priorityItems = append(x.priorityItems, sliceAndDice)
-	}
-
-	// Expose Armor
-	if rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Maintain ||
-		rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Once {
-		minPoints := int32(1)
-		maxCasts := int32(0)
-		if rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Once {
-			minPoints = rogue.Rotation.MinimumComboPointsExposeArmor
-			maxCasts = 1
+		if rogue.Talents.FocusedAttacks > 0 {
+			procChance := []float64{0, 0.33, 0.66, 1}[rogue.Talents.FocusedAttacks]
+			critSuppression := rogue.AttackTables[rogue.CurrentTarget.UnitIndex].CritSuppression
+			effectiveCrit := rogue.GetStat(stats.MeleeCrit)/(core.CritRatingPerCritChance*100) - critSuppression
+			critsPerSecond := effectiveCrit * (1/rogue.AutoAttacks.MainhandSwingSpeed().Seconds() + 1/rogue.AutoAttacks.OffhandSwingSpeed().Seconds())
+			eps += critsPerSecond * procChance * 2
 		}
-		x.priorityItems = append(x.priorityItems, roguePriorityItem{
-			MaxCasts:           maxCasts,
-			MaximumComboPoints: 5,
-			MinimumComboPoints: minPoints,
-			Aura:               rogue.ExposeArmorAuras.Get(rogue.CurrentTarget),
-			EnergyCost:         rogue.ExposeArmor.DefaultCast.Cost,
-			GetDuration: func(rogue *Rogue, cp int32) time.Duration {
-				return rogue.exposeArmorDurations[cp]
-			},
-			GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
-				return rogue.ExposeArmor
-			},
-		})
+		return 10*rogue.EnergyTickMultiplier + eps
 	}
 
-	// Hunger for Blood
-	if rogue.Talents.HungerForBlood {
-		x.priorityItems = append(x.priorityItems, roguePriorityItem{
-			MaximumComboPoints: 0,
-			Aura:               rogue.HungerForBloodAura,
-			EnergyCost:         rogue.HungerForBlood.DefaultCast.Cost,
-			GetDuration: func(rogue *Rogue, cp int32) time.Duration {
-				return rogue.HungerForBloodAura.Duration
-			},
-			GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
-				return rogue.HungerForBlood
-			},
-		})
+	// Glyph of Backstab support
+	var bonusDuration float64
+	rupRemaining := func(sim *core.Simulation) time.Duration {
+		if dot := rogue.Rupture.CurDot(); dot.IsActive() {
+			return dot.RemainingDuration(sim)
+		}
+		return 0
 	}
 
-	// Dummy priority to enable CDs
-	x.priorityItems = append(x.priorityItems, roguePriorityItem{
-		MaxCasts:           1,
-		MaximumComboPoints: 0,
-		GetDuration: func(rogue *Rogue, cp int32) time.Duration {
+	if x.builder == rogue.Backstab && rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfBackstab) {
+		bonusDuration = 6
+		rupRemaining = func(sim *core.Simulation) time.Duration {
+			if dot := rogue.Rupture.CurDot(); dot.IsActive() {
+				dur := dot.RemainingDuration(sim)
+				dur += dot.TickLength * time.Duration(dot.MaxStacks+3-dot.NumberOfTicks)
+				return dur
+			}
 			return 0
-		},
-		GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
-			if rogue.allMCDsDisabled {
-				for _, mcd := range rogue.GetMajorCooldowns() {
-					mcd.Enable()
+		}
+	}
+
+	// Garrote
+	if rogue.Rotation.OpenWithGarrote && !rogue.PseudoStats.InFrontOfTarget {
+		x.prios = append(x.prios, prio{
+			func(sim *core.Simulation, rogue *Rogue) PriorityAction {
+				if rogue.CurrentEnergy() > rogue.Garrote.DefaultCast.Cost {
+					return Once
 				}
-				rogue.allMCDsDisabled = false
+				return Wait
+			},
+			func(sim *core.Simulation, rogue *Rogue) bool {
+				return rogue.Garrote.Cast(sim, rogue.CurrentTarget)
+			},
+			rogue.Garrote.DefaultCast.Cost,
+		})
+	}
+
+	// Slice And Dice
+	x.prios = append(x.prios, prio{
+		func(sim *core.Simulation, rogue *Rogue) PriorityAction {
+			cp, e := rogue.ComboPoints(), rogue.CurrentEnergy()
+
+			if sndDur := rogue.SliceAndDiceAura.RemainingDuration(sim); sndDur > 0 {
+				if cp == 5 { // pool for snd if pooling for rupture fails
+					rupDur := rupRemaining(sim)
+					if e+rupDur.Seconds()*energyPerSecond() > maxPool {
+						if e+sndDur.Seconds()*energyPerSecond() <= maxPool {
+							return Wait
+						}
+					}
+					return Skip
+				}
+
+				if cp >= 1 { // don't build if it reduces uptime
+					if e+sndDur.Seconds()*energyPerSecond() < sndCost+bldCost || sndDur < time.Second {
+						return Wait
+					}
+				}
+				return Skip
 			}
-			return nil
+
+			// end of fight - heuristically, 2s of snd beat a 3 CP eviscerate for DPE, and 3s are close to a 5 CP one.
+			if cp >= 3 && sim.GetRemainingDuration() < time.Duration(2000+600*cp)*time.Millisecond {
+				return Skip
+			}
+
+			if cp >= 1 && e >= sndCost {
+				return Cast
+			}
+			if cp < 1 && e >= bldCost {
+				return Build
+			}
+			return Wait
 		},
+		func(sim *core.Simulation, rogue *Rogue) bool {
+			return rogue.SliceAndDice.Cast(sim, rogue.CurrentTarget)
+		},
+		sndCost,
 	})
 
-	// Rupture
-	rupture := roguePriorityItem{
-		MinimumComboPoints: 3,
-		MaximumComboPoints: 5,
-		Aura:               rogue.Rupture.CurDot().Aura,
-		EnergyCost:         rogue.Rupture.DefaultCast.Cost,
-		GetDuration: func(rogue *Rogue, cp int32) time.Duration {
-			return rogue.RuptureDuration(cp)
-		},
-		GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
-			return rogue.Rupture
-		},
-	}
-
-	// Eviscerate
-	eviscerate := roguePriorityItem{
-		MinimumComboPoints: 1,
-		MaximumComboPoints: 5,
-		EnergyCost:         rogue.Eviscerate.DefaultCast.Cost,
-		GetDuration: func(rogue *Rogue, cp int32) time.Duration {
-			return 0
-		},
-		GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
-			return rogue.Eviscerate
-		},
-	}
-
-	if isMultiTarget {
-		x.priorityItems = append(x.priorityItems, roguePriorityItem{
-			MaximumComboPoints: 0,
-			EnergyCost:         rogue.FanOfKnives.DefaultCast.Cost,
-			GetSpell: func(rogue *Rogue, i int32) *core.Spell {
-				return rogue.FanOfKnives
+	// Expose armor - update this as well
+	if rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Once || rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Maintain {
+		hasCastExpose := false
+		x.prios = append(x.prios, prio{
+			func(sim *core.Simulation, rogue *Rogue) PriorityAction {
+				if hasCastExpose && rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Once {
+					return Skip
+				}
+				timeLeft := rogue.ExposeArmorAuras.Get(rogue.CurrentTarget).RemainingDuration(sim)
+				minPoints := core.MaxInt32(1, core.MinInt32(rogue.Rotation.MinimumComboPointsExposeArmor, 5))
+				if rogue.Rotation.ExposeArmorFrequency != proto.Rogue_Rotation_Once {
+					minPoints = 1
+				}
+				if timeLeft <= 0 {
+					if rogue.ComboPoints() < minPoints {
+						if rogue.CurrentEnergy() >= bldCost {
+							return Build
+						} else {
+							return Wait
+						}
+					} else {
+						if rogue.CurrentEnergy() >= rogue.ExposeArmor.DefaultCast.Cost {
+							return Cast
+						} else {
+							return Wait
+						}
+					}
+				} else {
+					energyGained := energyPerSecond() * timeLeft.Seconds()
+					cpGenerated := energyGained / bldCost
+					currentCp := float64(rogue.ComboPoints())
+					if currentCp+cpGenerated > 5 {
+						return Skip
+					} else {
+						if currentCp < 5 {
+							if rogue.CurrentEnergy() >= bldCost {
+								return Build
+							}
+						}
+						return Wait
+					}
+				}
 			},
+			func(sim *core.Simulation, rogue *Rogue) bool {
+				casted := rogue.ExposeArmor.Cast(sim, rogue.CurrentTarget)
+				if casted {
+					hasCastExpose = true
+				}
+				return casted
+			},
+			rogue.ExposeArmor.DefaultCast.Cost,
 		})
-
-	} else if rogue.Talents.MasterPoisoner > 0 || rogue.Talents.CutToTheChase > 0 {
-		// Envenom
-		envenom := roguePriorityItem{
-			MinimumComboPoints: 1,
-			MaximumComboPoints: 5,
-			Aura:               rogue.EnvenomAura,
-			EnergyCost:         rogue.Envenom.DefaultCast.Cost,
-			GetDuration: func(rogue *Rogue, cp int32) time.Duration {
-				return rogue.EnvenomAura.Duration
-			},
-			GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
-				return rogue.Envenom
-			},
-		}
-		switch rogue.Rotation.AssassinationFinisherPriority {
-		case proto.Rogue_Rotation_EnvenomRupture:
-			envenom.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
-			x.priorityItems = append(x.priorityItems, envenom)
-			rupture.MinimumComboPoints = rogue.Rotation.MinimumComboPointsSecondaryFinisher
-			rupture.IsFiller = true
-			if rupture.MinimumComboPoints > 0 && rupture.MinimumComboPoints <= 5 {
-				x.priorityItems = append(x.priorityItems, rupture)
-			}
-		case proto.Rogue_Rotation_RuptureEnvenom:
-			rupture.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
-			x.priorityItems = append(x.priorityItems, rupture)
-			envenom.MinimumComboPoints = rogue.Rotation.MinimumComboPointsSecondaryFinisher
-			envenom.IsFiller = true
-			if envenom.MinimumComboPoints > 0 && envenom.MinimumComboPoints <= 5 {
-				x.priorityItems = append(x.priorityItems, envenom)
-			}
-		}
-		eviscerate.IsFiller = true
-		eviscerate.MinimumComboPoints = 1
-		x.priorityItems = append(x.priorityItems, eviscerate)
-	} else {
-		if rogue.Talents.Vitality > 0 {
-			switch rogue.Rotation.CombatFinisherPriority {
-			case proto.Rogue_Rotation_RuptureEviscerate:
-				rupture.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
-				x.priorityItems = append(x.priorityItems, rupture)
-				eviscerate.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsSecondaryFinisher)
-				eviscerate.IsFiller = true
-				x.priorityItems = append(x.priorityItems, eviscerate)
-			case proto.Rogue_Rotation_EviscerateRupture:
-				eviscerate.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
-				x.priorityItems = append(x.priorityItems, eviscerate)
-				rupture.MinimumComboPoints = rogue.Rotation.MinimumComboPointsSecondaryFinisher
-				rupture.IsFiller = true
-				if rupture.MinimumComboPoints > 0 && rupture.MinimumComboPoints <= 5 {
-					x.priorityItems = append(x.priorityItems, rupture)
-				}
-			}
-		} else {
-			switch rogue.Rotation.SubtletyFinisherPriority {
-			case proto.Rogue_Rotation_SubtletyEviscerate:
-				rupture.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
-				x.priorityItems = append(x.priorityItems, rupture)
-				eviscerate.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsSecondaryFinisher)
-				eviscerate.IsFiller = true
-				x.priorityItems = append(x.priorityItems, eviscerate)
-			case proto.Rogue_Rotation_SubtletyEnvenom:
-				eviscerate.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsPrimaryFinisher)
-				x.priorityItems = append(x.priorityItems, eviscerate)
-				rupture.MinimumComboPoints = rogue.Rotation.MinimumComboPointsSecondaryFinisher
-				rupture.IsFiller = true
-				if rupture.MinimumComboPoints > 0 && rupture.MinimumComboPoints <= 5 {
-					x.priorityItems = append(x.priorityItems, rupture)
-				}
-			}
-		}
 	}
-	x.rotationItems = x.planRotation(sim, rogue)
+
+	// Enable CDs
+	x.prios = append(x.prios, prio{
+		func(sim *core.Simulation, rogue *Rogue) PriorityAction {
+			for _, mcd := range rogue.GetMajorCooldowns() {
+				mcd.Enable()
+			}
+			return Once
+		},
+		func(s *core.Simulation, r *Rogue) bool {
+			return true
+		},
+		0,
+	})
+
+	const ruptureMinDuration = time.Second * 10 // heuristically, 4-5 rupture ticks are better DPE than eviscerate
+
+	// seconds a 5 cp rupture can be delayed to match a 4 cp rupture's dps. for rup4to5 and rup3to4, this delay is < 2s,
+	// which also means that clipping 3 or 4 cp ruptures is usually a dps loss
+	rup4to5 := (rogue.RuptureDuration(4).Seconds() + bonusDuration) * (1 - rogue.RuptureDamage(4)/rogue.RuptureDamage(5))
+	rup3to4 := (rogue.RuptureDuration(3).Seconds() + bonusDuration) * (1 - rogue.RuptureDamage(3)/rogue.RuptureDamage(4))
+
+	// Rupture
+	x.prios = append(x.prios, prio{
+		func(sim *core.Simulation, rogue *Rogue) PriorityAction {
+			cp, e := rogue.ComboPoints(), rogue.CurrentEnergy()
+
+			if sim.GetRemainingDuration() < ruptureMinDuration {
+				return Skip
+			}
+
+			rupDot := rogue.Rupture.CurDot()
+			if !rupDot.IsActive() {
+				if cp == 5 && e >= rupCost {
+					return Cast
+				}
+				if cp == 4 && e+rup4to5*energyPerSecond() < bldCost+rupCost {
+					return Cast
+				}
+				if cp == 3 && e+rup3to4*energyPerSecond() < bldCost+rupCost {
+					return Cast
+				}
+				if e >= bldCost {
+					return Build
+				}
+				return Wait
+			}
+
+			// there's ample time to rebuild, simply skip
+			dur := rupRemaining(sim).Seconds()
+			if e+dur*baseEps > maxPool {
+				return Skip
+			}
+
+			if cp == 5 {
+				if e+dur*energyPerSecond() > maxPool {
+					return Skip // can't pool any longer, maybe we can fit in Eviscerate
+				}
+				return Wait
+			}
+			if cp == 4 && e+(dur+rup4to5)*energyPerSecond() < bldCost+rupCost {
+				return Wait
+			}
+			if cp == 3 && e+(dur+rup3to4)*energyPerSecond() < bldCost+rupCost {
+				return Wait
+			}
+			if e >= bldCost {
+				return Build
+			}
+			return Wait
+		},
+		func(sim *core.Simulation, rogue *Rogue) bool {
+			return rogue.Rupture.Cast(sim, rogue.CurrentTarget)
+		},
+		rupCost,
+	})
+
+	bldPerCp := 1.0
+	if x.builder == rogue.SinisterStrike {
+		attackTable := rogue.AttackTables[rogue.CurrentTarget.UnitIndex]
+		crit := rogue.SinisterStrike.PhysicalCritChance(rogue.CurrentTarget, attackTable)
+		var extraChance float64
+		if rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfSinisterStrike) {
+			extraChance = 0.5
+		}
+		bldPerCp = 1 / (1 + crit*(extraChance+0.2*float64(rogue.Talents.SealFate)))
+	}
+	if x.builder == rogue.Backstab {
+		attackTable := rogue.AttackTables[rogue.CurrentTarget.UnitIndex]
+		crit := rogue.Backstab.PhysicalCritChance(rogue.CurrentTarget, attackTable)
+		bldPerCp = 1 / (1 + crit*(0.2*float64(rogue.Talents.SealFate)))
+	}
+	if x.builder == rogue.Hemorrhage {
+		attackTable := rogue.AttackTables[rogue.CurrentTarget.UnitIndex]
+		crit := rogue.Hemorrhage.PhysicalCritChance(rogue.CurrentTarget, attackTable)
+		bldPerCp = 1 / (1 + crit*(0.2*float64(rogue.Talents.SealFate)))
+	}
+	if x.builder == rogue.Mutilate {
+		attackTable := rogue.AttackTables[rogue.CurrentTarget.UnitIndex]
+		critMH := rogue.MutilateMH.PhysicalCritChance(rogue.CurrentTarget, attackTable)
+		critOH := rogue.MutilateOH.PhysicalCritChance(rogue.CurrentTarget, attackTable)
+		crit := 1 - (1-critMH)*(1-critOH)
+		bldPerCp = 1 / (2 + crit*(0.2*float64(rogue.Talents.SealFate)))
+	}
+
+	// direct damage finisher (Eviscerate/Envenom)
+	finisher := rogue.Eviscerate
+	if rogue.Talents.MasterPoisoner > 0 {
+		finisher = rogue.Envenom
+	}
+	finisherCost := finisher.DefaultCast.Cost
+	x.prios = append(x.prios, prio{
+		func(sim *core.Simulation, rogue *Rogue) PriorityAction {
+			e, cp := rogue.CurrentEnergy(), rogue.ComboPoints()
+
+			if dur := sim.GetRemainingDuration(); dur <= ruptureMinDuration {
+				// end of fight handling - build towards a 3+ cp finisher, or just spam the builder
+				switch cp {
+				case 5:
+					if e >= finisherCost {
+						return Cast
+					}
+					return Wait
+				default:
+					if e+dur.Seconds()*energyPerSecond() >= bldCost+finisherCost {
+						return Build
+					}
+					if cp >= 3 && e >= finisherCost {
+						return Cast
+					}
+					if cp < 3 && e >= bldCost {
+						return Build
+					}
+				}
+				return Wait
+			}
+
+			// we only get here if there's ample time left on rupture, or rupture pooling failed: in these cases, we
+			// can try to fill in a 5 cp finisher, if it's not too disruptive. lower cp finishers aren't worth it,
+			// since builder spam isn't all that much worse
+			if cp <= 4 {
+				return Build
+			}
+
+			cost := finisherCost - 5*rsPerCp + (4-ruthCp)*bldCost*bldPerCp + rupCost
+
+			rupDur := rupRemaining(sim)
+			sndDur := rogue.SliceAndDiceAura.RemainingDuration(sim)
+			if sndDur < rupDur {
+				cost += sndCost - 1*rsPerCp + (1-ruthCp)*bldCost*bldPerCp
+			}
+
+			if avail := e + rupDur.Seconds()*energyPerSecond(); avail >= cost {
+				return Cast
+			}
+
+			// we'd lose a CP here, so we just wait...
+			if e <= maxPool {
+				return Wait
+			}
+
+			// ... and if that doesn't work, allow to clip snd
+			if sndDur < rogue.sliceAndDiceDurations[2]-rogue.sliceAndDiceDurations[1] {
+				rogue.SliceAndDice.Cast(sim, rogue.CurrentTarget)
+				return Wait
+			}
+
+			return Build
+		},
+		func(sim *core.Simulation, rogue *Rogue) bool {
+			return finisher.Cast(sim, rogue.CurrentTarget)
+		},
+		finisherCost,
+	})
 }
 
 func (x *rotation_generic) run(sim *core.Simulation, rogue *Rogue) {
@@ -267,251 +382,35 @@ func (x *rotation_generic) run(sim *core.Simulation, rogue *Rogue) {
 		return
 	}
 
-	if len(x.rotationItems) < 1 {
-		panic("Rotation is empty")
-	}
-	eps := x.getExpectedEnergyPerSecond(rogue)
-	shouldCast := x.shouldCastNextRotationItem(sim, rogue, eps)
-	item := x.rotationItems[0]
-	prio := x.priorityItems[item.PrioIndex]
-
-	switch shouldCast {
-	case ShouldNotCast:
-		x.rotationItems = x.rotationItems[1:]
-		x.run(sim, rogue)
-	case ShouldBuild:
-		spell := x.builder
-		if spell == nil || spell.Cast(sim, rogue.CurrentTarget) {
-			if rogue.GCD.IsReady(sim) {
-				x.run(sim, rogue)
+	for i := 0; i < len(x.prios); i++ {
+		switch p := x.prios[i]; p.check(sim, rogue) {
+		case Skip:
+			continue
+		case Build:
+			if !x.builder.Cast(sim, rogue.CurrentTarget) {
+				rogue.WaitForEnergy(sim, x.builder.DefaultCast.Cost)
+				return
 			}
-		} else {
-			panic("Unexpected builder cast failure")
-		}
-	case ShouldCast:
-		spell := prio.GetSpell(rogue, rogue.ComboPoints())
-		if spell == nil || spell.Cast(sim, rogue.CurrentTarget) {
-			x.priorityItems[item.PrioIndex].CastCount += 1
-			x.rotationItems = x.planRotation(sim, rogue)
-			if rogue.GCD.IsReady(sim) {
-				x.run(sim, rogue)
+		case Cast:
+			if !p.cast(sim, rogue) {
+				rogue.WaitForEnergy(sim, p.cost)
+				return
 			}
-		} else {
-			panic("Unexpected cast failure")
-		}
-	case ShouldWait:
-		desiredEnergy := 100.0
-		if rogue.ComboPoints() == 5 {
-			desiredEnergy = prio.EnergyCost
-		} else {
-			if rogue.CurrentEnergy() < prio.EnergyCost && rogue.ComboPoints() >= prio.MinimumComboPoints {
-				desiredEnergy = prio.EnergyCost
-			} else if rogue.ComboPoints() < 5 {
-				desiredEnergy = x.builder.DefaultCast.Cost
+		case Once:
+			if !p.cast(sim, rogue) {
+				rogue.WaitForEnergy(sim, p.cost)
+				return
 			}
-		}
-		cdAvailableTime := time.Second * 10
-		if sim.CurrentTime > cdAvailableTime {
-			cdAvailableTime = core.NeverExpires
-		}
-		nextExpiration := cdAvailableTime
-		for _, otherItem := range x.rotationItems {
-			if otherItem.ExpiresAt < nextExpiration {
-				nextExpiration = otherItem.ExpiresAt
-			}
-		}
-		neededEnergy := desiredEnergy - rogue.CurrentEnergy()
-		energyAvailableTime := time.Second*time.Duration(neededEnergy/eps) + 1*time.Second
-		energyAt := sim.CurrentTime + energyAvailableTime
-		if energyAt < nextExpiration {
-			rogue.WaitForEnergy(sim, desiredEnergy)
-		} else if nextExpiration > sim.CurrentTime {
-			rogue.WaitUntil(sim, nextExpiration)
-		} else {
+			x.prios = slices.Delete(x.prios, i, i+1)
+			i--
+		case Wait:
 			rogue.DoNothing()
+			return
+		}
+
+		if !rogue.GCD.IsReady(sim) {
+			return
 		}
 	}
-}
-
-func (x *rotation_generic) energyToBuild(points int32) float64 {
-	costPerBuilder := x.builder.DefaultCast.Cost
-
-	buildersNeeded := math.Ceil(float64(points) / float64(x.builderPoints))
-	return buildersNeeded * costPerBuilder
-}
-
-func (x *rotation_generic) timeToBuild(points int32, builderPoints int32, eps float64, finisherCost float64) time.Duration {
-	energyNeeded := x.energyToBuild(points) + finisherCost
-	secondsNeeded := energyNeeded / eps
-	globalsNeeded := math.Ceil(float64(points)/float64(builderPoints)) + 1
-	// Return greater of the time it takes to use the globals and the time it takes to build the energy
-	return core.MaxDuration(time.Second*time.Duration(secondsNeeded), time.Second*time.Duration(globalsNeeded))
-}
-
-func (x *rotation_generic) shouldCastNextRotationItem(sim *core.Simulation, rogue *Rogue, eps float64) shouldCastRotationItemResult {
-	if len(x.rotationItems) == 0 {
-		panic("Empty rotation")
-	}
-	currentEnergy := rogue.CurrentEnergy()
-	comboPoints := rogue.ComboPoints()
-	currentTime := sim.CurrentTime
-	item := x.rotationItems[0]
-	prio := x.priorityItems[item.PrioIndex]
-	tte := item.ExpiresAt - currentTime
-	clippingThreshold := time.Second * 2
-	timeUntilNextGCD := rogue.GCD.TimeToReady(sim)
-
-	// Check to see if a higher prio item will expire
-	if len(x.rotationItems) >= 2 {
-		timeElapsed := time.Second * 1
-		for _, nextItem := range x.rotationItems[1:] {
-			if nextItem.ExpiresAt <= currentTime+timeElapsed {
-				return ShouldNotCast
-			}
-			timeElapsed += nextItem.MinimumBuildDuration
-		}
-	}
-
-	// Expires before next GCD
-	if tte <= timeUntilNextGCD {
-		if comboPoints >= prio.MinimumComboPoints && currentEnergy >= (prio.EnergyCost+prio.PoolAmount) {
-			return ShouldCast
-		} else if comboPoints < prio.MinimumComboPoints && currentEnergy >= x.builder.DefaultCast.Cost {
-			return ShouldBuild
-		} else {
-			return ShouldWait
-		}
-	}
-	if comboPoints >= prio.MaximumComboPoints { // Don't need CP
-		// Cast
-		if tte <= clippingThreshold && currentEnergy >= (prio.EnergyCost+prio.PoolAmount) {
-			return ShouldCast
-		}
-		// Pool energy
-		if tte <= clippingThreshold && currentEnergy < (prio.EnergyCost+prio.PoolAmount) {
-			return ShouldWait
-		}
-		// We have time to squeeze in another spell
-		if tte > item.MinimumBuildDuration {
-			// Find the first lower prio item that can be cast and use it
-			for lpi, lowerPrio := range x.priorityItems[item.PrioIndex+1:] {
-				if comboPoints > lowerPrio.MinimumComboPoints && currentEnergy > lowerPrio.EnergyCost && lowerPrio.MaxCasts == 0 {
-					x.rotationItems = append([]rogueRotationItem{
-						{ExpiresAt: currentTime, PrioIndex: lpi + item.PrioIndex + 1},
-					}, x.rotationItems...)
-					return ShouldCast
-				}
-			}
-		}
-		// Overcap CP with builder
-		if x.timeToBuild(1, x.builderPoints, eps, prio.EnergyCost+prio.PoolAmount) <= tte && currentEnergy >= x.builder.DefaultCast.Cost {
-			return ShouldBuild
-		}
-	} else if comboPoints < prio.MinimumComboPoints { // Need CP
-		if currentEnergy >= x.builder.DefaultCast.Cost {
-			return ShouldBuild
-		} else {
-			return ShouldWait
-		}
-	} else { // Between MinimumComboPoints and MaximumComboPoints
-		if currentEnergy >= prio.EnergyCost+prio.PoolAmount && tte <= timeUntilNextGCD {
-			return ShouldCast
-		}
-		ttb := x.timeToBuild(1, 2, eps, prio.EnergyCost+prio.PoolAmount-currentEnergy)
-		if currentEnergy >= x.builder.DefaultCast.Cost && tte > ttb {
-			return ShouldBuild
-		}
-	}
-	return ShouldWait
-}
-
-func (x *rotation_generic) getExpectedEnergyPerSecond(rogue *Rogue) float64 {
-	const finishersPerSecond = 1.0 / 6
-	const averageComboPointsSpendOnFinisher = 4.0
-	bonusEnergyPerSecond := float64(rogue.Talents.CombatPotency) * 3 * 0.2 * 1.0 / (rogue.AutoAttacks.OH.SwingSpeed / 1.4)
-	bonusEnergyPerSecond += float64(rogue.Talents.FocusedAttacks)
-	bonusEnergyPerSecond += float64(rogue.Talents.RelentlessStrikes) * 0.04 * 25 * finishersPerSecond * averageComboPointsSpendOnFinisher
-	return (core.EnergyPerTick*rogue.EnergyTickMultiplier)/core.EnergyTickDuration.Seconds() + bonusEnergyPerSecond
-}
-
-func (x *rotation_generic) planRotation(sim *core.Simulation, rogue *Rogue) []rogueRotationItem {
-	var rotationItems []rogueRotationItem
-	eps := x.getExpectedEnergyPerSecond(rogue)
-	for pi, prio := range x.priorityItems {
-		if prio.MaxCasts > 0 && prio.CastCount >= prio.MaxCasts {
-			continue
-		}
-		maxCP := prio.MaximumComboPoints
-		for maxCP > 0 && prio.GetDuration(rogue, maxCP)+sim.CurrentTime > sim.Duration {
-			maxCP--
-		}
-		var expiresAt time.Duration
-		if prio.Aura != nil {
-			expiresAt = prio.Aura.ExpiresAt()
-		} else if prio.MaxCasts == 1 {
-			expiresAt = sim.CurrentTime // TODO looks fishy, repeated expiresAt = sim.CurrentTime
-		} else {
-			expiresAt = sim.CurrentTime
-		}
-		minimumBuildDuration := x.timeToBuild(prio.MinimumComboPoints, x.builderPoints, eps, prio.EnergyCost)
-		maximumBuildDuration := x.timeToBuild(maxCP, x.builderPoints, eps, prio.EnergyCost)
-		rotationItems = append(rotationItems, rogueRotationItem{
-			ExpiresAt:            expiresAt,
-			MaximumBuildDuration: maximumBuildDuration,
-			MinimumBuildDuration: minimumBuildDuration,
-			PrioIndex:            pi,
-		})
-	}
-
-	currentTime := sim.CurrentTime
-	comboPoints := rogue.ComboPoints()
-	currentEnergy := rogue.CurrentEnergy()
-
-	var prioStack []rogueRotationItem
-	for _, item := range rotationItems {
-		if item.ExpiresAt >= sim.Duration {
-			continue
-		}
-		prio := x.priorityItems[item.PrioIndex]
-		maxBuildAt := item.ExpiresAt - item.MaximumBuildDuration
-		if prio.Aura == nil {
-			timeValueOfResources := time.Duration((float64(comboPoints)*x.builder.DefaultCast.Cost/float64(x.builderPoints) + currentEnergy) / eps)
-			maxBuildAt = currentTime - item.MaximumBuildDuration - timeValueOfResources
-		}
-		if currentTime < maxBuildAt {
-			// Put it on the to cast stack
-			prioStack = append(prioStack, item)
-			if prio.MinimumComboPoints > 0 {
-				comboPoints = 0
-			}
-			currentTime += item.MaximumBuildDuration
-		} else {
-			cpUsed := core.MaxInt32(0, prio.MinimumComboPoints-comboPoints)
-			energyUsed := core.MaxFloat(0, prio.EnergyCost-currentEnergy)
-			minBuildTime := x.timeToBuild(cpUsed, x.builderPoints, eps, energyUsed)
-			if currentTime+minBuildTime <= item.ExpiresAt || !prio.IsFiller {
-				prioStack = append(prioStack, item)
-				currentTime = core.MaxDuration(item.ExpiresAt, currentTime+minBuildTime)
-				currentEnergy = 0
-				if prio.MinimumComboPoints > 0 {
-					comboPoints = 0
-				}
-			} else if len(prioStack) < 1 || (prio.Aura != nil && !prio.Aura.IsActive() && !prio.IsFiller) || prio.MaxCasts == 1 {
-				// Plan to cast it as soon as possible
-				prioStack = append(prioStack, item)
-				currentTime += item.MinimumBuildDuration
-				currentEnergy = 0
-				if prio.MinimumComboPoints > 0 {
-					comboPoints = 0
-				}
-			}
-		}
-	}
-
-	// Reverse
-	for i, j := 0, len(prioStack)-1; i < j; i, j = i+1, j-1 {
-		prioStack[i], prioStack[j] = prioStack[j], prioStack[i]
-	}
-
-	return prioStack
+	log.Panic("skipped all prios")
 }

--- a/sim/rogue/rotation_multi.go
+++ b/sim/rogue/rotation_multi.go
@@ -1,0 +1,410 @@
+package rogue
+
+import (
+	"math"
+	"time"
+
+	"github.com/wowsims/wotlk/sim/core"
+	"github.com/wowsims/wotlk/sim/core/proto"
+)
+
+type rogueRotationItem struct {
+	ExpiresAt            time.Duration
+	MinimumBuildDuration time.Duration
+	MaximumBuildDuration time.Duration
+	PrioIndex            int
+}
+
+type roguePriorityItem struct {
+	Aura               *core.Aura
+	CastCount          int32
+	EnergyCost         float64
+	PoolAmount         float64
+	GetDuration        func(*Rogue, int32) time.Duration
+	GetSpell           func(*Rogue, int32) *core.Spell
+	IsFiller           bool
+	MaximumComboPoints int32
+	MaxCasts           int32
+	MinimumComboPoints int32
+}
+
+type shouldCastRotationItemResult int32
+
+const (
+	ShouldNotCast shouldCastRotationItemResult = iota
+	ShouldBuild
+	ShouldCast
+	ShouldWait
+)
+
+type rotation_multi struct {
+	priorityItems []roguePriorityItem
+	rotationItems []rogueRotationItem
+
+	builder       *core.Spell
+	builderPoints int32
+}
+
+func (x *rotation_multi) setup(sim *core.Simulation, rogue *Rogue) {
+	x.builder = rogue.SinisterStrike
+	x.builderPoints = 1
+
+	if rogue.CanMutilate() {
+		x.builder = rogue.Mutilate
+		x.builderPoints = 2
+	}
+
+	if rogue.Talents.Hemorrhage {
+		x.builder = rogue.Hemorrhage
+		x.builderPoints = 1
+	}
+
+	if rogue.Talents.SlaughterFromTheShadows > 0 && !rogue.Rotation.HemoWithDagger && !rogue.PseudoStats.InFrontOfTarget && rogue.HasDagger(core.MainHand) {
+		x.builder = rogue.Backstab
+		x.builderPoints = 1
+	}
+
+	// Slice and Dice
+	x.priorityItems = x.priorityItems[:0]
+
+	sliceAndDice := roguePriorityItem{
+		MinimumComboPoints: 1,
+		MaximumComboPoints: 5,
+		Aura:               rogue.SliceAndDiceAura,
+		EnergyCost:         rogue.SliceAndDice.DefaultCast.Cost,
+		GetDuration: func(rogue *Rogue, cp int32) time.Duration {
+			return rogue.sliceAndDiceDurations[cp]
+		},
+		GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
+			return rogue.SliceAndDice
+		},
+	}
+	if rogue.Rotation.MultiTargetSliceFrequency != proto.Rogue_Rotation_Never {
+		sliceAndDice.MinimumComboPoints = core.MaxInt32(1, rogue.Rotation.MinimumComboPointsMultiTargetSlice)
+		if rogue.Rotation.MultiTargetSliceFrequency == proto.Rogue_Rotation_Once {
+			sliceAndDice.MaxCasts = 1
+		}
+		x.priorityItems = append(x.priorityItems, sliceAndDice)
+	}
+
+	// Expose Armor
+	if rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Maintain ||
+		rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Once {
+		minPoints := int32(1)
+		maxCasts := int32(0)
+		if rogue.Rotation.ExposeArmorFrequency == proto.Rogue_Rotation_Once {
+			minPoints = rogue.Rotation.MinimumComboPointsExposeArmor
+			maxCasts = 1
+		}
+		x.priorityItems = append(x.priorityItems, roguePriorityItem{
+			MaxCasts:           maxCasts,
+			MaximumComboPoints: 5,
+			MinimumComboPoints: minPoints,
+			Aura:               rogue.ExposeArmorAuras.Get(rogue.CurrentTarget),
+			EnergyCost:         rogue.ExposeArmor.DefaultCast.Cost,
+			GetDuration: func(rogue *Rogue, cp int32) time.Duration {
+				return rogue.exposeArmorDurations[cp]
+			},
+			GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
+				return rogue.ExposeArmor
+			},
+		})
+	}
+
+	// Hunger for Blood
+	if rogue.Talents.HungerForBlood {
+		x.priorityItems = append(x.priorityItems, roguePriorityItem{
+			MaximumComboPoints: 0,
+			Aura:               rogue.HungerForBloodAura,
+			EnergyCost:         rogue.HungerForBlood.DefaultCast.Cost,
+			GetDuration: func(rogue *Rogue, cp int32) time.Duration {
+				return rogue.HungerForBloodAura.Duration
+			},
+			GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
+				return rogue.HungerForBlood
+			},
+		})
+	}
+
+	// Dummy priority to enable CDs
+	x.priorityItems = append(x.priorityItems, roguePriorityItem{
+		MaxCasts:           1,
+		MaximumComboPoints: 0,
+		GetDuration: func(rogue *Rogue, cp int32) time.Duration {
+			return 0
+		},
+		GetSpell: func(rogue *Rogue, cp int32) *core.Spell {
+			if rogue.allMCDsDisabled {
+				for _, mcd := range rogue.GetMajorCooldowns() {
+					mcd.Enable()
+				}
+				rogue.allMCDsDisabled = false
+			}
+			return nil
+		},
+	})
+
+	x.priorityItems = append(x.priorityItems, roguePriorityItem{
+		MaximumComboPoints: 0,
+		EnergyCost:         rogue.FanOfKnives.DefaultCast.Cost,
+		GetSpell: func(rogue *Rogue, i int32) *core.Spell {
+			return rogue.FanOfKnives
+		},
+	})
+	x.rotationItems = x.planRotation(sim, rogue)
+}
+
+func (x *rotation_multi) run(sim *core.Simulation, rogue *Rogue) {
+	if rogue.KillingSpreeAura.IsActive() {
+		rogue.DoNothing()
+		return
+	}
+
+	if len(x.rotationItems) < 1 {
+		panic("Rotation is empty")
+	}
+	eps := x.getExpectedEnergyPerSecond(rogue)
+	shouldCast := x.shouldCastNextRotationItem(sim, rogue, eps)
+	item := x.rotationItems[0]
+	prio := x.priorityItems[item.PrioIndex]
+
+	switch shouldCast {
+	case ShouldNotCast:
+		x.rotationItems = x.rotationItems[1:]
+		x.run(sim, rogue)
+	case ShouldBuild:
+		spell := x.builder
+		if spell == nil || spell.Cast(sim, rogue.CurrentTarget) {
+			if rogue.GCD.IsReady(sim) {
+				x.run(sim, rogue)
+			}
+		} else {
+			panic("Unexpected builder cast failure")
+		}
+	case ShouldCast:
+		spell := prio.GetSpell(rogue, rogue.ComboPoints())
+		if spell == nil || spell.Cast(sim, rogue.CurrentTarget) {
+			x.priorityItems[item.PrioIndex].CastCount += 1
+			x.rotationItems = x.planRotation(sim, rogue)
+			if rogue.GCD.IsReady(sim) {
+				x.run(sim, rogue)
+			}
+		} else {
+			panic("Unexpected cast failure")
+		}
+	case ShouldWait:
+		desiredEnergy := 100.0
+		if rogue.ComboPoints() == 5 {
+			desiredEnergy = prio.EnergyCost
+		} else {
+			if rogue.CurrentEnergy() < prio.EnergyCost && rogue.ComboPoints() >= prio.MinimumComboPoints {
+				desiredEnergy = prio.EnergyCost
+			} else if rogue.ComboPoints() < 5 {
+				desiredEnergy = x.builder.DefaultCast.Cost
+			}
+		}
+		cdAvailableTime := time.Second * 10
+		if sim.CurrentTime > cdAvailableTime {
+			cdAvailableTime = core.NeverExpires
+		}
+		nextExpiration := cdAvailableTime
+		for _, otherItem := range x.rotationItems {
+			if otherItem.ExpiresAt < nextExpiration {
+				nextExpiration = otherItem.ExpiresAt
+			}
+		}
+		neededEnergy := desiredEnergy - rogue.CurrentEnergy()
+		energyAvailableTime := time.Second*time.Duration(neededEnergy/eps) + 1*time.Second
+		energyAt := sim.CurrentTime + energyAvailableTime
+		if energyAt < nextExpiration {
+			rogue.WaitForEnergy(sim, desiredEnergy)
+		} else if nextExpiration > sim.CurrentTime {
+			rogue.WaitUntil(sim, nextExpiration)
+		} else {
+			rogue.DoNothing()
+		}
+	}
+}
+
+func (x *rotation_multi) energyToBuild(points int32) float64 {
+	costPerBuilder := x.builder.DefaultCast.Cost
+
+	buildersNeeded := math.Ceil(float64(points) / float64(x.builderPoints))
+	return buildersNeeded * costPerBuilder
+}
+
+func (x *rotation_multi) timeToBuild(points int32, builderPoints int32, eps float64, finisherCost float64) time.Duration {
+	energyNeeded := x.energyToBuild(points) + finisherCost
+	secondsNeeded := energyNeeded / eps
+	globalsNeeded := math.Ceil(float64(points)/float64(builderPoints)) + 1
+	// Return greater of the time it takes to use the globals and the time it takes to build the energy
+	return core.MaxDuration(time.Second*time.Duration(secondsNeeded), time.Second*time.Duration(globalsNeeded))
+}
+
+func (x *rotation_multi) shouldCastNextRotationItem(sim *core.Simulation, rogue *Rogue, eps float64) shouldCastRotationItemResult {
+	if len(x.rotationItems) == 0 {
+		panic("Empty rotation")
+	}
+	currentEnergy := rogue.CurrentEnergy()
+	comboPoints := rogue.ComboPoints()
+	currentTime := sim.CurrentTime
+	item := x.rotationItems[0]
+	prio := x.priorityItems[item.PrioIndex]
+	tte := item.ExpiresAt - currentTime
+	clippingThreshold := time.Second * 2
+	timeUntilNextGCD := rogue.GCD.TimeToReady(sim)
+
+	// Check to see if a higher prio item will expire
+	if len(x.rotationItems) >= 2 {
+		timeElapsed := time.Second * 1
+		for _, nextItem := range x.rotationItems[1:] {
+			if nextItem.ExpiresAt <= currentTime+timeElapsed {
+				return ShouldNotCast
+			}
+			timeElapsed += nextItem.MinimumBuildDuration
+		}
+	}
+
+	// Expires before next GCD
+	if tte <= timeUntilNextGCD {
+		if comboPoints >= prio.MinimumComboPoints && currentEnergy >= (prio.EnergyCost+prio.PoolAmount) {
+			return ShouldCast
+		} else if comboPoints < prio.MinimumComboPoints && currentEnergy >= x.builder.DefaultCast.Cost {
+			return ShouldBuild
+		} else {
+			return ShouldWait
+		}
+	}
+	if comboPoints >= prio.MaximumComboPoints { // Don't need CP
+		// Cast
+		if tte <= clippingThreshold && currentEnergy >= (prio.EnergyCost+prio.PoolAmount) {
+			return ShouldCast
+		}
+		// Pool energy
+		if tte <= clippingThreshold && currentEnergy < (prio.EnergyCost+prio.PoolAmount) {
+			return ShouldWait
+		}
+		// We have time to squeeze in another spell
+		if tte > item.MinimumBuildDuration {
+			// Find the first lower prio item that can be cast and use it
+			for lpi, lowerPrio := range x.priorityItems[item.PrioIndex+1:] {
+				if comboPoints > lowerPrio.MinimumComboPoints && currentEnergy > lowerPrio.EnergyCost && lowerPrio.MaxCasts == 0 {
+					x.rotationItems = append([]rogueRotationItem{
+						{ExpiresAt: currentTime, PrioIndex: lpi + item.PrioIndex + 1},
+					}, x.rotationItems...)
+					return ShouldCast
+				}
+			}
+		}
+		// Overcap CP with builder
+		if x.timeToBuild(1, x.builderPoints, eps, prio.EnergyCost+prio.PoolAmount) <= tte && currentEnergy >= x.builder.DefaultCast.Cost {
+			return ShouldBuild
+		}
+	} else if comboPoints < prio.MinimumComboPoints { // Need CP
+		if currentEnergy >= x.builder.DefaultCast.Cost {
+			return ShouldBuild
+		} else {
+			return ShouldWait
+		}
+	} else { // Between MinimumComboPoints and MaximumComboPoints
+		if currentEnergy >= prio.EnergyCost+prio.PoolAmount && tte <= timeUntilNextGCD {
+			return ShouldCast
+		}
+		ttb := x.timeToBuild(1, 2, eps, prio.EnergyCost+prio.PoolAmount-currentEnergy)
+		if currentEnergy >= x.builder.DefaultCast.Cost && tte > ttb {
+			return ShouldBuild
+		}
+	}
+	return ShouldWait
+}
+
+func (x *rotation_multi) getExpectedEnergyPerSecond(rogue *Rogue) float64 {
+	const finishersPerSecond = 1.0 / 6
+	const averageComboPointsSpendOnFinisher = 4.0
+	bonusEnergyPerSecond := float64(rogue.Talents.CombatPotency) * 3 * 0.2 * 1.0 / (rogue.AutoAttacks.OH.SwingSpeed / 1.4)
+	bonusEnergyPerSecond += float64(rogue.Talents.FocusedAttacks)
+	bonusEnergyPerSecond += float64(rogue.Talents.RelentlessStrikes) * 0.04 * 25 * finishersPerSecond * averageComboPointsSpendOnFinisher
+	return (core.EnergyPerTick*rogue.EnergyTickMultiplier)/core.EnergyTickDuration.Seconds() + bonusEnergyPerSecond
+}
+
+func (x *rotation_multi) planRotation(sim *core.Simulation, rogue *Rogue) []rogueRotationItem {
+	var rotationItems []rogueRotationItem
+	eps := x.getExpectedEnergyPerSecond(rogue)
+	for pi, prio := range x.priorityItems {
+		if prio.MaxCasts > 0 && prio.CastCount >= prio.MaxCasts {
+			continue
+		}
+		maxCP := prio.MaximumComboPoints
+		for maxCP > 0 && prio.GetDuration(rogue, maxCP)+sim.CurrentTime > sim.Duration {
+			maxCP--
+		}
+		var expiresAt time.Duration
+		if prio.Aura != nil {
+			expiresAt = prio.Aura.ExpiresAt()
+		} else if prio.MaxCasts == 1 {
+			expiresAt = sim.CurrentTime // TODO looks fishy, repeated expiresAt = sim.CurrentTime
+		} else {
+			expiresAt = sim.CurrentTime
+		}
+		minimumBuildDuration := x.timeToBuild(prio.MinimumComboPoints, x.builderPoints, eps, prio.EnergyCost)
+		maximumBuildDuration := x.timeToBuild(maxCP, x.builderPoints, eps, prio.EnergyCost)
+		rotationItems = append(rotationItems, rogueRotationItem{
+			ExpiresAt:            expiresAt,
+			MaximumBuildDuration: maximumBuildDuration,
+			MinimumBuildDuration: minimumBuildDuration,
+			PrioIndex:            pi,
+		})
+	}
+
+	currentTime := sim.CurrentTime
+	comboPoints := rogue.ComboPoints()
+	currentEnergy := rogue.CurrentEnergy()
+
+	var prioStack []rogueRotationItem
+	for _, item := range rotationItems {
+		if item.ExpiresAt >= sim.Duration {
+			continue
+		}
+		prio := x.priorityItems[item.PrioIndex]
+		maxBuildAt := item.ExpiresAt - item.MaximumBuildDuration
+		if prio.Aura == nil {
+			timeValueOfResources := time.Duration((float64(comboPoints)*x.builder.DefaultCast.Cost/float64(x.builderPoints) + currentEnergy) / eps)
+			maxBuildAt = currentTime - item.MaximumBuildDuration - timeValueOfResources
+		}
+		if currentTime < maxBuildAt {
+			// Put it on the to cast stack
+			prioStack = append(prioStack, item)
+			if prio.MinimumComboPoints > 0 {
+				comboPoints = 0
+			}
+			currentTime += item.MaximumBuildDuration
+		} else {
+			cpUsed := core.MaxInt32(0, prio.MinimumComboPoints-comboPoints)
+			energyUsed := core.MaxFloat(0, prio.EnergyCost-currentEnergy)
+			minBuildTime := x.timeToBuild(cpUsed, x.builderPoints, eps, energyUsed)
+			if currentTime+minBuildTime <= item.ExpiresAt || !prio.IsFiller {
+				prioStack = append(prioStack, item)
+				currentTime = core.MaxDuration(item.ExpiresAt, currentTime+minBuildTime)
+				currentEnergy = 0
+				if prio.MinimumComboPoints > 0 {
+					comboPoints = 0
+				}
+			} else if len(prioStack) < 1 || (prio.Aura != nil && !prio.Aura.IsActive() && !prio.IsFiller) || prio.MaxCasts == 1 {
+				// Plan to cast it as soon as possible
+				prioStack = append(prioStack, item)
+				currentTime += item.MinimumBuildDuration
+				currentEnergy = 0
+				if prio.MinimumComboPoints > 0 {
+					comboPoints = 0
+				}
+			}
+		}
+	}
+
+	// Reverse
+	for i, j := 0, len(prioStack)-1; i < j; i, j = i+1, j-1 {
+		prioStack[i], prioStack[j] = prioStack[j], prioStack[i]
+	}
+
+	return prioStack
+}

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -543,14 +543,14 @@ func (rogue *Rogue) registerAdrenalineRushCD() {
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			rogue.ResetEnergyTick(sim)
 			rogue.ApplyEnergyTickMultiplier(1.0)
-			if r, ok := rogue.rotation.(*rotation_generic); ok {
+			if r, ok := rogue.rotation.(*rotation_multi); ok {
 				r.planRotation(sim, rogue)
 			}
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			rogue.ResetEnergyTick(sim)
 			rogue.ApplyEnergyTickMultiplier(-1.0)
-			if r, ok := rogue.rotation.(*rotation_generic); ok {
+			if r, ok := rogue.rotation.(*rotation_multi); ok {
 				r.planRotation(sim, rogue)
 			}
 		},

--- a/sim/rogue/tricks_of_the_trade.go
+++ b/sim/rogue/tricks_of_the_trade.go
@@ -58,6 +58,13 @@ func (rogue *Rogue) registerTricksOfTheTradeSpell() {
 			Spell:    rogue.TricksOfTheTrade,
 			Priority: core.CooldownPriorityDrums,
 			Type:     core.CooldownTypeDPS,
+			ShouldActivate: func(sim *core.Simulation, character *core.Character) bool {
+				if hasShadowblades {
+					return rogue.CurrentEnergy() <= rogue.maxEnergy-15-rogue.EnergyTickMultiplier*10
+				} else {
+					return rogue.CurrentEnergy() >= rogue.TricksOfTheTrade.DefaultCast.Cost
+				}
+			},
 		})
 	}
 }


### PR DESCRIPTION
[rogue] introduce a new generic rotation, fixing all posted rogue crashes; the former is still kept to support multi-target (>=3) situations, but should probably be removed soon

[rogue] add support for 2t10 bonus for tricks of the trade, and a similar check for blood elfs' "arcane torrent" ability