### PR TITLE
Fix CLI output file option parsing

### DIFF
--- a/cmd/wowsimcli/cmd/basic_sim.go
+++ b/cmd/wowsimcli/cmd/basic_sim.go
@@ -19,7 +19,7 @@ var simCmd = &cobra.Command{
 
 func init() {
 	simCmd.Flags().StringVar(&infile, "infile", "input.json", "location of input file (RaidSimRequest in protojson format)")
-	simCmd.Flags().StringVar(&infile, "output", "", "location of output file, defaults to stdout")
+	simCmd.Flags().StringVar(&outfile, "outfile", "", "location of output file, defaults to stdout")
 	simCmd.Flags().BoolVar(&verbose, "verbose", false, "print information during runtime")
 	simCmd.MarkFlagRequired("infile")
 }


### PR DESCRIPTION
We are currently overwriting `&infile` when there exists both `--infile` and `--output` options. Rename the option to `outfile`, and resolve the overwrite by renaming the variable to what use during the output file write step.