### PR TITLE
ProcMask and PPMManager related cleanups

### DIFF
--- a/sim/common/tbc/melee_sets.go
+++ b/sim/common/tbc/melee_sets.go
@@ -30,7 +30,7 @@ var ItemSetFistsOfFury = core.NewItemSet(core.ItemSet{
 				},
 			})
 
-			ppmm := character.AutoAttacks.NewPPMManager(2, core.ProcMaskMelee)
+			ppmm := character.AutoAttacks.NewPPMManager(2.0, core.ProcMaskMelee)
 
 			character.RegisterAura(core.Aura{
 				Label:    "Fists of Fury",
@@ -39,14 +39,13 @@ var ItemSetFistsOfFury = core.NewItemSet(core.ItemSet{
 					aura.Activate(sim)
 				},
 				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-					if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
-						return
-					}
-					if !ppmm.Proc(sim, spell.ProcMask, "The Fists of Fury") {
+					if !result.Landed() {
 						return
 					}
 
-					procSpell.Cast(sim, result.Target)
+					if ppmm.Proc(sim, spell.ProcMask, "The Fists of Fury") {
+						procSpell.Cast(sim, result.Target)
+					}
 				},
 			})
 		},
@@ -157,20 +156,14 @@ var ItemSetTwinBladesOfAzzinoth = core.NewItemSet(core.ItemSet{
 						return
 					}
 
-					// https://wotlk.wowhead.com/spell=41434/the-twin-blades-of-azzinoth, proc mask = 20.
-					if !spell.ProcMask.Matches(core.ProcMaskMelee) {
-						return
-					}
-
 					if !icd.IsReady(sim) {
 						return
 					}
 
-					if !ppmm.Proc(sim, spell.ProcMask, "Twin Blades of Azzinoth") {
-						return
+					if ppmm.Proc(sim, spell.ProcMask, "Twin Blades of Azzinoth") {
+						icd.Use(sim)
+						procAura.Activate(sim)
 					}
-					icd.Use(sim)
-					procAura.Activate(sim)
 				},
 			})
 		},

--- a/sim/common/tbc/melee_trinkets.go
+++ b/sim/common/tbc/melee_trinkets.go
@@ -92,19 +92,18 @@ func init() {
 				aura.Activate(sim)
 			},
 			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				// mask: 340
-				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
+				if !result.Landed() {
 					return
 				}
+
 				if !icd.IsReady(sim) {
 					return
 				}
-				if !ppmm.Proc(sim, spell.ProcMask, "dragonspine") {
-					return
-				}
-				icd.Use(sim)
 
-				procAura.Activate(sim)
+				if ppmm.Proc(sim, spell.ProcMask, "dragonspine") {
+					icd.Use(sim)
+					procAura.Activate(sim)
+				}
 			},
 		})
 	})
@@ -158,15 +157,13 @@ func init() {
 				aura.Activate(sim)
 			},
 			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				// mask 340
-				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
-					return
-				}
-				if !ppmm.Proc(sim, spell.ProcMask, "Madness of the Betrayer") {
+				if !result.Landed() {
 					return
 				}
 
-				procAura.Activate(sim)
+				if ppmm.Proc(sim, spell.ProcMask, "Madness of the Betrayer") {
+					procAura.Activate(sim)
+				}
 			},
 		})
 	})

--- a/sim/common/tbc/metagems.go
+++ b/sim/common/tbc/metagems.go
@@ -72,7 +72,7 @@ func init() {
 			Timer:    character.NewTimer(),
 			Duration: time.Second * 40,
 		}
-		ppmm := character.AutoAttacks.NewPPMManager(1.5, core.ProcMaskMeleeOrRanged)
+		ppmm := character.AutoAttacks.NewPPMManager(1.5, core.ProcMaskWhiteHit) // Mask 68, melee or ranged auto attacks.
 
 		character.RegisterAura(core.Aura{
 			Label:    "Thundering Skyfire Diamond",
@@ -81,18 +81,18 @@ func init() {
 				aura.Activate(sim)
 			},
 			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				// Mask 68, melee or ranged auto attacks.
-				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskWhiteHit) {
+				if !result.Landed() {
 					return
 				}
+
 				if !icd.IsReady(sim) {
 					return
 				}
-				if !ppmm.Proc(sim, spell.ProcMask, "Thundering Skyfire Diamond") {
-					return
+
+				if ppmm.Proc(sim, spell.ProcMask, "Thundering Skyfire Diamond") {
+					icd.Use(sim)
+					procAura.Activate(sim)
 				}
-				icd.Use(sim)
-				procAura.Activate(sim)
 			},
 		})
 	})
@@ -106,7 +106,7 @@ func init() {
 		agent.GetCharacter().MultiplyStat(stats.Intellect, 1.02)
 	})
 
-	// These are handled in character.go, but create empty effects so they are included in tests.
+	// These are handled in character.go, but create empty effects, so they are included in tests.
 	core.NewItemEffect(34220, func(_ core.Agent) {}) // Chaotic Skyfire Diamond
 	core.NewItemEffect(32409, func(_ core.Agent) {}) // Relentless Earthstorm Diamond
 

--- a/sim/common/wotlk/capacitors.go
+++ b/sim/common/wotlk/capacitors.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/wowsims/wotlk/sim/core"
-	//"github.com/wowsims/wotlk/sim/core/stats"
 )
 
 type CapacitorHandler func(*core.Simulation)

--- a/sim/common/wotlk/enchant_effects.go
+++ b/sim/common/wotlk/enchant_effects.go
@@ -17,10 +17,8 @@ func init() {
 
 	core.NewEnchantEffect(3251, func(agent core.Agent) {
 		character := agent.GetCharacter()
-		mh := character.Equip[proto.ItemSlot_ItemSlotMainHand].Enchant.EffectID == 3251
-		oh := character.Equip[proto.ItemSlot_ItemSlotOffHand].Enchant.EffectID == 3251
 
-		procMask := core.GetMeleeProcMaskForHands(mh, oh)
+		procMask := character.GetMeleeProcMaskForEnchant(3251)
 		ppmm := character.AutoAttacks.NewPPMManager(4.0, procMask)
 
 		procSpell := character.RegisterSpell(core.SpellConfig{
@@ -44,7 +42,7 @@ func init() {
 				aura.Activate(sim)
 			},
 			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+				if !result.Landed() {
 					return
 				}
 
@@ -63,9 +61,8 @@ func init() {
 
 	core.NewEnchantEffect(3239, func(agent core.Agent) {
 		character := agent.GetCharacter()
-		mh := character.Equip[proto.ItemSlot_ItemSlotMainHand].Enchant.EffectID == 3239
-		oh := character.Equip[proto.ItemSlot_ItemSlotOffHand].Enchant.EffectID == 3239
-		procMask := core.GetMeleeProcMaskForHands(mh, oh)
+
+		procMask := character.GetMeleeProcMaskForEnchant(3239)
 		ppmm := character.AutoAttacks.NewPPMManager(4.0, procMask)
 
 		procSpell := character.RegisterSpell(core.SpellConfig{
@@ -89,7 +86,7 @@ func init() {
 				aura.Activate(sim)
 			},
 			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+				if !result.Landed() {
 					return
 				}
 
@@ -169,10 +166,8 @@ func init() {
 
 	core.NewEnchantEffect(3789, func(agent core.Agent) {
 		character := agent.GetCharacter()
-		mh := character.Equip[proto.ItemSlot_ItemSlotMainHand].Enchant.EffectID == 3789
-		oh := character.Equip[proto.ItemSlot_ItemSlotOffHand].Enchant.EffectID == 3789
 
-		procMask := core.GetMeleeProcMaskForHands(mh, oh)
+		procMask := character.GetMeleeProcMaskForEnchant(3789)
 		ppmm := character.AutoAttacks.NewPPMManager(1.0, procMask)
 
 		// Modify only gear armor, including from agility
@@ -187,7 +182,7 @@ func init() {
 				aura.Activate(sim)
 			},
 			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+				if !result.Landed() {
 					return
 				}
 
@@ -207,9 +202,8 @@ func init() {
 	// TODO: These are stand-in values without any real reference.
 	core.NewEnchantEffect(3241, func(agent core.Agent) {
 		character := agent.GetCharacter()
-		mh := character.Equip[proto.ItemSlot_ItemSlotMainHand].Enchant.EffectID == 3241
-		oh := character.Equip[proto.ItemSlot_ItemSlotOffHand].Enchant.EffectID == 3241
-		procMask := core.GetMeleeProcMaskForHands(mh, oh)
+
+		procMask := character.GetMeleeProcMaskForEnchant(3241)
 		ppmm := character.AutoAttacks.NewPPMManager(3.0, procMask)
 
 		healthMetrics := character.NewHealthMetrics(core.ActionID{ItemID: 44494})
@@ -221,7 +215,7 @@ func init() {
 				aura.Activate(sim)
 			},
 			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+				if !result.Landed() {
 					return
 				}
 

--- a/sim/common/wotlk/other_effects.go
+++ b/sim/common/wotlk/other_effects.go
@@ -906,8 +906,8 @@ func init() {
 
 		core.NewItemEffect(itemID, func(agent core.Agent) {
 			character := agent.GetCharacter()
-			mh, oh := character.GetWeaponHands(itemID)
-			procMask := core.GetMeleeProcMaskForHands(mh, oh)
+
+			procMask := character.GetMeleeProcMaskForItem(itemID)
 			ppmm := character.AutoAttacks.NewPPMManager(2.0, procMask)
 
 			procActionID := core.ActionID{ItemID: itemID}
@@ -935,6 +935,7 @@ func init() {
 					if !result.Landed() {
 						return
 					}
+
 					if ppmm.Proc(sim, spell.ProcMask, name) {
 						proc.Cast(sim, result.Target)
 					}

--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -228,12 +228,12 @@ func JudgementOfWisdomAura(target *Unit) *Aura {
 			}
 
 			if spell.ProcMask.Matches(ProcMaskEmpty | ProcMaskProc | ProcMaskWeaponProc) {
-				return // Phantom spells (Romulo's, Lightning Capacitor, etc) don't proc JoW.
+				return // Phantom spells (Romulo's, Lightning Capacitor, etc.) don't proc JoW.
 			}
 
 			if spell.ProcMask.Matches(ProcMaskMeleeOrRanged) {
 				// Apparently ranged/melee can still proc on miss
-				if !unit.AutoAttacks.PPMProc(sim, 15, spell.ProcMask, "jow") {
+				if !unit.AutoAttacks.PPMProc(sim, 15, ProcMaskMeleeOrRanged, "jow", spell) {
 					return
 				}
 			} else { // spell casting
@@ -247,7 +247,7 @@ func JudgementOfWisdomAura(target *Unit) *Aura {
 					// Perhaps this is a bug introduced in classic when converting JoW to wotlk.
 					ct = 0.75
 				}
-				procChance := ct * 0.25 // ct / 60.0 * 15.0PPM (algabra) = ct*0.25
+				procChance := ct * 0.25 // ct / 60.0 * 15.0PPM (algebra) = ct*0.25
 				if sim.RandomFloat("jow") > procChance {
 					return
 				}

--- a/sim/core/flags.go
+++ b/sim/core/flags.go
@@ -1,11 +1,10 @@
 package core
 
 import (
-	"math/bits"
-	"strconv"
-
 	"github.com/wowsims/wotlk/sim/core/proto"
 	"github.com/wowsims/wotlk/sim/core/stats"
+	"math/bits"
+	"strconv"
 )
 
 type ProcMask uint32

--- a/sim/core/item_swaps.go
+++ b/sim/core/item_swaps.go
@@ -58,10 +58,7 @@ func (character *Character) RegisterOnItemSwap(callback OnSwapItem) {
 func (swap *ItemSwap) RegisterOnSwapItemForEffectWithPPMManager(effectID int32, ppm float64, ppmm *PPMManager, aura *Aura) {
 	character := swap.character
 	character.RegisterOnItemSwap(func(sim *Simulation) {
-		mh := character.Equip[proto.ItemSlot_ItemSlotMainHand].Enchant.EffectID == effectID
-		oh := character.Equip[proto.ItemSlot_ItemSlotOffHand].Enchant.EffectID == effectID
-
-		procMask := GetMeleeProcMaskForHands(mh, oh)
+		procMask := character.GetMeleeProcMaskForEnchant(effectID)
 		*ppmm = character.AutoAttacks.NewPPMManager(ppm, procMask)
 
 		if ppmm.Chance(procMask) == 0 {
@@ -77,10 +74,9 @@ func (swap *ItemSwap) RegisterOnSwapItemForEffectWithPPMManager(effectID int32, 
 func (swap *ItemSwap) RegisterOnSwapItemForEffect(effectID int32, aura *Aura) {
 	character := swap.character
 	character.RegisterOnItemSwap(func(sim *Simulation) {
-		mh := character.Equip[proto.ItemSlot_ItemSlotMainHand].Enchant.EffectID == effectID
-		oh := character.Equip[proto.ItemSlot_ItemSlotOffHand].Enchant.EffectID == effectID
+		procMask := character.GetMeleeProcMaskForEnchant(effectID)
 
-		if !mh && !oh {
+		if procMask == ProcMaskUnknown {
 			aura.Deactivate(sim)
 		} else {
 			aura.Activate(sim)

--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -152,13 +152,13 @@ func (sim *Simulation) labelRand(label string) Rand {
 		return sim.rand
 	}
 
-	labelRand, isPresent := sim.testRands[label]
-	if !isPresent {
-		// Add rseed to the label to we still have run-run variance for stat weights.
-		labelRand = NewSplitMix(uint64(makeTestRandSeed(sim.rseed, label)))
-		sim.testRands[label] = labelRand
+	labelRng, ok := sim.testRands[label]
+	if !ok {
+		// Add rseed to the label, so we still have run-run variance for stat weights.
+		labelRng = NewSplitMix(uint64(makeTestRandSeed(sim.rseed, label)))
+		sim.testRands[label] = labelRng
 	}
-	return labelRand
+	return labelRng
 }
 
 func (sim *Simulation) reseedRands(i int64) {
@@ -166,8 +166,8 @@ func (sim *Simulation) reseedRands(i int64) {
 	sim.rand.Seed(rseed)
 
 	if sim.isTest {
-		for label, rand := range sim.testRands {
-			rand.Seed(makeTestRandSeed(rseed, label))
+		for label, rng := range sim.testRands {
+			rng.Seed(makeTestRandSeed(rseed, label))
 		}
 	}
 }

--- a/sim/deathknight/blood_strike.go
+++ b/sim/deathknight/blood_strike.go
@@ -96,7 +96,7 @@ func (dk *Deathknight) registerDrwBloodStrikeSpell() {
 	dk.RuneWeapon.BloodStrike = dk.RuneWeapon.RegisterSpell(core.SpellConfig{
 		ActionID:    BloodStrikeActionID.WithTag(1),
 		SpellSchool: core.SpellSchoolPhysical,
-		ProcMask:    core.ProcMaskMeleeSpecial,
+		ProcMask:    core.ProcMaskMeleeMHSpecial,
 		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage,
 
 		BonusCritRating: (dk.subversionCritBonus() + dk.annihilationCritBonus()) * core.CritRatingPerCritChance,

--- a/sim/deathknight/death_strike.go
+++ b/sim/deathknight/death_strike.go
@@ -104,7 +104,7 @@ func (dk *Deathknight) registerDrwDeathStrikeSpell() {
 	dk.RuneWeapon.DeathStrike = dk.RuneWeapon.RegisterSpell(core.SpellConfig{
 		ActionID:    DeathStrikeActionID.WithTag(1),
 		SpellSchool: core.SpellSchoolPhysical,
-		ProcMask:    core.ProcMaskMeleeSpecial,
+		ProcMask:    core.ProcMaskMeleeMHSpecial,
 		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage,
 
 		BonusCritRating:  (dk.annihilationCritBonus() + dk.improvedDeathStrikeCritBonus()) * core.CritRatingPerCritChance,

--- a/sim/deathknight/heart_strike.go
+++ b/sim/deathknight/heart_strike.go
@@ -15,7 +15,7 @@ func (dk *Deathknight) newHeartStrikeSpell(isMainTarget bool, isDrw bool) *core.
 	conf := core.SpellConfig{
 		ActionID:    HeartStrikeActionID.WithTag(core.TernaryInt32(isMainTarget, 1, 2)),
 		SpellSchool: core.SpellSchoolPhysical,
-		ProcMask:    core.ProcMaskMeleeSpecial,
+		ProcMask:    core.ProcMaskMeleeMHSpecial,
 		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage,
 
 		RuneCost: core.RuneCostOptions{

--- a/sim/druid/talents.go
+++ b/sim/druid/talents.go
@@ -377,6 +377,9 @@ func (druid *Druid) applyOmenOfClarity() {
 
 	hasOocGlyph := druid.HasMajorGlyph(proto.DruidMajorGlyph_GlyphOfOmenOfClarity)
 
+	// Based on ingame testing by druid discord, subject to change or incorrectness
+	chanceToProcGotW := 1.0 - math.Pow(1.0-0.0875, float64(druid.RaidBuffTargets))
+
 	druid.RegisterAura(core.Aura{
 		Label:    "Omen of Clarity",
 		Duration: core.NeverExpires,
@@ -390,7 +393,7 @@ func (druid *Druid) applyOmenOfClarity() {
 				hurricaneCoeff := 1.0 - (7.0 / 9.0)
 				spellCoeff := hurricaneCoeff * curCastTickSpeed
 				chanceToProc := ((1.5 / 60) * 3.5) * spellCoeff
-				if sim.RandomFloat("Clearcasting") <= chanceToProc {
+				if sim.RandomFloat("Clearcasting") < chanceToProc {
 					druid.ProcOoc(sim)
 				}
 			}
@@ -399,9 +402,7 @@ func (druid *Druid) applyOmenOfClarity() {
 			if !result.Landed() {
 				return
 			}
-			// Not ideal to have new ppm manager here, but this needs to account for feral druid bear<->cat swaps
-			ppmm := druid.AutoAttacks.NewPPMManager(3.5, core.ProcMaskMeleeWhiteHit)
-			if ppmm.Proc(sim, spell.ProcMask, "Omen of Clarity") { // Melee
+			if druid.AutoAttacks.PPMProc(sim, 3.5, core.ProcMaskMeleeWhiteHit, "Omen of Clarity", spell) { // Melee
 				druid.ProcOoc(sim)
 			} else if spell.Flags.Matches(SpellFlagOmenTrigger) { // Spells
 				// Heavily based on comment here
@@ -420,7 +421,7 @@ func (druid *Druid) applyOmenOfClarity() {
 				} else {
 					chanceToProc *= 0.666
 				}
-				if sim.RandomFloat("Clearcasting") <= chanceToProc {
+				if sim.RandomFloat("Clearcasting") < chanceToProc {
 					druid.ProcOoc(sim)
 				}
 			}
@@ -430,9 +431,7 @@ func (druid *Druid) applyOmenOfClarity() {
 				druid.ProcOoc(sim)
 			}
 			if druid.GiftOfTheWild.IsEqual(spell) {
-				// Based on ingame testing by druid discord, subject to change or incorrectness
-				chanceToProc := 1.0 - math.Pow(1.0-0.0875, float64(druid.RaidBuffTargets))
-				if sim.RandomFloat("Clearcasting") <= chanceToProc {
+				if sim.RandomFloat("Clearcasting") < chanceToProcGotW {
 					druid.ProcOoc(sim)
 				}
 			}

--- a/sim/rogue/poisons.go
+++ b/sim/rogue/poisons.go
@@ -132,11 +132,19 @@ func (rogue *Rogue) procDeadlyPoison(sim *core.Simulation, spell *core.Spell, re
 	rogue.DeadlyPoison.Cast(sim, result.Target)
 }
 
-func (rogue *Rogue) applyDeadlyPoison() {
-	procMask := core.GetMeleeProcMaskForHands(
-		rogue.Options.MhImbue == proto.Rogue_Options_DeadlyPoison,
-		rogue.Options.OhImbue == proto.Rogue_Options_DeadlyPoison)
+func (rogue *Rogue) getPoisonProcMask(imbue proto.Rogue_Options_PoisonImbue) core.ProcMask {
+	var mask core.ProcMask
+	if rogue.Options.MhImbue == imbue {
+		mask |= core.ProcMaskMeleeMH
+	}
+	if rogue.Options.OhImbue == imbue {
+		mask |= core.ProcMaskMeleeOH
+	}
+	return mask
+}
 
+func (rogue *Rogue) applyDeadlyPoison() {
+	procMask := rogue.getPoisonProcMask(proto.Rogue_Options_DeadlyPoison)
 	if procMask == core.ProcMaskUnknown {
 		return
 	}
@@ -159,10 +167,7 @@ func (rogue *Rogue) applyDeadlyPoison() {
 }
 
 func (rogue *Rogue) applyWoundPoison() {
-	procMask := core.GetMeleeProcMaskForHands(
-		rogue.Options.MhImbue == proto.Rogue_Options_WoundPoison,
-		rogue.Options.OhImbue == proto.Rogue_Options_WoundPoison)
-
+	procMask := rogue.getPoisonProcMask(proto.Rogue_Options_WoundPoison)
 	if procMask == core.ProcMaskUnknown {
 		return
 	}
@@ -180,6 +185,7 @@ func (rogue *Rogue) applyWoundPoison() {
 			if !result.Landed() {
 				return
 			}
+
 			if rogue.woundPoisonPPMM.Proc(sim, spell.ProcMask, "Wound Poison") {
 				rogue.WoundPoison[NormalProc].Cast(sim, result.Target)
 			}
@@ -295,10 +301,7 @@ func (rogue *Rogue) GetDeadlyPoisonProcChance() float64 {
 }
 
 func (rogue *Rogue) UpdateInstantPoisonPPM(bonusChance float64) {
-	procMask := core.GetMeleeProcMaskForHands(
-		rogue.Options.MhImbue == proto.Rogue_Options_InstantPoison,
-		rogue.Options.OhImbue == proto.Rogue_Options_InstantPoison)
-
+	procMask := rogue.getPoisonProcMask(proto.Rogue_Options_InstantPoison)
 	if procMask == core.ProcMaskUnknown {
 		return
 	}
@@ -310,10 +313,7 @@ func (rogue *Rogue) UpdateInstantPoisonPPM(bonusChance float64) {
 }
 
 func (rogue *Rogue) applyInstantPoison() {
-	procMask := core.GetMeleeProcMaskForHands(
-		rogue.Options.MhImbue == proto.Rogue_Options_InstantPoison,
-		rogue.Options.OhImbue == proto.Rogue_Options_InstantPoison)
-
+	procMask := rogue.getPoisonProcMask(proto.Rogue_Options_InstantPoison)
 	if procMask == core.ProcMaskUnknown {
 		return
 	}
@@ -330,6 +330,7 @@ func (rogue *Rogue) applyInstantPoison() {
 			if !result.Landed() {
 				return
 			}
+
 			if rogue.instantPoisonPPMM.Proc(sim, spell.ProcMask, "Instant Poison") {
 				rogue.InstantPoison[NormalProc].Cast(sim, result.Target)
 			}

--- a/sim/shaman/shamanistic_rage.go
+++ b/sim/shaman/shamanistic_rage.go
@@ -37,15 +37,14 @@ func (shaman *Shaman) registerShamanisticRageCD() {
 			}
 		},
 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-			// proc mask: 20
-			if !result.Landed() || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+			if !result.Landed() {
 				return
 			}
-			if !ppmm.Proc(sim, spell.ProcMask, "shamanistic rage") {
-				return
+
+			if ppmm.Proc(sim, spell.ProcMask, "shamanistic rage") {
+				mana := aura.Unit.GetStat(stats.AttackPower) * 0.15
+				aura.Unit.AddMana(sim, mana, manaMetrics)
 			}
-			mana := aura.Unit.GetStat(stats.AttackPower) * 0.15
-			aura.Unit.AddMana(sim, mana, manaMetrics)
 		},
 	})
 

--- a/sim/shaman/talents.go
+++ b/sim/shaman/talents.go
@@ -440,14 +440,14 @@ func (shaman *Shaman) applyMaelstromWeapon() {
 			aura.Activate(sim)
 		},
 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-			if !spell.ProcMask.Matches(core.ProcMaskMelee) || !result.Landed() {
+			if !result.Landed() {
 				return
 			}
-			if !ppmm.Proc(sim, spell.ProcMask, "Maelstrom Weapon") {
-				return
+
+			if ppmm.Proc(sim, spell.ProcMask, "Maelstrom Weapon") {
+				shaman.MaelstromWeaponAura.Activate(sim)
+				shaman.MaelstromWeaponAura.AddStack(sim)
 			}
-			shaman.MaelstromWeaponAura.Activate(sim)
-			shaman.MaelstromWeaponAura.AddStack(sim)
 		},
 	})
 }

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -480,7 +480,8 @@ func (warrior *Warrior) applyUnbridledWrath() {
 		return
 	}
 
-	ppmm := warrior.AutoAttacks.NewPPMManager(3*float64(warrior.Talents.UnbridledWrath), core.ProcMaskMelee)
+	ppmm := warrior.AutoAttacks.NewPPMManager(3*float64(warrior.Talents.UnbridledWrath), core.ProcMaskMeleeWhiteHit)
+
 	rageMetrics := warrior.NewRageMetrics(core.ActionID{SpellID: 13002})
 
 	warrior.RegisterAura(core.Aura{
@@ -494,15 +495,9 @@ func (warrior *Warrior) applyUnbridledWrath() {
 				return
 			}
 
-			if !spell.ProcMask.Matches(core.ProcMaskMeleeWhiteHit) {
-				return
+			if ppmm.Proc(sim, spell.ProcMask, "Unbrided Wrath") {
+				warrior.AddRage(sim, 1, rageMetrics)
 			}
-
-			if !ppmm.Proc(sim, spell.ProcMask, "Unbrided Wrath") {
-				return
-			}
-
-			warrior.AddRage(sim, 1, rageMetrics)
 		},
 	})
 }


### PR DESCRIPTION
[core] add specialized GetMeleeProcMaskForItem() and GetMeleeProcMaskForEnchant() methods, to simplify the typical use cases (GetWeaponHands() has been removed, and most usages of GetMeleeProcMaskForHands() outside of shaman imbues have been replaced)

[core] improve PPMManager to do less procMask matching 

[all] related changes, including cleanup of PPMManager usages 

[druid] OOC auto attack handling has been specialized, to prevent repetitive setup work for nearly every spell hit