### PR TITLE
Small Feral gem optimizer bugfix

### DIFF
--- a/ui/feral_druid/sim.ts
+++ b/ui/feral_druid/sim.ts
@@ -306,7 +306,7 @@ export class FeralDruidSimUI extends IndividualSimUI<Spec.SpecFeralDruid> {
 	}
 
 	socketTear(gear: Gear, tearSlot: ItemSlot | null): Gear {
-		if (tearSlot) {
+		if (tearSlot != null) {
 			const tearSlotItem = gear.getEquippedItem(tearSlot);
 
 			for (const [socketIdx, socketColor] of tearSlotItem!.allSocketColors().entries()) {


### PR DESCRIPTION
Fixed a bug where Nightmare Tear was not being socketed by the Feral gem optimizer in cases where the optimal slot for it was the helm slot.

 Changes to be committed:
	modified:   ui/feral_druid/sim.ts