### PR TITLE
Add cooldown reduction from Elusiveness to Overkill

### DIFF
--- a/sim/rogue/overkill.go
+++ b/sim/rogue/overkill.go
@@ -28,7 +28,7 @@ func (rogue *Rogue) registerOverkillCD() {
 		Cast: core.CastConfig{
 			CD: core.Cooldown{
 				Timer:    rogue.NewTimer(),
-				Duration: time.Minute * 3,
+				Duration: time.Second * time.Duration(180-30*rogue.Talents.Elusiveness),
 			},
 		},
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {


### PR DESCRIPTION
Fixes an issue where Overkill was not affected by the cooldown reduction to vanish from the Elusiveness talent.