### PR TITLE
do not clone all items when changing batch items

### DIFF
--- a/ui/core/components/individual_sim_ui/bulk_tab.ts
+++ b/ui/core/components/individual_sim_ui/bulk_tab.ts
@@ -158,10 +158,10 @@ export class BulkItemPicker extends Component {
           gearData: {
             equipItem: (eventID: EventID, equippedItem: EquippedItem | null) => {
               if (equippedItem) {
-                const otherItems = this.bulkUI.getItems();
-                otherItems[this.index] = equippedItem.asSpec();
+                const allItems = this.bulkUI.getItems();
+                allItems[this.index] = equippedItem.asSpec();
                 this.item = equippedItem;
-                this.bulkUI.setItems(otherItems);
+                this.bulkUI.setItems(allItems);
                 changeEvent.emit(TypedEvent.nextEventID());
               }
             },

--- a/ui/core/components/individual_sim_ui/bulk_tab.ts
+++ b/ui/core/components/individual_sim_ui/bulk_tab.ts
@@ -161,7 +161,7 @@ export class BulkItemPicker extends Component {
                 const otherItems = this.bulkUI.getItems();
                 otherItems[this.index] = equippedItem.asSpec();
                 this.item = equippedItem;
-                this.bulkUI.addItems(otherItems);
+                this.bulkUI.setItems(otherItems);
                 changeEvent.emit(TypedEvent.nextEventID());
               }
             },


### PR DESCRIPTION
Currently, this causes all existing items to be duplicated when modifying an item (e.g. changing its enchant or gems).