### PR TITLE
Fix Multi-Target Ignoring Blade Flurry

### DIFF
--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -516,6 +516,12 @@ func (rogue *Rogue) registerBladeFlurryCD() {
 		Type:     core.CooldownTypeDPS,
 		Priority: core.CooldownPriorityDefault,
 		ShouldActivate: func(sim *core.Simulation, character *core.Character) bool {
+
+			if rogue.Rotation.MultiTargetSliceFrequency == proto.Rogue_Rotation_Never {
+				// Well let's just cast BF now, no need to optimize around slices that will never be cast
+				return true
+			}
+
 			if sim.GetRemainingDuration() > cooldownDur+dur {
 				// We'll have enough time to cast another BF, so use it immediately to make sure we get the 2nd one.
 				return true


### PR DESCRIPTION
The activation condition for Blade Flurry included a check for an active Slice and Dice - this check was never satisfied on aoe rotations that ignore Slice and Dice. This now slaps Blade Flurry back into the cooldown priority if you have opted to not cast Slice and Dice.