### PR TITLE
Calculate EP from weights in the frontend

### DIFF
--- a/ui/core/components/stat_weights_action.ts
+++ b/ui/core/components/stat_weights_action.ts
@@ -59,6 +59,24 @@ class EpWeightsMenu extends BaseModal {
 				</div>
 				<div class="show-all-stats-container col col-sm-3"></div>
 			</div>
+			<div class="ep-reference-options row experimental">
+				<div class="col col-sm-3 damage-metrics">
+					<span>DPS/TPS reference:</span>
+					<select class="ref-stat-select form-select damage-metrics">
+					</select>
+				</div>
+				<div class="col col-sm-3 healing-metrics">
+					<span>Healing reference:</span>
+					<select class="ref-stat-select form-select healing-metrics">
+					</select>
+				</div>
+				<div class="col col-sm-3 threat-metrics">
+					<span>Mitigation reference:</span>
+					<select class="ref-stat-select form-select threat-metrics">
+					</select>
+				</div>
+				<p>The above stat selectors control which reference stat is used for EP normalisation for the different EP columns.</p>
+			</div>
 			<p>The 'Current EP' column displays the values currently used by the item pickers to sort items.</br>
 			Use the <a href='javascript:void(0)' class="fa fa-copy"></a> icon above the EPs to use newly calculated EPs.</p>
 			<div class="results-ep-table-container modal-scroll-table">
@@ -209,6 +227,37 @@ class EpWeightsMenu extends BaseModal {
 
 			return undefined;
 		};
+
+		const updateEpRefStat = () => {
+			this.simUI.prevEpSimResult = this.calculateEp(this.getPrevSimResult());
+			this.updateTable(this.simUI.prevEpIterations || 1, this.getPrevSimResult());
+		};
+
+		const epRefSelects = this.rootElem.querySelectorAll('.ref-stat-select') as NodeListOf<HTMLSelectElement>;
+		epRefSelects.forEach((epSelect: HTMLSelectElement, idx: number) => {
+			this.epStats.forEach((stat) => {
+				epSelect.options[epSelect.options.length] = new Option(getNameFromStat(stat));
+			});
+			if (epSelect.classList.contains('damage-metrics')) {
+				epSelect.addEventListener('input', event => {
+					this.simUI.dpsRefStat = getStatFromName(epSelect.value);
+					updateEpRefStat();
+				});
+				epSelect.value = getNameFromStat(this.getDpsEpRefStat());
+			} else if (epSelect.classList.contains('healing-metrics')) {
+				epSelect.addEventListener('input', event => {
+					this.simUI.healRefStat = getStatFromName(epSelect.value);
+					updateEpRefStat();
+				});
+				epSelect.value = getNameFromStat(this.getHealEpRefStat());
+			} else if (epSelect.classList.contains('threat-metrics')) {
+				epSelect.addEventListener('input', event => {
+					this.simUI.tankRefStat = getStatFromName(epSelect.value);
+					updateEpRefStat();
+				});
+				epSelect.value = getNameFromStat(this.getTankEpRefStat());
+			}
+		});
 
 		const optimizeGemsButton = this.rootElem.getElementsByClassName('optimize-gems')[0] as HTMLElement;
 		Tooltip.getOrCreateInstance(optimizeGemsButton);

--- a/ui/core/components/stat_weights_action.ts
+++ b/ui/core/components/stat_weights_action.ts
@@ -196,6 +196,20 @@ class EpWeightsMenu extends BaseModal {
 		selectElem.value = this.statsType;
 		updateType();
 
+		const getNameFromStat = (stat: Stat|undefined) => {
+			return stat !== undefined ? getClassStatName(stat, this.simUI.player.getClass()) : '??';
+		};
+
+		const getStatFromName = (value: string) => {
+			for (let stat of this.epStats) {
+				if (getNameFromStat(stat) == value) {
+					return stat;
+				}
+			}
+
+			return undefined;
+		};
+
 		const optimizeGemsButton = this.rootElem.getElementsByClassName('optimize-gems')[0] as HTMLElement;
 		Tooltip.getOrCreateInstance(optimizeGemsButton);
 		optimizeGemsButton.addEventListener('click', async event => {

--- a/ui/core/components/stat_weights_action.ts
+++ b/ui/core/components/stat_weights_action.ts
@@ -245,16 +245,24 @@ class EpWeightsMenu extends BaseModal {
 		});
 
 		const colActionButtons = Array.from(this.rootElem.getElementsByClassName('col-action')) as Array<HTMLSelectElement>;
-		const makeUpdateWeights = (button: HTMLElement, labelTooltip: string, tooltip: string, weightsFunc: () => UnitStats|undefined) => {
+		const makeUpdateWeights = (button: HTMLElement, labelTooltip: string, tooltip: string, weightsFunc: () => UnitStats|undefined, epRefStat?: () => Stat) => {
 			const label = button.previousElementSibling as HTMLElement;
-			label!.setAttribute('data-bs-toggle', 'tooltip');
-			label!.setAttribute('data-bs-title', labelTooltip);
-			label!.setAttribute('data-bs-html',	'true');
+			const title = () => {
+				if (!epRefStat) return labelTooltip;
+
+				const refStatName = getNameFromStat(epRefStat());
+				return labelTooltip + ` Normalized by ${refStatName}.`;
+			};
+			const labelTooltipConfig = {
+				toggle: 'tooltip',
+				html: true,
+				title: title
+			};
 			button.setAttribute('data-bs-toggle', 'tooltip');
 			button.setAttribute('data-bs-title', tooltip);
 			button.setAttribute('data-bs-html', 'true');
 
-			Tooltip.getOrCreateInstance(label);
+			new Tooltip(label, labelTooltipConfig);
 			Tooltip.getOrCreateInstance(button);
 
 			button.addEventListener('click', event => {
@@ -262,16 +270,14 @@ class EpWeightsMenu extends BaseModal {
 			});
 		};
 
-		const epRefStatName = getClassStatName(this.epReferenceStat, this.simUI.player.getClass());
-		const armorStatName = getClassStatName(Stat.StatArmor, this.simUI.player.getClass());
 		makeUpdateWeights(colActionButtons[0], 'Per-point increase in DPS (Damage Per Second) for each stat.', 'Copy to Current EP', () => this.getPrevSimResult().dps!.weights);
-		makeUpdateWeights(colActionButtons[1], `EP (Equivalency Points) for DPS (Damage Per Second) for each stat. Normalized by ${epRefStatName}.`, 'Copy to Current EP', () => this.getPrevSimResult().dps!.epValues);
+		makeUpdateWeights(colActionButtons[1], 'EP (Equivalency Points) for DPS (Damage Per Second) for each stat.', 'Copy to Current EP', () => this.getPrevSimResult().dps!.epValues, () => this.getDpsEpRefStat());
 		makeUpdateWeights(colActionButtons[2], 'Per-point increase in HPS (Healing Per Second) for each stat.', 'Copy to Current EP', () => this.getPrevSimResult().hps!.weights);
-		makeUpdateWeights(colActionButtons[3], `EP (Equivalency Points) for HPS (Healing Per Second) for each stat. Normalized by ${epRefStatName}.`, 'Copy to Current EP', () => this.getPrevSimResult().hps!.epValues);
+		makeUpdateWeights(colActionButtons[3], 'EP (Equivalency Points) for HPS (Healing Per Second) for each stat.', 'Copy to Current EP', () => this.getPrevSimResult().hps!.epValues, () => this.getHealEpRefStat());
 		makeUpdateWeights(colActionButtons[4], 'Per-point increase in TPS (Threat Per Second) for each stat.', 'Copy to Current EP', () => this.getPrevSimResult().tps!.weights);
-		makeUpdateWeights(colActionButtons[5], `EP (Equivalency Points) for TPS (Threat Per Second) for each stat. Normalized by ${epRefStatName}.`, 'Copy to Current EP', () => this.getPrevSimResult().tps!.epValues);
+		makeUpdateWeights(colActionButtons[5], 'EP (Equivalency Points) for TPS (Threat Per Second) for each stat.', 'Copy to Current EP', () => this.getPrevSimResult().tps!.epValues, () => this.getDpsEpRefStat());
 		makeUpdateWeights(colActionButtons[6], 'Per-point increase in DTPS (Damage Taken Per Second) for each stat.', 'Copy to Current EP', () => this.getPrevSimResult().dtps!.weights);
-		makeUpdateWeights(colActionButtons[7], `EP (Equivalency Points) for DTPS (Damage Taken Per Second) for each stat. Normalized by ${armorStatName}.`, 'Copy to Current EP', () => this.getPrevSimResult().dtps!.epValues);
+		makeUpdateWeights(colActionButtons[7], 'EP (Equivalency Points) for DTPS (Damage Taken Per Second) for each stat.', 'Copy to Current EP', () => this.getPrevSimResult().dtps!.epValues, () => this.getTankEpRefStat());
 		makeUpdateWeights(colActionButtons[8], 'Current EP Weights. Used to sort the gear selector menus.', 'Restore Default EP', () => this.simUI.individualConfig.defaults.epWeights.toProto());
 
 		const showAllStatsContainer = this.rootElem.getElementsByClassName('show-all-stats-container')[0] as HTMLElement;

--- a/ui/core/individual_sim_ui.ts
+++ b/ui/core/individual_sim_ui.ts
@@ -173,6 +173,9 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 
 	prevEpIterations: number;
 	prevEpSimResult: StatWeightsResult | null;
+	dpsRefStat?: Stat;
+	healRefStat?: Stat;
+	tankRefStat?: Stat;
 
 	readonly bt: BulkTab;
 

--- a/ui/core/proto_utils/stats.ts
+++ b/ui/core/proto_utils/stats.ts
@@ -54,6 +54,14 @@ export class UnitStat {
 		}
 	}
 
+	setProtoValue(proto: UnitStats, val: number) {
+		if (this.isStat()) {
+			proto.stats[this.stat!] = val;
+		} else {
+			proto.pseudoStats[this.pseudoStat!] = val;
+		}
+	}
+
 	static fromStat(stat: Stat): UnitStat {
 		return new UnitStat(stat, null);
 	}

--- a/ui/scss/core/components/_stat_weights_action.scss
+++ b/ui/scss/core/components/_stat_weights_action.scss
@@ -5,6 +5,17 @@
 		margin-bottom: $block-spacer;
 	}
 
+	.ep-reference-options {
+		margin-bottom: $block-spacer;
+		span {
+			font-weight: bold;
+		}
+
+		p {
+			margin-top: $block-spacer;
+		}
+	}
+
 	.results-ep-table-container {
 		position: relative;
 


### PR DESCRIPTION
There's no reason to compute EP in the Go "backend", moving this computation into the frontend makes experimentation with different EP calculations cheaper by not having to rerun the whole stat weight calculation.