### PR TITLE
Fix WCL import getPlayer error

### DIFF
--- a/ui/core/raid.ts
+++ b/ui/core/raid.ts
@@ -91,6 +91,8 @@ export class Raid {
 	}
 
 	getPlayer(index: number): Player<any> | null {
+		if (index === -1) return null;
+
 		const party = this.parties[Math.floor(index / MAX_PARTY_SIZE)];
 		return party.getPlayer(index % MAX_PARTY_SIZE);
 	}

--- a/ui/raid/import_export.ts
+++ b/ui/raid/import_export.ts
@@ -231,6 +231,7 @@ export class RaidWCLImporter extends Importer {
 		try {
 			await this.doImport(importLink);
 		} catch (error) {
+			console.error(error);
 			alert('Failed import from WCL: ' + error);
 		}
 		this.importButton.disabled = false


### PR DESCRIPTION
re https://github.com/wowsims/wotlk/issues/3406

It looks like when importing players, the assignment picker uses `index == -1` since players aren't assigned anything in the settings tab. This was causing an out of bounds error when trying to get the player.