### PR TITLE
Update bone_shield.go

### DIFF
--- a/sim/deathknight/bone_shield.go
+++ b/sim/deathknight/bone_shield.go
@@ -28,12 +28,14 @@ func (dk *Deathknight) registerBoneShieldSpell() {
 			dk.BoneShieldAura.SetStacks(sim, dk.BoneShieldAura.MaxStacks)
 		},
 		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-			if sim.CurrentTime > stackRemovalCd+2*time.Second {
-				stackRemovalCd = sim.CurrentTime
+			if result.Landed() {
+				if sim.CurrentTime > stackRemovalCd+2*time.Second {
+					stackRemovalCd = sim.CurrentTime
 
-				aura.RemoveStack(sim)
-				if aura.GetStacks() == 0 {
-					aura.Deactivate(sim)
+					aura.RemoveStack(sim)
+					if aura.GetStacks() == 0 {
+						aura.Deactivate(sim)
+					}
 				}
 			}
 		},


### PR DESCRIPTION
Bone shield was being consumed with every enemy attack, regardless of it hitting or not. Added a check to see if the attack actually landed before running the stack removal logic.