### PR TITLE
Remove the database field from CLI export

### DIFF
--- a/ui/core/components/exporters.ts
+++ b/ui/core/components/exporters.ts
@@ -405,10 +405,10 @@ export class IndividualCLIExporter<SpecType extends Spec> extends Exporter {
   }
 
   getData(): string {
-    return JSON.stringify(
-      RaidSimRequest.toJson(this.simUI.sim.makeRaidSimRequest(false)),
-      null,
-      2
+    const raidSimJson: any = RaidSimRequest.toJson(
+      this.simUI.sim.makeRaidSimRequest(false)
     );
+    delete raidSimJson.raid?.parties[0]?.players[0]?.database;
+    return JSON.stringify(raidSimJson, null, 2);
   }
 }


### PR DESCRIPTION
Removes the `database` field from CLI export, reducing lines from ~1600 to ~300. This field is not required as the CLI is already bundled with item info.