### PR TITLE
Core: Added panic when Custom Rotation is empty

### DIFF
--- a/sim/common/custom_rotation.go
+++ b/sim/common/custom_rotation.go
@@ -120,6 +120,10 @@ func (cs *CustomSpell) CPM(sim *core.Simulation) float64 {
 }
 
 func (cr *CustomRotation) Cast(sim *core.Simulation) bool {
+	if cr == nil {
+		panic("Custom Rotation is empty")
+	}
+
 	spell := cr.ChooseSpell(sim)
 
 	if spell == nil {


### PR DESCRIPTION
Leave warning instead of the memory nil or dereference when custom rotation is empty