### PR TITLE
cmd: actually write to stdout by default

### DIFF
--- a/cmd/wowsimcli/cmd/basic_sim.go
+++ b/cmd/wowsimcli/cmd/basic_sim.go
@@ -57,7 +57,7 @@ func simMain(cmd *cobra.Command, args []string) {
 	}
 
 	if outfile == "" {
-		print(string(output))
+		fmt.Print(string(output))
 	} else {
 		err = os.WriteFile(outfile, output, 0666)
 		if err != nil {


### PR DESCRIPTION
print() writes to stderr by default, fmt.Print() to stdout.