### PR TITLE
Change Tricks to start on Cooldown

### DIFF
--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -46,523 +46,523 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7448.83287
-  tps: 5288.67134
+  dps: 7442.95883
+  tps: 5284.50077
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7590.29787
-  tps: 5389.11149
+  dps: 7579.71726
+  tps: 5381.59926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7646.65833
-  tps: 5429.12741
+  dps: 7640.81686
+  tps: 5424.97997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7422.27295
-  tps: 5269.81379
-  hps: 60.07923
+  dps: 7410.04498
+  tps: 5261.13193
+  hps: 60.00695
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7422.27295
-  tps: 5269.81379
-  hps: 60.07923
+  dps: 7410.04498
+  tps: 5261.13193
+  hps: 60.00695
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7650.55705
-  tps: 5431.89551
+  dps: 7622.0864
+  tps: 5411.68134
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50035"
  value: {
-  dps: 4918.97032
-  tps: 3492.46893
+  dps: 4938.46113
+  tps: 3506.3074
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50692"
  value: {
-  dps: 4990.83279
-  tps: 3543.49128
+  dps: 5011.06761
+  tps: 3557.858
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5799.07092
-  tps: 4117.34035
+  dps: 5776.09324
+  tps: 4101.0262
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6981.37646
-  tps: 4956.77728
+  dps: 6943.00444
+  tps: 4929.53315
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7590.29787
-  tps: 5281.32926
+  dps: 7579.71726
+  tps: 5273.96727
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7774.21843
-  tps: 5519.69509
+  dps: 7745.23511
+  tps: 5499.11693
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7588.34644
-  tps: 5387.72597
+  dps: 7540.7164
+  tps: 5353.90864
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7620.21704
-  tps: 5410.3541
+  dps: 7581.97222
+  tps: 5383.20028
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7585.13491
-  tps: 5385.44579
+  dps: 7584.06449
+  tps: 5384.68579
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7993.78378
-  tps: 5675.58648
+  dps: 7989.7912
+  tps: 5672.75175
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7536.50297
-  tps: 5350.91711
+  dps: 7539.80095
+  tps: 5353.25868
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7861.22984
-  tps: 5581.47318
+  dps: 7843.13915
+  tps: 5568.6288
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7911.20246
-  tps: 5616.95374
+  dps: 7897.81651
+  tps: 5607.44972
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7656.8012
-  tps: 5436.32885
+  dps: 7625.23956
+  tps: 5413.92009
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7668.23891
-  tps: 5444.44963
+  dps: 7634.36317
+  tps: 5420.39785
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7640.04972
-  tps: 5424.4353
+  dps: 7610.97273
+  tps: 5403.79064
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7590.29787
-  tps: 5389.11149
+  dps: 7579.71726
+  tps: 5381.59926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7590.29787
-  tps: 5389.11149
+  dps: 7579.71726
+  tps: 5381.59926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7650.55705
-  tps: 5431.89551
+  dps: 7622.0864
+  tps: 5411.68134
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7645.59098
-  tps: 5428.3696
+  dps: 7615.57647
+  tps: 5407.05929
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7515.74689
-  tps: 5336.18029
+  dps: 7494.90058
+  tps: 5321.37941
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7590.29787
-  tps: 5389.11149
+  dps: 7579.71726
+  tps: 5381.59926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7594.788
-  tps: 5392.29948
+  dps: 7573.43699
+  tps: 5377.14026
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7562.74848
-  tps: 5369.55142
+  dps: 7529.49193
+  tps: 5345.93927
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7421.89641
-  tps: 5269.54645
+  dps: 7408.49464
+  tps: 5260.03119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7525.97994
-  tps: 5343.44576
+  dps: 7504.64967
+  tps: 5328.30127
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7590.29787
-  tps: 5389.11149
+  dps: 7579.71726
+  tps: 5381.59926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7590.29787
-  tps: 5389.11149
+  dps: 7579.71726
+  tps: 5381.59926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7702.53211
-  tps: 5468.7978
+  dps: 7689.70796
+  tps: 5459.69265
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7498.06822
-  tps: 5323.62844
+  dps: 7446.57373
+  tps: 5287.06735
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7572.70483
-  tps: 5376.62043
+  dps: 7555.42459
+  tps: 5364.35146
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-49982"
  value: {
-  dps: 7761.60532
-  tps: 5510.73978
+  dps: 7749.32525
+  tps: 5502.02093
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-50641"
  value: {
-  dps: 7761.60532
-  tps: 5510.73978
+  dps: 7749.32525
+  tps: 5502.02093
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7650.55705
-  tps: 5431.89551
+  dps: 7622.0864
+  tps: 5411.68134
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7645.59098
-  tps: 5428.3696
+  dps: 7615.57647
+  tps: 5407.05929
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7592.53403
-  tps: 5390.69916
+  dps: 7578.72308
+  tps: 5380.89339
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7590.29787
-  tps: 5389.11149
+  dps: 7579.71726
+  tps: 5381.59926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7630.40626
-  tps: 5417.58845
+  dps: 7609.68097
+  tps: 5402.87349
   hps: 9.14161
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7683.43824
-  tps: 5455.24115
+  dps: 7668.88974
+  tps: 5444.91171
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7455.23528
-  tps: 5293.21705
+  dps: 7445.72424
+  tps: 5286.46421
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7620.35584
-  tps: 5410.45265
+  dps: 7609.73179
+  tps: 5402.90957
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7627.42831
-  tps: 5415.4741
+  dps: 7616.79404
+  tps: 5407.92377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7590.29787
-  tps: 5389.11149
+  dps: 7579.71726
+  tps: 5381.59926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7590.29787
-  tps: 5389.11149
+  dps: 7579.71726
+  tps: 5381.59926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7624.97767
-  tps: 5413.73414
+  dps: 7614.44873
+  tps: 5406.2586
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7650.21309
-  tps: 5431.65129
+  dps: 7639.76752
+  tps: 5424.23494
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7761.60532
-  tps: 5510.73978
+  dps: 7749.32525
+  tps: 5502.02093
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7590.29787
-  tps: 5389.11149
+  dps: 7579.71726
+  tps: 5381.59926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
@@ -575,553 +575,553 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 5719.03636
-  tps: 4060.51582
+  dps: 5694.16625
+  tps: 4042.85804
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7565.55505
-  tps: 5371.54408
+  dps: 7539.62546
+  tps: 5353.13407
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 7556.35277
-  tps: 5365.01047
+  dps: 7495.32872
+  tps: 5321.68339
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7563.0495
-  tps: 5369.76514
+  dps: 7547.95957
+  tps: 5359.0513
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StormshroudArmor"
  value: {
-  dps: 6053.68041
-  tps: 4298.11309
+  dps: 6010.45405
+  tps: 4267.42238
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7627.42831
-  tps: 5415.4741
+  dps: 7616.79404
+  tps: 5407.92377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7620.35584
-  tps: 5410.45265
+  dps: 7609.73179
+  tps: 5402.90957
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7607.97903
-  tps: 5401.66511
+  dps: 7597.37287
+  tps: 5394.13474
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 7365.69472
-  tps: 5229.64325
+  dps: 7333.2554
+  tps: 5206.61133
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheFistsofFury"
  value: {
-  dps: 4227.34765
-  tps: 3001.41683
+  dps: 4257.43993
+  tps: 3022.78235
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7672.38129
-  tps: 5447.39071
+  dps: 7684.51052
+  tps: 5456.00247
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7882.45671
-  tps: 5596.54427
+  dps: 7841.17691
+  tps: 5567.2356
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7955.44865
-  tps: 5648.36854
+  dps: 7875.24155
+  tps: 5591.4215
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7590.29787
-  tps: 5389.11149
+  dps: 7579.71726
+  tps: 5381.59926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7590.29787
-  tps: 5389.11149
+  dps: 7579.71726
+  tps: 5381.59926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7459.75606
-  tps: 5296.4268
+  dps: 7442.8415
+  tps: 5284.41747
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7590.29787
-  tps: 5389.11149
+  dps: 7579.71726
+  tps: 5381.59926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7590.29787
-  tps: 5389.11149
+  dps: 7579.71726
+  tps: 5381.59926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6164.46072
-  tps: 4376.76711
+  dps: 6129.59313
+  tps: 4352.01112
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 7157.21494
-  tps: 5081.62261
+  dps: 7111.37969
+  tps: 5049.07958
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7421.95128
-  tps: 5269.58541
+  dps: 7409.66177
+  tps: 5260.85986
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 7773.30418
-  tps: 5519.04597
+  dps: 7753.14248
+  tps: 5504.73116
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28361.14643
-  tps: 20136.41396
+  dps: 28533.06445
+  tps: 20258.47576
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7761.60532
-  tps: 5510.73978
+  dps: 7749.32525
+  tps: 5502.02093
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8908.16218
-  tps: 6324.79515
+  dps: 8919.19581
+  tps: 6332.62903
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15371.20282
-  tps: 10913.554
+  dps: 15396.65926
+  tps: 10931.62808
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3749.75237
-  tps: 2662.32418
+  dps: 3734.78466
+  tps: 2651.69711
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3815.50047
-  tps: 2709.00534
+  dps: 3833.11268
+  tps: 2721.51
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21534.87875
-  tps: 15289.76391
+  dps: 21639.37601
+  tps: 15363.95696
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5063.93231
-  tps: 3595.39194
+  dps: 5052.76519
+  tps: 3587.46328
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5850.70964
-  tps: 4154.00385
+  dps: 5834.69772
+  tps: 4142.63538
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12930.61595
-  tps: 9180.73732
+  dps: 12966.5162
+  tps: 9206.2265
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2455.7035
-  tps: 1743.54948
+  dps: 2448.69119
+  tps: 1738.57075
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2581.42308
-  tps: 1832.81039
+  dps: 2594.43726
+  tps: 1842.05046
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27131.91561
-  tps: 19263.66008
+  dps: 27402.67821
+  tps: 19455.90153
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7339.08333
-  tps: 5210.74917
+  dps: 7324.09162
+  tps: 5200.10505
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8383.90693
-  tps: 5952.57392
+  dps: 8383.27524
+  tps: 5952.12542
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14728.80828
-  tps: 10457.45388
+  dps: 14799.15618
+  tps: 10507.40089
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3539.55267
-  tps: 2513.0824
+  dps: 3527.78463
+  tps: 2504.72709
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3577.29864
-  tps: 2539.88203
+  dps: 3593.61629
+  tps: 2551.46757
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18047.87407
-  tps: 12813.99059
+  dps: 18187.5719
+  tps: 12913.17605
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3806.24152
-  tps: 2702.43148
+  dps: 3835.03799
+  tps: 2722.87697
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4635.57465
-  tps: 3291.258
+  dps: 4668.71972
+  tps: 3314.791
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9352.08794
-  tps: 6639.98244
+  dps: 9400.15496
+  tps: 6674.11002
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1678.54219
-  tps: 1191.76496
+  dps: 1683.77264
+  tps: 1195.47857
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1774.22659
-  tps: 1259.70088
+  dps: 1772.75988
+  tps: 1258.65951
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28474.88576
-  tps: 20217.16889
+  dps: 28707.53957
+  tps: 20382.35309
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7797.6117
-  tps: 5536.30431
+  dps: 7782.3014
+  tps: 5525.43399
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9008.24352
-  tps: 6395.8529
+  dps: 9024.30649
+  tps: 6407.25761
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15452.69366
-  tps: 10971.4125
+  dps: 15470.10187
+  tps: 10983.77232
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3766.09546
-  tps: 2673.92778
+  dps: 3753.52033
+  tps: 2664.99943
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3857.36279
-  tps: 2738.72758
+  dps: 3875.80457
+  tps: 2751.82125
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21649.15041
-  tps: 15370.89679
+  dps: 21752.87183
+  tps: 15444.539
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5087.98341
-  tps: 3612.46822
+  dps: 5073.85266
+  tps: 3602.43539
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5920.21343
-  tps: 4203.35153
+  dps: 5905.88868
+  tps: 4193.18096
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13004.29574
-  tps: 9233.04998
+  dps: 13057.58722
+  tps: 9270.88693
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2467.7296
-  tps: 1752.08801
+  dps: 2461.10402
+  tps: 1747.38386
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2612.48554
-  tps: 1854.86473
+  dps: 2623.939
+  tps: 1862.99669
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27305.68158
-  tps: 19387.03392
+  dps: 27542.79019
+  tps: 19555.38103
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7371.2184
-  tps: 5233.56507
+  dps: 7352.35536
+  tps: 5220.1723
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8477.44985
-  tps: 6018.9894
+  dps: 8480.45745
+  tps: 6021.12479
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14816.41755
-  tps: 10519.65646
+  dps: 14897.66937
+  tps: 10577.34525
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3558.35416
-  tps: 2526.43145
+  dps: 3546.34315
+  tps: 2517.90364
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3615.36306
-  tps: 2566.90777
+  dps: 3630.24875
+  tps: 2577.47661
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18144.68646
-  tps: 12882.72739
+  dps: 18298.46729
+  tps: 12991.91178
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3824.19332
-  tps: 2715.17726
+  dps: 3853.99842
+  tps: 2736.33888
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4689.7131
-  tps: 3329.6963
+  dps: 4722.92501
+  tps: 3353.27676
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9415.80913
-  tps: 6685.22448
+  dps: 9467.35782
+  tps: 6721.82405
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1686.52541
-  tps: 1197.43304
+  dps: 1692.65905
+  tps: 1201.78793
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1795.38098
-  tps: 1274.7205
+  dps: 1793.83045
+  tps: 1273.61962
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7284.93475
-  tps: 5172.30367
+  dps: 7264.57011
+  tps: 5157.84478
  }
 }

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -46,537 +46,537 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 6397.57592
-  tps: 4542.2789
+  dps: 6413.67121
+  tps: 4553.70656
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6517.53498
-  tps: 4627.44984
+  dps: 6537.75931
+  tps: 4641.80911
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6583.28387
-  tps: 4674.13155
+  dps: 6595.2917
+  tps: 4682.65711
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6384.45482
-  tps: 4532.96292
-  hps: 88.8379
+  dps: 6396.91031
+  tps: 4541.80632
+  hps: 88.09446
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6384.45482
-  tps: 4532.96292
-  hps: 88.8379
+  dps: 6396.91031
+  tps: 4541.80632
+  hps: 88.09446
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6545.34835
-  tps: 4647.19733
+  dps: 6563.70365
+  tps: 4660.22959
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50035"
  value: {
-  dps: 6905.2226
-  tps: 4902.70805
+  dps: 6912.85891
+  tps: 4908.12982
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50692"
  value: {
-  dps: 7015.29901
-  tps: 4980.8623
+  dps: 7021.88234
+  tps: 4985.53646
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5078.34487
-  tps: 3605.62486
+  dps: 5101.79298
+  tps: 3622.27302
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6059.90405
-  tps: 4302.53188
+  dps: 6067.44946
+  tps: 4307.88911
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6517.53498
-  tps: 4534.90084
+  dps: 6537.75931
+  tps: 4548.97293
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6667.81402
-  tps: 4734.14795
+  dps: 6687.83113
+  tps: 4748.3601
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6667.81402
-  tps: 4734.14795
+  dps: 6687.83113
+  tps: 4748.3601
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6662.5646
-  tps: 4730.42087
+  dps: 6681.36128
+  tps: 4743.76651
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
   hps: 64
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6512.63756
-  tps: 4623.97267
+  dps: 6529.02096
+  tps: 4635.60488
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6545.42958
-  tps: 4647.255
+  dps: 6560.44785
+  tps: 4657.91798
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6532.77487
-  tps: 4638.27016
+  dps: 6552.3228
+  tps: 4652.14919
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6864.61462
-  tps: 4873.87638
+  dps: 6888.29452
+  tps: 4890.68911
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6490.13332
-  tps: 4607.99466
+  dps: 6505.23042
+  tps: 4618.7136
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6824.02998
-  tps: 4845.06128
+  dps: 6829.5578
+  tps: 4848.98604
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6869.89353
-  tps: 4877.6244
+  dps: 6883.70556
+  tps: 4887.43095
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6548.04369
-  tps: 4649.11102
+  dps: 6566.87001
+  tps: 4662.47771
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6600.03026
-  tps: 4686.02149
+  dps: 6628.75378
+  tps: 4706.41519
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6599.44903
-  tps: 4685.60881
+  dps: 6604.86644
+  tps: 4689.45517
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6517.53498
-  tps: 4627.44984
+  dps: 6537.75931
+  tps: 4641.80911
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6517.53498
-  tps: 4627.44984
+  dps: 6537.75931
+  tps: 4641.80911
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6545.34835
-  tps: 4647.19733
+  dps: 6563.70365
+  tps: 4660.22959
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6539.45768
-  tps: 4643.01495
+  dps: 6559.10419
+  tps: 4656.96397
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6533.49999
-  tps: 4638.785
+  dps: 6530.32413
+  tps: 4636.53013
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6517.53498
-  tps: 4627.44984
+  dps: 6537.75931
+  tps: 4641.80911
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6545.59749
-  tps: 4647.37422
+  dps: 6561.62711
+  tps: 4658.75525
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6496.20382
-  tps: 4612.30471
+  dps: 6513.16517
+  tps: 4624.34727
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6392.24999
-  tps: 4538.49749
+  dps: 6398.87834
+  tps: 4543.20362
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6470.93385
-  tps: 4594.36304
+  dps: 6486.77517
+  tps: 4605.61037
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6517.53498
-  tps: 4627.44984
+  dps: 6537.75931
+  tps: 4641.80911
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6517.53498
-  tps: 4627.44984
+  dps: 6537.75931
+  tps: 4641.80911
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6626.81102
-  tps: 4705.03583
+  dps: 6639.3952
+  tps: 4713.97059
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Gladiator'sVestments"
  value: {
-  dps: 6464.45276
-  tps: 4589.76146
+  dps: 6475.15189
+  tps: 4597.35784
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6520.45389
-  tps: 4629.52226
+  dps: 6535.80464
+  tps: 4640.4213
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-49982"
  value: {
-  dps: 6667.81402
-  tps: 4734.14795
+  dps: 6687.83113
+  tps: 4748.3601
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-50641"
  value: {
-  dps: 6667.81402
-  tps: 4734.14795
+  dps: 6687.83113
+  tps: 4748.3601
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6545.34835
-  tps: 4647.19733
+  dps: 6563.70365
+  tps: 4660.22959
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6539.45768
-  tps: 4643.01495
+  dps: 6559.10419
+  tps: 4656.96397
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6566.61385
-  tps: 4662.29583
+  dps: 6578.22371
+  tps: 4670.53884
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6517.53498
-  tps: 4627.44984
+  dps: 6537.75931
+  tps: 4641.80911
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6549.65914
-  tps: 4650.25799
+  dps: 6570.71184
+  tps: 4665.20541
   hps: 9.14161
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6612.76011
-  tps: 4695.05968
+  dps: 6630.33963
+  tps: 4707.54114
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6434.24221
-  tps: 4568.31197
+  dps: 6444.91058
+  tps: 4575.88651
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6543.47038
-  tps: 4645.86397
+  dps: 6563.74776
+  tps: 4660.26091
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6549.57282
-  tps: 4650.1967
+  dps: 6569.8627
+  tps: 4664.60251
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6517.53498
-  tps: 4627.44984
+  dps: 6537.75931
+  tps: 4641.80911
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6517.53498
-  tps: 4627.44984
+  dps: 6537.75931
+  tps: 4641.80911
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6530.06298
-  tps: 4636.34472
+  dps: 6543.36869
+  tps: 4645.79177
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6548.50271
-  tps: 4649.43692
+  dps: 6562.06076
+  tps: 4659.06314
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6667.81402
-  tps: 4734.14795
+  dps: 6687.83113
+  tps: 4748.3601
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6517.53498
-  tps: 4627.44984
+  dps: 6537.75931
+  tps: 4641.80911
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
@@ -589,574 +589,574 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6667.81402
-  tps: 4734.14795
+  dps: 6687.83113
+  tps: 4748.3601
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Slayer'sArmor"
  value: {
-  dps: 5015.96009
-  tps: 3561.33166
+  dps: 5024.82176
+  tps: 3567.62345
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6501.21086
-  tps: 4615.85971
+  dps: 6518.09402
+  tps: 4627.84675
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SparkofLife-37657"
  value: {
-  dps: 6483.14239
-  tps: 4603.0311
+  dps: 6490.43401
+  tps: 4608.20814
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6565.47453
-  tps: 4661.48692
+  dps: 6595.04013
+  tps: 4682.4785
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StormshroudArmor"
  value: {
-  dps: 5126.2974
-  tps: 3639.67115
+  dps: 5141.63375
+  tps: 3650.55996
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6549.57282
-  tps: 4650.1967
+  dps: 6569.8627
+  tps: 4664.60251
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6543.47038
-  tps: 4645.86397
+  dps: 6563.74776
+  tps: 4660.26091
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6532.7911
-  tps: 4638.28168
+  dps: 6553.04664
+  tps: 4652.66311
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6444.08709
-  tps: 4575.30183
+  dps: 6452.0614
+  tps: 4580.9636
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheFistsofFury"
  value: {
-  dps: 5864.97963
-  tps: 4164.13554
+  dps: 5874.61903
+  tps: 4170.97951
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5958.56634
-  tps: 4230.5821
+  dps: 5980.75695
+  tps: 4246.33744
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6617.08213
-  tps: 4698.12831
+  dps: 6619.29126
+  tps: 4699.69679
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6704.22511
-  tps: 4759.99983
+  dps: 6715.9823
+  tps: 4768.34744
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6755.87012
-  tps: 4796.66779
+  dps: 6756.66289
+  tps: 4797.23065
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6517.53498
-  tps: 4627.44984
+  dps: 6537.75931
+  tps: 4641.80911
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6517.53498
-  tps: 4627.44984
+  dps: 6537.75931
+  tps: 4641.80911
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6474.04877
-  tps: 4596.57463
+  dps: 6480.10632
+  tps: 4600.87549
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6517.53498
-  tps: 4627.44984
+  dps: 6537.75931
+  tps: 4641.80911
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6517.53498
-  tps: 4627.44984
+  dps: 6537.75931
+  tps: 4641.80911
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5372.965
-  tps: 3814.80515
+  dps: 5404.65792
+  tps: 3837.30712
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6278.622
-  tps: 4457.82162
+  dps: 6289.56927
+  tps: 4465.59418
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6202.96269
-  tps: 4404.10351
+  dps: 6228.82036
+  tps: 4422.46246
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6384.05666
-  tps: 4532.68023
+  dps: 6396.38797
+  tps: 4541.43546
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 6660.12173
-  tps: 4728.68643
+  dps: 6671.53884
+  tps: 4736.79258
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19291.55474
-  tps: 13697.00387
+  dps: 19371.78223
+  tps: 13753.96539
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4947.74988
-  tps: 3512.90241
+  dps: 4968.86622
+  tps: 3527.89501
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5762.90906
-  tps: 4091.66543
+  dps: 5845.1005
+  tps: 4150.02136
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11723.44322
-  tps: 8323.64469
+  dps: 11772.35547
+  tps: 8358.37238
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2472.10303
-  tps: 1755.19315
+  dps: 2475.48752
+  tps: 1757.59614
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2573.849
-  tps: 1827.43279
+  dps: 2615.82528
+  tps: 1857.23595
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21256.79272
-  tps: 15092.32283
+  dps: 21286.35667
+  tps: 15113.31324
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6667.81402
-  tps: 4734.14795
+  dps: 6687.83113
+  tps: 4748.3601
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7789.25093
-  tps: 5530.36816
+  dps: 7871.07925
+  tps: 5588.46627
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12390.08142
-  tps: 8796.95781
+  dps: 12447.87371
+  tps: 8837.99034
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3314.70343
-  tps: 2353.43944
+  dps: 3321.97027
+  tps: 2358.59889
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3403.98011
-  tps: 2416.82588
+  dps: 3456.48943
+  tps: 2454.1075
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20345.5176
-  tps: 14445.31749
+  dps: 20440.95482
+  tps: 14513.07792
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6365.82872
-  tps: 4519.73839
+  dps: 6375.73752
+  tps: 4526.77364
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7375.04899
-  tps: 5236.28478
+  dps: 7463.30494
+  tps: 5298.94651
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11913.66488
-  tps: 8458.70207
+  dps: 11873.97114
+  tps: 8430.51951
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3156.67366
-  tps: 2241.2383
+  dps: 3165.33618
+  tps: 2247.38869
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3215.60944
-  tps: 2283.0827
+  dps: 3275.53479
+  tps: 2325.6297
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15664.9941
-  tps: 11122.14581
+  dps: 15678.17688
+  tps: 11131.50559
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5710.46467
-  tps: 4054.42991
+  dps: 5728.87106
+  tps: 4067.49845
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6831.73062
-  tps: 4850.52874
+  dps: 6904.86281
+  tps: 4902.45259
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8903.54219
-  tps: 6321.51496
+  dps: 8941.67976
+  tps: 6348.59263
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2687.53532
-  tps: 1908.15007
+  dps: 2688.63683
+  tps: 1908.93215
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2827.98851
-  tps: 2007.87184
+  dps: 2879.3217
+  tps: 2044.3184
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19433.063
-  tps: 13797.47473
+  dps: 19521.78595
+  tps: 13860.46803
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4981.98009
-  tps: 3537.20587
+  dps: 5003.16866
+  tps: 3552.24975
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5842.69442
-  tps: 4148.31304
+  dps: 5926.51433
+  tps: 4207.82518
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11817.41206
-  tps: 8390.36257
+  dps: 11873.25699
+  tps: 8430.01246
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2490.49868
-  tps: 1768.25406
+  dps: 2494.71569
+  tps: 1771.24814
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2612.5419
-  tps: 1854.90475
+  dps: 2656.83217
+  tps: 1886.35084
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21411.75446
-  tps: 15202.34567
+  dps: 21450.68022
+  tps: 15229.98296
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6713.44439
-  tps: 4766.54552
+  dps: 6733.18623
+  tps: 4780.56223
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7893.65785
-  tps: 5604.49707
+  dps: 7977.81205
+  tps: 5664.24655
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12487.83726
-  tps: 8866.36445
+  dps: 12553.29857
+  tps: 8912.84198
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3338.54562
-  tps: 2370.36739
+  dps: 3347.11321
+  tps: 2376.45038
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3453.90325
-  tps: 2452.27131
+  dps: 3508.93388
+  tps: 2491.34305
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20492.90926
-  tps: 14549.96558
+  dps: 20599.06569
+  tps: 14625.33664
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6408.92316
-  tps: 4550.33544
+  dps: 6419.35008
+  tps: 4557.73856
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7474.00542
-  tps: 5306.54385
+  dps: 7563.8367
+  tps: 5370.32406
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12008.01073
-  tps: 8525.68762
+  dps: 11975.49445
+  tps: 8502.60106
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3179.49976
-  tps: 2257.44483
+  dps: 3189.26073
+  tps: 2264.37512
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3261.09559
-  tps: 2315.37787
+  dps: 3324.46097
+  tps: 2360.36729
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15792.97721
-  tps: 11213.01382
+  dps: 15813.77947
+  tps: 11227.78343
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5750.06653
-  tps: 4082.54723
+  dps: 5768.59168
+  tps: 4095.70009
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6926.28522
-  tps: 4917.66251
+  dps: 7001.52199
+  tps: 4971.08061
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8981.84061
-  tps: 6377.10683
+  dps: 9025.50665
+  tps: 6408.10972
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2707.50588
-  tps: 1922.32918
+  dps: 2709.58195
+  tps: 1923.80318
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2870.84644
-  tps: 2038.30097
+  dps: 2924.34704
+  tps: 2076.2864
  }
 }
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6423.04878
-  tps: 4560.36463
+  dps: 6437.71379
+  tps: 4570.77679
  }
 }

--- a/sim/rogue/tricks_of_the_trade.go
+++ b/sim/rogue/tricks_of_the_trade.go
@@ -61,6 +61,10 @@ func (rogue *Rogue) registerTricksOfTheTradeSpell() {
 			ShouldActivate: func(sim *core.Simulation, character *core.Character) bool {
 				if hasShadowblades {
 					return rogue.CurrentEnergy() <= rogue.maxEnergy-15-rogue.EnergyTickMultiplier*10
+				} else if sim.CurrentTime < (time.Second * time.Duration(30-5*rogue.Talents.FilthyTricks)) {
+					// This assumes you precast a Tricks before combat, and activated it (and the cooldown) at 0.00 on the sim.
+					// This was put intentionally below the hasShadowblades check, because once you have that set a precast is no longer optimal.
+					return false
 				} else {
 					return rogue.CurrentEnergy() >= rogue.TricksOfTheTrade.DefaultCast.Cost
 				}

--- a/sim/rogue/tricks_of_the_trade.go
+++ b/sim/rogue/tricks_of_the_trade.go
@@ -54,14 +54,15 @@ func (rogue *Rogue) registerTricksOfTheTradeSpell() {
 
 	if rogue.Rotation.TricksOfTheTradeFrequency != proto.Rogue_Rotation_Never {
 		// TODO: Support Rogue_Rotation_Once
+		tricksSpell := rogue.TricksOfTheTrade
 		rogue.AddMajorCooldown(core.MajorCooldown{
-			Spell:    rogue.TricksOfTheTrade,
+			Spell:    tricksSpell,
 			Priority: core.CooldownPriorityDrums,
 			Type:     core.CooldownTypeDPS,
 			ShouldActivate: func(sim *core.Simulation, character *core.Character) bool {
 				if hasShadowblades {
 					return rogue.CurrentEnergy() <= rogue.maxEnergy-15-rogue.EnergyTickMultiplier*10
-				} else if sim.CurrentTime < (time.Second * time.Duration(30-5*rogue.Talents.FilthyTricks)) {
+				} else if sim.CurrentTime < (tricksSpell.CD.Duration) {
 					// This assumes you precast a Tricks before combat, and activated it (and the cooldown) at 0.00 on the sim.
 					// This was put intentionally below the hasShadowblades check, because once you have that set a precast is no longer optimal.
 					return false


### PR DESCRIPTION
Before this change, Tricks would be cast along with other major cooldowns. This changes disallows the sim from casting Tricks before a time equal to the cooldown duration, to simulate having precast a Tricks and have it activate (and go on cooldown) when you first engage the enemy at 0.00.

This is generally optimal - unless you have the T10 2pc bonus - and this check comes after the T10 bonus so that optimal behaviour is maintained.

~~If someone more experience in Go can have it directly reference the Tricks spell cooldown, instead of my copy-paste of the cooldown code, that'd be rad. Otherwise this works great and looks a bit ugly.~~ ty cat

The tests see somewhere between a minor dps change, or a large dps gain. The large dps gain is expected on longer fights, when you cast one fewer Tricks over the length by delaying your first cast. The minor dps change in other tests is due to casting the same amount of Tricks, but casting it at a time where energy is differently valuable (you are clipping fewer envenoms 30s in, for example). This is a misleading dps difference, since the actual optimal play is to not cast any Tricks in the first 30 seconds and have it precast before combat, which is larger dps gain than previous tests indicate.