### PR TITLE
apply resistance before target mods

### DIFF
--- a/sim/core/spell_result.go
+++ b/sim/core/spell_result.go
@@ -188,10 +188,10 @@ func (spell *Spell) calcDamageInternal(sim *Simulation, target *Unit, baseDamage
 	} else {
 		result.Damage *= attackerMultiplier
 		afterAttackMods := result.Damage
-		result.applyTargetModifiers(spell, attackTable, isPeriodic)
-		afterTargetMods := result.Damage
 		result.applyResistances(sim, spell, isPeriodic, attackTable)
 		afterResistances := result.Damage
+		result.applyTargetModifiers(spell, attackTable, isPeriodic)
+		afterTargetMods := result.Damage
 		outcomeApplier(sim, result, attackTable)
 		afterOutcome := result.Damage
 		spell.ApplyPostOutcomeDamageModifiers(sim, result)
@@ -199,8 +199,8 @@ func (spell *Spell) calcDamageInternal(sim *Simulation, target *Unit, baseDamage
 
 		spell.Unit.Log(
 			sim,
-			"%s %s [DEBUG] MAP: %0.01f, RAP: %0.01f, SP: %0.01f, BaseDamage:%0.01f, AfterAttackerMods:%0.01f, AfterTargetMods:%0.01f, AfterResistances:%0.01f, AfterOutcome:%0.01f, AfterPostOutcome:%0.01f",
-			target.LogLabel(), spell.ActionID, spell.Unit.GetStat(stats.AttackPower), spell.Unit.GetStat(stats.RangedAttackPower), spell.Unit.GetStat(stats.SpellPower), baseDamage, afterAttackMods, afterTargetMods, afterResistances, afterOutcome, afterPostOutcome)
+			"%s %s [DEBUG] MAP: %0.01f, RAP: %0.01f, SP: %0.01f, BaseDamage:%0.01f, AfterAttackerMods:%0.01f, AfterResistances:%0.01f, AfterTargetMods:%0.01f, AfterOutcome:%0.01f, AfterPostOutcome:%0.01f",
+			target.LogLabel(), spell.ActionID, spell.Unit.GetStat(stats.AttackPower), spell.Unit.GetStat(stats.RangedAttackPower), spell.Unit.GetStat(stats.SpellPower), baseDamage, afterAttackMods, afterResistances, afterTargetMods, afterOutcome, afterPostOutcome)
 	}
 
 	result.Threat = spell.ThreatFromDamage(result.Outcome, result.Damage)


### PR DESCRIPTION
The following demonstrates that resistance is applied before target modifiers (13% magic damage taken from Ebon plaguebringer and 30% disease damage taken from crypt fever)

https://classic.warcraftlogs.com/reports/BXzqP3mx1ZvbRGcF/#source=1&view=events&fight=1

The first fight I have EP on the target which gives 13% magic damage and 30% disease damage taken.

You can see all resist values properly give 10% or 20% resisted with the following formulae:

```
# disease
resist / (resist + dmg/1.3/1.13)

# not disease 
resist / (resist + dmg/1.13)
```

For example:


Sailz Blood Plague Highlord's Nemesis Trainer Tick 148 (R: 25)
```
25/(25+148/1.3/1.13) = 19.88% which is within rounding error of 20%
```

[Sailz](https://classic.warcraftlogs.com/reports/BXzqP3mx1ZvbRGcF/#) [Death Coil](https://www.wowhead.com/wotlk/spell=47632) [Highlord's Nemesis Trainer](https://classic.warcraftlogs.com/reports/BXzqP3mx1ZvbRGcF/#) 1108 (R: 109)
```
109/(109+1108/1.13) = 10%
```

Now in the second fight I do not have EP / CF so no target modifiers and we can see all resist values properly give 10% or 20% resisted with the following:
```
resist / (resist + dmg)
```

For example:
[Sailz](https://classic.warcraftlogs.com/reports/BXzqP3mx1ZvbRGcF/#) [Blood Plague](https://www.wowhead.com/wotlk/spell=55078) [Highlord's Nemesis Trainer](https://classic.warcraftlogs.com/reports/BXzqP3mx1ZvbRGcF/#) Tick 83 (R: 9)
```
9/(9+83) = 9.78% within rounding error of 10%
```

[Sailz](https://classic.warcraftlogs.com/reports/BXzqP3mx1ZvbRGcF/#) [Death Coil](https://www.wowhead.com/wotlk/spell=47632) [Highlord's Nemesis Trainer](https://classic.warcraftlogs.com/reports/BXzqP3mx1ZvbRGcF/#) 461 (R: 115)
```
115/(115+461) = 19.96% within rounding error of 20%
```