### PR TITLE
Make dk faster

### DIFF
--- a/sim/core/flags.go
+++ b/sim/core/flags.go
@@ -193,6 +193,7 @@ const (
 	SpellFlagNoLogs                                         // Disables logs for a spell.
 	SpellFlagAPL                                            // Indicates this spell can be used from an APL rotation.
 	SpellFlagMCD                                            // Indicates this spell is a MajorCooldown.
+	SpellFlagNoOnDamageDealt                                // Disables OnSpellHitDealt and OnPeriodicDamageDealt aura callbacks for this spell.
 
 	// Used to let agents categorize their spells.
 	SpellFlagAgentReserved1

--- a/sim/core/spell_result.go
+++ b/sim/core/spell_result.go
@@ -247,12 +247,14 @@ func (spell *Spell) dealDamageInternal(sim *Simulation, isPeriodic bool, result 
 		}
 	}
 
-	if isPeriodic {
-		spell.Unit.OnPeriodicDamageDealt(sim, spell, result)
-		result.Target.OnPeriodicDamageTaken(sim, spell, result)
-	} else {
-		spell.Unit.OnSpellHitDealt(sim, spell, result)
-		result.Target.OnSpellHitTaken(sim, spell, result)
+	if !spell.Flags.Matches(SpellFlagNoOnDamageDealt) {
+		if isPeriodic {
+			spell.Unit.OnPeriodicDamageDealt(sim, spell, result)
+			result.Target.OnPeriodicDamageTaken(sim, spell, result)
+		} else {
+			spell.Unit.OnSpellHitDealt(sim, spell, result)
+			result.Target.OnSpellHitTaken(sim, spell, result)
+		}
 	}
 
 	spell.DisposeResult(result)

--- a/sim/deathknight/deathknight.go
+++ b/sim/deathknight/deathknight.go
@@ -74,6 +74,7 @@ type Deathknight struct {
 
 	Gargoyle                 *GargoylePet
 	SummonGargoyle           *core.Spell
+	SummonGargoyleAura       *core.Aura
 	GargoyleSummonDelay      time.Duration
 	OnGargoyleStartFirstCast func()
 

--- a/sim/deathknight/deathknight.go
+++ b/sim/deathknight/deathknight.go
@@ -183,7 +183,6 @@ type Deathknight struct {
 	KillingMachineAura  *core.Aura
 	IcyTalonsAura       *core.Aura
 	DesolationAura      *core.Aura
-	NecrosisAura        *core.Aura
 	BloodCakedBladeAura *core.Aura
 	ButcheryAura        *core.Aura
 	ButcheryPA          *core.PendingAction
@@ -196,9 +195,10 @@ type Deathknight struct {
 	LastDiseaseDamage float64
 	LastTickTime      time.Duration
 	WanderingPlague   *core.Spell
-
-	Deathchill     *core.Spell
-	DeathchillAura *core.Aura
+	NecrosisCoeff     float64
+	Necrosis          *core.Spell
+	Deathchill        *core.Spell
+	DeathchillAura    *core.Aura
 
 	// Presences
 	BloodPresence      *core.Spell

--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -60,15 +60,15 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7167.33423
-  tps: 3608.51771
+  dps: 7157.12096
+  tps: 3608.06795
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7053.43482
-  tps: 3587.78778
+  dps: 7053.58866
+  tps: 3587.88008
  }
 }
 dps_results: {
@@ -90,64 +90,64 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7186.30244
-  tps: 3618.46485
+  dps: 7175.92879
+  tps: 3617.96788
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7006.91394
-  tps: 3537.18049
+  dps: 7001.16978
+  tps: 3537.32788
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6000.97698
-  tps: 3029.23357
+  dps: 5993.7485
+  tps: 3028.91289
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5912.65931
-  tps: 3000.45113
+  dps: 5907.76802
+  tps: 3000.68671
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5693.99044
-  tps: 2886.27278
+  dps: 5689.39326
+  tps: 2885.56875
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7162.32891
-  tps: 3533.76313
+  dps: 7152.11564
+  tps: 3533.32236
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8600.75712
-  tps: 4419.5351
+  dps: 8598.92565
+  tps: 4418.97839
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8658.70608
-  tps: 4456.03734
+  dps: 8656.92741
+  tps: 4455.39951
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7305.12163
-  tps: 3683.52833
+  dps: 7294.7194
+  tps: 3683.06917
  }
 }
 dps_results: {
@@ -182,43 +182,43 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7030.31648
-  tps: 3578.29938
+  dps: 7026.99879
+  tps: 3577.70274
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7125.17275
-  tps: 3592.42986
+  dps: 7114.84076
+  tps: 3591.98944
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 6960.2722
-  tps: 3528.56568
+  dps: 6956.23129
+  tps: 3528.64053
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 6079.61882
-  tps: 3067.15612
+  dps: 6073.6222
+  tps: 3065.4025
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7204.04341
-  tps: 3625.03492
+  dps: 7193.71142
+  tps: 3624.5945
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7493.87553
-  tps: 3772.57196
+  dps: 7484.11687
+  tps: 3770.95274
  }
 }
 dps_results: {
@@ -252,8 +252,8 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7190.14947
-  tps: 3620.26465
+  dps: 7179.74564
+  tps: 3619.76768
  }
 }
 dps_results: {
@@ -273,29 +273,29 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7162.32891
-  tps: 3605.88074
+  dps: 7152.11564
+  tps: 3605.43098
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7162.32891
-  tps: 3605.88074
+  dps: 7152.11564
+  tps: 3605.43098
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7186.30244
-  tps: 3618.46485
+  dps: 7175.92879
+  tps: 3617.96788
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7183.55111
-  tps: 3617.22248
+  dps: 7173.20491
+  tps: 3616.72551
  }
 }
 dps_results: {
@@ -315,8 +315,8 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7162.32891
-  tps: 3605.88074
+  dps: 7152.11564
+  tps: 3605.43098
  }
 }
 dps_results: {
@@ -357,22 +357,22 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7162.32891
-  tps: 3605.88074
+  dps: 7152.11564
+  tps: 3605.43098
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7162.32891
-  tps: 3605.88074
+  dps: 7152.11564
+  tps: 3605.43098
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7205.49271
-  tps: 3625.58696
+  dps: 7195.16072
+  tps: 3625.14654
  }
 }
 dps_results: {
@@ -413,8 +413,8 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7199.2296
-  tps: 3623.5445
+  dps: 7188.89761
+  tps: 3623.10408
  }
 }
 dps_results: {
@@ -427,15 +427,15 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7186.30244
-  tps: 3618.46485
+  dps: 7175.92879
+  tps: 3617.96788
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7183.55111
-  tps: 3617.22248
+  dps: 7173.20491
+  tps: 3616.72551
  }
 }
 dps_results: {
@@ -448,15 +448,15 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7162.32891
-  tps: 3605.88074
+  dps: 7152.11564
+  tps: 3605.43098
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7190.55983
-  tps: 3620.76003
+  dps: 7181.00137
+  tps: 3620.41793
   hps: 12.48865
  }
 }
@@ -498,15 +498,15 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7185.11253
-  tps: 3617.88389
+  dps: 7174.89926
+  tps: 3617.43413
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7190.47338
-  tps: 3620.70816
+  dps: 7180.26011
+  tps: 3620.2584
  }
 }
 dps_results: {
@@ -526,15 +526,15 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7162.32891
-  tps: 3605.88074
+  dps: 7152.11564
+  tps: 3605.43098
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7162.32891
-  tps: 3605.88074
+  dps: 7152.11564
+  tps: 3605.43098
  }
 }
 dps_results: {
@@ -561,22 +561,22 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7300.75083
-  tps: 3681.43117
+  dps: 7290.41884
+  tps: 3680.99074
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7207.18355
-  tps: 3626.231
+  dps: 7196.85156
+  tps: 3625.79058
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7162.32891
-  tps: 3605.88074
+  dps: 7152.11564
+  tps: 3605.43098
  }
 }
 dps_results: {
@@ -589,36 +589,36 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7198.9542
-  tps: 3623.40075
+  dps: 7188.62221
+  tps: 3622.96033
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6617.31614
-  tps: 3340.00459
+  dps: 6609.5528
+  tps: 3338.58564
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 6081.53073
-  tps: 3070.7014
+  dps: 6076.83121
+  tps: 3069.62042
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7571.17886
-  tps: 3883.72376
+  dps: 7568.03918
+  tps: 3883.48334
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6399.80744
-  tps: 3229.96838
+  dps: 6393.8999
+  tps: 3228.31644
  }
 }
 dps_results: {
@@ -631,8 +631,8 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 9557.95336
-  tps: 4941.27055
+  dps: 9554.8012
+  tps: 4941.38985
  }
 }
 dps_results: {
@@ -645,50 +645,50 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7196.79692
-  tps: 3622.27472
+  dps: 7186.46493
+  tps: 3621.8343
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7228.30101
-  tps: 3638.92096
+  dps: 7217.91397
+  tps: 3638.53175
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7196.79692
-  tps: 3622.27472
+  dps: 7186.46493
+  tps: 3621.8343
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7526.81108
-  tps: 3790.7698
+  dps: 7516.47909
+  tps: 3790.32938
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7196.79692
-  tps: 3622.27472
+  dps: 7186.46493
+  tps: 3621.8343
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7528.41043
-  tps: 3796.24732
+  dps: 7518.07844
+  tps: 3795.8069
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7196.79692
-  tps: 3622.27472
+  dps: 7186.46493
+  tps: 3621.8343
  }
 }
 dps_results: {
@@ -743,29 +743,29 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 5605.79101
-  tps: 2843.47379
+  dps: 5602.82171
+  tps: 2843.4078
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7190.47338
-  tps: 3620.70816
+  dps: 7180.26011
+  tps: 3620.2584
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7185.11253
-  tps: 3617.88389
+  dps: 7174.89926
+  tps: 3617.43413
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7175.73104
-  tps: 3612.94142
+  dps: 7165.51777
+  tps: 3612.49166
  }
 }
 dps_results: {
@@ -785,15 +785,15 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7083.00789
-  tps: 3592.93211
+  dps: 7073.97815
+  tps: 3591.77194
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6265.24191
-  tps: 3165.58489
+  dps: 6260.71787
+  tps: 3164.62788
  }
 }
 dps_results: {
@@ -806,15 +806,15 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6212.42993
-  tps: 3077.7345
+  dps: 6211.23386
+  tps: 3077.0563
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7129.14055
-  tps: 3585.87108
+  dps: 7121.36499
+  tps: 3584.71952
  }
 }
 dps_results: {
@@ -834,15 +834,15 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7162.32891
-  tps: 3605.88074
+  dps: 7152.11564
+  tps: 3605.43098
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7162.32891
-  tps: 3605.88074
+  dps: 7152.11564
+  tps: 3605.43098
  }
 }
 dps_results: {
@@ -855,29 +855,29 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7162.32891
-  tps: 3605.88074
+  dps: 7152.11564
+  tps: 3605.43098
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7162.32891
-  tps: 3605.88074
+  dps: 7152.11564
+  tps: 3605.43098
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5928.19635
-  tps: 3010.85261
+  dps: 5922.27072
+  tps: 3009.68158
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5589.02935
-  tps: 2656.22009
+  dps: 5586.58871
+  tps: 2655.73374
  }
 }
 dps_results: {
@@ -890,105 +890,105 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7209.11595
-  tps: 3626.96705
+  dps: 7198.78396
+  tps: 3626.52663
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 7306.54378
-  tps: 3695.56572
+  dps: 7301.75255
+  tps: 3695.0485
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19638.32059
-  tps: 10271.63898
+  dps: 19603.68285
+  tps: 10252.53297
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7196.68544
-  tps: 3646.8792
+  dps: 7188.05033
+  tps: 3647.01804
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9288.12423
-  tps: 4153.56667
+  dps: 9280.75587
+  tps: 4149.14566
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10373.24194
-  tps: 5425.23603
+  dps: 10364.34965
+  tps: 5420.00347
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4074.94641
-  tps: 2080.73503
+  dps: 4073.50218
+  tps: 2081.10054
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4836.807
-  tps: 2148.50664
+  dps: 4834.70819
+  tps: 2147.27591
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19817.36112
-  tps: 10339.23937
+  dps: 19782.74167
+  tps: 10320.16034
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7300.75083
-  tps: 3681.43117
+  dps: 7290.41884
+  tps: 3680.99074
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9467.83156
-  tps: 4210.28744
+  dps: 9460.47137
+  tps: 4205.87132
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10466.51984
-  tps: 5466.69751
+  dps: 10454.31546
+  tps: 5459.50831
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4125.87442
-  tps: 2096.37044
+  dps: 4123.53983
+  tps: 2096.63841
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4927.63713
-  tps: 2176.96138
+  dps: 4925.53104
+  tps: 2175.72771
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6984.21727
-  tps: 3554.95662
+  dps: 6978.83994
+  tps: 3555.05133
  }
 }

--- a/sim/deathknight/dps/TestFrostUH.results
+++ b/sim/deathknight/dps/TestFrostUH.results
@@ -46,1033 +46,1033 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8122.85103
-  tps: 5773.78688
+  dps: 8123.25745
+  tps: 5774.086
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8039.33917
-  tps: 5740.15628
+  dps: 8039.58466
+  tps: 5740.33696
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7821.379
-  tps: 5579.7376
+  dps: 7821.24527
+  tps: 5579.63917
   hps: 60.92312
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7821.379
-  tps: 5579.7376
+  dps: 7821.24527
+  tps: 5579.63917
   hps: 60.92312
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8143.40609
-  tps: 5788.9154
+  dps: 8143.75669
+  tps: 5789.17344
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7888.73493
-  tps: 5612.2992
+  dps: 7888.49602
+  tps: 5612.12336
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6642.17105
-  tps: 4725.96337
+  dps: 6642.25464
+  tps: 4726.02489
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6602.56012
-  tps: 4703.8792
+  dps: 6602.72768
+  tps: 4704.00252
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6363.48656
-  tps: 4528.91894
+  dps: 6364.21487
+  tps: 4529.45497
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8122.85103
-  tps: 5658.31114
+  dps: 8123.25745
+  tps: 5658.60428
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8304.93682
-  tps: 5907.80202
+  dps: 8305.30828
+  tps: 5908.07541
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8304.93682
-  tps: 5907.80202
+  dps: 8305.30828
+  tps: 5908.07541
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8309.21891
-  tps: 5910.95364
+  dps: 8309.59544
+  tps: 5911.23076
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7951.17842
-  tps: 5675.26997
+  dps: 7951.06154
+  tps: 5675.18395
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 8004.32419
-  tps: 5714.38526
+  dps: 8001.99899
+  tps: 5712.67391
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 8092.96844
-  tps: 5758.21655
+  dps: 8093.34415
+  tps: 5758.49307
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7694.6311
-  tps: 5473.90562
+  dps: 7693.71991
+  tps: 5473.23498
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkrunedPlate"
  value: {
-  dps: 6776.55865
-  tps: 4810.87317
+  dps: 6776.76102
+  tps: 4811.02212
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7722.47117
-  tps: 5479.1073
+  dps: 7722.8415
+  tps: 5479.37986
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8514.51523
-  tps: 6053.48738
+  dps: 8515.08259
+  tps: 6053.90496
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7927.91581
-  tps: 5658.14869
+  dps: 7927.79252
+  tps: 5658.05795
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8347.36387
-  tps: 5957.23775
+  dps: 8347.31967
+  tps: 5957.20522
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8355.13042
-  tps: 5963.68069
+  dps: 8355.30695
+  tps: 5963.81062
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8147.50743
-  tps: 5791.93399
+  dps: 8147.85803
+  tps: 5792.19203
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 8028.43738
-  tps: 5727.98035
+  dps: 8028.51028
+  tps: 5728.034
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7980.993
-  tps: 5690.53511
+  dps: 7981.02822
+  tps: 5690.56103
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8122.85103
-  tps: 5773.78688
+  dps: 8123.25745
+  tps: 5774.086
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8122.85103
-  tps: 5773.78688
+  dps: 8123.25745
+  tps: 5774.086
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8143.40609
-  tps: 5788.9154
+  dps: 8143.75669
+  tps: 5789.17344
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8139.57036
-  tps: 5786.0923
+  dps: 8139.91618
+  tps: 5786.34682
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7939.1506
-  tps: 5656.70082
+  dps: 7939.38838
+  tps: 5656.87582
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8122.85103
-  tps: 5773.78688
+  dps: 8123.25745
+  tps: 5774.086
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7997.47283
-  tps: 5709.34265
+  dps: 7997.15272
+  tps: 5709.10705
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7934.95555
-  tps: 5663.32994
+  dps: 7934.83739
+  tps: 5663.24297
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7913.0442
-  tps: 5647.20318
+  dps: 7912.91838
+  tps: 5647.11058
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8122.85103
-  tps: 5773.78688
+  dps: 8123.25745
+  tps: 5774.086
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8122.85103
-  tps: 5773.78688
+  dps: 8123.25745
+  tps: 5774.086
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7723.32429
-  tps: 5479.7352
+  dps: 7723.69439
+  tps: 5480.00759
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8074.95001
-  tps: 5766.36586
+  dps: 8074.81225
+  tps: 5766.26446
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7940.09374
-  tps: 5667.11164
+  dps: 7940.14683
+  tps: 5667.15072
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7720.56264
-  tps: 5477.70262
+  dps: 7720.93332
+  tps: 5477.97544
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8143.40609
-  tps: 5788.9154
+  dps: 8143.75669
+  tps: 5789.17344
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8139.57036
-  tps: 5786.0923
+  dps: 8139.91618
+  tps: 5786.34682
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8029.3912
-  tps: 5732.83458
+  dps: 8029.24483
+  tps: 5732.72685
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8122.85103
-  tps: 5773.78688
+  dps: 8123.25745
+  tps: 5774.086
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8155.80262
-  tps: 5798.03925
+  dps: 8156.43406
+  tps: 5798.50399
   hps: 12.85179
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8028.66379
-  tps: 5727.28073
+  dps: 8028.42666
+  tps: 5727.1062
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7908.05378
-  tps: 5643.53024
+  dps: 7907.90013
+  tps: 5643.41715
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8149.53545
-  tps: 5793.42661
+  dps: 8149.94127
+  tps: 5793.7253
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8155.81414
-  tps: 5798.04772
+  dps: 8156.21982
+  tps: 5798.34631
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8122.85103
-  tps: 5773.78688
+  dps: 8123.25745
+  tps: 5774.086
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8122.85103
-  tps: 5773.78688
+  dps: 8123.25745
+  tps: 5774.086
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7831.92025
-  tps: 5587.49596
+  dps: 7832.25696
+  tps: 5587.74378
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7833.69131
-  tps: 5588.79946
+  dps: 7834.02802
+  tps: 5589.04728
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8304.93682
-  tps: 5907.80202
+  dps: 8305.30828
+  tps: 5908.07541
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7724.3196
-  tps: 5480.46775
+  dps: 7724.68944
+  tps: 5480.73994
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8122.85103
-  tps: 5773.78688
+  dps: 8123.25745
+  tps: 5774.086
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7720.2958
-  tps: 5477.50623
+  dps: 7720.66657
+  tps: 5477.77911
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7468.58523
-  tps: 5317.16155
+  dps: 7469.39241
+  tps: 5317.75563
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ScourgebornePlate"
  value: {
-  dps: 6640.67171
-  tps: 4712.46772
+  dps: 6639.94035
+  tps: 4711.92944
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8550.59549
-  tps: 6098.07635
+  dps: 8551.22254
+  tps: 6098.53786
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7082.74151
-  tps: 5024.28103
+  dps: 7082.59944
+  tps: 5024.17647
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8304.93682
-  tps: 5907.80202
+  dps: 8305.30828
+  tps: 5908.07541
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7718.20556
-  tps: 5475.96781
+  dps: 7718.57702
+  tps: 5476.2412
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7725.06162
-  tps: 5481.01387
+  dps: 7725.43308
+  tps: 5481.28726
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7718.20556
-  tps: 5475.96781
+  dps: 7718.57702
+  tps: 5476.2412
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8179.60117
-  tps: 5801.28107
+  dps: 8179.96273
+  tps: 5801.54718
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7718.20556
-  tps: 5475.96781
+  dps: 7718.57702
+  tps: 5476.2412
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 8219.62405
-  tps: 5829.38188
+  dps: 8219.98859
+  tps: 5829.65018
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7718.20556
-  tps: 5475.96781
+  dps: 7718.57702
+  tps: 5476.2412
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7939.44042
-  tps: 5666.6308
+  dps: 7939.33278
+  tps: 5666.55158
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SparkofLife-37657"
  value: {
-  dps: 7851.24902
-  tps: 5600.00964
+  dps: 7851.0663
+  tps: 5599.87516
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7941.61686
-  tps: 5666.7277
+  dps: 7941.70471
+  tps: 5666.79236
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-StormshroudArmor"
  value: {
-  dps: 6330.75083
-  tps: 4506.49544
+  dps: 6330.71593
+  tps: 4506.46975
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8155.81414
-  tps: 5798.04772
+  dps: 8156.21982
+  tps: 5798.34631
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8149.53545
-  tps: 5793.42661
+  dps: 8149.94127
+  tps: 5793.7253
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8138.54775
-  tps: 5785.33966
+  dps: 8138.95381
+  tps: 5785.63853
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7714.15061
-  tps: 5489.33622
+  dps: 7714.1379
+  tps: 5489.32686
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6671.75521
-  tps: 4734.98568
+  dps: 6671.44347
+  tps: 4734.75623
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7266.38732
-  tps: 5155.02981
+  dps: 7267.62106
+  tps: 5155.93784
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8216.83678
-  tps: 5839.33219
+  dps: 8217.37528
+  tps: 5839.72852
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7978.39258
-  tps: 5692.39772
+  dps: 7978.04735
+  tps: 5692.14364
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8042.36564
-  tps: 5742.42468
+  dps: 8042.49373
+  tps: 5742.51895
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8122.85103
-  tps: 5773.78688
+  dps: 8123.25745
+  tps: 5774.086
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8122.85103
-  tps: 5773.78688
+  dps: 8123.25745
+  tps: 5774.086
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7824.9447
-  tps: 5580.51099
+  dps: 7825.05004
+  tps: 5580.58852
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8122.85103
-  tps: 5773.78688
+  dps: 8123.25745
+  tps: 5774.086
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8122.85103
-  tps: 5773.78688
+  dps: 8123.25745
+  tps: 5774.086
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6567.42066
-  tps: 4680.2074
+  dps: 6567.49024
+  tps: 4680.25861
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7781.06221
-  tps: 5522.1904
+  dps: 7780.04771
+  tps: 5521.44374
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7821.46433
-  tps: 5579.8004
+  dps: 7821.33059
+  tps: 5579.70197
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7725.4571
-  tps: 5481.30494
+  dps: 7725.82663
+  tps: 5481.57692
  }
 }
 dps_results: {
  key: "TestFrostUH-Average-Default"
  value: {
-  dps: 8245.73303
-  tps: 5867.52057
+  dps: 8246.0035
+  tps: 5867.70094
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20766.47231
-  tps: 15098.05287
+  dps: 20762.20648
+  tps: 15094.91322
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8251.67231
-  tps: 5879.58488
+  dps: 8251.82769
+  tps: 5879.69924
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9524.69062
-  tps: 6537.32454
+  dps: 9521.00823
+  tps: 6534.6143
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10479.16044
-  tps: 7596.85393
+  dps: 10487.82054
+  tps: 7603.22776
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4820.43631
-  tps: 3424.30787
+  dps: 4820.90909
+  tps: 3424.65584
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5216.23658
-  tps: 3586.01612
+  dps: 5213.6593
+  tps: 3584.11924
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 24934.66954
-  tps: 18134.1589
+  dps: 24935.39063
+  tps: 18134.68962
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10090.32765
-  tps: 7203.66591
+  dps: 10090.8873
+  tps: 7204.07782
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11849.94951
-  tps: 8171.20654
+  dps: 11847.23215
+  tps: 8169.20657
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12653.40094
-  tps: 9177.74252
+  dps: 12657.86202
+  tps: 9181.02588
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5808.67531
-  tps: 4135.45338
+  dps: 5808.61217
+  tps: 4135.40691
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6572.64775
-  tps: 4541.77698
+  dps: 6569.58974
+  tps: 4539.52628
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20247.66038
-  tps: 14706.55005
+  dps: 20245.62442
+  tps: 14705.05158
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8304.93682
-  tps: 5907.80202
+  dps: 8305.30828
+  tps: 5908.07541
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9611.01827
-  tps: 6578.16616
+  dps: 9606.9489
+  tps: 6575.1711
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10295.16525
-  tps: 7454.85678
+  dps: 10300.18837
+  tps: 7458.5538
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4733.78377
-  tps: 3358.70956
+  dps: 4734.27667
+  tps: 3358.78091
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5226.44895
-  tps: 3582.96025
+  dps: 5223.6873
+  tps: 3580.92768
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25216.64963
-  tps: 18329.12742
+  dps: 25213.99448
+  tps: 18327.17323
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10151.28952
-  tps: 7233.94527
+  dps: 10151.3607
+  tps: 7233.99766
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11914.93695
-  tps: 8190.43772
+  dps: 11913.12306
+  tps: 8189.1027
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12744.55344
-  tps: 9237.81888
+  dps: 12750.24484
+  tps: 9242.00776
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5821.64314
-  tps: 4138.43265
+  dps: 5821.26756
+  tps: 4138.15623
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6601.4307
-  tps: 4549.03977
+  dps: 6598.37746
+  tps: 4546.79259
  }
 }
 dps_results: {
  key: "TestFrostUH-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7406.32932
-  tps: 5266.95394
+  dps: 7405.43937
+  tps: 5266.29894
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -62,16 +62,16 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8048.65606
-  tps: 5114.01737
+  dps: 8054.03974
+  tps: 5121.43929
   hps: 271.50279
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7739.50627
-  tps: 5016.46852
+  dps: 7739.1898
+  tps: 5016.19834
   hps: 265.28534
  }
 }
@@ -94,72 +94,72 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8070.24477
-  tps: 5136.11941
+  dps: 8076.8553
+  tps: 5144.34369
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7839.71346
-  tps: 4956.91505
+  dps: 7840.86614
+  tps: 4956.58172
   hps: 262.83591
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6580.14138
-  tps: 4206.05287
+  dps: 6582.06319
+  tps: 4209.19038
   hps: 236.44059
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6429.05423
-  tps: 4159.56255
+  dps: 6429.80898
+  tps: 4159.72526
   hps: 224.37409
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6214.32585
-  tps: 3980.56596
-  hps: 223.18668
+  dps: 6219.67125
+  tps: 3985.64033
+  hps: 223.72126
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8048.65606
-  tps: 5011.73702
+  dps: 8054.03974
+  tps: 5019.0105
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8125.18937
-  tps: 5188.16907
+  dps: 8132.58248
+  tps: 5196.3143
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8125.18937
-  tps: 5188.16907
+  dps: 8132.58248
+  tps: 5196.3143
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8139.47752
-  tps: 5202.4886
+  dps: 8146.3426
+  tps: 5211.04766
   hps: 266.55313
  }
 }
@@ -198,41 +198,41 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7669.46094
-  tps: 4976.66083
-  hps: 265.60229
+  dps: 7666.49191
+  tps: 4977.61234
+  hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7880.53683
-  tps: 5026.05584
+  dps: 7887.56507
+  tps: 5033.86727
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7684.30773
-  tps: 4967.93692
+  dps: 7685.5005
+  tps: 4969.12432
   hps: 279.31941
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 6747.60487
-  tps: 4299.4633
-  hps: 296.38143
+  dps: 6754.34188
+  tps: 4305.21747
+  hps: 296.02733
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8374.65138
-  tps: 5354.66548
-  hps: 266.55313
+  dps: 8371.53624
+  tps: 5352.67001
+  hps: 267.18703
  }
 }
 dps_results: {
@@ -270,8 +270,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8071.83069
-  tps: 5138.52308
+  dps: 8078.67869
+  tps: 5146.80397
   hps: 266.55313
  }
 }
@@ -294,32 +294,32 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8048.65606
-  tps: 5114.01737
+  dps: 8054.03974
+  tps: 5121.43929
   hps: 271.50279
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8048.65606
-  tps: 5114.01737
+  dps: 8054.03974
+  tps: 5121.43929
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8070.24477
-  tps: 5136.11941
+  dps: 8076.8553
+  tps: 5144.34369
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8066.39183
-  tps: 5132.80472
+  dps: 8073.58624
+  tps: 5140.69415
   hps: 266.55313
  }
 }
@@ -342,17 +342,17 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8048.65606
-  tps: 5114.01737
+  dps: 8054.03974
+  tps: 5121.43929
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7678.07308
-  tps: 4972.1548
-  hps: 267.18703
+  dps: 7662.00206
+  tps: 4971.62835
+  hps: 265.60229
  }
 }
 dps_results: {
@@ -390,24 +390,24 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8048.65606
-  tps: 5114.01737
+  dps: 8054.03974
+  tps: 5121.43929
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8048.65606
-  tps: 5114.01737
+  dps: 8054.03974
+  tps: 5121.43929
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 8142.32998
-  tps: 5201.78386
+  dps: 8149.70581
+  tps: 5209.94413
   hps: 266.55313
  }
 }
@@ -454,8 +454,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 8089.10383
-  tps: 5159.26166
+  dps: 8096.83413
+  tps: 5167.29821
   hps: 266.55313
  }
 }
@@ -470,16 +470,16 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8070.24477
-  tps: 5136.11941
+  dps: 8076.8553
+  tps: 5144.34369
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8066.39183
-  tps: 5132.80472
+  dps: 8073.58624
+  tps: 5140.69415
   hps: 266.55313
  }
 }
@@ -494,16 +494,16 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8048.65606
-  tps: 5114.01737
+  dps: 8054.03974
+  tps: 5121.43929
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8083.57566
-  tps: 5142.05231
+  dps: 8088.90494
+  tps: 5149.5227
   hps: 279.42181
  }
 }
@@ -542,16 +542,16 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8076.81617
-  tps: 5136.62865
+  dps: 8082.20552
+  tps: 5144.08436
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8083.44208
-  tps: 5141.94895
+  dps: 8088.83277
+  tps: 5149.41261
   hps: 266.55313
  }
 }
@@ -574,16 +574,16 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8048.65606
-  tps: 5114.01737
+  dps: 8054.03974
+  tps: 5121.43929
   hps: 270.57473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8048.65606
-  tps: 5114.01737
+  dps: 8054.03974
+  tps: 5121.43929
   hps: 271.50279
  }
 }
@@ -614,24 +614,24 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8125.18937
-  tps: 5188.16907
+  dps: 8132.58248
+  tps: 5196.3143
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 8162.32735
-  tps: 5217.66777
+  dps: 8169.68303
+  tps: 5225.84559
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8048.65606
-  tps: 5114.01737
+  dps: 8054.03974
+  tps: 5121.43929
   hps: 266.55313
  }
 }
@@ -646,40 +646,40 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 8083.48598
-  tps: 5154.82653
+  dps: 8091.18866
+  tps: 5162.86805
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7300.76191
-  tps: 4679.67581
+  dps: 7297.4812
+  tps: 4673.00794
   hps: 260.21107
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6688.9199
-  tps: 4257.65208
-  hps: 271.75087
+  dps: 6673.34388
+  tps: 4242.74485
+  hps: 272.07554
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8055.18775
-  tps: 5337.98829
-  hps: 293.99885
+  dps: 8062.37078
+  tps: 5349.64363
+  hps: 293.64548
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7317.40837
-  tps: 4811.75437
+  dps: 7307.27834
+  tps: 4798.18123
   hps: 312.89006
  }
 }
@@ -694,8 +694,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8125.18937
-  tps: 5188.16907
+  dps: 8132.58248
+  tps: 5196.3143
   hps: 266.55313
  }
 }
@@ -710,56 +710,56 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 8039.47948
-  tps: 5120.08471
+  dps: 8046.96581
+  tps: 5128.16517
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 8051.60895
-  tps: 5131.83825
+  dps: 8059.05236
+  tps: 5139.9964
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 8039.47948
-  tps: 5120.08471
+  dps: 8046.96581
+  tps: 5128.16517
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8039.47948
-  tps: 5120.08471
+  dps: 8046.96581
+  tps: 5128.16517
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 8039.47948
-  tps: 5120.08471
+  dps: 8046.96581
+  tps: 5128.16517
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 8039.47948
-  tps: 5120.08471
+  dps: 8046.96581
+  tps: 5128.16517
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 8039.47948
-  tps: 5120.08471
+  dps: 8046.96581
+  tps: 5128.16517
   hps: 266.55313
  }
 }
@@ -822,32 +822,32 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-StormshroudArmor"
  value: {
-  dps: 6104.62897
-  tps: 3936.15186
+  dps: 6103.51429
+  tps: 3935.07396
   hps: 207.55745
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8083.44208
-  tps: 5141.94895
+  dps: 8088.83277
+  tps: 5149.41261
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8076.81617
-  tps: 5136.62865
+  dps: 8082.20552
+  tps: 5144.08436
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8065.22083
-  tps: 5127.31812
+  dps: 8070.60785
+  tps: 5134.75992
   hps: 266.55313
  }
 }
@@ -870,17 +870,17 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7874.97337
-  tps: 5135.47329
+  dps: 7876.55987
+  tps: 5136.64256
   hps: 276.80769
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6797.66959
-  tps: 4325.64233
-  hps: 292.42209
+  dps: 6796.39951
+  tps: 4324.83817
+  hps: 291.7275
  }
 }
 dps_results: {
@@ -894,16 +894,16 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7480.35766
-  tps: 4720.17302
-  hps: 255.59126
+  dps: 7483.55118
+  tps: 4723.22594
+  hps: 254.97759
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8098.348
-  tps: 5130.44281
+  dps: 8098.89189
+  tps: 5130.86572
   hps: 266.87008
  }
 }
@@ -926,16 +926,16 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8048.65606
-  tps: 5114.01737
+  dps: 8054.03974
+  tps: 5121.43929
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8048.65606
-  tps: 5114.01737
+  dps: 8054.03974
+  tps: 5121.43929
   hps: 266.55313
  }
 }
@@ -950,32 +950,32 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8048.65606
-  tps: 5114.01737
+  dps: 8054.03974
+  tps: 5121.43929
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8048.65606
-  tps: 5114.01737
+  dps: 8054.03974
+  tps: 5121.43929
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6450.27076
-  tps: 4174.14739
+  dps: 6451.08804
+  tps: 4173.48806
   hps: 233.66417
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7810.46852
-  tps: 4950.03291
+  dps: 7811.71729
+  tps: 4951.27572
   hps: 268.3631
  }
 }
@@ -990,216 +990,216 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 8185.18149
-  tps: 5235.82082
+  dps: 8192.51414
+  tps: 5244.0187
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 8111.8275
-  tps: 5181.551
-  hps: 265.92605
+  dps: 8111.15263
+  tps: 5180.73157
+  hps: 265.83616
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 37002.69445
-  tps: 39837.53652
+  dps: 36990.15045
+  tps: 39810.66029
   hps: 264.81464
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7949.43082
-  tps: 5166.76244
-  hps: 265.1314
+  dps: 7954.23713
+  tps: 5174.07756
+  hps: 265.76493
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11380.10088
-  tps: 5697.43737
+  dps: 11374.00242
+  tps: 5692.01667
   hps: 229.65384
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 21909.8768
-  tps: 24056.02182
-  hps: 158.32685
+  dps: 22020.42797
+  tps: 24165.04585
+  hps: 159.09171
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3913.43615
-  tps: 2806.15471
-  hps: 162.34238
+  dps: 3907.76681
+  tps: 2801.53951
+  hps: 161.57752
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5008.5193
-  tps: 2897.63332
-  hps: 138.6316
+  dps: 4987.60013
+  tps: 2876.85913
+  hps: 140.54376
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 47472.80814
-  tps: 51339.17834
-  hps: 322.72748
+  dps: 47596.14182
+  tps: 51424.92833
+  hps: 324.29984
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10288.57272
-  tps: 6803.94317
+  dps: 10289.6107
+  tps: 6805.18552
   hps: 329.80311
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14343.78646
-  tps: 7446.47713
+  dps: 14337.81316
+  tps: 7442.34525
   hps: 277.12896
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 29559.52102
-  tps: 32650.94862
-  hps: 211.31998
+  dps: 29508.53618
+  tps: 32625.20471
+  hps: 211.57427
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5359.711
-  tps: 3922.45439
+  dps: 5361.22272
+  tps: 3922.40309
   hps: 211.82857
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6651.96422
-  tps: 4011.2016
+  dps: 6648.67952
+  tps: 4008.85109
   hps: 191.99348
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 37231.75036
-  tps: 39894.00472
+  dps: 37209.80203
+  tps: 39870.21745
   hps: 263.06671
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8125.18937
-  tps: 5188.16907
+  dps: 8132.58248
+  tps: 5196.3143
   hps: 266.55313
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11816.71493
-  tps: 5786.33461
+  dps: 11810.47267
+  tps: 5781.27367
   hps: 231.37192
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 22146.6096
-  tps: 24261.39418
-  hps: 158.4527
+  dps: 22270.01472
+  tps: 24399.63588
+  hps: 160.55775
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3998.36075
-  tps: 2825.75341
-  hps: 159.40954
+  dps: 3992.64896
+  tps: 2822.46989
+  hps: 159.79228
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5179.32291
-  tps: 2931.37351
-  hps: 138.7418
+  dps: 5158.1421
+  tps: 2910.16729
+  hps: 140.65548
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 47586.45262
-  tps: 51246.54095
+  dps: 47598.49363
+  tps: 51267.2548
   hps: 323.27175
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10501.61009
-  tps: 6840.29464
+  dps: 10499.51539
+  tps: 6841.52201
   hps: 326.41795
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14839.59422
-  tps: 7544.10508
+  dps: 14833.8244
+  tps: 7540.13009
   hps: 269.39313
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 29653.73126
-  tps: 32737.42104
-  hps: 211.95518
+  dps: 29679.32682
+  tps: 32765.84614
+  hps: 213.48187
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5420.80855
-  tps: 3894.44162
-  hps: 214.24522
+  dps: 5423.21644
+  tps: 3900.35678
+  hps: 214.49966
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6801.53118
-  tps: 4004.35276
+  dps: 6797.25344
+  tps: 4000.29188
   hps: 183.20256
  }
 }
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7747.07781
-  tps: 5017.46043
+  dps: 7746.5082
+  tps: 5016.81945
   hps: 265.91924
  }
 }

--- a/sim/deathknight/dps/dps_deathknight.go
+++ b/sim/deathknight/dps/dps_deathknight.go
@@ -341,7 +341,7 @@ func (dk *DpsDeathknight) gargoyleHasteCooldownSync(actionID core.ActionID, isPo
 
 		majorCd.ShouldActivate = func(sim *core.Simulation, character *core.Character) bool {
 			if !dk.Rotation.PreNerfedGargoyle {
-				aura := dk.GetAura("Summon Gargoyle")
+				aura := dk.SummonGargoyleAura
 
 				if aura != nil && aura.IsActive() {
 					return true

--- a/sim/deathknight/dps/dps_deathknight.go
+++ b/sim/deathknight/dps/dps_deathknight.go
@@ -70,13 +70,13 @@ func NewDpsDeathknight(character core.Character, player *proto.Player) *DpsDeath
 		MainHand:       dpsDk.WeaponFromMainHand(dpsDk.DefaultMeleeCritMultiplier()),
 		OffHand:        dpsDk.WeaponFromOffHand(dpsDk.DefaultMeleeCritMultiplier()),
 		AutoSwingMelee: true,
-		ReplaceMHSwing: func(sim *core.Simulation, mhSwingSpell *core.Spell) *core.Spell {
-			if dpsDk.RuneStrike.CanCast(sim, nil) {
-				return dpsDk.RuneStrike
-			} else {
-				return nil
-			}
-		},
+		// ReplaceMHSwing: func(sim *core.Simulation, mhSwingSpell *core.Spell) *core.Spell {
+		// 	if dpsDk.RuneStrike.CanCast(sim, nil) {
+		// 		return dpsDk.RuneStrike
+		// 	} else {
+		// 		return nil
+		// 	}
+		// },
 	})
 
 	if dpsDk.Talents.SummonGargoyle && dpsDk.Rotation.UseGargoyle && dpsDk.Rotation.EnableWeaponSwap {

--- a/sim/deathknight/dps/rotation_unholy.go
+++ b/sim/deathknight/dps/rotation_unholy.go
@@ -467,12 +467,12 @@ func (dk *DpsDeathknight) RotationActionUH_BS(sim *core.Simulation, target *core
 
 	bloodPresenceSwitch := false
 	// Go back to Blood Presence after Gargoyle
-	if !dk.Rotation.PreNerfedGargoyle && !dk.SummonGargoyle.IsReady(sim) && dk.Rotation.Presence == proto.Deathknight_Rotation_Blood && dk.Rotation.GargoylePresence == proto.Deathknight_Rotation_Unholy && dk.PresenceMatches(deathknight.UnholyPresence) && !dk.HasActiveAura("Summon Gargoyle") {
+	if !dk.Rotation.PreNerfedGargoyle && !dk.SummonGargoyle.IsReady(sim) && dk.Rotation.Presence == proto.Deathknight_Rotation_Blood && dk.Rotation.GargoylePresence == proto.Deathknight_Rotation_Unholy && dk.PresenceMatches(deathknight.UnholyPresence) && !dk.SummonGargoyleAura.IsActive() {
 		bloodPresenceSwitch = true
 	}
 
 	// Do not switch presences if gargoyle is still up if it's nerfed gargoyle
-	if !dk.Rotation.PreNerfedGargoyle && !dk.HasActiveAura("Summon Gargoyle") {
+	if !dk.Rotation.PreNerfedGargoyle && !dk.SummonGargoyleAura.IsActive() {
 		// Go back to Blood Presence after Bloodlust
 		if dk.Rotation.Presence == proto.Deathknight_Rotation_Blood && dk.Rotation.BlPresence == proto.Deathknight_Rotation_Unholy && dk.PresenceMatches(deathknight.UnholyPresence) && !dk.HasActiveAuraWithTag("Bloodlust") {
 			bloodPresenceSwitch = true

--- a/sim/deathknight/dps/rotation_unholy_helper.go
+++ b/sim/deathknight/dps/rotation_unholy_helper.go
@@ -138,7 +138,7 @@ func (dk *DpsDeathknight) weaponSwapCheck(sim *core.Simulation) bool {
 	}
 
 	// Swap if gargoyle will still be on CD for full ICD or if gargoyle is already active
-	shouldSwapBm := dk.ur.bmIcd < sim.CurrentTime && (dk.SummonGargoyle.CD.TimeToReady(sim) > 45*time.Second || dk.HasActiveAura("Summon Gargoyle"))
+	shouldSwapBm := dk.ur.bmIcd < sim.CurrentTime && (dk.SummonGargoyle.CD.TimeToReady(sim) > 45*time.Second || dk.SummonGargoyleAura.IsActive())
 	shouldSwapBackFromBm := dk.HasActiveAura("Black Magic Proc") // || dk.GetAura("Rune Of The Fallen Crusader Proc").RemainingDuration(sim) < 5*time.Second
 
 	if dk.ur.mhSwap == WeaponSwap_BlackMagic {
@@ -394,7 +394,7 @@ func (dk *DpsDeathknight) uhGargoyleCheck(sim *core.Simulation, target *core.Uni
 	}
 
 	// Go back to Unholy Presence after Gargoyle
-	if !dk.Rotation.PreNerfedGargoyle && !dk.SummonGargoyle.IsReady(sim) && dk.Rotation.Presence == proto.Deathknight_Rotation_Unholy && dk.Rotation.GargoylePresence == proto.Deathknight_Rotation_Blood && dk.PresenceMatches(deathknight.BloodPresence) && !dk.HasActiveAura("Summon Gargoyle") {
+	if !dk.Rotation.PreNerfedGargoyle && !dk.SummonGargoyle.IsReady(sim) && dk.Rotation.Presence == proto.Deathknight_Rotation_Unholy && dk.Rotation.GargoylePresence == proto.Deathknight_Rotation_Blood && dk.PresenceMatches(deathknight.BloodPresence) && !dk.SummonGargoyleAura.IsActive() {
 		if dk.BloodTapAura.IsActive() {
 			dk.BloodTapAura.Deactivate(sim)
 		}
@@ -402,7 +402,7 @@ func (dk *DpsDeathknight) uhGargoyleCheck(sim *core.Simulation, target *core.Uni
 	}
 
 	// Do not switch presences if gargoyle is still up if it's nerfed gargoyle
-	if !dk.Rotation.PreNerfedGargoyle && dk.HasActiveAura("Summon Gargoyle") {
+	if !dk.Rotation.PreNerfedGargoyle && dk.SummonGargoyleAura.IsActive() {
 		return false
 	}
 

--- a/sim/deathknight/summon_gargoyle.go
+++ b/sim/deathknight/summon_gargoyle.go
@@ -12,7 +12,7 @@ func (dk *Deathknight) registerSummonGargoyleCD() {
 		return
 	}
 
-	summonGargoyleAura := dk.RegisterAura(core.Aura{
+	dk.SummonGargoyleAura = dk.RegisterAura(core.Aura{
 		Label:    "Summon Gargoyle",
 		ActionID: core.ActionID{SpellID: 49206},
 		Duration: time.Second * 30,
@@ -48,7 +48,7 @@ func (dk *Deathknight) registerSummonGargoyleCD() {
 			dk.Gargoyle.updateCastSpeed()
 
 			// Add a dummy aura to show in metrics
-			summonGargoyleAura.Activate(sim)
+			dk.SummonGargoyleAura.Activate(sim)
 
 			// Start casting after a 2.5s delay to simulate the summon animation
 			pa := core.PendingAction{


### PR DESCRIPTION
only a tiny bit

1. added a no-on-dmg-dealt flag to spells that proc nothing (no need to iterate auras then)
2. dont check for AA replace on runestrike for dps dk
3. make necrosis its own AA function to get rid of extra wrapping
4. have UH dk use aura reference directly instead of doing a lookup all the time.
