### PR TITLE
Add docker release and onbuild action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,3 +43,20 @@ jobs:
           branch: gh-pages
           folder: dist/wotlk
           single-commit: true
+
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ secrets.DOCKER_USER }}/wotlk:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,3 +67,19 @@ jobs:
             wowsimwotlk-amd64-linux.zip
             wowsimwotlk-windows.exe.zip
             
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ secrets.DOCKER_USER }}/wotlk:${{ github.event.inputs.tag }}


### PR DESCRIPTION
Closes #3145 

This PR adds automatic docker image creation/upload.

Each push to master creates {docker_user}/wotlk:latest, while each release creates {docker_user}/wotlk:{version}.

Here it is shown based on Kruhlmann/wotlk:

![image](https://github.com/wowsims/wotlk/assets/3380818/2702af8b-0ae3-46bd-a790-6c8d105463f1)

The following secrets are needed for the new workflows:

* `DOCKER_USER` Docker hub username
* `DOCKER_TOKEN` Docker hub password