### PR TITLE
Update styles on APL rotation and results tab

### DIFF
--- a/sim/core/apl_values_aura.go
+++ b/sim/core/apl_values_aura.go
@@ -28,7 +28,7 @@ func (value *APLValueAuraIsActive) GetBool(sim *Simulation) bool {
 	return value.aura.Get().IsActive()
 }
 func (value *APLValueAuraIsActive) String() string {
-	return fmt.Sprintf("Aura Is Active(%s)", value.aura.String())
+	return fmt.Sprintf("Aura Active(%s)", value.aura.String())
 }
 
 type APLValueAuraRemainingTime struct {

--- a/ui/core/components/detailed_results/metrics_table.ts
+++ b/ui/core/components/detailed_results/metrics_table.ts
@@ -206,7 +206,7 @@ export abstract class MetricsTable<T> extends ResultComponent {
 			fillCell: (player: UnitMetrics, cellElem: HTMLElement, rowElem: HTMLElement) => {
 				cellElem.innerHTML = `
 				<img class="metrics-action-icon" src="${player.iconUrl}"></img>
-				<span class="metrics-action-name" style="color:${player.classColor}">${player.label}</span>
+				<span class="metrics-action-name text-${player.classColor}">${player.label}</span>
 				`;
 			},
 		};

--- a/ui/core/components/detailed_results/player_damage.ts
+++ b/ui/core/components/detailed_results/player_damage.ts
@@ -51,7 +51,7 @@ export class PlayerDamageMetricsTable extends MetricsTable<UnitMetrics> {
 							<span>${(player.dps.avg / this.raidDps * 100).toFixed(2)}%</span>
 						</div>
 						<div class="player-damage-bar-container">
-							<div class="player-damage-bar" style="background-color:${player.classColor}; width:${player.dps.avg / this.maxDps * 100}%"></div>
+							<div class="player-damage-bar bg-${player.classColor}" style="width:${player.dps.avg / this.maxDps * 100}%"></div>
 						</div>
 						<div class="player-damage-total">
 							<span>${(player.totalDamage / 1000).toFixed(1)}k</span>

--- a/ui/core/components/detailed_results/results_filter.ts
+++ b/ui/core/components/detailed_results/results_filter.ts
@@ -32,6 +32,7 @@ export class ResultsFilter extends ResultComponent {
 		this.playerFilter = new UnitPicker(this.rootElem, this.currentFilter, {
 			extraCssClasses: [
 				'player-filter-root',
+				'd-none',
 			],
 			changedEvent: (_filterData: FilterData) => this.changeEmitter,
 			sourceToValue: (src: UnitReference|undefined) => this.refToValue(src),
@@ -65,6 +66,7 @@ export class ResultsFilter extends ResultComponent {
 	onSimResult(resultData: SimResultData) {
 		this.playerFilter.setOptions(this.getUnitOptions(resultData.eventID, resultData.result, true));
 		this.targetFilter.setOptions(this.getUnitOptions(resultData.eventID, resultData.result, false));
+		this.playerFilter.rootElem.classList.remove('d-none');
 		this.targetFilter.rootElem.classList.remove('d-none');
 	}
 
@@ -87,14 +89,12 @@ export class ResultsFilter extends ResultComponent {
 			return {
 				iconUrl: '',
 				text: 'All Players',
-				color: 'black',
 				value: ref,
 			};
 		} else if (ref.type == UnitType.AllTargets) {
 			return {
 				iconUrl: '',
 				text: 'All Targets',
-				color: 'black',
 				value: ref,
 			};
 		} else if (this.hasLastSimResult()) {
@@ -109,7 +109,7 @@ export class ResultsFilter extends ResultComponent {
 				return {
 					iconUrl: unit.iconUrl || '',
 					text: unit.label,
-					color: unit.classColor || 'black',
+					color: unit.classColor || '',
 					value: ref,
 				};
 			}

--- a/ui/core/components/detailed_results/timeline.ts
+++ b/ui/core/components/detailed_results/timeline.ts
@@ -220,7 +220,7 @@ export class Timeline extends ResultComponent {
 			if (this.chartPicker.value == 'dps') {
 				let maxDps = 0;
 				players.forEach(player => {
-					const dpsData = this.addDpsSeries(player, options, player.classColor);
+					const dpsData = this.addDpsSeries(player, options, `var(--bs-${player.classColor}`);
 					maxDps = Math.max(maxDps, dpsData.maxDps);
 					tooltipHandlers.push(dpsData.tooltipHandler);
 				});

--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -711,7 +711,7 @@ const valueKindFactories: {[f in NonNullable<APLValueKind>]: ValueKindConfig<APL
 
 	// Auras
 	'auraIsActive': inputBuilder({
-		label: 'Aura Is Active',
+		label: 'Aura Active',
 		submenu: ['Aura'],
 		shortDescription: '<b>True</b> if the aura is currently active on self, otherwise <b>False</b>.',
 		newValue: APLValueAuraIsActive.create,

--- a/ui/core/components/unit_picker.ts
+++ b/ui/core/components/unit_picker.ts
@@ -24,7 +24,7 @@ export class UnitPicker<ModObject> extends DropdownPicker<ModObject, UnitReferen
                 const unitConfig = valueConfig.value;
 
                 if (unitConfig.color) {
-                    button.style.backgroundColor = unitConfig.color;
+                    button.classList.add(`bg-${unitConfig.color}-dampened`, `text-${unitConfig.color}`);
                 }
 
                 if (unitConfig.iconUrl) {
@@ -37,14 +37,13 @@ export class UnitPicker<ModObject> extends DropdownPicker<ModObject, UnitReferen
                         });
                         icon = img;
                     } else if (unitConfig.iconUrl.startsWith('fa-')) {
-                        const img = document.createElement('span');
-                        img.classList.add('fa', unitConfig.iconUrl);
-                        img.classList.add('unit-picker-item-label');
+                        const img = document.createElement('i');
+                        img.classList.add('fa', unitConfig.iconUrl, 'unit-picker-item-icon');
                         icon = img;
                     } else {
                         const img = document.createElement('img');
-                        img.src = unitConfig.iconUrl;
                         img.classList.add('unit-picker-item-icon');
+                        img.src = unitConfig.iconUrl;
                         icon = img;
                     }
                     button.appendChild(icon);
@@ -52,14 +51,7 @@ export class UnitPicker<ModObject> extends DropdownPicker<ModObject, UnitReferen
 
                 const hideLabel = config.hideLabelWhenDefaultSelected && isSelectButton && !unitConfig.value;
                 if (unitConfig.text && !hideLabel) {
-                    const label = document.createElement('span');
-                    if (unitConfig.text.startsWith('fa-')) {
-                        label.classList.add('fa', unitConfig.text);
-                    } else {
-                        label.textContent = unitConfig.text;
-                    }
-                    label.classList.add('unit-picker-item-label');
-                    button.appendChild(label);
+                    button.insertAdjacentText('beforeend', unitConfig.text);
                 }
 			}
 		});

--- a/ui/core/proto_utils/sim_result.ts
+++ b/ui/core/proto_utils/sim_result.ts
@@ -17,7 +17,7 @@ import { Class } from '../proto/common.js';
 import { Spec } from '../proto/common.js';
 import { SimRun } from '../proto/ui.js';
 import { ActionId, defaultTargetIcon } from '../proto_utils/action_id.js';
-import { classColors } from '../proto_utils/utils.js';
+import { classColors, cssClassForClass } from '../proto_utils/utils.js';
 import { getTalentTreeIcon } from '../proto_utils/utils.js';
 import { playerToSpec } from '../proto_utils/utils.js';
 import { specToClass } from '../proto_utils/utils.js';
@@ -329,7 +329,7 @@ export class UnitMetrics {
 		this.petActionId = petActionId;
 		this.iconUrl = this.isPlayer ? getTalentTreeIcon(this.spec, player!.talentsString) :
 			(this.isTarget ? defaultTargetIcon : '');
-		this.classColor = this.isTarget ? 'black' : classColors[specToClass[this.spec]];
+		this.classColor = this.isTarget ? '' : cssClassForClass(specToClass[this.spec]);
 		this.dps = this.metrics.dps!;
 		this.dpasp = this.metrics.dpasp!;
 		this.hps = this.metrics.hps!;

--- a/ui/scss/core/components/_dropdown_picker.scss
+++ b/ui/scss/core/components/_dropdown_picker.scss
@@ -1,7 +1,6 @@
 .dropdown-picker-button, .dropdown-picker-item .dropdown-item {
     display: flex;
     align-items: center;
-    padding: 2px;
 }
 
 .dropdown-picker-item .dropdown-submenu {

--- a/ui/scss/core/components/_icon_picker.scss
+++ b/ui/scss/core/components/_icon_picker.scss
@@ -8,9 +8,9 @@
 
   .icon-picker-button,
   .icon-dropdown-option {
-    min-width: 2.5rem;
-    width: 2.5rem;
-    height: 2.5rem;
+    min-width: $icon-size-md;
+    width: $icon-size-md;
+    height: $icon-size-md;
     border: $border-default;
     transition: border-color .15s ease-in-out;
     background-size: cover;

--- a/ui/scss/core/components/_unit_picker.scss
+++ b/ui/scss/core/components/_unit_picker.scss
@@ -1,22 +1,14 @@
 .unit-picker-root {
-	border: 1px solid white;
-	color: white;
-	text-shadow:
-		0 0 3px black,
-		0 0 3px black,
-		0 0 3px black;
-}
-
-.unit-filter-option {
-	height: 30px;
-}
-
-.unit-picker-item-icon {
-	margin: 2px;
-	height: 1rem;
-}
-
-.unit-picker-item-label {
-	font-size: 14px;
-	margin: 2px;
+	.unit-filter-option {
+		height: 30px;
+	}
+	
+	.unit-picker-item-icon {
+		width: $icon-size-sm;
+		height: $icon-size-sm;
+		margin-right: map-get($spacers, 1);
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}	
 }

--- a/ui/scss/core/components/individual_sim_ui/_apl_helpers.scss
+++ b/ui/scss/core/components/individual_sim_ui/_apl_helpers.scss
@@ -1,12 +1,12 @@
 .apl-actionid-item-icon {
-    display: inline-block;
-    width: 1rem;
-    height: 1rem;
-    margin: 2px;
-    background-size: cover;
+  display: inline-block;
+  width: $icon-size-sm;
+  height: $icon-size-sm;
+  margin-right: map-get($spacers, 1);
+  background-size: cover;
 }
 
 .apl-picker-builder-root {
-    flex-direction: row;
-    width: auto;
+  flex-direction: row;
+  width: auto;
 }

--- a/ui/scss/core/components/individual_sim_ui/_apl_rotation_picker.scss
+++ b/ui/scss/core/components/individual_sim_ui/_apl_rotation_picker.scss
@@ -84,6 +84,7 @@
 
 	.dropdown-picker-button {
 		padding: 0;
+		border: 0;
 	}
 
 	.dropdown-menu {
@@ -96,7 +97,7 @@
 	margin: 0;
 
 	.apl-action-condition {
-		margin-bottom: map-get($spacers, 3) !important;
+		margin-bottom: map-get($spacers, 2) !important;
 	}
 
 	.input-root {
@@ -111,7 +112,8 @@
 
 	.list-picker-new-button {
 		width: unset;
-		font-size: .5rem;
+		font-size: $content-font-size;
+		line-height: 1.5rem;
 	}
 }
 
@@ -143,7 +145,7 @@
 		.list-picker-item-container {
 			padding: 0 !important;
 			border: 0 !important;
-			margin-bottom: map-get($spacers, 2);
+			margin-bottom: 0;
 			display: flex;
 
 			.list-picker-item-header {

--- a/ui/scss/core/components/individual_sim_ui/_consumes_picker.scss
+++ b/ui/scss/core/components/individual_sim_ui/_consumes_picker.scss
@@ -21,7 +21,7 @@
   }
 
   .elixir-space {
-    width: 2.5rem;
+    width: $icon-size-md;
     text-align: center;;
   }
 }

--- a/ui/scss/core/talents/_glyphs_picker.scss
+++ b/ui/scss/core/talents/_glyphs_picker.scss
@@ -9,8 +9,8 @@
 .glyph-picker-root {
   &.minor {
     .glyph-picker-icon {
-      width: 2.5rem;
-      height: 2.5rem;
+      width: $icon-size-md;
+      height: $icon-size-md;
     }
   }
 

--- a/ui/scss/shared/_variables.scss
+++ b/ui/scss/shared/_variables.scss
@@ -88,6 +88,10 @@ $content-font-size: .75rem;
 $gap-width: 1.5rem;
 $gap-width-sm: .5rem;
 
+// Sizing
+$icon-size-sm: 1rem;
+$icon-size-md: 2.5rem;
+
 // Z-index variables
 $header-z-index: 100;
 $sidebar-z-index: 200;

--- a/ui/scss/sims/raid/_blessings_picker.scss
+++ b/ui/scss/sims/raid/_blessings_picker.scss
@@ -13,8 +13,8 @@
 			margin-right: $block-spacer * 2;
 
 			.blessings-spec-icon {
-				width: 2.5rem;
-				height: 2.5rem;
+				width: $icon-size-md;
+				height: $icon-size-md;
 			}
 		}
 

--- a/ui/scss/sims/raid/_raid_stats.scss
+++ b/ui/scss/sims/raid/_raid_stats.scss
@@ -77,8 +77,8 @@
 		}
 
 		.raid-stats-effect-icon {
-			width: 1rem;
-			height: 1rem;
+			width: $icon-size-sm;
+			height: $icon-size-sm;
 		}
 	}
 }

--- a/ui/shared/bootstrap_overrides.ts
+++ b/ui/shared/bootstrap_overrides.ts
@@ -1,7 +1,7 @@
 import { Dropdown, Popover, Tooltip } from 'bootstrap';
 import { isDescendant } from './utils';
 
-Dropdown.Default.offset = [0, 0];
+Dropdown.Default.offset = [0, -1];
 //Dropdown.Default.display = "static";
 
 Tooltip.Default.trigger = "hover";


### PR DESCRIPTION
### Remove excess spacing in APL rotation
<img width="984" alt="image" src="https://github.com/wowsims/wotlk/assets/12898988/767fb616-49c4-497b-98c3-d9d26598b199">

### Adjust styles on dropdown and unit pickers
<img width="690" alt="image" src="https://github.com/wowsims/wotlk/assets/12898988/ee16931a-f4db-4e0f-97f6-50c974726dcb">

### Raid sim results player picker now use consistent colors

<img width="252" alt="image" src="https://github.com/wowsims/wotlk/assets/12898988/d69da38c-de09-436b-9273-12226fd9e01e">
