### PR TITLE
Feint no longer procs poisons or weapon enchantments

### DIFF
--- a/sim/rogue/feint.go
+++ b/sim/rogue/feint.go
@@ -11,7 +11,7 @@ func (rogue *Rogue) registerFeintSpell() {
 	rogue.Feint = rogue.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 48659},
 		SpellSchool: core.SpellSchoolPhysical,
-		ProcMask:    core.ProcMaskMeleeMHSpecial,
+		ProcMask:    core.ProcMaskEmpty,
 		Flags:       core.SpellFlagMeleeMetrics,
 
 		EnergyCost: core.EnergyCostOptions{


### PR DESCRIPTION
As of patch 3.4.2 Feint will no longer proc poisons or enchantments. This code removes the proc behavior from Feint.