### PR TITLE
Revert "fix encounter selection dropdown menu"

### DIFF
--- a/ui/core/proto_utils/stats.ts
+++ b/ui/core/proto_utils/stats.ts
@@ -170,7 +170,7 @@ export class Stats {
 	}
 
 	asArray(): Array<number> {
-		return this.stats.slice().concat(this.pseudoStats.slice());
+		return this.stats.slice();
 	}
 
 	toJson(): Object {


### PR DESCRIPTION
Reverts wowsims/wotlk#2959

The issue is not the missing pseudo stats but missing stats in the stats enum (or extra stats in the Go enumeration). Reverting this for now.