### PR TITLE
improve timeline navigation

### DIFF
--- a/ui/core/components/detailed_results/timeline.ts
+++ b/ui/core/components/detailed_results/timeline.ts
@@ -54,8 +54,13 @@ export class Timeline extends ResultComponent {
 
 		this.rootElem.innerHTML = `
 		<div class="timeline-disclaimer">
-			<span class="warning wanings fa fa-exclamation-triangle fa-xl me-2"></span>
-			<span class="timeline-warning-description">Timeline data visualizes only 1 sim iteration.</span>
+			<div class="d-flex flex-column">
+				<p>
+					<i class="warning fa fa-exclamation-triangle fa-xl me-2"></i>
+					Timeline data visualizes only 1 sim iteration.
+				</p>
+				<p>Note: You can move the timeline by holding <kbd>Shift</kbd> while scrolling, or by clicking and dragging.</p>
+			</div>
 			<select class="timeline-chart-picker form-select">
 				<option class="rotation-option" value="rotation">Rotation</option>
 				<option class="dps-option" value="dps">DPS</option>
@@ -68,7 +73,7 @@ export class Timeline extends ResultComponent {
 				<div class="rotation-container">
 					<div class="rotation-labels">
 					</div>
-					<div class="rotation-timeline">
+					<div class="rotation-timeline" draggable="true">
 					</div>
 				</div>
 				<div class="rotation-hidden-ids">
@@ -119,6 +124,33 @@ export class Timeline extends ResultComponent {
 		this.rotationLabels = this.rootElem.getElementsByClassName('rotation-labels')[0] as HTMLElement;
 		this.rotationTimeline = this.rootElem.getElementsByClassName('rotation-timeline')[0] as HTMLElement;
 		this.rotationHiddenIdsContainer = this.rootElem.getElementsByClassName('rotation-hidden-ids')[0] as HTMLElement;
+
+		let isMouseDown = false
+		let startX = 0;
+		let scrollLeft = 0;
+		this.rotationTimeline.ondragstart = (event) => {
+			event.preventDefault();
+		}
+		this.rotationTimeline.onmousedown = (event) => {
+			isMouseDown = true;
+			startX = event.pageX - this.rotationTimeline.offsetLeft;
+  		scrollLeft = this.rotationTimeline.scrollLeft;
+		}
+		this.rotationTimeline.onmouseleave = (event) => {
+			isMouseDown = false;
+			this.rotationTimeline.classList.remove('active');
+		};
+		this.rotationTimeline.onmouseup = (event) => {
+			isMouseDown = false;
+			this.rotationTimeline.classList.remove('active');
+		};
+		this.rotationTimeline.onmousemove = (e) => {
+			if(!isMouseDown) return;
+			e.preventDefault();
+			const x = e.pageX - this.rotationTimeline.offsetLeft;
+			const walk = (x - startX) * 3; //scroll-fast
+			this.rotationTimeline.scrollLeft = scrollLeft - walk;
+		};
 	}
 
 	onSimResult(resultData: SimResultData) {

--- a/ui/raid/raid_picker.ts
+++ b/ui/raid/raid_picker.ts
@@ -477,7 +477,7 @@ export class PlayerPicker extends Component {
 			this.rootElem.className = `player-picker-root player bg-${classCssClass}-dampened`;
 			this.rootElem.innerHTML = `
 				<div class="player-label">
-					<img class="player-icon" src="${this.player.getSpecIcon()}" />
+					<img class="player-icon" src="${this.player.getSpecIcon()}" draggable="true" />
 					<div class="player-details">
 						<input
 							class="player-name text-${classCssClass}"

--- a/ui/scss/core/components/detailed_results/_timeline.scss
+++ b/ui/scss/core/components/detailed_results/_timeline.scss
@@ -37,7 +37,7 @@ $combo-points-color: #ffa07a;
 
 .timeline-disclaimer {
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 
 	.timeline-chart-picker {
 		width: 8rem;
@@ -143,9 +143,6 @@ $combo-points-color: #ffa07a;
 	color: white;
 }
 
-.rotation-plot {
-	margin-top: 2.5rem;
-}
 .rotation-container {
 	color: white;
 	display: flex;

--- a/ui/scss/shared/_global.scss
+++ b/ui/scss/shared/_global.scss
@@ -88,6 +88,11 @@ p {
   margin-bottom: $block-spacer;
 }
 
+kbd {
+  background: $body-bg;
+  color: white;
+}
+
 .dragto:not(.dragfrom) {
   filter: brightness(.75);
 }
@@ -109,5 +114,5 @@ p {
 }
 
 [draggable="true"] {
-  cursor: pointer;
+  cursor: grab;
 }


### PR DESCRIPTION
re https://github.com/wowsims/wotlk/issues/3224

Adds the ability to click and drag the timeline to scroll through it, as well as a disclaimer that you can shift+scroll or drag.

<img width="1346" alt="image" src="https://github.com/wowsims/wotlk/assets/12898988/1b9ced64-a1b4-4c09-9509-74c39fc81c93">