### PR TITLE
Enable Rogue APL rotation

### DIFF
--- a/sim/rogue/rotation.go
+++ b/sim/rogue/rotation.go
@@ -26,6 +26,9 @@ type prio struct {
 }
 
 func (rogue *Rogue) OnEnergyGain(sim *core.Simulation) {
+	if rogue.IsUsingAPL {
+		return
+	}
 	rogue.TryUseCooldowns(sim)
 
 	if !rogue.GCD.IsReady(sim) {
@@ -36,6 +39,9 @@ func (rogue *Rogue) OnEnergyGain(sim *core.Simulation) {
 }
 
 func (rogue *Rogue) OnGCDReady(sim *core.Simulation) {
+	if rogue.IsUsingAPL {
+		return
+	}
 	rogue.TryUseCooldowns(sim)
 
 	if rogue.IsWaitingForEnergy() {

--- a/ui/core/launched_sims.ts
+++ b/ui/core/launched_sims.ts
@@ -49,7 +49,7 @@ export const aplLaunchStatuses: Record<Spec, LaunchStatus> = {
 	[Spec.SpecRestorationShaman]: LaunchStatus.Unlaunched,
 	[Spec.SpecHunter]: LaunchStatus.Alpha,
 	[Spec.SpecMage]: LaunchStatus.Alpha,
-	[Spec.SpecRogue]: LaunchStatus.Unlaunched,
+	[Spec.SpecRogue]: LaunchStatus.Alpha,
 	[Spec.SpecHolyPaladin]: LaunchStatus.Unlaunched,
 	[Spec.SpecProtectionPaladin]: LaunchStatus.Unlaunched,
 	[Spec.SpecRetributionPaladin]: LaunchStatus.Unlaunched,


### PR DESCRIPTION
-Enable the rotation tab for Rogue sim
-APL rotation will now function in the Rogue sim