### PR TITLE
Rotation tab updates

### DIFF
--- a/ui/core/components/individual_sim_ui/apl_actions.ts
+++ b/ui/core/components/individual_sim_ui/apl_actions.ts
@@ -245,13 +245,16 @@ function actionListFieldConfig(field: string): AplHelpers.APLPickerBuilderFieldC
 			setValue: (eventID: EventID, player: Player<any>, newValue: Array<APLAction>) => {
 				config.setValue(eventID, player, newValue.map(val => val || APLAction.create()));
 			},
-
 			itemLabel: 'Action',
 			newItem: APLAction.create,
 			copyItem: (oldValue: APLAction) => oldValue ? APLAction.clone(oldValue) : oldValue,
 			newItemPicker: (parent: HTMLElement, listPicker: ListPicker<Player<any>, APLAction>, index: number, config: ListItemPickerConfig<Player<any>, APLAction>) => new APLActionPicker(parent, player, config),
-			horizontalLayout: true,
 			allowedActions: ['create', 'delete', 'move'],
+			actions: {
+				create: {
+					useIcon: true,
+				}
+			}
 		}),
 	};
 }

--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -332,13 +332,16 @@ export function valueListFieldConfig(field: string): AplHelpers.APLPickerBuilder
 			setValue: (eventID: EventID, player: Player<any>, newValue: Array<APLValue | undefined>) => {
 				config.setValue(eventID, player, newValue.map(val => val || APLValue.create()));
 			},
-
 			itemLabel: 'Value',
 			newItem: APLValue.create,
 			copyItem: (oldValue: APLValue | undefined) => oldValue ? APLValue.clone(oldValue) : oldValue,
 			newItemPicker: (parent: HTMLElement, listPicker: ListPicker<Player<any>, APLValue | undefined>, index: number, config: ListItemPickerConfig<Player<any>, APLValue | undefined>) => new APLValuePicker(parent, player, config),
-			horizontalLayout: true,
 			allowedActions: ['create', 'delete'],
+			actions: {
+				create: {
+					useIcon: true,
+				},
+			},
 		}),
 	};
 }

--- a/ui/core/components/list_picker.ts
+++ b/ui/core/components/list_picker.ts
@@ -60,7 +60,7 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 		`;
 
 		if (this.config.hideUi) {
-			this.rootElem.classList.add('hide-ui');
+			this.rootElem.classList.add('d-none');
 		}
 		if (this.config.horizontalLayout) {
 			this.config.inlineMenuBar = true;

--- a/ui/core/components/list_picker.ts
+++ b/ui/core/components/list_picker.ts
@@ -6,19 +6,36 @@ import { Input, InputConfig } from './input.js';
 
 export type ListItemAction = 'create' | 'delete' | 'move' | 'copy';
 
+export interface ListPickerActionsConfig {
+	create?: {
+		// Whether or not to use an icon for the create action button
+		// defaults to FALSE
+		useIcon?: boolean	
+	}
+}
+
 export interface ListPickerConfig<ModObject, ItemType> extends InputConfig<ModObject, Array<ItemType>> {
-	title?: string,
-	titleTooltip?: string,
 	itemLabel: string,
 	newItem: () => ItemType,
 	copyItem: (oldItem: ItemType) => ItemType,
 	newItemPicker: (parent: HTMLElement, listPicker: ListPicker<ModObject, ItemType>, index: number, config: ListItemPickerConfig<ModObject, ItemType>) => Input<ModObject, ItemType>,
+	actions?: ListPickerActionsConfig
+	title?: string,
+	titleTooltip?: string,
 	inlineMenuBar?: boolean,
 	hideUi?: boolean,
 	horizontalLayout?: boolean,
 
 	// If set, only actions included in the list are allowed. Otherwise, all actions are allowed.
 	allowedActions?: Array<ListItemAction>,
+}
+
+const DEFAULT_CONFIG = {
+	actions: {
+		create: {
+			useIcon: false,
+		}
+	}
 }
 
 export interface ListItemPickerConfig<ModObject, ItemType> extends InputConfig<ModObject, ItemType> {
@@ -45,7 +62,7 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 
 	constructor(parent: HTMLElement, modObject: ModObject, config: ListPickerConfig<ModObject, ItemType>) {
 		super(parent, 'list-picker-root', modObject, config);
-		this.config = config;
+		this.config = {...DEFAULT_CONFIG, ...config};
 		this.itemPickerPairs = [];
 
 		this.rootElem.innerHTML = `
@@ -60,7 +77,7 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 		`;
 
 		if (this.config.hideUi) {
-			this.rootElem.classList.add('d-none');
+			this.rootElem.classList.add('hide-ui');
 		}
 		if (this.config.horizontalLayout) {
 			this.config.inlineMenuBar = true;
@@ -75,7 +92,7 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 		if (this.actionEnabled('create')) {
 			let newItemButton = null;
 			let newButtonTooltip: Tooltip | null = null;
-			if (this.config.horizontalLayout) {
+			if (this.config.actions?.create?.useIcon) {
 				newItemButton = ListPicker.makeActionElem('link-success', `New ${config.itemLabel}`, 'fa-plus')
 				newButtonTooltip = Tooltip.getOrCreateInstance(newItemButton);
 			} else {

--- a/ui/scss/core/components/_content_block.scss
+++ b/ui/scss/core/components/_content_block.scss
@@ -1,9 +1,12 @@
 @use "sass:map";
 
 .content-block {
-  margin-bottom: 2 * map.get($spacers, 3);
   display: flex;
   flex-direction: column;
+
+  &:not(:last-child) {
+    margin-bottom: 2 * map.get($spacers, 3);
+  }
 
   .content-block-header {
     border-bottom: $border-default;

--- a/ui/scss/core/components/_icon_picker.scss
+++ b/ui/scss/core/components/_icon_picker.scss
@@ -94,8 +94,22 @@
   }
 }
 
-.picker-group.icon-group {
-  &> :not(:last-child) {
-    margin-right: map.get($spacers, 1);
+.picker-group {
+  &.icon-group {
+    display: flex;
+    flex-wrap: wrap;
+
+    &> :not(:last-child) {
+      margin-right: map.get($spacers, 1);
+    }
+
+    &> * {
+      margin-bottom: $block-spacer;
+      flex: 0;
+  
+      &:not(:last-child) {
+        margin-right: $block-spacer;
+      }
+    }
   }
 }

--- a/ui/scss/core/components/_list_picker.scss
+++ b/ui/scss/core/components/_list_picker.scss
@@ -59,7 +59,7 @@
 				}
 		
 				.list-picker-item-action {
-					margin-left: map.get($spacers, 3);
+					margin-left: map.get($spacers, 2);
 				}
 			}
 		}

--- a/ui/scss/core/components/_list_picker.scss
+++ b/ui/scss/core/components/_list_picker.scss
@@ -4,11 +4,17 @@
 	flex-direction: column;
 	align-items: center;
 
+	&:not(:last-child) {
+		margin-bottom: 2 * map.get($spacers, 3);
+	}
+
 	.list-picker-title {
 		width: 100%;
-		padding-bottom: $block-spacer;
+		padding-bottom: map-get($spacers, 2);
 		border-bottom: $border-default;
 		margin-bottom: $block-spacer;
+		font-size: 1rem;
+		font-weight: bold;
 	}
 
 	.list-picker-items {

--- a/ui/scss/core/components/individual_sim_ui/_apl_helpers.scss
+++ b/ui/scss/core/components/individual_sim_ui/_apl_helpers.scss
@@ -1,4 +1,3 @@
-
 .apl-actionid-item-icon {
     display: inline-block;
     width: 1rem;
@@ -9,6 +8,5 @@
 
 .apl-picker-builder-root {
     flex-direction: row;
-    align-items: center;
     width: auto;
 }

--- a/ui/scss/core/components/individual_sim_ui/_apl_rotation_picker.scss
+++ b/ui/scss/core/components/individual_sim_ui/_apl_rotation_picker.scss
@@ -8,9 +8,8 @@
 		align-items: flex-start !important;
 
 		.list-picker-title {
-			width: unset;
-			padding: 0;
 			border: 0;
+			margin: 0;
 		}
 
 		.list-picker-new-button {

--- a/ui/scss/core/components/individual_sim_ui/_apl_rotation_picker.scss
+++ b/ui/scss/core/components/individual_sim_ui/_apl_rotation_picker.scss
@@ -12,23 +12,40 @@
 			margin: 0;
 		}
 
-		.list-picker-new-button {
-			width: 100%;
+		&> .list-picker-new-button {
+			width: 12rem;
+			margin: 0;
 		}
 
 		>* > .list-picker-item-container {
 			background-color: rgba(21, 23, 30, 0.8);
 			border: 1px solid var(--bs-primary) !important;
-			padding: 0 5px 0 1px;
-			margin: 0 0 5px 0;
+			padding: map-get($spacers, 2);
+			margin-bottom: map-get($spacers, 2);
 
-			>.list-picker-item {
+			.list-picker-item-header {
+				align-items: flex-start;
+			}
+
+			&>.list-picker-item {
 				flex-grow: 1;
 			}
 		}
+
+		.form-label {
+			margin-right: map-get($spacers, 2);
+			margin-bottom: 0;
+		}
 	}
 
-	.apl-list-item-picker .apl-prepull-actions-only, .apl-prepull-action-picker .apl-priority-list-only {
+	.apl-prepull-action-picker {
+		.list-picker-item-container {
+			align-items: center;
+		}
+	}
+
+	.apl-list-item-picker .apl-prepull-actions-only,
+	.apl-prepull-action-picker .apl-priority-list-only {
 		display: none;
 	}
 
@@ -37,12 +54,8 @@
 	}
 
 	.apl-prepull-actions-doat {
-		width: auto;
-		margin: 3px;
-
-		.form-label {
-			margin: 0 5px 0 0;
-		}
+		width: unset;
+		margin: 0;
 	}
 }
 
@@ -50,10 +63,10 @@
 	display: flex;
 	align-items: center;
 	flex-direction: row;
-	margin: 2px;
+	margin: 0;
 
 	&> :not(:last-child) {
-		margin-right: map.get($spacers, 2);
+		margin-right: map-get($spacers, 2);
 	}
 
 	.number-picker-input {
@@ -61,7 +74,7 @@
 	}
 
 	.dropdown-menu {
-		background-color: #696b71;
+		background-color: $table-row-odd-bg;
 	}
 }
 
@@ -69,40 +82,74 @@
 	flex-direction: row;
 	margin: 0;
 
+	.apl-action-condition {
+		margin-bottom: map-get($spacers, 3) !important;
+	}
+
+	.form-label {
+		font-size: 1rem;
+		line-height: map-get($spacers, 4);
+	}
+
 	.input-root {
 		margin: 0;
 		width: auto;
-		align-items: center;
 		border: none;
 	}
+
+	.list-picker-new-button {
+		width: unset;
+		font-size: .5rem;
+	}
 }
+
 .apl-list-item-picker-root > .apl-action-picker-root {
 	flex-direction: column;
 }
 
 .apl-picker-builder-root {
-	.form-label {
-		margin: 0 1px 0 5px;
-	}
-}
+	padding: 0 map-get($spacers, 2);
+	flex-wrap: wrap;
 
-.apl-value-picker-root {
-	* {
-		font-size: calc(var(--bs-btn-font-size) - 0.2rem);
+	.apl-picker-builder-multi {
+		padding-left: map-get($spacers, 2);
+		border-left: 1px solid $border-color;
 	}
 
-	.form-label {
-		margin: 0 1px 0 5px;
+	.list-picker-item-header {
+		.list-picker-item-title {
+			display: none !important;
+		}
+	}
+
+	.list-picker-root {
+		align-items: flex-start;
+
+		&> .list-picker-new-button {
+			margin: 0;
+		}
+
+		.list-picker-item-container {
+			padding: 0 !important;
+			border: 0 !important;
+			margin-bottom: map-get($spacers, 2);
+			display: flex;
+
+			.list-picker-item-header {
+				order: 1;
+				line-height: map-get($spacers, 4);
+			}
+		}
 	}
 }
 
 .apl-action-picker-action {
 	display: flex;
 	flex-direction: row;
-	align-items: center;
 }
 
 .hide-picker-root {
+	width: unset;
 	margin: 0;
 }
 

--- a/ui/scss/core/components/individual_sim_ui/_apl_rotation_picker.scss
+++ b/ui/scss/core/components/individual_sim_ui/_apl_rotation_picker.scss
@@ -95,6 +95,10 @@
 		margin: 0;
 		width: auto;
 		border: none;
+
+		&:not(:last-child) {
+			margin-right: map-get($spacers, 2);
+		}
 	}
 
 	.list-picker-new-button {
@@ -108,7 +112,6 @@
 }
 
 .apl-picker-builder-root {
-	padding: 0 map-get($spacers, 2);
 	flex-wrap: wrap;
 
 	.apl-picker-builder-multi {
@@ -137,6 +140,7 @@
 
 			.list-picker-item-header {
 				order: 1;
+				margin-left: map-get($spacers, 2) !important;
 				line-height: map-get($spacers, 4);
 			}
 		}

--- a/ui/scss/core/components/individual_sim_ui/_rotation_tab.scss
+++ b/ui/scss/core/components/individual_sim_ui/_rotation_tab.scss
@@ -5,10 +5,12 @@
 #rotation-tab {
 	&.rotation-type-legacy {
 		.rotation-tab-main {
+			width: 100%;
 			display: none;
 		}
 	
-		.enum-picker-selector {
+		.enum-picker-selector,
+		.number-picker-input {
 			width: 8rem;
 		}
 	}

--- a/ui/scss/core/components/individual_sim_ui/_rotation_tab.scss
+++ b/ui/scss/core/components/individual_sim_ui/_rotation_tab.scss
@@ -2,20 +2,49 @@
 
 @import "./apl_rotation_picker";
 
-.rotation-tab-left {
-    flex-direction: column;
+#rotation-tab {
+	&.rotation-type-legacy {
+		.rotation-tab-main {
+			display: none;
+		}
+	
+		.enum-picker-selector {
+			width: 8rem;
+		}
+	}
+
+	&.rotation-type-apl {
+		.cooldown-settings {
+			display: none;
+		}
+	
+		.rotation-settings {
+			display: none;
+		}
+	}
+
+	.rotation-tab-left {
+		flex-wrap: wrap;
+	}
+
+	.rotation-tab-header {
+		width: 100%;
+	}
+
+	.rotation-settings {
+		flex: 1;
+		margin-right: 2 * map.get($spacers, 3);
+	}
+
+	.cooldown-settings {
+		flex: 1;
+	}
 }
 
-.rotation-type-legacy {
-    .rotation-tab-main {
-        display: none;
-    }
-}
-.rotation-type-apl {
-    .cooldown-settings {
-        display: none;
-    }
-    .rotation-settings {
-        display: none;
-    }
+@include media-breakpoint-down(md) {
+	#rotation-tab {
+		.rotation-settings {
+			margin-right: 0;
+		}
+	}	
 }

--- a/ui/scss/core/components/individual_sim_ui/_rotation_tab.scss
+++ b/ui/scss/core/components/individual_sim_ui/_rotation_tab.scss
@@ -5,7 +5,6 @@
 #rotation-tab {
 	&.rotation-type-legacy {
 		.rotation-tab-main {
-			width: 100%;
 			display: none;
 		}
 	
@@ -30,6 +29,10 @@
 	}
 
 	.rotation-tab-header {
+		width: 100%;
+	}
+
+	.rotation-tab-main {
 		width: 100%;
 	}
 

--- a/ui/scss/core/components/individual_sim_ui/_settings_tab.scss
+++ b/ui/scss/core/components/individual_sim_ui/_settings_tab.scss
@@ -32,24 +32,6 @@
   }
 
   .rotation-settings,
-  .player-settings,
-  .custom-section {
-    .icon-group {
-      display: flex;
-      flex-wrap: wrap;
-
-      &> * {
-        margin-bottom: $block-spacer;
-        flex: 0;
-
-        &:not(:last-child) {
-          margin-right: $block-spacer;
-        }
-      }
-    }
-  }
-
-  .rotation-settings,
   .other-settings {
     .input-root {
       label {


### PR DESCRIPTION
Legacy changed to 2-column with some tweaks to styling of fields

<img width="1728" alt="image" src="https://github.com/wowsims/wotlk/assets/12898988/1a4c34eb-d0b8-41c5-bc47-17b7e19cdac4">

More substantial APL improvements. It's not perfect, as sometimes you still get things like trinket buff targets wrapping to a newline

<img width="1728" alt="image" src="https://github.com/wowsims/wotlk/assets/12898988/11108f9f-bb63-427e-915d-011bbdfe1ccc">

<img width="1728" alt="image" src="https://github.com/wowsims/wotlk/assets/12898988/2720b9e4-7649-4fb1-8154-1dce8d896f90">

<img width="1728" alt="image" src="https://github.com/wowsims/wotlk/assets/12898988/60980ee1-011a-4755-a630-f3ff0df9446f">
