### PR TITLE
fix JoW proc rate on specials

### DIFF
--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -231,9 +231,9 @@ func JudgementOfWisdomAura(target *Unit) *Aura {
 				return // Phantom spells (Romulo's, Lightning Capacitor, etc.) don't proc JoW.
 			}
 
-			if spell.ProcMask.Matches(ProcMaskMeleeOrRanged) {
+			if spell.ProcMask.Matches(ProcMaskWhiteHit) {
 				// Apparently ranged/melee can still proc on miss
-				if !unit.AutoAttacks.PPMProc(sim, 15, ProcMaskMeleeOrRanged, "jow", spell) {
+				if !unit.AutoAttacks.PPMProc(sim, 15, ProcMaskWhiteHit, "jow", spell) {
 					return
 				}
 			} else { // spell casting

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -534,7 +534,7 @@ dps_results: {
  key: "TestFeral-AllItems-LasherweaveRegalia"
  value: {
   dps: 6189.59339
-  tps: 4504.17136
+  tps: 4504.3793
  }
 }
 dps_results: {
@@ -562,7 +562,7 @@ dps_results: {
  key: "TestFeral-AllItems-Malfurion'sRegalia"
  value: {
   dps: 5832.47798
-  tps: 4242.04856
+  tps: 4241.66685
  }
 }
 dps_results: {
@@ -1017,21 +1017,21 @@ dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Flower-Aoe-FullBuffs-LongMultiTarget"
  value: {
   dps: 22992.33137
-  tps: 16645.5556
+  tps: 16642.91976
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Flower-Aoe-FullBuffs-LongSingleTarget"
  value: {
   dps: 4749.28634
-  tps: 3450.72612
+  tps: 3450.62913
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P1-Flower-Aoe-FullBuffs-ShortSingleTarget"
  value: {
   dps: 5674.76106
-  tps: 4093.28701
+  tps: 4093.24023
  }
 }
 dps_results: {
@@ -1143,21 +1143,21 @@ dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Flower-Aoe-FullBuffs-LongMultiTarget"
  value: {
   dps: 31448.6377
-  tps: 22628.51999
+  tps: 22626.21798
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Flower-Aoe-FullBuffs-LongSingleTarget"
  value: {
   dps: 6340.54825
-  tps: 4579.07443
+  tps: 4579.03905
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-P2-Flower-Aoe-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7566.49644
-  tps: 5436.30673
+  tps: 5436.16938
  }
 }
 dps_results: {

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -274,7 +274,7 @@ dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerGarb"
  value: {
   dps: 2114.05411
-  tps: 4515.38985
+  tps: 4515.36564
   dtps: 6.91076
  }
 }
@@ -418,7 +418,7 @@ dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sWildhide"
  value: {
   dps: 2086.96108
-  tps: 4439.62262
+  tps: 4439.92105
   dtps: 7.20775
  }
 }
@@ -595,7 +595,7 @@ dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveRegalia"
  value: {
   dps: 2286.14727
-  tps: 4914.27981
+  tps: 4914.44434
   dtps: 7.20775
  }
 }
@@ -627,7 +627,7 @@ dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sRegalia"
  value: {
   dps: 2132.96209
-  tps: 4575.94641
+  tps: 4576.98525
   dtps: 6.91076
  }
 }
@@ -659,7 +659,7 @@ dps_results: {
  key: "TestFeralTank-AllItems-NightsongGarb"
  value: {
   dps: 2082.14878
-  tps: 4470.70539
+  tps: 4470.9721
   dtps: 6.66421
  }
 }
@@ -931,7 +931,7 @@ dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartRegalia"
  value: {
   dps: 1830.17431
-  tps: 3923.22412
+  tps: 3923.21265
   dtps: 6.66421
  }
 }

--- a/sim/hunter/TestAPL.results
+++ b/sim/hunter/TestAPL.results
@@ -47,834 +47,834 @@ dps_results: {
  key: "TestAPL-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
   dps: 6808.96356
-  tps: 5951.29213
+  tps: 5940.81132
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 6401.74174
-  tps: 5509.96006
+  dps: 6400.93941
+  tps: 5497.70253
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-AustereEarthsiegeDiamond"
  value: {
   dps: 6476.17822
-  tps: 5569.54307
+  tps: 5558.13642
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6518.60324
-  tps: 5621.44772
+  dps: 6517.72253
+  tps: 5609.11181
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-BeamingEarthsiegeDiamond"
  value: {
   dps: 6483.47273
-  tps: 5579.41989
+  tps: 5568.1118
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6412.07598
-  tps: 5511.95099
+  dps: 6383.80949
+  tps: 5471.99585
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-BlackBowoftheBetrayer-32336"
  value: {
   dps: 6169.18928
-  tps: 5271.16095
+  tps: 5260.05717
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-BlackBruise-50035"
  value: {
   dps: 6264.09343
-  tps: 5375.25876
+  tps: 5364.34267
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-BlackBruise-50692"
  value: {
   dps: 6255.47539
-  tps: 5366.93658
+  tps: 5356.02048
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5397.75217
-  tps: 4647.25566
+  dps: 5100.48952
+  tps: 4335.62355
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5167.24821
-  tps: 4433.22141
+  dps: 4903.80766
+  tps: 4156.56856
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-BracingEarthsiegeDiamond"
  value: {
   dps: 6468.08722
-  tps: 5454.02341
+  tps: 5442.61677
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
   dps: 6673.52612
-  tps: 5754.67868
+  tps: 5743.29278
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
   dps: 6676.61671
-  tps: 5756.78631
+  tps: 5745.40041
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-ChaoticSkyflareDiamond"
  value: {
   dps: 6617.22867
-  tps: 5713.22885
+  tps: 5701.84443
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6417.32613
-  tps: 5510.75727
+  dps: 6416.51622
+  tps: 5498.49215
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 5958.17752
-  tps: 5113.53204
+  dps: 5925.87289
+  tps: 5068.90968
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
   dps: 6441.01333
-  tps: 5552.1386
+  tps: 5540.72083
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-DarkmoonCard:Death-42990"
  value: {
   dps: 6494.8915
-  tps: 5605.8839
+  tps: 5594.45323
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-DarkmoonCard:Greatness-44255"
  value: {
   dps: 6555.82137
-  tps: 5654.14177
+  tps: 5643.05951
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6752.04761
-  tps: 5835.02878
+  dps: 6746.73243
+  tps: 5818.28521
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-DeathKnight'sAnguish-38212"
  value: {
   dps: 6415.33902
-  tps: 5526.30693
+  tps: 5514.86713
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6664.48865
-  tps: 5762.28514
+  dps: 6663.69575
+  tps: 5750.11125
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Deathbringer'sWill-50363"
  value: {
   dps: 6709.66421
-  tps: 5807.375
+  tps: 5795.98819
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-DestructiveSkyflareDiamond"
  value: {
   dps: 6486.92446
-  tps: 5582.94647
+  tps: 5571.56205
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6492.46346
-  tps: 5599.06894
+  dps: 6480.59362
+  tps: 5575.33268
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6496.96236
-  tps: 5605.15102
+  dps: 6493.73559
+  tps: 5590.21664
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-EffulgentSkyflareDiamond"
  value: {
   dps: 6476.17822
-  tps: 5569.54307
+  tps: 5558.13642
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-EmberSkyflareDiamond"
  value: {
   dps: 6474.21918
-  tps: 5569.58931
+  tps: 5558.23911
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-EnigmaticSkyflareDiamond"
  value: {
   dps: 6483.47273
-  tps: 5579.47291
+  tps: 5568.08849
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-EnigmaticStarflareDiamond"
  value: {
   dps: 6481.67889
-  tps: 5577.6608
+  tps: 5566.2749
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6387.61846
-  tps: 5490.6013
+  dps: 6386.81244
+  tps: 5478.34007
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-EternalEarthsiegeDiamond"
  value: {
   dps: 6468.08722
-  tps: 5564.07329
+  tps: 5552.66665
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-ExtractofNecromanticPower-40373"
  value: {
   dps: 6498.29719
-  tps: 5609.50298
+  tps: 5598.08072
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-EyeoftheBroodmother-45308"
  value: {
   dps: 6430.97762
-  tps: 5542.04377
+  tps: 5530.6131
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Figurine-SapphireOwl-42413"
  value: {
   dps: 6383.62204
-  tps: 5493.26651
+  tps: 5481.98974
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-ForgeEmber-37660"
  value: {
   dps: 6414.1501
-  tps: 5525.06258
+  tps: 5513.62774
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-ForlornSkyflareDiamond"
  value: {
   dps: 6468.08722
-  tps: 5564.07329
+  tps: 5552.66665
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-ForlornStarflareDiamond"
  value: {
   dps: 6468.08722
-  tps: 5564.07329
+  tps: 5552.66665
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6519.7946
-  tps: 5616.93491
+  dps: 6518.96295
+  tps: 5604.64805
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Gladiator'sPursuit"
  value: {
   dps: 6386.84952
-  tps: 5523.64032
+  tps: 5513.15017
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-GnomishLightningGenerator-41121"
  value: {
   dps: 6423.97327
-  tps: 5534.96926
+  tps: 5523.53858
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 4796.96914
-  tps: 4082.44498
+  dps: 4457.0225
+  tps: 3729.89326
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Heartpierce-49982"
  value: {
   dps: 6699.39813
-  tps: 5783.51782
+  tps: 5772.13192
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Heartpierce-50641"
  value: {
   dps: 6702.78202
-  tps: 5786.06624
+  tps: 5774.68034
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-ImpassiveSkyflareDiamond"
  value: {
   dps: 6483.47273
-  tps: 5579.47291
+  tps: 5568.08849
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-ImpassiveStarflareDiamond"
  value: {
   dps: 6481.67889
-  tps: 5577.6608
+  tps: 5566.2749
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6436.91893
-  tps: 5541.7171
+  dps: 6436.10305
+  tps: 5529.44601
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-InsightfulEarthsiegeDiamond"
  value: {
   dps: 6480.09946
-  tps: 5580.68007
+  tps: 5570.44222
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
   dps: 6491.23677
-  tps: 5585.16956
+  tps: 5573.75907
   hps: 12.04564
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6467.32008
-  tps: 5576.5126
+  dps: 6467.99212
+  tps: 5566.02135
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-PersistentEarthshatterDiamond"
  value: {
   dps: 6485.76758
-  tps: 5580.0833
+  tps: 5568.67666
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-PersistentEarthsiegeDiamond"
  value: {
   dps: 6489.92766
-  tps: 5583.85037
+  tps: 5572.44372
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-PowerfulEarthshatterDiamond"
  value: {
   dps: 6474.66115
-  tps: 5568.51748
+  tps: 5557.11084
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-PowerfulEarthsiegeDiamond"
  value: {
   dps: 6476.17822
-  tps: 5569.54307
+  tps: 5558.13642
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-RelentlessEarthsiegeDiamond"
  value: {
   dps: 6632.06067
-  tps: 5726.40128
+  tps: 5715.01538
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-RevitalizingSkyflareDiamond"
  value: {
   dps: 6468.08722
-  tps: 5563.83841
+  tps: 5552.54101
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-ScourgestalkerBattlegear"
  value: {
   dps: 6383.20425
-  tps: 5520.39543
+  tps: 5509.1445
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Shadowmourne-49623"
  value: {
   dps: 6845.52927
-  tps: 5924.22606
+  tps: 5912.86896
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6417.32613
-  tps: 5510.75727
+  dps: 6416.51622
+  tps: 5498.49215
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-SouloftheDead-40382"
  value: {
   dps: 6433.21824
-  tps: 5544.32328
+  tps: 5532.90102
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-SparkofLife-37657"
  value: {
   dps: 6399.70067
-  tps: 5504.1737
+  tps: 5492.93059
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-StormshroudArmor"
  value: {
-  dps: 5085.74265
-  tps: 4364.52879
+  dps: 4595.74927
+  tps: 3859.80635
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-SwiftSkyflareDiamond"
  value: {
   dps: 6489.92766
-  tps: 5583.85037
+  tps: 5572.44372
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-SwiftStarflareDiamond"
  value: {
   dps: 6485.76758
-  tps: 5580.0833
+  tps: 5568.67666
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-SwiftWindfireDiamond"
  value: {
   dps: 6478.48743
-  tps: 5573.49095
+  tps: 5562.0843
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-TearsoftheVanquished-47215"
  value: {
   dps: 6407.80982
-  tps: 5515.07346
+  tps: 5503.9439
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-TheFistsofFury"
  value: {
   dps: 6301.46857
-  tps: 5410.93312
+  tps: 5400.03745
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-TheTwinBladesofAzzinoth"
  value: {
   dps: 6412.39172
-  tps: 5522.21184
+  tps: 5511.33992
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-ThunderingSkyflareDiamond"
  value: {
   dps: 6479.42874
-  tps: 5575.04073
+  tps: 5563.90938
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-TirelessSkyflareDiamond"
  value: {
   dps: 6468.08722
-  tps: 5564.07329
+  tps: 5552.66665
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-TirelessStarflareDiamond"
  value: {
   dps: 6468.08722
-  tps: 5564.07329
+  tps: 5552.66665
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-TrenchantEarthshatterDiamond"
  value: {
   dps: 6468.08722
-  tps: 5564.07329
+  tps: 5552.66665
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-TrenchantEarthsiegeDiamond"
  value: {
   dps: 6468.08722
-  tps: 5564.07329
+  tps: 5552.66665
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5385.9469
-  tps: 4633.38774
+  dps: 4847.72402
+  tps: 4083.25816
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
   dps: 6308.03184
-  tps: 5425.2498
+  tps: 5414.35459
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Windrunner'sPursuit"
  value: {
   dps: 6528.29134
-  tps: 5645.75948
+  tps: 5634.97995
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6359.43426
-  tps: 5471.47896
+  dps: 6358.63193
+  tps: 5459.22143
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
   dps: 6854.85389
-  tps: 5947.56465
+  tps: 5937.3236
  }
 }
 dps_results: {
  key: "TestAPL-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
   dps: 7002.34181
-  tps: 6090.21221
+  tps: 6079.44148
  }
 }
 dps_results: {
  key: "TestAPL-Average-Default"
  value: {
-  dps: 6602.97134
-  tps: 5696.02201
+  dps: 6601.78516
+  tps: 5683.65531
  }
 }
 dps_results: {
  key: "TestAPL-Settings-Dwarf-P1-SV-FullBuffs-LongMultiTarget"
  value: {
   dps: 7814.03408
-  tps: 8183.20283
+  tps: 7967.19338
  }
 }
 dps_results: {
  key: "TestAPL-Settings-Dwarf-P1-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7172.39789
-  tps: 6180.43806
+  dps: 7166.09758
+  tps: 6163.94485
  }
 }
 dps_results: {
  key: "TestAPL-Settings-Dwarf-P1-SV-FullBuffs-ShortSingleTarget"
  value: {
   dps: 8033.57756
-  tps: 6884.92977
+  tps: 6880.54212
  }
 }
 dps_results: {
@@ -902,21 +902,21 @@ dps_results: {
  key: "TestAPL-Settings-Orc-P1-SV-FullBuffs-LongMultiTarget"
  value: {
   dps: 7859.12519
-  tps: 8163.96818
+  tps: 7947.67323
  }
 }
 dps_results: {
  key: "TestAPL-Settings-Orc-P1-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7204.8402
-  tps: 6157.44416
+  dps: 7196.52123
+  tps: 6139.01664
  }
 }
 dps_results: {
  key: "TestAPL-Settings-Orc-P1-SV-FullBuffs-ShortSingleTarget"
  value: {
   dps: 8109.76009
-  tps: 6893.60828
+  tps: 6889.25748
  }
 }
 dps_results: {
@@ -944,6 +944,6 @@ dps_results: {
  key: "TestAPL-SwitchInFrontOfTarget-Default"
  value: {
   dps: 6515.44339
-  tps: 5676.43692
+  tps: 5665.13261
  }
 }

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -46,838 +46,838 @@ character_stats_results: {
 dps_results: {
  key: "TestBM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 6427.83511
-  tps: 4454.43226
+  dps: 6289.15885
+  tps: 4308.25268
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 6176.62285
-  tps: 4082.63865
+  dps: 6013.33251
+  tps: 3916.28169
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6184.71543
-  tps: 4085.51689
+  dps: 6018.30264
+  tps: 3914.41726
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6268.20595
-  tps: 4166.02461
+  dps: 6103.3311
+  tps: 3998.18072
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6114.96774
-  tps: 4037.80642
+  dps: 5954.57077
+  tps: 3874.41322
   hps: 90.67931
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6114.96774
-  tps: 4037.80642
+  dps: 5954.57077
+  tps: 3874.41322
   hps: 90.67931
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6207.55667
-  tps: 4112.54604
+  dps: 6043.31036
+  tps: 3943.52773
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6073.12921
-  tps: 4007.36749
+  dps: 5948.2966
+  tps: 3874.54605
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 5773.96796
-  tps: 3677.18945
+  dps: 5635.45134
+  tps: 3532.45433
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBruise-50035"
  value: {
-  dps: 5973.43527
-  tps: 3916.47479
+  dps: 5836.57668
+  tps: 3778.63952
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBruise-50692"
  value: {
-  dps: 5963.48312
-  tps: 3909.2779
+  dps: 5826.84882
+  tps: 3771.66206
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5165.85118
-  tps: 3408.02377
+  dps: 5063.88203
+  tps: 3303.06664
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5003.05012
-  tps: 3275.27206
+  dps: 4904.21464
+  tps: 3180.23063
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6184.71543
-  tps: 4004.85573
+  dps: 6018.30264
+  tps: 3837.05117
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6290.12282
-  tps: 4191.58177
+  dps: 6119.50581
+  tps: 4014.44038
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6290.12282
-  tps: 4191.58177
+  dps: 6119.50581
+  tps: 4014.44038
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6282.3581
-  tps: 4187.06194
+  dps: 6110.40088
+  tps: 4009.8334
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
   hps: 64
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 5724.96689
-  tps: 3750.24608
+  dps: 5574.59728
+  tps: 3596.11105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6189.71159
-  tps: 4104.63477
+  dps: 6021.59411
+  tps: 3931.35246
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6233.32539
-  tps: 4153.91943
+  dps: 6061.37473
+  tps: 3975.83689
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6256.8969
-  tps: 4148.4603
+  dps: 6112.54156
+  tps: 3994.30881
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6405.85902
-  tps: 4273.07231
+  dps: 6230.09303
+  tps: 4091.48853
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6164.56005
-  tps: 4088.87166
+  dps: 5990.43715
+  tps: 3908.30346
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6450.26142
-  tps: 4332.42675
+  dps: 6276.7373
+  tps: 4156.58339
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6489.03805
-  tps: 4368.83264
+  dps: 6320.7523
+  tps: 4199.12766
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6206.46727
-  tps: 4110.98241
+  dps: 6037.14439
+  tps: 3936.67176
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6175.59917
-  tps: 4094.39889
+  dps: 6033.36763
+  tps: 3947.45482
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6165.62392
-  tps: 4089.44043
+  dps: 6012.44704
+  tps: 3928.25775
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6184.71543
-  tps: 4085.51689
+  dps: 6018.30264
+  tps: 3914.41726
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6194.55644
-  tps: 4093.93956
+  dps: 6034.79247
+  tps: 3931.07758
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6201.59133
-  tps: 4106.29517
+  dps: 6033.38405
+  tps: 3932.81657
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6200.57794
-  tps: 4104.87197
+  dps: 6033.42977
+  tps: 3931.39224
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6141.61188
-  tps: 4068.97181
+  dps: 5987.60476
+  tps: 3911.03764
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6184.71543
-  tps: 4085.51689
+  dps: 6018.30264
+  tps: 3914.41726
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6214.14931
-  tps: 4127.96594
+  dps: 6046.44498
+  tps: 3953.1694
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6176.85953
-  tps: 4094.73898
+  dps: 6010.76287
+  tps: 3922.37708
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6145.565
-  tps: 4063.07348
+  dps: 5991.18193
+  tps: 3900.20575
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6163.33187
-  tps: 4079.3152
+  dps: 5993.00141
+  tps: 3904.35789
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6184.71543
-  tps: 4085.51689
+  dps: 6018.30264
+  tps: 3914.41726
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6184.71543
-  tps: 4085.51689
+  dps: 6018.30264
+  tps: 3914.41726
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6264.49484
-  tps: 4146.59915
+  dps: 6100.02329
+  tps: 3979.13235
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 6008.7563
-  tps: 4088.30919
+  dps: 5893.99104
+  tps: 3967.01551
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6210.24133
-  tps: 4130.8174
+  dps: 6038.5368
+  tps: 3952.87081
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 4826.14368
-  tps: 3131.17758
+  dps: 4756.58378
+  tps: 3065.97332
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Heartpierce-49982"
  value: {
-  dps: 6335.4672
-  tps: 4224.74137
+  dps: 6163.57267
+  tps: 4046.31694
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Heartpierce-50641"
  value: {
-  dps: 6336.44235
-  tps: 4225.45448
+  dps: 6164.52034
+  tps: 4047.00246
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6201.59133
-  tps: 4106.29517
+  dps: 6033.38405
+  tps: 3932.81657
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6200.57794
-  tps: 4104.87197
+  dps: 6033.42977
+  tps: 3931.39224
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6256.25852
-  tps: 4159.7254
+  dps: 6093.3987
+  tps: 3993.85308
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6213.26049
-  tps: 4117.14817
+  dps: 6137.15196
+  tps: 4029.29459
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6205.79548
-  tps: 4101.14392
-  hps: 11.18675
+  dps: 6040.95529
+  tps: 3931.80282
+  hps: 11.11315
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5955.64928
+  tps: 3875.55625
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6197.49592
-  tps: 4111.96765
+  dps: 6050.02378
+  tps: 3957.81464
  }
 }
 dps_results: {
  key: "TestBM-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6223.42565
-  tps: 4140.76577
+  dps: 6056.98168
+  tps: 3969.17019
  }
 }
 dps_results: {
  key: "TestBM-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6201.01053
-  tps: 4097.35008
+  dps: 6034.15004
+  tps: 3925.80431
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6204.84467
-  tps: 4100.13436
+  dps: 6037.87884
+  tps: 3928.48361
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6184.71543
-  tps: 4085.51689
+  dps: 6018.30264
+  tps: 3914.41726
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6184.71543
-  tps: 4085.51689
+  dps: 6018.30264
+  tps: 3914.41726
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6290.12282
-  tps: 4191.58177
+  dps: 6119.50581
+  tps: 4014.44038
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6189.6095
-  tps: 4090.06442
+  dps: 6028.7662
+  tps: 3925.58533
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 6155.34266
-  tps: 4108.25542
+  dps: 5993.17377
+  tps: 3938.18967
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6490.64836
-  tps: 4382.99794
+  dps: 6319.36292
+  tps: 4207.49554
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6130.44446
-  tps: 4057.98567
+  dps: 6027.91516
+  tps: 3950.39114
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6131.69948
-  tps: 4059.75957
+  dps: 6045.31987
+  tps: 3968.12579
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6182.25922
-  tps: 4096.24964
+  dps: 6015.75554
+  tps: 3922.61817
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SparkofLife-37657"
  value: {
-  dps: 6141.09671
-  tps: 4059.43003
+  dps: 6009.9718
+  tps: 3920.54219
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6239.05792
-  tps: 4100.36723
+  dps: 6087.76439
+  tps: 3951.14658
  }
 }
 dps_results: {
  key: "TestBM-AllItems-StormshroudArmor"
  value: {
-  dps: 4862.88001
-  tps: 3143.27306
+  dps: 4776.32154
+  tps: 3064.94434
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6204.84467
-  tps: 4100.13436
+  dps: 6037.87884
+  tps: 3928.48361
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6201.01053
-  tps: 4097.35008
+  dps: 6034.15004
+  tps: 3925.80431
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6194.30078
-  tps: 4092.47759
+  dps: 6027.62464
+  tps: 3921.11552
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5955.70357
+  tps: 3875.59373
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6172.79534
-  tps: 4083.02976
+  dps: 6024.84801
+  tps: 3930.41535
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheFistsofFury"
  value: {
-  dps: 6000.88874
-  tps: 3939.20632
+  dps: 5858.35494
+  tps: 3795.21922
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6148.22638
-  tps: 4063.55567
+  dps: 5992.72572
+  tps: 3907.82906
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6209.14333
-  tps: 4093.13484
+  dps: 6060.69042
+  tps: 3941.6107
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6159.18879
-  tps: 4043.10793
+  dps: 6008.36454
+  tps: 3894.29994
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6159.18879
-  tps: 4043.10793
+  dps: 6008.36454
+  tps: 3894.29994
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6184.71543
-  tps: 4085.51689
+  dps: 6018.30264
+  tps: 3914.41726
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6184.71543
-  tps: 4085.51689
+  dps: 6018.30264
+  tps: 3914.41726
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6150.92755
-  tps: 4070.33485
+  dps: 5999.31922
+  tps: 3905.99542
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6184.71543
-  tps: 4085.51689
+  dps: 6018.30264
+  tps: 3914.41726
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6184.71543
-  tps: 4085.51689
+  dps: 6018.30264
+  tps: 3914.41726
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5093.03954
-  tps: 3342.09472
+  dps: 4997.39399
+  tps: 3258.96126
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6074.44289
-  tps: 4016.31925
+  dps: 5922.08049
+  tps: 3855.89806
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 6263.63289
-  tps: 4210.72724
+  dps: 6108.62106
+  tps: 4048.46853
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6114.88893
-  tps: 4037.80642
+  dps: 5954.52307
+  tps: 3874.41322
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 6677.04673
-  tps: 4581.512
+  dps: 6509.98615
+  tps: 4405.70847
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 6892.84512
-  tps: 4805.2683
+  dps: 6722.56673
+  tps: 4627.94173
  }
 }
 dps_results: {
  key: "TestBM-Average-Default"
  value: {
-  dps: 6222.17357
-  tps: 4122.20296
+  dps: 6093.34683
+  tps: 3988.18902
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-P1-BM-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6842.37401
-  tps: 5848.8431
+  dps: 6673.38477
+  tps: 5561.87478
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-P1-BM-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6195.42887
-  tps: 4196.10237
+  dps: 6027.96902
+  tps: 4025.93106
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-P1-BM-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7407.42134
-  tps: 4938.12938
+  tps: 4933.51533
  }
 }
 dps_results: {
@@ -904,22 +904,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Settings-Orc-P1-BM-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6947.41448
-  tps: 5842.17172
+  dps: 6765.39492
+  tps: 5535.75914
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-P1-BM-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6290.12282
-  tps: 4191.58177
+  dps: 6119.50581
+  tps: 4014.44038
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-P1-BM-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7571.73865
-  tps: 4959.42206
+  tps: 4954.80856
  }
 }
 dps_results: {
@@ -946,7 +946,7 @@ dps_results: {
 dps_results: {
  key: "TestBM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6120.42139
-  tps: 4169.34514
+  dps: 5971.22761
+  tps: 4015.66645
  }
 }

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -46,838 +46,838 @@ character_stats_results: {
 dps_results: {
  key: "TestMM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 7561.22937
-  tps: 6654.01049
+  dps: 7542.24617
+  tps: 6622.65797
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 6901.06561
-  tps: 5979.54251
+  dps: 6769.29502
+  tps: 5835.20332
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6908.98067
-  tps: 5984.88425
+  dps: 6778.00168
+  tps: 5841.91728
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6994.2196
-  tps: 6068.37442
+  dps: 6863.75458
+  tps: 5925.33872
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6833.71418
-  tps: 5918.52842
-  hps: 90.0153
+  dps: 6705.0721
+  tps: 5777.26497
+  hps: 89.9503
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6833.71418
-  tps: 5918.52842
-  hps: 90.0153
+  dps: 6705.0721
+  tps: 5777.26497
+  hps: 89.9503
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6946.25469
-  tps: 6020.30942
+  dps: 6828.46745
+  tps: 5890.56906
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6918.75424
-  tps: 6004.4521
+  dps: 6754.00383
+  tps: 5826.91136
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 6390.91304
-  tps: 5470.61625
+  dps: 6378.914
+  tps: 5445.43551
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50035"
  value: {
-  dps: 6747.66464
-  tps: 5827.95088
+  dps: 6638.06662
+  tps: 5705.90008
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50692"
  value: {
-  dps: 6735.60231
-  tps: 5817.09781
+  dps: 6626.1837
+  tps: 5695.22665
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6020.63295
-  tps: 5218.57211
+  dps: 5832.55519
+  tps: 5020.48129
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5773.99482
-  tps: 4988.23346
+  dps: 5621.14902
+  tps: 4824.90401
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6908.98067
-  tps: 5866.30386
+  dps: 6778.00168
+  tps: 5725.94077
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7098.24364
-  tps: 6170.99145
+  dps: 6958.47732
+  tps: 6019.91613
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7098.24364
-  tps: 6170.99145
+  dps: 6958.47732
+  tps: 6019.91613
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7090.77387
-  tps: 6164.88728
+  dps: 6950.25412
+  tps: 6013.05666
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
   hps: 64
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 6512.87251
-  tps: 5613.09208
+  dps: 6391.46644
+  tps: 5478.24585
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6945.20062
-  tps: 6029.7055
+  dps: 6809.64477
+  tps: 5882.74022
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6998.2345
-  tps: 6081.32264
+  dps: 6854.23224
+  tps: 5925.477
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7017.05857
-  tps: 6090.42281
+  dps: 6996.94022
+  tps: 6057.02939
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7240.72502
-  tps: 6298.92587
+  dps: 7102.0351
+  tps: 6147.774
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6928.67207
-  tps: 6013.01333
+  dps: 6786.03174
+  tps: 5858.34172
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7232.52585
-  tps: 6306.49171
+  dps: 7097.93846
+  tps: 6159.78987
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7287.65825
-  tps: 6360.16653
+  dps: 7154.07043
+  tps: 6214.58969
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6949.74555
-  tps: 6023.85895
+  dps: 6813.20672
+  tps: 5876.00926
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6991.77533
-  tps: 6070.11141
+  dps: 6866.27779
+  tps: 5933.55766
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6978.30687
-  tps: 6057.81278
+  dps: 6853.98621
+  tps: 5921.89252
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6908.98067
-  tps: 5984.88425
+  dps: 6778.00168
+  tps: 5841.91728
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6916.00779
-  tps: 5991.17656
+  dps: 6783.97722
+  tps: 5846.7266
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6946.25469
-  tps: 6020.36809
+  dps: 6809.40008
+  tps: 5872.20262
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6940.70473
-  tps: 6014.81814
+  dps: 6804.47767
+  tps: 5867.28021
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6928.84463
-  tps: 6004.91061
+  dps: 6805.15529
+  tps: 5868.72719
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6908.98067
-  tps: 5984.88425
+  dps: 6778.00168
+  tps: 5841.91728
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6997.76319
-  tps: 6082.28138
+  dps: 6862.43105
+  tps: 5935.4861
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6940.78722
-  tps: 6024.76741
+  dps: 6801.01707
+  tps: 5873.27949
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6861.21914
-  tps: 5943.72694
+  dps: 6785.58753
+  tps: 5854.809
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6928.84199
-  tps: 6012.01128
+  dps: 6784.76033
+  tps: 5856.06728
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6908.98067
-  tps: 5984.88425
+  dps: 6778.00168
+  tps: 5841.91728
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6908.98067
-  tps: 5984.88425
+  dps: 6778.00168
+  tps: 5841.91728
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7013.06588
-  tps: 6080.33538
+  dps: 6881.15981
+  tps: 5935.86112
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 7051.56009
-  tps: 6170.23245
+  dps: 7033.99776
+  tps: 6140.55931
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6977.04521
-  tps: 6059.96805
+  dps: 6834.33422
+  tps: 5905.39931
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5445.21349
-  tps: 4676.3762
+  dps: 5273.42348
+  tps: 4494.6727
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-49982"
  value: {
-  dps: 7152.88142
-  tps: 6220.34279
+  dps: 7012.11538
+  tps: 6068.27501
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-50641"
  value: {
-  dps: 7154.05643
-  tps: 6221.40411
+  dps: 7013.26889
+  tps: 6069.31499
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6946.25469
-  tps: 6020.36809
+  dps: 6809.40008
+  tps: 5872.20262
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6940.70473
-  tps: 6014.81814
+  dps: 6804.47767
+  tps: 5867.28021
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6993.24781
-  tps: 6069.83473
+  dps: 6863.27975
+  tps: 5927.29746
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6922.7432
-  tps: 6004.62512
+  dps: 6916.16811
+  tps: 5984.26451
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6937.73514
-  tps: 6011.28462
+  dps: 6806.27316
+  tps: 5867.83622
   hps: 11.29459
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6703.92326
+  tps: 5776.35556
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7003.59952
-  tps: 6087.30885
+  dps: 6892.35052
+  tps: 5963.50184
  }
 }
 dps_results: {
  key: "TestMM-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6993.41389
-  tps: 6078.49894
+  dps: 6866.44639
+  tps: 5939.11092
  }
 }
 dps_results: {
  key: "TestMM-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6928.45326
-  tps: 6002.4278
+  dps: 6797.13528
+  tps: 5859.12323
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6933.03505
-  tps: 6006.55569
+  dps: 6801.63731
+  tps: 5863.17168
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6908.98067
-  tps: 5984.88425
+  dps: 6778.00168
+  tps: 5841.91728
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6908.98067
-  tps: 5984.88425
+  dps: 6778.00168
+  tps: 5841.91728
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7098.24364
-  tps: 6170.99145
+  dps: 6958.47732
+  tps: 6019.91613
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6908.98067
-  tps: 5984.65041
+  dps: 6800.92381
+  tps: 5864.49884
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 6880.85788
-  tps: 5991.18642
+  dps: 6819.61761
+  tps: 5916.40948
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7360.41105
-  tps: 6433.23011
+  dps: 7211.30139
+  tps: 6272.80908
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6833.52604
-  tps: 5923.49402
+  dps: 6814.76906
+  tps: 5892.3147
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6833.52604
-  tps: 5923.90244
+  dps: 6818.50536
+  tps: 5896.5629
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6938.636
-  tps: 6023.22183
+  dps: 6801.79127
+  tps: 5874.92726
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SparkofLife-37657"
  value: {
-  dps: 6926.38195
-  tps: 6010.27153
+  dps: 6909.58367
+  tps: 5980.84097
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6926.40557
-  tps: 6001.63984
+  dps: 6797.98882
+  tps: 5860.68355
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StormshroudArmor"
  value: {
-  dps: 5678.32948
-  tps: 4890.49297
+  dps: 5440.87866
+  tps: 4648.38527
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6933.03505
-  tps: 6006.55569
+  dps: 6801.63731
+  tps: 5863.17168
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6928.45326
-  tps: 6002.4278
+  dps: 6797.13528
+  tps: 5859.12323
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6920.43514
-  tps: 5995.20399
+  dps: 6789.25674
+  tps: 5852.03843
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6888.9085
-  tps: 5968.16254
+  dps: 6861.91058
+  tps: 5927.87927
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheFistsofFury"
  value: {
-  dps: 6783.05798
-  tps: 5862.09921
+  dps: 6673.39631
+  tps: 5739.99244
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6903.41101
-  tps: 5980.57758
+  dps: 6793.83572
+  tps: 5859.43018
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6951.10064
-  tps: 6019.12934
+  dps: 6821.66538
+  tps: 5878.90114
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6833.73328
-  tps: 5918.73567
+  dps: 6705.04195
+  tps: 5777.47425
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6833.73328
-  tps: 5918.73567
+  dps: 6705.04195
+  tps: 5777.47425
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6908.98067
-  tps: 5984.88425
+  dps: 6778.00168
+  tps: 5841.91728
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6908.98067
-  tps: 5984.88425
+  dps: 6778.00168
+  tps: 5841.91728
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6913.26895
-  tps: 5991.86453
+  dps: 6746.1209
+  tps: 5811.36555
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6908.98067
-  tps: 5984.88425
+  dps: 6778.00168
+  tps: 5841.91728
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6908.98067
-  tps: 5984.88425
+  dps: 6778.00168
+  tps: 5841.91728
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5994.71217
-  tps: 5198.18374
+  dps: 5766.16736
+  tps: 4963.43801
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6829.21662
-  tps: 5927.99003
+  dps: 6781.64632
+  tps: 5868.03879
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 7074.4822
-  tps: 6153.83283
+  dps: 7053.5945
+  tps: 6120.43548
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6833.52604
-  tps: 5918.52842
+  dps: 6704.83268
+  tps: 5777.26497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7674.97047
-  tps: 6746.23688
+  dps: 7589.73415
+  tps: 6649.29658
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 7893.56698
-  tps: 6974.04491
+  dps: 7785.83762
+  tps: 6853.94759
  }
 }
 dps_results: {
  key: "TestMM-Average-Default"
  value: {
-  dps: 7111.01213
-  tps: 6185.03624
+  dps: 6985.14761
+  tps: 6046.99614
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-P1-MM-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7775.12639
-  tps: 7996.33117
+  dps: 7503.91423
+  tps: 7534.64109
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-P1-MM-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7061.98483
-  tps: 6184.71229
+  dps: 6928.66131
+  tps: 6039.75204
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-P1-MM-FullBuffs-ShortSingleTarget"
  value: {
   dps: 8032.79038
-  tps: 7020.87835
+  tps: 7015.56235
  }
 }
 dps_results: {
@@ -904,22 +904,22 @@ dps_results: {
 dps_results: {
  key: "TestMM-Settings-Orc-P1-MM-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7799.05849
-  tps: 7971.16468
+  dps: 7524.17942
+  tps: 7506.11575
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-P1-MM-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7098.24364
-  tps: 6170.99145
+  dps: 6958.47732
+  tps: 6019.91613
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-P1-MM-FullBuffs-ShortSingleTarget"
  value: {
   dps: 8122.72413
-  tps: 7048.76714
+  tps: 7043.45491
  }
 }
 dps_results: {
@@ -946,7 +946,7 @@ dps_results: {
 dps_results: {
  key: "TestMM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7049.03457
-  tps: 6172.55894
+  dps: 6913.35105
+  tps: 6025.38731
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -46,838 +46,838 @@ character_stats_results: {
 dps_results: {
  key: "TestSV-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 7465.98252
-  tps: 6466.74403
+  dps: 7465.43436
+  tps: 6455.93217
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 6963.65607
-  tps: 5928.92873
+  dps: 6950.09152
+  tps: 5905.43438
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7038.64666
-  tps: 5990.13461
+  dps: 7030.18352
+  tps: 5971.59541
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7075.15103
-  tps: 6034.18426
+  dps: 7061.11221
+  tps: 6010.21565
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6916.38904
-  tps: 5885.95961
+  dps: 6902.84603
+  tps: 5862.4868
   hps: 90.56904
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6916.38904
-  tps: 5885.95961
+  dps: 6902.84603
+  tps: 5862.4868
   hps: 90.56904
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7050.54804
-  tps: 6005.15496
+  dps: 7044.58246
+  tps: 5988.98476
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7029.62466
-  tps: 5990.63424
+  dps: 7016.10513
+  tps: 5967.38908
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 6805.84312
-  tps: 5765.48197
+  dps: 6802.90532
+  tps: 5751.75044
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50035"
  value: {
-  dps: 6842.41228
-  tps: 5817.59342
+  dps: 6833.86851
+  tps: 5799.51152
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50692"
  value: {
-  dps: 6833.15933
-  tps: 5808.67802
+  dps: 6824.62983
+  tps: 5790.61038
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5905.1909
-  tps: 5037.8417
+  dps: 5820.6954
+  tps: 4944.33621
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5632.33248
-  tps: 4780.49476
+  dps: 5538.49304
+  tps: 4676.81576
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7029.91077
-  tps: 5865.90316
+  dps: 7021.456
+  tps: 5847.54137
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7249.57508
-  tps: 6187.48389
+  dps: 7241.2128
+  tps: 6169.01307
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7252.90936
-  tps: 6189.72288
+  dps: 7244.54385
+  tps: 6171.24883
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7193.60061
-  tps: 6148.25773
+  dps: 7187.04112
+  tps: 6131.5858
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6978.9616
-  tps: 5927.75484
+  dps: 6965.29378
+  tps: 5904.15722
   hps: 64
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 6461.05143
-  tps: 5483.92965
+  dps: 6445.67195
+  tps: 5458.54229
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7014.1855
-  tps: 5984.16253
+  dps: 7005.30051
+  tps: 5965.11264
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7062.10481
-  tps: 6031.24583
+  dps: 7053.01255
+  tps: 6012.03436
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Greatness-44255"
  value: {
   dps: 7122.46623
-  tps: 6078.98799
+  tps: 6068.26544
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7342.73732
-  tps: 6279.01357
+  dps: 7337.16931
+  tps: 6263.28656
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6992.60467
-  tps: 5962.56675
+  dps: 6985.09685
+  tps: 5945.02806
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7257.16164
-  tps: 6214.21556
+  dps: 7248.21429
+  tps: 6195.21973
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7292.96399
-  tps: 6248.83245
+  dps: 7282.26138
+  tps: 6228.02485
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7054.22327
-  tps: 6008.90734
+  dps: 7047.8297
+  tps: 5992.40097
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7070.13892
-  tps: 6033.30963
+  dps: 7054.7574
+  tps: 6007.57887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7072.70958
-  tps: 6037.09266
+  dps: 7059.42109
+  tps: 6013.77068
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7038.64666
-  tps: 5990.13461
+  dps: 7030.18352
+  tps: 5971.59541
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7036.46462
-  tps: 5990.18856
+  dps: 7028.87043
+  tps: 5972.35846
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7050.54804
-  tps: 6005.20516
+  dps: 7044.15446
+  tps: 5988.69915
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7045.74472
-  tps: 6000.19925
+  dps: 7037.84589
+  tps: 5982.15898
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7004.40429
-  tps: 5970.53148
+  dps: 6996.40868
+  tps: 5952.532
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6946.86508
-  tps: 5906.33043
+  dps: 6933.25025
+  tps: 5882.78581
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7029.91077
-  tps: 5984.31949
+  dps: 7021.456
+  tps: 5965.78866
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7072.51425
-  tps: 6041.78911
+  dps: 7062.26583
+  tps: 6021.52691
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7003.07045
-  tps: 5972.35477
+  dps: 6992.82135
+  tps: 5952.08349
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6942.26748
-  tps: 5909.97543
+  dps: 6936.18986
+  tps: 5893.40318
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6982.20512
-  tps: 5951.85552
+  dps: 6972.64389
+  tps: 5932.27027
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7029.91077
-  tps: 5984.31949
+  dps: 7021.456
+  tps: 5965.78866
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7029.91077
-  tps: 5984.31949
+  dps: 7021.456
+  tps: 5965.78866
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7087.81396
-  tps: 6040.55746
+  dps: 7073.85013
+  tps: 6016.66384
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gladiator'sPursuit"
  value: {
   dps: 6991.06466
-  tps: 5997.3533
+  tps: 5986.96696
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7034.26924
-  tps: 6003.52582
+  dps: 7025.48412
+  tps: 5984.58861
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5245.52168
-  tps: 4425.08898
+  dps: 5136.68265
+  tps: 4308.06901
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-49982"
  value: {
-  dps: 7276.94565
-  tps: 6218.12038
+  dps: 7268.53921
+  tps: 6199.60538
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-50641"
  value: {
-  dps: 7280.58471
-  tps: 6220.82762
+  dps: 7272.17436
+  tps: 6202.30872
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7050.54804
-  tps: 6005.20516
+  dps: 7044.15446
+  tps: 5988.69915
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7045.74472
-  tps: 6000.19925
+  dps: 7037.84589
+  tps: 5982.15898
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7056.52155
-  tps: 6017.95105
+  dps: 7042.56322
+  tps: 5994.06292
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsightfulEarthsiegeDiamond"
  value: {
   dps: 7042.74948
-  tps: 6002.07633
+  tps: 5991.81012
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7057.79642
-  tps: 6010.00366
+  dps: 7048.29753
+  tps: 5990.46159
   hps: 12.04564
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7099.15406
-  tps: 6071.1527
+  dps: 7093.62617
+  tps: 6055.32419
  }
 }
 dps_results: {
  key: "TestSV-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7033.77482
-  tps: 6003.79745
+  dps: 7027.32981
+  tps: 5987.20123
  }
 }
 dps_results: {
  key: "TestSV-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7048.80757
-  tps: 6001.34033
+  dps: 7040.32829
+  tps: 5982.78498
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7053.25388
-  tps: 6005.34524
+  dps: 7044.76883
+  tps: 5986.78412
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7037.00868
-  tps: 5989.04428
+  dps: 7028.54711
+  tps: 5970.50664
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7038.64666
-  tps: 5990.13461
+  dps: 7030.18352
+  tps: 5971.59541
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7204.8402
-  tps: 6157.44416
+  dps: 7196.52123
+  tps: 6139.01664
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7029.91077
-  tps: 5984.10821
+  dps: 7022.78373
+  tps: 5966.71391
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 6939.65308
-  tps: 5945.6053
+  dps: 6934.27183
+  tps: 5929.98531
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7480.24148
-  tps: 6412.18763
+  dps: 7472.44398
+  tps: 6394.21475
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6978.9616
-  tps: 5927.75484
+  dps: 6965.29378
+  tps: 5904.15722
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SliverofPureIce-50339"
  value: {
   dps: 6916.41454
-  tps: 5890.20356
+  tps: 5880.6904
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SliverofPureIce-50346"
  value: {
   dps: 6916.41454
-  tps: 5890.54522
+  tps: 5881.27114
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7008.88685
-  tps: 5978.15729
+  dps: 6998.63775
+  tps: 5957.89442
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SparkofLife-37657"
  value: {
-  dps: 7023.86474
-  tps: 5985.46932
+  dps: 7023.57996
+  tps: 5974.11421
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7006.37575
-  tps: 5966.77159
+  dps: 6992.56269
+  tps: 5943.02873
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StormshroudArmor"
  value: {
-  dps: 5489.32914
-  tps: 4650.41158
+  dps: 5336.95914
+  tps: 4490.25857
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7053.25388
-  tps: 6005.34524
+  dps: 7044.76883
+  tps: 5986.78412
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7048.80757
-  tps: 6001.34033
+  dps: 7040.32829
+  tps: 5982.78498
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7041.02654
-  tps: 5994.33175
+  dps: 7032.55735
+  tps: 5975.7865
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6968.12492
-  tps: 5932.34913
+  dps: 6966.45556
+  tps: 5920.09072
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheFistsofFury"
  value: {
-  dps: 6886.48627
-  tps: 5860.36404
+  dps: 6878.57287
+  tps: 5842.97515
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7008.27585
-  tps: 5981.778
+  dps: 7000.80408
+  tps: 5964.75478
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7058.16523
-  tps: 6013.00509
+  dps: 7052.22747
+  tps: 5997.0566
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6916.56306
-  tps: 5886.15324
+  dps: 6902.99851
+  tps: 5862.65889
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6916.56306
-  tps: 5886.15324
+  dps: 6902.99851
+  tps: 5862.65889
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7029.91077
-  tps: 5984.31949
+  dps: 7021.456
+  tps: 5965.78866
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7029.91077
-  tps: 5984.31949
+  dps: 7021.456
+  tps: 5965.78866
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6980.12445
-  tps: 5942.90832
+  dps: 6970.23928
+  tps: 5922.85165
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7029.91077
-  tps: 5984.31949
+  dps: 7021.456
+  tps: 5965.78866
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7029.91077
-  tps: 5984.31949
+  dps: 7021.456
+  tps: 5965.78866
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5851.0354
-  tps: 4980.65822
+  dps: 5652.55949
+  tps: 4774.02675
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6892.3461
-  tps: 5863.46862
+  dps: 6891.07585
+  tps: 5851.62747
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 7098.83075
-  tps: 6075.59466
+  dps: 7097.95899
+  tps: 6064.30685
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6916.41454
-  tps: 5886.00471
+  dps: 6902.84998
+  tps: 5862.51036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7536.56578
-  tps: 6480.28106
+  dps: 7533.17463
+  tps: 6467.2051
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 7633.98517
-  tps: 6589.06468
+  dps: 7631.77458
+  tps: 6576.94983
  }
 }
 dps_results: {
  key: "TestSV-Average-Default"
  value: {
-  dps: 7230.36044
-  tps: 6181.38125
+  dps: 7219.94075
+  tps: 6161.07466
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-AOE-FullBuffs-LongMultiTarget"
  value: {
   dps: 19860.92105
-  tps: 20188.08849
+  tps: 19989.82659
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7167.83745
-  tps: 6164.75162
+  dps: 7167.1044
+  tps: 6154.16515
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-AOE-FullBuffs-ShortSingleTarget"
  value: {
   dps: 8066.75192
-  tps: 6925.95101
+  tps: 6920.56018
  }
 }
 dps_results: {
@@ -905,21 +905,21 @@ dps_results: {
  key: "TestSV-Settings-Dwarf-P1-SV-FullBuffs-LongMultiTarget"
  value: {
   dps: 7814.03408
-  tps: 8183.20283
+  tps: 7967.19338
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7172.39789
-  tps: 6180.43806
+  dps: 7166.09758
+  tps: 6163.94485
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-SV-FullBuffs-ShortSingleTarget"
  value: {
   dps: 8033.57756
-  tps: 6884.92977
+  tps: 6880.54212
  }
 }
 dps_results: {
@@ -947,21 +947,21 @@ dps_results: {
  key: "TestSV-Settings-Orc-P1-AOE-FullBuffs-LongMultiTarget"
  value: {
   dps: 19966.66695
-  tps: 20231.2158
+  tps: 20030.40933
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-P1-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7223.19209
-  tps: 6163.60298
+  dps: 7221.06766
+  tps: 6151.65661
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-P1-AOE-FullBuffs-ShortSingleTarget"
  value: {
   dps: 8146.75981
-  tps: 6938.67955
+  tps: 6933.31858
  }
 }
 dps_results: {
@@ -989,21 +989,21 @@ dps_results: {
  key: "TestSV-Settings-Orc-P1-SV-FullBuffs-LongMultiTarget"
  value: {
   dps: 7859.12519
-  tps: 8163.96818
+  tps: 7947.67323
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-P1-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7204.8402
-  tps: 6157.44416
+  dps: 7196.52123
+  tps: 6139.01664
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-P1-SV-FullBuffs-ShortSingleTarget"
  value: {
   dps: 8109.76009
-  tps: 6893.60828
+  tps: 6889.25748
  }
 }
 dps_results: {
@@ -1030,7 +1030,7 @@ dps_results: {
 dps_results: {
  key: "TestSV-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7135.43685
-  tps: 6176.36751
+  dps: 7126.11683
+  tps: 6156.94663
  }
 }

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -46,1112 +46,1112 @@ character_stats_results: {
 dps_results: {
  key: "TestProtection-AllItems-AegisBattlegear"
  value: {
-  dps: 3469.53338
-  tps: 8285.9601
+  dps: 3357.2005
+  tps: 7992.34625
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AegisPlate"
  value: {
-  dps: 3133.19945
-  tps: 7537.34196
+  dps: 3087.79978
+  tps: 7407.85084
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 3154.43766
-  tps: 7574.0778
+  dps: 3087.81314
+  tps: 7401.9761
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 3156.85028
-  tps: 7580.2879
+  dps: 3090.02263
+  tps: 7407.66331
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AshtongueTalismanofZeal-32489"
  value: {
-  dps: 3157.65061
-  tps: 7582.34794
+  dps: 3091.1951
+  tps: 7410.68126
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 3120.13779
-  tps: 7485.78995
+  dps: 3054.65856
+  tps: 7316.63619
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 3257.8296
-  tps: 7762.9157
+  dps: 3190.85025
+  tps: 7589.52179
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 3134.97726
-  tps: 7523.98675
-  hps: 87.7113
+  dps: 3069.97431
+  tps: 7356.05894
+  hps: 87.90752
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 3134.97726
-  tps: 7523.98675
-  hps: 87.7113
+  dps: 3069.97431
+  tps: 7356.05894
+  hps: 87.90752
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 3146.33238
-  tps: 7551.41679
+  dps: 3071.40256
+  tps: 7356.00983
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 3066.49465
-  tps: 7355.5999
+  dps: 3000.55197
+  tps: 7183.6835
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 2847.07282
-  tps: 6831.36548
+  dps: 2748.76482
+  tps: 6569.38071
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
   dps: 2806.95645
-  tps: 6745.10515
+  tps: 6739.3993
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
   dps: 2697.6449
-  tps: 6493.34991
+  tps: 6488.24387
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 3122.87941
-  tps: 7344.94205
+  dps: 3057.16933
+  tps: 7178.45103
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 3161.62157
-  tps: 7581.81655
+  dps: 3094.30788
+  tps: 7408.35588
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 3134.80768
-  tps: 7523.55024
+  dps: 3069.83597
+  tps: 7355.70286
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 3134.80768
-  tps: 7523.55024
+  dps: 3069.83597
+  tps: 7355.70286
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 3134.80768
-  tps: 7523.55024
+  dps: 3069.83597
+  tps: 7355.70286
   hps: 64
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 3177.46554
-  tps: 7622.35332
+  dps: 3109.22419
+  tps: 7446.45482
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 3236.12531
-  tps: 7703.34324
+  dps: 3168.2793
+  tps: 7529.23891
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Greatness-44255"
  value: {
   dps: 3271.27787
-  tps: 7857.52912
+  tps: 7851.31953
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DeadlyGladiator'sLibramofFortitude-42852"
  value: {
-  dps: 3099.63274
-  tps: 7433.00994
+  dps: 3036.63165
+  tps: 7270.23495
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Death'sChoice-47464"
  value: {
-  dps: 3450.79115
-  tps: 8260.72371
+  dps: 3377.80289
+  tps: 8072.84466
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 3166.52929
-  tps: 7598.36967
+  dps: 3098.53171
+  tps: 7422.99456
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 3299.506
-  tps: 7889.20442
+  dps: 3233.08363
+  tps: 7706.80728
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 3326.76169
-  tps: 7944.72761
+  dps: 3259.32629
+  tps: 7768.47734
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Defender'sCode-40257"
  value: {
-  dps: 3134.80768
-  tps: 7523.55024
+  dps: 3069.83597
+  tps: 7355.70286
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 3134.414
-  tps: 7519.48097
+  dps: 3068.00344
+  tps: 7348.13905
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 3306.89738
-  tps: 7936.68617
+  dps: 3233.4559
+  tps: 7740.90254
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 3308.77168
-  tps: 7942.45361
+  dps: 3245.80173
+  tps: 7774.2284
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 3120.13779
-  tps: 7485.78995
+  dps: 3054.65856
+  tps: 7316.63619
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 3131.52213
-  tps: 7514.68947
+  dps: 3071.56895
+  tps: 7358.62967
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 3132.90152
-  tps: 7515.97776
+  dps: 3066.09209
+  tps: 7343.60916
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 3130.96335
-  tps: 7511.74883
+  dps: 3064.15392
+  tps: 7339.38022
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 3184.38201
-  tps: 7633.44107
+  dps: 3128.32729
+  tps: 7475.77391
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 3134.80768
-  tps: 7523.55024
+  dps: 3069.83597
+  tps: 7355.70286
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 3229.89051
-  tps: 7692.70433
+  dps: 3157.49253
+  tps: 7510.67737
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 3187.12542
-  tps: 7648.18876
+  dps: 3117.85564
+  tps: 7469.47261
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 3147.53859
-  tps: 7562.23591
+  dps: 3139.22638
+  tps: 7533.56243
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 3146.98046
-  tps: 7554.88297
+  dps: 3080.98383
+  tps: 7384.39744
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ForgeEmber-37660"
  value: {
-  dps: 3167.01885
-  tps: 7599.33443
+  dps: 3099.31498
+  tps: 7424.85241
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 3122.87941
-  tps: 7492.84687
+  dps: 3057.16933
+  tps: 7323.09894
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 3122.33108
-  tps: 7491.43548
+  dps: 3056.66718
+  tps: 7321.80639
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FuriousGladiator'sLibramofFortitude-42853"
  value: {
-  dps: 3099.63274
-  tps: 7433.00994
+  dps: 3036.63165
+  tps: 7270.23495
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 3254.13226
-  tps: 7799.31989
+  dps: 3185.99521
+  tps: 7623.63319
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FuturesightRune-38763"
  value: {
-  dps: 3141.60689
-  tps: 7541.05141
+  dps: 3076.0627
+  tps: 7371.73046
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gladiator'sVindication"
  value: {
-  dps: 3587.93378
-  tps: 8564.04084
+  dps: 3460.99357
+  tps: 8239.89611
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 3155.64397
-  tps: 7577.18285
+  dps: 3088.91789
+  tps: 7404.81971
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 3158.38559
-  tps: 7584.23977
+  dps: 3091.42866
+  tps: 7411.28245
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 3205.72844
-  tps: 7655.16374
+  dps: 3138.34895
+  tps: 7481.27962
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HatefulGladiator'sLibramofFortitude-42851"
  value: {
-  dps: 3099.63274
-  tps: 7433.00994
+  dps: 3036.63165
+  tps: 7270.23495
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 3134.80768
-  tps: 7523.55024
+  dps: 3069.83597
+  tps: 7355.70286
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 3132.90152
-  tps: 7515.97776
+  dps: 3066.09209
+  tps: 7343.60916
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 3130.96335
-  tps: 7511.74883
+  dps: 3064.15392
+  tps: 7339.38022
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IncisorFragment-37723"
  value: {
-  dps: 3200.71012
-  tps: 7667.91088
+  dps: 3134.07597
+  tps: 7496.154
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-InsightfulEarthsiegeDiamond"
  value: {
   dps: 3133.12078
-  tps: 7530.31227
+  tps: 7524.94725
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 3136.33211
-  tps: 7523.17111
-  hps: 16.14611
+  dps: 3070.43742
+  tps: 7352.98844
+  hps: 15.89084
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 3156.51835
-  tps: 7579.43352
+  dps: 3094.1427
+  tps: 7418.26837
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofFuriousBlows-37574"
  value: {
-  dps: 3112.73487
-  tps: 7464.2355
+  dps: 3046.32969
+  tps: 7292.8905
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofReciprocation-40706"
  value: {
-  dps: 3099.63274
-  tps: 7433.00994
+  dps: 3036.63165
+  tps: 7270.23495
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofThreeTruths-50455"
  value: {
-  dps: 3099.63274
-  tps: 7433.00994
+  dps: 3036.63165
+  tps: 7270.23495
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofValiance-47661"
  value: {
-  dps: 3332.83055
-  tps: 7983.16568
+  dps: 3263.73907
+  tps: 7805.19754
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramoftheSacredShield-45145"
  value: {
-  dps: 3099.63274
-  tps: 7433.00994
+  dps: 3036.63165
+  tps: 7270.23495
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerBattlegear"
  value: {
   dps: 2728.13679
-  tps: 6526.13214
+  tps: 6524.93741
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightswornBattlegear"
  value: {
-  dps: 3779.34609
-  tps: 9011.01061
+  dps: 3678.82123
+  tps: 8729.51431
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightswornPlate"
  value: {
-  dps: 3247.92904
-  tps: 7777.03646
+  dps: 3168.80873
+  tps: 7567.39555
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 3134.80768
-  tps: 7523.55024
+  dps: 3069.83597
+  tps: 7355.70286
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 3233.97098
-  tps: 7761.03687
+  dps: 3174.18235
+  tps: 7597.50214
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 3207.51144
-  tps: 7692.89027
+  dps: 3141.51481
+  tps: 7522.40473
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 3134.80768
-  tps: 7523.55024
+  dps: 3069.83597
+  tps: 7355.70286
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 3133.24747
-  tps: 7516.05089
+  dps: 3067.43192
+  tps: 7346.0642
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 3136.33211
-  tps: 7523.17111
+  dps: 3070.43742
+  tps: 7352.98844
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 3134.80768
-  tps: 7523.55024
+  dps: 3069.83597
+  tps: 7355.70286
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 3134.80768
-  tps: 7523.55024
+  dps: 3069.83597
+  tps: 7355.70286
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 3134.80768
-  tps: 7523.55024
+  dps: 3069.83597
+  tps: 7355.70286
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 3120.13779
-  tps: 7485.78995
+  dps: 3054.65856
+  tps: 7316.63619
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 3120.13779
-  tps: 7485.78995
+  dps: 3054.65856
+  tps: 7316.63619
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 3134.80768
-  tps: 7523.55024
+  dps: 3069.83597
+  tps: 7355.70286
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RedemptionBattlegear"
  value: {
-  dps: 3237.72456
-  tps: 7716.6291
+  dps: 3139.31208
+  tps: 7462.82332
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RedemptionPlate"
  value: {
-  dps: 3036.62651
-  tps: 7294.31061
+  dps: 2973.66047
+  tps: 7124.34857
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 3274.52229
-  tps: 7748.43842
+  dps: 3206.5009
+  tps: 7572.88378
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 3291.2028
-  tps: 7774.5501
+  dps: 3223.00028
+  tps: 7598.54674
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 3160.47724
-  tps: 7579.05957
+  dps: 3093.16355
+  tps: 7405.5989
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RelentlessGladiator'sLibramofFortitude-42854"
  value: {
-  dps: 3099.63274
-  tps: 7433.00994
+  dps: 3036.63165
+  tps: 7270.23495
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 3129.9194
-  tps: 7510.02455
+  dps: 3056.82466
+  tps: 7318.83576
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 3134.80768
-  tps: 7523.55024
+  dps: 3069.83597
+  tps: 7355.70286
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SavageGladiator'sLibramofFortitude-42611"
  value: {
-  dps: 3099.63274
-  tps: 7433.00994
+  dps: 3036.63165
+  tps: 7270.23495
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 3134.80768
-  tps: 7523.55024
+  dps: 3069.83597
+  tps: 7355.70286
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 3134.80768
-  tps: 7523.55024
+  dps: 3069.83597
+  tps: 7355.70286
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 3134.80768
-  tps: 7523.55024
+  dps: 3069.83597
+  tps: 7355.70286
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 3165.16872
-  tps: 7606.73889
+  dps: 3149.91193
+  tps: 7558.97394
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 3167.40038
-  tps: 7612.90318
+  dps: 3157.69634
+  tps: 7580.24274
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SoulPreserver-37111"
  value: {
-  dps: 3143.03253
-  tps: 7544.72101
+  dps: 3077.36831
+  tps: 7375.09109
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SouloftheDead-40382"
  value: {
-  dps: 3174.6824
-  tps: 7615.75353
+  dps: 3106.61244
+  tps: 7440.12571
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SparkofLife-37657"
  value: {
-  dps: 3180.59789
-  tps: 7627.83443
+  dps: 3142.01276
+  tps: 7520.20896
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 3228.06445
-  tps: 7746.05491
+  dps: 3186.65187
+  tps: 7634.25846
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StormshroudArmor"
  value: {
-  dps: 2569.08761
-  tps: 6171.58279
+  dps: 2530.0282
+  tps: 6066.34928
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 3136.33211
-  tps: 7523.17111
+  dps: 3070.43742
+  tps: 7352.98844
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 3133.24747
-  tps: 7516.05089
+  dps: 3067.43192
+  tps: 7346.0642
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 3127.84937
-  tps: 7503.5905
+  dps: 3062.1723
+  tps: 7333.94679
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 3134.80768
-  tps: 7523.55024
+  dps: 3069.83597
+  tps: 7355.70286
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TearsoftheVanquished-47215"
  value: {
   dps: 3147.53859
-  tps: 7565.99721
+  tps: 7559.36184
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 3134.80768
-  tps: 7523.55024
+  dps: 3069.83597
+  tps: 7355.70286
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 2991.11809
-  tps: 7203.62799
+  dps: 2906.05629
+  tps: 6975.26644
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 3131.52119
-  tps: 7510.94555
+  dps: 3056.98332
+  tps: 7315.03056
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 3330.61033
-  tps: 7944.85364
+  dps: 3272.22255
+  tps: 7786.4825
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 3369.78615
-  tps: 8036.54267
+  dps: 3312.19618
+  tps: 7877.16935
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 3122.87941
-  tps: 7492.84687
+  dps: 3057.16933
+  tps: 7323.09894
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 3122.33108
-  tps: 7491.43548
+  dps: 3056.66718
+  tps: 7321.80639
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 3169.26413
-  tps: 7603.518
+  dps: 3088.4469
+  tps: 7388.98831
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TomeoftheLightbringer-32368"
  value: {
-  dps: 3120.95304
-  tps: 7487.88841
+  dps: 3056.75752
+  tps: 7322.03893
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 3122.33108
-  tps: 7491.43548
+  dps: 3056.66718
+  tps: 7321.80639
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 3122.87941
-  tps: 7492.84687
+  dps: 3057.16933
+  tps: 7323.09894
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Turalyon'sBattlegear"
  value: {
-  dps: 3497.37756
-  tps: 8355.31248
+  dps: 3394.85481
+  tps: 8083.31618
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Turalyon'sPlate"
  value: {
-  dps: 3200.38625
-  tps: 7679.35963
+  dps: 3129.92372
+  tps: 7491.17797
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 2809.13172
-  tps: 6734.90308
+  dps: 2730.36435
+  tps: 6525.3081
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
   dps: 3086.72076
-  tps: 7445.56756
+  tps: 7441.84298
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WingedTalisman-37844"
  value: {
-  dps: 3142.17965
-  tps: 7542.52569
+  dps: 3076.62989
+  tps: 7373.19042
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathfulGladiator'sLibramofFortitude-51478"
  value: {
-  dps: 3099.63274
-  tps: 7433.00994
+  dps: 3036.63165
+  tps: 7270.23495
  }
 }
 dps_results: {
  key: "TestProtection-Average-Default"
  value: {
   dps: 3512.11867
-  tps: 8391.60832
+  tps: 8390.2508
   dtps: 8.32573
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11635.40894
-  tps: 31226.99602
+  dps: 10825.42842
+  tps: 29006.42391
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2927.44432
-  tps: 6958.9487
+  dps: 2875.65463
+  tps: 6817.73333
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOC-FullBuffs-ShortSingleTarget"
  value: {
   dps: 3146.92215
-  tps: 7432.74235
+  tps: 7430.1108
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2927.7533
-  tps: 8371.08633
+  dps: 2837.99935
+  tps: 8104.76052
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1294.35524
-  tps: 3114.02581
+  dps: 1262.00804
+  tps: 3026.39333
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOC-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1699.56672
-  tps: 4159.28168
+  dps: 1570.51855
+  tps: 3816.60941
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10607.79608
-  tps: 28596.18353
+  dps: 9783.98863
+  tps: 26339.72611
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2906.69027
-  tps: 6909.15001
+  dps: 2834.43493
+  tps: 6718.42496
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOR-FullBuffs-ShortSingleTarget"
  value: {
   dps: 3093.28407
-  tps: 7307.56852
+  tps: 7305.50441
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2423.46192
-  tps: 7074.56373
+  dps: 2348.89833
+  tps: 6844.44076
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1212.31168
-  tps: 2903.68027
+  dps: 1183.58918
+  tps: 2827.07244
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOR-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1645.89611
-  tps: 4019.1441
+  dps: 1546.06641
+  tps: 3752.02709
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11520.61637
-  tps: 30929.42979
+  dps: 10727.19584
+  tps: 28752.33153
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3237.22132
-  tps: 7765.35241
+  dps: 3167.71613
+  tps: 7577.93109
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOV-FullBuffs-ShortSingleTarget"
  value: {
   dps: 3389.37775
-  tps: 8065.80072
+  tps: 8063.12725
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2879.33762
-  tps: 8244.72355
+  dps: 2788.93621
+  tps: 7975.93113
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1412.93779
-  tps: 3418.92565
+  dps: 1380.02317
+  tps: 3334.97726
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-P1-Protection Paladin SOV-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1791.33318
-  tps: 4395.32452
+  dps: 1676.58474
+  tps: 4095.67251
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11370.10448
-  tps: 30500.09059
+  dps: 10550.50568
+  tps: 28250.07461
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2903.31302
-  tps: 6896.41194
+  dps: 2872.6907
+  tps: 6808.21708
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOC-FullBuffs-ShortSingleTarget"
  value: {
   dps: 3150.19657
-  tps: 7440.24096
+  tps: 7437.547
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2852.08759
-  tps: 8128.55055
+  dps: 2754.13251
+  tps: 7841.73238
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1247.56943
-  tps: 2992.02726
+  dps: 1238.09342
+  tps: 2961.50144
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOC-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1612.32249
-  tps: 3935.23601
+  dps: 1588.65371
+  tps: 3858.26106
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10334.79027
-  tps: 27850.87132
+  dps: 9529.54377
+  tps: 25640.68039
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2874.92327
-  tps: 6827.20585
+  dps: 2827.46331
+  tps: 6698.85925
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOR-FullBuffs-ShortSingleTarget"
  value: {
   dps: 3096.85022
-  tps: 7315.78375
+  tps: 7313.73679
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2350.93442
-  tps: 6841.8112
+  dps: 2246.30234
+  tps: 6536.32692
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1171.62526
-  tps: 2798.74695
+  dps: 1164.00895
+  tps: 2775.04626
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOR-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1573.2113
-  tps: 3828.34619
+  dps: 1543.90665
+  tps: 3744.56113
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11264.93161
-  tps: 30232.64169
+  dps: 10430.77496
+  tps: 27942.02927
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3213.04049
-  tps: 7698.7182
+  dps: 3174.79241
+  tps: 7589.73655
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOV-FullBuffs-ShortSingleTarget"
  value: {
   dps: 3393.19327
-  tps: 8074.69013
+  tps: 8072.03841
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2803.50859
-  tps: 8001.23661
+  dps: 2708.08461
+  tps: 7719.79229
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1372.38557
-  tps: 3313.31693
+  dps: 1356.39866
+  tps: 3273.37973
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-P1-Protection Paladin SOV-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1713.50883
-  tps: 4192.98257
+  dps: 1669.6916
+  tps: 4069.60871
  }
 }
 dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
   dps: 3625.98023
-  tps: 8657.07422
+  tps: 8655.95525
   dtps: 10.07858
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -46,170 +46,170 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AegisBattlegear"
  value: {
-  dps: 6228.11968
-  tps: 6325.98776
+  dps: 6213.47942
+  tps: 6310.34326
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AegisPlate"
  value: {
-  dps: 5540.33937
-  tps: 5638.43328
+  dps: 5542.3884
+  tps: 5637.72275
   dtps: 8.90286
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6388.70098
-  tps: 6489.66821
+  dps: 6411.66027
+  tps: 6510.93573
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6394.93184
-  tps: 6495.89907
+  dps: 6417.93454
+  tps: 6517.21
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AshtongueTalismanofZeal-32489"
  value: {
-  dps: 6363.4832
-  tps: 6464.45044
+  dps: 6388.34533
+  tps: 6487.6208
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6451.41239
-  tps: 6552.37963
+  dps: 6477.21145
+  tps: 6576.48692
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6534.10449
-  tps: 6635.05431
+  dps: 6558.44199
+  tps: 6657.48844
   dtps: 10.03858
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6339.04375
-  tps: 6440.01098
+  dps: 6361.50801
+  tps: 6460.78348
   dtps: 9.48456
-  hps: 95.68219
+  hps: 96.07729
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6339.04375
-  tps: 6440.01098
+  dps: 6361.50801
+  tps: 6460.78348
   dtps: 9.48456
-  hps: 95.68219
+  hps: 96.07729
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6468.13704
-  tps: 6568.97942
+  dps: 6483.72942
+  tps: 6582.72278
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6278.55005
-  tps: 6377.1949
+  dps: 6274.5946
+  tps: 6371.52534
   dtps: 9.56591
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 5316.16684
-  tps: 5414.95711
+  dps: 5314.00646
+  tps: 5410.47261
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5151.63267
-  tps: 5249.91417
+  dps: 5128.1537
+  tps: 5224.20136
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5101.77922
-  tps: 5199.70637
+  dps: 5062.75359
+  tps: 5158.66107
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6458.34267
-  tps: 6430.14305
+  dps: 6484.19202
+  tps: 6453.78364
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6932.90527
-  tps: 7033.87251
+  dps: 6958.38133
+  tps: 7057.65679
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6965.58115
-  tps: 7066.54839
+  dps: 6991.21261
+  tps: 7090.48808
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6588.47343
-  tps: 6689.44066
+  dps: 6612.45153
+  tps: 6711.727
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6338.00444
-  tps: 6438.97168
+  dps: 6360.61052
+  tps: 6459.88599
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6338.00444
-  tps: 6438.97168
+  dps: 6360.61052
+  tps: 6459.88599
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6338.00444
-  tps: 6438.97168
+  dps: 6360.61052
+  tps: 6459.88599
   dtps: 9.92959
   hps: 64
  }
@@ -217,304 +217,304 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6429.12159
-  tps: 6530.08882
+  dps: 6452.80363
+  tps: 6552.0791
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6472.26173
-  tps: 6573.25229
+  dps: 6482.56427
+  tps: 6581.56435
   dtps: 9.77043
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6338.21271
-  tps: 6437.94684
+  dps: 6341.21925
+  tps: 6437.78473
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6941.62101
-  tps: 7042.58824
+  dps: 6965.96753
+  tps: 7065.24299
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6393.4332
-  tps: 6494.40043
+  dps: 6422.5232
+  tps: 6521.79867
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6652.30051
-  tps: 6753.26402
+  dps: 6640.90003
+  tps: 6739.81023
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6714.53138
-  tps: 6815.57184
+  dps: 6727.87115
+  tps: 6827.05067
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6338.00444
-  tps: 6438.97168
+  dps: 6360.61052
+  tps: 6459.88599
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6469.80651
-  tps: 6570.77375
+  dps: 6491.69226
+  tps: 6590.96773
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6525.24882
-  tps: 6626.61675
+  dps: 6510.3345
+  tps: 6609.6629
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6486.78899
-  tps: 6588.24711
+  dps: 6491.19839
+  tps: 6590.69165
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6451.41239
-  tps: 6552.37963
+  dps: 6477.21145
+  tps: 6576.48692
   dtps: 9.731
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6458.34267
-  tps: 6559.24741
+  dps: 6483.75506
+  tps: 6582.94656
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6468.13704
-  tps: 6569.10427
+  dps: 6490.69128
+  tps: 6589.96675
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6466.15284
-  tps: 6567.12008
+  dps: 6488.56837
+  tps: 6587.84384
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6392.67749
-  tps: 6493.62885
+  dps: 6371.54401
+  tps: 6470.73994
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6338.00444
-  tps: 6438.97168
+  dps: 6360.61052
+  tps: 6459.88599
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6451.41239
-  tps: 6552.37963
+  dps: 6477.21145
+  tps: 6576.48692
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6489.79203
-  tps: 6590.73736
+  dps: 6507.62252
+  tps: 6606.31881
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6456.33084
-  tps: 6557.29808
+  dps: 6479.11767
+  tps: 6578.39314
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6338.00444
-  tps: 6438.3928
+  dps: 6358.30316
+  tps: 6456.17868
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6369.44196
-  tps: 6470.40919
+  dps: 6392.26707
+  tps: 6491.54253
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6414.06703
-  tps: 6515.03426
+  dps: 6438.03017
+  tps: 6537.30564
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6458.34267
-  tps: 6559.3099
+  dps: 6484.19202
+  tps: 6583.46748
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6456.95661
-  tps: 6557.92384
+  dps: 6482.7959
+  tps: 6582.07137
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuriousGladiator'sLibramofFortitude-42853"
  value: {
-  dps: 6606.99007
-  tps: 6707.95731
+  dps: 6630.9168
+  tps: 6730.19226
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6355.56414
-  tps: 6456.53137
+  dps: 6378.29256
+  tps: 6477.56802
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Gladiator'sVindication"
  value: {
-  dps: 6278.90981
-  tps: 6378.76498
+  dps: 6286.77426
+  tps: 6383.81291
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6391.81641
-  tps: 6492.78364
+  dps: 6414.7974
+  tps: 6514.07287
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6398.89693
-  tps: 6499.86416
+  dps: 6421.92726
+  tps: 6521.20272
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6444.37534
-  tps: 6545.34713
+  dps: 6462.00479
+  tps: 6560.77184
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HatefulGladiator'sLibramofFortitude-42851"
  value: {
-  dps: 6575.00606
-  tps: 6675.97329
+  dps: 6598.70013
+  tps: 6697.9756
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6344.50879
-  tps: 6445.47602
+  dps: 6366.82531
+  tps: 6466.10078
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6468.13704
-  tps: 6569.10427
+  dps: 6490.69128
+  tps: 6589.96675
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6466.15284
-  tps: 6567.12008
+  dps: 6488.56837
+  tps: 6587.84384
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6498.1123
-  tps: 6599.07953
+  dps: 6522.98117
+  tps: 6622.25663
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6451.41239
-  tps: 6553.43545
+  dps: 6452.96147
+  tps: 6553.27925
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6485.20695
-  tps: 6586.17418
+  dps: 6511.30453
+  tps: 6610.58
   dtps: 9.92959
   hps: 11.51045
  }
@@ -522,536 +522,536 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6338.00444
-  tps: 6438.97168
+  dps: 6360.61052
+  tps: 6459.88599
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofFuriousBlows-37574"
  value: {
-  dps: 6519.66014
-  tps: 6620.62737
+  dps: 6541.9024
+  tps: 6641.17787
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofObstruction-40707"
  value: {
-  dps: 6491.64743
-  tps: 6592.61466
+  dps: 6515.02133
+  tps: 6614.29679
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofReciprocation-40706"
  value: {
-  dps: 6491.64743
-  tps: 6592.61466
+  dps: 6515.02133
+  tps: 6614.29679
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofThreeTruths-50455"
  value: {
-  dps: 6921.02876
-  tps: 7021.996
+  dps: 6946.53949
+  tps: 7045.81495
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofValiance-47661"
  value: {
-  dps: 6887.6609
-  tps: 6988.62814
+  dps: 6913.06908
+  tps: 7012.34454
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramoftheSacredShield-45145"
  value: {
-  dps: 6491.64743
-  tps: 6592.61466
+  dps: 6515.02133
+  tps: 6614.29679
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerBattlegear"
  value: {
-  dps: 4846.25011
-  tps: 4943.0821
+  dps: 4850.96692
+  tps: 4945.32489
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornBattlegear"
  value: {
-  dps: 6871.15714
-  tps: 6978.81058
+  dps: 6826.60302
+  tps: 6928.53161
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornPlate"
  value: {
-  dps: 5656.73001
-  tps: 5754.81732
+  dps: 5695.74205
+  tps: 5791.5414
   dtps: 8.90286
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6338.00444
-  tps: 6438.97168
+  dps: 6360.61052
+  tps: 6459.88599
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6464.59959
-  tps: 6565.70765
+  dps: 6460.58628
+  tps: 6559.59386
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6469.90357
-  tps: 6570.87081
+  dps: 6493.89918
+  tps: 6593.17464
   dtps: 10.29273
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6338.00444
-  tps: 6438.97168
+  dps: 6360.61052
+  tps: 6459.88599
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6478.29962
-  tps: 6579.26686
+  dps: 6504.23406
+  tps: 6603.50953
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6484.62603
-  tps: 6585.59326
+  dps: 6510.59232
+  tps: 6609.86779
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6338.00444
-  tps: 6438.97168
+  dps: 6360.61052
+  tps: 6459.88599
   dtps: 8.19524
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6338.00444
-  tps: 6438.97168
+  dps: 6360.61052
+  tps: 6459.88599
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6338.00444
-  tps: 6438.97168
+  dps: 6360.61052
+  tps: 6459.88599
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6451.41239
-  tps: 6552.37963
+  dps: 6477.21145
+  tps: 6576.48692
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6451.41239
-  tps: 6552.37963
+  dps: 6477.21145
+  tps: 6576.48692
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6338.00444
-  tps: 6438.97168
+  dps: 6360.61052
+  tps: 6459.88599
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionBattlegear"
  value: {
-  dps: 5817.40325
-  tps: 5918.38437
+  dps: 5802.52854
+  tps: 5901.6474
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionPlate"
  value: {
-  dps: 5285.57647
-  tps: 5383.73475
+  dps: 5322.79274
+  tps: 5418.16373
   dtps: 8.90286
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6611.26802
-  tps: 6712.23433
+  dps: 6624.49041
+  tps: 6723.40121
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6646.10101
-  tps: 6747.06732
+  dps: 6658.89975
+  tps: 6757.81055
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6587.7663
-  tps: 6688.73353
+  dps: 6611.60088
+  tps: 6710.87635
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessGladiator'sLibramofFortitude-42854"
  value: {
-  dps: 6629.41781
-  tps: 6730.38505
+  dps: 6653.45203
+  tps: 6752.72749
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6451.41239
-  tps: 6551.53209
+  dps: 6467.57897
+  tps: 6565.37814
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6338.00444
-  tps: 6438.97168
+  dps: 6360.61052
+  tps: 6459.88599
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SavageGladiator'sLibramofFortitude-42611"
  value: {
-  dps: 6565.56923
-  tps: 6666.53647
+  dps: 6589.22706
+  tps: 6688.50252
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6338.00444
-  tps: 6438.97168
+  dps: 6360.61052
+  tps: 6459.88599
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7778.81301
-  tps: 7879.73752
+  dps: 7799.16343
+  tps: 7898.15925
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6338.00444
-  tps: 6438.97168
+  dps: 6360.61052
+  tps: 6459.88599
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6338.00444
-  tps: 6438.97168
+  dps: 6360.61052
+  tps: 6459.88599
   dtps: 6.55074
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6382.75334
-  tps: 6483.74974
+  dps: 6397.56561
+  tps: 6496.39852
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6388.41776
-  tps: 6489.41416
+  dps: 6403.25215
+  tps: 6502.08506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6359.24601
-  tps: 6460.21324
+  dps: 6382.00008
+  tps: 6481.27555
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6420.00452
-  tps: 6521.50013
+  dps: 6432.67936
+  tps: 6531.74745
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SparkofLife-37657"
  value: {
-  dps: 6402.44122
-  tps: 6498.37814
+  dps: 6407.47663
+  tps: 6501.78499
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6477.48091
-  tps: 6578.4518
+  dps: 6503.58232
+  tps: 6602.65669
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StormshroudArmor"
  value: {
-  dps: 5024.36724
-  tps: 5122.17501
+  dps: 5014.61261
+  tps: 5110.24404
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6484.62603
-  tps: 6585.59326
+  dps: 6510.59232
+  tps: 6609.86779
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6478.29962
-  tps: 6579.26686
+  dps: 6504.23406
+  tps: 6603.50953
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6467.22841
-  tps: 6568.19564
+  dps: 6493.1071
+  tps: 6592.38257
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6338.00444
-  tps: 6438.97168
+  dps: 6360.61052
+  tps: 6459.88599
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6338.21271
-  tps: 6438.03022
+  dps: 6340.89665
+  tps: 6437.87375
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6338.00444
-  tps: 6438.97168
+  dps: 6360.61052
+  tps: 6459.88599
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5377.85236
-  tps: 5478.24826
+  dps: 5372.867
+  tps: 5471.59005
   dtps: 9.56591
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6512.66988
-  tps: 6613.45193
+  dps: 6505.28245
+  tps: 6603.75876
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6727.35887
-  tps: 6828.73243
+  dps: 6744.60518
+  tps: 6843.55502
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6790.92697
-  tps: 6892.3433
+  dps: 6791.95147
+  tps: 6890.44812
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6458.34267
-  tps: 6559.3099
+  dps: 6484.19202
+  tps: 6583.46748
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6456.95661
-  tps: 6557.92384
+  dps: 6482.7959
+  tps: 6582.07137
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6413.52085
-  tps: 6514.38897
+  dps: 6405.5755
+  tps: 6504.49832
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeoftheLightbringer-32368"
  value: {
-  dps: 6491.64743
-  tps: 6592.61466
+  dps: 6515.02133
+  tps: 6614.29679
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6456.95661
-  tps: 6557.92384
+  dps: 6482.7959
+  tps: 6582.07137
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6458.34267
-  tps: 6559.3099
+  dps: 6484.19202
+  tps: 6583.46748
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sBattlegear"
  value: {
-  dps: 6251.7657
-  tps: 6350.30574
+  dps: 6255.5362
+  tps: 6351.86978
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sPlate"
  value: {
-  dps: 5589.23837
-  tps: 5687.41883
+  dps: 5642.92316
+  tps: 5738.74568
   dtps: 8.90286
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5144.79066
-  tps: 5243.59008
+  dps: 5183.15142
+  tps: 5279.98629
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5195.5791
-  tps: 5293.83817
+  dps: 5185.35651
+  tps: 5282.94153
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6359.38272
-  tps: 6460.34995
+  dps: 6382.3273
+  tps: 6481.60277
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathfulGladiator'sLibramofFortitude-51478"
  value: {
-  dps: 6655.04951
-  tps: 6756.01674
+  dps: 6679.20657
+  tps: 6778.48204
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 6592.8233
-  tps: 6693.26804
-  dtps: 12.6155
+  dps: 6585.35059
+  tps: 6683.68825
+  dtps: 13.13333
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21212.67338
-  tps: 23297.08258
+  dps: 21240.69622
+  tps: 23293.97492
   dtps: 8.81235
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5317.32183
-  tps: 5417.15225
+  dps: 5331.09868
+  tps: 5428.75339
   dtps: 9.85058
  }
 }
@@ -1059,44 +1059,44 @@ dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-FullBuffs-ShortSingleTarget"
  value: {
   dps: 5942.91511
-  tps: 6046.17801
+  tps: 6044.94956
   dtps: 49.25289
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12458.63826
-  tps: 14714.51864
+  dps: 12214.48279
+  tps: 14253.50355
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2967.12331
-  tps: 3077.69025
+  dps: 2963.84404
+  tps: 3067.64792
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-NoBuffs-ShortSingleTarget"
  value: {
   dps: 3063.27753
-  tps: 3169.81969
+  tps: 3165.06689
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19358.50412
-  tps: 21443.00984
+  dps: 19408.41029
+  tps: 21460.75583
   dtps: 8.61128
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5781.08805
-  tps: 5880.95619
+  dps: 5778.34412
+  tps: 5875.40509
   dtps: 9.85058
  }
 }
@@ -1104,44 +1104,44 @@ dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-FullBuffs-ShortSingleTarget"
  value: {
   dps: 6345.0808
-  tps: 6448.64212
+  tps: 6447.34413
   dtps: 49.25289
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11341.82602
-  tps: 13597.69817
+  dps: 11107.8495
+  tps: 13152.436
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3053.5144
-  tps: 3164.19072
+  dps: 3032.78757
+  tps: 3136.48661
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-NoBuffs-ShortSingleTarget"
  value: {
   dps: 3165.69224
-  tps: 3272.23481
+  tps: 3267.37956
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21654.10225
-  tps: 23738.6705
+  dps: 21686.21441
+  tps: 23724.79574
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6587.7663
-  tps: 6688.73353
+  dps: 6611.60088
+  tps: 6710.87635
   dtps: 9.92959
  }
 }
@@ -1149,44 +1149,44 @@ dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7175.94133
-  tps: 7276.67785
+  tps: 7274.61715
   dtps: 49.64794
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12723.63151
-  tps: 14971.34845
+  dps: 11999.90424
+  tps: 13960.96299
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3593.95715
-  tps: 3704.2113
+  dps: 3610.71362
+  tps: 3714.42686
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-ShortSingleTarget"
  value: {
   dps: 3686.10702
-  tps: 3792.60909
+  tps: 3787.85482
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21527.86791
-  tps: 23621.44312
+  dps: 21537.81097
+  tps: 23591.52308
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6587.7663
-  tps: 6688.73353
+  dps: 6611.60088
+  tps: 6710.87635
   dtps: 9.92959
  }
 }
@@ -1194,44 +1194,44 @@ dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7175.94133
-  tps: 7276.67785
+  tps: 7274.61715
   dtps: 49.64794
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12619.49512
-  tps: 14892.93214
+  dps: 12205.40268
+  tps: 14244.78961
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3593.95715
-  tps: 3704.2113
+  dps: 3610.71362
+  tps: 3714.42686
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-NoBuffs-ShortSingleTarget"
  value: {
   dps: 3686.10702
-  tps: 3792.60909
+  tps: 3787.85482
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21518.43514
-  tps: 23612.32453
+  dps: 21466.04549
+  tps: 23500.15483
   dtps: 8.81235
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5328.27304
-  tps: 5427.92686
+  dps: 5321.69964
+  tps: 5418.13769
   dtps: 9.85058
  }
 }
@@ -1239,44 +1239,44 @@ dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-FullBuffs-ShortSingleTarget"
  value: {
   dps: 5953.80166
-  tps: 6057.09968
+  tps: 6055.77718
   dtps: 49.25289
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12554.07707
-  tps: 14798.0981
+  dps: 12198.12043
+  tps: 14210.5368
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2986.71232
-  tps: 3096.68599
+  dps: 2975.09035
+  tps: 3077.58827
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-NoBuffs-ShortSingleTarget"
  value: {
   dps: 3069.02744
-  tps: 3175.33036
+  tps: 3169.00679
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19664.50514
-  tps: 21758.46655
+  dps: 19629.775
+  tps: 21664.35482
   dtps: 8.61128
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5795.10573
-  tps: 5894.79413
+  dps: 5775.22305
+  tps: 5871.82589
   dtps: 9.85058
  }
 }
@@ -1284,44 +1284,44 @@ dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-FullBuffs-ShortSingleTarget"
  value: {
   dps: 6357.81896
-  tps: 6461.41558
+  tps: 6460.06129
   dtps: 49.25289
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11436.46574
-  tps: 13680.48649
+  dps: 11078.41024
+  tps: 13084.38208
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3065.99564
-  tps: 3176.003
+  dps: 3042.26546
+  tps: 3144.64
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-NoBuffs-ShortSingleTarget"
  value: {
   dps: 3175.97892
-  tps: 3282.30835
+  tps: 3275.8653
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21818.59435
-  tps: 23897.82312
+  dps: 21842.87892
+  tps: 23861.34537
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6601.77725
-  tps: 6702.66712
+  dps: 6600.47427
+  tps: 6698.85694
   dtps: 9.92959
  }
 }
@@ -1329,44 +1329,44 @@ dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7190.3984
-  tps: 7291.16132
+  tps: 7288.804
   dtps: 49.64794
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12834.36852
-  tps: 15062.57204
+  dps: 11976.28927
+  tps: 13889.67553
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3604.17485
-  tps: 3714.2429
+  dps: 3618.15171
+  tps: 3720.8637
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-ShortSingleTarget"
  value: {
   dps: 3683.00968
-  tps: 3789.52182
+  tps: 3784.74529
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21697.38442
-  tps: 23785.32184
+  dps: 21667.60008
+  tps: 23703.25537
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6601.77725
-  tps: 6702.66712
+  dps: 6600.47427
+  tps: 6698.85694
   dtps: 9.92959
  }
 }
@@ -1374,44 +1374,44 @@ dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7190.3984
-  tps: 7291.16132
+  tps: 7288.804
   dtps: 49.64794
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12728.00399
-  tps: 14982.66645
+  dps: 12170.01514
+  tps: 14182.86344
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3604.17485
-  tps: 3714.2429
+  dps: 3618.15171
+  tps: 3720.8637
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-NoBuffs-ShortSingleTarget"
  value: {
   dps: 3683.00968
-  tps: 3789.52182
+  tps: 3784.74529
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21405.25032
-  tps: 23497.43614
+  dps: 21367.99227
+  tps: 23400.0898
   dtps: 8.81235
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5326.06505
-  tps: 5425.70774
+  dps: 5321.27542
+  tps: 5417.80474
   dtps: 9.85058
  }
 }
@@ -1419,44 +1419,44 @@ dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-FullBuffs-ShortSingleTarget"
  value: {
   dps: 5956.56395
-  tps: 6059.87367
+  tps: 6058.54797
   dtps: 49.25289
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12484.34851
-  tps: 14728.68182
+  dps: 12082.42052
+  tps: 14084.70736
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2985.98413
-  tps: 3096.1326
+  dps: 2972.78273
+  tps: 3075.14721
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-NoBuffs-ShortSingleTarget"
  value: {
   dps: 3070.35877
-  tps: 3176.67175
+  tps: 3170.32139
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19554.1049
-  tps: 21646.36068
+  dps: 19510.07455
+  tps: 21543.19421
   dtps: 8.61128
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5795.37572
-  tps: 5895.05299
+  dps: 5778.01046
+  tps: 5874.49102
   dtps: 9.85058
  }
 }
@@ -1464,44 +1464,44 @@ dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-FullBuffs-ShortSingleTarget"
  value: {
   dps: 6361.48897
-  tps: 6465.09736
+  tps: 6463.74067
   dtps: 49.25289
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11365.45571
-  tps: 13609.79054
+  dps: 11000.98766
+  tps: 13000.19869
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3067.60556
-  tps: 3177.78676
+  dps: 3039.40708
+  tps: 3141.81762
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-NoBuffs-ShortSingleTarget"
  value: {
   dps: 3175.56675
-  tps: 3281.86966
+  tps: 3275.32504
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21704.35334
-  tps: 23784.05445
+  dps: 21742.07379
+  tps: 23758.06262
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6601.34907
-  tps: 6702.25115
+  dps: 6601.73004
+  tps: 6700.23782
   dtps: 9.92959
  }
 }
@@ -1509,44 +1509,44 @@ dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7193.53468
-  tps: 7294.30641
+  tps: 7292.25261
   dtps: 49.64794
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12761.51528
-  tps: 14986.45545
+  dps: 11935.38901
+  tps: 13865.02486
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3611.31669
-  tps: 3721.40409
+  dps: 3613.61197
+  tps: 3716.16454
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-ShortSingleTarget"
  value: {
   dps: 3681.14095
-  tps: 3787.65644
+  tps: 3782.87315
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21581.65021
-  tps: 23670.33133
+  dps: 21578.47984
+  tps: 23617.49677
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6601.34907
-  tps: 6702.25115
+  dps: 6601.73004
+  tps: 6700.23782
   dtps: 9.92959
  }
 }
@@ -1554,44 +1554,44 @@ dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7193.53468
-  tps: 7294.30641
+  tps: 7292.25261
   dtps: 49.64794
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12662.8213
-  tps: 14917.19368
+  dps: 12121.58122
+  tps: 14135.43942
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3611.31669
-  tps: 3721.40409
+  dps: 3613.61197
+  tps: 3716.16454
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-NoBuffs-ShortSingleTarget"
  value: {
   dps: 3681.14095
-  tps: 3787.65644
+  tps: 3782.87315
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21378.5012
-  tps: 23470.51294
+  dps: 21341.24293
+  tps: 23373.33217
   dtps: 8.81235
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5320.85195
-  tps: 5420.48216
+  dps: 5312.70514
+  tps: 5409.1964
   dtps: 9.85058
  }
 }
@@ -1599,44 +1599,44 @@ dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-FullBuffs-ShortSingleTarget"
  value: {
   dps: 5948.03343
-  tps: 6051.33145
+  tps: 6050.00894
   dtps: 49.25289
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12466.04715
-  tps: 14710.32071
+  dps: 12114.61779
+  tps: 14126.08213
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2981.5304
-  tps: 3091.59384
+  dps: 2968.78742
+  tps: 3071.17123
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-NoBuffs-ShortSingleTarget"
  value: {
   dps: 3065.45465
-  tps: 3171.75757
+  tps: 3165.43399
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19526.31666
-  tps: 21618.40042
+  dps: 19481.60007
+  tps: 21514.76166
   dtps: 8.61128
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5786.00823
-  tps: 5885.67302
+  dps: 5761.61816
+  tps: 5858.23367
   dtps: 9.85058
  }
 }
@@ -1644,44 +1644,44 @@ dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-FullBuffs-ShortSingleTarget"
  value: {
   dps: 6351.23386
-  tps: 6454.83049
+  tps: 6453.4762
   dtps: 49.25289
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11348.25211
-  tps: 13592.52539
+  dps: 10997.96726
+  tps: 13002.8406
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3062.88964
-  tps: 3172.98549
+  dps: 3032.99527
+  tps: 3135.33462
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-NoBuffs-ShortSingleTarget"
  value: {
   dps: 3169.39518
-  tps: 3275.688
+  tps: 3269.17171
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21678.14446
-  tps: 23757.58179
+  dps: 21707.951
+  tps: 23727.13112
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6593.111
-  tps: 6693.99959
+  dps: 6594.27157
+  tps: 6692.65425
   dtps: 9.92959
  }
 }
@@ -1689,44 +1689,44 @@ dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7182.53884
-  tps: 7283.30176
+  tps: 7281.24623
   dtps: 49.64794
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12751.48226
-  tps: 14980.89986
+  dps: 11899.84304
+  tps: 13813.26478
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3597.7683
-  tps: 3707.80571
+  dps: 3610.0624
+  tps: 3712.63526
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-ShortSingleTarget"
  value: {
   dps: 3678.95562
-  tps: 3785.46776
+  tps: 3780.69122
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21554.2315
-  tps: 23642.65913
+  dps: 21524.93119
+  tps: 23561.32252
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6593.111
-  tps: 6693.99959
+  dps: 6594.27157
+  tps: 6692.65425
   dtps: 9.92959
  }
 }
@@ -1734,36 +1734,36 @@ dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-FullBuffs-ShortSingleTarget"
  value: {
   dps: 7182.53884
-  tps: 7283.30176
+  tps: 7281.24623
   dtps: 49.64794
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12636.54087
-  tps: 14890.05334
+  dps: 12083.64791
+  tps: 14098.18058
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3597.7683
-  tps: 3707.80571
+  dps: 3610.0624
+  tps: 3712.63526
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-NoBuffs-ShortSingleTarget"
  value: {
   dps: 3678.95562
-  tps: 3785.46776
+  tps: 3780.69122
  }
 }
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6269.59811
-  tps: 6370.5333
+  dps: 6263.63023
+  tps: 6362.50658
   dtps: 9.92959
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -46,936 +46,936 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7173.83466
-  tps: 4069.95467
+  dps: 7177.41759
+  tps: 4066.21332
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7192.43547
-  tps: 4081.64971
+  dps: 7196.02192
+  tps: 4077.91247
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7085.31992
-  tps: 4014.58632
+  dps: 7065.03222
+  tps: 3996.88038
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7199.00151
-  tps: 4078.40304
+  dps: 7233.65456
+  tps: 4097.12897
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7022.31847
-  tps: 3974.67825
-  hps: 95.25776
+  dps: 7026.2483
+  tps: 3971.16635
+  hps: 95.59877
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7022.31847
-  tps: 3974.67825
-  hps: 95.25776
+  dps: 7026.2483
+  tps: 3971.16635
+  hps: 95.59877
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7116.97524
-  tps: 4032.65341
+  dps: 7092.68343
+  tps: 4009.14545
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6857.30921
-  tps: 3869.15427
+  dps: 6843.01145
+  tps: 3858.47972
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 7460.04517
-  tps: 4239.05978
+  dps: 7471.98205
+  tps: 4236.27842
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50035"
  value: {
-  dps: 7106.14594
-  tps: 3997.23961
+  dps: 7116.03832
+  tps: 4009.51131
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50692"
  value: {
-  dps: 7172.94774
-  tps: 4034.37966
+  dps: 7176.8314
+  tps: 4042.67644
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5768.05711
-  tps: 3246.62799
+  dps: 5756.56507
+  tps: 3238.98058
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5704.18478
-  tps: 3221.68061
+  dps: 5698.58945
+  tps: 3216.82738
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7106.64592
-  tps: 3916.25143
+  dps: 7086.2969
+  tps: 3898.84442
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7265.50906
-  tps: 4118.61063
+  dps: 7259.44932
+  tps: 4107.28981
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7265.50906
-  tps: 4118.61063
+  dps: 7259.44932
+  tps: 4107.28981
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7268.52678
-  tps: 4121.65403
+  dps: 7274.19087
+  tps: 4117.26629
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7022.49177
-  tps: 3974.79956
+  dps: 7026.04598
+  tps: 3971.02472
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7022.49177
-  tps: 3974.79956
+  dps: 7026.04598
+  tps: 3971.02472
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7022.48856
-  tps: 3974.79956
+  dps: 7026.05446
+  tps: 3971.02472
   hps: 64
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7152.26813
-  tps: 4048.32773
+  dps: 7176.38433
+  tps: 4059.17431
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7174.87653
-  tps: 4067.25288
+  dps: 7187.4732
+  tps: 4073.41726
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7203.37787
-  tps: 4076.40064
+  dps: 7227.73228
+  tps: 4083.20642
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 7246.52719
-  tps: 4105.94279
+  dps: 7238.9588
+  tps: 4097.65335
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7381.4786
-  tps: 4174.56566
+  dps: 7413.18761
+  tps: 4186.79461
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7121.63341
-  tps: 4032.94502
+  dps: 7132.73153
+  tps: 4031.71686
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7336.78699
-  tps: 4147.64606
+  dps: 7358.76233
+  tps: 4155.56645
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7393.42847
-  tps: 4187.31304
+  dps: 7381.96199
+  tps: 4163.42345
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7022.49766
-  tps: 3974.79956
+  dps: 7026.05446
+  tps: 3971.02472
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7112.83565
-  tps: 4032.77292
+  dps: 7118.30305
+  tps: 4027.37325
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7408.04306
-  tps: 4209.34978
+  dps: 7417.07701
+  tps: 4205.09956
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7367.65631
-  tps: 4192.37935
+  dps: 7365.46238
+  tps: 4182.04051
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 6454.65216
-  tps: 3632.88408
+  dps: 6443.71703
+  tps: 3629.60741
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterGarb"
  value: {
-  dps: 6045.52068
-  tps: 3429.51927
+  dps: 6046.42448
+  tps: 3428.56325
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7085.31992
-  tps: 4014.58632
+  dps: 7065.03222
+  tps: 3996.88038
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7105.42578
-  tps: 4025.03951
+  dps: 7113.49227
+  tps: 4026.24414
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7104.67206
-  tps: 4026.18802
+  dps: 7109.61857
+  tps: 4021.3188
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7102.11412
-  tps: 4023.86041
+  dps: 7106.60925
+  tps: 4018.62989
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7164.5604
-  tps: 4057.37828
+  dps: 7182.34787
+  tps: 4065.82179
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7022.49177
-  tps: 3974.79956
+  dps: 7026.04598
+  tps: 3971.02472
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7085.31992
-  tps: 4014.58632
+  dps: 7065.03222
+  tps: 3996.88038
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7186.82231
-  tps: 4072.94779
+  dps: 7193.00346
+  tps: 4074.42211
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7247.32667
-  tps: 4108.9349
+  dps: 7281.7499
+  tps: 4127.09151
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7055.21948
-  tps: 3996.54055
+  dps: 7091.94124
+  tps: 4015.05107
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7116.34127
-  tps: 4033.80636
+  dps: 7119.91329
+  tps: 4030.05229
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7181.93055
-  tps: 4069.26741
+  dps: 7203.37495
+  tps: 4076.34466
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7106.64592
-  tps: 4028.02491
+  dps: 7086.2969
+  tps: 4010.28057
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7102.38072
-  tps: 4025.33719
+  dps: 7082.04396
+  tps: 4007.60053
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 7164.43666
-  tps: 4025.22902
+  dps: 7162.92857
+  tps: 4024.48613
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 6742.18323
-  tps: 3835.2366
+  dps: 6731.37157
+  tps: 3829.01975
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 7258.39061
-  tps: 4113.39229
+  dps: 7250.82587
+  tps: 4105.10797
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7219.63093
-  tps: 4083.64629
+  dps: 7220.39899
+  tps: 4077.91146
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7074.90927
-  tps: 4007.75831
+  dps: 7078.47637
+  tps: 4003.99507
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 6785.08661
-  tps: 3821.55356
+  dps: 6808.67964
+  tps: 3824.82446
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sWartide"
  value: {
-  dps: 5834.60191
-  tps: 3314.49756
+  dps: 5811.32873
+  tps: 3294.86664
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7183.13506
-  tps: 4075.80219
+  dps: 7186.71975
+  tps: 4072.06289
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7204.27234
-  tps: 4089.09201
+  dps: 7207.86104
+  tps: 4085.35739
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7158.92193
-  tps: 4055.57314
+  dps: 7145.24981
+  tps: 4041.11672
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 7224.07169
-  tps: 4091.26582
+  dps: 7216.46661
+  tps: 4082.92669
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-49982"
  value: {
-  dps: 7265.50906
-  tps: 4118.61063
+  dps: 7259.44932
+  tps: 4107.28981
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-50641"
  value: {
-  dps: 7265.50906
-  tps: 4118.61063
+  dps: 7259.44932
+  tps: 4107.28981
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7183.5285
-  tps: 4075.90608
+  dps: 7187.11333
+  tps: 4072.16866
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7104.67206
-  tps: 4026.18802
+  dps: 7109.61857
+  tps: 4021.3188
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7102.11412
-  tps: 4023.86041
+  dps: 7106.60925
+  tps: 4018.62989
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7149.52129
-  tps: 4044.08017
+  dps: 7152.45212
+  tps: 4039.94665
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7098.27178
-  tps: 4025.21678
+  dps: 7100.02914
+  tps: 4024.92235
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7111.83886
-  tps: 4029.17051
+  dps: 7090.83485
+  tps: 4010.85444
   hps: 11.01073
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7022.48882
-  tps: 3974.79956
+  dps: 7026.05741
+  tps: 3971.02472
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7022.48588
-  tps: 3974.79956
+  dps: 7026.03862
+  tps: 3971.02472
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7191.6292
-  tps: 4077.59637
+  dps: 7207.39926
+  tps: 4080.71394
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7022.49471
-  tps: 3974.79956
+  dps: 7026.04892
+  tps: 3971.02472
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7106.78763
-  tps: 4026.39155
+  dps: 7085.79622
+  tps: 4008.08699
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7111.83886
-  tps: 4029.17051
+  dps: 7090.83485
+  tps: 4010.85444
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7022.48588
-  tps: 3974.79956
+  dps: 7026.03862
+  tps: 3971.02472
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7022.49177
-  tps: 3974.79956
+  dps: 7026.04598
+  tps: 3971.02472
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7022.49177
-  tps: 3974.79956
+  dps: 7026.04598
+  tps: 3971.02472
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7085.31992
-  tps: 4014.58632
+  dps: 7065.03222
+  tps: 3996.88038
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7085.31992
-  tps: 4014.58632
+  dps: 7065.03222
+  tps: 3996.88038
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7022.49177
-  tps: 3974.79956
+  dps: 7026.04598
+  tps: 3971.02472
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7450.9307
-  tps: 4269.65785
+  dps: 7440.88764
+  tps: 4257.72811
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7500.91396
-  tps: 4303.57176
+  dps: 7490.72035
+  tps: 4291.53392
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7265.50906
-  tps: 4118.61063
+  dps: 7259.44932
+  tps: 4107.28981
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 7272.7962
-  tps: 4122.43811
+  dps: 7265.23588
+  tps: 4114.16001
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7077.06685
-  tps: 4009.32391
+  dps: 7079.08584
+  tps: 4003.49299
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7022.49766
-  tps: 3974.79956
+  dps: 7026.05446
+  tps: 3971.02472
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 7218.12627
-  tps: 4087.62541
+  dps: 7210.52548
+  tps: 4079.29017
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7022.49766
-  tps: 3974.79956
+  dps: 7026.05446
+  tps: 3971.02472
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7265.50906
-  tps: 4118.61063
+  dps: 7259.44932
+  tps: 4107.28981
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7022.49177
-  tps: 3974.79956
+  dps: 7026.04598
+  tps: 3971.02472
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7022.47638
-  tps: 3974.79956
+  dps: 7026.04598
+  tps: 3971.02472
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkycallTotem-33506"
  value: {
-  dps: 7184.17223
-  tps: 4069.14985
+  dps: 7189.97194
+  tps: 4068.87646
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterHarness"
  value: {
-  dps: 5120.71735
-  tps: 2880.51172
+  dps: 5098.98918
+  tps: 2866.12096
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterRegalia"
  value: {
-  dps: 5097.51935
-  tps: 2885.75611
+  dps: 5074.09189
+  tps: 2874.35217
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7169.60558
-  tps: 4070.2605
+  dps: 7172.73382
+  tps: 4066.2336
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7175.99824
-  tps: 4075.38807
+  dps: 7191.56917
+  tps: 4078.30597
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7085.90359
-  tps: 4014.66902
+  dps: 7089.46984
+  tps: 4010.90821
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7143.46507
-  tps: 4044.08768
+  dps: 7127.06915
+  tps: 4030.09143
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SparkofLife-37657"
  value: {
-  dps: 7115.48326
-  tps: 4024.74138
+  dps: 7106.31514
+  tps: 4015.63659
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7161.71969
-  tps: 4052.23044
+  dps: 7171.58506
+  tps: 4050.80589
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 7219.93803
-  tps: 4086.44886
+  dps: 7214.52218
+  tps: 4078.84609
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StormshroudArmor"
  value: {
-  dps: 5382.64114
-  tps: 3032.52024
+  dps: 5400.19532
+  tps: 3051.13565
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7111.83886
-  tps: 4029.17051
+  dps: 7090.83485
+  tps: 4010.85444
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7106.78763
-  tps: 4026.39155
+  dps: 7085.79622
+  tps: 4008.08699
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7097.94799
-  tps: 4021.52747
+  dps: 7076.97863
+  tps: 4003.24278
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7022.48882
-  tps: 3974.79956
+  dps: 7026.04598
+  tps: 3971.02472
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7109.1538
-  tps: 4019.48013
+  dps: 7104.52788
+  tps: 4020.78351
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheFistsofFury"
  value: {
-  dps: 5612.31419
-  tps: 3096.34017
+  dps: 5611.08229
+  tps: 3091.59047
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7022.49177
-  tps: 3974.79956
+  dps: 7026.04598
+  tps: 3971.02472
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 6975.19817
-  tps: 3964.40307
+  dps: 6985.4974
+  tps: 3964.11836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sRegalia"
  value: {
-  dps: 6572.18057
-  tps: 3760.94078
+  dps: 6578.44008
+  tps: 3755.53961
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7153.30922
-  tps: 4058.61127
+  dps: 7139.65758
+  tps: 4041.60413
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TidefuryRaiment"
  value: {
-  dps: 5102.11905
-  tps: 2877.79462
+  dps: 5099.64659
+  tps: 2875.89883
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7271.02754
-  tps: 4124.02512
+  dps: 7235.64836
+  tps: 4096.2192
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7271.25757
-  tps: 4128.28233
+  dps: 7268.04907
+  tps: 4116.82854
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7106.64592
-  tps: 4028.02491
+  dps: 7086.2969
+  tps: 4010.28057
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7102.38072
-  tps: 4025.33719
+  dps: 7082.04396
+  tps: 4007.60053
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7143.43879
-  tps: 4054.12371
+  dps: 7158.61715
+  tps: 4053.62777
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 7423.11182
-  tps: 4219.62624
+  dps: 7409.64344
+  tps: 4203.81802
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofQuakingEarth-47667"
  value: {
-  dps: 7332.80599
-  tps: 4148.19124
+  dps: 7327.0117
+  tps: 4141.20043
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 7466.24909
-  tps: 4221.73461
+  dps: 7456.05382
+  tps: 4212.2621
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheElementalPlane-40708"
  value: {
-  dps: 7261.95956
-  tps: 4114.96868
+  dps: 7248.86926
+  tps: 4101.16378
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7102.38072
-  tps: 4025.33719
+  dps: 7082.04396
+  tps: 4007.60053
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7106.64592
-  tps: 4028.02491
+  dps: 7086.2969
+  tps: 4010.28057
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5673.51614
-  tps: 3194.28001
+  dps: 5740.03992
+  tps: 3236.74342
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7363.70382
-  tps: 4180.68675
+  dps: 7358.39113
+  tps: 4170.20158
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7086.04422
-  tps: 4015.15374
+  dps: 7090.32038
+  tps: 4011.93792
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 6951.06284
-  tps: 3956.5625
+  dps: 6943.08876
+  tps: 3947.57411
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerGarb"
  value: {
-  dps: 6572.59394
-  tps: 3757.36135
+  dps: 6590.99131
+  tps: 3766.68943
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 7288.04918
-  tps: 4132.01603
+  dps: 7280.49354
+  tps: 4123.74452
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 7240.29712
-  tps: 4104.75861
+  dps: 7237.83006
+  tps: 4097.04107
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21343.89024
-  tps: 12317.3181
+  dps: 21250.82797
+  tps: 12162.58014
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7231.49581
-  tps: 4084.76367
+  dps: 7227.65388
+  tps: 4079.5322
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
   dps: 8570.33925
-  tps: 4436.9868
+  tps: 4426.6562
  }
 }
 dps_results: {
@@ -1002,22 +1002,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21634.81174
-  tps: 12050.52727
+  dps: 21486.66153
+  tps: 12138.20387
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7594.86656
-  tps: 4094.18733
+  dps: 7612.5254
+  tps: 4100.56863
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhFireElemental-FullBuffs-ShortSingleTarget"
  value: {
   dps: 9362.72653
-  tps: 4456.68532
+  tps: 4446.75769
  }
 }
 dps_results: {
@@ -1044,22 +1044,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhItemSwap-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21182.74697
-  tps: 12024.55815
+  dps: 21150.70608
+  tps: 12146.15976
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhItemSwap-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7431.69128
-  tps: 4050.29413
+  dps: 7425.18652
+  tps: 4036.91112
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhItemSwap-FullBuffs-ShortSingleTarget"
  value: {
   dps: 8993.78668
-  tps: 4331.14202
+  tps: 4322.38665
  }
 }
 dps_results: {
@@ -1086,22 +1086,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21299.66134
-  tps: 12354.79994
+  dps: 21177.94285
+  tps: 12153.26114
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7265.50906
-  tps: 4118.61063
+  dps: 7259.44932
+  tps: 4107.28981
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
   dps: 8693.93986
-  tps: 4551.66407
+  tps: 4541.84634
  }
 }
 dps_results: {
@@ -1128,22 +1128,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21265.28868
-  tps: 11989.7054
+  dps: 21214.54969
+  tps: 12135.25268
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7571.99365
-  tps: 4135.03886
+  dps: 7566.2316
+  tps: 4127.93155
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhFireElemental-FullBuffs-ShortSingleTarget"
  value: {
   dps: 9298.01192
-  tps: 4535.76948
+  tps: 4526.27068
  }
 }
 dps_results: {
@@ -1170,22 +1170,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhItemSwap-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20789.92507
-  tps: 11882.05555
+  dps: 20882.62659
+  tps: 12179.23808
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhItemSwap-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7392.86738
-  tps: 4068.18877
+  dps: 7422.01798
+  tps: 4081.87742
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhItemSwap-FullBuffs-ShortSingleTarget"
  value: {
   dps: 8903.92823
-  tps: 4384.7103
+  tps: 4376.10147
  }
 }
 dps_results: {
@@ -1212,7 +1212,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6869.12693
-  tps: 3872.32717
+  dps: 6848.60002
+  tps: 3856.8999
  }
 }

--- a/sim/warlock/TestDemonology.results
+++ b/sim/warlock/TestDemonology.results
@@ -46,288 +46,288 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 9997.07883
-  tps: 8359.73207
+  dps: 10006.29271
+  tps: 8368.32213
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 9819.98083
-  tps: 8182.00051
+  dps: 9825.30984
+  tps: 8187.69368
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 9818.47038
-  tps: 8181.56123
+  dps: 9826.35975
+  tps: 8189.43673
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 9848.71589
-  tps: 8206.52533
+  dps: 9856.7925
+  tps: 8214.65849
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 10010.75718
-  tps: 8373.84803
+  dps: 10019.13966
+  tps: 8382.21665
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 9466.411
-  tps: 8023.43283
+  dps: 9463.56045
+  tps: 8020.10033
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DeathbringerGarb"
  value: {
-  dps: 8718.25291
-  tps: 7331.25831
+  dps: 8712.30974
+  tps: 7326.17407
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 9821.98364
-  tps: 8185.07449
+  dps: 9829.873
+  tps: 8192.94999
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 9819.98083
-  tps: 8182.00051
+  dps: 9825.30984
+  tps: 8187.69368
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 9848.71589
-  tps: 8206.52533
+  dps: 9856.7925
+  tps: 8214.65849
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 9818.47038
-  tps: 8181.56123
+  dps: 9826.35975
+  tps: 8189.43673
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 9818.1525
-  tps: 8181.24335
+  dps: 9826.04187
+  tps: 8189.11886
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 9810.11358
-  tps: 8173.20443
+  dps: 9818.00295
+  tps: 8181.07994
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 9848.71589
-  tps: 8206.52533
+  dps: 9856.7925
+  tps: 8214.65849
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 9842.26859
-  tps: 8201.01617
+  dps: 9848.86052
+  tps: 8207.97272
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 8669.64375
-  tps: 7254.38914
+  dps: 8666.96541
+  tps: 7251.00358
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 9002.87043
-  tps: 7467.32416
+  dps: 9005.928
+  tps: 7470.63892
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 9818.47038
-  tps: 8181.56123
+  dps: 9826.35975
+  tps: 8189.43673
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 9818.1525
-  tps: 8181.24335
+  dps: 9826.04187
+  tps: 8189.11886
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 9824.59359
-  tps: 8185.09019
+  dps: 9819.34261
+  tps: 8179.19259
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 9810.11358
-  tps: 8173.20443
+  dps: 9818.00295
+  tps: 8181.07994
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MaleficRaiment"
  value: {
-  dps: 6837.35292
-  tps: 5632.06201
+  dps: 6838.73808
+  tps: 5633.65062
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 9810.11358
-  tps: 8173.20443
+  dps: 9818.00295
+  tps: 8181.07994
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 9810.11358
-  tps: 8173.20443
+  dps: 9818.00295
+  tps: 8181.07994
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PlagueheartGarb"
  value: {
-  dps: 8348.36758
-  tps: 6996.44891
+  dps: 8345.99942
+  tps: 6994.38564
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 9818.74407
-  tps: 8180.91668
+  dps: 9824.07244
+  tps: 8186.60917
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 9819.98083
-  tps: 8182.00051
+  dps: 9825.30984
+  tps: 8187.69368
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 10001.64827
-  tps: 8364.73912
+  dps: 10010.03075
+  tps: 8373.10774
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 9830.09296
-  tps: 8190.7423
+  dps: 9830.84674
+  tps: 8191.55164
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 9810.11358
-  tps: 8173.20443
+  dps: 9818.00295
+  tps: 8181.07994
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 9810.11358
-  tps: 8173.20443
+  dps: 9818.00295
+  tps: 8181.07994
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 9810.11358
-  tps: 8173.20443
+  dps: 9818.00295
+  tps: 8181.07994
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 9810.11358
-  tps: 8173.20443
+  dps: 9818.00295
+  tps: 8181.07994
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 9848.71589
-  tps: 8206.52533
+  dps: 9856.7925
+  tps: 8214.65849
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 9842.26859
-  tps: 8201.01617
+  dps: 9848.86052
+  tps: 8207.97272
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 9842.26859
-  tps: 8201.01617
+  dps: 9848.86052
+  tps: 8207.97272
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 9848.71589
-  tps: 8206.52533
+  dps: 9856.7925
+  tps: 8214.65849
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 10118.91423
-  tps: 8474.71266
+  dps: 10120.02245
+  tps: 8475.8817
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 34143.62867
-  tps: 38418.89301
+  dps: 34126.62519
+  tps: 38400.98979
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10024.11
-  tps: 8385.45903
+  dps: 10024.80215
+  tps: 8386.22188
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-FullBuffs-ShortSingleTarget"
  value: {
   dps: 11615.85212
-  tps: 9772.83552
+  tps: 9772.86765
  }
 }
 dps_results: {
@@ -354,7 +354,7 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 9882.05518
-  tps: 8373.84803
+  dps: 9902.90503
+  tps: 8394.81094
  }
 }


### PR DESCRIPTION
Judgement of Wisdom was using the white hit PPM proc chance on specials. After testing with several paladins it was confirmed it should not. After this change values reported in the sim are much closer to what paladins are seeing in their logs. 