### PR TITLE
Raid sim ui tweaks

### DIFF
--- a/ui/raid/raid_picker.ts
+++ b/ui/raid/raid_picker.ts
@@ -233,7 +233,7 @@ export class PartyPicker extends Component {
 				return;
 			}
 
-			dpsResultElem.textContent = partyDps.toFixed(1);
+			dpsResultElem.textContent = `${partyDps.toFixed(1)} DPS`;
 
 			if (!referenceData) {
 				referenceDeltaElem.textContent = '';
@@ -354,7 +354,7 @@ export class PlayerPicker extends Component {
 
 			if (this.player) {
 				this.resultsElem?.classList.remove('hide');
-				(this.dpsResultElem as HTMLElement).textContent = playerDps.toFixed(1);
+				(this.dpsResultElem as HTMLElement).textContent = `${playerDps.toFixed(1)} DPS`;
 
 				if (referenceData)
 					formatDeltaTextElem(this.referenceDeltaElem as HTMLElement, referenceDps, playerDps, 1);
@@ -475,10 +475,9 @@ export class PlayerPicker extends Component {
 			const classCssClass = cssClassForClass(this.player.getClass());
 
 			this.rootElem.className = `player-picker-root player bg-${classCssClass}-dampened`;
-			this.rootElem.setAttribute('draggable', 'true');
 			this.rootElem.innerHTML = `
 				<div class="player-label">
-					<img class="player-icon" src="${this.player.getSpecIcon()}" draggable="false"/>
+					<img class="player-icon" src="${this.player.getSpecIcon()}" />
 					<div class="player-details">
 						<input
 							class="player-name text-${classCssClass}"
@@ -498,7 +497,6 @@ export class PlayerPicker extends Component {
 						href="javascript:void(0)"
 						class="player-edit"
 						role="button"
-						draggable="false"
 						data-bs-toggle="tooltip"
 						data-bs-title="Click to Edit"
 					>
@@ -518,7 +516,6 @@ export class PlayerPicker extends Component {
 						href="javascript:void(0)"
 						class="player-delete link-danger"
 						role="button"
-						draggable="false"
 						data-bs-toggle="tooltip"
 						data-bs-title="Click to Delete"
 					>
@@ -544,12 +541,10 @@ export class PlayerPicker extends Component {
 		});
 
 		this.nameElem?.addEventListener('mousedown', event => {
-			this.rootElem.setAttribute('draggable', 'false')
 			this.partyPicker.rootElem.setAttribute('draggable', 'false')
 		})
 
 		this.nameElem?.addEventListener('mouseup', event => {
-			this.rootElem.setAttribute('draggable', 'true')
 			this.partyPicker.rootElem.setAttribute('draggable', 'true')
 		})
 
@@ -582,16 +577,14 @@ export class PlayerPicker extends Component {
 		const copyElem = this.rootElem.querySelector('.player-copy') as HTMLElement;
 		const deleteElem = this.rootElem.querySelector('.player-delete') as HTMLElement;
 
-		this.rootElem.ondragstart = event => {
-			if (event.target != copyElem) {
-				dragStart(event, DragType.Swap)
-			}
-		}
-
 		const editTooltip = Tooltip.getOrCreateInstance(editElem);
 		const copyTooltip = Tooltip.getOrCreateInstance(copyElem);
 		const deleteTooltip = Tooltip.getOrCreateInstance(deleteElem);
 
+		(this.iconElem as HTMLElement).ondragstart = event => {
+			event.dataTransfer!.setDragImage(this.rootElem, 20, 20);
+			dragStart(event, DragType.Swap)
+		}
 		editElem.onclick = event => {
 			new PlayerEditorModal(this.player as Player<any>);
 		};

--- a/ui/scss/shared/_variables.scss
+++ b/ui/scss/shared/_variables.scss
@@ -9,6 +9,9 @@
 //////////////////////////
 
 // Custom theme color mapping
+$brand: #e0a335;
+$success: #1eff00;
+
 $death-knight: rgb(194, 46, 70);
 $druid:        rgb(255, 125, 10);
 $hunter:       rgb(171, 212, 115);
@@ -27,17 +30,12 @@ $class-colors: (
   "mage":         $mage,
   "paladin":      $paladin,
   "priest":       $priest,
-  "raid":         $primary,
+  "raid":         $brand,
   "rogue":        $rogue,
   "shaman":       $shaman,
   "warlock":      $warlock,
   "warrior":      $warrior,
 );
-
-$theme-colors: map-merge($theme-colors, $class-colors);
-
-$brand: #e0a335;
-$success: #1eff00;
 
 $custom-colors: (
   "brand": $brand,
@@ -101,6 +99,7 @@ $sidebar-z-index: 200;
 /////////////////////////////////////////////
 
 // Map overrides
+$theme-colors: map-merge($theme-colors, $class-colors);
 $theme-colors: map-merge($theme-colors, $custom-colors);
 $grid-breakpoints: map-merge($grid-breakpoints, $custom-breakpoints);
 

--- a/ui/scss/sims/raid/_player.scss
+++ b/ui/scss/sims/raid/_player.scss
@@ -3,7 +3,7 @@
 .player {
   width: 100%;
   height: 2.5rem;
-	padding: calc(.25rem - 1px) .25rem;
+	padding: calc(map-get($spacers, 1) - 1px) map-get($spacers, 1);
 	border: $border-default;
 	display: flex;
 	justify-content: space-between;
@@ -15,7 +15,7 @@
 	}
 
   .player-label {
-		margin-right: map.get($spacers, 2);
+		margin-right: map-get($spacers, 2);
 		display: flex;
 		align-items: center;
 		flex-grow: 1;
@@ -29,6 +29,7 @@
 
 			.player-name {
 				height: 1rem;
+				padding: 0;
 				border: none;
 				outline: none;
 				background: transparent;

--- a/ui/scss/sims/raid/_raid_picker.scss
+++ b/ui/scss/sims/raid/_raid_picker.scss
@@ -80,6 +80,7 @@
 .player-results {
 	display: flex;
 	align-items: flex-end;
+	font-size: $content-font-size;
 }
 
 .party-results-reference-delta,


### PR DESCRIPTION
- Add "DPS" after player and party numbers when running sim
- Make player swap dragging easier by using the spec icon
- Fix save reference icon color in raid sim