### PR TITLE
Add arms and fury P3 presets

### DIFF
--- a/ui/raid/presets.ts
+++ b/ui/raid/presets.ts
@@ -743,10 +743,12 @@ export const playerPresets: Array<PresetSpecSettings<any>> = [
 			[Faction.Alliance]: {
 				1: WarriorPresets.P1_ARMS_PRESET.gear,
 				2: WarriorPresets.P2_ARMS_PRESET.gear,
+				3: WarriorPresets.P3_ARMS_4P_PRESET_ALLIANCE.gear,
 			},
 			[Faction.Horde]: {
 				1: WarriorPresets.P1_ARMS_PRESET.gear,
 				2: WarriorPresets.P2_ARMS_PRESET.gear,
+				3: WarriorPresets.P3_ARMS_4P_PRESET_HORDE.gear,
 			},
 		},
 		tooltip: 'Arms Warrior',
@@ -769,10 +771,12 @@ export const playerPresets: Array<PresetSpecSettings<any>> = [
 			[Faction.Alliance]: {
 				1: WarriorPresets.P1_FURY_PRESET.gear,
 				2: WarriorPresets.P2_FURY_PRESET.gear,
+				3: WarriorPresets.P3_FURY_PRESET_ALLIANCE.gear,
 			},
 			[Faction.Horde]: {
 				1: WarriorPresets.P1_FURY_PRESET.gear,
 				2: WarriorPresets.P2_FURY_PRESET.gear,
+				3: WarriorPresets.P3_FURY_PRESET_HORDE.gear,
 			},
 		},
 		tooltip: 'Fury Warrior',

--- a/ui/warrior/presets.ts
+++ b/ui/warrior/presets.ts
@@ -1,4 +1,4 @@
-import { Consumes } from '../core/proto/common.js';
+import { Consumes, Faction } from '../core/proto/common.js';
 import { EquipmentSpec } from '../core/proto/common.js';
 import { Flask } from '../core/proto/common.js';
 import { Food } from '../core/proto/common.js';
@@ -218,6 +218,56 @@ export const P2_FURY_PRESET = {
 	]}`),
 };
 
+export const P3_FURY_PRESET_ALLIANCE = {
+	name: 'P3 Fury Preset [A]',
+	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
+	enableWhen: (player: Player<Spec.SpecWarrior>) => player.getTalentTree() != 0 && player.getFaction() == Faction.Alliance,
+	gear: EquipmentSpec.fromJsonString(`{ "items": [
+		{"id":48383,"enchant":3817,"gems":[41398,49110]},
+		{"id":47060,"gems":[40117]},
+		{"id":48381,"enchant":3808,"gems":[40111]},
+		{"id":47545,"enchant":3831,"gems":[40111]},
+		{"id":48385,"enchant":3832,"gems":[40117,40117]},
+		{"id":47074,"enchant":3845,"gems":[40143,0]},
+		{"id":47240,"enchant":3604,"gems":[40111,40111,0]},
+		{"id":47002,"gems":[40143,40143,40111]},
+		{"id":48382,"enchant":3823,"gems":[40142,40117]},
+		{"id":47154,"enchant":3606,"gems":[40142,40117]},
+		{"id":46966,"gems":[40143]},
+		{"id":47075,"gems":[40111]},
+		{"id":45931},
+		{"id":47131},
+		{"id":47078,"enchant":3789,"gems":[42142,40111]},
+		{"id":47078,"enchant":3789,"gems":[42142,42142]},
+		{"id":46995,"gems":[40111]}
+	]}`)
+}
+
+export const P3_FURY_PRESET_HORDE = {
+	name: 'P3 Fury Preset [H]',
+	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
+	enableWhen: (player: Player<Spec.SpecWarrior>) => player.getTalentTree() != 0 && player.getFaction() == Faction.Horde,
+	gear: EquipmentSpec.fromJsonString(`{ "items": [
+		{"id":48398,"enchant":3817,"gems":[41398,49110]},
+		{"id":47433,"gems":[40111]},
+		{"id":48400,"enchant":3808,"gems":[40117]},
+		{"id":47546,"enchant":3831,"gems":[40111]},
+		{"id":48396,"enchant":3832,"gems":[40111,40111]},
+		{"id":47414,"enchant":3845,"gems":[40142,0]},
+		{"id":47240,"enchant":3604,"gems":[40111,40111,0]},
+		{"id":47429,"gems":[40142,40142,42142]},
+		{"id":48399,"enchant":3823,"gems":[40142,40111]},
+		{"id":47445,"enchant":3606,"gems":[40142,45862]},
+		{"id":47413,"gems":[40142]},
+		{"id":47443,"gems":[40111]},
+		{"id":45931},
+		{"id":47464},
+		{"id":47446,"enchant":3789,"gems":[40117,40117]},
+		{"id":47446,"enchant":3789,"gems":[42142,42142]},
+		{"id":47428,"gems":[40117]}
+	]}`)
+}
+
 export const P1_PRERAID_ARMS_PRESET = {
 	name: 'P1 Pre-Raid Arms Preset',
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
@@ -290,5 +340,105 @@ export const P2_ARMS_PRESET = {
 		  {"id":45533,"enchant":3789,"gems":[39996,39996]},
 		  {},
 		  {"id":45296,"gems":[39996]}
+	]}`),
+};
+
+export const P3_ARMS_2P_PRESET_ALLIANCE = {
+	name: 'P3 Arms 2p Preset [A]',
+	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
+	enableWhen: (player: Player<Spec.SpecWarrior>) => player.getTalentTree() == 0 && player.getFaction() == Faction.Alliance,
+	gear: EquipmentSpec.fromJsonString(`{"items": [
+		{"id":49478,"enchant":3817,"gems":[41398,40117]},
+		{"id":47915,"gems":[40117]},
+		{"id":48381,"enchant":3808,"gems":[42142]},
+		{"id":47545,"enchant":3605,"gems":[40117]},
+		{"id":48385,"enchant":3832,"gems":[42142,42142]},
+		{"id":47074,"enchant":3845,"gems":[40143,0]},
+		{"id":47240,"enchant":3604,"gems":[49110,40117,0]},
+		{"id":47153,"gems":[40143,40117,40117]},
+		{"id":47191,"enchant":3823,"gems":[40117,40117,40117]},
+		{"id":47077,"enchant":3606,"gems":[40143,40117]},
+		{"id":47934,"gems":[40142]},
+		{"id":45608,"gems":[40117]},
+		{"id":47131},
+		{"id":46038},
+		{"id":47078,"enchant":3789,"gems":[40117,40117]},
+		{},
+		{"id":45296,"gems":[40117]}
+	]}`),
+};
+
+export const P3_ARMS_4P_PRESET_ALLIANCE = {
+	name: 'P3 Arms 4p Preset [A]',
+	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
+	enableWhen: (player: Player<Spec.SpecWarrior>) => player.getTalentTree() == 0 && player.getFaction() == Faction.Alliance,
+	gear: EquipmentSpec.fromJsonString(`{"items": [
+		{"id":48383,"enchant":3817,"gems":[41398,40117]},
+		{"id":47915,"gems":[40117]},
+		{"id":48381,"enchant":3808,"gems":[42153]},
+		{"id":47545,"enchant":3605,"gems":[40117]},
+		{"id":48385,"enchant":3832,"gems":[42153,42153]},
+		{"id":47074,"enchant":3845,"gems":[40117,0]},
+		{"id":47240,"enchant":3604,"gems":[49110,40117,0]},
+		{"id":47153,"gems":[40117,40117,40117]},
+		{"id":48382,"enchant":3823,"gems":[40142,40117]},
+		{"id":47077,"enchant":3606,"gems":[40117,40117]},
+		{"id":47934,"gems":[40117]},
+		{"id":45608,"gems":[40117]},
+		{"id":46038},
+		{"id":47131},
+		{"id":47078,"enchant":3789,"gems":[40117,40117]},
+		{},
+		{"id":46995,"gems":[40117]}
+	]}`),
+};
+
+export const P3_ARMS_2P_PRESET_HORDE = {
+	name: 'P3 Arms 2p Preset [H]',
+	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
+	enableWhen: (player: Player<Spec.SpecWarrior>) => player.getTalentTree() == 0 && player.getFaction() == Faction.Horde,
+	gear: EquipmentSpec.fromJsonString(`{"items": [
+		{"id":49478,"enchant":3817,"gems":[41398,40111]},
+		{"id":45459,"gems":[40111]},
+		{"id":48400,"enchant":3808,"gems":[42153]},
+		{"id":47546,"enchant":3605,"gems":[40111]},
+		{"id":48396,"enchant":3832,"gems":[42153,42153]},
+		{"id":47442,"enchant":3845,"gems":[40143,0]},
+		{"id":47492,"enchant":3604,"gems":[49110,40117,0]},
+		{"id":47472,"gems":[40143,40117,40117]},
+		{"id":47480,"enchant":3823,"gems":[40117,40117,40117]},
+		{"id":47445,"enchant":3606,"gems":[40143,40117]},
+		{"id":48007,"gems":[40143]},
+		{"id":45608,"gems":[40117]},
+		{"id":47464},
+		{"id":46038},
+		{"id":47446,"enchant":3789,"gems":[40111,40111]},
+		{},
+		{"id":47428,"gems":[40111]}
+	]}`),
+};
+
+export const P3_ARMS_4P_PRESET_HORDE = {
+	name: 'P3 Arms 4p Preset [H]',
+	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
+	enableWhen: (player: Player<Spec.SpecWarrior>) => player.getTalentTree() == 0 && player.getFaction() == Faction.Horde,
+	gear: EquipmentSpec.fromJsonString(`{"items": [
+		{"id":48398,"enchant":3817,"gems":[41398,40117]},
+		{"id":47988,"gems":[40117]},
+		{"id":48400,"enchant":3808,"gems":[42153]},
+		{"id":47546,"enchant":3605,"gems":[40117]},
+		{"id":48396,"enchant":3832,"gems":[42153,42153]},
+		{"id":47442,"enchant":3845,"gems":[40117,0]},
+		{"id":47492,"enchant":3604,"gems":[49110,40117,0]},
+		{"id":47472,"gems":[40117,40117,40117]},
+		{"id":48399,"enchant":3823,"gems":[40142,40117]},
+		{"id":47445,"enchant":3606,"gems":[40117,40117]},
+		{"id":48007,"gems":[40117]},
+		{"id":45608,"gems":[40117]},
+		{"id":46038},
+		{"id":47464},
+		{"id":47446,"enchant":3789,"gems":[40117,40117]},
+		{},
+		{"id":47428,"gems":[40117]}
 	]}`),
 };

--- a/ui/warrior/sim.ts
+++ b/ui/warrior/sim.ts
@@ -73,7 +73,7 @@ export class WarriorSimUI extends IndividualSimUI<Spec.SpecWarrior> {
 
 			defaults: {
 				// Default equipped gear.
-				gear: Presets.P2_FURY_PRESET.gear,
+				gear: Presets.P3_FURY_PRESET_ALLIANCE.gear,
 				// Default EP weights for sorting gear in the gear picker.
 				epWeights: Stats.fromMap({
 					[Stat.StatStrength]: 2.72,
@@ -169,9 +169,15 @@ export class WarriorSimUI extends IndividualSimUI<Spec.SpecWarrior> {
 					Presets.P1_PRERAID_FURY_PRESET,
 					Presets.P1_FURY_PRESET,
 					Presets.P2_FURY_PRESET,
+					Presets.P3_FURY_PRESET_ALLIANCE,
+					Presets.P3_FURY_PRESET_HORDE,
 					Presets.P1_PRERAID_ARMS_PRESET,
 					Presets.P1_ARMS_PRESET,
 					Presets.P2_ARMS_PRESET,
+					Presets.P3_ARMS_2P_PRESET_ALLIANCE,
+					Presets.P3_ARMS_4P_PRESET_ALLIANCE,
+					Presets.P3_ARMS_2P_PRESET_HORDE,
+					Presets.P3_ARMS_4P_PRESET_HORDE,
 				],
 			},
 		});


### PR DESCRIPTION
### Fury
- [x] Presets added
- [x] Raid sim updated

https://www.wowhead.com/wotlk/guide/classes/warrior/fury/dps-bis-gear-pve-phase-3#bis-p3-raid-bis-alliance

I didn't update any talents/glyphs as it seems like wowhead consistently suggested rend whereas we don't use rend. I updated some items that were not using the appropriate faction.

Sets Added:
- P3 Fury Preset [A]
- P3 Fury Preset [H]

### Arms
- [x] Presets added
- [x] Raid sim updated

https://www.wowhead.com/wotlk/guide/classes/warrior/arms/dps-bis-gear-pve-phase-3#bis-p3-raid-bis-four-set

I didn't update any talents/glyphs. The only difference I noticed was wowhead uses 2/2 Weapon Mastery instead of 1/2 Weapon Mastery + 1/1 Juggernaut. I updated some items that were not using the appropriate faction.

Sets Added:
- P3 Arms 2p Preset [A]
- P3 Arms 4p Preset [A]
- P3 Arms 2p Preset [H]
- P3 Arms 4p Preset [H]