### PR TITLE
fix APL wait

### DIFF
--- a/sim/core/apl.go
+++ b/sim/core/apl.go
@@ -181,10 +181,8 @@ func (apl *APLRotation) DoNextAction(sim *Simulation) {
 }
 
 func (apl *APLRotation) getNextAction(sim *Simulation) *APLAction {
-	for _, unit := range sim.AllUnits {
-		if sim.CurrentTime < unit.waitUntilTime {
-			return nil
-		}
+	if sim.CurrentTime < apl.unit.waitUntilTime {
+		return nil
 	}
 
 	if apl.strictSequence != nil {

--- a/sim/core/apl.go
+++ b/sim/core/apl.go
@@ -181,13 +181,13 @@ func (apl *APLRotation) DoNextAction(sim *Simulation) {
 }
 
 func (apl *APLRotation) getNextAction(sim *Simulation) *APLAction {
-	if apl.strictSequence != nil {
-		for _, unit := range sim.AllUnits {
-			if sim.CurrentTime < unit.waitUntilTime {
-				return nil
-			}
+	for _, unit := range sim.AllUnits {
+		if sim.CurrentTime < unit.waitUntilTime {
+			return nil
 		}
+	}
 
+	if apl.strictSequence != nil {
 		ss := apl.strictSequence.impl.(*APLActionStrictSequence)
 		if ss.actions[ss.curIdx].IsReady(sim) {
 			return apl.strictSequence

--- a/sim/core/apl.go
+++ b/sim/core/apl.go
@@ -182,6 +182,12 @@ func (apl *APLRotation) DoNextAction(sim *Simulation) {
 
 func (apl *APLRotation) getNextAction(sim *Simulation) *APLAction {
 	if apl.strictSequence != nil {
+		for _, unit := range sim.AllUnits {
+			if sim.CurrentTime < unit.waitUntilTime {
+				return nil
+			}
+		}
+
 		ss := apl.strictSequence.impl.(*APLActionStrictSequence)
 		if ss.actions[ss.curIdx].IsReady(sim) {
 			return apl.strictSequence

--- a/sim/core/apl_action.go
+++ b/sim/core/apl_action.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"fmt"
-
 	"github.com/wowsims/wotlk/sim/core/proto"
 )
 

--- a/sim/core/apl_actions_core.go
+++ b/sim/core/apl_actions_core.go
@@ -217,11 +217,18 @@ func (action *APLActionWait) IsReady(sim *Simulation) bool {
 
 func (action *APLActionWait) Execute(sim *Simulation) {
 	waitUntilTime := sim.CurrentTime + action.duration.GetDuration(sim)
+	action.unit.waitUntilTime = waitUntilTime
+
 	if waitUntilTime > action.unit.GCD.ReadyAt() {
 		action.unit.WaitUntil(sim, waitUntilTime)
 		return
 	}
-	action.unit.waitUntilTime = waitUntilTime
+	pa := &PendingAction{
+		Priority:     ActionPriorityLow,
+		OnAction:     action.unit.gcdAction.OnAction,
+		NextActionAt: waitUntilTime,
+	}
+	sim.AddPendingAction(pa)
 }
 
 func (action *APLActionWait) String() string {

--- a/sim/core/apl_actions_core.go
+++ b/sim/core/apl_actions_core.go
@@ -214,9 +214,16 @@ func (rot *APLRotation) newActionWait(config *proto.APLActionWait) APLActionImpl
 func (action *APLActionWait) IsReady(sim *Simulation) bool {
 	return action.duration != nil
 }
+
 func (action *APLActionWait) Execute(sim *Simulation) {
-	action.unit.WaitUntil(sim, sim.CurrentTime+action.duration.GetDuration(sim))
+	waitUntilTime := sim.CurrentTime + action.duration.GetDuration(sim)
+	if waitUntilTime > action.unit.GCD.ReadyAt() {
+		action.unit.WaitUntil(sim, waitUntilTime)
+		return
+	}
+	action.unit.waitUntilTime = waitUntilTime
 }
+
 func (action *APLActionWait) String() string {
 	return fmt.Sprintf("Wait(%s)", action.duration)
 }

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -452,6 +452,8 @@ func (unit *Unit) reset(sim *Simulation, agent Agent) {
 	if unit.Rotation != nil {
 		unit.Rotation.reset(sim)
 	}
+
+	unit.waitUntilTime = 0
 }
 
 func (unit *Unit) startPull(sim *Simulation) {

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -137,6 +137,7 @@ type Unit struct {
 	waitingForEnergy float64
 	waitingForMana   float64
 	waitStartTime    time.Duration
+	waitUntilTime    time.Duration
 
 	// Cached mana return values per tick.
 	manaTickWhileCasting    float64


### PR DESCRIPTION
Fixes issue with current APL wait where it was reducing GCD timer eg:
<img width="175" alt="image" src="https://github.com/wowsims/wotlk/assets/9436142/4e9bb4b5-9436-45af-be30-94d457359fbb">
(see plague strike + oblit being casted at the same time)

Now, with the fix:

With config:
<img width="762" alt="image" src="https://github.com/wowsims/wotlk/assets/9436142/d0b9e36d-4ba7-463f-80eb-8d812779e02e">

<img width="307" alt="image" src="https://github.com/wowsims/wotlk/assets/9436142/ec133a5d-04c1-4c96-88de-dda5263855c0">

Making wait time 2000ms:
<img width="363" alt="image" src="https://github.com/wowsims/wotlk/assets/9436142/f0e28a67-e875-4733-9372-73e9edce3391">
