### PR TITLE
Fix detailed result toolbar overlap with header dropdowns

### DIFF
--- a/ui/scss/core/components/_detailed_results.scss
+++ b/ui/scss/core/components/_detailed_results.scss
@@ -63,7 +63,8 @@
 	margin-right: calc(-1 * var(--container-padding));
 	display: flex;
 	transition: background-color .15s ease-in-out;
-	z-index: $header-z-index;
+	// This needs to be less than $header-z-index otherwise the toolbar overlaps the import/export dropdowns
+	z-index: $header-z-index - 1;
 
 	&::after {
 		content: ' ';


### PR DESCRIPTION
I noticed that the import/export dropdowns get overlapped by the detailed results toolbar because of the recent changes to both elements. This is because the toolbar is using the same z-index as the header. I went ahead and just set it to 1 lower to ensure that the header takes render priority.

<img width="856" alt="image" src="https://github.com/wowsims/wotlk/assets/12898988/842c204d-4b22-4fd4-9c6d-d4eb56925fa2">
