### PR TITLE
dnd doesn't snapshot crit

### DIFF
--- a/sim/deathknight/death_and_decay.go
+++ b/sim/deathknight/death_and_decay.go
@@ -44,14 +44,13 @@ func (dk *Deathknight) registerDeathAndDecaySpell() {
 			NumberOfTicks: 10,
 			TickLength:    time.Second * 1,
 			OnSnapshot: func(sim *core.Simulation, _ *core.Unit, dot *core.Dot, _ bool) {
-				target := dk.CurrentTarget
 				dot.SnapshotBaseDamage = 62 + 0.0475*dk.getImpurityBonus(dot.Spell)
-				dot.SnapshotCritChance = dot.Spell.SpellCritChance(target)
 			},
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
 				for _, aoeTarget := range sim.Encounter.TargetUnits {
-					// DnD recalculates attack multipliers dynamically on every tick so this is here on purpose
+					// DnD recalculates attack multipliers + crit dynamically on every tick so this is here on purpose
 					dot.SnapshotAttackerMultiplier = dot.Spell.AttackerDamageMultiplier(dot.Spell.Unit.AttackTables[aoeTarget.UnitIndex]) * dk.RoRTSBonus(aoeTarget)
+					dot.SnapshotCritChance = dot.Spell.SpellCritChance(aoeTarget)
 					dot.CalcAndDealPeriodicSnapshotDamage(sim, aoeTarget, dot.OutcomeMagicHitAndSnapshotCrit)
 				}
 			},

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -238,24 +238,24 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7576.16034
-  tps: 4898.48364
+  dps: 7577.27117
+  tps: 4900.16273
   hps: 265.91924
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7867.09723
-  tps: 5177.18653
+  dps: 7866.42643
+  tps: 5175.95597
   hps: 271.94125
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7891.46374
-  tps: 5224.79306
+  dps: 7890.28539
+  tps: 5222.72235
   hps: 273.84293
  }
 }
@@ -526,8 +526,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7580.84719
-  tps: 4912.7054
+  dps: 7578.35183
+  tps: 4907.52849
   hps: 265.91924
  }
 }
@@ -726,8 +726,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 8015.39896
-  tps: 5105.94015
+  dps: 8014.73148
+  tps: 5104.87561
   hps: 266.87008
  }
 }
@@ -1014,8 +1014,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36820.88911
-  tps: 39683.38793
+  dps: 36273.62948
+  tps: 38807.00848
   hps: 262.91405
  }
 }
@@ -1062,8 +1062,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 47344.6291
-  tps: 51228.40956
+  dps: 46675.01029
+  tps: 50154.38353
   hps: 321.9413
  }
 }
@@ -1110,8 +1110,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 37408.38064
-  tps: 40186.30687
+  dps: 36861.33305
+  tps: 39309.86547
   hps: 263.38366
  }
 }
@@ -1158,8 +1158,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 47429.93616
-  tps: 51005.51052
+  dps: 46763.45057
+  tps: 49938.90935
   hps: 323.27175
  }
 }


### PR DESCRIPTION
I ran: https://github.com/lime-green/WCL-dk-analysis/blob/main/tools/detect_dnd_crit_snapshot.py on around 400 reports and received:
```
Overall total ticks:  130605
Overall snapshot crit rate 0.36314280909870594
Overall unsnapshotted crit rate 0.3082355364379008
Overall unsnapshotted buffed crit rate 0.41398684505640465
Overall buffed crit rate 0.4390957767234313
Overall unbuffed crit rate 0.28973378098355324
```

- "Snapshotted" means Dark Matter crit proc was present on DnD cast
- "Buffed" means Dark Matter crit proc was present on DnD tick

Dark Matter gives `692/45.91=15.07%` crit which lines up with `0.439-0.289=0.15=15%`

so it's clear that buffed vs unbuffed ticks is what DnD crit rate is based on (note snapshotted still has slightly higher crit since it would necessarily include some buffed ticks)
