### PR TITLE
core: disable trinket desync when using APL

### DIFF
--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -441,7 +441,9 @@ func (character *Character) AddPartyBuffs(partyBuffs *proto.PartyBuffs) {
 
 func (character *Character) initialize(agent Agent) {
 	character.majorCooldownManager.initialize(character)
-	character.DesyncTrinketProcs()
+	if !character.IsUsingAPL {
+		character.DesyncTrinketProcs()
+	}
 
 	character.gcdAction = &PendingAction{
 		Priority: ActionPriorityGCD,


### PR DESCRIPTION
APL has it's own action for desyncing now, so we don't need to use the legacy rotation option for it.