### PR TITLE
fix encounter selection dropdown menu

### DIFF
--- a/ui/core/proto_utils/stats.ts
+++ b/ui/core/proto_utils/stats.ts
@@ -170,7 +170,7 @@ export class Stats {
 	}
 
 	asArray(): Array<number> {
-		return this.stats.slice();
+		return this.stats.slice().concat(this.pseudoStats.slice());
 	}
 
 	toJson(): Object {


### PR DESCRIPTION
The Settings > Encounter > NPC dropdown is currently broken and keeps defaulting back to the "Custom" entry when specifying anything else.

In #2138, a new stat `StatBonusArmor` was added, increasing the number of stats by 1 from 40 to 41, but the database encounters were not updated. When the `EnumPicker` for the dropdown menu attempts to find the selected target preset, it cannot find it due to the mismatch in number of stats.

```
getValue: (encounter: Encounter) => presetTargets.findIndex(pe => encounter.primaryTarget.matchesPreset(pe)),
```

```
	matchesPreset(preset: PresetTarget): boolean {
		return TargetProto.equals(this.toProto(), preset.target);
	}
```


This `matchesPreset` check will always return false because the `preset.target` comes from the loaded database (stats length 40), whereas the live encounter stats are produced via `this.stats.asArray()`.

When findIndex() fails, it defaults to returning -1, which happens to be the index for the "Custom" entry:

```
				values: [
					{ name: 'Custom', value: -1 },
```

This PR changes the encounter database entries to match the expected number of stats (35 normal stats + 6 pseudo stats), and fixes `asArray()` to return the pseudo stats as well, otherwise the comparison would not work.

In the future, this should probably also be migrated to use the new Stats proto instead of relying on repeated doubles, but that's a larger undertaking.