### PR TITLE
Enhancement p3 updates

### DIFF
--- a/ui/enhancement_shaman/presets.ts
+++ b/ui/enhancement_shaman/presets.ts
@@ -53,6 +53,19 @@ export const StandardTalents = {
 	}),
 };
 
+export const Phase3Talents = {
+	name: 'Phase 3',
+	data: SavedTalents.create({
+		talentsString: '053030152-30505003105001333031131131051',
+		glyphs: Glyphs.create({
+			major1: ShamanMajorGlyph.GlyphOfStormstrike,
+			major2: ShamanMajorGlyph.GlyphOfFlametongueWeapon,
+			major3: ShamanMajorGlyph.GlyphOfFeralSpirit,
+			//minor glyphs dont affect damage done, all convenience/QoL
+		})
+	}),
+};
+
 export const DefaultRotation = EnhancementShamanRotation.create({
 	totems: ShamanTotems.create({
 		earth: EarthTotem.StrengthOfEarthTotem,
@@ -253,7 +266,7 @@ export const P2_PRESET_WF = {
 };
 
 export const P3_PRESET_ALLIANCE	 = {
-	name: 'P3 Preset Alliance',
+	name: 'P3 Preset [A]',
 	enableWhen: (player: Player<Spec.SpecElementalShaman>) => player.getFaction() == Faction.Alliance,
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
 	gear: EquipmentSpec.fromJsonString(`{  "items": [
@@ -275,11 +288,10 @@ export const P3_PRESET_ALLIANCE	 = {
 		{"id":47156,"enchant":3789,"gems":[40128]},
 		{"id":47666}
 	]}`),
-}
-
+};
 
 export const P3_PRESET_HORDE = {
-	name: 'P3 Preset Horde',
+	name: 'P3 Preset [H]',
 	enableWhen: (player: Player<Spec.SpecElementalShaman>) => player.getFaction() == Faction.Horde,
 	tooltip: Tooltips.BASIC_BIS_DISCLAIMER,
 	gear: EquipmentSpec.fromJsonString(`{  "items": [
@@ -301,4 +313,4 @@ export const P3_PRESET_HORDE = {
 		{"id":47475,"enchant":3789,"gems":[40128]},
 		{"id":47666}
 	]}`),
-}
+};

--- a/ui/enhancement_shaman/sim.ts
+++ b/ui/enhancement_shaman/sim.ts
@@ -149,6 +149,7 @@ export class EnhancementShamanSimUI extends IndividualSimUI<Spec.SpecEnhancement
 				// Preset talents that the user can quickly select.
 				talents: [
 					Presets.StandardTalents,
+					Presets.Phase3Talents,
 				],
 				// Preset rotations that the user can quickly select.
 				rotations: [

--- a/ui/raid/presets.ts
+++ b/ui/raid/presets.ts
@@ -587,10 +587,12 @@ export const playerPresets: Array<PresetSpecSettings<any>> = [
 			[Faction.Alliance]: {
 				1: EnhancementShamanPresets.P1_PRESET.gear,
 				2: EnhancementShamanPresets.P2_PRESET_FT.gear,
+				3: EnhancementShamanPresets.P3_PRESET_ALLIANCE.gear,
 			},
 			[Faction.Horde]: {
 				1: EnhancementShamanPresets.P1_PRESET.gear,
 				2: EnhancementShamanPresets.P2_PRESET_FT.gear,
+				3: EnhancementShamanPresets.P3_PRESET_HORDE.gear,
 			},
 		},
 		tooltip: specNames[Spec.SpecEnhancementShaman],


### PR DESCRIPTION
- Add enhancement phase 3 sets to raid sim
- Add recommended talent set from https://discord.com/channels/891730968493305867/911516823936184390/1142915783853342811
- Update P3 enh set names to use shorthand `[A]` and `[H]`