### PR TITLE
revert tsconfig changes

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
-        "target": "esnext",
-        "module": "esnext",
+        "target": "ES2020",
+        "module": "es2015",
         "moduleResolution": "node",
         "strict": true,
         "lib": [


### PR DESCRIPTION
In https://github.com/wowsims/wotlk/pull/3469 I made some changes to the tsconfig options that don't seem to be needed. I noticed that the mobile site is now failing to load, so I'm thinking the change to target esnext may be responsible.