### PR TITLE
Fix Frostband imbue

### DIFF
--- a/sim/shaman/enhancement/enhancement.go
+++ b/sim/shaman/enhancement/enhancement.go
@@ -82,7 +82,6 @@ func NewEnhancementShaman(character core.Character, options *proto.Player) *Enha
 	enh.RegisterFlametongueImbue(enh.getImbueProcMask(proto.ShamanImbue_FlametongueWeapon), false)
 	enh.RegisterFlametongueImbue(enh.getImbueProcMask(proto.ShamanImbue_FlametongueWeaponDownrank), true)
 	enh.RegisterWindfuryImbue(enh.getImbueProcMask(proto.ShamanImbue_WindfuryWeapon))
-	enh.RegisterFrostbrandImbue(enh.getImbueProcMask(proto.ShamanImbue_FrostbrandWeapon))
 
 	enh.SpiritWolves = &shaman.SpiritWolves{
 		SpiritWolf1: enh.NewSpiritWolf(1),
@@ -120,6 +119,8 @@ func (enh *EnhancementShaman) GetShaman() *shaman.Shaman {
 
 func (enh *EnhancementShaman) Initialize() {
 	enh.Shaman.Initialize()
+	// In the Initialize due to frost brand adding the aura to the enemy
+	enh.RegisterFrostbrandImbue(enh.getImbueProcMask(proto.ShamanImbue_FrostbrandWeapon))
 
 	if enh.ItemSwap.IsEnabled() {
 		mh := enh.ItemSwap.GetItem(proto.ItemSlot_ItemSlotMainHand)


### PR DESCRIPTION
Frostband imbue from NewEnhancementShaman back to the initialize method, due to Frostbrand register relying on adding aura to enenmy.