### PR TITLE
PR to compute weighted EP from a mix of DPS/TPS/DTPS

### DIFF
--- a/proto/ui.proto
+++ b/proto/ui.proto
@@ -251,6 +251,7 @@ message IndividualSimSettings {
 	// Deprecate after 2 months (on 2023/02/13)
 	repeated double ep_weights = 6;
 	UnitStats ep_weights_stats = 10;
+	repeated double ep_ratios = 11;
 }
 
 // Local storage data for gear settings.

--- a/ui/core/components/stat_weights_action.ts
+++ b/ui/core/components/stat_weights_action.ts
@@ -115,15 +115,15 @@ class EpWeightsMenu extends BaseModal {
 									<i class="fa fa-copy"></i>
 								</a>
 							</th>
-							<th>
+							<th style="text-align: center;">
 								<span>Current EP</span>
 								<a href="javascript:void(0)" role="button" class="col-action">
 									<i class="fas fa-arrows-rotate"></i>
 								</a>
 							</th>
 						</tr>
-						<tr>
-							<th>Ratio</th>
+						<tr class="ep-ratios">
+							<td>EP Ratio</td>
 							<td class="damage-metrics type-ratio type-weight">
 							</td>
 							<td class="damage-metrics type-ratio type-ep">
@@ -140,7 +140,7 @@ class EpWeightsMenu extends BaseModal {
 							</td>
 							<td class="threat-metrics type-ratio type-ep">
 							</td>
-							<td>
+							<td style="text-align: center; vertical-align: middle;">
 								<button class="btn btn-primary compute-ep">
 									<i class="fas fa-calculator"></i>
 									Compute EP

--- a/ui/core/individual_sim_ui.ts
+++ b/ui/core/individual_sim_ui.ts
@@ -498,6 +498,8 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 			this.player.getParty()!.setBuffs(eventID, this.individualConfig.defaults.partyBuffs);
 			this.player.getRaid()!.setBuffs(eventID, this.individualConfig.defaults.raidBuffs);
 			this.player.setEpWeights(eventID, this.individualConfig.defaults.epWeights);
+			const defaultRatios = this.player.getDefaultEpRatios(tankSpec, healingSpec)
+			this.player.setEpRatios(eventID, defaultRatios);
 			this.player.setProfession1(eventID, this.individualConfig.defaults.other?.profession1 || Profession.Engineering);
 			this.player.setProfession2(eventID, this.individualConfig.defaults.other?.profession2 || Profession.Jewelcrafting);
 			this.player.setDistanceFromTarget(eventID, this.individualConfig.defaults.other?.distanceFromTarget || 0);
@@ -552,6 +554,7 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 			partyBuffs: this.player.getParty()?.getBuffs() || PartyBuffs.create(),
 			encounter: this.sim.encounter.toProto(),
 			epWeightsStats: this.player.getEpWeights().toProto(),
+			epRatios: this.player.getEpRatios(),
 			targetDummies: this.sim.raid.getTargetDummies(),
 		});
 	}
@@ -584,6 +587,16 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 			} else {
 				this.player.setEpWeights(eventID, this.individualConfig.defaults.epWeights);
 			}
+
+			if (settings.epRatios) {
+				this.player.setEpRatios(eventID, settings.epRatios);
+			} else {
+				const tankSpec = isTankSpec(this.player.spec);
+				const healingSpec = isHealingSpec(this.player.spec);
+				const defaultRatios = this.player.getDefaultEpRatios(tankSpec, healingSpec)
+				this.player.setEpRatios(eventID, defaultRatios);
+			}
+
 			this.sim.raid.setBuffs(eventID, settings.raidBuffs || RaidBuffs.create());
 			this.sim.raid.setDebuffs(eventID, settings.debuffs || Debuffs.create());
 			this.sim.raid.setTanks(eventID, settings.tanks || []);

--- a/ui/core/proto_utils/stats.ts
+++ b/ui/core/proto_utils/stats.ts
@@ -152,6 +152,12 @@ export class Stats {
 			this.pseudoStats.map((value, stat) => value - other.pseudoStats[stat]));
 	}
 
+	scale(scalar: number): Stats {
+		return new Stats(
+			this.stats.map((value, stat) => value * scalar),
+			this.pseudoStats.map((value, stat) => value * scalar));
+	}
+
 	computeEP(epWeights: Stats): number {
 		let total = 0;
 		this.stats.forEach((stat, idx) => {

--- a/ui/core/sim_ui.ts
+++ b/ui/core/sim_ui.ts
@@ -109,6 +109,25 @@ export abstract class SimUI extends Component {
 		updateShowHealingMetrics();
 		this.sim.showHealingMetricsChangeEmitter.on(updateShowHealingMetrics);
 
+		const updateShowEpRatios = () => {
+			// Threat metrics *always* shows multiple columns, so
+			// always show ratios when they are shown
+			if (this.sim.getShowThreatMetrics()) {
+				this.rootElem.classList.remove('hide-ep-ratios');
+			// This case doesn't currently happen, but who knows
+			// what the future holds...
+			} else if (this.sim.getShowDamageMetrics() && this.sim.getShowHealingMetrics()) {
+				this.rootElem.classList.remove('hide-ep-ratios');
+			} else {
+				this.rootElem.classList.add('hide-ep-ratios');
+			}
+		};
+
+		updateShowEpRatios();
+		this.sim.showDamageMetricsChangeEmitter.on(updateShowEpRatios);
+		this.sim.showHealingMetricsChangeEmitter.on(updateShowEpRatios);
+		this.sim.showThreatMetricsChangeEmitter.on(updateShowEpRatios);
+
 		const updateShowExperimental = () => {
 			if (this.sim.getShowExperimental())
 				this.rootElem.classList.remove('hide-experimental');

--- a/ui/scss/core/components/_stat_weights_action.scss
+++ b/ui/scss/core/components/_stat_weights_action.scss
@@ -52,6 +52,23 @@
 				text-align: left;
 			}
 
+			.ep-ratios {
+				background-color: $table-row-even-bg;
+
+				td {
+					padding: $table-cell-padding;
+				}
+
+				.input-root {
+					align-items: flex-end;
+				}
+
+				input {
+					text-align: right;
+					width: 65%;
+				}
+			}
+
 			tbody {
 				tr:nth-child(even) {
 					background-color: $table-row-even-bg;	

--- a/ui/scss/core/sim_ui/_shared.scss
+++ b/ui/scss/core/sim_ui/_shared.scss
@@ -104,6 +104,10 @@ td, th {
 .hide-in-front-of-target .in-front-of-target {
 	display: none !important;
 }
+
+.hide-ep-ratios .ep-ratios {
+	display: none !important;
+}
 // END TODO
 
 @include media-breakpoint-down(lg) {


### PR DESCRIPTION
Basically, we assign a ratio to each EP column and update the current EP with a weighted sum of those columns. Needs two things to be ready for the main sim:

1) The UI looks terrible currently, someone more comfortable with the CSS/front-end stuff can probably make it look better,

2) should probably default to hiding the number cells and compute button for DPS specs, who will only be interested in DPS EP anyway