### PR TITLE
Added 18/2 and 13/7 Presets for Mutilate Rogues

### DIFF
--- a/ui/raid/presets.ts
+++ b/ui/raid/presets.ts
@@ -489,7 +489,7 @@ export const playerPresets: Array<PresetSpecSettings<any>> = [
 	{
 		spec: Spec.SpecRogue,
 		rotation: RoguePresets.DefaultRotation,
-		talents: RoguePresets.AssassinationTalents.data,
+		talents: RoguePresets.AssassinationTalents137.data,
 		specOptions: RoguePresets.DefaultOptions,
 		consumes: RoguePresets.DefaultConsumes,
 		defaultName: 'Assassination',

--- a/ui/rogue/presets.ts
+++ b/ui/rogue/presets.ts
@@ -43,10 +43,22 @@ export const CombatCQCTalents = {
 	}),
 };
 
-export const AssassinationTalents = {
+export const AssassinationTalents137 = {
 	name: 'Assassination',
 	data: SavedTalents.create({
 		talentsString: '005303104352100520103331051-005005003-502',
+		glyphs: Glyphs.create({
+			major1: RogueMajorGlyph.GlyphOfMutilate,
+			major2: RogueMajorGlyph.GlyphOfTricksOfTheTrade,
+			major3: RogueMajorGlyph.GlyphOfHungerForBlood,
+		})
+	}),
+};
+
+export const AssassinationTalents182 = {
+	name: 'Assassination',
+	data: SavedTalents.create({
+		talentsString: '005303104352100520103331051-005005005003-2',
 		glyphs: Glyphs.create({
 			major1: RogueMajorGlyph.GlyphOfMutilate,
 			major2: RogueMajorGlyph.GlyphOfTricksOfTheTrade,

--- a/ui/rogue/presets.ts
+++ b/ui/rogue/presets.ts
@@ -44,7 +44,7 @@ export const CombatCQCTalents = {
 };
 
 export const AssassinationTalents137 = {
-	name: 'Assassination',
+	name: 'Assassination 13/7',
 	data: SavedTalents.create({
 		talentsString: '005303104352100520103331051-005005003-502',
 		glyphs: Glyphs.create({
@@ -56,7 +56,7 @@ export const AssassinationTalents137 = {
 };
 
 export const AssassinationTalents182 = {
-	name: 'Assassination',
+	name: 'Assassination 18/2',
 	data: SavedTalents.create({
 		talentsString: '005303104352100520103331051-005005005003-2',
 		glyphs: Glyphs.create({

--- a/ui/rogue/sim.ts
+++ b/ui/rogue/sim.ts
@@ -208,7 +208,7 @@ export class RogueSimUI extends IndividualSimUI<Spec.SpecRogue> {
 				// Default rotation settings.
 				rotation: Presets.DefaultRotation,
 				// Default talents.
-				talents: Presets.AssassinationTalents.data,
+				talents: Presets.AssassinationTalents137.data,
 				// Default spec-specific settings.
 				specOptions: Presets.DefaultOptions,
 				// Default raid/party buffs settings.
@@ -279,7 +279,8 @@ export class RogueSimUI extends IndividualSimUI<Spec.SpecRogue> {
 			presets: {
 				// Preset talents that the user can quickly select.
 				talents: [
-					Presets.AssassinationTalents,
+					Presets.AssassinationTalents137,
+					Presets.AssassinationTalents182,
 					Presets.CombatHackTalents,
 					Presets.CombatCQCTalents,
 					Presets.SubtletyTalents,


### PR DESCRIPTION
Adds the almost interchangeable 18/2 and 13/7 talent spreads as preset options.