### PR TITLE
update blood plague crit multiplier

### DIFF
--- a/sim/deathknight/diseases.go
+++ b/sim/deathknight/diseases.go
@@ -125,7 +125,7 @@ func (dk *Deathknight) registerBloodPlague() {
 		Flags:       core.SpellFlagDisease,
 
 		DamageMultiplier: 1,
-		CritMultiplier:   dk.DefaultMeleeCritMultiplier(),
+		CritMultiplier:   dk.MeleeCritMultiplier(2, 0) - 1.0, // Don't know if bugged or intentional
 		ThreatMultiplier: 1,
 
 		Dot: core.DotConfig{

--- a/sim/deathknight/diseases.go
+++ b/sim/deathknight/diseases.go
@@ -125,7 +125,7 @@ func (dk *Deathknight) registerBloodPlague() {
 		Flags:       core.SpellFlagDisease,
 
 		DamageMultiplier: 1,
-		CritMultiplier:   dk.MeleeCritMultiplier(2, 0) - 1.0, // Don't know if bugged or intentional
+		CritMultiplier:   dk.MeleeCritMultiplier(2, 0) - 1.0,
 		ThreatMultiplier: 1,
 
 		Dot: core.DotConfig{

--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -46,35 +46,35 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7171.06213
+  dps: 7306.68437
   tps: 3622.05345
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7046.34972
+  dps: 7179.9235
   tps: 3583.2906
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6884.36912
+  dps: 7011.7042
   tps: 3500.45674
   hps: 91.21323
  }
@@ -82,7 +82,7 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6884.36912
+  dps: 7011.7042
   tps: 3500.45674
   hps: 91.21323
  }
@@ -90,84 +90,84 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7188.3291
+  dps: 7324.58011
   tps: 3630.67733
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6968.6399
+  dps: 7096.74067
   tps: 3520.611
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 5973.29979
+  dps: 6095.44586
   tps: 3023.33032
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5927.82052
+  dps: 6051.8577
   tps: 3012.64544
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5681.42093
+  dps: 5797.75177
   tps: 2872.89919
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7166.0404
+  dps: 7301.57979
   tps: 3547.01501
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8496.07211
+  dps: 8647.68605
   tps: 4355.93796
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8611.91328
+  dps: 8763.241
   tps: 4423.48806
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7309.05722
+  dps: 7447.90593
   tps: 3697.06719
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
   hps: 64
  }
@@ -175,287 +175,287 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6982.48566
+  dps: 7112.10149
   tps: 3552.862
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7021.23871
+  dps: 7151.66028
   tps: 3577.0307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7130.92616
+  dps: 7266.68267
   tps: 3606.73031
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 6936.55503
+  dps: 7082.5842
   tps: 3518.46493
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 6049.15324
+  dps: 6171.23805
   tps: 3056.22276
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7205.99986
+  dps: 7340.16473
   tps: 3638.20896
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7499.01719
+  dps: 7643.29736
   tps: 3785.52378
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6949.69499
+  dps: 7079.61125
   tps: 3535.70134
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7329.10041
+  dps: 7459.70431
   tps: 3743.52263
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7392.95054
+  dps: 7525.06911
   tps: 3781.48206
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6900.53419
+  dps: 7028.13609
   tps: 3508.99332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7190.65127
+  dps: 7327.19297
   tps: 3631.7857
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7035.65953
+  dps: 7158.89467
   tps: 3561.32458
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7010.76743
+  dps: 7134.34353
   tps: 3550.07211
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7166.0404
+  dps: 7301.57979
   tps: 3619.40307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7166.0404
+  dps: 7301.57979
   tps: 3619.40307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7188.3291
+  dps: 7324.58011
   tps: 3630.67733
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7186.54341
+  dps: 7322.61954
   tps: 3629.89096
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6949.9188
+  dps: 7078.16923
   tps: 3504.13959
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7166.0404
+  dps: 7301.57979
   tps: 3619.40307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7002.50556
+  dps: 7132.62607
   tps: 3567.54889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6967.92305
+  dps: 7096.96509
   tps: 3546.04462
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6951.02625
+  dps: 7079.97772
   tps: 3536.80811
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7166.0404
+  dps: 7301.57979
   tps: 3619.40307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7166.0404
+  dps: 7301.57979
   tps: 3619.40307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7207.34802
+  dps: 7341.58918
   tps: 3638.72105
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7090.27587
+  dps: 7220.71576
   tps: 3611.42495
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6980.94234
+  dps: 7113.70668
   tps: 3551.3498
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7201.37194
+  dps: 7335.15536
   tps: 3636.82359
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7188.3291
+  dps: 7324.58011
   tps: 3630.67733
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7186.54341
+  dps: 7322.61954
   tps: 3629.89096
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7075.49542
+  dps: 7204.50295
   tps: 3607.84593
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7166.0404
+  dps: 7301.57979
   tps: 3619.40307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7195.36042
+  dps: 7331.41895
   tps: 3634.37138
   hps: 12.53201
  }
@@ -463,532 +463,532 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6983.58513
+  dps: 7114.34049
   tps: 3537.60407
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7050.26451
+  dps: 7187.63868
   tps: 3575.69403
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6894.82686
+  dps: 7022.33459
   tps: 3505.9792
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7188.89869
+  dps: 7324.81524
   tps: 3631.46727
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7194.27711
+  dps: 7330.28241
   tps: 3634.3059
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6927.77717
+  dps: 7055.82856
   tps: 3523.3807
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6933.37035
+  dps: 7061.51403
   tps: 3526.33453
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7166.0404
+  dps: 7301.57979
   tps: 3619.40307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7166.0404
+  dps: 7301.57979
   tps: 3619.40307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6917.89585
+  dps: 7046.87452
   tps: 3520.00767
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6925.06272
+  dps: 7054.0414
   tps: 3524.3078
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7305.89693
+  dps: 7444.41801
   tps: 3695.66551
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7208.92088
+  dps: 7343.25104
   tps: 3639.31848
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7166.0404
+  dps: 7301.57979
   tps: 3619.40307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7201.13274
+  dps: 7334.91617
   tps: 3636.69056
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6600.36569
+  dps: 6734.84999
   tps: 3335.15996
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 6008.36948
+  dps: 6131.44501
   tps: 3032.02715
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7556.74498
+  dps: 7716.88646
   tps: 3875.56115
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6369.43806
+  dps: 6497.27968
   tps: 3221.62785
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6899.69198
+  dps: 7027.34228
   tps: 3508.28817
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 9461.03923
+  dps: 9623.43525
   tps: 4876.14254
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7199.25907
+  dps: 7333.0425
   tps: 3635.64853
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7230.65178
+  dps: 7364.66792
   tps: 3652.81343
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7199.25907
+  dps: 7333.0425
   tps: 3635.64853
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 7528.17531
+  dps: 7667.27763
   tps: 3804.37015
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7199.25907
+  dps: 7333.0425
   tps: 3635.64853
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7531.12008
+  dps: 7669.72414
   tps: 3809.91899
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7199.25907
+  dps: 7333.0425
   tps: 3635.64853
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6971.35554
+  dps: 7100.84292
   tps: 3547.45177
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofLife-37657"
  value: {
-  dps: 6934.45725
+  dps: 7062.17378
   tps: 3514.61474
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7062.61331
+  dps: 7204.89871
   tps: 3576.24951
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 5547.24913
+  dps: 5666.57708
   tps: 2802.52764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7194.27711
+  dps: 7330.28241
   tps: 3634.3059
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7188.89869
+  dps: 7324.81524
   tps: 3631.46727
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7179.48645
+  dps: 7315.2477
   tps: 3626.49966
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7068.48526
-  tps: 3589.05005
+  dps: 7314.57403
+  tps: 3650.98127
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6203.31691
+  dps: 6336.41859
   tps: 3130.83932
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6229.54038
+  dps: 6373.99246
   tps: 3088.63939
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7179.27014
+  dps: 7316.17388
   tps: 3617.24047
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7105.60947
+  dps: 7244.0944
   tps: 3613.04596
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7119.10105
+  dps: 7258.12855
   tps: 3616.56305
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7166.0404
+  dps: 7301.57979
   tps: 3619.40307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7166.0404
+  dps: 7301.57979
   tps: 3619.40307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6922.39687
+  dps: 7046.66415
   tps: 3501.51525
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7166.0404
+  dps: 7301.57979
   tps: 3619.40307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7166.0404
+  dps: 7301.57979
   tps: 3619.40307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5911.06176
+  dps: 6034.65802
   tps: 2997.70639
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5600.19886
+  dps: 5754.46233
   tps: 2658.21066
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6884.36343
+  dps: 7011.69851
   tps: 3500.45332
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7210.71842
+  dps: 7345.1503
   tps: 3640.00126
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 7286.71395
+  dps: 7428.81744
   tps: 3684.61495
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19546.36301
+  dps: 20105.06406
   tps: 10226.96469
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7226.39211
+  dps: 7341.17572
   tps: 3675.57049
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9283.32386
+  dps: 9458.65037
   tps: 4155.11066
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10301.1857
+  dps: 10571.70023
   tps: 5393.16093
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4058.95241
+  dps: 4133.92175
   tps: 2071.8325
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4846.99189
+  dps: 4976.60796
   tps: 2158.86347
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19748.98527
+  dps: 20435.68524
   tps: 10295.28701
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7305.89693
+  dps: 7444.41801
   tps: 3695.66551
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9448.29982
+  dps: 9657.39675
   tps: 4196.3357
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10406.99586
+  dps: 10742.93237
   tps: 5431.85413
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4107.29261
+  dps: 4197.33535
   tps: 2086.82819
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4932.21794
+  dps: 5085.93116
   tps: 2184.43148
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6901.74426
+  dps: 7030.94254
   tps: 3512.2829
  }
 }

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -785,8 +785,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7699.49047
-  tps: 4502.5479
+  dps: 7814.75792
+  tps: 4571.70837
  }
 }
 dps_results: {

--- a/sim/deathknight/dps/TestFrostUH.results
+++ b/sim/deathknight/dps/TestFrostUH.results
@@ -785,8 +785,8 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7684.57561
-  tps: 5467.09135
+  dps: 7769.83922
+  tps: 5529.84537
  }
 }
 dps_results: {

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -46,1160 +46,1160 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7478.79964
-  tps: 4811.1259
+  dps: 7439.04671
+  tps: 4775.37251
   hps: 369.70049
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7478.79964
-  tps: 4811.1259
+  dps: 7439.04671
+  tps: 4775.37251
   hps: 383.51422
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7989.04843
-  tps: 5086.54752
+  dps: 7946.98378
+  tps: 5048.69917
   hps: 269.88862
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7702.03218
-  tps: 4987.89909
+  dps: 7660.84926
+  tps: 4950.91476
   hps: 266.23619
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7478.73852
-  tps: 4811.03557
+  dps: 7438.9864
+  tps: 4775.28283
   hps: 354.49962
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7478.73852
-  tps: 4811.03557
+  dps: 7438.9864
+  tps: 4775.28283
   hps: 354.49962
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8015.84955
-  tps: 5110.86861
+  dps: 7973.53377
+  tps: 5072.80025
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7796.80864
-  tps: 4936.09982
+  dps: 7755.94289
+  tps: 4899.3469
   hps: 260.36507
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6572.84987
-  tps: 4218.65912
+  dps: 6538.06758
+  tps: 4187.34763
   hps: 238.99517
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6387.22868
-  tps: 4135.37798
+  dps: 6353.04634
+  tps: 4104.60985
   hps: 226.26186
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6183.82698
-  tps: 3964.54726
+  dps: 6151.11544
+  tps: 3935.07915
   hps: 224.52313
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7989.04843
-  tps: 4984.81657
+  dps: 7946.98378
+  tps: 4947.72519
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8070.33355
-  tps: 5162.89073
+  dps: 8027.63999
+  tps: 5124.47557
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8070.33355
-  tps: 5162.89073
+  dps: 8027.63999
+  tps: 5124.47557
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8084.65387
-  tps: 5176.97709
+  dps: 8041.8429
+  tps: 5138.45474
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 363.66614
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7578.41191
-  tps: 4906.83391
+  dps: 7537.71277
+  tps: 4870.23973
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7630.06097
-  tps: 4943.58157
+  dps: 7589.27728
+  tps: 4906.975
   hps: 265.60229
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7827.93537
-  tps: 5002.08904
+  dps: 7786.5902
+  tps: 4964.89774
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7641.22375
-  tps: 4929.11279
+  dps: 7600.39435
+  tps: 4892.32217
   hps: 279.65273
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 6711.43158
-  tps: 4292.26108
+  dps: 6676.02856
+  tps: 4260.26873
   hps: 295.31913
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8313.52747
-  tps: 5323.23712
+  dps: 8269.46311
+  tps: 5283.57389
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7564.86308
-  tps: 4892.87851
+  dps: 7524.32938
+  tps: 4856.43575
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7856.75878
-  tps: 5163.06177
+  dps: 7816.71922
+  tps: 5127.01138
   hps: 271.30735
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7881.93735
-  tps: 5220.18448
+  dps: 7841.48471
+  tps: 5183.76233
   hps: 272.25819
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8017.73879
-  tps: 5112.68914
+  dps: 7975.40687
+  tps: 5074.60372
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7723.08809
-  tps: 4932.31137
+  dps: 7682.23094
+  tps: 4895.64041
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7697.85558
-  tps: 4927.18614
+  dps: 7657.12767
+  tps: 4890.59418
   hps: 263.38366
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7989.04843
-  tps: 5086.54752
+  dps: 7946.98378
+  tps: 5048.69917
   hps: 269.88862
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7989.04843
-  tps: 5086.54752
+  dps: 7946.98378
+  tps: 5048.69917
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8015.84955
-  tps: 5110.86861
+  dps: 7973.53377
+  tps: 5072.80025
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8012.42823
-  tps: 5108.08836
+  dps: 7970.14555
+  tps: 5070.04615
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7625.1725
-  tps: 4820.84285
+  dps: 7585.55435
+  tps: 4785.24532
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 281.69807
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7989.04843
-  tps: 5086.54752
+  dps: 7946.98378
+  tps: 5048.69917
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7625.55605
-  tps: 4950.01217
+  dps: 7584.55878
+  tps: 4913.25422
   hps: 264.3345
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7567.00758
-  tps: 4896.56788
+  dps: 7526.41091
+  tps: 4860.0648
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7545.52467
-  tps: 4876.83784
+  dps: 7505.1275
+  tps: 4840.50152
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7989.04843
-  tps: 5086.54752
+  dps: 7946.98378
+  tps: 5048.69917
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7989.04843
-  tps: 5086.54752
+  dps: 7946.98378
+  tps: 5048.69917
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 8087.34659
-  tps: 5176.43191
+  dps: 8044.53832
+  tps: 5137.91331
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7740.81927
-  tps: 5023.27069
+  dps: 7699.25671
+  tps: 4985.87537
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7595.94254
-  tps: 4926.14499
+  dps: 7555.27431
+  tps: 4889.6119
   hps: 267.50398
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 8033.97642
-  tps: 5134.08556
+  dps: 7991.53911
+  tps: 5095.89356
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8015.84955
-  tps: 5110.86861
+  dps: 7973.53377
+  tps: 5072.80025
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8012.42823
-  tps: 5108.08836
+  dps: 7970.14555
+  tps: 5070.04615
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7643.95311
-  tps: 4947.21885
+  dps: 7603.10573
+  tps: 4910.49719
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7989.04843
-  tps: 5086.54752
+  dps: 7946.98378
+  tps: 5048.69917
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8023.77425
-  tps: 5114.50893
+  dps: 7981.47557
+  tps: 5076.4482
   hps: 277.83707
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7565.07758
-  tps: 4905.11818
+  dps: 7525.0262
+  tps: 4869.07791
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8017.10814
-  tps: 5109.15065
+  dps: 7974.85377
+  tps: 5071.13017
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8023.71042
-  tps: 5114.46903
+  dps: 7981.41141
+  tps: 5076.40805
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7989.04843
-  tps: 5086.54752
+  dps: 7946.98378
+  tps: 5048.69917
   hps: 268.96608
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7989.04843
-  tps: 5086.54752
+  dps: 7946.98378
+  tps: 5048.69917
   hps: 269.88862
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7554.56047
-  tps: 4871.53501
+  dps: 7514.05323
+  tps: 4835.225
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7564.5273
-  tps: 4879.85028
+  dps: 7523.94042
+  tps: 4843.47625
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8070.33355
-  tps: 5162.89073
+  dps: 8027.63999
+  tps: 5124.47557
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 8107.19515
-  tps: 5192.22996
+  dps: 8064.25303
+  tps: 5153.59066
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7989.04843
-  tps: 5086.54752
+  dps: 7946.98378
+  tps: 5048.69917
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 8028.46299
-  tps: 5129.68275
+  dps: 7986.06151
+  tps: 5091.52389
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7226.59228
-  tps: 4635.651
+  dps: 7187.9336
+  tps: 4600.76798
   hps: 258.0478
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6652.33451
-  tps: 4228.4161
+  dps: 6617.71862
+  tps: 4197.10722
   hps: 271.10152
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8006.59261
-  tps: 5303.32065
+  dps: 7962.0142
+  tps: 5263.22359
   hps: 295.76567
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7276.88352
-  tps: 4775.67338
+  dps: 7238.07698
+  tps: 4739.97781
   hps: 314.76815
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8070.33355
-  tps: 5162.89073
+  dps: 8027.63999
+  tps: 5124.47557
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7985.26833
-  tps: 5095.18481
+  dps: 7943.14838
+  tps: 5057.28691
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7997.13986
-  tps: 5106.08836
+  dps: 7954.88546
+  tps: 5068.06977
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7985.26833
-  tps: 5095.18481
+  dps: 7943.14838
+  tps: 5057.28691
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8211.87129
-  tps: 5184.17628
+  dps: 8168.23885
+  tps: 5145.02408
   hps: 238.97867
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7985.26833
-  tps: 5095.18481
+  dps: 7943.14838
+  tps: 5057.28691
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7985.26833
-  tps: 5095.18481
+  dps: 7943.14838
+  tps: 5057.28691
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7985.26833
-  tps: 5095.18481
+  dps: 7943.14838
+  tps: 5057.28691
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 299.66614
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7569.33447
-  tps: 4898.27654
+  dps: 7528.72012
+  tps: 4861.75682
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 7576.66178
-  tps: 4850.90849
+  dps: 7536.36901
+  tps: 4814.751
   hps: 268.45482
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7694.05898
-  tps: 4924.89803
+  dps: 7653.7198
+  tps: 4888.59856
   hps: 266.23619
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StormshroudArmor"
  value: {
-  dps: 6088.91269
-  tps: 3930.26384
+  dps: 6056.76057
+  tps: 3901.2672
   hps: 209.04532
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8023.71042
-  tps: 5114.46903
+  dps: 7981.41141
+  tps: 5076.40805
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8017.10814
-  tps: 5109.15065
+  dps: 7974.85377
+  tps: 5071.13017
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8005.55414
-  tps: 5099.84348
+  dps: 7963.37789
+  tps: 5061.89387
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7826.94783
-  tps: 5097.68764
+  dps: 7922.0137
+  tps: 5175.13082
   hps: 276.80769
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6772.66684
-  tps: 4313.63331
+  dps: 6737.49116
+  tps: 4281.76488
   hps: 289.64373
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7456.23279
-  tps: 4705.01564
+  dps: 7416.88536
+  tps: 4669.60163
   hps: 256.51175
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8074.99628
-  tps: 5111.58156
+  dps: 8032.39734
+  tps: 5073.30233
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7682.7226
-  tps: 4963.51285
+  dps: 7641.64548
+  tps: 4926.69088
   hps: 269.40566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7679.59876
-  tps: 4977.26171
+  dps: 7638.45516
+  tps: 4940.36045
   hps: 266.23619
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7989.04843
-  tps: 5086.54752
+  dps: 7946.98378
+  tps: 5048.69917
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7989.04843
-  tps: 5086.54752
+  dps: 7946.98378
+  tps: 5048.69917
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7562.63792
-  tps: 4814.91037
+  dps: 7523.07696
+  tps: 4779.36631
   hps: 265.28534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7989.04843
-  tps: 5086.54752
+  dps: 7946.98378
+  tps: 5048.69917
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7989.04843
-  tps: 5086.54752
+  dps: 7946.98378
+  tps: 5048.69917
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6427.92839
-  tps: 4174.62061
+  dps: 6393.68986
+  tps: 4143.83351
   hps: 233.66417
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7766.98624
-  tps: 4934.08006
+  dps: 7725.69099
+  tps: 4896.94769
   hps: 267.35534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7478.70522
-  tps: 4811.03677
+  dps: 7438.9529
+  tps: 4775.28388
   hps: 264.65145
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 8129.87921
-  tps: 5210.28487
+  dps: 8086.78412
+  tps: 5171.50764
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 8074.91266
-  tps: 5162.0552
+  dps: 8032.28779
+  tps: 5123.72183
   hps: 266.31641
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36921.37475
-  tps: 39768.72502
+  dps: 36715.65408
+  tps: 39561.22964
   hps: 263.54758
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7882.83286
-  tps: 5124.83046
+  dps: 7840.3439
+  tps: 5086.63619
   hps: 263.86435
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11346.44639
-  tps: 5714.1568
+  dps: 11326.12484
+  tps: 5695.26195
   hps: 224.90238
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 21782.72379
-  tps: 23935.38175
+  dps: 21655.68412
+  tps: 23808.01386
   hps: 158.70928
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3891.54234
-  tps: 2786.31184
+  dps: 3868.37297
+  tps: 2765.23638
   hps: 162.15117
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4995.54752
-  tps: 2889.66212
+  dps: 4985.94483
+  tps: 2880.63005
   hps: 142.45592
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 47344.6291
-  tps: 51228.40956
+  dps: 47079.63468
+  tps: 50960.67064
   hps: 321.9413
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10301.52105
-  tps: 6829.45603
+  dps: 10243.85162
+  tps: 6777.85991
   hps: 329.41002
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14385.60752
-  tps: 7498.25895
+  dps: 14358.23569
+  tps: 7473.13861
   hps: 284.99077
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 29320.55007
-  tps: 32387.22633
+  dps: 29152.61665
+  tps: 32217.58808
   hps: 209.5399
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5313.98591
-  tps: 3884.91441
+  dps: 5281.40558
+  tps: 3855.38909
   hps: 211.57427
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6559.88393
-  tps: 3948.34302
+  dps: 6545.79364
+  tps: 3935.17896
   hps: 183.09312
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 37300.24708
-  tps: 40126.24994
+  dps: 37093.59438
+  tps: 39917.83049
   hps: 263.7006
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8070.33355
-  tps: 5162.89073
+  dps: 8027.63999
+  tps: 5124.47557
   hps: 264.96839
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11729.60953
-  tps: 5777.57078
+  dps: 11709.42654
+  tps: 5758.78919
   hps: 228.20244
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 22069.95137
-  tps: 24190.02517
+  dps: 21942.54446
+  tps: 24062.29116
   hps: 159.98365
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3974.06739
-  tps: 2805.52825
+  dps: 3950.90587
+  tps: 2784.46121
   hps: 161.51459
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5166.23214
-  tps: 2925.18294
+  dps: 5156.62461
+  tps: 2916.13399
   hps: 142.56916
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 47429.93616
-  tps: 51005.51052
+  dps: 47163.20726
+  tps: 50736.71743
   hps: 323.27175
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10455.26526
-  tps: 6797.41217
+  dps: 10398.01373
+  tps: 6746.2262
   hps: 329.17087
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14825.7838
-  tps: 7552.85592
+  dps: 14799.04299
+  tps: 7528.30143
   hps: 281.19137
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 29493.96738
-  tps: 32501.22148
+  dps: 29330.37285
+  tps: 32336.42337
   hps: 210.68294
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5418.33462
-  tps: 3901.23021
+  dps: 5385.53104
+  tps: 3871.51222
   hps: 211.95518
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6744.57334
-  tps: 3969.22913
+  dps: 6730.18355
+  tps: 3955.78141
   hps: 179.38584
  }
 }
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7736.24992
-  tps: 5002.99039
+  dps: 7694.84911
+  tps: 4965.56803
   hps: 266.55313
  }
 }

--- a/sim/deathknight/dps/dps_deathknight.go
+++ b/sim/deathknight/dps/dps_deathknight.go
@@ -51,7 +51,7 @@ func NewDpsDeathknight(character core.Character, player *proto.Player) *DpsDeath
 			DrwPestiApply:       dk.Options.DrwPestiApply,
 			BloodOpener:         dk.Rotation.BloodOpener,
 			IsDps:               true,
-			NewDrw:              dk.Options.NewDrw,
+			NewDrw:              true,
 			DiseaseDowntime:     dk.Options.DiseaseDowntime,
 			VirulenceRefresh:    dk.Rotation.VirulenceRefresh,
 

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -785,8 +785,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 1673.16575
-  tps: 5078.2325
+  dps: 1725.33464
+  tps: 5186.4047
  }
 }
 dps_results: {

--- a/ui/deathknight/inputs.ts
+++ b/ui/deathknight/inputs.ts
@@ -429,7 +429,7 @@ export const DeathKnightRotationConfig = {
 		WeaponSwapInputs,
 		UseEmpowerRuneWeapon,
 		UseDancingRuneWeapon,
-		NewDrwInput,
+		//NewDrwInput,
 		HoldErwArmy,
 		BloodTapInput,
 		BloodSpenderInput,


### PR DESCRIPTION
Updated Blood Plague crit multiplier to include the `Effect #2` entry from the tier bonus aura

![image](https://github.com/wowsims/wotlk/assets/5707996/bfced06f-a424-47ba-b697-782f8af0c97c)

Logs that show the crit multiplier being increased:
https://classic.warcraftlogs.com/reports/mwRv8cLQYxGMdhA6#fight=last&type=damage-done&source=6&ability=55078&view=events
https://classic.warcraftlogs.com/reports/vY3mRzGWVjnaL8x4#fight=last&type=damage-done&source=3&ability=55078&target=47&view=events