### PR TITLE
ui: remove bonus stats from gear instead of base

### DIFF
--- a/ui/core/components/character_stats.ts
+++ b/ui/core/components/character_stats.ts
@@ -76,8 +76,8 @@ export class CharacterStats extends Component {
 		const debuffStats = this.getDebuffStats();
 		const bonusStats = player.getBonusStats();
 
-		const baseDelta = baseStats.subtract(bonusStats);
-		const gearDelta = gearStats.subtract(baseStats);
+		const baseDelta = baseStats;
+		const gearDelta = gearStats.subtract(baseStats).subtract(bonusStats);
 		const talentsDelta = talentsStats.subtract(gearStats).add(statMods.talents);
 		const buffsDelta = buffsStats.subtract(talentsStats);
 		const consumesDelta = consumesStats.subtract(buffsStats);


### PR DESCRIPTION
 - internally bonus stats are added to 'gear' for calculations, removing them from base creates an odd display where base stats end up getting lowered below standard values
 - fixes #3408 