### PR TITLE
vigo/rogueSets

### DIFF
--- a/sim/rogue/ambush.go
+++ b/sim/rogue/ambush.go
@@ -28,8 +28,7 @@ func (rogue *Rogue) registerAmbushSpell() {
 			return !rogue.PseudoStats.InFrontOfTarget && rogue.GetMHWeapon().WeaponType == proto.WeaponType_WeaponTypeDagger
 		},
 
-		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0) +
-			[]float64{0, 2, 4, 6}[rogue.Talents.TurnTheTables]*core.CritRatingPerCritChance +
+		BonusCritRating: []float64{0, 2, 4, 6}[rogue.Talents.TurnTheTables]*core.CritRatingPerCritChance +
 			25*core.CritRatingPerCritChance*float64(rogue.Talents.ImprovedAmbush),
 		// All of these use "Apply Aura: Modifies Damage/Healing Done", and stack additively.
 		DamageMultiplier: 2.75 * (1 +

--- a/sim/rogue/backstab.go
+++ b/sim/rogue/backstab.go
@@ -30,7 +30,7 @@ func (rogue *Rogue) registerBackstabSpell() {
 			return !rogue.PseudoStats.InFrontOfTarget && rogue.GetMHWeapon().WeaponType == proto.WeaponType_WeaponTypeDagger
 		},
 
-		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0) +
+		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(Tier9, 4), 5*core.CritRatingPerCritChance, 0) +
 			[]float64{0, 2, 4, 6}[rogue.Talents.TurnTheTables]*core.CritRatingPerCritChance +
 			10*core.CritRatingPerCritChance*float64(rogue.Talents.PuncturingWounds),
 		// All of these use "Apply Aura: Modifies Damage/Healing Done", and stack additively (up to 142%).
@@ -40,7 +40,7 @@ func (rogue *Rogue) registerBackstabSpell() {
 			0.03*float64(rogue.Talents.Aggression) +
 			0.05*float64(rogue.Talents.BladeTwisting) +
 			core.TernaryFloat64(rogue.Talents.SurpriseAttacks, 0.1, 0) +
-			core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0)) *
+			core.TernaryFloat64(rogue.HasSetBonus(Tier6, 4), 0.06, 0)) *
 			(1 + 0.02*float64(rogue.Talents.SinisterCalling)),
 		CritMultiplier:   rogue.MeleeCritMultiplier(true),
 		ThreatMultiplier: 1,

--- a/sim/rogue/ghostly_strike.go
+++ b/sim/rogue/ghostly_strike.go
@@ -37,8 +37,7 @@ func (rogue *Rogue) registerGhostlyStrikeSpell() {
 			IgnoreHaste: true,
 		},
 
-		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0) +
-			[]float64{0, 2, 4, 6}[rogue.Talents.TurnTheTables]*core.CritRatingPerCritChance,
+		BonusCritRating: []float64{0, 2, 4, 6}[rogue.Talents.TurnTheTables] * core.CritRatingPerCritChance,
 
 		DamageMultiplier: core.TernaryFloat64(rogue.HasDagger(core.MainHand), 1.8, 1.25) * core.TernaryFloat64(hasGlyph, 1.4, 1) * (1 + 0.02*float64(rogue.Talents.FindWeakness)),
 		CritMultiplier:   rogue.MeleeCritMultiplier(true),

--- a/sim/rogue/hemorrhage.go
+++ b/sim/rogue/hemorrhage.go
@@ -68,12 +68,12 @@ func (rogue *Rogue) registerHemorrhageSpell() {
 			IgnoreHaste: true,
 		},
 
-		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0) +
+		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(Tier9, 4), 5*core.CritRatingPerCritChance, 0) +
 			[]float64{0, 2, 4, 6}[rogue.Talents.TurnTheTables]*core.CritRatingPerCritChance,
 
 		DamageMultiplier: core.TernaryFloat64(rogue.HasDagger(core.MainHand), 1.6, 1.1) * (1 +
 			0.02*float64(rogue.Talents.FindWeakness) +
-			core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0)) *
+			core.TernaryFloat64(rogue.HasSetBonus(Tier6, 4), 0.06, 0)) *
 			(1 + 0.02*float64(rogue.Talents.SinisterCalling)),
 		CritMultiplier:   rogue.MeleeCritMultiplier(true),
 		ThreatMultiplier: 1,

--- a/sim/rogue/items.go
+++ b/sim/rogue/items.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wowsims/wotlk/sim/core/stats"
 )
 
-var ItemSetGladiatorsVestments = core.NewItemSet(core.ItemSet{
+var Arena = core.NewItemSet(core.ItemSet{
 	Name: "Gladiator's Vestments",
 	Bonuses: map[int32]core.ApplyEffect{
 		2: func(agent core.Agent) {
@@ -21,8 +21,23 @@ var ItemSetGladiatorsVestments = core.NewItemSet(core.ItemSet{
 	},
 })
 
-var ItemSetVanCleefs = core.NewItemSet(core.ItemSet{
-	Name: "VanCleef's Battlegear",
+var Tier10 = core.NewItemSet(core.ItemSet{
+	Name: "Shadowblade's Battlegear",
+	Bonuses: map[int32]core.ApplyEffect{
+		2: func(agent core.Agent) {
+			// Your Tricks of the Trade now grants you 15 energy instead of costing energy.
+			// Handled in tricks_of_the_trade.go.
+		},
+		4: func(agent core.Agent) {
+			// Gives your melee finishing moves a 13% chance to add 3 combo points to your target.
+			// Handled in the finishing move effect applier
+		},
+	},
+})
+
+var Tier9 = core.NewItemSet(core.ItemSet{
+	Name:            "VanCleef's Battlegear",
+	AlternativeName: "Garona's Battlegear",
 	Bonuses: map[int32]core.ApplyEffect{
 		2: func(agent core.Agent) {
 			// Your Rupture ability has a chance each time it deals damage to reduce the cost of your next ability by 40 energy.
@@ -88,7 +103,7 @@ var ItemSetVanCleefs = core.NewItemSet(core.ItemSet{
 	},
 })
 
-var ItemSetTerrorblade = core.NewItemSet(core.ItemSet{
+var Tier8 = core.NewItemSet(core.ItemSet{
 	Name: "Terrorblade Battlegear",
 	Bonuses: map[int32]core.ApplyEffect{
 		2: func(agent core.Agent) {
@@ -102,21 +117,7 @@ var ItemSetTerrorblade = core.NewItemSet(core.ItemSet{
 	},
 })
 
-var ItemSetShadowblades = core.NewItemSet(core.ItemSet{
-	Name: "Shadowblade's Battlegear",
-	Bonuses: map[int32]core.ApplyEffect{
-		2: func(agent core.Agent) {
-			// Your Tricks of the Trade now grants you 15 energy instead of costing energy.
-			// Handled in tricks_of_the_trade.go.
-		},
-		4: func(agent core.Agent) {
-			// Gives your melee finishing moves a 13% chance to add 3 combo points to your target.
-			// Handled in the finishing move effect applier
-		},
-	},
-})
-
-var ItemSetBonescythe = core.NewItemSet(core.ItemSet{
+var Tier7 = core.NewItemSet(core.ItemSet{
 	Name: "Bonescythe Battlegear",
 	Bonuses: map[int32]core.ApplyEffect{
 		2: func(agent core.Agent) {
@@ -130,7 +131,7 @@ var ItemSetBonescythe = core.NewItemSet(core.ItemSet{
 	},
 })
 
-var ItemSetSlayers = core.NewItemSet(core.ItemSet{
+var Tier6 = core.NewItemSet(core.ItemSet{
 	Name: "Slayer's Armor",
 	Bonuses: map[int32]core.ApplyEffect{
 		2: func(agent core.Agent) {

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -23,14 +23,14 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 		ProcMask:    procMask,
 		Flags:       core.SpellFlagMeleeMetrics | SpellFlagBuilder | SpellFlagColdBlooded,
 
-		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0) +
+		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(Tier9, 4), 5*core.CritRatingPerCritChance, 0) +
 			[]float64{0, 2, 4, 6}[rogue.Talents.TurnTheTables]*core.CritRatingPerCritChance +
 			5*core.CritRatingPerCritChance*float64(rogue.Talents.PuncturingWounds),
 
 		DamageMultiplierAdditive: 1 +
 			0.1*float64(rogue.Talents.Opportunity) +
 			0.02*float64(rogue.Talents.FindWeakness) +
-			core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0),
+			core.TernaryFloat64(rogue.HasSetBonus(Tier6, 4), 0.06, 0),
 		DamageMultiplier: 1 *
 			core.TernaryFloat64(isMH, 1, rogue.dwsMultiplier()),
 		CritMultiplier:   rogue.MeleeCritMultiplier(true),

--- a/sim/rogue/poisons.go
+++ b/sim/rogue/poisons.go
@@ -29,7 +29,7 @@ func (rogue *Rogue) registerPoisonAuras() {
 
 func (rogue *Rogue) registerDeadlyPoisonSpell() {
 	var energyMetrics *core.ResourceMetrics
-	if rogue.HasSetBonus(ItemSetTerrorblade, 2) {
+	if rogue.HasSetBonus(Tier8, 2) {
 		energyMetrics = rogue.NewEnergyMetrics(core.ActionID{SpellID: 64913})
 	}
 

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -250,7 +250,7 @@ func NewRogue(character core.Character, options *proto.Player) *Rogue {
 	if rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfVigor) {
 		maxEnergy += 10
 	}
-	if rogue.HasSetBonus(ItemSetGladiatorsVestments, 4) {
+	if rogue.HasSetBonus(Arena, 4) {
 		maxEnergy += 10
 	}
 	rogue.maxEnergy = maxEnergy

--- a/sim/rogue/rupture.go
+++ b/sim/rogue/rupture.go
@@ -41,8 +41,8 @@ func (rogue *Rogue) registerRupture() {
 		DamageMultiplier: 1 +
 			0.15*float64(rogue.Talents.BloodSpatter) +
 			0.02*float64(rogue.Talents.FindWeakness) +
-			core.TernaryFloat64(rogue.HasSetBonus(ItemSetBonescythe, 2), 0.1, 0) +
-			core.TernaryFloat64(rogue.HasSetBonus(ItemSetTerrorblade, 4), 0.2, 0) +
+			core.TernaryFloat64(rogue.HasSetBonus(Tier7, 2), 0.1, 0) +
+			core.TernaryFloat64(rogue.HasSetBonus(Tier8, 4), 0.2, 0) +
 			0.1*float64(rogue.Talents.SerratedBlades),
 		CritMultiplier:   rogue.MeleeCritMultiplier(false),
 		ThreatMultiplier: 1,

--- a/sim/rogue/sinister_strike.go
+++ b/sim/rogue/sinister_strike.go
@@ -27,14 +27,14 @@ func (rogue *Rogue) registerSinisterStrikeSpell() {
 			IgnoreHaste: true,
 		},
 
-		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(ItemSetVanCleefs, 4), 5*core.CritRatingPerCritChance, 0) +
+		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(Tier9, 4), 5*core.CritRatingPerCritChance, 0) +
 			[]float64{0, 2, 4, 6}[rogue.Talents.TurnTheTables]*core.CritRatingPerCritChance,
 		DamageMultiplier: 1 +
 			0.02*float64(rogue.Talents.FindWeakness) +
 			0.03*float64(rogue.Talents.Aggression) +
 			0.05*float64(rogue.Talents.BladeTwisting) +
 			core.TernaryFloat64(rogue.Talents.SurpriseAttacks, 0.1, 0) +
-			core.TernaryFloat64(rogue.HasSetBonus(ItemSetSlayers, 4), 0.06, 0),
+			core.TernaryFloat64(rogue.HasSetBonus(Tier6, 4), 0.06, 0),
 		CritMultiplier:   rogue.MeleeCritMultiplier(true),
 		ThreatMultiplier: 1,
 

--- a/sim/rogue/slice_and_dice.go
+++ b/sim/rogue/slice_and_dice.go
@@ -25,7 +25,7 @@ func (rogue *Rogue) registerSliceAndDice() {
 	}
 
 	hasteBonus := 1.4
-	if rogue.HasSetBonus(ItemSetSlayers, 2) {
+	if rogue.HasSetBonus(Tier6, 2) {
 		hasteBonus += 0.05
 	}
 	inverseHasteBonus := 1.0 / hasteBonus

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -72,7 +72,7 @@ func (rogue *Rogue) makeFinishingMoveEffectApplier() func(sim *core.Simulation, 
 	ruthlessnessMetrics := rogue.NewComboPointMetrics(core.ActionID{SpellID: 14161})
 	relentlessStrikesMetrics := rogue.NewEnergyMetrics(core.ActionID{SpellID: getRelentlessStrikesSpellID(rogue.Talents.RelentlessStrikes)})
 	var mayhemMetrics *core.ResourceMetrics
-	if rogue.HasSetBonus(ItemSetShadowblades, 4) {
+	if rogue.HasSetBonus(Tier10, 4) {
 		mayhemMetrics = rogue.NewComboPointMetrics(core.ActionID{SpellID: 70802})
 	}
 
@@ -96,7 +96,7 @@ func (rogue *Rogue) makeFinishingMoveEffectApplier() func(sim *core.Simulation, 
 }
 
 func (rogue *Rogue) makeCostModifier() func(baseCost float64) float64 {
-	if rogue.HasSetBonus(ItemSetBonescythe, 4) {
+	if rogue.HasSetBonus(Tier7, 4) {
 		return func(baseCost float64) float64 {
 			return math.RoundToEven(0.95 * baseCost)
 		}

--- a/sim/rogue/tricks_of_the_trade.go
+++ b/sim/rogue/tricks_of_the_trade.go
@@ -10,7 +10,7 @@ import (
 func (rogue *Rogue) registerTricksOfTheTradeSpell() {
 	actionID := core.ActionID{SpellID: 57934}
 	energyMetrics := rogue.NewEnergyMetrics(actionID)
-	hasShadowblades := rogue.HasSetBonus(ItemSetShadowblades, 2)
+	hasShadowblades := rogue.HasSetBonus(Tier10, 2)
 	energyCost := 15 - 5*float64(rogue.Talents.FilthyTricks)
 
 	hasGlyph := rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfTricksOfTheTrade)


### PR DESCRIPTION
[rogue] add "Garona's Battlegear" as alternative name for "VanCleef's Battlegear"
[rogue] rename all tier sets to "TierX", and Gladiator's Vestments to "Arena" 
[rogue] Tier9-4pc doesn't wrongly apply to Ghostly Strike and Ambush anymore