### PR TITLE
Use the correct bootstrap column sizing for reference EP selectors.

### DIFF
--- a/ui/core/components/stat_weights_action.ts
+++ b/ui/core/components/stat_weights_action.ts
@@ -60,17 +60,17 @@ class EpWeightsMenu extends BaseModal {
 				<div class="show-all-stats-container col col-sm-3"></div>
 			</div>
 			<div class="ep-reference-options row experimental">
-				<div class="col col-sm-3 damage-metrics">
+				<div class="col col-sm-4 damage-metrics">
 					<span>DPS/TPS reference:</span>
 					<select class="ref-stat-select form-select damage-metrics">
 					</select>
 				</div>
-				<div class="col col-sm-3 healing-metrics">
+				<div class="col col-sm-4 healing-metrics">
 					<span>Healing reference:</span>
 					<select class="ref-stat-select form-select healing-metrics">
 					</select>
 				</div>
-				<div class="col col-sm-3 threat-metrics">
+				<div class="col col-sm-4 threat-metrics">
 					<span>Mitigation reference:</span>
 					<select class="ref-stat-select form-select threat-metrics">
 					</select>


### PR DESCRIPTION
Original version used `sm-3`, which would correspond to 4 columns, rather than `sm-4` which, confusingly, corresponds to the correct number of 3 columns.