### PR TITLE
do not populate ActionID for proc trigger auras

### DIFF
--- a/sim/core/aura.go
+++ b/sim/core/aura.go
@@ -44,7 +44,8 @@ type Aura struct {
 	// For easily grouping auras.
 	Tag string
 
-	ActionID ActionID // If set, metrics will be tracked for this aura.
+	ActionID        ActionID // If set, metrics will be tracked for this aura.
+	ActionIDForProc ActionID // If set, indicates that this aura is a trigger aura for the specified proc.
 
 	Duration time.Duration // Duration of aura, upon being applied.
 

--- a/sim/core/aura_helpers.go
+++ b/sim/core/aura_helpers.go
@@ -129,9 +129,9 @@ func ApplyProcTriggerCallback(unit *Unit, aura *Aura, config ProcTrigger) {
 
 func MakeProcTriggerAura(unit *Unit, config ProcTrigger) *Aura {
 	aura := Aura{
-		Label:    config.Name,
-		ActionID: config.ActionID,
-		Duration: config.Duration,
+		Label:           config.Name,
+		ActionIDForProc: config.ActionID,
+		Duration:        config.Duration,
 	}
 	if config.Duration == 0 {
 		aura.Duration = NeverExpires

--- a/sim/core/major_cooldown.go
+++ b/sim/core/major_cooldown.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"strings"
 	"time"
 
 	"golang.org/x/exp/slices"
@@ -326,10 +325,7 @@ func desyncTrinketProcAura(aura *Aura, delay time.Duration) {
 
 func findTrinketAura(character *Character, trinketID int32) *Aura {
 	for _, aura := range character.auras {
-		if strings.HasSuffix(aura.Label, "Proc") {
-			continue
-		}
-		if aura.ActionID.ItemID == trinketID || aura.metrics.ID.ItemID == trinketID {
+		if aura.ActionIDForProc.ItemID == trinketID {
 			return aura
 		}
 	}


### PR DESCRIPTION
Instead refer to the proc aura that the synthetic trigger aura refers to. This way no synthetic trigger aura will ever be transmitted through the metrics, and the trinket desync functionality can still find the relevant synthetic aura to apply the desync to.