### PR TITLE
Mage APL Support

### DIFF
--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -46,711 +46,711 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6580.00017
-  tps: 5261.16624
+  dps: 6595.34553
+  tps: 5274.02123
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6615.74607
-  tps: 5289.34402
+  dps: 6631.14399
+  tps: 5302.24456
  }
 }
 dps_results: {
  key: "TestFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6497.76031
-  tps: 5195.46222
+  dps: 6531.12749
+  tps: 5221.74562
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6278.05197
-  tps: 5023.0908
-  hps: 94.20519
+  dps: 6307.36507
+  tps: 5047.35537
+  hps: 93.89422
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6278.05197
-  tps: 5023.0908
-  hps: 94.20519
+  dps: 6307.36507
+  tps: 5047.35537
+  hps: 93.89422
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6550.64496
-  tps: 5240.12179
+  dps: 6561.52651
+  tps: 5249.84644
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4959.78368
-  tps: 3961.94737
+  dps: 5013.92205
+  tps: 4004.98139
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 7225.59805
-  tps: 5776.71159
+  dps: 7279.96355
+  tps: 5820.38355
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6538.32482
-  tps: 5124.57708
+  dps: 6571.85815
+  tps: 5150.46585
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6683.37584
-  tps: 5344.01874
+  dps: 6709.16637
+  tps: 5363.99722
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
   hps: 64
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6407.04359
-  tps: 5126.15375
+  dps: 6447.77552
+  tps: 5160.26595
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6457.5912
-  tps: 5176.06701
+  dps: 6499.60362
+  tps: 5209.89231
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6436.59732
-  tps: 5152.53267
+  dps: 6479.44602
+  tps: 5187.99863
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6310.13819
-  tps: 5047.67862
+  dps: 6314.74562
+  tps: 5052.08007
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6510.04824
-  tps: 5205.11112
+  dps: 6535.09941
+  tps: 5224.50408
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6661.76381
-  tps: 5330.37224
+  dps: 6696.82858
+  tps: 5355.65873
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6582.19484
-  tps: 5264.69253
+  dps: 6614.76502
+  tps: 5289.80582
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6497.76031
-  tps: 5195.46222
+  dps: 6531.12749
+  tps: 5221.74562
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6593.15729
-  tps: 5273.33559
+  dps: 6617.62177
+  tps: 5294.49961
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6503.20603
-  tps: 5199.8829
+  dps: 6527.90654
+  tps: 5218.98936
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6486.09058
-  tps: 5186.10466
+  dps: 6511.96385
+  tps: 5206.18553
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6357.91153
-  tps: 5087.29342
+  dps: 6348.54147
+  tps: 5078.69013
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6497.76031
-  tps: 5195.46222
+  dps: 6531.12749
+  tps: 5221.74562
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6398.97007
-  tps: 5127.71081
+  dps: 6520.63571
+  tps: 5225.1936
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6630.9316
-  tps: 5303.96801
+  dps: 6643.90344
+  tps: 5315.56748
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6326.90414
-  tps: 5064.9617
+  dps: 6368.24071
+  tps: 5098.66941
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6469.51286
-  tps: 5174.07128
+  dps: 6484.69574
+  tps: 5186.78549
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6532.3189
-  tps: 5225.6355
+  dps: 6533.31763
+  tps: 5227.81791
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6538.32482
-  tps: 5227.42492
+  dps: 6571.85815
+  tps: 5253.84099
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6530.21192
-  tps: 5221.03238
+  dps: 6563.71202
+  tps: 5247.42192
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FrostfireGarb"
  value: {
-  dps: 5936.05985
-  tps: 4750.01623
+  dps: 6000.53873
+  tps: 4801.21934
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6461.82038
-  tps: 5168.7696
+  dps: 6468.03887
+  tps: 5173.69047
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 6429.59078
-  tps: 5132.12277
+  dps: 6478.34111
+  tps: 5171.18503
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6597.87312
-  tps: 5275.25513
+  dps: 6613.24476
+  tps: 5288.1329
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6638.49346
-  tps: 5307.27534
+  dps: 6653.92483
+  tps: 5320.20486
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6474.87407
-  tps: 5189.04916
+  dps: 6480.74809
+  tps: 5194.35328
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-49982"
  value: {
-  dps: 6683.37584
-  tps: 5344.01874
+  dps: 6709.16637
+  tps: 5363.99722
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 6683.37584
-  tps: 5344.01874
+  dps: 6709.16637
+  tps: 5363.99722
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6600.40029
-  tps: 5278.98085
+  dps: 6615.79195
+  tps: 5291.87555
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6503.20603
-  tps: 5199.8829
+  dps: 6527.90654
+  tps: 5218.98936
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6486.09058
-  tps: 5186.10466
+  dps: 6511.96385
+  tps: 5206.18553
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6544.0029
-  tps: 5238.8474
+  dps: 6573.0629
+  tps: 5261.16357
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6497.76031
-  tps: 5195.46222
+  dps: 6531.12749
+  tps: 5221.74562
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 6685.53439
-  tps: 5345.80257
+  dps: 6737.71193
+  tps: 5388.65708
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KirinTorGarb"
  value: {
-  dps: 6729.82073
-  tps: 5375.88036
+  dps: 6767.57382
+  tps: 5405.51323
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6501.98561
-  tps: 5202.07275
+  dps: 6530.4664
+  tps: 5225.15268
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6387.6169
-  tps: 5110.15169
+  dps: 6389.64404
+  tps: 5113.1322
  }
 }
 dps_results: {
  key: "TestFire-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6505.3738
-  tps: 5202.80644
+  dps: 6549.48843
+  tps: 5238.65236
  }
 }
 dps_results: {
  key: "TestFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6497.76031
-  tps: 5195.46222
+  dps: 6531.12749
+  tps: 5221.74562
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6497.76031
-  tps: 5195.46222
+  dps: 6531.12749
+  tps: 5221.74562
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6497.76031
-  tps: 5195.46222
+  dps: 6531.12749
+  tps: 5221.74562
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6497.76031
-  tps: 5195.46222
+  dps: 6531.12749
+  tps: 5221.74562
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6707.64726
-  tps: 5395.79057
+  dps: 6750.33339
+  tps: 5428.2302
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6756.43682
-  tps: 5438.37338
+  dps: 6798.97158
+  tps: 5470.62302
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6677.56823
-  tps: 5339.30855
+  dps: 6712.02436
+  tps: 5366.46312
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6505.88687
-  tps: 5201.55023
+  dps: 6557.27673
+  tps: 5244.55875
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6582.90892
-  tps: 5268.56769
+  dps: 6613.31821
+  tps: 5294.67515
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6609.17729
-  tps: 5289.41143
+  dps: 6636.55812
+  tps: 5312.91499
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6411.01957
-  tps: 5127.96218
+  dps: 6426.11645
+  tps: 5140.60187
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6483.9593
-  tps: 5196.14991
+  dps: 6486.3606
+  tps: 5196.89375
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 6427.42748
-  tps: 5142.5786
+  dps: 6450.47271
+  tps: 5160.22424
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6419.82451
-  tps: 5135.1337
+  dps: 6461.24847
+  tps: 5168.48211
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6497.76031
-  tps: 5195.46222
+  dps: 6531.12749
+  tps: 5221.74562
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6497.76031
-  tps: 5195.46222
+  dps: 6531.12749
+  tps: 5221.74562
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6497.76031
-  tps: 5195.46222
+  dps: 6531.12749
+  tps: 5221.74562
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6372.72127
-  tps: 5099.41303
+  dps: 6371.14776
+  tps: 5097.90773
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6349.74584
-  tps: 5081.5557
+  dps: 6388.48722
+  tps: 5112.80854
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TempestRegalia"
  value: {
-  dps: 4611.27268
-  tps: 3685.03757
+  dps: 4620.51093
+  tps: 3692.06326
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6289.15856
-  tps: 5031.90156
+  dps: 6304.07624
+  tps: 5044.38598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5370.20953
-  tps: 4302.19481
+  dps: 5396.73617
+  tps: 4325.27727
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6497.76031
-  tps: 5195.46222
+  dps: 6531.12749
+  tps: 5221.74562
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6493.06863
-  tps: 5193.30832
+  dps: 6529.90686
+  tps: 5222.68762
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6493.06863
-  tps: 5193.30832
+  dps: 6529.90686
+  tps: 5222.68762
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6538.32482
-  tps: 5227.42492
+  dps: 6571.85815
+  tps: 5253.84099
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6530.21192
-  tps: 5221.03238
+  dps: 6563.71202
+  tps: 5247.42192
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6440.75923
-  tps: 5151.59914
+  dps: 6456.34423
+  tps: 5164.73149
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6530.21192
-  tps: 5221.03238
+  dps: 6563.71202
+  tps: 5247.42192
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6538.32482
-  tps: 5227.42492
+  dps: 6571.85815
+  tps: 5253.84099
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6418.63754
-  tps: 5135.48475
+  dps: 6434.58568
+  tps: 5148.79353
  }
 }
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
-  dps: 6834.64893
-  tps: 5465.33793
+  dps: 6869.20716
+  tps: 5492.85979
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19768.3511
-  tps: 19413.64346
+  dps: 22461.63766
+  tps: 21568.2727
  }
 }
 dps_results: {
@@ -770,8 +770,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13078.78715
-  tps: 13020.60099
+  dps: 14314.56137
+  tps: 14009.22037
  }
 }
 dps_results: {
@@ -791,49 +791,49 @@ dps_results: {
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9375.80554
-  tps: 9524.10357
+  dps: 9915.84606
+  tps: 9954.00796
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6734.7567
-  tps: 5386.08711
+  dps: 6741.16393
+  tps: 5391.25771
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8171.13136
-  tps: 6440.14497
+  dps: 8215.45277
+  tps: 6475.58508
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4638.69704
-  tps: 5366.39576
+  dps: 4945.41544
+  tps: 5620.47155
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2521.73594
-  tps: 2010.57185
+  dps: 2526.77715
+  tps: 2014.50687
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3766.34599
-  tps: 2912.70341
+  dps: 3797.57469
+  tps: 2940.46165
  }
 }
 dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6683.37584
-  tps: 5344.01874
+  dps: 6709.16637
+  tps: 5363.99722
  }
 }

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -46,704 +46,704 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6595.34553
-  tps: 5274.02123
+  dps: 6612.75498
+  tps: 5287.37009
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6631.14399
-  tps: 5302.24456
+  dps: 6648.65436
+  tps: 5315.67066
  }
 }
 dps_results: {
  key: "TestFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6531.12749
-  tps: 5221.74562
+  dps: 6527.55358
+  tps: 5219.29683
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6307.36507
-  tps: 5047.35537
-  hps: 93.89422
+  dps: 6310.3794
+  tps: 5048.95275
+  hps: 94.20519
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6307.36507
-  tps: 5047.35537
-  hps: 93.89422
+  dps: 6310.3794
+  tps: 5048.95275
+  hps: 94.20519
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6561.52651
-  tps: 5249.84644
+  dps: 6577.14461
+  tps: 5261.3215
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5013.92205
-  tps: 4004.98139
+  dps: 4980.67719
+  tps: 3978.66217
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 7279.96355
-  tps: 5820.38355
+  dps: 7261.80178
+  tps: 5805.67458
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6571.85815
-  tps: 5150.46585
+  dps: 6568.27802
+  tps: 5148.06039
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6709.16637
-  tps: 5363.99722
+  dps: 6716.60614
+  tps: 5370.60298
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
   hps: 64
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6447.77552
-  tps: 5160.26595
+  dps: 6440.01155
+  tps: 5152.52811
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6499.60362
-  tps: 5209.89231
+  dps: 6488.56949
+  tps: 5200.84964
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6479.44602
-  tps: 5187.99863
+  dps: 6468.24274
+  tps: 5177.849
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6314.74562
-  tps: 5052.08007
+  dps: 6341.52545
+  tps: 5072.78844
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6535.09941
-  tps: 5224.50408
+  dps: 6542.0385
+  tps: 5230.70333
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6696.82858
-  tps: 5355.65873
+  dps: 6691.49024
+  tps: 5354.15338
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6614.76502
-  tps: 5289.80582
+  dps: 6614.81025
+  tps: 5290.78486
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6531.12749
-  tps: 5221.74562
+  dps: 6527.55358
+  tps: 5219.29683
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6617.62177
-  tps: 5294.49961
+  dps: 6618.95193
+  tps: 5293.9713
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6527.90654
-  tps: 5218.98936
+  dps: 6535.15612
+  tps: 5225.44297
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6511.96385
-  tps: 5206.18553
+  dps: 6518.09668
+  tps: 5211.70954
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6348.54147
-  tps: 5078.69013
+  dps: 6389.64116
+  tps: 5112.67713
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6531.12749
-  tps: 5221.74562
+  dps: 6527.55358
+  tps: 5219.29683
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6520.63571
-  tps: 5225.1936
+  dps: 6429.83835
+  tps: 5152.40544
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6643.90344
-  tps: 5315.56748
+  dps: 6663.77561
+  tps: 5330.24322
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6368.24071
-  tps: 5098.66941
+  dps: 6358.37642
+  tps: 5090.13952
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6484.69574
-  tps: 5186.78549
+  dps: 6501.79325
+  tps: 5199.8956
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6533.31763
-  tps: 5227.81791
+  dps: 6563.37391
+  tps: 5250.47951
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6571.85815
-  tps: 5253.84099
+  dps: 6568.27802
+  tps: 5251.38748
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6563.71202
-  tps: 5247.42192
+  dps: 6560.13313
+  tps: 5244.96935
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FrostfireGarb"
  value: {
-  dps: 6000.53873
-  tps: 4801.21934
+  dps: 5964.96748
+  tps: 4773.14234
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6468.03887
-  tps: 5173.69047
+  dps: 6496.47516
+  tps: 5196.49343
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 6478.34111
-  tps: 5171.18503
+  dps: 6459.84938
+  tps: 5156.32965
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6613.24476
-  tps: 5288.1329
+  dps: 6630.70467
+  tps: 5301.52038
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6653.92483
-  tps: 5320.20486
+  dps: 6671.49943
+  tps: 5333.68012
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6480.74809
-  tps: 5194.35328
+  dps: 6504.84068
+  tps: 5213.02245
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-49982"
  value: {
-  dps: 6709.16637
-  tps: 5363.99722
+  dps: 6716.60614
+  tps: 5370.60298
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 6709.16637
-  tps: 5363.99722
+  dps: 6716.60614
+  tps: 5370.60298
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6615.79195
-  tps: 5291.87555
+  dps: 6633.28204
+  tps: 5305.28625
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6527.90654
-  tps: 5218.98936
+  dps: 6535.15612
+  tps: 5225.44297
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6511.96385
-  tps: 5206.18553
+  dps: 6518.09668
+  tps: 5211.70954
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6573.0629
-  tps: 5261.16357
+  dps: 6572.29844
+  tps: 5261.48384
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6531.12749
-  tps: 5221.74562
+  dps: 6527.55358
+  tps: 5219.29683
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 6737.71193
-  tps: 5388.65708
+  dps: 6718.26737
+  tps: 5371.98895
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KirinTorGarb"
  value: {
-  dps: 6767.57382
-  tps: 5405.51323
+  dps: 6761.11994
+  tps: 5400.91973
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6530.4664
-  tps: 5225.15268
+  dps: 6533.62079
+  tps: 5227.3809
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6389.64404
-  tps: 5113.1322
+  dps: 6417.97654
+  tps: 5134.4394
  }
 }
 dps_results: {
  key: "TestFire-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6549.48843
-  tps: 5238.65236
+  dps: 6542.05374
+  tps: 5232.15039
  }
 }
 dps_results: {
  key: "TestFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6531.12749
-  tps: 5221.74562
+  dps: 6527.55358
+  tps: 5219.29683
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6531.12749
-  tps: 5221.74562
+  dps: 6527.55358
+  tps: 5219.29683
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6531.12749
-  tps: 5221.74562
+  dps: 6527.55358
+  tps: 5219.29683
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6531.12749
-  tps: 5221.74562
+  dps: 6527.55358
+  tps: 5219.29683
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6750.33339
-  tps: 5428.2302
+  dps: 6745.58694
+  tps: 5426.14232
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6798.97158
-  tps: 5470.62302
+  dps: 6794.52282
+  tps: 5468.84218
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6712.02436
-  tps: 5366.46312
+  dps: 6708.55622
+  tps: 5364.09894
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6557.27673
-  tps: 5244.55875
+  dps: 6536.36799
+  tps: 5225.93512
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6613.31821
-  tps: 5294.67515
+  dps: 6614.03364
+  tps: 5293.46746
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6636.55812
-  tps: 5312.91499
+  dps: 6640.89519
+  tps: 5314.78574
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6426.11645
-  tps: 5140.60187
+  dps: 6443.0488
+  tps: 5153.58557
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6486.3606
-  tps: 5196.89375
+  dps: 6515.78015
+  tps: 5221.6066
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 6450.47271
-  tps: 5160.22424
+  dps: 6459.38476
+  tps: 5168.14442
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6461.24847
-  tps: 5168.48211
+  dps: 6451.82539
+  tps: 5160.7344
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6531.12749
-  tps: 5221.74562
+  dps: 6527.55358
+  tps: 5219.29683
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6531.12749
-  tps: 5221.74562
+  dps: 6527.55358
+  tps: 5219.29683
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6531.12749
-  tps: 5221.74562
+  dps: 6527.55358
+  tps: 5219.29683
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6371.14776
-  tps: 5097.90773
+  dps: 6405.90748
+  tps: 5125.96199
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6388.48722
-  tps: 5112.80854
+  dps: 6383.74241
+  tps: 5108.75295
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TempestRegalia"
  value: {
-  dps: 4620.51093
-  tps: 3692.06326
+  dps: 4632.3501
+  tps: 3701.89951
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6304.07624
-  tps: 5044.38598
+  dps: 6320.66454
+  tps: 5057.10635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5396.73617
-  tps: 4325.27727
+  dps: 5398.44018
+  tps: 4324.77932
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6531.12749
-  tps: 5221.74562
+  dps: 6527.55358
+  tps: 5219.29683
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6529.90686
-  tps: 5222.68762
+  dps: 6524.87227
+  tps: 5218.75123
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6529.90686
-  tps: 5222.68762
+  dps: 6524.87227
+  tps: 5218.75123
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6571.85815
-  tps: 5253.84099
+  dps: 6568.27802
+  tps: 5251.38748
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6563.71202
-  tps: 5247.42192
+  dps: 6560.13313
+  tps: 5244.96935
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6456.34423
-  tps: 5164.73149
+  dps: 6468.54627
+  tps: 5173.82876
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6563.71202
-  tps: 5247.42192
+  dps: 6560.13313
+  tps: 5244.96935
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6571.85815
-  tps: 5253.84099
+  dps: 6568.27802
+  tps: 5251.38748
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6434.58568
-  tps: 5148.79353
+  dps: 6450.72178
+  tps: 5161.15214
  }
 }
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
-  dps: 6869.20716
-  tps: 5492.85979
+  dps: 6868.36052
+  tps: 5492.3072
  }
 }
 dps_results: {
@@ -791,49 +791,49 @@ dps_results: {
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9915.84606
-  tps: 9954.00796
+  dps: 9872.16148
+  tps: 9921.18832
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6741.16393
-  tps: 5391.25771
+  dps: 6766.64016
+  tps: 5411.59388
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8215.45277
-  tps: 6475.58508
+  dps: 8198.96993
+  tps: 6462.41583
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4945.41544
-  tps: 5620.47155
+  dps: 4888.64372
+  tps: 5566.3531
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2526.77715
-  tps: 2014.50687
+  dps: 2530.28191
+  tps: 2017.40862
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3797.57469
-  tps: 2940.46165
+  dps: 3777.29337
+  tps: 2921.46132
  }
 }
 dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6709.16637
-  tps: 5363.99722
+  dps: 6716.60614
+  tps: 5370.60298
  }
 }

--- a/sim/mage/TestFrostFire.results
+++ b/sim/mage/TestFrostFire.results
@@ -46,752 +46,752 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostFire-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6250.66268
-  tps: 4975.355
+  dps: 6302.87608
+  tps: 5018.59296
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6285.19448
-  tps: 5002.56098
+  dps: 6337.69239
+  tps: 5046.03293
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6135.47095
-  tps: 4882.04205
+  dps: 6169.29574
+  tps: 4909.09694
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 5969.32537
-  tps: 4753.67548
-  hps: 94.63921
+  dps: 6019.80714
+  tps: 4795.53847
+  hps: 94.823
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 5969.32537
-  tps: 4753.67548
-  hps: 94.63921
+  dps: 6019.80714
+  tps: 4795.53847
+  hps: 94.823
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6168.21972
-  tps: 4908.47028
+  dps: 6190.36842
+  tps: 4927.06048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4970.74324
-  tps: 3963.15672
+  dps: 5005.85281
+  tps: 3988.00721
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 6999.15625
-  tps: 5572.60738
+  dps: 6995.77316
+  tps: 5571.11897
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6174.39752
-  tps: 4815.69466
+  dps: 6208.37459
+  tps: 4842.32342
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6349.14785
-  tps: 5053.03726
+  dps: 6372.41061
+  tps: 5072.52057
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
   hps: 64
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6072.86608
-  tps: 4839.00082
+  dps: 6127.32565
+  tps: 4882.74348
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6132.67951
-  tps: 4897.67402
+  dps: 6124.19791
+  tps: 4889.29159
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6072.36241
-  tps: 4838.73891
+  dps: 6112.00267
+  tps: 4870.17275
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Death'sChoice-47464"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6027.03399
-  tps: 4801.40028
+  dps: 6060.40638
+  tps: 4827.8437
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6173.84746
-  tps: 4912.82186
+  dps: 6194.30366
+  tps: 4930.043
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6441.57993
-  tps: 5132.0289
+  dps: 6460.40007
+  tps: 5146.21159
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6402.38158
-  tps: 5100.44825
+  dps: 6406.96291
+  tps: 5103.08789
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6135.47095
-  tps: 4882.04205
+  dps: 6169.29574
+  tps: 4909.09694
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6185.00306
-  tps: 4921.34209
+  dps: 6208.93816
+  tps: 4940.54789
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6168.18271
-  tps: 4908.26515
+  dps: 6190.61544
+  tps: 4927.08443
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6163.63809
-  tps: 4904.58897
+  dps: 6190.71644
+  tps: 4926.93447
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6074.84868
-  tps: 4837.08849
+  dps: 6117.3507
+  tps: 4870.93502
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6135.47095
-  tps: 4882.04205
+  dps: 6169.29574
+  tps: 4909.09694
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6145.44647
-  tps: 4904.66724
+  dps: 6195.56713
+  tps: 4944.02468
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6293.02255
-  tps: 5012.87862
+  dps: 6338.45051
+  tps: 5048.93998
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6004.38702
-  tps: 4785.33694
+  dps: 6027.81896
+  tps: 4804.60953
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6143.92804
-  tps: 4891.26377
+  dps: 6195.26204
+  tps: 4933.77851
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6212.98509
-  tps: 4949.93353
+  dps: 6251.6025
+  tps: 4980.43617
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6174.39752
-  tps: 4912.69099
+  dps: 6208.37459
+  tps: 4939.86704
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6166.61221
-  tps: 4906.56121
+  dps: 6200.55882
+  tps: 4933.71302
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FrostfireGarb"
  value: {
-  dps: 5585.77877
-  tps: 4446.74616
+  dps: 5649.63
+  tps: 4497.62872
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6088.2959
-  tps: 4847.69612
+  dps: 6142.49199
+  tps: 4892.15738
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 6124.80416
-  tps: 4868.76485
+  dps: 6141.00765
+  tps: 4880.30636
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6267.92858
-  tps: 4988.95799
+  dps: 6320.28423
+  tps: 5032.31295
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6307.16926
-  tps: 5019.87388
+  dps: 6359.84822
+  tps: 5063.49473
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6109.09938
-  tps: 4873.86466
+  dps: 6159.01012
+  tps: 4913.09622
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Heartpierce-49982"
  value: {
-  dps: 6349.14785
-  tps: 5053.03726
+  dps: 6372.41061
+  tps: 5072.52057
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 6349.14785
-  tps: 5053.03726
+  dps: 6372.41061
+  tps: 5072.52057
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6270.87602
-  tps: 4992.97315
+  dps: 6323.33227
+  tps: 5036.42848
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6168.18271
-  tps: 4908.26515
+  dps: 6190.61544
+  tps: 4927.08443
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6163.63809
-  tps: 4904.58897
+  dps: 6190.71644
+  tps: 4926.93447
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6145.7337
-  tps: 4896.09571
+  dps: 6168.69725
+  tps: 4914.43647
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6135.47095
-  tps: 4882.04205
+  dps: 6169.29574
+  tps: 4909.09694
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 6274.43907
-  tps: 4994.60456
+  dps: 6264.65748
+  tps: 4985.79995
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-KirinTorGarb"
  value: {
-  dps: 6341.96007
-  tps: 5040.5202
+  dps: 6367.87821
+  tps: 5061.60381
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6107.32894
-  tps: 4865.34601
+  dps: 6188.34865
+  tps: 4930.8638
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6067.98098
-  tps: 4834.21527
+  dps: 6114.26643
+  tps: 4870.82433
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6225.11788
-  tps: 4958.08036
+  dps: 6242.32028
+  tps: 4972.2501
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6135.47095
-  tps: 4882.04205
+  dps: 6169.29574
+  tps: 4909.09694
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6135.47095
-  tps: 4882.04205
+  dps: 6169.29574
+  tps: 4909.09694
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6135.47095
-  tps: 4882.04205
+  dps: 6169.29574
+  tps: 4909.09694
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6135.47095
-  tps: 4882.04205
+  dps: 6169.29574
+  tps: 4909.09694
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6409.83108
-  tps: 5140.10416
+  dps: 6385.7379
+  tps: 5120.14698
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6460.9309
-  tps: 5185.19909
+  dps: 6436.60377
+  tps: 5165.02819
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6314.57879
-  tps: 5025.32832
+  dps: 6349.63273
+  tps: 5053.36653
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6139.69475
-  tps: 4885.41558
+  dps: 6168.83466
+  tps: 4908.73444
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6218.03275
-  tps: 4955.62288
+  dps: 6270.46095
+  tps: 4999.02921
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6249.4253
-  tps: 4981.03892
+  dps: 6302.11214
+  tps: 5024.65797
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6087.42147
-  tps: 4846.74489
+  dps: 6138.2899
+  tps: 4888.87675
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6091.47236
-  tps: 4860.71277
+  dps: 6134.20647
+  tps: 4894.91142
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 6060.40455
-  tps: 4827.79095
+  dps: 6065.47586
+  tps: 4831.37533
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6102.50591
-  tps: 4859.72567
+  dps: 6126.22967
+  tps: 4878.45073
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6135.47095
-  tps: 4882.04205
+  dps: 6169.29574
+  tps: 4909.09694
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6135.47095
-  tps: 4882.04205
+  dps: 6169.29574
+  tps: 4909.09694
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6135.47095
-  tps: 4882.04205
+  dps: 6169.29574
+  tps: 4909.09694
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6040.89857
-  tps: 4812.56158
+  dps: 6073.91626
+  tps: 4838.69624
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6028.09222
-  tps: 4802.3943
+  dps: 6043.73258
+  tps: 4815.0686
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TempestRegalia"
  value: {
-  dps: 4458.62285
-  tps: 3555.95043
+  dps: 4482.30412
+  tps: 3577.6796
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 5969.69944
-  tps: 4753.99722
+  dps: 6019.59794
+  tps: 4795.3314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5111.79907
-  tps: 4076.00027
+  dps: 5137.88804
+  tps: 4096.41082
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6135.47095
-  tps: 4882.04205
+  dps: 6169.29574
+  tps: 4909.09694
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6171.91879
-  tps: 4914.298
+  dps: 6197.72311
+  tps: 4934.77549
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6171.91879
-  tps: 4914.298
+  dps: 6197.72311
+  tps: 4934.77549
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6174.39752
-  tps: 4912.69099
+  dps: 6208.37459
+  tps: 4939.86704
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6166.61221
-  tps: 4906.56121
+  dps: 6200.55882
+  tps: 4933.71302
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6184.19154
-  tps: 4926.4211
+  dps: 6207.64299
+  tps: 4944.006
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6166.61221
-  tps: 4906.56121
+  dps: 6200.55882
+  tps: 4933.71302
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6174.39752
-  tps: 4912.69099
+  dps: 6208.37459
+  tps: 4939.86704
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6095.92441
-  tps: 4854.97719
+  dps: 6146.86444
+  tps: 4897.1446
  }
 }
 dps_results: {
  key: "TestFrostFire-Average-Default"
  value: {
-  dps: 6410.55151
-  tps: 5103.3867
+  dps: 6427.71376
+  tps: 5117.10793
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8665.4902
-  tps: 8603.99978
+  dps: 9288.27983
+  tps: 9086.59238
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6336.24053
-  tps: 5044.82706
+  dps: 6378.50586
+  tps: 5078.0914
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7399.71865
-  tps: 5807.32044
+  dps: 7404.40513
+  tps: 5802.17859
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4676.29073
-  tps: 5394.74554
+  dps: 4944.75949
+  tps: 5619.74548
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2676.50479
-  tps: 2135.56818
+  dps: 2690.73971
+  tps: 2147.31828
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3173.4779
-  tps: 2437.67182
+  dps: 3218.3284
+  tps: 2474.3743
  }
 }
 dps_results: {
  key: "TestFrostFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6349.14785
-  tps: 5053.03726
+  dps: 6372.41061
+  tps: 5072.52057
  }
 }

--- a/sim/mage/TestFrostFire.results
+++ b/sim/mage/TestFrostFire.results
@@ -46,752 +46,752 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostFire-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6302.87608
-  tps: 5018.59296
+  dps: 6277.84166
+  tps: 4997.09818
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6337.69239
-  tps: 5046.03293
+  dps: 6312.49905
+  tps: 5024.40464
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6169.29574
-  tps: 4909.09694
+  dps: 6165.35192
+  tps: 4905.94682
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6019.80714
-  tps: 4795.53847
-  hps: 94.823
+  dps: 5995.48351
+  tps: 4774.602
+  hps: 94.63921
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6019.80714
-  tps: 4795.53847
-  hps: 94.823
+  dps: 5995.48351
+  tps: 4774.602
+  hps: 94.63921
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6190.36842
-  tps: 4927.06048
+  dps: 6198.2423
+  tps: 4932.48834
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5005.85281
-  tps: 3988.00721
+  dps: 4994.8568
+  tps: 3982.44757
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 6995.77316
-  tps: 5571.11897
+  dps: 7030.67206
+  tps: 5597.82003
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6208.37459
-  tps: 4842.32342
+  dps: 6204.4379
+  tps: 4839.24632
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6372.41061
-  tps: 5072.52057
+  dps: 6380.37617
+  tps: 5078.01992
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
   hps: 64
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6127.32565
-  tps: 4882.74348
+  dps: 6102.25173
+  tps: 4862.50934
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6124.19791
-  tps: 4889.29159
+  dps: 6165.2422
+  tps: 4923.72417
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6112.00267
-  tps: 4870.17275
+  dps: 6101.25648
+  tps: 4861.85416
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6060.40638
-  tps: 4827.8437
+  dps: 6052.64711
+  tps: 4821.89077
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6194.30366
-  tps: 4930.043
+  dps: 6203.88236
+  tps: 4936.84978
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6460.40007
-  tps: 5146.21159
+  dps: 6472.81339
+  tps: 5157.01567
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6406.96291
-  tps: 5103.08789
+  dps: 6435.77761
+  tps: 5127.16508
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6169.29574
-  tps: 4909.09694
+  dps: 6165.35192
+  tps: 4905.94682
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6208.93816
-  tps: 4940.54789
+  dps: 6214.93872
+  tps: 4945.29061
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6190.61544
-  tps: 4927.08443
+  dps: 6198.21762
+  tps: 4932.29307
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6190.71644
-  tps: 4926.93447
+  dps: 6193.72062
+  tps: 4928.655
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6117.3507
-  tps: 4870.93502
+  dps: 6104.6584
+  tps: 4860.93627
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6169.29574
-  tps: 4909.09694
+  dps: 6165.35192
+  tps: 4905.94682
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6195.56713
-  tps: 4944.02468
+  dps: 6178.06604
+  tps: 4930.7629
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6338.45051
-  tps: 5048.93998
+  dps: 6320.774
+  tps: 5035.07978
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6027.81896
-  tps: 4804.60953
+  dps: 6030.17897
+  tps: 4805.9705
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6195.26204
-  tps: 4933.77851
+  dps: 6170.71881
+  tps: 4912.69639
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6251.6025
-  tps: 4980.43617
+  dps: 6241.00164
+  tps: 4972.34677
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6208.37459
-  tps: 4939.86704
+  dps: 6204.4379
+  tps: 4936.7233
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6200.55882
-  tps: 4933.71302
+  dps: 6196.6207
+  tps: 4930.568
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FrostfireGarb"
  value: {
-  dps: 5649.63
-  tps: 4497.62872
+  dps: 5613.46339
+  tps: 4468.89386
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6142.49199
-  tps: 4892.15738
+  dps: 6118.91059
+  tps: 4872.18788
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 6141.00765
-  tps: 4880.30636
+  dps: 6172.20759
+  tps: 4906.6876
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6320.28423
-  tps: 5032.31295
+  dps: 6295.17035
+  tps: 5010.75141
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6359.84822
-  tps: 5063.49473
+  dps: 6334.55375
+  tps: 5041.78148
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6159.01012
-  tps: 4913.09622
+  dps: 6141.67772
+  tps: 4899.92733
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Heartpierce-49982"
  value: {
-  dps: 6372.41061
-  tps: 5072.52057
+  dps: 6380.37617
+  tps: 5078.01992
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 6372.41061
-  tps: 5072.52057
+  dps: 6380.37617
+  tps: 5078.01992
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6323.33227
-  tps: 5036.42848
+  dps: 6298.17273
+  tps: 5014.81052
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6190.61544
-  tps: 4927.08443
+  dps: 6198.21762
+  tps: 4932.29307
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6190.71644
-  tps: 4926.93447
+  dps: 6193.72062
+  tps: 4928.655
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6168.69725
-  tps: 4914.43647
+  dps: 6175.47677
+  tps: 4919.89016
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6169.29574
-  tps: 4909.09694
+  dps: 6165.35192
+  tps: 4905.94682
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 6264.65748
-  tps: 4985.79995
+  dps: 6301.51134
+  tps: 5016.26238
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-KirinTorGarb"
  value: {
-  dps: 6367.87821
-  tps: 5061.60381
+  dps: 6378.8655
+  tps: 5070.04454
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6188.34865
-  tps: 4930.8638
+  dps: 6138.05953
+  tps: 4889.93049
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6114.26643
-  tps: 4870.82433
+  dps: 6095.56336
+  tps: 4856.28118
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6242.32028
-  tps: 4972.2501
+  dps: 6255.06609
+  tps: 4982.03892
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6169.29574
-  tps: 4909.09694
+  dps: 6165.35192
+  tps: 4905.94682
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6169.29574
-  tps: 4909.09694
+  dps: 6165.35192
+  tps: 4905.94682
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6169.29574
-  tps: 4909.09694
+  dps: 6165.35192
+  tps: 4905.94682
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6169.29574
-  tps: 4909.09694
+  dps: 6165.35192
+  tps: 4905.94682
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6385.7379
-  tps: 5120.14698
+  dps: 6441.48974
+  tps: 5165.43108
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6436.60377
-  tps: 5165.02819
+  dps: 6492.71072
+  tps: 5210.62295
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6349.63273
-  tps: 5053.36653
+  dps: 6345.64607
+  tps: 5050.18214
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6168.83466
-  tps: 4908.73444
+  dps: 6169.55748
+  tps: 4909.30576
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6270.46095
-  tps: 4999.02921
+  dps: 6245.13059
+  tps: 4977.30115
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6302.11214
-  tps: 5024.65797
+  dps: 6276.63731
+  tps: 5002.80854
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6138.2899
-  tps: 4888.87675
+  dps: 6114.00671
+  tps: 4868.01308
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6134.20647
-  tps: 4894.91142
+  dps: 6118.76474
+  tps: 4882.54668
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 6065.47586
-  tps: 4831.37533
+  dps: 6088.98811
+  tps: 4850.65779
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6126.22967
-  tps: 4878.45073
+  dps: 6133.08502
+  tps: 4884.18896
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6169.29574
-  tps: 4909.09694
+  dps: 6165.35192
+  tps: 4905.94682
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6169.29574
-  tps: 4909.09694
+  dps: 6165.35192
+  tps: 4905.94682
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6169.29574
-  tps: 4909.09694
+  dps: 6165.35192
+  tps: 4905.94682
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6073.91626
-  tps: 4838.69624
+  dps: 6066.58362
+  tps: 4833.10962
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6043.73258
-  tps: 4815.0686
+  dps: 6053.44916
+  tps: 4822.67986
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TempestRegalia"
  value: {
-  dps: 4482.30412
-  tps: 3577.6796
+  dps: 4478.10488
+  tps: 3571.53606
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6019.59794
-  tps: 4795.3314
+  dps: 5995.85651
+  tps: 4774.92287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5137.88804
-  tps: 4096.41082
+  dps: 5136.85272
+  tps: 4096.04319
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6169.29574
-  tps: 4909.09694
+  dps: 6165.35192
+  tps: 4905.94682
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6197.72311
-  tps: 4934.77549
+  dps: 6203.70886
+  tps: 4939.73006
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6197.72311
-  tps: 4934.77549
+  dps: 6203.70886
+  tps: 4939.73006
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6208.37459
-  tps: 4939.86704
+  dps: 6204.4379
+  tps: 4936.7233
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6200.55882
-  tps: 4933.71302
+  dps: 6196.6207
+  tps: 4930.568
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6207.64299
-  tps: 4944.006
+  dps: 6212.17316
+  tps: 4948.8064
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6200.55882
-  tps: 4933.71302
+  dps: 6196.6207
+  tps: 4930.568
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6208.37459
-  tps: 4939.86704
+  dps: 6204.4379
+  tps: 4936.7233
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6146.86444
-  tps: 4897.1446
+  dps: 6122.57258
+  tps: 4876.29573
  }
 }
 dps_results: {
  key: "TestFrostFire-Average-Default"
  value: {
-  dps: 6427.71376
-  tps: 5117.10793
+  dps: 6443.25482
+  tps: 5129.54934
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9288.27983
-  tps: 9086.59238
+  dps: 9230.37414
+  tps: 9055.90693
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6378.50586
-  tps: 5078.0914
+  dps: 6442.70929
+  tps: 5130.00206
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7404.40513
-  tps: 5802.17859
+  dps: 7563.18739
+  tps: 5938.09544
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4944.75949
-  tps: 5619.74548
+  dps: 4940.19718
+  tps: 5605.87069
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2690.73971
-  tps: 2147.31828
+  dps: 2696.83169
+  tps: 2151.8297
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3218.3284
-  tps: 2474.3743
+  dps: 3206.42063
+  tps: 2464.026
  }
 }
 dps_results: {
  key: "TestFrostFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6372.41061
-  tps: 5072.52057
+  dps: 6380.37617
+  tps: 5078.01992
  }
 }

--- a/sim/mage/arcane_barrage.go
+++ b/sim/mage/arcane_barrage.go
@@ -16,7 +16,7 @@ func (mage *Mage) registerArcaneBarrageSpell() {
 		ActionID:     core.ActionID{SpellID: 44781},
 		SpellSchool:  core.SpellSchoolFrost,
 		ProcMask:     core.ProcMaskSpellDamage,
-		Flags:        SpellFlagMage | BarrageSpells,
+		Flags:        SpellFlagMage | BarrageSpells | core.SpellFlagAPL,
 		MissileSpeed: 24,
 
 		ManaCost: core.ManaCostOptions{

--- a/sim/mage/arcane_blast.go
+++ b/sim/mage/arcane_blast.go
@@ -35,7 +35,7 @@ func (mage *Mage) registerArcaneBlastSpell() {
 		ActionID:    actionID,
 		SpellSchool: core.SpellSchoolArcane,
 		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       SpellFlagMage | BarrageSpells,
+		Flags:       SpellFlagMage | BarrageSpells | core.SpellFlagAPL,
 
 		ManaCost: core.ManaCostOptions{
 			BaseCost:   0.07,

--- a/sim/mage/arcane_explosion.go
+++ b/sim/mage/arcane_explosion.go
@@ -10,7 +10,7 @@ func (mage *Mage) registerArcaneExplosionSpell() {
 		ActionID:    core.ActionID{SpellID: 42921},
 		SpellSchool: core.SpellSchoolArcane,
 		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       SpellFlagMage,
+		Flags:       SpellFlagMage | core.SpellFlagAPL,
 
 		ManaCost: core.ManaCostOptions{
 			BaseCost:   0.22,

--- a/sim/mage/arcane_missiles.go
+++ b/sim/mage/arcane_missiles.go
@@ -16,7 +16,7 @@ func (mage *Mage) registerArcaneMissilesSpell() {
 		ActionID:     core.ActionID{SpellID: 42846},
 		SpellSchool:  core.SpellSchoolArcane,
 		ProcMask:     core.ProcMaskSpellDamage,
-		Flags:        SpellFlagMage | core.SpellFlagChanneled,
+		Flags:        SpellFlagMage | core.SpellFlagChanneled | core.SpellFlagAPL,
 		MissileSpeed: 20,
 
 		ManaCost: core.ManaCostOptions{

--- a/sim/mage/blizzard.go
+++ b/sim/mage/blizzard.go
@@ -13,7 +13,7 @@ func (mage *Mage) registerBlizzardSpell() {
 		ActionID:    core.ActionID{SpellID: 42939},
 		SpellSchool: core.SpellSchoolFrost,
 		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       SpellFlagMage | core.SpellFlagChanneled,
+		Flags:       SpellFlagMage | core.SpellFlagChanneled | core.SpellFlagAPL,
 
 		ManaCost: core.ManaCostOptions{
 			BaseCost: 0.74,

--- a/sim/mage/deep_freeze.go
+++ b/sim/mage/deep_freeze.go
@@ -15,7 +15,7 @@ func (mage *Mage) registerDeepFreezeSpell() {
 		ActionID:    core.ActionID{SpellID: 44572},
 		SpellSchool: core.SpellSchoolFrost,
 		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       SpellFlagMage,
+		Flags:       SpellFlagMage | core.SpellFlagAPL,
 
 		ManaCost: core.ManaCostOptions{
 			BaseCost: 0.09,

--- a/sim/mage/evocation.go
+++ b/sim/mage/evocation.go
@@ -29,6 +29,7 @@ func (mage *Mage) registerEvocationCD() {
 
 	evocationSpell := mage.RegisterSpell(core.SpellConfig{
 		ActionID: actionID,
+		Flags:    core.SpellFlagAPL,
 
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{

--- a/sim/mage/fire_blast.go
+++ b/sim/mage/fire_blast.go
@@ -11,7 +11,7 @@ func (mage *Mage) registerFireBlastSpell() {
 		ActionID:    core.ActionID{SpellID: 42873},
 		SpellSchool: core.SpellSchoolFire,
 		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       SpellFlagMage | HotStreakSpells,
+		Flags:       SpellFlagMage | HotStreakSpells | core.SpellFlagAPL,
 
 		ManaCost: core.ManaCostOptions{
 			BaseCost: 0.21,

--- a/sim/mage/fireball.go
+++ b/sim/mage/fireball.go
@@ -15,7 +15,7 @@ func (mage *Mage) registerFireballSpell() {
 		ActionID:     core.ActionID{SpellID: 42833},
 		SpellSchool:  core.SpellSchoolFire,
 		ProcMask:     core.ProcMaskSpellDamage,
-		Flags:        SpellFlagMage | BarrageSpells | HotStreakSpells,
+		Flags:        SpellFlagMage | BarrageSpells | HotStreakSpells | core.SpellFlagAPL,
 		MissileSpeed: 24,
 
 		ManaCost: core.ManaCostOptions{

--- a/sim/mage/flamestrike.go
+++ b/sim/mage/flamestrike.go
@@ -11,7 +11,7 @@ func (mage *Mage) registerFlamestrikeSpell() {
 		ActionID:    core.ActionID{SpellID: 42926},
 		SpellSchool: core.SpellSchoolFire,
 		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       SpellFlagMage,
+		Flags:       SpellFlagMage | core.SpellFlagAPL,
 
 		ManaCost: core.ManaCostOptions{
 			BaseCost: 0.30,

--- a/sim/mage/frostbolt.go
+++ b/sim/mage/frostbolt.go
@@ -20,7 +20,7 @@ func (mage *Mage) registerFrostboltSpell() {
 		ActionID:     core.ActionID{SpellID: 42842},
 		SpellSchool:  core.SpellSchoolFrost,
 		ProcMask:     core.ProcMaskSpellDamage,
-		Flags:        SpellFlagMage | BarrageSpells,
+		Flags:        SpellFlagMage | BarrageSpells | core.SpellFlagAPL,
 		MissileSpeed: 28,
 
 		ManaCost: core.ManaCostOptions{

--- a/sim/mage/frostfire_bolt.go
+++ b/sim/mage/frostfire_bolt.go
@@ -15,7 +15,7 @@ func (mage *Mage) registerFrostfireBoltSpell() {
 		ActionID:     core.ActionID{SpellID: 47610},
 		SpellSchool:  core.SpellSchoolFire | core.SpellSchoolFrost,
 		ProcMask:     core.ProcMaskSpellDamage,
-		Flags:        SpellFlagMage | BarrageSpells | HotStreakSpells,
+		Flags:        SpellFlagMage | BarrageSpells | HotStreakSpells | core.SpellFlagAPL,
 		MissileSpeed: 28,
 
 		ManaCost: core.ManaCostOptions{

--- a/sim/mage/ice_lance.go
+++ b/sim/mage/ice_lance.go
@@ -9,7 +9,7 @@ func (mage *Mage) registerIceLanceSpell() {
 		ActionID:     core.ActionID{SpellID: 42914},
 		SpellSchool:  core.SpellSchoolFrost,
 		ProcMask:     core.ProcMaskSpellDamage,
-		Flags:        SpellFlagMage,
+		Flags:        SpellFlagMage | core.SpellFlagAPL,
 		MissileSpeed: 38,
 
 		ManaCost: core.ManaCostOptions{

--- a/sim/mage/ignite.go
+++ b/sim/mage/ignite.go
@@ -1,7 +1,6 @@
 package mage
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/wowsims/wotlk/sim/core"
@@ -9,7 +8,6 @@ import (
 
 // If two spells proc Ignite at almost exactly the same time, the latter
 // overwrites the former.
-const IgniteMunchWindow = time.Millisecond * 10
 const IgniteTicks = 2
 
 func (mage *Mage) applyIgnite() {
@@ -74,18 +72,8 @@ func (mage *Mage) procIgnite(sim *core.Simulation, result *core.SpellResult) {
 	newDamage := result.Damage * 0.08 * float64(mage.Talents.Ignite)
 	outstandingDamage := core.TernaryFloat64(dot.IsActive(), dot.SnapshotBaseDamage*float64(dot.NumberOfTicks-dot.TickCount), 0)
 
-	var munchPenalty float64
-	if mage.Options.IgniteMunching && sim.CurrentTime <= mage.igniteMunchTime+IgniteMunchWindow {
-		munchPenalty = mage.igniteMunchDmg
-		if sim.Log != nil {
-			mage.Log(sim, fmt.Sprintf("Ignite munched: %0.01f", mage.igniteMunchDmg))
-		}
-	}
-
 	dot.SnapshotAttackerMultiplier = 1
-	dot.SnapshotBaseDamage = (outstandingDamage + newDamage - munchPenalty) / float64(IgniteTicks)
-	mage.igniteMunchDmg = newDamage
-	mage.igniteMunchTime = sim.CurrentTime
+	dot.SnapshotBaseDamage = (outstandingDamage + newDamage) / float64(IgniteTicks)
 	mage.Ignite.Cast(sim, result.Target)
 }
 

--- a/sim/mage/living_bomb.go
+++ b/sim/mage/living_bomb.go
@@ -48,7 +48,7 @@ func (mage *Mage) registerLivingBombSpell() {
 		ActionID:    core.ActionID{SpellID: 55360},
 		SpellSchool: core.SpellSchoolFire,
 		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       SpellFlagMage,
+		Flags:       SpellFlagMage | core.SpellFlagAPL,
 
 		ManaCost: core.ManaCostOptions{
 			BaseCost: 0.22,

--- a/sim/mage/mage.go
+++ b/sim/mage/mage.go
@@ -46,8 +46,6 @@ type Mage struct {
 	arcaneBlastStreak int32
 	arcanePowerMCD    *core.MajorCooldown
 	heatingUp         bool
-	igniteMunchDmg    float64
-	igniteMunchTime   time.Duration
 	delayedPyroAt     time.Duration
 
 	waterElemental *WaterElemental
@@ -149,8 +147,6 @@ func (mage *Mage) Initialize() {
 func (mage *Mage) Reset(sim *core.Simulation) {
 	mage.arcaneBlastStreak = 0
 	mage.arcanePowerMCD = mage.GetMajorCooldown(core.ActionID{SpellID: 12042})
-	mage.igniteMunchDmg = 0
-	mage.igniteMunchTime = 0
 	mage.delayedPyroAt = 0
 }
 

--- a/sim/mage/mage.go
+++ b/sim/mage/mage.go
@@ -45,7 +45,6 @@ type Mage struct {
 
 	arcaneBlastStreak int32
 	arcanePowerMCD    *core.MajorCooldown
-	heatingUp         bool
 	delayedPyroAt     time.Duration
 
 	waterElemental *WaterElemental
@@ -81,6 +80,7 @@ type Mage struct {
 	MissileBarrageAura *core.Aura
 	ClearcastingAura   *core.Aura
 	ScorchAuras        core.AuraArray
+	hotStreakCritAura  *core.Aura
 	HotStreakAura      *core.Aura
 	CombustionAura     *core.Aura
 	FingersOfFrostAura *core.Aura

--- a/sim/mage/mana_gems.go
+++ b/sim/mage/mana_gems.go
@@ -40,7 +40,7 @@ func (mage *Mage) registerManaGemsCD() {
 
 	spell := mage.RegisterSpell(core.SpellConfig{
 		ActionID: actionID,
-		Flags:    core.SpellFlagNoOnCastComplete,
+		Flags:    core.SpellFlagNoOnCastComplete | core.SpellFlagAPL,
 
 		Cast: core.CastConfig{
 			CD: core.Cooldown{

--- a/sim/mage/mirror_image.go
+++ b/sim/mage/mirror_image.go
@@ -28,6 +28,7 @@ func (mage *Mage) registerMirrorImageCD() {
 
 	mage.MirrorImage = mage.RegisterSpell(core.SpellConfig{
 		ActionID: core.ActionID{SpellID: 55342},
+		Flags:    core.SpellFlagAPL,
 
 		ManaCost: core.ManaCostOptions{
 			BaseCost: 0.1,

--- a/sim/mage/pyroblast.go
+++ b/sim/mage/pyroblast.go
@@ -21,7 +21,7 @@ func (mage *Mage) registerPyroblastSpell() {
 		ActionID:     core.ActionID{SpellID: 42891},
 		SpellSchool:  core.SpellSchoolFire,
 		ProcMask:     core.ProcMaskSpellDamage,
-		Flags:        SpellFlagMage,
+		Flags:        SpellFlagMage | core.SpellFlagAPL,
 		MissileSpeed: 24,
 
 		ManaCost: core.ManaCostOptions{

--- a/sim/mage/rotations.go
+++ b/sim/mage/rotations.go
@@ -124,7 +124,7 @@ func (mage *Mage) doFireRotation(sim *core.Simulation) *core.Spell {
 	}
 
 	noBomb := mage.LivingBomb != nil && !mage.LivingBomb.Dot(mage.CurrentTarget).IsActive() && sim.GetRemainingDuration() > time.Second*12
-	if noBomb && !mage.heatingUp {
+	if noBomb && mage.hotStreakCritAura.GetStacks() == 0 {
 		return mage.LivingBomb
 	}
 

--- a/sim/mage/rotations.go
+++ b/sim/mage/rotations.go
@@ -12,6 +12,10 @@ func (mage *Mage) OnGCDReady(sim *core.Simulation) {
 }
 
 func (mage *Mage) tryUseGCD(sim *core.Simulation) {
+	if mage.IsUsingAPL {
+		return
+	}
+
 	spell := mage.chooseSpell(sim)
 	if spell != nil {
 		if success := spell.Cast(sim, mage.CurrentTarget); !success {

--- a/sim/mage/scorch.go
+++ b/sim/mage/scorch.go
@@ -20,7 +20,7 @@ func (mage *Mage) registerScorchSpell() {
 		ActionID:    core.ActionID{SpellID: 42859},
 		SpellSchool: core.SpellSchoolFire,
 		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       SpellFlagMage | HotStreakSpells,
+		Flags:       SpellFlagMage | HotStreakSpells | core.SpellFlagAPL,
 
 		ManaCost: core.ManaCostOptions{
 			BaseCost: 0.08,

--- a/sim/mage/talents.go
+++ b/sim/mage/talents.go
@@ -88,7 +88,7 @@ func (mage *Mage) applyHotStreak() {
 		//},
 	})
 
-	hotStreakProcAura := mage.RegisterAura(core.Aura{
+	mage.hotStreakCritAura = mage.RegisterAura(core.Aura{
 		Label:     "Hot Streak Proc Aura",
 		ActionID:  core.ActionID{SpellID: 44448, Tag: 1},
 		MaxStacks: 2,
@@ -107,21 +107,21 @@ func (mage *Mage) applyHotStreak() {
 			}
 
 			if !result.DidCrit() {
-				hotStreakProcAura.SetStacks(sim, 0)
-				hotStreakProcAura.Deactivate(sim)
+				mage.hotStreakCritAura.SetStacks(sim, 0)
+				mage.hotStreakCritAura.Deactivate(sim)
 				return
 			}
 
-			if hotStreakProcAura.GetStacks() == 1 {
+			if mage.hotStreakCritAura.GetStacks() == 1 {
 				if procChance == 1 || sim.Proc(procChance, "Hot Streak") {
-					hotStreakProcAura.SetStacks(sim, 0)
-					hotStreakProcAura.Deactivate(sim)
+					mage.hotStreakCritAura.SetStacks(sim, 0)
+					mage.hotStreakCritAura.Deactivate(sim)
 
 					mage.HotStreakAura.Activate(sim)
 				}
 			} else {
-				hotStreakProcAura.Activate(sim)
-				hotStreakProcAura.AddStack(sim)
+				mage.hotStreakCritAura.Activate(sim)
+				mage.hotStreakCritAura.AddStack(sim)
 			}
 		},
 	})

--- a/sim/mage/talents.go
+++ b/sim/mage/talents.go
@@ -88,12 +88,18 @@ func (mage *Mage) applyHotStreak() {
 		//},
 	})
 
+	hotStreakProcAura := mage.RegisterAura(core.Aura{
+		Label:     "Hot Streak Proc Aura",
+		ActionID:  core.ActionID{SpellID: 44448, Tag: 1},
+		MaxStacks: 2,
+		Duration:  time.Hour,
+	})
+
 	mage.RegisterAura(core.Aura{
 		Label:    "Hot Streak Trigger",
 		Duration: core.NeverExpires,
 		OnReset: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Activate(sim)
-			mage.heatingUp = false
 		},
 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !spell.Flags.Matches(HotStreakSpells) {
@@ -101,17 +107,21 @@ func (mage *Mage) applyHotStreak() {
 			}
 
 			if !result.DidCrit() {
-				mage.heatingUp = false
+				hotStreakProcAura.SetStacks(sim, 0)
+				hotStreakProcAura.Deactivate(sim)
 				return
 			}
 
-			if mage.heatingUp {
+			if hotStreakProcAura.GetStacks() == 1 {
 				if procChance == 1 || sim.Proc(procChance, "Hot Streak") {
+					hotStreakProcAura.SetStacks(sim, 0)
+					hotStreakProcAura.Deactivate(sim)
+
 					mage.HotStreakAura.Activate(sim)
-					mage.heatingUp = false
 				}
 			} else {
-				mage.heatingUp = true
+				hotStreakProcAura.Activate(sim)
+				hotStreakProcAura.AddStack(sim)
 			}
 		},
 	})

--- a/sim/mage/water_elemental.go
+++ b/sim/mage/water_elemental.go
@@ -23,6 +23,7 @@ func (mage *Mage) registerSummonWaterElementalCD() {
 	summonDuration := time.Second*45 + time.Second*5*time.Duration(mage.Talents.EnduringWinter)
 	mage.SummonWaterElemental = mage.RegisterSpell(core.SpellConfig{
 		ActionID: core.ActionID{SpellID: 31687},
+		Flags:    core.SpellFlagAPL,
 
 		ManaCost: core.ManaCostOptions{
 			BaseCost: 0.16,

--- a/ui/core/launched_sims.ts
+++ b/ui/core/launched_sims.ts
@@ -48,7 +48,7 @@ export const aplLaunchStatuses: Record<Spec, LaunchStatus> = {
 	[Spec.SpecEnhancementShaman]: LaunchStatus.Unlaunched,
 	[Spec.SpecRestorationShaman]: LaunchStatus.Unlaunched,
 	[Spec.SpecHunter]: LaunchStatus.Alpha,
-	[Spec.SpecMage]: LaunchStatus.Unlaunched,
+	[Spec.SpecMage]: LaunchStatus.Alpha,
 	[Spec.SpecRogue]: LaunchStatus.Unlaunched,
 	[Spec.SpecHolyPaladin]: LaunchStatus.Unlaunched,
 	[Spec.SpecProtectionPaladin]: LaunchStatus.Unlaunched,

--- a/ui/core/proto_utils/action_id.ts
+++ b/ui/core/proto_utils/action_id.ts
@@ -238,6 +238,9 @@ export class ActionId {
 					name += ` (${this.tag - 1} Stacks)`;
 				}
 				break;
+			case 'Hot Streak':
+				if (this.tag) name += ' (Crits)';
+				break;
 			case 'Fireball':
 			case 'Flamestrike':
 			case 'Pyroblast':

--- a/ui/mage/inputs.ts
+++ b/ui/mage/inputs.ts
@@ -29,18 +29,6 @@ export const Armor = InputHelpers.makeSpecOptionsEnumIconInput<Spec.SpecMage, Ar
 	],
 });
 
-export const IgniteMunching = InputHelpers.makeSpecOptionsBooleanInput<Spec.SpecMage>({
-	fieldName: 'igniteMunching',
-	label: 'Ignite Munching',
-	labelTooltip: `
-		<p>When two spells crit at the same time, only the latter spell will count towards ignite.</p>
-		<p>For example when an instant pyroblast lands right after a fireball, or when Living Bomb explodes at the same time as another spell lands on the target.</p>
-		<p>However, this does not affect Hot Streak with Frostfire Bolt due to Frostfire Bolt having a faster travel time. </p>
-	`,
-	showWhen: (player: Player<Spec.SpecMage>) => player.getRotation().type == RotationType.Fire,
-	changeEmitter: (player: Player<Spec.SpecMage>) => player.rotationChangeEmitter,
-});
-
 export const EvocationTicks = InputHelpers.makeSpecOptionsNumberInput<Spec.SpecMage>({
 	fieldName: 'evocationTicks',
 	label: '# Evocation Ticks',

--- a/ui/mage/presets.ts
+++ b/ui/mage/presets.ts
@@ -230,8 +230,8 @@ export const FIRE_ROTATION_PRESET_DEFAULT = {
 			  {"action":{"autocastOtherCooldowns":{}}},
 			  {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":44448}}},"castSpell":{"spellId":{"spellId":42891}}}},
 			  {"action":{"condition":{"and":{"vals":[{"not":{"val":{"dotIsActive":{"spellId":{"spellId":55360}}}}},{"cmp":{"op":"OpGt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"12s"}}}}]}},"castSpell":{"spellId":{"spellId":55360}}}},
-			  {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"1.5s"}}}},"castSpell":{"spellId":{"spellId":42873}}}},
-			  {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"2.5s"}}}},"castSpell":{"spellId":{"spellId":42859}}}},
+			  {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"remainingTime":{}},"rhs":{"spellCastTime":{"spellId":{"spellId":42859}}}}},"castSpell":{"spellId":{"spellId":42873}}}},
+			  {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"4s"}}}},"castSpell":{"spellId":{"spellId":42859}}}},
 			  {"action":{"castSpell":{"spellId":{"spellId":42833}}}}
 			]
 		}`),
@@ -251,8 +251,8 @@ export const FROSTFIRE_ROTATION_PRESET_DEFAULT = {
 			  {"action":{"autocastOtherCooldowns":{}}},
 			  {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":44448}}},"castSpell":{"spellId":{"spellId":42891}}}},
 			  {"action":{"condition":{"and":{"vals":[{"not":{"val":{"dotIsActive":{"spellId":{"spellId":55360}}}}},{"cmp":{"op":"OpGt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"12s"}}}}]}},"castSpell":{"spellId":{"spellId":55360}}}},
-			  {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"1.5s"}}}},"castSpell":{"spellId":{"spellId":42873}}}},
-			  {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"2.5s"}}}},"castSpell":{"spellId":{"spellId":42859}}}},
+			  {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"remainingTime":{}},"rhs":{"spellCastTime":{"spellId":{"spellId":42859}}}}},"castSpell":{"spellId":{"spellId":42873}}}},
+			  {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"3.5s"}}}},"castSpell":{"spellId":{"spellId":42859}}}},
 			  {"action":{"castSpell":{"spellId":{"spellId":47610}}}}
 			]
 		}`),

--- a/ui/mage/presets.ts
+++ b/ui/mage/presets.ts
@@ -238,6 +238,27 @@ export const FIRE_ROTATION_PRESET_DEFAULT = {
 	}),
 }
 
+export const FROSTFIRE_ROTATION_PRESET_DEFAULT = {
+	name: 'Frostfire APL',
+	rotation: SavedRotation.create({
+		specRotationOptionsJson: MageRotation.toJsonString(DefaultFFBRotation),
+		rotation: APLRotation.fromJsonString(`{
+			"enabled": true,
+			"prepullActions": [
+			  {"action":{"castSpell":{"spellId":{"otherId":"OtherActionPotion"}}},"doAt":"-1s"}
+			],
+			"priorityList": [
+			  {"action":{"autocastOtherCooldowns":{}}},
+			  {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":44448}}},"castSpell":{"spellId":{"spellId":42891}}}},
+			  {"action":{"condition":{"and":{"vals":[{"not":{"val":{"dotIsActive":{"spellId":{"spellId":55360}}}}},{"cmp":{"op":"OpGt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"12s"}}}}]}},"castSpell":{"spellId":{"spellId":55360}}}},
+			  {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"1.5s"}}}},"castSpell":{"spellId":{"spellId":42873}}}},
+			  {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"2.5s"}}}},"castSpell":{"spellId":{"spellId":42859}}}},
+			  {"action":{"castSpell":{"spellId":{"spellId":47610}}}}
+			]
+		}`),
+	}),
+}
+
 export const FROST_ROTATION_PRESET_DEFAULT = {
 	name: 'Frost APL',
 	rotation: SavedRotation.create({

--- a/ui/mage/presets.ts
+++ b/ui/mage/presets.ts
@@ -204,10 +204,12 @@ export const ARCANE_ROTATION_PRESET_DEFAULT = {
 			],
 			"priorityList": [
 			  {"action":{"autocastOtherCooldowns":{}}},
-			  {"action":{"condition":{"not":{"val":{"auraIsActive":{"auraId":{"spellId":12042}}}}},"castSpell":{"spellId":{"spellId":26297}}}},
-			  {"action":{"condition":{"not":{"val":{"auraIsActive":{"auraId":{"spellId":12042}}}}},"castSpell":{"spellId":{"itemId":40211}}}},
+			  {"action":{"condition":{"not":{"val":{"auraIsActive":{"auraId":{"spellId":12472}}}}},"castSpell":{"spellId":{"spellId":26297}}}},
+			  {"action":{"condition":{"not":{"val":{"auraIsActive":{"auraId":{"spellId":12472}}}}},"castSpell":{"spellId":{"spellId":54758}}}},
+			  {"action":{"condition":{"not":{"val":{"auraIsActive":{"auraId":{"spellId":12472}}}}},"castSpell":{"spellId":{"itemId":40211}}}},
 			  {"action":{"condition":{"cmp":{"op":"OpLt","lhs":{"auraNumStacks":{"auraId":{"spellId":36032}}},"rhs":{"const":{"val":"4"}}}},"castSpell":{"spellId":{"spellId":42897}}}},
 			  {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":44401}}},"castSpell":{"spellId":{"spellId":42846}}}},
+			  {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"currentManaPercent":{}},"rhs":{"const":{"val":"25%"}}}},"castSpell":{"spellId":{"spellId":12051}}}},
 			  {"action":{"condition":{"cmp":{"op":"OpGt","lhs":{"currentManaPercent":{}},"rhs":{"const":{"val":"25%"}}}},"castSpell":{"spellId":{"spellId":42897}}}},
 			  {"action":{"castSpell":{"spellId":{"spellId":42846}}}}
 			]

--- a/ui/mage/presets.ts
+++ b/ui/mage/presets.ts
@@ -270,8 +270,11 @@ export const FROST_ROTATION_PRESET_DEFAULT = {
 			],
 			"priorityList": [
 			  {"action":{"autocastOtherCooldowns":{}}},
+			  {"action":{"condition":{"not":{"val":{"auraIsActive":{"auraId":{"spellId":12472}}}}},"castSpell":{"spellId":{"spellId":26297}}}},
+			  {"action":{"condition":{"not":{"val":{"auraIsActive":{"auraId":{"spellId":12472}}}}},"castSpell":{"spellId":{"spellId":54758}}}},
+			  {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"currentManaPercent":{}},"rhs":{"const":{"val":"25%"}}}},"castSpell":{"spellId":{"spellId":12051}}}},
 			  {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":44545}}},"castSpell":{"spellId":{"spellId":44572}}}},
-			  {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":44545}}},{"auraIsActive":{"auraId":{"spellId":44549}}}]}},"castSpell":{"spellId":{"spellId":47610}}}},
+			  {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":44549}}},"castSpell":{"spellId":{"spellId":47610}}}},
 			  {"action":{"castSpell":{"spellId":{"spellId":42842}}}}
 			]
 		}`),

--- a/ui/mage/presets.ts
+++ b/ui/mage/presets.ts
@@ -9,7 +9,7 @@ import { Potions } from '../core/proto/common.js';
 import { Spec } from '../core/proto/common.js';
 import { Faction } from '../core/proto/common.js';
 import { RaidTarget } from '../core/proto/common.js';
-import { SavedTalents } from '../core/proto/ui.js';
+import { SavedRotation, SavedTalents } from '../core/proto/ui.js';
 import { Player } from '../core/player.js';
 import { NO_TARGET } from '../core/proto_utils/utils';
 
@@ -27,6 +27,7 @@ import {
 } from '../core/proto/mage.js';
 
 import * as Tooltips from '../core/constants/tooltips.js';
+import { APLRotation } from '../core/proto/apl.js';
 
 // Preset options for this spec.
 // Eventually we will import these values for the raid sim too, so its good to
@@ -192,10 +193,72 @@ export const OtherDefaults = {
 	distanceFromTarget: 25,
 };
 
+export const ARCANE_ROTATION_PRESET_DEFAULT = {
+	name: 'Arcane APL',
+	rotation: SavedRotation.create({
+		specRotationOptionsJson: MageRotation.toJsonString(DefaultArcaneRotation),
+		rotation: APLRotation.fromJsonString(`{
+			"enabled": true,
+			"prepullActions": [
+			  {"action":{"castSpell":{"spellId":{"otherId":"OtherActionPotion"}}},"doAt":"-1s"}
+			],
+			"priorityList": [
+			  {"action":{"autocastOtherCooldowns":{}}},
+			  {"action":{"condition":{"not":{"val":{"auraIsActive":{"auraId":{"spellId":12042}}}}},"castSpell":{"spellId":{"spellId":26297}}}},
+			  {"action":{"condition":{"not":{"val":{"auraIsActive":{"auraId":{"spellId":12042}}}}},"castSpell":{"spellId":{"itemId":40211}}}},
+			  {"action":{"condition":{"cmp":{"op":"OpLt","lhs":{"auraNumStacks":{"auraId":{"spellId":36032}}},"rhs":{"const":{"val":"4"}}}},"castSpell":{"spellId":{"spellId":42897}}}},
+			  {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":44401}}},"castSpell":{"spellId":{"spellId":42846}}}},
+			  {"action":{"condition":{"cmp":{"op":"OpGt","lhs":{"currentManaPercent":{}},"rhs":{"const":{"val":"25%"}}}},"castSpell":{"spellId":{"spellId":42897}}}},
+			  {"action":{"castSpell":{"spellId":{"spellId":42846}}}}
+			]
+		}`)
+	}),
+}
+
+export const FIRE_ROTATION_PRESET_DEFAULT = {
+	name: 'Fire APL',
+	rotation: SavedRotation.create({
+		specRotationOptionsJson: MageRotation.toJsonString(DefaultFireRotation),
+		rotation: APLRotation.fromJsonString(`{
+			"enabled": true,
+			"prepullActions": [
+			  {"action":{"castSpell":{"spellId":{"otherId":"OtherActionPotion"}}},"doAt":"-1s"}
+			],
+			"priorityList": [
+			  {"action":{"autocastOtherCooldowns":{}}},
+			  {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":44448}}},"castSpell":{"spellId":{"spellId":42891}}}},
+			  {"action":{"condition":{"and":{"vals":[{"not":{"val":{"dotIsActive":{"spellId":{"spellId":55360}}}}},{"cmp":{"op":"OpGt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"12s"}}}}]}},"castSpell":{"spellId":{"spellId":55360}}}},
+			  {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"1.5s"}}}},"castSpell":{"spellId":{"spellId":42873}}}},
+			  {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"2.5s"}}}},"castSpell":{"spellId":{"spellId":42859}}}},
+			  {"action":{"castSpell":{"spellId":{"spellId":42833}}}}
+			]
+		}`),
+	}),
+}
+
+export const FROST_ROTATION_PRESET_DEFAULT = {
+	name: 'Frost APL',
+	rotation: SavedRotation.create({
+		specRotationOptionsJson: MageRotation.toJsonString(DefaultFrostRotation),
+		rotation: APLRotation.fromJsonString(`{
+			"enabled": true,
+			"prepullActions": [
+			  {"action":{"castSpell":{"spellId":{"otherId":"OtherActionPotion"}}},"doAt":"-1s"}
+			],
+			"priorityList": [
+			  {"action":{"autocastOtherCooldowns":{}}},
+			  {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":44545}}},"castSpell":{"spellId":{"spellId":44572}}}},
+			  {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":44545}}},{"auraIsActive":{"auraId":{"spellId":44549}}}]}},"castSpell":{"spellId":{"spellId":47610}}}},
+			  {"action":{"castSpell":{"spellId":{"spellId":42842}}}}
+			]
+		}`),
+	}),
+}
+
 export const ARCANE_PRERAID_PRESET = {
 	name: "Arcane Preraid Preset",
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
-	enableWhen: (player: Player<Spec.SpecMage>) => player.getRotation().type == RotationType.Arcane,
+	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 0,
 	gear: EquipmentSpec.fromJsonString(`{"items": [
 		{"id":42553,"enchant":3820,"gems":[41285,40049]},
 		{"id":39472},
@@ -220,7 +283,7 @@ export const ARCANE_PRERAID_PRESET = {
 export const FIRE_PRERAID_PRESET = {
 	name: "Fire Preraid Preset",
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
-	enableWhen: (player: Player<Spec.SpecMage>) => player.getRotation().type == RotationType.Fire,
+	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 1,
 	gear: EquipmentSpec.fromJsonString(`{"items": [
 		{"id":42553,"enchant":3820,"gems":[41285,40014]},
 		{"id":39472},
@@ -245,7 +308,7 @@ export const FIRE_PRERAID_PRESET = {
 export const ARCANE_P1_PRESET = {
 	name: 'Arcane P1 Preset',
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
-	enableWhen: (player: Player<Spec.SpecMage>) => player.getRotation().type == RotationType.Arcane,
+	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 0,
 	gear: EquipmentSpec.fromJsonString(`{"items": [
 		{"id":40416,"enchant":3820,"gems":[41285,39998]},
 		{"id":44661,"gems":[40026]},
@@ -270,7 +333,7 @@ export const ARCANE_P1_PRESET = {
 export const FIRE_P1_PRESET = {
 	name: 'Fire P1 Preset',
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
-	enableWhen: (player: Player<Spec.SpecMage>) => player.getRotation().type == RotationType.Fire,
+	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 1,
 	gear: EquipmentSpec.fromJsonString(`{"items": [
 		{"id":40416,"enchant":3820,"gems":[41285,39998]},
 		{"id":44661,"gems":[40026]},
@@ -295,7 +358,7 @@ export const FIRE_P1_PRESET = {
 export const FROST_P1_PRESET = {
 	name: 'Frost P1 Preset',
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
-	enableWhen: (player: Player<Spec.SpecMage>) => player.getRotation().type == RotationType.Frost,
+	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 2,
 	gear: EquipmentSpec.fromJsonString(`{"items": [
 		{"id":40416,"enchant":3820,"gems":[41285,39998]},
 		{"id":44661,"gems":[40026]},
@@ -320,7 +383,7 @@ export const FROST_P1_PRESET = {
 export const ARCANE_P2_PRESET = {
 	name: 'Arcane P2 Preset',
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
-	enableWhen: (player: Player<Spec.SpecMage>) => player.getRotation().type == RotationType.Arcane,
+	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 0,
 	gear: EquipmentSpec.fromJsonString(`{"items": [
 		{"id":45497,"enchant":3820,"gems":[41285,45883]},
 		{"id":45243,"gems":[39998]},
@@ -345,7 +408,7 @@ export const ARCANE_P2_PRESET = {
 export const FIRE_P2_PRESET = {
 	name: 'Fire P2 Preset',
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
-	enableWhen: (player: Player<Spec.SpecMage>) => player.getRotation().type == RotationType.Fire,
+	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 1,
 	gear: EquipmentSpec.fromJsonString(`{"items": [
 		{"id":46129,"enchant":3820,"gems":[41285,45883]},
 		{"id":45133,"gems":[40048]},
@@ -370,7 +433,7 @@ export const FIRE_P2_PRESET = {
 export const FROST_P2_PRESET = {
 	name: 'Frost P2 Preset',
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
-	enableWhen: (player: Player<Spec.SpecMage>) => player.getRotation().type == RotationType.Frost,
+	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 2,
 	gear: EquipmentSpec.fromJsonString(`{"items": [
 		{"id":45497,"enchant":3820,"gems":[41285,45883]},
 		{"id":45133,"gems":[40051]},
@@ -395,7 +458,7 @@ export const FROST_P2_PRESET = {
 export const FFB_P2_PRESET = {
 	name: 'FFB P2 Preset',
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
-	enableWhen: (player: Player<Spec.SpecMage>) => (player.getTalentTree() == 1 && player.getTalents().icyVeins) || (player.getRotation().type == RotationType.Fire && player.getRotation().primaryFireSpell == PrimaryFireSpell.FrostfireBolt),
+	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 1 && player.getTalents().icyVeins,
 	gear: EquipmentSpec.fromJsonString(`{"items": [
 		{"id":45497,"enchant":3820,"gems":[41285,45883]},
 		{"id":45133,"gems":[40048]},
@@ -419,7 +482,7 @@ export const FFB_P2_PRESET = {
 
 export const ARCANE_P3_PRESET_HORDE = {
 	name: 'Arcane P3 Preset Horde',
-	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 0 && player.getRotation().type == RotationType.Arcane && player.getFaction() == Faction.Horde,
+	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 0 && player.getFaction() == Faction.Horde,
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
 	gear: EquipmentSpec.fromJsonString(`{"items": [
         {"id":47764,"enchant":3820,"gems":[41285,40133]},
@@ -444,7 +507,7 @@ export const ARCANE_P3_PRESET_HORDE = {
 
 export const ARCANE_P3_PRESET_ALLIANCE = {
 	name: 'Arcane P3 Preset Alliance',
-	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 0 && player.getRotation().type == RotationType.Arcane && player.getFaction() == Faction.Alliance,
+	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 0 && player.getFaction() == Faction.Alliance,
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
 	gear: EquipmentSpec.fromJsonString(`{"items": [
         {"id":47761,"enchant":3820,"gems":[41285,40133]},
@@ -469,7 +532,7 @@ export const ARCANE_P3_PRESET_ALLIANCE = {
 
 export const FROST_P3_PRESET_HORDE = {
 	name: 'Frost P3 Preset Horde',
-	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 2 && player.getRotation().type == RotationType.Frost && player.getFaction() == Faction.Horde,
+	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 2 && player.getFaction() == Faction.Horde,
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
 	gear: EquipmentSpec.fromJsonString(`{"items": [
         {"id":47764,"enchant":3820,"gems":[41285,40133]},
@@ -494,7 +557,7 @@ export const FROST_P3_PRESET_HORDE = {
 
 export const FROST_P3_PRESET_ALLIANCE = {
 	name: 'Frost P3 Preset Alliance',
-	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 2 && player.getRotation().type == RotationType.Frost && player.getFaction() == Faction.Alliance,
+	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 2 && player.getFaction() == Faction.Alliance,
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
 	gear: EquipmentSpec.fromJsonString(`{"items": [
         {"id":47761,"enchant":3820,"gems":[41285,40133]},
@@ -519,7 +582,7 @@ export const FROST_P3_PRESET_ALLIANCE = {
 
 export const FIRE_P3_PRESET_HORDE = {
 	name: 'Fire P3 Preset Horde',
-	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 1 && player.getRotation().type == RotationType.Fire && player.getFaction() == Faction.Horde,
+	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 1 && !player.getTalents().icyVeins && player.getFaction() == Faction.Horde,
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
 	gear: EquipmentSpec.fromJsonString(`{"items": [
         {"id":47764,"enchant":3820,"gems":[41285,40133]},
@@ -544,7 +607,7 @@ export const FIRE_P3_PRESET_HORDE = {
 
 export const FIRE_P3_PRESET_ALLIANCE = {
 	name: 'Fire P3 Preset Alliance',
-	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 1 && player.getRotation().type == RotationType.Fire && player.getFaction() == Faction.Alliance,
+	enableWhen: (player: Player<Spec.SpecMage>) => player.getTalentTree() == 1 && !player.getTalents().icyVeins && player.getFaction() == Faction.Alliance,
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
 	gear: EquipmentSpec.fromJsonString(`{  "items": [
         {"id":47761,"enchant":3820,"gems":[41285,40133]},
@@ -572,7 +635,7 @@ export const FIRE_P3_PRESET_ALLIANCE = {
 
 export const FFB_P3_PRESET_HORDE = {
 	name: 'FFB P3 Preset Horde',
-	enableWhen: (player: Player<Spec.SpecMage>) => ((player.getFaction() == Faction.Horde) && ((player.getTalentTree() == 1 && player.getTalents().icyVeins) || (player.getRotation().type == RotationType.Fire && player.getRotation().primaryFireSpell == PrimaryFireSpell.FrostfireBolt))),
+	enableWhen: (player: Player<Spec.SpecMage>) => player.getFaction() == Faction.Horde && player.getTalentTree() == 1 && player.getTalents().icyVeins,
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
 	gear: EquipmentSpec.fromJsonString(`{"items": [
         {"id":47764,"enchant":3820,"gems":[41285,40133]},
@@ -597,7 +660,7 @@ export const FFB_P3_PRESET_HORDE = {
 
 export const FFB_P3_PRESET_ALLIANCE = {
 	name: 'FFB P3 Preset Alliance',
-	enableWhen: (player: Player<Spec.SpecMage>) => ((player.getFaction() == Faction.Alliance) && ((player.getTalentTree() == 1 && player.getTalents().icyVeins) || (player.getRotation().type == RotationType.Fire && player.getRotation().primaryFireSpell == PrimaryFireSpell.FrostfireBolt))),
+	enableWhen: (player: Player<Spec.SpecMage>) => player.getFaction() == Faction.Alliance && player.getTalentTree() == 1 && player.getTalents().icyVeins,
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
 	gear: EquipmentSpec.fromJsonString(`{   "items": [
         {"id":47761,"enchant":3820,"gems":[41285,40133]},

--- a/ui/mage/sim.ts
+++ b/ui/mage/sim.ts
@@ -138,7 +138,6 @@ export class MageSimUI extends IndividualSimUI<Spec.SpecMage> {
 			// Inputs to include in the 'Other' section on the settings tab.
 			otherInputs: {
 				inputs: [
-					MageInputs.IgniteMunching,
 					MageInputs.EvocationTicks,
 					MageInputs.FocusMagicUptime,
 					MageInputs.ReactionTime,
@@ -152,6 +151,12 @@ export class MageSimUI extends IndividualSimUI<Spec.SpecMage> {
 			},
 
 			presets: {
+				// Preset rotations that the user can quickly select.
+				rotations: [
+					Presets.ARCANE_ROTATION_PRESET_DEFAULT,
+					Presets.FIRE_ROTATION_PRESET_DEFAULT,
+					Presets.FROST_ROTATION_PRESET_DEFAULT,
+				],
 				// Preset talents that the user can quickly select.
 				talents: [
 					Presets.ArcaneTalents,

--- a/ui/mage/sim.ts
+++ b/ui/mage/sim.ts
@@ -155,6 +155,7 @@ export class MageSimUI extends IndividualSimUI<Spec.SpecMage> {
 				rotations: [
 					Presets.ARCANE_ROTATION_PRESET_DEFAULT,
 					Presets.FIRE_ROTATION_PRESET_DEFAULT,
+					Presets.FROSTFIRE_ROTATION_PRESET_DEFAULT,
 					Presets.FROST_ROTATION_PRESET_DEFAULT,
 				],
 				// Preset talents that the user can quickly select.


### PR DESCRIPTION
- Added support for all mage spells to APL
- Removed Ignite Munching
- Refactored Hot Streak proc to an aura with stacks so its usable in APL
- Refactored how mage gear presets are filtered for simplicity
- Added base APL presets for all mage sets that perform better then legacy rotations