### PR TITLE
add activate aura APL value

### DIFF
--- a/proto/apl.proto
+++ b/proto/apl.proto
@@ -44,6 +44,7 @@ message APLAction {
         // Misc
         APLActionAutocastOtherCooldowns autocast_other_cooldowns = 7;
         APLActionChangeTarget change_target = 9;
+        APLActionActivateAura activate_aura = 13;
         APLActionCancelAura cancel_aura = 10;
         APLActionTriggerICD trigger_icd = 11;
         APLActionWait wait = 4;
@@ -159,6 +160,10 @@ message APLActionChangeTarget {
 }
 
 message APLActionCancelAura {
+    ActionID aura_id = 1;
+}
+
+message APLActionActivateAura {
     ActionID aura_id = 1;
 }
 

--- a/sim/core/apl_action.go
+++ b/sim/core/apl_action.go
@@ -101,6 +101,8 @@ func (rot *APLRotation) newAPLActionImpl(config *proto.APLAction) APLActionImpl 
 		return rot.newActionAutocastOtherCooldowns(config.GetAutocastOtherCooldowns())
 	case *proto.APLAction_ChangeTarget:
 		return rot.newActionChangeTarget(config.GetChangeTarget())
+	case *proto.APLAction_ActivateAura:
+		return rot.newActionActivateAura(config.GetActivateAura())
 	case *proto.APLAction_CancelAura:
 		return rot.newActionCancelAura(config.GetCancelAura())
 	case *proto.APLAction_TriggerIcd:

--- a/sim/core/apl_actions_misc.go
+++ b/sim/core/apl_actions_misc.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"fmt"
-
 	"github.com/wowsims/wotlk/sim/core/proto"
 )
 
@@ -39,6 +38,11 @@ type APLActionCancelAura struct {
 	aura *Aura
 }
 
+type APLActionActivateAura struct {
+	defaultAPLActionImpl
+	aura *Aura
+}
+
 func (rot *APLRotation) newActionCancelAura(config *proto.APLActionCancelAura) APLActionImpl {
 	aura := rot.aplGetAura(rot.getSourceUnit(&proto.UnitReference{Type: proto.UnitReference_Self}), config.AuraId)
 	if aura.Get() == nil {
@@ -48,6 +52,17 @@ func (rot *APLRotation) newActionCancelAura(config *proto.APLActionCancelAura) A
 		aura: aura.Get(),
 	}
 }
+
+func (rot *APLRotation) newActionActivateAura(config *proto.APLActionActivateAura) APLActionImpl {
+	aura := rot.aplGetAura(rot.getSourceUnit(&proto.UnitReference{Type: proto.UnitReference_Self}), config.AuraId)
+	if aura.Get() == nil {
+		return nil
+	}
+	return &APLActionActivateAura{
+		aura: aura.Get(),
+	}
+}
+
 func (action *APLActionCancelAura) IsReady(sim *Simulation) bool {
 	return action.aura.IsActive()
 }
@@ -59,6 +74,21 @@ func (action *APLActionCancelAura) Execute(sim *Simulation) {
 }
 func (action *APLActionCancelAura) String() string {
 	return fmt.Sprintf("Cancel Aura(%s)", action.aura.ActionID)
+}
+
+func (action *APLActionActivateAura) IsReady(sim *Simulation) bool {
+	return true
+}
+
+func (action *APLActionActivateAura) Execute(sim *Simulation) {
+	if sim.Log != nil {
+		action.aura.Unit.Log(sim, "Activating aura %s", action.aura.ActionID)
+	}
+	action.aura.Activate(sim)
+}
+
+func (action *APLActionActivateAura) String() string {
+	return fmt.Sprintf("Activate Aura(%s)", action.aura.ActionID)
 }
 
 type APLActionTriggerICD struct {

--- a/sim/deathknight/deathknight.go
+++ b/sim/deathknight/deathknight.go
@@ -305,7 +305,6 @@ func (dk *Deathknight) Initialize() {
 	dk.registerArmyOfTheDeadCD()
 	dk.registerDancingRuneWeaponCD()
 	dk.registerDeathPactSpell()
-
 	dk.registerUnholyFrenzyCD()
 
 	dk.RegisterAura(core.Aura{
@@ -470,6 +469,8 @@ func NewDeathknight(character core.Character, inputs DeathknightInputs, talents 
 	}
 
 	dk.RotationSequence = &Sequence{}
+	// done here so enchants that modify stats are applied before stats are calculated
+	dk.registerItems()
 
 	return dk
 }

--- a/sim/deathknight/items.go
+++ b/sim/deathknight/items.go
@@ -300,8 +300,21 @@ func (dk *Deathknight) sigilOfTheVengefulHeartFrostStrike() float64 {
 	return core.TernaryFloat64(dk.Equip[proto.ItemSlot_ItemSlotRanged].ID == 45254, 218, 0) // (1 / 0.55) * 120
 }
 
-func init() {
+func addEnchantEffect(id int32, effect func(core.Agent)) {
+	if core.HasEnchantEffect(id) {
+		return
+	}
+	core.NewEnchantEffect(id, effect)
+}
 
+func addItemEffect(id int32, effect func(core.Agent)) {
+	if core.HasItemEffect(id) {
+		return
+	}
+	core.NewItemEffect(id, effect)
+}
+
+func (dk *Deathknight) registerItems() {
 	// Rune of Razorice
 	newRazoriceHitSpell := func(character *core.Character, isMH bool) *core.Spell {
 		dmg := 0.0
@@ -328,7 +341,7 @@ func init() {
 		})
 	}
 
-	core.NewEnchantEffect(3370, func(agent core.Agent) {
+	addEnchantEffect(3370, func(agent core.Agent) {
 		character := agent.GetCharacter()
 		mh := character.Equip[proto.ItemSlot_ItemSlotMainHand].Enchant.EffectID == 3370
 		oh := character.HasOHWeapon() && character.Equip[proto.ItemSlot_ItemSlotOffHand].HandType != proto.HandType_HandTypeTwoHand && character.Equip[proto.ItemSlot_ItemSlotOffHand].Enchant.EffectID == 3370
@@ -399,7 +412,7 @@ func init() {
 	// ApplyRuneOfTheFallenCrusader will be applied twice if there is two weapons with this enchant.
 	//   However it will automatically overwrite one of them so it should be ok.
 	//   A single application of the aura will handle both mh and oh procs.
-	core.NewEnchantEffect(3368, func(agent core.Agent) {
+	addEnchantEffect(3368, func(agent core.Agent) {
 		character := agent.GetCharacter()
 		mh := character.Equip[proto.ItemSlot_ItemSlotMainHand].Enchant.EffectID == 3368
 		oh := character.Equip[proto.ItemSlot_ItemSlotOffHand].Enchant.EffectID == 3368
@@ -430,7 +443,7 @@ func init() {
 	})
 
 	// Rune of the Nerubian Carapace
-	core.NewEnchantEffect(3883, func(agent core.Agent) {
+	addEnchantEffect(3883, func(agent core.Agent) {
 		character := agent.GetCharacter()
 		mh := character.Equip[proto.ItemSlot_ItemSlotMainHand].Enchant.EffectID == 3883
 		oh := character.Equip[proto.ItemSlot_ItemSlotOffHand].Enchant.EffectID == 3883
@@ -443,7 +456,7 @@ func init() {
 	})
 
 	// Rune of the Stoneskin Gargoyle
-	core.NewEnchantEffect(3847, func(agent core.Agent) {
+	addEnchantEffect(3847, func(agent core.Agent) {
 		character := agent.GetCharacter()
 		mh := character.Equip[proto.ItemSlot_ItemSlotMainHand].Enchant.EffectID == 3847
 		oh := character.Equip[proto.ItemSlot_ItemSlotOffHand].Enchant.EffectID == 3847
@@ -460,7 +473,7 @@ func init() {
 	})
 
 	// Rune of the Swordbreaking
-	core.NewEnchantEffect(3594, func(agent core.Agent) {
+	addEnchantEffect(3594, func(agent core.Agent) {
 		character := agent.GetCharacter()
 		mh := character.Equip[proto.ItemSlot_ItemSlotMainHand].Enchant.EffectID == 3594
 		oh := character.Equip[proto.ItemSlot_ItemSlotOffHand].Enchant.EffectID == 3594
@@ -472,7 +485,7 @@ func init() {
 	})
 
 	// Rune of Swordshattering
-	core.NewEnchantEffect(3365, func(agent core.Agent) {
+	addEnchantEffect(3365, func(agent core.Agent) {
 		character := agent.GetCharacter()
 		mh := character.Equip[proto.ItemSlot_ItemSlotMainHand].Enchant.EffectID == 3365
 		oh := character.Equip[proto.ItemSlot_ItemSlotOffHand].Enchant.EffectID == 3365
@@ -488,7 +501,7 @@ func init() {
 	})
 
 	// Rune of the Spellbreaking
-	core.NewEnchantEffect(3595, func(agent core.Agent) {
+	addEnchantEffect(3595, func(agent core.Agent) {
 		character := agent.GetCharacter()
 		mh := character.Equip[proto.ItemSlot_ItemSlotMainHand].Enchant.EffectID == 3595
 		oh := character.Equip[proto.ItemSlot_ItemSlotOffHand].Enchant.EffectID == 3595
@@ -501,7 +514,7 @@ func init() {
 	})
 
 	// Rune of Spellshattering
-	core.NewEnchantEffect(3367, func(agent core.Agent) {
+	addEnchantEffect(3367, func(agent core.Agent) {
 		character := agent.GetCharacter()
 		mh := character.Equip[proto.ItemSlot_ItemSlotMainHand].Enchant.EffectID == 3367
 		oh := character.Equip[proto.ItemSlot_ItemSlotOffHand].Enchant.EffectID == 3367
@@ -517,8 +530,65 @@ func init() {
 		// Add 4% magic deflection
 	})
 
+	cinderBonusCoeff := 1.2
+
+	consumeSpells := [5]core.ActionID{
+		BloodBoilActionID,
+		DeathCoilActionID,
+		FrostStrikeMHActionID,
+		HowlingBlastActionID,
+		IcyTouchActionID,
+	}
+
+	cinderProcAura := dk.GetOrRegisterAura(core.Aura{
+		ActionID:  core.ActionID{SpellID: 53386},
+		Label:     "Cinderglacier",
+		Duration:  time.Second * 30,
+		MaxStacks: 2,
+		OnGain: func(aura *core.Aura, sim *core.Simulation) {
+			aura.SetStacks(sim, aura.MaxStacks)
+			aura.Unit.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexShadow] *= cinderBonusCoeff
+			aura.Unit.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexFrost] *= cinderBonusCoeff
+			dk.modifyShadowDamageModifier(0.2)
+		},
+		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
+			aura.Unit.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexShadow] /= cinderBonusCoeff
+			aura.Unit.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexFrost] /= cinderBonusCoeff
+			dk.modifyShadowDamageModifier(-0.2)
+		},
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if spell.ActionID == HowlingBlastActionID || spell.ActionID == BloodBoilActionID {
+				if result.Target.Index == sim.GetNumTargets()-1 {
+					// Last target, consume a stack for every target hit
+					for i := int32(0); i < dk.AoESpellNumTargetsHit; i++ {
+						if aura.IsActive() {
+							aura.RemoveStack(sim)
+						}
+					}
+				}
+				return
+			}
+
+			if !result.Outcome.Matches(core.OutcomeLanded) {
+				return
+			}
+
+			shouldConsume := false
+			for _, consumeSpell := range consumeSpells {
+				if spell.ActionID == consumeSpell {
+					shouldConsume = true
+					break
+				}
+			}
+
+			if shouldConsume {
+				aura.RemoveStack(sim)
+			}
+		},
+	})
+
 	// Rune of Cinderglacier
-	core.NewEnchantEffect(3369, func(agent core.Agent) {
+	addEnchantEffect(3369, func(agent core.Agent) {
 		character := agent.GetCharacter()
 
 		mh := character.Equip[proto.ItemSlot_ItemSlotMainHand].Enchant.EffectID == 3369
@@ -529,65 +599,6 @@ func init() {
 
 		procMask := core.GetMeleeProcMaskForHands(mh, oh)
 		ppmm := character.AutoAttacks.NewPPMManager(1.0, procMask)
-
-		cinderBonusCoeff := 1.2
-
-		consumeSpells := [5]core.ActionID{
-			BloodBoilActionID,
-			DeathCoilActionID,
-			FrostStrikeMHActionID,
-			HowlingBlastActionID,
-			IcyTouchActionID,
-		}
-
-		dk := agent.(DeathKnightAgent).GetDeathKnight()
-
-		cinderProcAura := character.GetOrRegisterAura(core.Aura{
-			ActionID:  core.ActionID{SpellID: 53386},
-			Label:     "Cinderglacier",
-			Duration:  time.Second * 30,
-			MaxStacks: 2,
-			OnGain: func(aura *core.Aura, sim *core.Simulation) {
-				aura.SetStacks(sim, aura.MaxStacks)
-				aura.Unit.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexShadow] *= cinderBonusCoeff
-				aura.Unit.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexFrost] *= cinderBonusCoeff
-				dk.modifyShadowDamageModifier(0.2)
-			},
-			OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-				aura.Unit.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexShadow] /= cinderBonusCoeff
-				aura.Unit.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexFrost] /= cinderBonusCoeff
-				dk.modifyShadowDamageModifier(-0.2)
-			},
-			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				if spell.ActionID == HowlingBlastActionID || spell.ActionID == BloodBoilActionID {
-					if result.Target.Index == sim.GetNumTargets()-1 {
-						// Last target, consume a stack for every target hit
-						for i := int32(0); i < dk.AoESpellNumTargetsHit; i++ {
-							if aura.IsActive() {
-								aura.RemoveStack(sim)
-							}
-						}
-					}
-					return
-				}
-
-				if !result.Outcome.Matches(core.OutcomeLanded) {
-					return
-				}
-
-				shouldConsume := false
-				for _, consumeSpell := range consumeSpells {
-					if spell.ActionID == consumeSpell {
-						shouldConsume = true
-						break
-					}
-				}
-
-				if shouldConsume {
-					aura.RemoveStack(sim)
-				}
-			},
-		})
 
 		core.MakePermanent(character.GetOrRegisterAura(core.Aura{
 			Label: "Rune of Cinderglacier",
@@ -619,7 +630,7 @@ func init() {
 
 	// Sigils
 
-	core.NewItemEffect(40714, func(agent core.Agent) {
+	addItemEffect(40714, func(agent core.Agent) {
 		dk := agent.(DeathKnightAgent).GetDeathKnight()
 		procAura := dk.NewTemporaryStatsAura("Sigil of the Unfaltering Knight Proc", core.ActionID{SpellID: 62146}, stats.Stats{stats.Defense: 53.0 / core.DefenseRatingPerDefense}, time.Second*30)
 
@@ -635,7 +646,7 @@ func init() {
 		}))
 	})
 
-	core.NewItemEffect(40715, func(agent core.Agent) {
+	addItemEffect(40715, func(agent core.Agent) {
 		dk := agent.(DeathKnightAgent).GetDeathKnight()
 		procAura := dk.NewTemporaryStatsAura("Sigil of Haunted Dreams Proc", core.ActionID{SpellID: 60828}, stats.Stats{stats.MeleeCrit: 173.0, stats.SpellCrit: 173.0}, time.Second*10)
 
@@ -660,7 +671,7 @@ func init() {
 		}))
 	})
 
-	core.NewItemEffect(45144, func(agent core.Agent) {
+	addItemEffect(45144, func(agent core.Agent) {
 		dk := agent.(DeathKnightAgent).GetDeathKnight()
 		procAura := dk.NewTemporaryStatsAura("Sigil of Deflection Proc", core.ActionID{SpellID: 64963}, stats.Stats{stats.Dodge: 144.0}, time.Second*5)
 
@@ -676,7 +687,7 @@ func init() {
 		}))
 	})
 
-	core.NewItemEffect(47672, func(agent core.Agent) {
+	addItemEffect(47672, func(agent core.Agent) {
 		dk := agent.(DeathKnightAgent).GetDeathKnight()
 		procAura := dk.NewTemporaryStatsAura("Sigil of Insolence Proc", core.ActionID{SpellID: 67380}, stats.Stats{stats.Dodge: 200.0}, time.Second*20)
 
@@ -701,7 +712,7 @@ func init() {
 		}))
 	})
 
-	core.NewItemEffect(47673, func(agent core.Agent) {
+	addItemEffect(47673, func(agent core.Agent) {
 		dk := agent.(DeathKnightAgent).GetDeathKnight()
 		procAura := dk.NewTemporaryStatsAura("Sigil of Virulence Proc", core.ActionID{SpellID: 67383}, stats.Stats{stats.Strength: 200.0}, time.Second*20)
 
@@ -726,7 +737,7 @@ func init() {
 		}))
 	})
 
-	core.NewItemEffect(50459, func(agent core.Agent) {
+	addItemEffect(50459, func(agent core.Agent) {
 		character := agent.GetCharacter()
 		dk := agent.(DeathKnightAgent).GetDeathKnight()
 
@@ -753,7 +764,7 @@ func init() {
 		}))
 	})
 
-	core.NewItemEffect(50462, func(agent core.Agent) {
+	addItemEffect(50462, func(agent core.Agent) {
 		character := agent.GetCharacter()
 		dk := agent.(DeathKnightAgent).GetDeathKnight()
 
@@ -789,7 +800,7 @@ func init() {
 }
 
 func CreateGladiatorsSigil(id int32, name string, ap float64, seconds time.Duration) {
-	core.NewItemEffect(id, func(agent core.Agent) {
+	addItemEffect(id, func(agent core.Agent) {
 		dk := agent.(DeathKnightAgent).GetDeathKnight()
 		procAura := dk.NewTemporaryStatsAura(name+" Gladiator's Sigil of Strife Proc", core.ActionID{ItemID: id}, stats.Stats{stats.AttackPower: ap}, time.Second*seconds)
 

--- a/ui/core/components/individual_sim_ui/apl_actions.ts
+++ b/ui/core/components/individual_sim_ui/apl_actions.ts
@@ -7,6 +7,7 @@ import {
 	APLActionMultidot,
 	APLActionAutocastOtherCooldowns,
 	APLActionChangeTarget,
+	APLActionActivateAura,
 	APLActionCancelAura,
 	APLActionTriggerICD,
 	APLActionWait,
@@ -413,6 +414,15 @@ const actionKindFactories: {[f in NonNullable<APLActionKind>]: ActionKindConfig<
 		newValue: () => APLActionChangeTarget.create(),
 		fields: [
 			AplHelpers.unitFieldConfig('newTarget', 'targets'),
+		],
+	}),
+	['activateAura']: inputBuilder({
+		label: 'Activate Aura',
+		submenu: ['Misc'],
+		shortDescription: 'Activates an aura',
+		newValue: () => APLActionActivateAura.create(),
+		fields: [
+			AplHelpers.actionIdFieldConfig('auraId', 'auras'),
 		],
 	}),
 	['cancelAura']: inputBuilder({


### PR DESCRIPTION
- Adds aura activate APL value (useful for things like pre-pull cinderglacier, icy talons, trinket, etc.)
- Re-factors DK item stuff so that cinderglacier is exposed as an aura even if it's not on one of the applied weapons