### PR TITLE
Improve crash handler

### DIFF
--- a/cmd/wowsimcli/cmd/decode_link.go
+++ b/cmd/wowsimcli/cmd/decode_link.go
@@ -51,11 +51,17 @@ func decodeLink(link string) error {
 		return fmt.Errorf("reading zlib data failed: %w", err)
 	}
 
-	settings := &proto.IndividualSimSettings{}
+	var settings goproto.Message
+	if strings.Contains(link, "/raid/") {
+		settings = &proto.RaidSimSettings{}
+	} else {
+		settings = &proto.IndividualSimSettings{}
+	}
+
 	if err := goproto.Unmarshal(buf.Bytes(), settings); err != nil {
 		return fmt.Errorf("cannot unmarshal raw proto: %w", err)
 	}
 
-	fmt.Println(protojson.Format(settings))
+	fmt.Println(protojson.Format(goproto.MessageV2(settings)))
 	return nil
 }

--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -74,6 +74,7 @@ func runSim(rsr *proto.RaidSimRequest, progress chan *proto.ProgressMetrics, ski
 	}()
 
 	sim := NewSim(rsr)
+	panic("lololo")
 
 	if !skipPresim {
 		if progress != nil {

--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -74,7 +74,6 @@ func runSim(rsr *proto.RaidSimRequest, progress chan *proto.ProgressMetrics, ski
 	}()
 
 	sim := NewSim(rsr)
-	panic("lololo")
 
 	if !skipPresim {
 		if progress != nil {

--- a/ui/core/sim_ui.ts
+++ b/ui/core/sim_ui.ts
@@ -14,6 +14,7 @@ import { EventID, TypedEvent } from './typed_event.js';
 
 import { Tooltip } from 'bootstrap';
 import { SimTab } from './components/sim_tab.js';
+import { BaseModal } from './components/base_modal.js';
 
 const URLMAXLEN = 2048;
 const noticeText = '';
@@ -279,9 +280,21 @@ export abstract class SimUI extends Component {
 						const base_url = 'https://github.com/wowsims/wotlk/issues/new?assignees=&labels=&title=Crash%20Report%20'
 						const base = `${base_url}${hash}&body=`;
 						const maxBodyLength = URLMAXLEN - base.length;
-						let issueBody = encodeURIComponent(`Link:\n${link}\n\nRNG Seed: ${rngSeed}\n\n${errorStr}`)
-						while (issueBody.length > maxBodyLength) {
-							issueBody = issueBody.slice(0, issueBody.lastIndexOf('%')) // Avoid truncating in the middle of a URLencoded segment
+						let issueBody = encodeURIComponent(`Link:\n${link}\n\nRNG Seed: ${rngSeed}\n\n${errorStr}`);
+						if (link.includes('/raid/')) {
+							// Move the actual error before the link, as it will likely get truncated.
+							issueBody = encodeURIComponent(`${errorStr}\nRNG Seed: ${rngSeed}\nLink:\n${link}`);
+						}
+						let truncated = false;
+						while (issueBody.length > maxBodyLength - (truncated ? 3 : 0)) {
+							issueBody = issueBody.slice(0, issueBody.lastIndexOf('%')) // Avoid truncating in the middle of a URLencoded segment.
+							truncated = true;
+						}
+						if (truncated) {
+							issueBody += "...";
+							// The raid links are too large and will always cause truncation.
+							// Prompt the user to add more information to the issue.
+							new CrashModal(this.rootElem, link);
 						}
 						window.open(base + issueBody, '_blank');
 					}
@@ -290,7 +303,6 @@ export abstract class SimUI extends Component {
 				alert('Failed to file report... try again another time:' + fetchErr);
 			});
 		}
-		return;
 	}
 
 	hashCode(str: string): number {
@@ -305,6 +317,20 @@ export abstract class SimUI extends Component {
 
 	abstract applyDefaults(eventID: EventID): void;
 	abstract toLink(): string;
+}
+
+class CrashModal extends BaseModal {
+	constructor(parent: HTMLElement, link: string) {
+		super(parent, 'crash', {title: 'Extra Crash Information'});
+		this.body.innerHTML = `
+			<div class="sim-crash-report">
+				<h3 class="sim-crash-report-header">Please append the following complete link to the issue you just created. This will simplify debugging the issue.</h3>
+				<textarea class="sim-crash-report-text form-control"></textarea>
+			</div>
+		`;
+		let text = document.createTextNode(link);
+		this.body.querySelector('textarea')?.appendChild(text);
+	}
 }
 
 const simHTML = `

--- a/ui/scss/core/sim_ui/_main.scss
+++ b/ui/scss/core/sim_ui/_main.scss
@@ -17,6 +17,19 @@
   }
 }
 
+.sim-crash-report {
+  .sim-crash-report-header {
+    font-size: 1rem;
+    font-family: SimDefaultFont;
+  }
+
+  .sim-crash-report-text {
+		width: 100%;
+		height: 80vh;
+		resize: none;
+  }
+}
+
 @include media-breakpoint-down(lg) {
   .sim-content {
     .sim-main {


### PR DESCRIPTION
We have gotten a couple of raid sim crash reports recently:
* https://github.com/wowsims/wotlk/issues/3031
* https://github.com/wowsims/wotlk/issues/3041
* https://github.com/wowsims/wotlk/issues/3043

Unfortunately, these error reports are not really actionable. The links (which under the hood are zlib deflated and base64 encoded settings protos) are truncated. Furthermore, the actual error message and the RNG seed are also truncated (because they are appended after the link, which is already too large).

This PR changes the order of the information: print the error and rng first, and then the (possibly truncated) link. If the link has to be truncated, then a new modal is opened to prompt users to append the full link to the issue manually.

The link can be decoded into the settings proto using the CLI (decodelink command).