### PR TITLE
Fix APL usage of Hemorrhage, Mutilate, and Hunger for Blood

### DIFF
--- a/sim/rogue/hemorrhage.go
+++ b/sim/rogue/hemorrhage.go
@@ -8,6 +8,10 @@ import (
 )
 
 func (rogue *Rogue) registerHemorrhageSpell() {
+	if !rogue.Talents.Hemorrhage {
+		return
+	}
+
 	actionID := core.ActionID{SpellID: 48660}
 
 	var numPlayers int

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -21,7 +21,7 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 		ActionID:    actionID,
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    procMask,
-		Flags:       core.SpellFlagMeleeMetrics | SpellFlagBuilder | SpellFlagColdBlooded | core.SpellFlagAPL,
+		Flags:       core.SpellFlagMeleeMetrics | SpellFlagBuilder | SpellFlagColdBlooded,
 
 		BonusCritRating: core.TernaryFloat64(rogue.HasSetBonus(Tier9, 4), 5*core.CritRatingPerCritChance, 0) +
 			[]float64{0, 2, 4, 6}[rogue.Talents.TurnTheTables]*core.CritRatingPerCritChance +
@@ -54,6 +54,10 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 }
 
 func (rogue *Rogue) registerMutilateSpell() {
+	if !rogue.Talents.Mutilate {
+		return
+	}
+	
 	rogue.MutilateMH = rogue.newMutilateHitSpell(true)
 	rogue.MutilateOH = rogue.newMutilateHitSpell(false)
 
@@ -61,7 +65,7 @@ func (rogue *Rogue) registerMutilateSpell() {
 		ActionID:    core.ActionID{SpellID: MutilateSpellID},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
-		Flags:       core.SpellFlagMeleeMetrics,
+		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagAPL,
 
 		EnergyCost: core.EnergyCostOptions{
 			Cost:   rogue.costModifier(60 - core.TernaryFloat64(rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfMutilate), 5, 0)),

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -145,6 +145,7 @@ func (rogue *Rogue) registerHungerForBlood() {
 
 	rogue.HungerForBlood = rogue.RegisterSpell(core.SpellConfig{
 		ActionID: actionID,
+		Flags: core.SpellFlagAPL,
 
 		EnergyCost: core.EnergyCostOptions{
 			Cost: 15,


### PR DESCRIPTION
Fixed APL to:
- Only show Hemorrhage when talented
- Cast the "ghost" hit of Mutilate rather than the per hand hits
- Hunger for Blood is now castable