### PR TITLE
rogue:fix the tanlent "mace specialization"

### DIFF
--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -346,7 +346,7 @@ func (rogue *Rogue) applyWeaponSpecializations() {
 			})
 		case proto.WeaponType_WeaponTypeMace:
 			rogue.OnSpellRegistered(func(spell *core.Spell) {
-				if spell.ProcMask.Matches(core.ProcMaskMeleeMH) {
+				if spell.ProcMask.Matches(core.ProcMaskMeleeMH) || spell.ProcMask.Matches(core.ProcMaskMeleeOH) {
 					spell.BonusArmorPenRating += 3 * core.ArmorPenPerPercentArmor * float64(rogue.Talents.MaceSpecialization)
 				}
 			})
@@ -364,7 +364,7 @@ func (rogue *Rogue) applyWeaponSpecializations() {
 			})
 		case proto.WeaponType_WeaponTypeMace:
 			rogue.OnSpellRegistered(func(spell *core.Spell) {
-				if spell.ProcMask.Matches(core.ProcMaskMeleeOH) {
+				if spell.ProcMask.Matches(core.ProcMaskMeleeOH) || spell.ProcMask.Matches(core.ProcMaskMeleeMH) {
 					spell.BonusArmorPenRating += 3 * core.ArmorPenPerPercentArmor * float64(rogue.Talents.MaceSpecialization)
 				}
 			})


### PR DESCRIPTION
rogue talent "mace specialization" will cause 15% armorpen, when you get a mace in main-hand and a sword in off-hand, simc will only counting this 15% armorpen in main-hand melee, but in real game, the off-hand melee will also benefit with "mace specialization" in case you has a mace in main-hand