### PR TITLE
Cleanup of previously merged branch for armorscaling

### DIFF
--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -192,16 +192,9 @@ func (character *Character) ApplyDynamicEquipScaling(sim *Simulation, stat stats
 	character.AddStatDynamic(sim, stat, statDiff)
 }
 
-func (character *Character) removeEquipScaling(stat stats.Stat, multiplier float64) float64 {
-	var oldValue = character.EquipStats()[stat]
-	character.itemStatMultipliers[stat] /= multiplier
-	var newValue = character.EquipStats()[stat]
-	return (newValue - oldValue)
-}
-
 func (character *Character) RemoveEquipScaling(stat stats.Stat, multiplier float64) {
 	var statDiff stats.Stats
-	statDiff[stat] = character.removeEquipScaling(stat, multiplier)
+	statDiff[stat] = character.applyEquipScaling(stat, 1/multiplier)
 	// Equipment stats already applied, so need to manually at the bonus to
 	// the character now to ensure correct values
 	if (character.equipStatsApplied) {
@@ -210,7 +203,7 @@ func (character *Character) RemoveEquipScaling(stat stats.Stat, multiplier float
 }
 
 func (character *Character) RemoveDynamicEquipScaling(sim *Simulation, stat stats.Stat, multiplier float64) {
-	statDiff := character.removeEquipScaling(stat, multiplier)
+	statDiff := character.applyEquipScaling(stat, 1/multiplier)
 	character.AddStatDynamic(sim, stat, statDiff)
 }
 


### PR DESCRIPTION
Simplify by removing redundant removeEquipScaling function

The same can be achieved without duplication by calling applyEquipScaling with inverted multiplier.