### PR TITLE
Add CLI export option

### DIFF
--- a/ui/core/components/exporters.ts
+++ b/ui/core/components/exporters.ts
@@ -12,6 +12,7 @@ import { specNames } from '../proto_utils/utils';
 import { downloadString } from '../utils';
 import { BaseModal } from './base_modal';
 import { IndividualWowheadGearPlannerImporter } from './importers';
+import { RaidSimRequest } from '../proto/api';
 
 import * as Mechanics from '../constants/mechanics';
 
@@ -392,4 +393,22 @@ export class IndividualPawnEPExporter<SpecType extends Spec> extends Exporter {
 		[PseudoStat.PseudoStatMainHandDps]: 'MeleeDps',
 		[PseudoStat.PseudoStatRangedDps]: 'RangedDps',
 	}
+}
+
+export class IndividualCLIExporter<SpecType extends Spec> extends Exporter {
+  private readonly simUI: IndividualSimUI<SpecType>;
+
+  constructor(parent: HTMLElement, simUI: IndividualSimUI<SpecType>) {
+    super(parent, simUI, "CLI Export", true);
+    this.simUI = simUI;
+    this.init();
+  }
+
+  getData(): string {
+    return JSON.stringify(
+      RaidSimRequest.toJson(this.simUI.sim.makeRaidSimRequest(false)),
+      null,
+      2
+    );
+  }
 }

--- a/ui/core/individual_sim_ui.ts
+++ b/ui/core/individual_sim_ui.ts
@@ -477,6 +477,7 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 		this.simHeader.addExportLink('WoWHead', _parent => new Exporters.IndividualWowheadGearPlannerExporter(this.rootElem, this), false);
 		this.simHeader.addExportLink('80U EP', _parent => new Exporters.Individual80UEPExporter(this.rootElem, this), false);
 		this.simHeader.addExportLink('Pawn EP', _parent => new Exporters.IndividualPawnEPExporter(this.rootElem, this), false);
+		this.simHeader.addExportLink("CLI", _parent => new Exporters.IndividualCLIExporter(this.rootElem, this), true);
 	}
 
 	applyDefaults(eventID: EventID) {

--- a/ui/core/sim.ts
+++ b/ui/core/sim.ts
@@ -1,17 +1,7 @@
 import { ArmorType, SimDatabase } from './proto/common.js';
-import { Class, Faction } from './proto/common.js';
-import { Consumes } from './proto/common.js';
-import { Encounter as EncounterProto } from './proto/common.js';
-import { EquipmentSpec } from './proto/common.js';
-import { GemColor } from './proto/common.js';
-import { ItemQuality } from './proto/common.js';
-import { ItemSlot } from './proto/common.js';
-import { ItemSpec } from './proto/common.js';
-import { ItemType } from './proto/common.js';
-import { Profession } from './proto/common.js';
-import { Race } from './proto/common.js';
+import { Faction } from './proto/common.js';
+import { Profession } from './proto/common.js';;
 import { RaidTarget } from './proto/common.js';
-import { Spec } from './proto/common.js';
 import { Stat, PseudoStat } from './proto/common.js';
 import { RangedWeaponType, WeaponType } from './proto/common.js';
 import { BulkSimRequest, BulkSimResult, BulkSettings, Raid as RaidProto } from './proto/api.js';
@@ -25,36 +15,14 @@ import {
 	SourceFilterOption,
 	RaidFilterOption,
 } from './proto/ui.js';
-import {
-	UIEnchant as Enchant,
-	UIGem as Gem,
-	UIItem as Item,
-} from './proto/ui.js';
-
 import { Database } from './proto_utils/database.js';
-import { EquippedItem } from './proto_utils/equipped_item.js';
-import { Gear } from './proto_utils/gear.js';
 import { SimResult } from './proto_utils/sim_result.js';
-import { Stats } from './proto_utils/stats.js';
-import { SpecRotation } from './proto_utils/utils.js';
-import { SpecTalents } from './proto_utils/utils.js';
-import { SpecTypeFunctions } from './proto_utils/utils.js';
-import { specTypeFunctions } from './proto_utils/utils.js';
-import { SpecOptions } from './proto_utils/utils.js';
-import { specToClass } from './proto_utils/utils.js';
-import { specToEligibleRaces } from './proto_utils/utils.js';
-import { getEligibleItemSlots } from './proto_utils/utils.js';
-import { playerToSpec } from './proto_utils/utils.js';
-
 import { getBrowserLanguageCode, setLanguageCode } from './constants/lang.js';
 import { Encounter } from './encounter.js';
 import { Player } from './player.js';
 import { Raid } from './raid.js';
-import { Listener } from './typed_event.js';
 import { EventID, TypedEvent } from './typed_event.js';
 import { getEnumValues } from './utils.js';
-import { sum } from './utils.js';
-import { wait } from './utils.js';
 import { WorkerPool } from './worker_pool.js';
 
 import * as OtherConstants from './constants/other.js';
@@ -200,7 +168,7 @@ export class Sim {
 		return raidProto;
 	}
 
-	private makeRaidSimRequest(debug: boolean): RaidSimRequest {
+	makeRaidSimRequest(debug: boolean): RaidSimRequest {
 		const raid = this.getModifiedRaidProto();
 		const encounter = this.encounter.toProto();
 


### PR DESCRIPTION
Implements a RaidSimRequest protojson format export option for use in CLI simulations.

https://github.com/wowsims/wotlk/assets/6005240/bfb04bde-40bd-417d-ab08-670370c7c1f3

Output is indentical to what is found in the console after starting a web simulation.

![image](https://github.com/wowsims/wotlk/assets/6005240/f51b5b3b-3815-418c-93ae-e4e9dfe14224)

