### PR TITLE
druid spell form check / auto unshift

### DIFF
--- a/sim/druid/balance/balance.go
+++ b/sim/druid/balance/balance.go
@@ -52,7 +52,7 @@ type BalanceDruid struct {
 
 	Rotation           *proto.BalanceDruid_Rotation
 	CooldownsAvailable []*core.MajorCooldown
-	LastCast           *core.Spell
+	LastCast           *druid.DruidSpell
 
 	// CDS
 	hyperSpeedMCD      *core.MajorCooldown

--- a/sim/druid/balance/rotation.go
+++ b/sim/druid/balance/rotation.go
@@ -6,6 +6,7 @@ import (
 	"github.com/wowsims/wotlk/sim/core"
 	"github.com/wowsims/wotlk/sim/core/proto"
 	"github.com/wowsims/wotlk/sim/core/stats"
+	"github.com/wowsims/wotlk/sim/druid"
 )
 
 func (moonkin *BalanceDruid) OnGCDReady(sim *core.Simulation) {
@@ -20,7 +21,7 @@ func (moonkin *BalanceDruid) tryUseGCD(sim *core.Simulation) {
 	moonkin.LastCast = spell
 }
 
-func (moonkin *BalanceDruid) rotation(sim *core.Simulation) (*core.Spell, *core.Unit) {
+func (moonkin *BalanceDruid) rotation(sim *core.Simulation) (*druid.DruidSpell, *core.Unit) {
 	moonkin.CurrentTarget = sim.Environment.GetTargetUnit(0)
 	rotation := moonkin.Rotation
 	target := moonkin.CurrentTarget

--- a/sim/druid/barkskin.go
+++ b/sim/druid/barkskin.go
@@ -36,7 +36,7 @@ func (druid *Druid) registerBarkskinCD() {
 		},
 	})
 
-	druid.Barkskin = druid.RegisterSpell(core.SpellConfig{
+	druid.Barkskin = druid.RegisterSpell(Any, core.SpellConfig{
 		ActionID: actionId,
 		Flags:    SpellFlagOmenTrigger | core.SpellFlagAPL,
 		Cast: core.CastConfig{
@@ -52,7 +52,7 @@ func (druid *Druid) registerBarkskinCD() {
 	})
 
 	druid.AddMajorCooldown(core.MajorCooldown{
-		Spell: druid.Barkskin,
+		Spell: druid.Barkskin.Spell,
 		Type:  core.CooldownTypeSurvival,
 	})
 }

--- a/sim/druid/berserk.go
+++ b/sim/druid/berserk.go
@@ -14,14 +14,14 @@ func (druid *Druid) registerBerserkCD() {
 
 	actionId := core.ActionID{SpellID: 50334}
 	glyphBonus := core.TernaryDuration(druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfBerserk), time.Second*5.0, 0.0)
-	var affectedSpells []*core.Spell
+	var affectedSpells []*DruidSpell
 
 	druid.BerserkAura = druid.RegisterAura(core.Aura{
 		Label:    "Berserk",
 		ActionID: actionId,
 		Duration: (time.Second * 15) + glyphBonus,
 		OnInit: func(aura *core.Aura, sim *core.Simulation) {
-			affectedSpells = core.FilterSlice([]*core.Spell{
+			affectedSpells = core.FilterSlice([]*DruidSpell{
 				druid.MangleCat,
 				druid.FerociousBite,
 				druid.Rake,
@@ -29,7 +29,7 @@ func (druid *Druid) registerBerserkCD() {
 				druid.SavageRoar,
 				druid.SwipeCat,
 				druid.Shred,
-			}, func(spell *core.Spell) bool { return spell != nil })
+			}, func(spell *DruidSpell) bool { return spell != nil })
 		},
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			for _, spell := range affectedSpells {
@@ -43,7 +43,7 @@ func (druid *Druid) registerBerserkCD() {
 		},
 	})
 
-	druid.Berserk = druid.RegisterSpell(core.SpellConfig{
+	druid.Berserk = druid.RegisterSpell(Cat|Bear, core.SpellConfig{
 		ActionID: actionId,
 		Flags:    core.SpellFlagAPL,
 
@@ -63,7 +63,7 @@ func (druid *Druid) registerBerserkCD() {
 	})
 
 	druid.AddMajorCooldown(core.MajorCooldown{
-		Spell: druid.Berserk,
+		Spell: druid.Berserk.Spell,
 		Type:  core.CooldownTypeDPS,
 	})
 }

--- a/sim/druid/berserk.go
+++ b/sim/druid/berserk.go
@@ -62,8 +62,10 @@ func (druid *Druid) registerBerserkCD() {
 		},
 	})
 
-	druid.AddMajorCooldown(core.MajorCooldown{
-		Spell: druid.Berserk.Spell,
-		Type:  core.CooldownTypeDPS,
-	})
+	if druid.IsUsingAPL {
+		druid.AddMajorCooldown(core.MajorCooldown{
+			Spell: druid.Berserk.Spell,
+			Type:  core.CooldownTypeDPS,
+		})
+	}
 }

--- a/sim/druid/demoralizing_roar.go
+++ b/sim/druid/demoralizing_roar.go
@@ -11,7 +11,7 @@ func (druid *Druid) registerDemoralizingRoarSpell() {
 		return core.DemoralizingRoarAura(target, druid.Talents.FeralAggression)
 	})
 
-	druid.DemoralizingRoar = druid.RegisterSpell(core.SpellConfig{
+	druid.DemoralizingRoar = druid.RegisterSpell(Bear, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 48560},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskEmpty,

--- a/sim/druid/enrage.go
+++ b/sim/druid/enrage.go
@@ -39,7 +39,7 @@ func (druid *Druid) registerEnrageSpell() {
 		},
 	})
 
-	druid.Enrage = druid.RegisterSpell(core.SpellConfig{
+	druid.Enrage = druid.RegisterSpell(Bear, core.SpellConfig{
 		ActionID: actionID,
 		Flags:    core.SpellFlagAPL,
 
@@ -49,9 +49,6 @@ func (druid *Druid) registerEnrageSpell() {
 				Duration: time.Minute,
 			},
 			IgnoreHaste: true,
-		},
-		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return druid.InForm(Bear)
 		},
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, _ *core.Spell) {
@@ -72,7 +69,7 @@ func (druid *Druid) registerEnrageSpell() {
 	})
 
 	druid.AddMajorCooldown(core.MajorCooldown{
-		Spell: druid.Enrage,
+		Spell: druid.Enrage.Spell,
 		Type:  core.CooldownTypeDPS,
 	})
 }

--- a/sim/druid/faerie_fire.go
+++ b/sim/druid/faerie_fire.go
@@ -16,6 +16,7 @@ func (druid *Druid) registerFaerieFireSpell() {
 	cd := core.Cooldown{}
 	flatThreatBonus := 66. * 2.
 	flags := SpellFlagOmenTrigger
+	formMask := Humanoid | Moonkin
 
 	if druid.InForm(Cat | Bear) {
 		actionID = core.ActionID{SpellID: 16857}
@@ -23,6 +24,7 @@ func (druid *Druid) registerFaerieFireSpell() {
 		gcd = time.Second
 		ignoreHaste = true
 		flags = core.SpellFlagNone
+		formMask = Cat | Bear
 		cd = core.Cooldown{
 			Timer:    druid.NewTimer(),
 			Duration: time.Second * 6,
@@ -35,7 +37,7 @@ func (druid *Druid) registerFaerieFireSpell() {
 		return core.FaerieFireAura(target, druid.Talents.ImprovedFaerieFire)
 	})
 
-	druid.FaerieFire = druid.RegisterSpell(core.SpellConfig{
+	druid.FaerieFire = druid.RegisterSpell(formMask, core.SpellConfig{
 		ActionID:    actionID,
 		SpellSchool: core.SpellSchoolNature,
 		ProcMask:    core.ProcMaskSpellDamage,

--- a/sim/druid/fake_gotw.go
+++ b/sim/druid/fake_gotw.go
@@ -10,7 +10,7 @@ import (
 func (druid *Druid) registerFakeGotw() {
 	baseCost := core.TernaryFloat64(druid.HasMinorGlyph(proto.DruidMinorGlyph_GlyphOfTheWild), 0.32, 0.64)
 
-	druid.GiftOfTheWild = druid.RegisterSpell(core.SpellConfig{
+	druid.GiftOfTheWild = druid.RegisterSpell(Humanoid|Moonkin|Tree, core.SpellConfig{
 		ActionID: core.ActionID{SpellID: 48470},
 		Flags:    SpellFlagOmenTrigger | core.SpellFlagHelpful | core.SpellFlagAPL,
 
@@ -22,9 +22,6 @@ func (druid *Druid) registerFakeGotw() {
 			DefaultCast: core.Cast{
 				GCD: core.GCDDefault,
 			},
-		},
-		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return druid.InForm(Humanoid | Moonkin | Tree)
 		},
 	})
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -46,1145 +46,1145 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7570.60839
-  tps: 5439.82242
+  dps: 7560.29119
+  tps: 5432.87115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7565.84705
-  tps: 5434.27306
+  dps: 7593.60431
+  tps: 5454.27986
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7406.93992
-  tps: 5321.449
+  dps: 7439.67589
+  tps: 5344.61675
   hps: 89.11518
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7406.93992
-  tps: 5321.449
+  dps: 7439.67589
+  tps: 5344.61675
   hps: 89.11518
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7586.92315
-  tps: 5451.40591
+  dps: 7586.36733
+  tps: 5451.38521
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6135.27426
-  tps: 4417.29501
+  dps: 6149.77007
+  tps: 4427.96097
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7570.60839
-  tps: 5331.02597
+  dps: 7560.29119
+  tps: 5324.21372
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 7596.74148
-  tps: 5458.37692
+  dps: 7593.36531
+  tps: 5456.35377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7736.33704
-  tps: 5557.48977
+  dps: 7735.89978
+  tps: 5557.55325
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7547.40798
-  tps: 5420.95696
+  dps: 7541.07721
+  tps: 5416.5369
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7583.70991
-  tps: 5446.8809
+  dps: 7572.5553
+  tps: 5439.03592
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 7596.74148
-  tps: 5458.37692
+  dps: 7593.36531
+  tps: 5456.35377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7878.77492
-  tps: 5656.45185
+  dps: 7873.87819
+  tps: 5652.90038
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7516.32011
-  tps: 5399.03414
+  dps: 7523.08172
+  tps: 5403.83489
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7883.73944
-  tps: 5660.05145
+  dps: 7851.64245
+  tps: 5637.41215
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7932.03343
-  tps: 5693.66709
+  dps: 7931.83617
+  tps: 5694.20012
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7588.15255
-  tps: 5452.12921
+  dps: 7589.07641
+  tps: 5453.30865
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7545.77247
-  tps: 5419.94532
+  dps: 7574.13248
+  tps: 5440.30529
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7573.02596
-  tps: 5438.99615
+  dps: 7592.6349
+  tps: 5453.44201
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 6995.81325
-  tps: 5028.35247
+  dps: 6984.00442
+  tps: 5020.86564
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreamwalkerGarb"
  value: {
-  dps: 5990.0304
-  tps: 4316.41546
+  dps: 5990.93222
+  tps: 4316.8314
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7570.60839
-  tps: 5439.82242
+  dps: 7560.29119
+  tps: 5432.87115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7570.60839
-  tps: 5439.82242
+  dps: 7560.29119
+  tps: 5432.87115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7586.92315
-  tps: 5451.40591
+  dps: 7586.36733
+  tps: 5451.38521
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7585.18074
-  tps: 5450.1688
+  dps: 7580.79626
+  tps: 5447.42974
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7484.61416
-  tps: 5376.0742
+  dps: 7572.19706
+  tps: 5438.85635
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7570.60839
-  tps: 5439.82242
+  dps: 7560.29119
+  tps: 5432.87115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7581.91004
-  tps: 5445.90214
+  dps: 7569.80361
+  tps: 5436.93265
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7537.55195
-  tps: 5414.03396
+  dps: 7527.8599
+  tps: 5407.07782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7518.88739
-  tps: 5400.78213
+  dps: 7508.01446
+  tps: 5392.98756
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7570.60839
-  tps: 5439.82242
+  dps: 7560.29119
+  tps: 5432.87115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7570.60839
-  tps: 5439.82242
+  dps: 7560.29119
+  tps: 5432.87115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 7596.74148
-  tps: 5458.37692
+  dps: 7593.36531
+  tps: 5456.35377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7588.40525
-  tps: 5450.28938
+  dps: 7617.35647
+  tps: 5470.76996
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 7538.66585
-  tps: 5413.92739
+  dps: 7517.40091
+  tps: 5399.57715
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 6045.30453
-  tps: 4353.71564
+  dps: 6057.95459
+  tps: 4363.37026
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7561.06319
-  tps: 5430.72695
+  dps: 7549.1448
+  tps: 5422.48925
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 7596.74148
-  tps: 5458.37692
+  dps: 7593.36531
+  tps: 5456.35377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-49982"
  value: {
-  dps: 7857.20349
-  tps: 5643.37973
+  dps: 7820.74684
+  tps: 5617.49551
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 7914.39287
-  tps: 5683.53547
+  dps: 7931.98427
+  tps: 5696.32451
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdolofLunarFury-47670"
  value: {
-  dps: 7596.74148
-  tps: 5458.37692
+  dps: 7593.36531
+  tps: 5456.35377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 7900.70711
-  tps: 5674.41688
+  dps: 7880.6686
+  tps: 5660.3391
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 7596.74148
-  tps: 5458.37692
+  dps: 7593.36531
+  tps: 5456.35377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 7918.75297
-  tps: 5686.93029
+  dps: 7889.50712
+  tps: 5666.53967
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 7596.74148
-  tps: 5458.37692
+  dps: 7593.36531
+  tps: 5456.35377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 7634.43875
-  tps: 5484.99241
+  dps: 7644.19059
+  tps: 5492.43972
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 7596.74148
-  tps: 5458.37692
+  dps: 7593.36531
+  tps: 5456.35377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 7596.74148
-  tps: 5458.37692
+  dps: 7593.36531
+  tps: 5456.35377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7586.92315
-  tps: 5451.40591
+  dps: 7586.36733
+  tps: 5451.38521
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7585.18074
-  tps: 5450.1688
+  dps: 7580.79626
+  tps: 5447.42974
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7576.07364
-  tps: 5441.53394
+  dps: 7608.6812
+  tps: 5464.61052
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7570.60839
-  tps: 5439.82242
+  dps: 7560.29119
+  tps: 5432.87115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7595.18298
-  tps: 5457.27038
+  dps: 7586.5748
+  tps: 5451.53251
   hps: 12.24352
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 8266.44026
-  tps: 5930.49765
+  dps: 8273.01361
+  tps: 5935.16473
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LasherweaveRegalia"
  value: {
-  dps: 6176.17275
-  tps: 4494.13837
+  dps: 6189.59339
+  tps: 4504.17136
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 7419.48796
-  tps: 5333.05042
+  dps: 7442.62122
+  tps: 5348.87675
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 5869.72912
-  tps: 4273.7658
+  dps: 5832.47798
+  tps: 4242.04856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7598.12849
-  tps: 5457.04331
+  dps: 7591.21968
+  tps: 5452.58677
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7636.01776
-  tps: 5483.94469
+  dps: 7613.48633
+  tps: 5468.02216
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NightsongBattlegear"
  value: {
-  dps: 7311.21807
-  tps: 5253.71084
+  dps: 7385.33022
+  tps: 5306.10611
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NightsongGarb"
  value: {
-  dps: 5959.46621
-  tps: 4297.55678
+  dps: 5896.11258
+  tps: 4252.65049
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7590.62687
-  tps: 5454.03554
+  dps: 7580.30624
+  tps: 5447.08183
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7595.3371
-  tps: 5457.37981
+  dps: 7585.01566
+  tps: 5450.42552
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7570.60839
-  tps: 5439.82242
+  dps: 7560.29119
+  tps: 5432.87115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7570.60839
-  tps: 5439.82242
+  dps: 7560.29119
+  tps: 5432.87115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7746.87401
-  tps: 5564.97101
+  dps: 7742.73374
+  tps: 5562.40536
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 7596.74148
-  tps: 5458.37692
+  dps: 7593.36531
+  tps: 5456.35377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7570.60839
-  tps: 5439.82242
+  dps: 7560.29119
+  tps: 5432.87115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 7596.74148
-  tps: 5458.37692
+  dps: 7593.36531
+  tps: 5456.35377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7541.99091
-  tps: 5417.18563
+  dps: 7529.74464
+  tps: 5408.41599
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 7472.726
-  tps: 5368.00754
+  dps: 7467.89454
+  tps: 5364.87635
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7571.42931
-  tps: 5440.10613
+  dps: 7583.72433
+  tps: 5448.53645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StormshroudArmor"
  value: {
-  dps: 6232.59846
-  tps: 4486.24561
+  dps: 6262.70055
+  tps: 4507.6181
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7595.3371
-  tps: 5457.37981
+  dps: 7585.01566
+  tps: 5450.42552
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7590.62687
-  tps: 5454.03554
+  dps: 7580.30624
+  tps: 5447.08183
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7582.38397
-  tps: 5448.18308
+  dps: 7572.06475
+  tps: 5441.23037
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartHarness"
  value: {
-  dps: 6078.62789
-  tps: 4378.12309
+  dps: 6072.83734
+  tps: 4374.90925
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartRegalia"
  value: {
-  dps: 5198.774
-  tps: 3754.773
+  dps: 5256.68083
+  tps: 3795.73727
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7574.78837
-  tps: 5442.93978
+  dps: 7625.7738
+  tps: 5479.51337
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7606.06931
-  tps: 5465.29882
+  dps: 7591.20338
+  tps: 5454.66923
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7639.60044
-  tps: 5489.03114
+  dps: 7633.51231
+  tps: 5484.70856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7570.60839
-  tps: 5439.82242
+  dps: 7560.29119
+  tps: 5432.87115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7570.60839
-  tps: 5439.82242
+  dps: 7560.29119
+  tps: 5432.87115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7471.05691
-  tps: 5366.89727
+  dps: 7464.78658
+  tps: 5362.6697
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7570.60839
-  tps: 5439.82242
+  dps: 7560.29119
+  tps: 5432.87115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7570.60839
-  tps: 5439.82242
+  dps: 7560.29119
+  tps: 5432.87115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6433.93705
-  tps: 4629.56994
+  dps: 6427.34382
+  tps: 4625.48704
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6374.6777
-  tps: 4590.93599
+  dps: 6334.68127
+  tps: 4562.91246
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 7596.74148
-  tps: 5458.37692
+  dps: 7593.36531
+  tps: 5456.35377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7406.89649
-  tps: 5321.41816
+  dps: 7435.35977
+  tps: 5341.5523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 7596.74148
-  tps: 5458.37692
+  dps: 7593.36531
+  tps: 5456.35377
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 7790.28345
-  tps: 5595.73491
+  dps: 7788.0939
+  tps: 5594.44081
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7746.87401
-  tps: 5564.97101
+  dps: 7742.73374
+  tps: 5562.40536
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7746.87401
-  tps: 5564.97101
+  dps: 7742.73374
+  tps: 5562.40536
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8542.95421
-  tps: 6120.83962
+  dps: 8472.85959
+  tps: 6073.31604
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBleed-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7777.77246
-  tps: 5587.13327
+  dps: 7775.9294
+  tps: 5585.97427
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBleed-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7777.77246
-  tps: 5587.13327
+  dps: 7775.9294
+  tps: 5585.97427
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBleed-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8476.9692
-  tps: 6073.99026
+  dps: 8611.69099
+  tps: 6171.13847
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBleed-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4856.96743
-  tps: 3511.49203
+  dps: 4874.10809
+  tps: 3523.96105
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBleed-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4856.96743
-  tps: 3511.49203
+  dps: 4874.10809
+  tps: 3523.96105
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBleed-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5080.49582
-  tps: 3659.87663
+  dps: 5069.91858
+  tps: 3655.35826
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4851.74041
-  tps: 3507.93042
+  dps: 4849.90006
+  tps: 3506.62378
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4851.74041
-  tps: 3507.93042
+  dps: 4849.90006
+  tps: 3506.62378
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5117.48766
-  tps: 3686.14084
+  dps: 5098.10689
+  tps: 3674.62409
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Flower-Aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22860.1726
-  tps: 16534.17882
+  dps: 22992.33137
+  tps: 16645.5556
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Flower-Aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4756.54831
-  tps: 3455.18339
+  dps: 4749.28634
+  tps: 3450.72612
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Flower-Aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5627.02645
-  tps: 4059.4234
+  dps: 5674.76106
+  tps: 4093.28701
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Flower-Aoe-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14513.64196
-  tps: 10690.98136
+  dps: 14733.85351
+  tps: 10879.67439
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Flower-Aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2560.5779
-  tps: 1897.82888
+  dps: 2572.50188
+  tps: 1908.10689
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Flower-Aoe-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2811.72934
-  tps: 2060.87709
+  dps: 2862.92701
+  tps: 2097.3836
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10079.62949
-  tps: 7220.25518
+  dps: 10105.41652
+  tps: 7238.19004
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10079.62949
-  tps: 7220.25518
+  dps: 10105.41652
+  tps: 7238.19004
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11525.23547
-  tps: 8234.89392
+  dps: 11585.59846
+  tps: 8279.99524
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Default-NoBleed-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10067.64068
-  tps: 7211.81791
+  dps: 10060.83211
+  tps: 7207.05861
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Default-NoBleed-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10067.64068
-  tps: 7211.81791
+  dps: 10060.83211
+  tps: 7207.05861
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Default-NoBleed-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11575.09147
-  tps: 8271.03954
+  dps: 11545.98902
+  tps: 8251.49861
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Default-NoBleed-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6285.6676
-  tps: 4525.12129
+  dps: 6269.60608
+  tps: 4514.09155
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Default-NoBleed-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6285.6676
-  tps: 4525.12129
+  dps: 6269.60608
+  tps: 4514.09155
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Default-NoBleed-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6885.95483
-  tps: 4939.88287
+  dps: 6889.90957
+  tps: 4946.05613
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6312.36343
-  tps: 4543.47704
+  dps: 6263.03005
+  tps: 4509.7965
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6312.36343
-  tps: 4543.47704
+  dps: 6263.03005
+  tps: 4509.7965
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6873.9667
-  tps: 4931.37129
+  dps: 6860.04227
+  tps: 4925.59821
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Flower-Aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31741.19376
-  tps: 22847.55886
+  dps: 31448.6377
+  tps: 22628.51999
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Flower-Aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6329.79182
-  tps: 4569.76952
+  dps: 6340.54825
+  tps: 4579.07443
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Flower-Aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7639.2528
-  tps: 5487.01218
+  dps: 7566.49644
+  tps: 5436.30673
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Flower-Aoe-NoBuffs-LongMultiTarget"
  value: {
-  dps: 20694.54267
-  tps: 15099.29804
+  dps: 20666.67348
+  tps: 15082.61032
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Flower-Aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3496.10886
-  tps: 2561.7007
+  dps: 3509.95358
+  tps: 2572.82049
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Flower-Aoe-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3879.92814
-  tps: 2815.94847
+  dps: 3961.51157
+  tps: 2877.49187
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6274.08483
-  tps: 4517.27145
+  dps: 6270.42779
+  tps: 4515.34803
  }
 }

--- a/sim/druid/feral/TestFeralDoubleArmorPenTrinketsNoDesync.results
+++ b/sim/druid/feral/TestFeralDoubleArmorPenTrinketsNoDesync.results
@@ -46,935 +46,935 @@ character_stats_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 9614.07257
-  tps: 6892.17773
+  dps: 9659.30529
+  tps: 6924.0686
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 9801.72784
-  tps: 7022.57107
+  dps: 9842.44041
+  tps: 7051.70136
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
   hps: 90.47701
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
   hps: 90.47701
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 9641.38288
-  tps: 6911.56804
+  dps: 9703.71202
+  tps: 6955.52259
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 7578.56824
-  tps: 5445.69828
+  dps: 7571.46168
+  tps: 5441.25091
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 9614.07257
-  tps: 6754.33417
+  dps: 9659.30529
+  tps: 6785.58723
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 9572.54108
-  tps: 6862.69037
+  dps: 9632.23982
+  tps: 6904.77732
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 9855.85907
-  tps: 7063.84614
+  dps: 9919.58257
+  tps: 7108.79068
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 9815.77529
-  tps: 7033.06827
+  dps: 9802.53899
+  tps: 7023.82007
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 9816.24536
-  tps: 7032.87851
+  dps: 9837.64883
+  tps: 7048.29934
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 9817.44531
-  tps: 7034.10441
+  dps: 9845.1149
+  tps: 7053.60024
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 9572.54108
-  tps: 6862.69037
+  dps: 9632.23982
+  tps: 6904.77732
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Death'sChoice-47464"
  value: {
-  dps: 10222.13884
-  tps: 7321.43682
+  dps: 10189.55873
+  tps: 7298.23015
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 9740.16485
-  tps: 6978.78656
+  dps: 9794.67709
+  tps: 7018.01376
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10227.43143
-  tps: 7324.59626
+  dps: 10184.47917
+  tps: 7294.84802
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 10302.63469
-  tps: 7378.73845
+  dps: 10297.68185
+  tps: 7375.29671
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Defender'sCode-40257"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 9648.74213
-  tps: 6916.79311
+  dps: 9710.65824
+  tps: 6960.4544
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 9832.74881
-  tps: 7044.14724
+  dps: 9851.14205
+  tps: 7057.95431
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 9859.13014
-  tps: 7063.02756
+  dps: 9841.05209
+  tps: 7050.64087
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 8411.00012
-  tps: 6036.65012
+  dps: 8479.28017
+  tps: 6086.32555
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DreamwalkerGarb"
  value: {
-  dps: 7221.86031
-  tps: 5194.3801
+  dps: 7223.97117
+  tps: 5196.32753
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 9614.07257
-  tps: 6892.17773
+  dps: 9659.30529
+  tps: 6924.0686
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 9614.07257
-  tps: 6892.17773
+  dps: 9659.30529
+  tps: 6924.0686
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 9641.38288
-  tps: 6911.56804
+  dps: 9703.71202
+  tps: 6955.52259
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 9635.79121
-  tps: 6907.59796
+  dps: 9698.81875
+  tps: 6952.04837
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 9684.26008
-  tps: 6939.31854
+  dps: 9783.73176
+  tps: 7010.31736
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 9614.07257
-  tps: 6892.17773
+  dps: 9659.30529
+  tps: 6924.0686
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 9811.72424
-  tps: 7029.81809
+  dps: 9837.11882
+  tps: 7047.5491
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 9766.84527
-  tps: 6998.02881
+  dps: 9790.95429
+  tps: 7015.07143
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ForgeEmber-37660"
  value: {
-  dps: 9721.32986
-  tps: 6965.78766
+  dps: 9777.49629
+  tps: 7005.51625
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 9614.07257
-  tps: 6892.17773
+  dps: 9659.30529
+  tps: 6924.0686
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 9614.07257
-  tps: 6892.17773
+  dps: 9659.30529
+  tps: 6924.0686
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 9572.54108
-  tps: 6862.69037
+  dps: 9632.23982
+  tps: 6904.77732
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 9837.52375
-  tps: 7048.21053
+  dps: 9879.02588
+  tps: 7077.82662
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-FuturesightRune-38763"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 9116.23461
-  tps: 6537.36661
+  dps: 9096.15861
+  tps: 6523.56138
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 7372.25391
-  tps: 5299.06553
+  dps: 7339.64617
+  tps: 5276.36275
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 9792.4215
-  tps: 7016.11315
+  dps: 9814.68898
+  tps: 7031.6987
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 9572.54108
-  tps: 6862.69037
+  dps: 9632.23982
+  tps: 6904.77732
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Heartpierce-49982"
  value: {
-  dps: 10057.44557
-  tps: 7206.29947
+  dps: 10054.56117
+  tps: 7204.70027
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Heartpierce-50641"
  value: {
-  dps: 10088.6735
-  tps: 7228.39652
+  dps: 10079.08846
+  tps: 7222.11464
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IdolofLunarFury-47670"
  value: {
-  dps: 9572.54108
-  tps: 6862.69037
+  dps: 9632.23982
+  tps: 6904.77732
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 9925.21748
-  tps: 7113.09061
+  dps: 10013.24542
+  tps: 7175.8896
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 9572.54108
-  tps: 6862.69037
+  dps: 9632.23982
+  tps: 6904.77732
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 9895.19813
-  tps: 7091.77687
+  dps: 9954.12278
+  tps: 7133.98731
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 9572.54108
-  tps: 6862.69037
+  dps: 9632.23982
+  tps: 6904.77732
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 9637.71854
-  tps: 6909.04115
+  dps: 9691.76332
+  tps: 6947.03901
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 9572.54108
-  tps: 6862.69037
+  dps: 9632.23982
+  tps: 6904.77732
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 9572.54108
-  tps: 6862.69037
+  dps: 9632.23982
+  tps: 6904.77732
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 9641.38288
-  tps: 6911.56804
+  dps: 9703.71202
+  tps: 6955.52259
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 9635.79121
-  tps: 6907.59796
+  dps: 9698.81875
+  tps: 6952.04837
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IncisorFragment-37723"
  value: {
-  dps: 9827.0824
-  tps: 7040.49803
+  dps: 9835.66883
+  tps: 7046.96832
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 9614.07257
-  tps: 6892.17773
+  dps: 9659.30529
+  tps: 6924.0686
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 9643.67647
-  tps: 6913.19649
+  dps: 9689.01093
+  tps: 6945.1596
   hps: 13.49381
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 9839.71736
-  tps: 7050.96458
+  dps: 9827.26395
+  tps: 7041.8983
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-LasherweaveRegalia"
  value: {
-  dps: 7533.33074
-  tps: 5416.04761
+  dps: 7507.03544
+  tps: 5398.2006
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 8798.28245
-  tps: 6314.61205
+  dps: 8807.83132
+  tps: 6321.54132
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 7166.97454
-  tps: 5156.0095
+  dps: 7173.94501
+  tps: 5161.40725
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 9900.04027
-  tps: 7092.14854
+  dps: 9903.74384
+  tps: 7095.07722
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 9833.41238
-  tps: 7045.74017
+  dps: 9884.19489
+  tps: 7080.89832
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-NightsongBattlegear"
  value: {
-  dps: 8818.29735
-  tps: 6326.65381
+  dps: 8810.70284
+  tps: 6322.38351
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-NightsongGarb"
  value: {
-  dps: 7118.67332
-  tps: 5121.71563
+  dps: 7090.35739
+  tps: 5102.58355
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 9638.03763
-  tps: 6909.19292
+  dps: 9683.35271
+  tps: 6941.14227
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 9643.67647
-  tps: 6913.19649
+  dps: 9689.01093
+  tps: 6945.1596
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 9614.07257
-  tps: 6892.17773
+  dps: 9659.30529
+  tps: 6924.0686
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 9614.07257
-  tps: 6892.17773
+  dps: 9659.30529
+  tps: 6924.0686
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 9860.2215
-  tps: 7066.94346
+  dps: 9924.98693
+  tps: 7112.62777
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 9572.54108
-  tps: 6862.69037
+  dps: 9632.23982
+  tps: 6904.77732
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 9614.07257
-  tps: 6892.17773
+  dps: 9659.30529
+  tps: 6924.0686
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 9572.54108
-  tps: 6862.69037
+  dps: 9632.23982
+  tps: 6904.77732
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SoulPreserver-37111"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SouloftheDead-40382"
  value: {
-  dps: 9770.34931
-  tps: 7000.51668
+  dps: 9795.66346
+  tps: 7018.41494
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SparkofLife-37657"
  value: {
-  dps: 9688.2825
-  tps: 6941.80052
+  dps: 9760.24534
+  tps: 6993.49243
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 9791.40197
-  tps: 7017.55809
+  dps: 9821.23574
+  tps: 7038.51571
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-StormshroudArmor"
  value: {
-  dps: 7719.9569
-  tps: 5545.48593
+  dps: 7718.35933
+  tps: 5543.60379
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 9643.67647
-  tps: 6913.19649
+  dps: 9689.01093
+  tps: 6945.1596
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 9638.03763
-  tps: 6909.19292
+  dps: 9683.35271
+  tps: 6941.14227
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 9628.16966
-  tps: 6902.18666
+  dps: 9673.45083
+  tps: 6934.11193
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ThunderheartHarness"
  value: {
-  dps: 6982.80231
-  tps: 5020.8348
+  dps: 6995.63198
+  tps: 5030.24301
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ThunderheartRegalia"
  value: {
-  dps: 6156.02874
-  tps: 4434.72301
+  dps: 6146.99098
+  tps: 4428.75491
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 9641.88057
-  tps: 6911.84662
+  dps: 9656.62189
+  tps: 6922.53731
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 9839.51425
-  tps: 7052.39089
+  dps: 9798.31036
+  tps: 7022.98656
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 9872.10021
-  tps: 7074.62948
+  dps: 9819.41374
+  tps: 7038.04475
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 9614.07257
-  tps: 6892.17773
+  dps: 9659.30529
+  tps: 6924.0686
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 9614.07257
-  tps: 6892.17773
+  dps: 9659.30529
+  tps: 6924.0686
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 9686.47155
-  tps: 6940.51475
+  dps: 9677.91151
+  tps: 6934.88584
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 9614.07257
-  tps: 6892.17773
+  dps: 9659.30529
+  tps: 6924.0686
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 9614.07257
-  tps: 6892.17773
+  dps: 9659.30529
+  tps: 6924.0686
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 7898.59926
-  tps: 5673.14466
+  dps: 7898.39575
+  tps: 5673.22453
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7493.86612
-  tps: 5386.45721
+  dps: 7436.02725
+  tps: 5345.84033
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 9572.54108
-  tps: 6862.69037
+  dps: 9632.23982
+  tps: 6904.77732
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-WingedTalisman-37844"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 9572.54108
-  tps: 6862.69037
+  dps: 9632.23982
+  tps: 6904.77732
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-Average-Default"
  value: {
-  dps: 9924.52334
-  tps: 7112.22712
+  dps: 9935.96195
+  tps: 7120.64338
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-Settings-Tauren-P2DoubleArmorPenTrinkets-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9860.2215
-  tps: 7066.94346
+  dps: 9924.98693
+  tps: 7112.62777
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-Settings-Tauren-P2DoubleArmorPenTrinkets-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9860.2215
-  tps: 7066.94346
+  dps: 9924.98693
+  tps: 7112.62777
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-Settings-Tauren-P2DoubleArmorPenTrinkets-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11192.03862
-  tps: 8001.31562
+  dps: 11222.82517
+  tps: 8025.04374
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-Settings-Tauren-P2DoubleArmorPenTrinkets-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6154.17682
-  tps: 4433.70729
+  dps: 6111.88693
+  tps: 4403.83104
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-Settings-Tauren-P2DoubleArmorPenTrinkets-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6154.17682
-  tps: 4433.70729
+  dps: 6111.88693
+  tps: 4403.83104
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-Settings-Tauren-P2DoubleArmorPenTrinkets-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6580.96349
-  tps: 4725.20868
+  dps: 6633.18983
+  tps: 4767.15051
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7595.23162
-  tps: 5456.33269
+  dps: 7553.98656
+  tps: 5428.02093
  }
 }

--- a/sim/druid/feral/TestFeralDoubleArmorPenTrinketsWithDesync.results
+++ b/sim/druid/feral/TestFeralDoubleArmorPenTrinketsWithDesync.results
@@ -46,935 +46,935 @@ character_stats_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 9699.26953
-  tps: 6952.29363
+  dps: 9713.85047
+  tps: 6962.87046
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 9798.51663
-  tps: 7020.44069
+  dps: 9838.74018
+  tps: 7049.37334
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
   hps: 90.47701
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
   hps: 90.47701
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 9721.42987
-  tps: 6967.95269
+  dps: 9753.3043
+  tps: 6990.88268
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 7594.01516
-  tps: 5456.88995
+  dps: 7594.33406
+  tps: 5457.56509
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 9699.26953
-  tps: 6813.24776
+  dps: 9713.85047
+  tps: 6823.61305
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 9655.79647
-  tps: 6921.42776
+  dps: 9671.5797
+  tps: 6932.85822
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 9937.72604
-  tps: 7121.52297
+  dps: 9970.82705
+  tps: 7145.32383
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 9793.40033
-  tps: 7017.10726
+  dps: 9802.52155
+  tps: 7023.65811
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 9814.0667
-  tps: 7031.33166
+  dps: 9837.52225
+  tps: 7047.91032
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 9802.98649
-  tps: 7023.24035
+  dps: 9845.26593
+  tps: 7053.93184
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 9655.79647
-  tps: 6921.42776
+  dps: 9671.5797
+  tps: 6932.85822
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Death'sChoice-47464"
  value: {
-  dps: 10149.96491
-  tps: 7269.52024
+  dps: 10184.14362
+  tps: 7294.46021
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 9740.16485
-  tps: 6978.78656
+  dps: 9794.67709
+  tps: 7018.01376
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10223.65865
-  tps: 7322.14195
+  dps: 10212.55822
+  tps: 7314.63457
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 10253.15287
-  tps: 7343.30721
+  dps: 10212.77289
+  tps: 7314.78699
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Defender'sCode-40257"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 9729.06699
-  tps: 6973.37504
+  dps: 9761.55953
+  tps: 6996.74389
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 9832.74881
-  tps: 7044.14724
+  dps: 9851.14205
+  tps: 7057.95431
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 9859.13014
-  tps: 7063.02756
+  dps: 9841.05209
+  tps: 7050.64087
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 8434.42691
-  tps: 6053.05879
+  dps: 8486.39881
+  tps: 6091.00584
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DreamwalkerGarb"
  value: {
-  dps: 7223.40095
-  tps: 5195.69831
+  dps: 7228.44466
+  tps: 5199.42892
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 9699.26953
-  tps: 6952.29363
+  dps: 9713.85047
+  tps: 6962.87046
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 9699.26953
-  tps: 6952.29363
+  dps: 9713.85047
+  tps: 6962.87046
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 9721.42987
-  tps: 6967.95269
+  dps: 9753.3043
+  tps: 6990.88268
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 9716.42879
-  tps: 6964.40192
+  dps: 9749.60291
+  tps: 6988.25469
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 9684.26008
-  tps: 6939.31854
+  dps: 9783.73176
+  tps: 7010.31736
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 9699.26953
-  tps: 6952.29363
+  dps: 9713.85047
+  tps: 6962.87046
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 9810.25026
-  tps: 7028.99593
+  dps: 9836.57951
+  tps: 7047.16619
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 9766.84527
-  tps: 6998.02881
+  dps: 9790.95429
+  tps: 7015.07143
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ForgeEmber-37660"
  value: {
-  dps: 9721.32986
-  tps: 6965.78766
+  dps: 9777.49629
+  tps: 7005.51625
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 9699.26953
-  tps: 6952.29363
+  dps: 9713.85047
+  tps: 6962.87046
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 9699.26953
-  tps: 6952.29363
+  dps: 9713.85047
+  tps: 6962.87046
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 9655.79647
-  tps: 6921.42776
+  dps: 9671.5797
+  tps: 6932.85822
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 9824.46183
-  tps: 7038.93657
+  dps: 9867.00729
+  tps: 7069.29342
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-FuturesightRune-38763"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 9085.82224
-  tps: 6515.84862
+  dps: 9101.8802
+  tps: 6527.6237
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 7333.36972
-  tps: 5271.45775
+  dps: 7352.43662
+  tps: 5285.36918
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 9792.4215
-  tps: 7016.11315
+  dps: 9814.68898
+  tps: 7031.6987
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 9655.79647
-  tps: 6921.42776
+  dps: 9671.5797
+  tps: 6932.85822
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Heartpierce-49982"
  value: {
-  dps: 10154.76897
-  tps: 7275.09994
+  dps: 10177.52973
+  tps: 7291.93316
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Heartpierce-50641"
  value: {
-  dps: 10177.71189
-  tps: 7291.4642
+  dps: 10178.17658
+  tps: 7292.24285
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IdolofLunarFury-47670"
  value: {
-  dps: 9655.79647
-  tps: 6921.42776
+  dps: 9671.5797
+  tps: 6932.85822
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 10028.9884
-  tps: 7186.39403
+  dps: 10071.29436
+  tps: 7216.65562
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 9655.79647
-  tps: 6921.42776
+  dps: 9671.5797
+  tps: 6932.85822
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 9977.96897
-  tps: 7150.17024
+  dps: 10010.99072
+  tps: 7173.91482
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 9655.79647
-  tps: 6921.42776
+  dps: 9671.5797
+  tps: 6932.85822
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 9719.0073
-  tps: 6966.23266
+  dps: 9739.54342
+  tps: 6981.11246
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 9655.79647
-  tps: 6921.42776
+  dps: 9671.5797
+  tps: 6932.85822
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 9655.79647
-  tps: 6921.42776
+  dps: 9671.5797
+  tps: 6932.85822
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 9721.42987
-  tps: 6967.95269
+  dps: 9753.3043
+  tps: 6990.88268
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 9716.42879
-  tps: 6964.40192
+  dps: 9749.60291
+  tps: 6988.25469
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IncisorFragment-37723"
  value: {
-  dps: 9827.0824
-  tps: 7040.49803
+  dps: 9835.66883
+  tps: 7046.96832
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 9699.26953
-  tps: 6952.29363
+  dps: 9713.85047
+  tps: 6962.87046
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 9729.15806
-  tps: 6973.51449
+  dps: 9743.7678
+  tps: 6984.11177
   hps: 13.49381
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 9926.30474
-  tps: 7112.29204
+  dps: 9915.58778
+  tps: 7104.90736
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-LasherweaveRegalia"
  value: {
-  dps: 7496.92221
-  tps: 5390.34713
+  dps: 7496.24954
+  tps: 5390.31825
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 8802.43222
-  tps: 6317.55838
+  dps: 8831.1925
+  tps: 6338.12776
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 7162.60665
-  tps: 5152.53436
+  dps: 7192.43481
+  tps: 5174.83416
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 9903.75146
-  tps: 7094.93305
+  dps: 9882.6174
+  tps: 7080.30181
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 9833.41238
-  tps: 7045.74017
+  dps: 9884.19489
+  tps: 7080.89832
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-NightsongBattlegear"
  value: {
-  dps: 8831.72278
-  tps: 6336.03629
+  dps: 8846.10211
+  tps: 6346.46998
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-NightsongGarb"
  value: {
-  dps: 7106.79023
-  tps: 5113.503
+  dps: 7110.75147
+  tps: 5116.61463
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 9723.46501
-  tps: 6969.47242
+  dps: 9738.06926
+  tps: 6980.0658
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 9729.15806
-  tps: 6973.51449
+  dps: 9743.7678
+  tps: 6984.11177
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 9699.26953
-  tps: 6952.29363
+  dps: 9713.85047
+  tps: 6962.87046
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 9699.26953
-  tps: 6952.29363
+  dps: 9713.85047
+  tps: 6962.87046
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 9950.19119
-  tps: 7130.44801
+  dps: 9968.5641
+  tps: 7143.71714
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 9655.79647
-  tps: 6921.42776
+  dps: 9671.5797
+  tps: 6932.85822
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 9699.26953
-  tps: 6952.29363
+  dps: 9713.85047
+  tps: 6962.87046
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 9655.79647
-  tps: 6921.42776
+  dps: 9671.5797
+  tps: 6932.85822
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SoulPreserver-37111"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SouloftheDead-40382"
  value: {
-  dps: 9770.34931
-  tps: 7000.51668
+  dps: 9795.66346
+  tps: 7018.41494
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SparkofLife-37657"
  value: {
-  dps: 9688.2825
-  tps: 6941.80052
+  dps: 9760.24534
+  tps: 6993.49243
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 9791.40197
-  tps: 7017.55809
+  dps: 9821.23574
+  tps: 7038.51571
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-StormshroudArmor"
  value: {
-  dps: 7736.43482
-  tps: 5557.26004
+  dps: 7754.63019
+  tps: 5569.80482
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 9729.15806
-  tps: 6973.51449
+  dps: 9743.7678
+  tps: 6984.11177
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 9723.46501
-  tps: 6969.47242
+  dps: 9738.06926
+  tps: 6980.0658
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 9713.50217
-  tps: 6962.3988
+  dps: 9728.09682
+  tps: 6972.98537
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ThunderheartHarness"
  value: {
-  dps: 6991.79393
-  tps: 5027.518
+  dps: 6977.09888
+  tps: 5017.1593
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ThunderheartRegalia"
  value: {
-  dps: 6114.00871
-  tps: 4405.11314
+  dps: 6097.74231
+  tps: 4393.78836
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 9744.21714
-  tps: 6984.4308
+  dps: 9722.19954
+  tps: 6968.94788
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 9808.64811
-  tps: 7030.102
+  dps: 9808.61348
+  tps: 7030.60092
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 9749.55556
-  tps: 6988.22107
+  dps: 9829.98692
+  tps: 7045.70127
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 9699.26953
-  tps: 6952.29363
+  dps: 9713.85047
+  tps: 6962.87046
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 9699.26953
-  tps: 6952.29363
+  dps: 9713.85047
+  tps: 6962.87046
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 9686.47155
-  tps: 6940.51475
+  dps: 9677.91151
+  tps: 6934.88584
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 9699.26953
-  tps: 6952.29363
+  dps: 9713.85047
+  tps: 6962.87046
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 9699.26953
-  tps: 6952.29363
+  dps: 9713.85047
+  tps: 6962.87046
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 7920.82372
-  tps: 5688.92403
+  dps: 7943.752
+  tps: 5705.57704
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7523.08564
-  tps: 5406.75435
+  dps: 7533.05943
+  tps: 5414.13489
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 9655.79647
-  tps: 6921.42776
+  dps: 9671.5797
+  tps: 6932.85822
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-WingedTalisman-37844"
  value: {
-  dps: 9615.85142
-  tps: 6890.82318
+  dps: 9656.30557
+  tps: 6919.69519
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 9655.79647
-  tps: 6921.42776
+  dps: 9671.5797
+  tps: 6932.85822
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-Average-Default"
  value: {
-  dps: 9991.32891
-  tps: 7159.6304
+  dps: 10015.55245
+  tps: 7177.13577
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-Settings-Tauren-P2DoubleArmorPenTrinkets-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9950.19119
-  tps: 7130.44801
+  dps: 9968.5641
+  tps: 7143.71714
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-Settings-Tauren-P2DoubleArmorPenTrinkets-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9950.19119
-  tps: 7130.44801
+  dps: 9968.5641
+  tps: 7143.71714
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-Settings-Tauren-P2DoubleArmorPenTrinkets-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11270.05825
-  tps: 8055.58776
+  dps: 11394.223
+  tps: 8146.36227
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-Settings-Tauren-P2DoubleArmorPenTrinkets-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6173.73894
-  tps: 4447.89554
+  dps: 6159.80284
+  tps: 4438.15048
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-Settings-Tauren-P2DoubleArmorPenTrinkets-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6173.73894
-  tps: 4447.89554
+  dps: 6159.80284
+  tps: 4438.15048
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-Settings-Tauren-P2DoubleArmorPenTrinkets-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6610.60711
-  tps: 4746.62958
+  dps: 6693.51492
+  tps: 4809.60739
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7625.50102
-  tps: 5477.82397
+  dps: 7610.83932
+  tps: 5467.78809
  }
 }

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -142,7 +142,7 @@ func (cat *FeralDruid) checkReplaceMaul(sim *core.Simulation) *core.Spell {
 	}
 
 	if cat.CurrentRage() >= maulRageThresh {
-		return cat.Maul
+		return cat.Maul.Spell
 	} else {
 		return nil
 	}

--- a/sim/druid/ferocious_bite.go
+++ b/sim/druid/ferocious_bite.go
@@ -9,7 +9,7 @@ import (
 func (druid *Druid) registerFerociousBiteSpell() {
 	dmgPerComboPoint := 290.0 + core.TernaryFloat64(druid.Equip[core.ItemSlotRanged].ID == 25667, 14, 0)
 
-	druid.FerociousBite = druid.RegisterSpell(core.SpellConfig{
+	druid.FerociousBite = druid.RegisterSpell(Cat, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 48577},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
@@ -27,7 +27,7 @@ func (druid *Druid) registerFerociousBiteSpell() {
 			IgnoreHaste: true,
 		},
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return druid.InForm(Cat) && druid.ComboPoints() > 0
+			return druid.ComboPoints() > 0
 		},
 
 		BonusCritRating: 0 +

--- a/sim/druid/force_of_nature.go
+++ b/sim/druid/force_of_nature.go
@@ -17,7 +17,7 @@ func (druid *Druid) registerForceOfNatureCD() {
 		ActionID: core.ActionID{SpellID: 65861},
 		Duration: time.Second * 30,
 	})
-	druid.ForceOfNature = druid.RegisterSpell(core.SpellConfig{
+	druid.ForceOfNature = druid.RegisterSpell(Humanoid|Moonkin, core.SpellConfig{
 		ActionID: core.ActionID{SpellID: 65861},
 		Flags:    core.SpellFlagAPL,
 		ManaCost: core.ManaCostOptions{

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -17,6 +17,7 @@ const (
 	Cat
 	Moonkin
 	Tree
+	Any = Humanoid | Bear | Cat | Moonkin | Tree
 )
 
 // Converts from 0.009327 to 0.0085
@@ -204,7 +205,7 @@ func (druid *Druid) registerCatFormSpell() {
 
 	energyMetrics := druid.NewEnergyMetrics(actionID)
 
-	druid.CatForm = druid.RegisterSpell(core.SpellConfig{
+	druid.CatForm = druid.RegisterSpell(Any, core.SpellConfig{
 		ActionID: actionID,
 		Flags:    core.SpellFlagNoOnCastComplete | core.SpellFlagAPL,
 
@@ -340,7 +341,7 @@ func (druid *Druid) registerBearFormSpell() {
 
 	furorProcChance := []float64{0, 0.2, 0.4, 0.6, 0.8, 1}[druid.Talents.Furor]
 
-	druid.BearForm = druid.RegisterSpell(core.SpellConfig{
+	druid.BearForm = druid.RegisterSpell(Any, core.SpellConfig{
 		ActionID: actionID,
 		Flags:    core.SpellFlagNoOnCastComplete | core.SpellFlagAPL,
 
@@ -410,7 +411,7 @@ func (druid *Druid) applyMoonkinForm() {
 		},
 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if result.DidCrit() {
-				if spell == druid.Moonfire || spell == druid.Starfire || spell == druid.Wrath {
+				if druid.Moonfire.IsEqual(spell) || druid.Starfire.IsEqual(spell) || druid.Wrath.IsEqual(spell) {
 					druid.AddMana(sim, 0.02*druid.MaxMana(), manaMetrics)
 				}
 			}

--- a/sim/druid/frenzied_regeneration.go
+++ b/sim/druid/frenzied_regeneration.go
@@ -29,7 +29,7 @@ func (druid *Druid) registerFrenziedRegenerationCD() {
 		},
 	})
 
-	druid.FrenziedRegeneration = druid.RegisterSpell(core.SpellConfig{
+	druid.FrenziedRegeneration = druid.RegisterSpell(Bear, core.SpellConfig{
 		ActionID: actionID,
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
@@ -40,9 +40,6 @@ func (druid *Druid) registerFrenziedRegenerationCD() {
 				Duration: cd,
 			},
 			IgnoreHaste: true,
-		},
-		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return druid.InForm(Bear)
 		},
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			core.StartPeriodicAction(sim, core.PeriodicActionOptions{
@@ -64,7 +61,7 @@ func (druid *Druid) registerFrenziedRegenerationCD() {
 	})
 
 	druid.AddMajorCooldown(core.MajorCooldown{
-		Spell: druid.FrenziedRegeneration,
+		Spell: druid.FrenziedRegeneration.Spell,
 		Type:  core.CooldownTypeSurvival,
 	})
 }

--- a/sim/druid/hurricane.go
+++ b/sim/druid/hurricane.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (druid *Druid) registerHurricaneSpell() {
-	druid.Hurricane = druid.RegisterSpell(core.SpellConfig{
+	druid.Hurricane = druid.RegisterSpell(Humanoid|Moonkin, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 48467},
 		SpellSchool: core.SpellSchoolNature,
 		ProcMask:    core.ProcMaskSpellDamage,

--- a/sim/druid/innervate.go
+++ b/sim/druid/innervate.go
@@ -14,7 +14,7 @@ func (druid *Druid) registerInnervateCD() {
 	innervateTargetChar := druid.Env.Raid.GetPlayerFromUnit(innervateTarget).GetCharacter()
 
 	actionID := core.ActionID{SpellID: 29166, Tag: druid.Index}
-	var innervateSpell *core.Spell
+	var innervateSpell *DruidSpell
 
 	innervateCD := core.InnervateCD
 
@@ -36,7 +36,7 @@ func (druid *Druid) registerInnervateCD() {
 		innervateAura = core.InnervateAura(innervateTargetChar, actionID.Tag)
 	})
 
-	innervateSpell = druid.RegisterSpell(core.SpellConfig{
+	innervateSpell = druid.RegisterSpell(Humanoid|Moonkin|Tree, core.SpellConfig{
 		ActionID: actionID,
 		Flags:    SpellFlagOmenTrigger,
 
@@ -55,17 +55,8 @@ func (druid *Druid) registerInnervateCD() {
 		},
 
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			// Technically this shouldn't be allowed in bear form either, but bear
-			// doesn't have shifting implemented in its rotation.
-			if druid.InForm(Cat) {
-				return false
-			}
 			// If target already has another innervate, don't cast.
-			if innervateTarget.HasActiveAuraWithTag(core.InnervateAuraTag) {
-				return false
-			}
-
-			return true
+			return innervateTarget.HasActiveAuraWithTag(core.InnervateAuraTag)
 		},
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, _ *core.Spell) {
@@ -74,7 +65,7 @@ func (druid *Druid) registerInnervateCD() {
 	})
 
 	druid.AddMajorCooldown(core.MajorCooldown{
-		Spell: innervateSpell,
+		Spell: innervateSpell.Spell,
 		Type:  core.CooldownTypeMana,
 		ShouldActivate: func(sim *core.Simulation, character *core.Character) bool {
 			// Innervate needs to be activated as late as possible to maximize DPS. The issue is that

--- a/sim/druid/insect_swarm.go
+++ b/sim/druid/insect_swarm.go
@@ -28,14 +28,14 @@ func (druid *Druid) registerInsectSwarmSpell() {
 				druid.Starfire.CastTimeMultiplier += 1
 			},
 			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				if spell == druid.Starfire && (druid.Starfire.CurCast.CastTime < (10*time.Second - aura.RemainingDuration(sim))) {
+				if druid.Starfire.IsEqual(spell) && (druid.Starfire.CurCast.CastTime < (10*time.Second - aura.RemainingDuration(sim))) {
 					aura.Deactivate(sim)
 				}
 			},
 		})
 	}
 
-	druid.InsectSwarm = druid.RegisterSpell(core.SpellConfig{
+	druid.InsectSwarm = druid.RegisterSpell(Humanoid|Moonkin, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 48468},
 		SpellSchool: core.SpellSchoolNature,
 		ProcMask:    core.ProcMaskSpellDamage,

--- a/sim/druid/items.go
+++ b/sim/druid/items.go
@@ -89,7 +89,7 @@ var ItemSetLasherweaveRegalia = core.NewItemSet(core.ItemSet{
 			// Your critical strikes from Starfire and Wrath cause the target to languish for an additional 7% of your spell's damage over 4 sec.
 			druid := agent.(DruidAgent).GetDruid()
 
-			druid.Languish = druid.RegisterSpell(core.SpellConfig{
+			druid.Languish = druid.RegisterSpell(Any, core.SpellConfig{
 				ActionID:         core.ActionID{SpellID: 71023},
 				SpellSchool:      core.SpellSchoolNature,
 				ProcMask:         core.ProcMaskEmpty,
@@ -120,7 +120,7 @@ var ItemSetLasherweaveRegalia = core.NewItemSet(core.ItemSet{
 					aura.Activate(sim)
 				},
 				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-					if spell != druid.Starfire && spell != druid.Wrath {
+					if !druid.Starfire.IsEqual(spell) && !druid.Wrath.IsEqual(spell) {
 						return
 					}
 					if result.DidCrit() {
@@ -163,7 +163,7 @@ var ItemSetGladiatorsWildhide = core.NewItemSet(core.ItemSet{
 					druid.Starfire.CastTimeMultiplier += percentReduction
 				},
 				OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
-					if spell == druid.Starfire {
+					if druid.Starfire.IsEqual(spell) {
 						aura.Deactivate(sim)
 					}
 				},
@@ -176,7 +176,7 @@ var ItemSetGladiatorsWildhide = core.NewItemSet(core.ItemSet{
 					aura.Activate(sim)
 				},
 				OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
-					if spell == druid.Wrath && sim.RandomFloat("Swift Starfire proc") > 0.85 {
+					if druid.Wrath.IsEqual(spell) && sim.RandomFloat("Swift Starfire proc") > 0.85 {
 						swiftStarfireAura.Activate(sim)
 					}
 				},
@@ -228,7 +228,7 @@ var ItemSetNightsongBattlegear = core.NewItemSet(core.ItemSet{
 					}
 				},
 				OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-					if spell != druid.Rake && spell != druid.Rip && spell != druid.Lacerate {
+					if !druid.Rake.IsEqual(spell) && !druid.Rip.IsEqual(spell) && !druid.Lacerate.IsEqual(spell) {
 						return
 					}
 					if !icd.IsReady(sim) {
@@ -309,7 +309,7 @@ func init() {
 				if !result.Landed() {
 					return
 				}
-				if spell == druid.Starfire {
+				if druid.Starfire.IsEqual(spell) {
 					if sim.RandomFloat("Ashtongue Talisman") < 0.25 {
 						procAura.Activate(sim)
 					}
@@ -353,7 +353,7 @@ func init() {
 					return
 				}
 
-				if spell == druid.Moonfire {
+				if druid.Moonfire.IsEqual(spell) {
 					if sim.RandomFloat("Idol of the Unseen Moon") > 0.5 {
 						return
 					}
@@ -424,9 +424,9 @@ func init() {
 				}
 
 				procChance := 0.0
-				if spell == druid.MangleBear {
+				if druid.MangleBear.IsEqual(spell) {
 					procChance = procChanceBear
-				} else if spell == druid.MangleCat {
+				} else if druid.MangleCat.IsEqual(spell) {
 					procChance = procChanceCat
 				} else {
 					return
@@ -468,11 +468,11 @@ func init() {
 				if sim.RandomFloat("Idol of Mutilation") > procChance {
 					return
 				}
-				if spell == druid.SwipeBear || spell == druid.Lacerate {
+				if druid.SwipeBear.IsEqual(spell) || druid.Lacerate.IsEqual(spell) {
 					icd.Use(sim)
 					bearAura.Activate(sim)
 				}
-				if spell == druid.MangleCat || spell == druid.Shred {
+				if druid.MangleCat.IsEqual(spell) || druid.Shred.IsEqual(spell) {
 					icd.Use(sim)
 					catAura.Activate(sim)
 				}
@@ -495,7 +495,7 @@ func init() {
 		core.MakePermanent(druid.RegisterAura(core.Aura{
 			Label: "Idol of the Crying Moon",
 			OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				if spell != druid.Rake && spell != druid.Lacerate {
+				if !druid.Rake.IsEqual(spell) && !druid.Lacerate.IsEqual(spell) {
 					return
 				}
 				procAura.Activate(sim)
@@ -546,7 +546,7 @@ func init() {
 		core.MakePermanent(druid.RegisterAura(core.Aura{
 			Label: "Idol of Lunar Fury",
 			OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				if spell == druid.Moonfire && icd.IsReady(sim) && sim.RandomFloat("lunar fire") < 0.7 {
+				if druid.Moonfire.IsEqual(spell) && icd.IsReady(sim) && sim.RandomFloat("lunar fire") < 0.7 {
 					icd.Use(sim)
 					procAura.Activate(sim)
 				}

--- a/sim/druid/lacerate.go
+++ b/sim/druid/lacerate.go
@@ -22,7 +22,7 @@ func (druid *Druid) registerLacerateSpell() {
 		core.TernaryFloat64(druid.HasSetBonus(ItemSetLasherweaveBattlegear, 2), 1.2, 1) *
 		core.TernaryFloat64(druid.HasSetBonus(ItemSetMalfurionsBattlegear, 2), 1.05, 1)
 
-	druid.Lacerate = druid.RegisterSpell(core.SpellConfig{
+	druid.Lacerate = druid.RegisterSpell(Bear, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 48568},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,

--- a/sim/druid/mangle.go
+++ b/sim/druid/mangle.go
@@ -16,7 +16,7 @@ func (druid *Druid) registerMangleBearSpell() {
 	durReduction := (0.5) * float64(druid.Talents.ImprovedMangle)
 	glyphBonus := core.TernaryFloat64(druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfMangle), 1.1, 1.0)
 
-	druid.MangleBear = druid.RegisterSpell(core.SpellConfig{
+	druid.MangleBear = druid.RegisterSpell(Bear, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 48564},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
@@ -35,9 +35,6 @@ func (druid *Druid) registerMangleBearSpell() {
 				Timer:    druid.NewTimer(),
 				Duration: time.Duration(float64(time.Second) * (6 - durReduction)),
 			},
-		},
-		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return druid.InForm(Bear)
 		},
 
 		DamageMultiplier: (1 + 0.1*float64(druid.Talents.SavageFury)) * 1.15 * glyphBonus,
@@ -74,7 +71,7 @@ func (druid *Druid) registerMangleCatSpell() {
 	mangleAuras := druid.NewEnemyAuraArray(core.MangleAura)
 	glyphBonus := core.TernaryFloat64(druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfMangle), 1.1, 1.0)
 
-	druid.MangleCat = druid.RegisterSpell(core.SpellConfig{
+	druid.MangleCat = druid.RegisterSpell(Cat, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 48566},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
@@ -89,9 +86,6 @@ func (druid *Druid) registerMangleCatSpell() {
 				GCD: time.Second,
 			},
 			IgnoreHaste: true,
-		},
-		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return druid.InForm(Cat)
 		},
 
 		DamageMultiplier: (1 + 0.1*float64(druid.Talents.SavageFury)) * 2.0 * glyphBonus,
@@ -122,9 +116,9 @@ func (druid *Druid) CurrentMangleCatCost() float64 {
 }
 
 func (druid *Druid) IsMangle(spell *core.Spell) bool {
-	if druid.MangleBear != nil && druid.MangleBear == spell {
+	if druid.MangleBear != nil && druid.MangleBear.IsEqual(spell) {
 		return true
-	} else if druid.MangleCat != nil && druid.MangleCat == spell {
+	} else if druid.MangleCat != nil && druid.MangleCat.IsEqual(spell) {
 		return true
 	}
 	return false

--- a/sim/druid/maul.go
+++ b/sim/druid/maul.go
@@ -15,7 +15,7 @@ func (druid *Druid) registerMaulSpell(rageThreshold float64) {
 
 	numHits := core.TernaryInt32(druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfMaul) && druid.Env.GetNumTargets() > 1, 2, 1)
 
-	druid.Maul = druid.RegisterSpell(core.SpellConfig{
+	druid.Maul = druid.RegisterSpell(Bear, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 48480},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
@@ -71,7 +71,7 @@ func (druid *Druid) registerMaulSpell(rageThreshold float64) {
 		Duration: core.NeverExpires,
 	})
 
-	druid.MaulQueueSpell = druid.RegisterSpell(core.SpellConfig{
+	druid.MaulQueueSpell = druid.RegisterSpell(Bear, core.SpellConfig{
 		ActionID:    druid.Maul.WithTag(1),
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
@@ -116,7 +116,7 @@ func (druid *Druid) MaulReplaceMH(sim *core.Simulation, mhSwingSpell *core.Spell
 		}
 	}
 
-	return druid.Maul
+	return druid.Maul.Spell
 }
 
 func (druid *Druid) ShouldQueueMaul(sim *core.Simulation) bool {

--- a/sim/druid/moonfire.go
+++ b/sim/druid/moonfire.go
@@ -23,7 +23,7 @@ func (druid *Druid) registerMoonfireSpell() {
 		0.01*float64(druid.Talents.Genesis) +
 		core.TernaryFloat64(druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfMoonfire), 0.75, 0)
 
-	druid.Moonfire = druid.RegisterSpell(core.SpellConfig{
+	druid.Moonfire = druid.RegisterSpell(Humanoid|Moonkin, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 48463},
 		SpellSchool: core.SpellSchoolArcane,
 		ProcMask:    core.ProcMaskSpellDamage,

--- a/sim/druid/rake.go
+++ b/sim/druid/rake.go
@@ -11,7 +11,7 @@ func (druid *Druid) registerRakeSpell() {
 	numTicks := 3 + core.TernaryInt32(druid.HasSetBonus(ItemSetMalfurionsBattlegear, 2), 1, 0)
 	dotCanCrit := druid.HasSetBonus(ItemSetLasherweaveBattlegear, 4)
 
-	druid.Rake = druid.RegisterSpell(core.SpellConfig{
+	druid.Rake = druid.RegisterSpell(Cat, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 48574},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
@@ -26,9 +26,6 @@ func (druid *Druid) registerRakeSpell() {
 				GCD: time.Second,
 			},
 			IgnoreHaste: true,
-		},
-		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return druid.InForm(Cat)
 		},
 
 		DamageMultiplier: 1 + 0.1*float64(druid.Talents.SavageFury),

--- a/sim/druid/rebirth.go
+++ b/sim/druid/rebirth.go
@@ -11,8 +11,11 @@ import (
 // Then we can properly incur Rebirth cost through additional Moonkin form spell cast
 func (druid *Druid) registerRebirthSpell() {
 	baseCost := 0.68
+	castTime := time.Second * 2
 	if druid.InForm(Moonkin) {
 		baseCost += 0.13
+		baseCost *= 1 - 0.1*float64(druid.Talents.NaturalShapeshifter)
+		castTime = time.Second*3 + time.Millisecond*500
 	}
 
 	druid.Rebirth = druid.RegisterSpell(core.SpellConfig{
@@ -20,13 +23,12 @@ func (druid *Druid) registerRebirthSpell() {
 		Flags:    SpellFlagOmenTrigger | core.SpellFlagAPL,
 
 		ManaCost: core.ManaCostOptions{
-			BaseCost:   baseCost,
-			Multiplier: 1 - 0.1*float64(druid.Talents.NaturalShapeshifter),
+			BaseCost: baseCost,
 		},
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
 				GCD:      core.GCDDefault,
-				CastTime: time.Second*3 + time.Millisecond*500,
+				CastTime: castTime,
 			},
 			CD: core.Cooldown{
 				Timer:    druid.NewTimer(),

--- a/sim/druid/rebirth.go
+++ b/sim/druid/rebirth.go
@@ -12,13 +12,15 @@ import (
 func (druid *Druid) registerRebirthSpell() {
 	baseCost := 0.68
 	castTime := time.Second * 2
+	forms := Humanoid | Tree
 	if druid.InForm(Moonkin) {
+		forms |= Moonkin
 		baseCost += 0.13
 		baseCost *= 1 - 0.1*float64(druid.Talents.NaturalShapeshifter)
 		castTime = time.Second*3 + time.Millisecond*500
 	}
 
-	druid.Rebirth = druid.RegisterSpell(core.SpellConfig{
+	druid.Rebirth = druid.RegisterSpell(forms, core.SpellConfig{
 		ActionID: core.ActionID{SpellID: 48477},
 		Flags:    SpellFlagOmenTrigger | core.SpellFlagAPL,
 

--- a/sim/druid/rip.go
+++ b/sim/druid/rip.go
@@ -19,7 +19,7 @@ func (druid *Druid) registerRipSpell() {
 		comboPointCoeff += 21
 	}
 
-	druid.Rip = druid.RegisterSpell(core.SpellConfig{
+	druid.Rip = druid.RegisterSpell(Cat, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 49800},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
@@ -37,7 +37,7 @@ func (druid *Druid) registerRipSpell() {
 			IgnoreHaste: true,
 		},
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return druid.InForm(Cat) && druid.ComboPoints() > 0
+			return druid.ComboPoints() > 0
 		},
 
 		BonusCritRating:  core.TernaryFloat64(druid.HasSetBonus(ItemSetMalfurionsBattlegear, 4), 5*core.CritRatingPerCritChance, 0.0),

--- a/sim/druid/savage_roar.go
+++ b/sim/druid/savage_roar.go
@@ -40,7 +40,7 @@ func (druid *Druid) registerSavageRoarSpell() {
 		},
 	})
 
-	srSpell := druid.RegisterSpell(core.SpellConfig{
+	srSpell := druid.RegisterSpell(Cat, core.SpellConfig{
 		ActionID: actionID,
 		Flags:    core.SpellFlagAPL,
 		EnergyCost: core.EnergyCostOptions{
@@ -53,7 +53,7 @@ func (druid *Druid) registerSavageRoarSpell() {
 			IgnoreHaste: true,
 		},
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return druid.InForm(Cat) && druid.ComboPoints() > 0
+			return druid.ComboPoints() > 0
 		},
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {

--- a/sim/druid/shred.go
+++ b/sim/druid/shred.go
@@ -16,7 +16,7 @@ func (druid *Druid) registerShredSpell() {
 	hasGlyphofShred := druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfShred)
 	maxRipTicks := druid.MaxRipTicks()
 
-	druid.Shred = druid.RegisterSpell(core.SpellConfig{
+	druid.Shred = druid.RegisterSpell(Cat, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 48572},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,

--- a/sim/druid/starfall.go
+++ b/sim/druid/starfall.go
@@ -16,7 +16,7 @@ func (druid *Druid) registerStarfallSpell() {
 	numberOfTicks := core.TernaryInt32(druid.Env.GetNumTargets() > 1, 20, 10)
 	tickLength := core.TernaryDuration(druid.Env.GetNumTargets() > 1, time.Millisecond*500, time.Millisecond*1000)
 
-	druid.Starfall = druid.RegisterSpell(core.SpellConfig{
+	druid.Starfall = druid.RegisterSpell(Humanoid|Moonkin, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 53201},
 		SpellSchool: core.SpellSchoolArcane,
 		ProcMask:    core.ProcMaskSpellDamage,
@@ -63,7 +63,7 @@ func (druid *Druid) registerStarfallSpell() {
 		},
 	})
 
-	druid.StarfallSplash = druid.RegisterSpell(core.SpellConfig{
+	druid.StarfallSplash = druid.RegisterSpell(Any, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 53190},
 		SpellSchool: core.SpellSchoolArcane,
 		ProcMask:    core.ProcMaskSpellDamage,

--- a/sim/druid/starfire.go
+++ b/sim/druid/starfire.go
@@ -17,7 +17,7 @@ func (druid *Druid) registerStarfireSpell() {
 
 	hasGlyph := druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfStarfire)
 
-	druid.Starfire = druid.RegisterSpell(core.SpellConfig{
+	druid.Starfire = druid.RegisterSpell(Humanoid|Moonkin, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 48465},
 		SpellSchool: core.SpellSchoolArcane,
 		ProcMask:    core.ProcMaskSpellDamage,

--- a/sim/druid/survival_instincts.go
+++ b/sim/druid/survival_instincts.go
@@ -36,7 +36,7 @@ func (druid *Druid) registerSurvivalInstinctsCD() {
 		},
 	})
 
-	druid.SurvivalInstincts = druid.RegisterSpell(core.SpellConfig{
+	druid.SurvivalInstincts = druid.RegisterSpell(Cat|Bear, core.SpellConfig{
 		ActionID: actionID,
 		Flags:    SpellFlagOmenTrigger,
 		Cast: core.CastConfig{
@@ -45,16 +45,13 @@ func (druid *Druid) registerSurvivalInstinctsCD() {
 				Duration: cd,
 			},
 		},
-		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return druid.InForm(Cat | Bear)
-		},
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			druid.SurvivalInstinctsAura.Activate(sim)
 		},
 	})
 
 	druid.AddMajorCooldown(core.MajorCooldown{
-		Spell: druid.SurvivalInstincts,
+		Spell: druid.SurvivalInstincts.Spell,
 		Type:  core.CooldownTypeSurvival,
 	})
 }

--- a/sim/druid/swipe.go
+++ b/sim/druid/swipe.go
@@ -18,7 +18,7 @@ func (druid *Druid) registerSwipeBearSpell() {
 	thdm := core.TernaryFloat64(druid.HasSetBonus(ItemSetThunderheartHarness, 4), 1.15, 1.0)
 	fidm := 1.0 + 0.1*float64(druid.Talents.FeralInstinct)
 
-	druid.SwipeBear = druid.RegisterSpell(core.SpellConfig{
+	druid.SwipeBear = druid.RegisterSpell(Bear, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 48562},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
@@ -32,9 +32,6 @@ func (druid *Druid) registerSwipeBearSpell() {
 				GCD: core.GCDDefault,
 			},
 			IgnoreHaste: true,
-		},
-		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return druid.InForm(Bear)
 		},
 
 		DamageMultiplier: lbdm * thdm * fidm,
@@ -55,7 +52,7 @@ func (druid *Druid) registerSwipeCatSpell() {
 	weaponMulti := 2.5
 	fidm := 1.0 + 0.1*float64(druid.Talents.FeralInstinct)
 
-	druid.SwipeCat = druid.RegisterSpell(core.SpellConfig{
+	druid.SwipeCat = druid.RegisterSpell(Cat, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 62078},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
@@ -69,9 +66,6 @@ func (druid *Druid) registerSwipeCatSpell() {
 				GCD: time.Second,
 			},
 			IgnoreHaste: true,
-		},
-		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return druid.InForm(Cat)
 		},
 
 		DamageMultiplier: fidm * weaponMulti,
@@ -93,5 +87,5 @@ func (druid *Druid) CurrentSwipeCatCost() float64 {
 }
 
 func (druid *Druid) IsSwipeSpell(spell *core.Spell) bool {
-	return spell == druid.SwipeBear || spell == druid.SwipeCat
+	return druid.SwipeBear.IsEqual(spell) || druid.SwipeCat.IsEqual(spell)
 }

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -46,48 +46,48 @@ character_stats_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 2616.90218
-  tps: 5535.31072
+  dps: 2624.07718
+  tps: 5539.82256
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 2542.98989
-  tps: 5383.99834
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2639.98168
-  tps: 5575.47127
-  dtps: 6.74905
+  dps: 2664.88629
+  tps: 5631.39209
+  dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 2543.44945
-  tps: 5383.59026
+  dps: 2564.49172
+  tps: 5416.39008
   dtps: 6.41606
   hps: 85.38358
  }
@@ -95,8 +95,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 2543.44945
-  tps: 5383.59026
+  dps: 2564.49172
+  tps: 5416.39008
   dtps: 6.41606
   hps: 85.38358
  }
@@ -104,64 +104,64 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 2547.85868
-  tps: 5392.35593
+  dps: 2548.86876
+  tps: 5396.8437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 2083.14965
-  tps: 4434.00089
+  dps: 2080.67698
+  tps: 4426.72866
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2542.98989
-  tps: 5276.54779
+  dps: 2542.4148
+  tps: 5278.91915
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 2487.55817
-  tps: 5267.81883
+  dps: 2507.70578
+  tps: 5302.56542
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2574.35118
-  tps: 5442.74232
+  dps: 2598.02342
+  tps: 5483.53215
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
   hps: 64
  }
@@ -169,934 +169,934 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2616.09791
-  tps: 5533.50868
+  dps: 2613.10439
+  tps: 5521.55227
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2640.08196
-  tps: 5591.24693
-  dtps: 6.74617
+  dps: 2669.78217
+  tps: 5645.54193
+  dtps: 6.51435
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 2546.19437
-  tps: 5390.50298
+  dps: 2564.12486
+  tps: 5420.96487
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 2532.82861
-  tps: 5352.68558
+  dps: 2529.4019
+  tps: 5343.10851
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Death'sChoice-47464"
  value: {
-  dps: 2703.91576
-  tps: 5701.22504
+  dps: 2720.96283
+  tps: 5740.90583
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 2581.91842
-  tps: 5458.73187
+  dps: 2598.07838
+  tps: 5486.66116
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 2737.22228
-  tps: 5790.12772
+  dps: 2761.65726
+  tps: 5838.16899
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 2779.90088
-  tps: 5867.29127
+  dps: 2787.7723
+  tps: 5885.03148
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2544.90066
-  tps: 5389.05084
+  dps: 2560.57376
+  tps: 5418.68288
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 2665.67429
-  tps: 5655.41635
+  dps: 2656.61499
+  tps: 5634.77698
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 2640.85123
-  tps: 5593.19015
+  dps: 2662.0521
+  tps: 5642.36914
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 2469.40401
-  tps: 5216.78951
+  dps: 2441.97298
+  tps: 5154.60818
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerGarb"
  value: {
-  dps: 2088.90003
-  tps: 4466.81641
-  dtps: 7.20775
+  dps: 2114.05411
+  tps: 4515.38985
+  dtps: 6.91076
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 2543.36705
-  tps: 5385.18354
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.53093
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2546.81241
-  tps: 5392.58016
+  dps: 2543.11245
+  tps: 5388.04363
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 2547.85868
-  tps: 5392.35593
+  dps: 2548.86876
+  tps: 5396.8437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2546.47044
-  tps: 5391.21801
+  dps: 2548.91328
+  tps: 5396.90501
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 2596.16116
-  tps: 5498.47162
+  dps: 2610.17369
+  tps: 5528.21376
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 2542.98989
-  tps: 5383.99834
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2615.63966
-  tps: 5538.92905
+  dps: 2638.27056
+  tps: 5579.72948
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2593.91441
-  tps: 5486.4798
+  dps: 2618.81058
+  tps: 5533.0202
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 2541.84762
-  tps: 5381.54906
+  dps: 2564.02703
+  tps: 5419.96999
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2569.57051
-  tps: 5431.16177
+  dps: 2598.17216
+  tps: 5491.15326
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2542.98989
-  tps: 5383.99834
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2542.98989
-  tps: 5383.99834
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 2542.80906
-  tps: 5372.08892
+  dps: 2541.12186
+  tps: 5370.2897
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2645.16217
-  tps: 5595.88588
+  dps: 2657.13774
+  tps: 5612.37682
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 2636.16657
-  tps: 5534.99526
+  dps: 2628.12737
+  tps: 5522.84103
   dtps: 7.20775
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 2090.95376
-  tps: 4451.3795
+  dps: 2086.96108
+  tps: 4439.62262
   dtps: 7.20775
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 2625.42931
-  tps: 5559.60508
+  dps: 2650.28143
+  tps: 5597.85701
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 2519.74769
-  tps: 5330.28238
+  dps: 2537.62298
+  tps: 5364.4973
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Heartpierce-49982"
  value: {
-  dps: 2599.9673
-  tps: 5508.39437
+  dps: 2619.96966
+  tps: 5540.21714
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Heartpierce-50641"
  value: {
-  dps: 2621.26359
-  tps: 5555.90014
+  dps: 2608.49159
+  tps: 5531.01944
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdolofLunarFury-47670"
  value: {
-  dps: 2487.55817
-  tps: 5267.81883
+  dps: 2507.70578
+  tps: 5302.56542
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 2487.55817
-  tps: 5267.81883
+  dps: 2507.70578
+  tps: 5302.56542
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 2535.07709
-  tps: 5365.2147
+  dps: 2552.4729
+  tps: 5396.49003
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 2558.60783
-  tps: 5409.8124
+  dps: 2556.3877
+  tps: 5408.71385
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 2496.92692
-  tps: 5291.47113
+  dps: 2507.48124
+  tps: 5300.81974
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 2512.93787
-  tps: 5321.85174
+  dps: 2527.28911
+  tps: 5345.30357
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 2487.55817
-  tps: 5267.81883
+  dps: 2507.70578
+  tps: 5302.56542
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 2507.30502
-  tps: 5299.77048
+  dps: 2530.01325
+  tps: 5340.86946
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 2547.85868
-  tps: 5392.35593
+  dps: 2548.86876
+  tps: 5396.8437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2546.47044
-  tps: 5391.21801
+  dps: 2548.91328
+  tps: 5396.90501
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2624.80617
-  tps: 5550.10658
+  dps: 2663.00488
+  tps: 5628.49767
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 2546.85335
-  tps: 5392.60622
+  dps: 2541.37118
+  tps: 5381.39295
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2542.7589
-  tps: 5381.61158
+  dps: 2565.61903
+  tps: 5422.24032
   dtps: 6.66421
-  hps: 23.30004
+  hps: 23.59182
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 2849.5617
-  tps: 5934.31433
+  dps: 2864.12734
+  tps: 5952.05533
   dtps: 5.8645
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveRegalia"
  value: {
-  dps: 2273.83399
-  tps: 4903.35721
+  dps: 2286.14727
+  tps: 4914.27981
   dtps: 7.20775
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 2617.13538
-  tps: 5517.91636
+  dps: 2620.39838
+  tps: 5523.53973
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 2122.99078
-  tps: 4557.57123
-  dtps: 7.20775
+  dps: 2132.96209
+  tps: 4575.94641
+  dtps: 6.91076
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2656.43272
-  tps: 5639.87485
+  dps: 2651.68069
+  tps: 5617.87878
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 2649.52021
-  tps: 5572.72422
+  dps: 2653.86667
+  tps: 5576.53274
   dtps: 8.03899
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NightsongBattlegear"
  value: {
-  dps: 2583.84765
-  tps: 5455.72259
+  dps: 2597.53564
+  tps: 5485.73535
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NightsongGarb"
  value: {
-  dps: 2089.80333
-  tps: 4482.55519
+  dps: 2082.14878
+  tps: 4470.70539
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 2530.6182
-  tps: 5354.09229
+  dps: 2559.42395
+  tps: 5415.74871
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 2541.87178
-  tps: 5384.1804
+  dps: 2560.63463
+  tps: 5412.43588
   dtps: 5.50054
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 2542.98989
-  tps: 5383.99834
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 2542.98989
-  tps: 5383.99834
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 2555.77617
-  tps: 5409.01134
+  dps: 2569.21847
+  tps: 5436.30959
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 2557.64201
-  tps: 5412.93354
+  dps: 2571.07674
+  tps: 5440.21586
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2576.19815
-  tps: 5446.42556
+  dps: 2594.7435
+  tps: 5473.75285
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 2527.60223
-  tps: 5339.57747
+  dps: 2573.42193
+  tps: 5435.17774
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2542.98989
-  tps: 5383.99834
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 2507.66584
-  tps: 5303.97688
+  dps: 2528.48947
+  tps: 5340.11263
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2542.72959
-  tps: 5383.43509
+  dps: 2553.88177
+  tps: 5400.39822
   dtps: 4.4102
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SoulPreserver-37111"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SouloftheDead-40382"
  value: {
-  dps: 2603.70807
-  tps: 5507.32104
+  dps: 2613.14433
+  tps: 5520.45198
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 2572.72465
-  tps: 5457.23295
+  dps: 2594.20647
+  tps: 5493.02344
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 2623.9945
-  tps: 5555.74294
+  dps: 2631.85485
+  tps: 5560.99302
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-StormshroudArmor"
  value: {
-  dps: 2023.27491
-  tps: 4286.31573
+  dps: 2042.53924
+  tps: 4334.28999
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 2530.6182
-  tps: 5354.09229
+  dps: 2559.42395
+  tps: 5415.74871
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2531.09842
-  tps: 5361.72427
+  dps: 2543.04141
+  tps: 5386.56326
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 2546.19437
-  tps: 5390.50298
+  dps: 2564.12486
+  tps: 5420.96487
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartHarness"
  value: {
-  dps: 2066.03743
-  tps: 4506.05122
+  dps: 2073.80567
+  tps: 4523.42927
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartRegalia"
  value: {
-  dps: 1839.36996
-  tps: 3946.03654
+  dps: 1830.17431
+  tps: 3923.22412
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 2543.02166
-  tps: 5393.37939
+  dps: 2540.80334
+  tps: 5376.44132
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2652.07768
-  tps: 5623.52632
+  dps: 2658.84389
+  tps: 5628.73875
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2653.32531
-  tps: 5621.12468
+  dps: 2680.73182
+  tps: 5682.0938
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2542.98989
-  tps: 5383.99834
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2542.98989
-  tps: 5383.99834
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 2582.10895
-  tps: 5465.83662
+  dps: 2575.69942
+  tps: 5445.21012
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2542.98989
-  tps: 5383.99834
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2542.98989
-  tps: 5383.99834
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 2171.68213
-  tps: 4610.60813
+  dps: 2192.04301
+  tps: 4644.11896
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 2007.10951
-  tps: 4307.98709
+  dps: 2034.86879
+  tps: 4358.78889
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 2487.55817
-  tps: 5267.81883
+  dps: 2507.70578
+  tps: 5302.56542
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WingedTalisman-37844"
  value: {
-  dps: 2541.47993
-  tps: 5381.16775
+  dps: 2562.86066
+  tps: 5418.5065
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 2557.41143
-  tps: 5410.66687
+  dps: 2576.3066
+  tps: 5442.80627
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-Average-Default"
  value: {
-  dps: 2657.57976
-  tps: 5652.97568
-  dtps: 56.32679
+  dps: 2660.63198
+  tps: 5656.7151
+  dtps: 56.65538
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4681.21197
-  tps: 10670.13215
+  dps: 4801.25886
+  tps: 10954.86905
   dtps: 6.22692
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2663.00534
-  tps: 5633.75453
+  dps: 2664.9798
+  tps: 5638.97003
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2838.6314
-  tps: 6200.51581
+  dps: 2810.68757
+  tps: 6141.7009
   dtps: 33.32105
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1660.07682
-  tps: 4023.95601
+  dps: 1646.28
+  tps: 4007.99728
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1262.93213
-  tps: 2694.2397
+  dps: 1249.79542
+  tps: 2665.74497
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1092.571
-  tps: 2434.07074
+  dps: 1053.80282
+  tps: 2353.66624
  }
 }
 dps_results: {
  key: "TestFeralTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2758.39093
-  tps: 5871.52468
-  dtps: 48.91906
+  dps: 2775.48338
+  tps: 5906.44766
+  dtps: 47.07373
  }
 }

--- a/sim/druid/tigers_fury.go
+++ b/sim/druid/tigers_fury.go
@@ -26,7 +26,7 @@ func (druid *Druid) registerTigersFurySpell() {
 		},
 	})
 
-	spell := druid.RegisterSpell(core.SpellConfig{
+	spell := druid.RegisterSpell(Cat, core.SpellConfig{
 		ActionID: actionID,
 		Flags:    core.SpellFlagAPL,
 		Cast: core.CastConfig{

--- a/sim/druid/typhoon.go
+++ b/sim/druid/typhoon.go
@@ -12,7 +12,7 @@ func (druid *Druid) registerTyphoonSpell() {
 		return
 	}
 
-	druid.Typhoon = druid.RegisterSpell(core.SpellConfig{
+	druid.Typhoon = druid.RegisterSpell(Humanoid|Moonkin, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 61384},
 		SpellSchool: core.SpellSchoolNature,
 		ProcMask:    core.ProcMaskSpellDamage,

--- a/sim/druid/wrath.go
+++ b/sim/druid/wrath.go
@@ -14,7 +14,7 @@ func (druid *Druid) registerWrathSpell() {
 	bonusFlatDamage := core.TernaryFloat64(druid.Equip[core.ItemSlotRanged].ID == IdolAvenger, 25, 0) +
 		core.TernaryFloat64(druid.Equip[core.ItemSlotRanged].ID == IdolSteadfastRenewal, 70, 0)
 
-	druid.Wrath = druid.RegisterSpell(core.SpellConfig{
+	druid.Wrath = druid.RegisterSpell(Humanoid|Moonkin, core.SpellConfig{
 		ActionID:     core.ActionID{SpellID: 48461},
 		SpellSchool:  core.SpellSchoolNature,
 		ProcMask:     core.ProcMaskSpellDamage,


### PR DESCRIPTION
 - Refactors druidspells to require a formmask when creating
 - Enforces form checking on cast, and allows 'auto unshift' logic to match game and when using apl
 - fixes berserk usage broken from #3501 