### PR TITLE
[Rogue] Fix multi-target S&D UI settings for 3 targets

### DIFF
--- a/ui/rogue/sim.ts
+++ b/ui/rogue/sim.ts
@@ -359,7 +359,7 @@ export class RogueSimUI extends IndividualSimUI<Spec.SpecRogue> {
 			const rotation = this.player.getRotation()
 			const options = this.player.getSpecOptions()
 			const encounter = this.sim.encounter
-			if (this.sim.encounter.targets.length > 3) {
+			if (this.sim.encounter.targets.length >= 3) {
 				if (rotation.multiTargetSliceFrequency == Frequency.FrequencyUnknown) {
 					rotation.multiTargetSliceFrequency = Presets.DefaultRotation.multiTargetSliceFrequency;
 				}


### PR DESCRIPTION
When a generic rogue rotation was introduced in https://github.com/wowsims/wotlk/commit/c058642fa03260d49e6b2846ffc4654e9abec958, the number of required targets for multi-target rotation was lowered from 4 to 3.
UI settings for Slice n Dice were unchanged, so these only show up on 4+ targets instead of 3+.