### PR TITLE
Bonus Armor DB Refactor

### DIFF
--- a/sim/common/wotlk/metagems.go
+++ b/sim/common/wotlk/metagems.go
@@ -29,7 +29,6 @@ func init() {
 	core.NewItemEffect(41380, func(agent core.Agent) {
 		character := agent.GetCharacter()
 		character.AddStat(stats.Armor, character.Equip.Stats()[stats.Armor]*0.02)
-		character.AddStat(stats.BonusArmor, character.Equip.Stats()[stats.BonusArmor]*0.02)
 	})
 
 	core.NewItemEffect(41385, func(agent core.Agent) {

--- a/sim/common/wotlk/metagems.go
+++ b/sim/common/wotlk/metagems.go
@@ -29,6 +29,7 @@ func init() {
 	core.NewItemEffect(41380, func(agent core.Agent) {
 		character := agent.GetCharacter()
 		character.AddStat(stats.Armor, character.Equip.Stats()[stats.Armor]*0.02)
+		character.AddStat(stats.BonusArmor, character.Equip.Stats()[stats.BonusArmor]*0.02)
 	})
 
 	core.NewItemEffect(41385, func(agent core.Agent) {

--- a/sim/core/stats/deps.go
+++ b/sim/core/stats/deps.go
@@ -15,6 +15,7 @@ var safeDepsOrder = []Stat{
 	Stamina,
 	Intellect,
 	Spirit,
+	BonusArmor,
 	Armor,
 	AttackPower,
 	RangedAttackPower,

--- a/sim/deathknight/deathknight.go
+++ b/sim/deathknight/deathknight.go
@@ -431,6 +431,7 @@ func NewDeathknight(character core.Character, inputs DeathknightInputs, talents 
 	dk.AddStatDependency(stats.Agility, stats.Dodge, core.DodgeRatingPerDodgeChance/84.74576271)
 	dk.AddStatDependency(stats.Strength, stats.AttackPower, 2)
 	dk.AddStatDependency(stats.Strength, stats.Parry, 0.25)
+	dk.AddStatDependency(stats.BonusArmor, stats.Armor, 1)
 
 	dk.PseudoStats.CanParry = true
 	dk.PseudoStats.GracefulCastCDFailures = true

--- a/sim/deathknight/presences.go
+++ b/sim/deathknight/presences.go
@@ -129,7 +129,7 @@ func (dk *Deathknight) registerFrostPresenceAura(timer *core.Timer) {
 	threatMult := 2.0735
 	dmgMitigation := 1.0 - (0.08 + 0.01*float64(dk.Talents.ImprovedFrostPresence))
 	stamDep := dk.NewDynamicMultiplyStat(stats.Stamina, 1.08)
-	armorBonus := (dk.Equip.Stats()[stats.Armor] + dk.Equip.Stats()[stats.BonusArmor]) * 0.6
+	armorBonus := dk.Equip.Stats()[stats.Armor] * 0.6
 	dk.FrostPresenceAura = dk.GetOrRegisterAura(core.Aura{
 		Label:    "Frost Presence",
 		ActionID: core.ActionID{SpellID: 48263},

--- a/sim/deathknight/presences.go
+++ b/sim/deathknight/presences.go
@@ -129,7 +129,7 @@ func (dk *Deathknight) registerFrostPresenceAura(timer *core.Timer) {
 	threatMult := 2.0735
 	dmgMitigation := 1.0 - (0.08 + 0.01*float64(dk.Talents.ImprovedFrostPresence))
 	stamDep := dk.NewDynamicMultiplyStat(stats.Stamina, 1.08)
-	armorBonus := dk.Equip.Stats()[stats.Armor] * 0.6
+	armorBonus := (dk.Equip.Stats()[stats.Armor] + dk.Equip.Stats()[stats.BonusArmor]) * 0.6
 	dk.FrostPresenceAura = dk.GetOrRegisterAura(core.Aura{
 		Label:    "Frost Presence",
 		ActionID: core.ActionID{SpellID: 48263},

--- a/sim/deathknight/talents_frost.go
+++ b/sim/deathknight/talents_frost.go
@@ -17,6 +17,7 @@ func (dk *Deathknight) ApplyFrostTalents() {
 	// Toughness
 	if dk.Talents.Toughness > 0 {
 		dk.AddStat(stats.Armor, dk.Equip.Stats()[stats.Armor]*0.02*float64(dk.Talents.Toughness))
+		dk.AddStat(stats.BonusArmor, dk.Equip.Stats()[stats.BonusArmor]*0.02*float64(dk.Talents.Toughness))
 	}
 
 	// Icy Reach

--- a/sim/deathknight/talents_frost.go
+++ b/sim/deathknight/talents_frost.go
@@ -17,7 +17,6 @@ func (dk *Deathknight) ApplyFrostTalents() {
 	// Toughness
 	if dk.Talents.Toughness > 0 {
 		dk.AddStat(stats.Armor, dk.Equip.Stats()[stats.Armor]*0.02*float64(dk.Talents.Toughness))
-		dk.AddStat(stats.BonusArmor, dk.Equip.Stats()[stats.BonusArmor]*0.02*float64(dk.Talents.Toughness))
 	}
 
 	// Icy Reach

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -46,951 +46,951 @@ character_stats_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1483.51704
-  tps: 4501.71526
+  dps: 1478.36861
+  tps: 4486.08371
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 1400.14649
-  tps: 4289.54121
+  dps: 1395.01544
+  tps: 4273.95956
   hps: 82.8441
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 1400.14649
-  tps: 4289.54121
+  dps: 1395.01544
+  tps: 4273.95956
   hps: 82.8441
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1402.52415
-  tps: 4300.62779
+  dps: 1397.37991
+  tps: 4284.99203
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1372.38393
-  tps: 4211.07465
+  dps: 1367.27511
+  tps: 4195.54094
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1303.84477
-  tps: 4002.66463
+  dps: 1301.6179
+  tps: 3995.8852
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1264.71593
-  tps: 3857.39029
+  dps: 1262.47217
+  tps: 3850.60228
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1182.83043
-  tps: 3631.40719
+  dps: 1180.62219
+  tps: 3624.69235
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1398.51126
-  tps: 4198.93068
+  dps: 1393.38021
+  tps: 4183.66066
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 1820.31805
-  tps: 5249.57027
+  dps: 1814.58667
+  tps: 5232.71115
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 1863.17887
-  tps: 5345.14668
+  dps: 1857.45262
+  tps: 5328.30043
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1414.08707
-  tps: 4337.23953
+  dps: 1408.90476
+  tps: 4321.47985
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
   hps: 64
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1419.28049
-  tps: 4354.12542
+  dps: 1414.08694
+  tps: 4338.32589
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1469.9473
-  tps: 4471.45982
+  dps: 1464.75702
+  tps: 4455.6222
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 1450.82428
-  tps: 4451.87348
+  dps: 1445.69323
+  tps: 4436.29183
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 1597.79277
-  tps: 4877.95631
+  dps: 1595.41862
+  tps: 4870.74595
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedPlate"
  value: {
-  dps: 1411.49813
-  tps: 4318.11078
+  dps: 1409.28831
+  tps: 4311.40769
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 1409.62859
-  tps: 4310.43121
+  dps: 1404.49754
+  tps: 4294.84955
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Death'sChoice-47464"
  value: {
-  dps: 1542.81641
-  tps: 4736.22445
+  dps: 1537.68536
+  tps: 4720.64279
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1410.72954
-  tps: 4331.18979
+  dps: 1405.56423
+  tps: 4315.46745
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 1499.77153
-  tps: 4549.64577
+  dps: 1494.40775
+  tps: 4533.4881
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 1513.24379
-  tps: 4582.66815
+  dps: 1507.85787
+  tps: 4566.46029
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1408.18062
-  tps: 4313.98645
+  dps: 1400.24841
+  tps: 4289.89843
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1403.34654
-  tps: 4302.33302
+  dps: 1398.19971
+  tps: 4286.69187
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 1457.40573
-  tps: 4431.38772
+  dps: 1452.08845
+  tps: 4415.33482
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 1452.59296
-  tps: 4421.29767
+  dps: 1447.29215
+  tps: 4405.27957
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1398.51126
-  tps: 4284.62315
+  dps: 1393.38021
+  tps: 4269.04149
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1398.51126
-  tps: 4284.62315
+  dps: 1393.38021
+  tps: 4269.04149
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1402.52415
-  tps: 4300.62779
+  dps: 1397.37991
+  tps: 4284.99203
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1402.52415
-  tps: 4300.62779
+  dps: 1397.37991
+  tps: 4284.99203
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 1441.94181
-  tps: 4400.02759
+  dps: 1436.68481
+  tps: 4384.09779
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1398.51126
-  tps: 4284.62315
+  dps: 1393.38021
+  tps: 4269.04149
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1459.98883
-  tps: 4449.68638
+  dps: 1454.79523
+  tps: 4433.84519
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1417.84031
-  tps: 4358.78632
+  dps: 1412.65138
+  tps: 4342.96992
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1415.00557
-  tps: 4352.9085
+  dps: 1409.8261
+  tps: 4337.11172
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1398.51126
-  tps: 4284.62315
+  dps: 1393.38021
+  tps: 4269.04149
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1398.51126
-  tps: 4284.62315
+  dps: 1393.38021
+  tps: 4269.04149
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 1411.52418
-  tps: 4314.59714
+  dps: 1406.39313
+  tps: 4299.01548
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1458.79584
-  tps: 4458.0298
+  dps: 1453.66479
+  tps: 4442.44814
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 1454.12281
-  tps: 4430.99861
+  dps: 1448.93383
+  tps: 4415.19146
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 1405.59289
-  tps: 4301.10694
+  dps: 1400.46184
+  tps: 4285.52529
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1402.52415
-  tps: 4300.62779
+  dps: 1397.37991
+  tps: 4284.99203
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1402.52415
-  tps: 4300.62779
+  dps: 1397.37991
+  tps: 4284.99203
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1444.18385
-  tps: 4409.09238
+  dps: 1439.0067
+  tps: 4393.41513
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1398.51126
-  tps: 4284.62315
+  dps: 1393.38021
+  tps: 4269.04149
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1406.81585
-  tps: 4309.84201
+  dps: 1401.6848
+  tps: 4294.26036
   hps: 16.72057
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1450.59887
-  tps: 4435.21821
+  dps: 1445.31364
+  tps: 4419.17043
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 1424.79495
-  tps: 4408.43019
+  dps: 1419.58412
+  tps: 4392.44618
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1405.34651
-  tps: 4305.38001
+  dps: 1398.40295
+  tps: 4284.29423
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1405.23403
-  tps: 4305.03842
+  dps: 1400.10297
+  tps: 4289.45676
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1406.81585
-  tps: 4309.84201
+  dps: 1401.6848
+  tps: 4294.26036
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 1421.70875
-  tps: 4355.06784
+  dps: 1409.05743
+  tps: 4316.6491
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 1424.48618
-  tps: 4363.50215
+  dps: 1410.86599
+  tps: 4322.14121
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1398.51126
-  tps: 4284.62315
+  dps: 1393.38021
+  tps: 4269.04149
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1398.51126
-  tps: 4284.62315
+  dps: 1393.38021
+  tps: 4269.04149
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1403.81235
-  tps: 4298.48109
+  dps: 1398.69261
+  tps: 4282.9166
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1404.72714
-  tps: 4300.37792
+  dps: 1399.60741
+  tps: 4284.81342
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1413.57422
-  tps: 4328.27775
+  dps: 1408.39455
+  tps: 4312.55192
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 1413.7357
-  tps: 4319.45739
+  dps: 1408.60465
+  tps: 4303.87574
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1398.51126
-  tps: 4284.62315
+  dps: 1393.38021
+  tps: 4269.04149
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 1404.97679
-  tps: 4299.80445
+  dps: 1399.84574
+  tps: 4284.22279
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 1516.74639
-  tps: 4663.0957
+  dps: 1514.3673
+  tps: 4655.82743
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgebornePlate"
  value: {
-  dps: 1376.82098
-  tps: 4231.42906
+  dps: 1374.62582
+  tps: 4224.74505
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 1688.61326
-  tps: 5117.59205
+  dps: 1686.20877
+  tps: 5110.34074
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 1492.61241
-  tps: 4567.6777
+  dps: 1490.41095
+  tps: 4560.9964
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1404.31591
-  tps: 4301.15899
+  dps: 1399.18486
+  tps: 4285.57733
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Shadowmourne-49623"
  value: {
-  dps: 2053.01461
-  tps: 5884.08289
+  dps: 2047.05822
+  tps: 5866.59614
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 1402.22321
-  tps: 4293.89899
+  dps: 1397.08552
+  tps: 4278.30358
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SoulPreserver-37111"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SouloftheDead-40382"
  value: {
-  dps: 1418.86553
-  tps: 4360.91213
+  dps: 1413.67317
+  tps: 4345.08861
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 1421.03837
-  tps: 4340.74332
+  dps: 1415.84319
+  tps: 4324.99954
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 1445.64143
-  tps: 4443.426
+  dps: 1440.45768
+  tps: 4427.67484
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-StormshroudArmor"
  value: {
-  dps: 1156.29742
-  tps: 3574.36085
+  dps: 1154.13435
+  tps: 3567.74677
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1406.81585
-  tps: 4309.84201
+  dps: 1401.6848
+  tps: 4294.26036
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1405.23403
-  tps: 4305.03842
+  dps: 1400.10297
+  tps: 4289.45676
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1402.46583
-  tps: 4296.63213
+  dps: 1397.33478
+  tps: 4281.05047
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 1664.79539
-  tps: 5045.83922
+  dps: 1662.32723
+  tps: 5038.41253
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sPlate"
  value: {
-  dps: 1390.53697
-  tps: 4303.01469
+  dps: 1388.36757
+  tps: 4296.36363
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1393.91221
-  tps: 4300.81049
+  dps: 1388.2972
+  tps: 4284.15079
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1404.59015
-  tps: 4302.32379
+  dps: 1399.44294
+  tps: 4286.68951
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1457.07246
-  tps: 4439.7017
+  dps: 1451.76379
+  tps: 4423.63486
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1460.3386
-  tps: 4447.53897
+  dps: 1455.01938
+  tps: 4431.44632
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1398.51126
-  tps: 4284.62315
+  dps: 1393.38021
+  tps: 4269.04149
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1398.51126
-  tps: 4284.62315
+  dps: 1393.38021
+  tps: 4269.04149
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 1426.65001
-  tps: 4359.12795
+  dps: 1421.44244
+  tps: 4343.33467
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1398.51126
-  tps: 4284.62315
+  dps: 1393.38021
+  tps: 4269.04149
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1398.51126
-  tps: 4284.62315
+  dps: 1393.38021
+  tps: 4269.04149
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1257.34904
-  tps: 3841.666
+  dps: 1255.11152
+  tps: 3834.88604
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 1194.80508
-  tps: 3843.91101
+  dps: 1189.83051
+  tps: 3828.5494
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-WingedTalisman-37844"
  value: {
-  dps: 1400.15065
-  tps: 4289.60154
+  dps: 1395.0196
+  tps: 4274.01988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 1416.26316
-  tps: 4325.01197
+  dps: 1411.13211
+  tps: 4309.43032
  }
 }
 dps_results: {
  key: "TestBloodTank-Average-Default"
  value: {
-  dps: 1806.91381
-  tps: 6077.44423
-  dtps: 242.25652
+  dps: 1800.20961
+  tps: 6054.93647
+  dtps: 246.97083
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6204.89092
-  tps: 14240.80178
+  dps: 6177.09135
+  tps: 14178.1791
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1446.08184
-  tps: 4364.00589
+  dps: 1440.77485
+  tps: 4348.05503
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1661.53388
-  tps: 5962.47151
+  dps: 1655.56462
+  tps: 5940.99339
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3318.68178
-  tps: 7727.6053
+  dps: 3299.08493
+  tps: 7683.15845
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 823.02153
-  tps: 2554.33473
+  dps: 819.28753
+  tps: 2542.77249
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 874.38389
-  tps: 3374.42209
+  dps: 870.48449
+  tps: 3359.30001
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6225.41589
-  tps: 14305.03606
+  dps: 6197.61632
+  tps: 14242.41337
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1458.57298
-  tps: 4411.53949
+  dps: 1453.26599
+  tps: 4395.58863
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1686.32672
-  tps: 6092.59442
+  dps: 1680.35746
+  tps: 6071.1163
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3340.81339
-  tps: 7789.91947
+  dps: 3321.21816
+  tps: 7745.47598
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 831.08189
-  tps: 2587.64947
+  dps: 827.34949
+  tps: 2576.09052
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 890.40863
-  tps: 3467.52675
+  dps: 886.50923
+  tps: 3452.40467
  }
 }
 dps_results: {
  key: "TestBloodTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1835.83344
-  tps: 6106.97547
-  dtps: 242.09445
+  dps: 1829.04905
+  tps: 6084.41305
+  dtps: 246.81164
  }
 }

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -12,7 +12,7 @@ character_stats_results: {
   final_stats: 459.1
   final_stats: 0
   final_stats: 0
-  final_stats: 5161.66108
+  final_stats: 5160.70958
   final_stats: 137
   final_stats: 979.57249
   final_stats: 0
@@ -21,7 +21,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 20590.98
+  final_stats: 20559.84
   final_stats: 755.7
   final_stats: 670
   final_stats: 0
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 75
   final_stats: 75
   final_stats: 130
-  final_stats: 1743.84
+  final_stats: 1712.7
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -46,44 +46,44 @@ character_stats_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1478.36861
-  tps: 4486.08371
+  dps: 1478.197
+  tps: 4485.56266
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 1395.01544
-  tps: 4273.95956
+  dps: 1394.84441
+  tps: 4273.44017
   hps: 82.8441
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 1395.01544
-  tps: 4273.95956
+  dps: 1394.84441
+  tps: 4273.44017
   hps: 82.8441
  }
 }
@@ -97,29 +97,29 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1367.27511
-  tps: 4195.54094
+  dps: 1367.10481
+  tps: 4195.02315
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1301.6179
-  tps: 3995.8852
+  dps: 1301.54367
+  tps: 3995.65922
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1262.47217
-  tps: 3850.60228
+  dps: 1262.39738
+  tps: 3850.37601
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1180.62219
-  tps: 3624.69235
+  dps: 1180.54858
+  tps: 3624.46852
  }
 }
 dps_results: {
@@ -132,15 +132,15 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 1814.58667
-  tps: 5232.71115
+  dps: 1814.39562
+  tps: 5232.14918
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 1857.45262
-  tps: 5328.30043
+  dps: 1857.26174
+  tps: 5327.73889
  }
 }
 dps_results: {
@@ -153,44 +153,44 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
   hps: 64
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1414.08694
-  tps: 4338.32589
+  dps: 1413.91383
+  tps: 4337.79924
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1464.75702
-  tps: 4455.6222
+  dps: 1464.58401
+  tps: 4455.09428
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 1445.69323
-  tps: 4436.29183
+  dps: 1445.5222
+  tps: 4435.77244
  }
 }
 dps_results: {
@@ -210,43 +210,43 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 1404.49754
-  tps: 4294.84955
+  dps: 1404.32651
+  tps: 4294.33016
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Death'sChoice-47464"
  value: {
-  dps: 1537.68536
-  tps: 4720.64279
+  dps: 1537.51432
+  tps: 4720.1234
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1405.56423
-  tps: 4315.46745
+  dps: 1405.39206
+  tps: 4314.94337
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 1494.40775
-  tps: 4533.4881
+  dps: 1494.22895
+  tps: 4532.94952
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 1507.85787
-  tps: 4566.46029
+  dps: 1507.67834
+  tps: 4565.92003
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1400.24841
-  tps: 4289.89843
+  dps: 1399.98401
+  tps: 4289.09549
  }
 }
 dps_results: {
@@ -259,15 +259,15 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 1452.08845
-  tps: 4415.33482
+  dps: 1451.91121
+  tps: 4414.79972
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 1447.29215
-  tps: 4405.27957
+  dps: 1447.11545
+  tps: 4404.74563
  }
 }
 dps_results: {
@@ -301,15 +301,15 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 1436.68481
-  tps: 4384.09779
+  dps: 1436.50957
+  tps: 4383.56679
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
@@ -322,36 +322,36 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1454.79523
-  tps: 4433.84519
+  dps: 1454.62211
+  tps: 4433.31715
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1412.65138
-  tps: 4342.96992
+  dps: 1412.47841
+  tps: 4342.44271
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1409.8261
-  tps: 4337.11172
+  dps: 1409.65345
+  tps: 4336.58516
  }
 }
 dps_results: {
@@ -371,57 +371,57 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 1406.39313
-  tps: 4299.01548
+  dps: 1406.2221
+  tps: 4298.49609
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1453.66479
-  tps: 4442.44814
+  dps: 1453.49375
+  tps: 4441.92875
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 1448.93383
-  tps: 4415.19146
+  dps: 1448.76087
+  tps: 4414.66456
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 1400.46184
-  tps: 4285.52529
+  dps: 1400.29081
+  tps: 4285.0059
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
@@ -441,8 +441,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1439.0067
-  tps: 4393.41513
+  dps: 1438.83413
+  tps: 4392.89255
  }
 }
 dps_results: {
@@ -463,36 +463,36 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1445.31364
-  tps: 4419.17043
+  dps: 1445.13747
+  tps: 4418.63551
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 1419.58412
-  tps: 4392.44618
+  dps: 1419.41042
+  tps: 4391.91338
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1398.40295
-  tps: 4284.29423
+  dps: 1398.1715
+  tps: 4283.59137
  }
 }
 dps_results: {
@@ -512,15 +512,15 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 1409.05743
-  tps: 4316.6491
+  dps: 1408.63572
+  tps: 4315.36848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 1410.86599
-  tps: 4322.14121
+  dps: 1410.41198
+  tps: 4320.76251
  }
 }
 dps_results: {
@@ -540,22 +540,22 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1398.69261
-  tps: 4282.9166
+  dps: 1398.52196
+  tps: 4282.39778
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1399.60741
-  tps: 4284.81342
+  dps: 1399.43675
+  tps: 4284.2946
  }
 }
 dps_results: {
@@ -568,8 +568,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 1408.60465
-  tps: 4303.87574
+  dps: 1408.43362
+  tps: 4303.35635
  }
 }
 dps_results: {
@@ -582,15 +582,15 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 1399.84574
-  tps: 4284.22279
+  dps: 1399.6747
+  tps: 4283.7034
  }
 }
 dps_results: {
@@ -624,127 +624,127 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1399.18486
-  tps: 4285.57733
+  dps: 1399.01383
+  tps: 4285.05794
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Shadowmourne-49623"
  value: {
-  dps: 2047.05822
-  tps: 5866.59614
+  dps: 2046.85968
+  tps: 5866.01325
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 1397.08552
-  tps: 4278.30358
+  dps: 1396.91427
+  tps: 4277.78373
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SoulPreserver-37111"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SouloftheDead-40382"
  value: {
-  dps: 1413.67317
-  tps: 4345.08861
+  dps: 1413.50009
+  tps: 4344.56116
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 1415.84319
-  tps: 4324.99954
+  dps: 1415.67002
+  tps: 4324.47475
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 1440.45768
-  tps: 4427.67484
+  dps: 1440.28489
+  tps: 4427.1498
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-StormshroudArmor"
  value: {
-  dps: 1154.13435
-  tps: 3567.74677
+  dps: 1154.06225
+  tps: 3567.52631
  }
 }
 dps_results: {
@@ -771,15 +771,15 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
@@ -799,15 +799,15 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1388.2972
-  tps: 4284.15079
+  dps: 1388.11003
+  tps: 4283.59547
  }
 }
 dps_results: {
@@ -820,15 +820,15 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1451.76379
-  tps: 4423.63486
+  dps: 1451.58684
+  tps: 4423.0993
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1455.01938
-  tps: 4431.44632
+  dps: 1454.84207
+  tps: 4430.90989
  }
 }
 dps_results: {
@@ -848,8 +848,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 1421.44244
-  tps: 4343.33467
+  dps: 1421.26885
+  tps: 4342.80823
  }
 }
 dps_results: {
@@ -869,128 +869,128 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1255.11152
-  tps: 3834.88604
+  dps: 1255.03693
+  tps: 3834.66004
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 1189.83051
-  tps: 3828.5494
+  dps: 1189.66469
+  tps: 3828.03734
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-WingedTalisman-37844"
  value: {
-  dps: 1395.0196
-  tps: 4274.01988
+  dps: 1394.84856
+  tps: 4273.50049
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 1411.13211
-  tps: 4309.43032
+  dps: 1410.96107
+  tps: 4308.91093
  }
 }
 dps_results: {
  key: "TestBloodTank-Average-Default"
  value: {
-  dps: 1800.20961
-  tps: 6054.93647
-  dtps: 246.97083
+  dps: 1799.98613
+  tps: 6054.18621
+  dtps: 247.13114
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6177.09135
-  tps: 14178.1791
+  dps: 6176.16469
+  tps: 14176.09167
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1440.77485
-  tps: 4348.05503
+  dps: 1440.59795
+  tps: 4347.52333
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1655.56462
-  tps: 5940.99339
+  dps: 1655.36565
+  tps: 5940.27745
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3299.08493
-  tps: 7683.15845
+  dps: 3298.4317
+  tps: 7681.67689
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 819.28753
-  tps: 2542.77249
+  dps: 819.16306
+  tps: 2542.38708
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 870.48449
-  tps: 3359.30001
+  dps: 870.35451
+  tps: 3358.79595
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6197.61632
-  tps: 14242.41337
+  dps: 6196.68967
+  tps: 14240.32595
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1453.26599
-  tps: 4395.58863
+  dps: 1453.08909
+  tps: 4395.05693
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1680.35746
-  tps: 6071.1163
+  dps: 1680.15848
+  tps: 6070.40037
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3321.21816
-  tps: 7745.47598
+  dps: 3320.56499
+  tps: 7743.99453
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 827.34949
-  tps: 2576.09052
+  dps: 827.22508
+  tps: 2575.70522
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 886.50923
-  tps: 3452.40467
+  dps: 886.37925
+  tps: 3451.90061
  }
 }
 dps_results: {
  key: "TestBloodTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1829.04905
-  tps: 6084.41305
-  dtps: 246.81164
+  dps: 1828.82291
+  tps: 6083.66097
+  dtps: 246.97205
  }
 }

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 75
   final_stats: 75
   final_stats: 130
-  final_stats: 336
+  final_stats: 1743.84
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -12,7 +12,7 @@ character_stats_results: {
   final_stats: 459.1
   final_stats: 0
   final_stats: 0
-  final_stats: 5160.70958
+  final_stats: 5155.95208
   final_stats: 137
   final_stats: 979.57249
   final_stats: 0
@@ -21,7 +21,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 20559.84
+  final_stats: 20404.14
   final_stats: 755.7
   final_stats: 670
   final_stats: 0
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 75
   final_stats: 75
   final_stats: 130
-  final_stats: 1712.7
+  final_stats: 1557
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -46,951 +46,951 @@ character_stats_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1478.197
-  tps: 4485.56266
+  dps: 1477.33893
+  tps: 4482.9574
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 1394.84441
-  tps: 4273.44017
+  dps: 1393.98923
+  tps: 4270.84323
   hps: 82.8441
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 1394.84441
-  tps: 4273.44017
+  dps: 1393.98923
+  tps: 4270.84323
   hps: 82.8441
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1397.37991
-  tps: 4284.99203
+  dps: 1396.52254
+  tps: 4282.38607
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1367.10481
-  tps: 4195.02315
+  dps: 1366.25334
+  tps: 4192.4342
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1301.54367
-  tps: 3995.65922
+  dps: 1301.17252
+  tps: 3994.52931
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1262.39738
-  tps: 3850.37601
+  dps: 1262.02342
+  tps: 3849.24467
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1180.54858
-  tps: 3624.46852
+  dps: 1180.18054
+  tps: 3623.34939
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1393.38021
-  tps: 4183.66066
+  dps: 1392.52503
+  tps: 4181.11566
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 1814.39562
-  tps: 5232.14918
+  dps: 1813.44039
+  tps: 5229.33933
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 1857.26174
-  tps: 5327.73889
+  dps: 1856.30737
+  tps: 5324.93118
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1408.90476
-  tps: 4321.47985
+  dps: 1408.04104
+  tps: 4318.85324
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
   hps: 64
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1413.91383
-  tps: 4337.79924
+  dps: 1413.04824
+  tps: 4335.16599
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1464.58401
-  tps: 4455.09428
+  dps: 1463.71897
+  tps: 4452.45467
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 1445.5222
-  tps: 4435.77244
+  dps: 1444.66702
+  tps: 4433.1755
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 1595.41862
-  tps: 4870.74595
+  dps: 1595.02293
+  tps: 4869.54422
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedPlate"
  value: {
-  dps: 1409.28831
-  tps: 4311.40769
+  dps: 1408.92001
+  tps: 4310.29051
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 1404.32651
-  tps: 4294.33016
+  dps: 1403.47133
+  tps: 4291.73322
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Death'sChoice-47464"
  value: {
-  dps: 1537.51432
-  tps: 4720.1234
+  dps: 1536.65915
+  tps: 4717.52646
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1405.39206
-  tps: 4314.94337
+  dps: 1404.53117
+  tps: 4312.32299
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 1494.22895
-  tps: 4532.94952
+  dps: 1493.33499
+  tps: 4530.25657
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 1507.67834
-  tps: 4565.92003
+  dps: 1506.78069
+  tps: 4563.21872
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1399.98401
-  tps: 4289.09549
+  dps: 1398.66197
+  tps: 4285.08082
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1398.19971
-  tps: 4286.69187
+  dps: 1397.3419
+  tps: 4284.08502
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 1451.91121
-  tps: 4414.79972
+  dps: 1451.025
+  tps: 4412.12424
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 1447.11545
-  tps: 4404.74563
+  dps: 1446.23198
+  tps: 4402.07595
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1393.38021
-  tps: 4269.04149
+  dps: 1392.52503
+  tps: 4266.44455
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1393.38021
-  tps: 4269.04149
+  dps: 1392.52503
+  tps: 4266.44455
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1397.37991
-  tps: 4284.99203
+  dps: 1396.52254
+  tps: 4282.38607
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1397.37991
-  tps: 4284.99203
+  dps: 1396.52254
+  tps: 4282.38607
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 1436.50957
-  tps: 4383.56679
+  dps: 1435.6334
+  tps: 4380.91182
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1393.38021
-  tps: 4269.04149
+  dps: 1392.52503
+  tps: 4266.44455
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1454.62211
-  tps: 4433.31715
+  dps: 1453.7565
+  tps: 4430.67695
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1412.47841
-  tps: 4342.44271
+  dps: 1411.61359
+  tps: 4339.80664
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1409.65345
-  tps: 4336.58516
+  dps: 1408.79021
+  tps: 4333.95236
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1393.38021
-  tps: 4269.04149
+  dps: 1392.52503
+  tps: 4266.44455
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1393.38021
-  tps: 4269.04149
+  dps: 1392.52503
+  tps: 4266.44455
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 1406.2221
-  tps: 4298.49609
+  dps: 1405.36692
+  tps: 4295.89915
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1453.49375
-  tps: 4441.92875
+  dps: 1452.63858
+  tps: 4439.33181
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 1448.76087
-  tps: 4414.66456
+  dps: 1447.89604
+  tps: 4412.03003
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 1400.29081
-  tps: 4285.0059
+  dps: 1399.43563
+  tps: 4282.40896
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1397.37991
-  tps: 4284.99203
+  dps: 1396.52254
+  tps: 4282.38607
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1397.37991
-  tps: 4284.99203
+  dps: 1396.52254
+  tps: 4282.38607
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1438.83413
-  tps: 4392.89255
+  dps: 1437.97127
+  tps: 4390.27968
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1393.38021
-  tps: 4269.04149
+  dps: 1392.52503
+  tps: 4266.44455
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1401.6848
-  tps: 4294.26036
+  dps: 1400.82963
+  tps: 4291.66341
   hps: 16.72057
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1445.13747
-  tps: 4418.63551
+  dps: 1444.2566
+  tps: 4415.96087
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 1419.41042
-  tps: 4391.91338
+  dps: 1418.54195
+  tps: 4389.24938
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1398.1715
-  tps: 4283.59137
+  dps: 1397.01424
+  tps: 4280.07708
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1400.10297
-  tps: 4289.45676
+  dps: 1399.2478
+  tps: 4286.85982
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1401.6848
-  tps: 4294.26036
+  dps: 1400.82963
+  tps: 4291.66341
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 1408.63572
-  tps: 4315.36848
+  dps: 1406.52717
+  tps: 4308.96536
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 1410.41198
-  tps: 4320.76251
+  dps: 1408.14195
+  tps: 4313.86902
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1393.38021
-  tps: 4269.04149
+  dps: 1392.52503
+  tps: 4266.44455
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1393.38021
-  tps: 4269.04149
+  dps: 1392.52503
+  tps: 4266.44455
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1398.52196
-  tps: 4282.39778
+  dps: 1397.66867
+  tps: 4279.8037
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1399.43675
-  tps: 4284.2946
+  dps: 1398.58346
+  tps: 4281.70052
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1408.39455
-  tps: 4312.55192
+  dps: 1407.53128
+  tps: 4309.93095
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 1408.43362
-  tps: 4303.35635
+  dps: 1407.57844
+  tps: 4300.75941
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1393.38021
-  tps: 4269.04149
+  dps: 1392.52503
+  tps: 4266.44455
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 1399.6747
-  tps: 4283.7034
+  dps: 1398.81953
+  tps: 4281.10646
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 1514.3673
-  tps: 4655.82743
+  dps: 1513.97078
+  tps: 4654.61605
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgebornePlate"
  value: {
-  dps: 1374.62582
-  tps: 4224.74505
+  dps: 1374.25996
+  tps: 4223.63105
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 1686.20877
-  tps: 5110.34074
+  dps: 1685.80802
+  tps: 5109.13219
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 1490.41095
-  tps: 4560.9964
+  dps: 1490.04404
+  tps: 4559.88285
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1399.01383
-  tps: 4285.05794
+  dps: 1398.15865
+  tps: 4282.461
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Shadowmourne-49623"
  value: {
-  dps: 2046.85968
-  tps: 5866.01325
+  dps: 2045.86695
+  tps: 5863.09879
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 1396.91427
-  tps: 4277.78373
+  dps: 1396.05799
+  tps: 4275.1845
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SoulPreserver-37111"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SouloftheDead-40382"
  value: {
-  dps: 1413.50009
-  tps: 4344.56116
+  dps: 1412.6347
+  tps: 4341.92391
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 1415.67002
-  tps: 4324.47475
+  dps: 1414.80416
+  tps: 4321.85079
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 1440.28489
-  tps: 4427.1498
+  dps: 1439.42094
+  tps: 4424.5246
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-StormshroudArmor"
  value: {
-  dps: 1154.06225
-  tps: 3567.52631
+  dps: 1153.70174
+  tps: 3566.42396
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1401.6848
-  tps: 4294.26036
+  dps: 1400.82963
+  tps: 4291.66341
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1400.10297
-  tps: 4289.45676
+  dps: 1399.2478
+  tps: 4286.85982
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1397.33478
-  tps: 4281.05047
+  dps: 1396.4796
+  tps: 4278.45353
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 1662.32723
-  tps: 5038.41253
+  dps: 1661.91587
+  tps: 5037.17475
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sPlate"
  value: {
-  dps: 1388.36757
-  tps: 4296.36363
+  dps: 1388.006
+  tps: 4295.25512
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1388.11003
-  tps: 4283.59547
+  dps: 1387.1742
+  tps: 4280.81886
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1399.44294
-  tps: 4286.68951
+  dps: 1398.58507
+  tps: 4284.0838
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1451.58684
-  tps: 4423.0993
+  dps: 1450.70206
+  tps: 4420.4215
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1454.84207
-  tps: 4430.90989
+  dps: 1453.95554
+  tps: 4428.22779
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1393.38021
-  tps: 4269.04149
+  dps: 1392.52503
+  tps: 4266.44455
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1393.38021
-  tps: 4269.04149
+  dps: 1392.52503
+  tps: 4266.44455
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 1421.26885
-  tps: 4342.80823
+  dps: 1420.40093
+  tps: 4340.17602
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1393.38021
-  tps: 4269.04149
+  dps: 1392.52503
+  tps: 4266.44455
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1393.38021
-  tps: 4269.04149
+  dps: 1392.52503
+  tps: 4266.44455
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1255.03693
-  tps: 3834.66004
+  dps: 1254.66401
+  tps: 3833.53004
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 1189.66469
-  tps: 3828.03734
+  dps: 1188.83559
+  tps: 3825.47708
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-WingedTalisman-37844"
  value: {
-  dps: 1394.84856
-  tps: 4273.50049
+  dps: 1393.99339
+  tps: 4270.90355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 1410.96107
-  tps: 4308.91093
+  dps: 1410.1059
+  tps: 4306.31399
  }
 }
 dps_results: {
  key: "TestBloodTank-Average-Default"
  value: {
-  dps: 1799.98613
-  tps: 6054.18621
-  dtps: 247.13114
+  dps: 1798.86877
+  tps: 6050.43491
+  dtps: 247.93581
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6176.16469
-  tps: 14176.09167
+  dps: 6171.53143
+  tps: 14165.65456
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1440.59795
-  tps: 4347.52333
+  dps: 1439.71345
+  tps: 4344.86486
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1655.36565
-  tps: 5940.27745
+  dps: 1654.37077
+  tps: 5936.69776
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3298.4317
-  tps: 7681.67689
+  dps: 3295.16556
+  tps: 7674.26908
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 819.16306
-  tps: 2542.38708
+  dps: 818.54073
+  tps: 2540.46004
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 870.35451
-  tps: 3358.79595
+  dps: 869.70461
+  tps: 3356.2756
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6196.68967
-  tps: 14240.32595
+  dps: 6192.0564
+  tps: 14229.88884
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1453.08909
-  tps: 4395.05693
+  dps: 1452.20459
+  tps: 4392.39846
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1680.15848
-  tps: 6070.40037
+  dps: 1679.1636
+  tps: 6066.82068
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3320.56499
-  tps: 7743.99453
+  dps: 3317.29911
+  tps: 7736.58728
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 827.22508
-  tps: 2575.70522
+  dps: 826.60301
+  tps: 2573.77873
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 886.37925
-  tps: 3451.90061
+  dps: 885.72935
+  tps: 3449.38026
  }
 }
 dps_results: {
  key: "TestBloodTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1828.82291
-  tps: 6083.66097
-  dtps: 246.97205
+  dps: 1827.69217
+  tps: 6079.90056
+  dtps: 247.77724
  }
 }

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -138,28 +138,8 @@ func (druid *Druid) AddRaidBuffs(raidBuffs *proto.RaidBuffs) {
 	}
 }
 
-func (druid *Druid) IsScalableArmorSlot(itemType proto.ItemType) bool {
-	switch itemType {
-	case
-		proto.ItemType_ItemTypeNeck,
-		proto.ItemType_ItemTypeFinger,
-		proto.ItemType_ItemTypeTrinket,
-		proto.ItemType_ItemTypeWeapon:
-		return false
-	}
-	return true
-}
-
 func (druid *Druid) ScaleBaseArmor(multiplier float64) float64 {
-	addedArmor := 0.0
-
-	for _, item := range druid.Equip {
-		if druid.IsScalableArmorSlot(item.Type) {
-			addedArmor += multiplier * (item.Stats[stats.Armor] - item.Stats[stats.BonusArmor])
-		}
-	}
-
-	return addedArmor
+	return druid.Equip.Stats()[stats.Armor] * multiplier
 }
 
 func (druid *Druid) BalanceCritMultiplier() float64 {
@@ -266,6 +246,7 @@ func New(char core.Character, form DruidForm, selfBuffs SelfBuffs, talents strin
 	druid.EnableManaBar()
 
 	druid.AddStatDependency(stats.Strength, stats.AttackPower, 2)
+	druid.AddStatDependency(stats.BonusArmor, stats.Armor, 1)
 	// Druids get 0.012 crit per agi at level 80, roughly 1 per 83.33
 	druid.AddStatDependency(stats.Agility, stats.MeleeCrit, (1.0/83.33)*core.CritRatingPerCritChance)
 	// Druid get 0.0209 dodge per agi (before dr), roughly 1 per 47.16

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 161
   final_stats: 75
   final_stats: 140
-  final_stats: 336
+  final_stats: 3434
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/paladin/holy/TestHoly.results
+++ b/sim/paladin/holy/TestHoly.results
@@ -21,7 +21,7 @@ character_stats_results: {
   final_stats: 28652.8
   final_stats: 0
   final_stats: 0
-  final_stats: 25305.58
+  final_stats: 25147.78
   final_stats: 755.7
   final_stats: 0
   final_stats: 0
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 75
   final_stats: 75
   final_stats: 130
-  final_stats: 8047.8
+  final_stats: 7890
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/paladin/holy/TestHoly.results
+++ b/sim/paladin/holy/TestHoly.results
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 75
   final_stats: 75
   final_stats: 130
-  final_stats: 0
+  final_stats: 8047.8
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/paladin/paladin.go
+++ b/sim/paladin/paladin.go
@@ -199,6 +199,9 @@ func NewPaladin(character core.Character, talentsStr string) *Paladin {
 	// Paladins get 1 block value per 2 str
 	paladin.AddStatDependency(stats.Strength, stats.BlockValue, .5)
 
+	// Bonus Armor and Armor are treated identically for Paladins
+	paladin.AddStatDependency(stats.BonusArmor, stats.Armor, 1)
+
 	// Base dodge is unaffected by Diminishing Returns
 	paladin.PseudoStats.BaseDodge += 0.0327
 	paladin.PseudoStats.BaseParry += 0.05

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 75
   final_stats: 75
   final_stats: 130
-  final_stats: 0
+  final_stats: 10022.1
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -21,7 +21,7 @@ character_stats_results: {
   final_stats: 7942
   final_stats: 0
   final_stats: 0
-  final_stats: 28479.8
+  final_stats: 27568.7
   final_stats: 755.7
   final_stats: 703
   final_stats: 171
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 75
   final_stats: 75
   final_stats: 130
-  final_stats: 10022.1
+  final_stats: 9111
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -884,8 +884,8 @@ dps_results: {
  key: "TestProtection-Average-Default"
  value: {
   dps: 3671.48626
-  tps: 8806.70472
-  dtps: 13.88562
+  tps: 8806.70564
+  dtps: 14.16016
  }
 }
 dps_results: {
@@ -1144,7 +1144,7 @@ dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
   dps: 3791.73145
-  tps: 9094.82488
-  dtps: 11.937
+  tps: 9094.82591
+  dtps: 12.17236
  }
 }

--- a/sim/paladin/talents.go
+++ b/sim/paladin/talents.go
@@ -21,6 +21,7 @@ func (paladin *Paladin) ApplyTalents() {
 	paladin.PseudoStats.BaseDodge += 0.01 * float64(paladin.Talents.Anticipation)
 
 	paladin.AddStat(stats.Armor, paladin.Equip.Stats()[stats.Armor]*0.02*float64(paladin.Talents.Toughness))
+	paladin.AddStat(stats.BonusArmor, paladin.Equip.Stats()[stats.BonusArmor]*0.02*float64(paladin.Talents.Toughness))
 
 	if paladin.Talents.DivineStrength > 0 {
 		paladin.MultiplyStat(stats.Strength, 1.0+0.03*float64(paladin.Talents.DivineStrength))

--- a/sim/paladin/talents.go
+++ b/sim/paladin/talents.go
@@ -21,7 +21,6 @@ func (paladin *Paladin) ApplyTalents() {
 	paladin.PseudoStats.BaseDodge += 0.01 * float64(paladin.Talents.Anticipation)
 
 	paladin.AddStat(stats.Armor, paladin.Equip.Stats()[stats.Armor]*0.02*float64(paladin.Talents.Toughness))
-	paladin.AddStat(stats.BonusArmor, paladin.Equip.Stats()[stats.BonusArmor]*0.02*float64(paladin.Talents.Toughness))
 
 	if paladin.Talents.DivineStrength > 0 {
 		paladin.MultiplyStat(stats.Strength, 1.0+0.03*float64(paladin.Talents.DivineStrength))

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 75
   final_stats: 75
   final_stats: 130
-  final_stats: 0
+  final_stats: 7890
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/shaman/restoration/TestRestoration.results
+++ b/sim/shaman/restoration/TestRestoration.results
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 75
   final_stats: 75
   final_stats: 130
-  final_stats: 0
+  final_stats: 7890
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/shaman/shaman.go
+++ b/sim/shaman/shaman.go
@@ -41,6 +41,7 @@ func NewShaman(character core.Character, talents string, totems *proto.ShamanTot
 	shaman.AddStatDependency(stats.Strength, stats.AttackPower, 1)
 	shaman.AddStatDependency(stats.Agility, stats.AttackPower, 1)
 	shaman.AddStatDependency(stats.Agility, stats.MeleeCrit, core.CritRatingPerCritChance/83.3)
+	shaman.AddStatDependency(stats.BonusArmor, stats.Armor, 1)
 	// Set proper Melee Haste scaling
 	shaman.PseudoStats.MeleeHasteRatingPerHastePercent /= 1.3
 

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -245,8 +245,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7718.01335
-  tps: 6343.74348
+  dps: 7718.78768
+  tps: 6344.36752
  }
 }
 dps_results: {
@@ -512,8 +512,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7705.87134
-  tps: 6335.38657
+  dps: 7706.37463
+  tps: 6335.79211
  }
 }
 dps_results: {
@@ -547,15 +547,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7698.63303
-  tps: 6328.12719
+  dps: 7703.14604
+  tps: 6331.86671
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7695.02313
-  tps: 6325.35674
+  dps: 7688.27301
+  tps: 6319.58524
  }
 }
 dps_results: {

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -245,8 +245,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6485.68607
-  tps: 4799.50535
+  dps: 6486.41333
+  tps: 4800.03377
  }
 }
 dps_results: {
@@ -512,8 +512,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6472.02303
-  tps: 4789.23941
+  dps: 6472.49131
+  tps: 4789.57952
  }
 }
 dps_results: {
@@ -547,15 +547,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6516.01069
-  tps: 4820.72317
+  dps: 6516.53235
+  tps: 4821.09787
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6520.58607
-  tps: 4824.21653
+  dps: 6522.71275
+  tps: 4825.5931
  }
 }
 dps_results: {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -12,7 +12,7 @@ character_stats_results: {
   final_stats: 254.55
   final_stats: 0
   final_stats: 0
-  final_stats: 5216.2319
+  final_stats: 5209.87084
   final_stats: 226
   final_stats: 823.20962
   final_stats: 0
@@ -21,7 +21,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 30434.58
+  final_stats: 30226.4
   final_stats: 755.7
   final_stats: 672
   final_stats: 170.95
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 75
   final_stats: 75
   final_stats: 140
-  final_stats: 11658.08
+  final_stats: 11449.9
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -46,7 +46,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 1.02054
+  weights: 0.9856
   weights: 0
   weights: 0
   weights: 0
@@ -57,7 +57,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.16092
+  weights: 0.26685
   weights: 0
   weights: 0
   weights: 0
@@ -66,12 +66,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.00055
+  weights: -0.00743
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.42809
-  weights: -0.02177
+  weights: 0.42754
+  weights: 0.05381
   weights: 0
   weights: 0
   weights: 0
@@ -91,52 +91,52 @@ stat_weights_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 1607.43076
-  tps: 4164.76703
+  dps: 1607.7865
+  tps: 4168.33276
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1658.40848
-  tps: 4265.20632
+  dps: 1661.05205
+  tps: 4269.41726
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 1581.83954
-  tps: 4096.89432
-  hps: 82.04411
+  dps: 1584.29787
+  tps: 4110.17647
+  hps: 81.68509
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 1581.83954
-  tps: 4096.89432
-  hps: 82.04411
+  dps: 1584.29787
+  tps: 4110.17647
+  hps: 81.68509
  }
 }
 dps_results: {
@@ -149,43 +149,43 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1564.13462
-  tps: 4044.54121
+  dps: 1558.51455
+  tps: 4031.81819
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackBruise-50035"
  value: {
-  dps: 1644.8504
-  tps: 4188.90189
+  dps: 1656.89334
+  tps: 4223.79614
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackBruise-50692"
  value: {
-  dps: 1683.45533
-  tps: 4274.83768
+  dps: 1682.82793
+  tps: 4276.59853
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1353.33206
-  tps: 3508.83774
+  dps: 1356.0135
+  tps: 3520.396
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1352.02971
-  tps: 3511.12288
+  dps: 1342.30695
+  tps: 3481.99263
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1273.02384
-  tps: 3326.4149
+  dps: 1273.55367
+  tps: 3329.518
  }
 }
 dps_results: {
@@ -198,15 +198,15 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
@@ -219,72 +219,72 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
   hps: 64
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1635.53732
-  tps: 4227.32473
+  dps: 1635.5687
+  tps: 4228.27745
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1683.28452
-  tps: 4329.63752
+  dps: 1682.89952
+  tps: 4334.54191
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 1640.4434
-  tps: 4237.99338
+  dps: 1639.7732
+  tps: 4238.38374
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Death'sChoice-47464"
  value: {
-  dps: 1710.44167
-  tps: 4398.46966
+  dps: 1710.03219
+  tps: 4393.91278
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1620.38446
-  tps: 4195.27772
+  dps: 1636.29384
+  tps: 4236.45917
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 1727.86952
-  tps: 4442.43677
+  dps: 1734.46812
+  tps: 4459.73184
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 1745.64745
-  tps: 4490.88337
+  dps: 1745.35928
+  tps: 4493.16134
  }
 }
 dps_results: {
@@ -297,15 +297,15 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 1644.8448
-  tps: 4249.92883
+  dps: 1632.37954
+  tps: 4214.42861
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 1632.48945
-  tps: 4217.73491
+  dps: 1632.67607
+  tps: 4218.71667
  }
 }
 dps_results: {
@@ -353,15 +353,15 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 1623.47671
-  tps: 4203.6402
+  dps: 1616.4743
+  tps: 4185.60865
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
@@ -374,36 +374,36 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1664.70964
-  tps: 4289.37339
+  dps: 1667.15706
+  tps: 4300.33597
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1629.4677
-  tps: 4214.71756
+  dps: 1630.59284
+  tps: 4223.50717
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1631.31849
-  tps: 4218.95264
+  dps: 1632.90614
+  tps: 4229.24982
  }
 }
 dps_results: {
@@ -423,15 +423,15 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1633.55767
-  tps: 4221.42151
+  dps: 1631.67779
+  tps: 4219.21518
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
@@ -444,43 +444,43 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 1665.29396
-  tps: 4292.33962
+  dps: 1665.3693
+  tps: 4298.20113
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Heartpierce-49982"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Heartpierce-50641"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
@@ -500,8 +500,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1638.91318
-  tps: 4233.77812
+  dps: 1633.90658
+  tps: 4218.38495
  }
 }
 dps_results: {
@@ -522,36 +522,36 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1594.20048
-  tps: 4130.21386
+  dps: 1597.14968
+  tps: 4144.81917
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1651.70258
-  tps: 4258.91128
+  dps: 1659.48862
+  tps: 4283.30789
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 1653.37989
-  tps: 4276.76144
+  dps: 1657.12833
+  tps: 4287.61268
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1591.28253
-  tps: 4129.69751
+  dps: 1588.0056
+  tps: 4112.22371
  }
 }
 dps_results: {
@@ -585,15 +585,15 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 1605.70729
-  tps: 4160.80356
+  dps: 1608.15655
+  tps: 4166.93784
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 1610.6575
-  tps: 4175.26892
+  dps: 1611.79837
+  tps: 4177.49647
  }
 }
 dps_results: {
@@ -613,22 +613,22 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
@@ -648,29 +648,29 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1592.00301
-  tps: 4127.7341
+  dps: 1596.24268
+  tps: 4138.42453
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Shadowmourne-49623"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
@@ -690,57 +690,57 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SoulPreserver-37111"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SouloftheDead-40382"
  value: {
-  dps: 1630.77424
-  tps: 4219.03332
+  dps: 1632.92438
+  tps: 4229.34335
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SparkofLife-37657"
  value: {
-  dps: 1617.0827
-  tps: 4185.2195
+  dps: 1620.28826
+  tps: 4194.19588
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 1643.49311
-  tps: 4244.74028
+  dps: 1638.42779
+  tps: 4233.40917
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormshroudArmor"
  value: {
-  dps: 1242.43111
-  tps: 3234.67004
+  dps: 1249.23552
+  tps: 3251.60083
  }
 }
 dps_results: {
@@ -767,36 +767,36 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 1145.79409
-  tps: 2638.66591
+  dps: 1146.57864
+  tps: 2639.75696
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1235.57904
-  tps: 2842.78869
+  dps: 1234.6303
+  tps: 2836.31629
  }
 }
 dps_results: {
@@ -809,15 +809,15 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1625.83188
-  tps: 4197.58407
+  dps: 1626.61007
+  tps: 4196.93154
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1650.16161
-  tps: 4257.54593
+  dps: 1649.68694
+  tps: 4261.49648
  }
 }
 dps_results: {
@@ -837,8 +837,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 1603.02315
-  tps: 4146.69415
+  dps: 1603.65374
+  tps: 4143.72663
  }
 }
 dps_results: {
@@ -858,22 +858,22 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1355.1476
-  tps: 3518.86022
+  dps: 1357.03297
+  tps: 3528.97269
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 1486.69063
-  tps: 3866.59025
+  dps: 1487.70423
+  tps: 3871.66251
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WingedTalisman-37844"
  value: {
-  dps: 1581.85828
-  tps: 4096.94483
+  dps: 1584.24465
+  tps: 4110.03302
  }
 }
 dps_results: {
@@ -907,100 +907,100 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 2936.52947
-  tps: 7163.90269
-  dtps: 127.31609
+  dps: 2936.01381
+  tps: 7162.39945
+  dtps: 127.88714
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3014.18374
-  tps: 7151.36197
+  dps: 3015.32776
+  tps: 7157.06924
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1648.89186
-  tps: 4271.0496
+  dps: 1658.33932
+  tps: 4294.14448
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1806.09293
-  tps: 4642.9942
+  dps: 1814.07098
+  tps: 4665.10566
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1024.98265
-  tps: 3011.19825
+  dps: 1022.79532
+  tps: 3004.41714
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1024.98265
-  tps: 2963.38158
+  dps: 1022.79532
+  tps: 2956.60048
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 983.3837
-  tps: 2862.54345
+  dps: 989.94899
+  tps: 2883.44942
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3036.83378
-  tps: 7201.42024
+  dps: 3032.71962
+  tps: 7189.00351
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1682.23096
-  tps: 4356.49206
+  dps: 1672.31843
+  tps: 4333.2633
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1837.21493
-  tps: 4720.185
+  dps: 1836.52029
+  tps: 4720.67584
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1030.25473
-  tps: 3026.64808
+  dps: 1026.44961
+  tps: 3017.19675
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1030.25473
-  tps: 2979.14808
+  dps: 1026.44961
+  tps: 2969.38009
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1000.52478
-  tps: 2916.27652
+  dps: 1001.48762
+  tps: 2918.42063
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3045.40226
-  tps: 7439.22557
-  dtps: 121.11759
+  dps: 3046.59565
+  tps: 7439.14889
+  dtps: 121.65565
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 75
   final_stats: 75
   final_stats: 140
-  final_stats: 0
+  final_stats: 11658.08
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -12,7 +12,7 @@ character_stats_results: {
   final_stats: 254.55
   final_stats: 0
   final_stats: 0
-  final_stats: 5209.87084
+  final_stats: 5178.06557
   final_stats: 226
   final_stats: 823.20962
   final_stats: 0
@@ -21,7 +21,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 30226.4
+  final_stats: 29185.5
   final_stats: 755.7
   final_stats: 672
   final_stats: 170.95
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 75
   final_stats: 75
   final_stats: 140
-  final_stats: 11449.9
+  final_stats: 10409
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -46,7 +46,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 0.9856
+  weights: 1.04073
   weights: 0
   weights: 0
   weights: 0
@@ -57,7 +57,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.26685
+  weights: 0.33479
   weights: 0
   weights: 0
   weights: 0
@@ -66,12 +66,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.00743
+  weights: 0.01508
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.42754
-  weights: 0.05381
+  weights: 0.42627
+  weights: -0.00678
   weights: 0
   weights: 0
   weights: 0
@@ -91,916 +91,916 @@ stat_weights_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 1607.7865
-  tps: 4168.33276
+  dps: 1598.6405
+  tps: 4142.56229
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1661.05205
-  tps: 4269.41726
+  dps: 1667.34858
+  tps: 4292.21916
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 1584.29787
-  tps: 4110.17647
-  hps: 81.68509
+  dps: 1590.40693
+  tps: 4120.41222
+  hps: 81.77608
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 1584.29787
-  tps: 4110.17647
-  hps: 81.68509
+  dps: 1590.40693
+  tps: 4120.41222
+  hps: 81.77608
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1606.28663
-  tps: 4163.49838
+  dps: 1598.41991
+  tps: 4149.14393
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1558.51455
-  tps: 4031.81819
+  dps: 1556.48602
+  tps: 4020.29573
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackBruise-50035"
  value: {
-  dps: 1656.89334
-  tps: 4223.79614
+  dps: 1663.37661
+  tps: 4243.73378
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackBruise-50692"
  value: {
-  dps: 1682.82793
-  tps: 4276.59853
+  dps: 1685.61799
+  tps: 4292.05142
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1356.0135
-  tps: 3520.396
+  dps: 1352.89169
+  tps: 3513.88626
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1342.30695
-  tps: 3481.99263
+  dps: 1338.19909
+  tps: 3468.41525
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1273.55367
-  tps: 3329.518
+  dps: 1268.20236
+  tps: 3309.98623
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1588.69306
-  tps: 4039.29413
+  dps: 1603.00679
+  tps: 4082.61604
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1608.56848
-  tps: 4171.81496
+  dps: 1608.11811
+  tps: 4161.93379
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
   hps: 64
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1635.5687
-  tps: 4228.27745
+  dps: 1625.53852
+  tps: 4202.42
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1682.89952
-  tps: 4334.54191
+  dps: 1668.91814
+  tps: 4293.58457
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 1639.7732
-  tps: 4238.38374
+  dps: 1629.60092
+  tps: 4211.62627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Death'sChoice-47464"
  value: {
-  dps: 1710.03219
-  tps: 4393.91278
+  dps: 1698.17299
+  tps: 4370.19599
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1636.29384
-  tps: 4236.45917
+  dps: 1615.92748
+  tps: 4183.59376
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 1734.46812
-  tps: 4459.73184
+  dps: 1712.111
+  tps: 4408.52259
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 1745.35928
-  tps: 4493.16134
+  dps: 1745.94013
+  tps: 4487.89482
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1605.97855
-  tps: 4162.27256
+  dps: 1599.02302
+  tps: 4150.11416
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 1632.37954
-  tps: 4214.42861
+  dps: 1623.33231
+  tps: 4191.19134
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 1632.67607
-  tps: 4218.71667
+  dps: 1616.04074
+  tps: 4170.12295
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 1677.86236
-  tps: 4303.23786
+  dps: 1668.28019
+  tps: 4280.0851
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DreadnaughtPlate"
  value: {
-  dps: 1502.89868
-  tps: 3899.21584
+  dps: 1505.68395
+  tps: 3903.27449
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1588.69306
-  tps: 4121.67769
+  dps: 1603.00679
+  tps: 4165.88372
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1588.69306
-  tps: 4121.67769
+  dps: 1603.00679
+  tps: 4165.88372
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1606.28663
-  tps: 4163.49838
+  dps: 1598.41991
+  tps: 4149.14393
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1602.18493
-  tps: 4154.49969
+  dps: 1598.65443
+  tps: 4149.21333
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 1616.4743
-  tps: 4185.60865
+  dps: 1610.44179
+  tps: 4176.05209
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1601.89742
-  tps: 4157.27071
+  dps: 1616.52975
+  tps: 4202.33555
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1667.15706
-  tps: 4300.33597
+  dps: 1655.22319
+  tps: 4266.91025
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1630.59284
-  tps: 4223.50717
+  dps: 1621.52631
+  tps: 4196.38534
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1632.90614
-  tps: 4229.24982
+  dps: 1618.83523
+  tps: 4189.5989
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1588.69306
-  tps: 4121.67769
+  dps: 1603.00679
+  tps: 4165.88372
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1588.69306
-  tps: 4121.67769
+  dps: 1603.00679
+  tps: 4165.88372
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1631.67779
-  tps: 4219.21518
+  dps: 1639.08732
+  tps: 4243.41354
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 1767.46525
-  tps: 4481.23762
+  dps: 1755.738
+  tps: 4459.28737
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 1665.3693
-  tps: 4298.20113
+  dps: 1650.52881
+  tps: 4255.94292
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Heartpierce-49982"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Heartpierce-50641"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1606.28663
-  tps: 4163.49838
+  dps: 1598.41991
+  tps: 4149.14393
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1602.18493
-  tps: 4154.49969
+  dps: 1598.65443
+  tps: 4149.21333
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1633.90658
-  tps: 4218.38495
+  dps: 1616.04627
+  tps: 4173.05476
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1588.69306
-  tps: 4121.67769
+  dps: 1603.00679
+  tps: 4165.88372
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1595.54032
-  tps: 4135.67473
-  hps: 17.03611
+  dps: 1584.14472
+  tps: 4103.62222
+  hps: 17.12852
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1597.14968
-  tps: 4144.81917
+  dps: 1602.83197
+  tps: 4153.90453
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1659.48862
-  tps: 4283.30789
+  dps: 1644.51066
+  tps: 4243.88404
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 1657.12833
-  tps: 4287.61268
+  dps: 1654.02217
+  tps: 4278.52042
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1588.0056
-  tps: 4112.22371
+  dps: 1586.70427
+  tps: 4109.8562
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 1255.16201
-  tps: 3281.97255
+  dps: 1256.6457
+  tps: 3290.12662
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 1371.94336
-  tps: 3533.58719
+  dps: 1360.26491
+  tps: 3491.14308
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1601.96871
-  tps: 4151.5373
+  dps: 1589.31805
+  tps: 4117.93783
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1595.54032
-  tps: 4135.67473
+  dps: 1584.14472
+  tps: 4103.62222
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 1608.15655
-  tps: 4166.93784
+  dps: 1595.52969
+  tps: 4135.65095
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 1611.79837
-  tps: 4177.49647
+  dps: 1604.69853
+  tps: 4163.01614
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1588.69306
-  tps: 4121.67769
+  dps: 1603.00679
+  tps: 4165.88372
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1588.69306
-  tps: 4121.67769
+  dps: 1603.00679
+  tps: 4165.88372
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1613.89291
-  tps: 4188.01738
+  dps: 1605.23089
+  tps: 4157.24305
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1588.69306
-  tps: 4121.67769
+  dps: 1603.00679
+  tps: 4165.88372
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1596.24268
-  tps: 4138.42453
+  dps: 1593.91057
+  tps: 4132.14466
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Shadowmourne-49623"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 1707.21741
-  tps: 4365.13895
+  dps: 1705.61089
+  tps: 4373.80543
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SiegebreakerPlate"
  value: {
-  dps: 1513.50065
-  tps: 3916.39097
+  dps: 1518.79454
+  tps: 3928.97762
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SoulPreserver-37111"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SouloftheDead-40382"
  value: {
-  dps: 1632.92438
-  tps: 4229.34335
+  dps: 1621.39968
+  tps: 4196.75407
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SparkofLife-37657"
  value: {
-  dps: 1620.28826
-  tps: 4194.19588
+  dps: 1634.63789
+  tps: 4236.82577
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 1638.42779
-  tps: 4233.40917
+  dps: 1635.3297
+  tps: 4242.8321
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormshroudArmor"
  value: {
-  dps: 1249.23552
-  tps: 3251.60083
+  dps: 1234.36284
+  tps: 3219.75713
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1595.54032
-  tps: 4135.67473
+  dps: 1584.14472
+  tps: 4103.62222
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1601.96871
-  tps: 4151.5373
+  dps: 1589.31805
+  tps: 4117.93783
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1592.944
-  tps: 4125.24523
+  dps: 1582.54029
+  tps: 4095.61667
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 1146.57864
-  tps: 2639.75696
+  dps: 1140.62051
+  tps: 2624.89147
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1234.6303
-  tps: 2836.31629
+  dps: 1231.431
+  tps: 2829.62596
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1592.40265
-  tps: 4125.10752
+  dps: 1597.94783
+  tps: 4143.78023
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1626.61007
-  tps: 4196.93154
+  dps: 1628.06812
+  tps: 4204.75522
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1649.68694
-  tps: 4261.49648
+  dps: 1637.87205
+  tps: 4229.23014
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1588.69306
-  tps: 4121.67769
+  dps: 1603.00679
+  tps: 4165.88372
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1588.69306
-  tps: 4121.67769
+  dps: 1603.00679
+  tps: 4165.88372
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 1603.65374
-  tps: 4143.72663
+  dps: 1613.69181
+  tps: 4181.13569
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1588.69306
-  tps: 4121.67769
+  dps: 1603.00679
+  tps: 4165.88372
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1588.69306
-  tps: 4121.67769
+  dps: 1603.00679
+  tps: 4165.88372
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1357.03297
-  tps: 3528.97269
+  dps: 1365.78148
+  tps: 3554.17649
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 1487.70423
-  tps: 3871.66251
+  dps: 1469.72215
+  tps: 3824.1004
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WingedTalisman-37844"
  value: {
-  dps: 1584.24465
-  tps: 4110.03302
+  dps: 1590.3512
+  tps: 4120.26199
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 1764.51884
-  tps: 4497.05123
+  dps: 1761.49002
+  tps: 4489.61191
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Wrynn'sPlate"
  value: {
-  dps: 1516.86061
-  tps: 3922.43745
+  dps: 1501.05133
+  tps: 3881.19493
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 1920.31969
-  tps: 4863.06407
+  dps: 1923.93474
+  tps: 4867.44253
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-YmirjarLord'sPlate"
  value: {
-  dps: 1696.07785
-  tps: 4361.27566
+  dps: 1690.41545
+  tps: 4350.5517
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 2936.01381
-  tps: 7162.39945
-  dtps: 127.88714
+  dps: 2927.47725
+  tps: 7144.28973
+  dtps: 130.89112
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3015.32776
-  tps: 7157.06924
+  dps: 3006.01681
+  tps: 7137.67423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1658.33932
-  tps: 4294.14448
+  dps: 1647.2448
+  tps: 4267.80472
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1814.07098
-  tps: 4665.10566
+  dps: 1796.40861
+  tps: 4612.09547
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1022.79532
-  tps: 3004.41714
+  dps: 1014.69317
+  tps: 2981.30141
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1022.79532
-  tps: 2956.60048
+  dps: 1014.69317
+  tps: 2933.80141
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 989.94899
-  tps: 2883.44942
+  dps: 984.66172
+  tps: 2868.14259
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3032.71962
-  tps: 7189.00351
+  dps: 3024.08555
+  tps: 7171.61568
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1672.31843
-  tps: 4333.2633
+  dps: 1674.67728
+  tps: 4333.84005
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1836.52029
-  tps: 4720.67584
+  dps: 1841.20624
+  tps: 4735.71678
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1026.44961
-  tps: 3017.19675
+  dps: 1034.65885
+  tps: 3042.27781
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1026.44961
-  tps: 2969.38009
+  dps: 1034.65885
+  tps: 2994.14448
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1001.48762
-  tps: 2918.42063
+  dps: 997.45088
+  tps: 2907.00207
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3046.59565
-  tps: 7439.14889
-  dtps: 121.65565
+  dps: 3043.95245
+  tps: 7431.59995
+  dtps: 124.64014
  }
 }

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -12,7 +12,6 @@ func (warrior *Warrior) ApplyTalents() {
 	warrior.AddStat(stats.MeleeCrit, core.CritRatingPerCritChance*1*float64(warrior.Talents.Cruelty))
 	warrior.AddStat(stats.MeleeHit, core.MeleeHitRatingPerHitChance*1*float64(warrior.Talents.Precision))
 	warrior.AddStat(stats.Armor, warrior.Equip.Stats()[stats.Armor]*0.02*float64(warrior.Talents.Toughness))
-	warrior.AddStat(stats.BonusArmor, warrior.Equip.Stats()[stats.BonusArmor]*0.02*float64(warrior.Talents.Toughness))
 	warrior.PseudoStats.BaseDodge += 0.01 * float64(warrior.Talents.Anticipation)
 	warrior.PseudoStats.BaseParry += 0.01 * float64(warrior.Talents.Deflection)
 	warrior.PseudoStats.DodgeReduction += 0.01 * float64(warrior.Talents.WeaponMastery)

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -12,6 +12,7 @@ func (warrior *Warrior) ApplyTalents() {
 	warrior.AddStat(stats.MeleeCrit, core.CritRatingPerCritChance*1*float64(warrior.Talents.Cruelty))
 	warrior.AddStat(stats.MeleeHit, core.MeleeHitRatingPerHitChance*1*float64(warrior.Talents.Precision))
 	warrior.AddStat(stats.Armor, warrior.Equip.Stats()[stats.Armor]*0.02*float64(warrior.Talents.Toughness))
+	warrior.AddStat(stats.BonusArmor, warrior.Equip.Stats()[stats.BonusArmor]*0.02*float64(warrior.Talents.Toughness))
 	warrior.PseudoStats.BaseDodge += 0.01 * float64(warrior.Talents.Anticipation)
 	warrior.PseudoStats.BaseParry += 0.01 * float64(warrior.Talents.Deflection)
 	warrior.PseudoStats.DodgeReduction += 0.01 * float64(warrior.Talents.WeaponMastery)

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -193,6 +193,7 @@ func NewWarrior(character core.Character, talents string, inputs WarriorInputs) 
 	warrior.AddStatDependency(stats.Agility, stats.Dodge, core.DodgeRatingPerDodgeChance/84.746)
 	warrior.AddStatDependency(stats.Strength, stats.AttackPower, 2)
 	warrior.AddStatDependency(stats.Strength, stats.BlockValue, .5) // 50% block from str
+	warrior.AddStatDependency(stats.BonusArmor, stats.Armor, 1)
 
 	// Base dodge unaffected by Diminishing Returns
 	warrior.PseudoStats.BaseDodge += 0.03664

--- a/tools/database/enchant_overrides.go
+++ b/tools/database/enchant_overrides.go
@@ -53,7 +53,7 @@ var EnchantOverrides = []*proto.UIEnchant{
 	{EffectId: 1446, SpellId: 44590, Name: "Superior Shadow Resistance", Quality: proto.ItemQuality_ItemQualityCommon, Stats: stats.Stats{stats.ShadowResistance: 20}.ToFloatArray(), Type: proto.ItemType_ItemTypeBack},
 	{EffectId: 1951, ItemId: 37347, SpellId: 44591, Name: "Titanweave", Quality: proto.ItemQuality_ItemQualityUncommon, Stats: stats.Stats{stats.Defense: 16}.ToFloatArray(), Type: proto.ItemType_ItemTypeBack},
 	{EffectId: 3256, ItemId: 37349, SpellId: 44631, Name: "Shadow Armor", Quality: proto.ItemQuality_ItemQualityUncommon, Stats: stats.Stats{stats.Agility: 10}.ToFloatArray(), Type: proto.ItemType_ItemTypeBack},
-	{EffectId: 3294, ItemId: 44471, SpellId: 47672, Name: "Mighty Armor", Quality: proto.ItemQuality_ItemQualityUncommon, Stats: stats.Stats{stats.Armor: 225}.ToFloatArray(), Type: proto.ItemType_ItemTypeBack},
+	{EffectId: 3294, ItemId: 44471, SpellId: 47672, Name: "Mighty Armor", Quality: proto.ItemQuality_ItemQualityUncommon, Stats: stats.Stats{stats.BonusArmor: 225}.ToFloatArray(), Type: proto.ItemType_ItemTypeBack},
 	{EffectId: 3831, ItemId: 44472, SpellId: 47898, Name: "Greater Speed", Quality: proto.ItemQuality_ItemQualityUncommon, Stats: stats.Stats{stats.MeleeHaste: 23, stats.SpellHaste: 23}.ToFloatArray(), Type: proto.ItemType_ItemTypeBack},
 	{EffectId: 3296, ItemId: 44488, SpellId: 47899, Name: "Wisdom", Quality: proto.ItemQuality_ItemQualityUncommon, Stats: stats.Stats{stats.Spirit: 10}.ToFloatArray(), Type: proto.ItemType_ItemTypeBack},
 	{EffectId: 3243, SpellId: 44582, Name: "Spell Piercing", Quality: proto.ItemQuality_ItemQualityCommon, Stats: stats.Stats{stats.SpellPenetration: 35}.ToFloatArray(), Type: proto.ItemType_ItemTypeBack},
@@ -106,7 +106,7 @@ var EnchantOverrides = []*proto.UIEnchant{
 	{EffectId: 3234, SpellId: 44488, Name: "Precision", Quality: proto.ItemQuality_ItemQualityCommon, Stats: stats.Stats{stats.MeleeHit: 20, stats.SpellHit: 20}.ToFloatArray(), Type: proto.ItemType_ItemTypeHands},
 	{EffectId: 3603, SpellId: 54998, Name: "Hand-Mounted Pyro Rocket", Quality: proto.ItemQuality_ItemQualityCommon, Stats: stats.Stats{}.ToFloatArray(), Type: proto.ItemType_ItemTypeHands, RequiredProfession: proto.Profession_Engineering},
 	{EffectId: 3604, SpellId: 54999, Name: "Hyperspeed Accelerators", Quality: proto.ItemQuality_ItemQualityCommon, Stats: stats.Stats{}.ToFloatArray(), Type: proto.ItemType_ItemTypeHands, RequiredProfession: proto.Profession_Engineering},
-	{EffectId: 3860, SpellId: 63770, Name: "Reticulated Armor Webbing", Quality: proto.ItemQuality_ItemQualityCommon, Stats: stats.Stats{stats.Armor: 885}.ToFloatArray(), Type: proto.ItemType_ItemTypeHands, RequiredProfession: proto.Profession_Engineering},
+	{EffectId: 3860, SpellId: 63770, Name: "Reticulated Armor Webbing", Quality: proto.ItemQuality_ItemQualityCommon, Stats: stats.Stats{stats.BonusArmor: 885}.ToFloatArray(), Type: proto.ItemType_ItemTypeHands, RequiredProfession: proto.Profession_Engineering},
 
 	// Waist
 	{EffectId: 3599, SpellId: 54736, Name: "Personal Electromagnetic Pulse Generator", Quality: proto.ItemQuality_ItemQualityCommon, Stats: stats.Stats{}.ToFloatArray(), Type: proto.ItemType_ItemTypeWaist, RequiredProfession: proto.Profession_Engineering},
@@ -210,7 +210,7 @@ var EnchantOverrides = []*proto.UIEnchant{
 	{EffectId: 2605, ItemId: 20076, SpellId: 24421, Name: "Zandalar Signet of Mojo", Quality: proto.ItemQuality_ItemQualityRare, Stats: stats.Stats{stats.SpellPower: 18}.ToFloatArray(), Type: proto.ItemType_ItemTypeShoulder},
 	{EffectId: 2721, ItemId: 23545, SpellId: 29467, Name: "Power of the Scourge", Quality: proto.ItemQuality_ItemQualityEpic, Stats: stats.Stats{stats.SpellPower: 15, stats.SpellCrit: 14}.ToFloatArray(), Type: proto.ItemType_ItemTypeShoulder},
 	{EffectId: 2717, ItemId: 23548, SpellId: 29483, Name: "Might of the Scourge", Quality: proto.ItemQuality_ItemQualityEpic, Stats: stats.Stats{stats.AttackPower: 26, stats.RangedAttackPower: 26, stats.MeleeCrit: 14}.ToFloatArray(), Type: proto.ItemType_ItemTypeShoulder},
-	{EffectId: 2716, ItemId: 23549, SpellId: 29480, Name: "Fortitude of the Scourge", Quality: proto.ItemQuality_ItemQualityEpic, Stats: stats.Stats{stats.Stamina: 16, stats.Armor: 100}.ToFloatArray(), Type: proto.ItemType_ItemTypeShoulder},
+	{EffectId: 2716, ItemId: 23549, SpellId: 29480, Name: "Fortitude of the Scourge", Quality: proto.ItemQuality_ItemQualityEpic, Stats: stats.Stats{stats.Stamina: 16, stats.BonusArmor: 100}.ToFloatArray(), Type: proto.ItemType_ItemTypeShoulder},
 
 	// Back
 	{EffectId: 2622, ItemId: 33148, SpellId: 25086, Name: "Enchant Cloak - Dodge", Quality: proto.ItemQuality_ItemQualityRare, Stats: stats.Stats{stats.Dodge: 12}.ToFloatArray(), Type: proto.ItemType_ItemTypeBack},

--- a/tools/database/wowhead_tooltips.go
+++ b/tools/database/wowhead_tooltips.go
@@ -210,9 +210,10 @@ var bonusArmorRegex = regexp.MustCompile(`Has ([0-9]+) bonus armor`)
 func (item WowheadItemResponse) GetStats() Stats {
 	sp := float64(item.GetIntValue(spellPowerRegex)) + float64(item.GetIntValue(spellPowerRegex2))
 	baseAP := float64(item.GetIntValue(attackPowerRegex)) + float64(item.GetIntValue(attackPowerRegex2))
+	armor, bonusArmor := item.GetArmorValues()
 	return Stats{
-		proto.Stat_StatArmor:             float64(item.GetIntValue(armorRegex)),
-		proto.Stat_StatBonusArmor:        float64(item.GetIntValue(bonusArmorRegex)),
+		proto.Stat_StatArmor:             float64(armor),
+		proto.Stat_StatBonusArmor:        float64(bonusArmor),
 		proto.Stat_StatStrength:          float64(item.GetIntValue(strengthRegex)),
 		proto.Stat_StatAgility:           float64(item.GetIntValue(agilityRegex)),
 		proto.Stat_StatStamina:           float64(item.GetIntValue(staminaRegex)),
@@ -371,6 +372,32 @@ func (item WowheadItemResponse) GetItemType() proto.ItemType {
 		}
 	}
 	return proto.ItemType_ItemTypeUnknown
+}
+
+func (item WowheadItemResponse) IsScalableArmorSlot(itemType proto.ItemType) bool {
+	switch itemType {
+	case
+		proto.ItemType_ItemTypeNeck,
+		proto.ItemType_ItemTypeFinger,
+		proto.ItemType_ItemTypeTrinket,
+		proto.ItemType_ItemTypeWeapon:
+		return false
+	}
+	return true
+}
+
+func (item WowheadItemResponse) GetArmorValues() (int, int) {
+	armorValue := item.GetIntValue(armorRegex)
+	bonusArmorValue := item.GetIntValue(bonusArmorRegex)
+
+	if item.IsScalableArmorSlot(item.GetItemType()) {
+		armorValue = armorValue - bonusArmorValue
+	} else {
+		bonusArmorValue = armorValue
+		armorValue = 0
+	}
+
+	return armorValue, bonusArmorValue
 }
 
 var armorTypePatterns = map[proto.ArmorType]*regexp.Regexp{

--- a/ui/feral_tank_druid/sim.ts
+++ b/ui/feral_tank_druid/sim.ts
@@ -87,6 +87,7 @@ export class FeralTankDruidSimUI extends IndividualSimUI<Spec.SpecFeralTankDruid
 				// Default EP weights for sorting gear in the gear picker.
 				epWeights: Stats.fromMap({
 					[Stat.StatArmor]: 3.5665,
+					[Stat.StatBonusArmor]: 0.5187,
 					[Stat.StatStamina]: 7.3021,
 					[Stat.StatStrength]: 2.3786,
 					[Stat.StatAgility]: 4.4974,

--- a/ui/protection_paladin/sim.ts
+++ b/ui/protection_paladin/sim.ts
@@ -95,6 +95,7 @@ export class ProtectionPaladinSimUI extends IndividualSimUI<Spec.SpecProtectionP
 				// Default EP weights for sorting gear in the gear picker.
 				epWeights: Stats.fromMap({
 					[Stat.StatArmor]: 0.07,
+					[Stat.StatBonusArmor]: 0.06,
 					[Stat.StatStamina]: 1.14,
 					[Stat.StatStrength]: 1.00,
 					[Stat.StatAgility]: 0.62,

--- a/ui/protection_warrior/sim.ts
+++ b/ui/protection_warrior/sim.ts
@@ -87,6 +87,7 @@ export class ProtectionWarriorSimUI extends IndividualSimUI<Spec.SpecProtectionW
 				// Default EP weights for sorting gear in the gear picker.
 				epWeights: Stats.fromMap({
 					[Stat.StatArmor]: 0.174,
+					[Stat.StatBonusArmor]: 0.155,
 					[Stat.StatStamina]: 2.336,
 					[Stat.StatStrength]: 1.555,
 					[Stat.StatAgility]: 2.771,

--- a/ui/tank_deathknight/sim.ts
+++ b/ui/tank_deathknight/sim.ts
@@ -89,6 +89,7 @@ export class TankDeathknightSimUI extends IndividualSimUI<Spec.SpecTankDeathknig
 				// Default EP weights for sorting gear in the gear picker.
 				epWeights: Stats.fromMap({
 					[Stat.StatArmor]: 0.05,
+					[Stats.StatBonusArmor]: 0.03,
 					[Stat.StatStamina]: 1,
 					[Stat.StatStrength]: 0.33,
 					[Stat.StatAgility]: 0.6,

--- a/ui/tank_deathknight/sim.ts
+++ b/ui/tank_deathknight/sim.ts
@@ -89,7 +89,7 @@ export class TankDeathknightSimUI extends IndividualSimUI<Spec.SpecTankDeathknig
 				// Default EP weights for sorting gear in the gear picker.
 				epWeights: Stats.fromMap({
 					[Stat.StatArmor]: 0.05,
-					[Stats.StatBonusArmor]: 0.03,
+					[Stat.StatBonusArmor]: 0.03,
 					[Stat.StatStamina]: 1,
 					[Stat.StatStrength]: 0.33,
 					[Stat.StatAgility]: 0.6,


### PR DESCRIPTION
Commits are separated for ease of debugging:
- First commit refactors the DB to parse out Bonus Armor properly during DB creation, and then updates tank sim stat dependencies so that no test results change.
- Second through fourth commit then fix bugs with how Bonus Armor was previously handled in plate tank sims, which does change test results as expected.
- Final commit adds a default Bonus Armor EP to each tank sim so that jewelry slots will be correctly sorted in the UI.