### PR TITLE
Allow Combat Rotation to use Hemorrhage

### DIFF
--- a/proto/rogue.proto
+++ b/proto/rogue.proto
@@ -162,6 +162,7 @@ message Rogue {
 		enum CombatBuilder {
 			SinisterStrike = 0;
 			Backstab = 1;
+			HemorrhageCombat = 2;
 		}
 		CombatBuilder combat_builder = 25;
 

--- a/sim/rogue/rotation_combat.go
+++ b/sim/rogue/rotation_combat.go
@@ -22,7 +22,7 @@ func (x *rotation_combat) setup(_ *core.Simulation, rogue *Rogue) {
 	if rogue.Rotation.CombatBuilder == proto.Rogue_Rotation_Backstab && rogue.HasDagger(core.MainHand) && !rogue.PseudoStats.InFrontOfTarget {
 		x.builder = rogue.Backstab
 	}
-	if rogue.Talents.Hemorrhage {
+	if rogue.Talents.Hemorrhage && rogue.Rotation.CombatBuilder == proto.Rogue_Rotation_HemorrhageCombat {
 		x.builder = rogue.Hemorrhage
 	}
 
@@ -413,9 +413,8 @@ func (x *rotation_combat) run(sim *core.Simulation, rogue *Rogue) {
 					if rogue.Rotation.CombatBuilder == proto.Rogue_Rotation_Backstab && rogue.HasDagger(core.MainHand) && !rogue.PseudoStats.InFrontOfTarget {
 						x.builder = rogue.Backstab
 					}
-					if rogue.Talents.Hemorrhage {
+					if rogue.Talents.Hemorrhage && rogue.Rotation.CombatBuilder == proto.Rogue_Rotation_HemorrhageCombat {
 						x.builder = rogue.Hemorrhage
-						return
 					}
 
 					return
@@ -425,7 +424,7 @@ func (x *rotation_combat) run(sim *core.Simulation, rogue *Rogue) {
 				if rogue.Rotation.CombatBuilder == proto.Rogue_Rotation_Backstab && rogue.HasDagger(core.MainHand) && !rogue.PseudoStats.InFrontOfTarget {
 					x.builder = rogue.Backstab
 				}
-				if rogue.Talents.Hemorrhage {
+				if rogue.Talents.Hemorrhage && rogue.Rotation.CombatBuilder == proto.Rogue_Rotation_HemorrhageCombat {
 					x.builder = rogue.Hemorrhage
 				}
 				//Done with Ghostly Strike

--- a/sim/rogue/rotation_combat.go
+++ b/sim/rogue/rotation_combat.go
@@ -22,6 +22,9 @@ func (x *rotation_combat) setup(_ *core.Simulation, rogue *Rogue) {
 	if rogue.Rotation.CombatBuilder == proto.Rogue_Rotation_Backstab && rogue.HasDagger(core.MainHand) && !rogue.PseudoStats.InFrontOfTarget {
 		x.builder = rogue.Backstab
 	}
+	if rogue.Talents.Hemorrhage {
+		x.builder = rogue.Hemorrhage
+	}
 
 	bldCost := x.builder.DefaultCast.Cost
 	sndCost := rogue.SliceAndDice.DefaultCast.Cost
@@ -410,6 +413,10 @@ func (x *rotation_combat) run(sim *core.Simulation, rogue *Rogue) {
 					if rogue.Rotation.CombatBuilder == proto.Rogue_Rotation_Backstab && rogue.HasDagger(core.MainHand) && !rogue.PseudoStats.InFrontOfTarget {
 						x.builder = rogue.Backstab
 					}
+					if rogue.Talents.Hemorrhage {
+						x.builder = rogue.Hemorrhage
+						return
+					}
 
 					return
 				}
@@ -417,6 +424,9 @@ func (x *rotation_combat) run(sim *core.Simulation, rogue *Rogue) {
 				x.builder = rogue.SinisterStrike
 				if rogue.Rotation.CombatBuilder == proto.Rogue_Rotation_Backstab && rogue.HasDagger(core.MainHand) && !rogue.PseudoStats.InFrontOfTarget {
 					x.builder = rogue.Backstab
+				}
+				if rogue.Talents.Hemorrhage {
+					x.builder = rogue.Hemorrhage
 				}
 				//Done with Ghostly Strike
 			} else if !x.builder.Cast(sim, rogue.CurrentTarget) {

--- a/ui/rogue/inputs.ts
+++ b/ui/rogue/inputs.ts
@@ -96,10 +96,11 @@ export const RogueRotationConfig = {
 		InputHelpers.makeRotationEnumInput<Spec.SpecRogue, CombatBuilder>({
 			fieldName: 'combatBuilder',
 			label: "Builder",
-			labelTooltip: 'Use Sinister Strike or Backstab as builder.',
+			labelTooltip: 'Use Sinister Strike, Backstab, or Hemorrhage as builder.',
 			values: [
 				{ name: "Sinister Strike", value: CombatBuilder.SinisterStrike },
 				{ name: "Backstab", value: CombatBuilder.Backstab },
+				{ name: "Hemorrhage", value: CombatBuilder.HemorrhageCombat },
 			],
 			showWhen: (player: Player<Spec.SpecRogue>) => player.getTalents().combatPotency > 0
 		}),

--- a/ui/rogue/sim.ts
+++ b/ui/rogue/sim.ts
@@ -106,6 +106,18 @@ export class RogueSimUI extends IndividualSimUI<Spec.SpecRogue> {
 					return {
 						updateOn: simUI.player.changeEmitter,
 						getContent: () => {
+							if (simUI.player.getRotation().combatBuilder == CombatBuilder.HemorrhageCombat && !simUI.player.getTalents().hemorrhage) {
+								return 'Builder "Hemorrhage" selected, but Hemorrhage is not talented.';
+							} else {
+								return '';
+							}
+						},
+					};
+				},
+				(simUI: IndividualSimUI<Spec.SpecRogue>) => {
+					return {
+						updateOn: simUI.player.changeEmitter,
+						getContent: () => {
 							if (simUI.player.getRotation().useGhostlyStrike && !simUI.player.getMajorGlyphs().includes(RogueMajorGlyph.GlyphOfGhostlyStrike)) {
 								return '"Use Ghostly Strike" selected, but missing Glyph of Ghostly Strike.';
 							} else {


### PR DESCRIPTION
If Hemorrhage is talented, it will be used as the builder.