### PR TITLE
expose black magic aura for pre-pull actions

### DIFF
--- a/sim/common/wotlk/enchant_effects.go
+++ b/sim/common/wotlk/enchant_effects.go
@@ -8,6 +8,10 @@ import (
 	"github.com/wowsims/wotlk/sim/core/stats"
 )
 
+func CreateBlackMagicProcAura(character *core.Character) *core.Aura {
+	return character.NewTemporaryStatsAura("Black Magic Proc", core.ActionID{SpellID: 59626}, stats.Stats{stats.MeleeHaste: 250, stats.SpellHaste: 250}, time.Second*10)
+}
+
 func init() {
 	// Keep these in order by item ID.
 
@@ -233,7 +237,7 @@ func init() {
 	core.NewEnchantEffect(3790, func(agent core.Agent) {
 		character := agent.GetCharacter()
 
-		procAura := character.NewTemporaryStatsAura("Black Magic Proc", core.ActionID{SpellID: 59626}, stats.Stats{stats.MeleeHaste: 250, stats.SpellHaste: 250}, time.Second*10)
+		procAura := CreateBlackMagicProcAura(character)
 		icd := core.Cooldown{
 			Timer:    character.NewTimer(),
 			Duration: time.Second * 35,

--- a/sim/deathknight/deathknight.go
+++ b/sim/deathknight/deathknight.go
@@ -334,6 +334,7 @@ func (dk *Deathknight) Initialize() {
 
 	// allows us to use these auras in the APL pre-pull actions
 	wotlk.CreateBlackMagicProcAura(&dk.Character)
+	CreateVirulenceProcAura(&dk.Character)
 }
 
 func (dk *Deathknight) registerMindFreeze() {

--- a/sim/deathknight/deathknight.go
+++ b/sim/deathknight/deathknight.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/wowsims/wotlk/sim/common/wotlk"
 	"github.com/wowsims/wotlk/sim/core"
 	"github.com/wowsims/wotlk/sim/core/proto"
 	"github.com/wowsims/wotlk/sim/core/stats"
@@ -330,6 +331,9 @@ func (dk *Deathknight) Initialize() {
 			dk.ArmyOfTheDead.Cast(sim, nil)
 		})
 	}
+
+	// allows us to use these auras in the APL pre-pull actions
+	wotlk.CreateBlackMagicProcAura(&dk.Character)
 }
 
 func (dk *Deathknight) registerMindFreeze() {

--- a/sim/deathknight/items.go
+++ b/sim/deathknight/items.go
@@ -314,6 +314,10 @@ func addItemEffect(id int32, effect func(core.Agent)) {
 	core.NewItemEffect(id, effect)
 }
 
+func CreateVirulenceProcAura(character *core.Character) *core.Aura {
+	return character.NewTemporaryStatsAura("Sigil of Virulence Proc", core.ActionID{SpellID: 67383}, stats.Stats{stats.Strength: 200.0}, time.Second*20)
+}
+
 func (dk *Deathknight) registerItems() {
 	// Rune of Razorice
 	newRazoriceHitSpell := func(character *core.Character, isMH bool) *core.Spell {
@@ -712,16 +716,15 @@ func (dk *Deathknight) registerItems() {
 		}))
 	})
 
-	virulenceProc := dk.NewTemporaryStatsAura("Sigil of Virulence Proc", core.ActionID{SpellID: 67383}, stats.Stats{stats.Strength: 200.0}, time.Second*20)
-
 	addItemEffect(47673, func(agent core.Agent) {
 		dk := agent.(DeathKnightAgent).GetDeathKnight()
+		procAura := CreateVirulenceProcAura(dk.GetCharacter())
 
 		icd := core.Cooldown{
 			Timer:    dk.NewTimer(),
 			Duration: time.Second * 10.0,
 		}
-		virulenceProc.Icd = &icd
+		procAura.Icd = &icd
 
 		core.MakePermanent(dk.GetOrRegisterAura(core.Aura{
 			Label: "Sigil of Virulence",
@@ -732,7 +735,7 @@ func (dk *Deathknight) registerItems() {
 
 				if sim.RandomFloat("SigilOfVirulence") < 0.80 {
 					icd.Use(sim)
-					virulenceProc.Activate(sim)
+					procAura.Activate(sim)
 				}
 			},
 		}))

--- a/sim/deathknight/items.go
+++ b/sim/deathknight/items.go
@@ -712,15 +712,16 @@ func (dk *Deathknight) registerItems() {
 		}))
 	})
 
+	virulenceProc := dk.NewTemporaryStatsAura("Sigil of Virulence Proc", core.ActionID{SpellID: 67383}, stats.Stats{stats.Strength: 200.0}, time.Second*20)
+
 	addItemEffect(47673, func(agent core.Agent) {
 		dk := agent.(DeathKnightAgent).GetDeathKnight()
-		procAura := dk.NewTemporaryStatsAura("Sigil of Virulence Proc", core.ActionID{SpellID: 67383}, stats.Stats{stats.Strength: 200.0}, time.Second*20)
 
 		icd := core.Cooldown{
 			Timer:    dk.NewTimer(),
 			Duration: time.Second * 10.0,
 		}
-		procAura.Icd = &icd
+		virulenceProc.Icd = &icd
 
 		core.MakePermanent(dk.GetOrRegisterAura(core.Aura{
 			Label: "Sigil of Virulence",
@@ -731,7 +732,7 @@ func (dk *Deathknight) registerItems() {
 
 				if sim.RandomFloat("SigilOfVirulence") < 0.80 {
 					icd.Use(sim)
-					procAura.Activate(sim)
+					virulenceProc.Activate(sim)
 				}
 			},
 		}))


### PR DESCRIPTION
Exposes these auras even if not equipped so they can be used in APL pre-pull actions