### PR TITLE
remove divine storm from group inference to fix wcl import

### DIFF
--- a/ui/core/raid.ts
+++ b/ui/core/raid.ts
@@ -228,18 +228,20 @@ export class Raid {
 
 	fromProto(eventID: EventID, proto: RaidProto) {
 		TypedEvent.freezeAllAndDo(() => {
-			if (proto.buffs!.demonicPact > 0 && proto.buffs!.demonicPactSp == 0) {
-				proto.buffs!.demonicPactSp = proto.buffs!.demonicPact;
-				if (proto.buffs!.demonicPactSp > 1000) {
-					proto.buffs!.demonicPactSp /= 10;
+			if (proto.buffs) {
+				if (proto.buffs.demonicPact > 0 && proto.buffs.demonicPactSp == 0) {
+					proto.buffs.demonicPactSp = proto.buffs.demonicPact;
+					if (proto.buffs.demonicPactSp > 1000) {
+						proto.buffs.demonicPactSp /= 10;
+					}
+					proto.buffs.demonicPact = 0;
+				} else if (proto.buffs.demonicPactOld > 0 && proto.buffs.demonicPactSp == 0) {
+					proto.buffs.demonicPactSp = proto.buffs.demonicPactOld;
+					if (proto.buffs.demonicPactSp > 1000) {
+						proto.buffs.demonicPactSp /= 10;
+					}
+					proto.buffs.demonicPactOld = 0;
 				}
-				proto.buffs!.demonicPact = 0;
-			} else if (proto.buffs!.demonicPactOld > 0 && proto.buffs!.demonicPactSp == 0) {
-				proto.buffs!.demonicPactSp = proto.buffs!.demonicPactOld;
-				if (proto.buffs!.demonicPactSp > 1000) {
-					proto.buffs!.demonicPactSp /= 10;
-				}
-				proto.buffs!.demonicPactOld = 0;
 			}
 			this.setBuffs(eventID, proto.buffs || RaidBuffs.create());
 			this.setDebuffs(eventID, proto.debuffs || Debuffs.create());

--- a/ui/raid/import_export.ts
+++ b/ui/raid/import_export.ts
@@ -718,7 +718,6 @@ const externalCDSpells: Array<{id: number, name: string, class: Class, applyFunc
 
 // Healing spells which only affect the caster's party.
 const samePartyHealingSpells: Array<{id: number, name: string}> = [
-	{id: 54172, name: 'Divine Storm'},
 	{id: 52042, name: 'Healing Stream Totem'},
 	{id: 48076, name: 'Holy Nova'},
 	{id: 48445, name: 'Tranquility'},


### PR DESCRIPTION
TL:DR: Fixes #2926 (incorrect group inference leading to large and invalid player raid index)

Divine Storm can heal the raid too, so it should not be used as a group-only heal inference spell: https://www.wowhead.com/wotlk/spell=53385/divine-storm

The log reported in #2926 shows that the ret pala is healing more than 4 other people (doubt the player is being moved around in the raid): https://classic.warcraftlogs.com/reports/fnvAzdmN46VcthWR#fight=4&type=healing&source=5&ability=54172

The tooltip says group or raid:

> The Divine Storm heals up to 3 party or raid members totaling 25% of the damage caused.

Inspecting the inferred groups showed that the paladin allegedly had 10 other players in their group, whereas every other player had 4 expected members.

The PR also fixes a startup bug where an empty buffs object (loading defaults) leads to a non-fatal error being logged in the console about demonicPact (not the reason for the WCL import issues though).