### PR TITLE
Make the default rogue not maintain Expose Armor

### DIFF
--- a/ui/rogue/presets.ts
+++ b/ui/rogue/presets.ts
@@ -68,7 +68,7 @@ export const HemoSubtletyTalents = {
 }
 
 export const DefaultRotation = RogueRotation.create({
-	exposeArmorFrequency: Rogue_Rotation_Frequency.Maintain,
+	exposeArmorFrequency: Rogue_Rotation_Frequency.Never,
 	minimumComboPointsExposeArmor: 2,
 	tricksOfTheTradeFrequency: Rogue_Rotation_Frequency.Maintain,
 	assassinationFinisherPriority: Rogue_Rotation_AssassinationPriority.EnvenomRupture,


### PR DESCRIPTION
Most users (in my experience from troubleshooting) specify if they want to Expose, and assume they are not exposing - especially Mutilate rogues.