### PR TITLE
hunter: filter out thrown weapons

### DIFF
--- a/ui/core/proto_utils/utils.ts
+++ b/ui/core/proto_utils/utils.ts
@@ -1547,7 +1547,6 @@ export const classToEligibleRangedWeaponTypes: Record<Class, Array<RangedWeaponT
 		RangedWeaponType.RangedWeaponTypeBow,
 		RangedWeaponType.RangedWeaponTypeCrossbow,
 		RangedWeaponType.RangedWeaponTypeGun,
-		RangedWeaponType.RangedWeaponTypeThrown,
 	],
 	[Class.ClassMage]: [RangedWeaponType.RangedWeaponTypeWand],
 	[Class.ClassPaladin]: [RangedWeaponType.RangedWeaponTypeLibram],


### PR DESCRIPTION
While they can technically be equipped, you can't use shots so it's not a real consideration