### PR TITLE
Warrior: added more granularity to DPS warrior sunder armor usage

### DIFF
--- a/sim/warrior/dps/dps_warrior.go
+++ b/sim/warrior/dps/dps_warrior.go
@@ -35,6 +35,8 @@ type DpsWarrior struct {
 
 	// Prevent swapping stances until this time, to account for human reaction time.
 	canSwapStanceAt time.Duration
+	// Last time sunder was applied. Used for maintaining sunder even if sunder is enabled as debuff in individual sim
+	lastSunderAt time.Duration
 
 	maintainSunder  bool
 	thunderClapNext bool

--- a/sim/warrior/dps/rotation.go
+++ b/sim/warrior/dps/rotation.go
@@ -51,6 +51,7 @@ func (war *DpsWarrior) doRotation(sim *core.Simulation) {
 			war.Devastate.Cast(sim, war.CurrentTarget)
 		} else {
 			war.SunderArmor.Cast(sim, war.CurrentTarget)
+			war.lastSunderAt = sim.CurrentTime
 		}
 		war.tryQueueHsCleave(sim)
 		return
@@ -75,7 +76,7 @@ func (war *DpsWarrior) doRotation(sim *core.Simulation) {
 		}
 
 		if war.Rotation.SunderArmor == proto.Warrior_Rotation_SunderArmorMaintain {
-			nextSunderAt := war.SunderArmorAuras.Get(war.CurrentTarget).ExpiresAt() - SunderWindow
+			nextSunderAt := war.lastSunderAt + 30*time.Second - sim.CurrentTime - SunderWindow
 			// TODO looks fishy, nextCD is unused
 			nextCD = core.MinDuration(nextCD, nextSunderAt)
 		}
@@ -283,7 +284,7 @@ func (war *DpsWarrior) shouldSunder(sim *core.Simulation) bool {
 		war.maintainSunder = false
 	}
 
-	return stacks < 5 || saAura.RemainingDuration(sim) <= SunderWindow
+	return stacks < 5 || (war.lastSunderAt+30*time.Second-sim.CurrentTime) <= SunderWindow
 }
 
 // Returns whether any ability was cast.


### PR DESCRIPTION
- Maintain Debuff: If sunder armor is set as debuff it'll stack to 5 at beginning and then keep casting sunder to refresh it. Regardless if there's another sunder debuff already or not.

- Help Stack: This option will only stack sunder at beginning. If sunder is not set as debuff then it'll stack to 5 and the sunder will be refreshed automatically. Putting sunder as debuff would reduce the amount of sunder this option stacks at the start of the fight.