### PR TITLE
vigo/advanced-advance

### DIFF
--- a/sim/common/tbc/other_items.go
+++ b/sim/common/tbc/other_items.go
@@ -8,11 +8,11 @@ import (
 func init() {
 	core.NewItemEffect(30892, func(agent core.Agent) {
 		for _, pet := range agent.GetCharacter().Pets {
-			if pet.GetPet().IsGuardian() {
+			if pet.IsGuardian() {
 				continue // not sure if this applies to guardians.
 			}
-			pet.GetCharacter().PseudoStats.DamageDealtMultiplier *= 1.03
-			pet.GetCharacter().AddStat(stats.MeleeCrit, core.CritRatingPerCritChance*2)
+			pet.PseudoStats.DamageDealtMultiplier *= 1.03
+			pet.AddStat(stats.MeleeCrit, core.CritRatingPerCritChance*2)
 		}
 	})
 }

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -600,12 +600,9 @@ func BloodlustAura(character *Character, actionTag int32) *Aura {
 		OnGain: func(aura *Aura, sim *Simulation) {
 			character.MultiplyAttackSpeed(sim, 1.3)
 
-			if len(character.Pets) > 0 {
-				for _, petAgent := range character.Pets {
-					pet := petAgent.GetPet()
-					if pet.IsEnabled() && !pet.IsGuardian() {
-						BloodlustAura(&pet.Character, actionTag).Activate(sim)
-					}
+			for _, pet := range character.Pets {
+				if pet.IsEnabled() && !pet.IsGuardian() {
+					BloodlustAura(&pet.Character, actionTag).Activate(sim)
 				}
 			}
 		},

--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -116,7 +116,7 @@ func (spell *Spell) wrapCastFuncInit(config CastConfig, onCastComplete CastSucce
 	}
 }
 
-func (spell *Spell) wrapCastFuncExtraCond(config CastConfig, onCastComplete CastSuccessFunc) CastSuccessFunc {
+func (spell *Spell) wrapCastFuncExtraCond(_ CastConfig, onCastComplete CastSuccessFunc) CastSuccessFunc {
 	if spell.ExtraCastCondition == nil {
 		return onCastComplete
 	} else {
@@ -133,7 +133,7 @@ func (spell *Spell) wrapCastFuncExtraCond(config CastConfig, onCastComplete Cast
 	}
 }
 
-func (spell *Spell) wrapCastFuncCDsReady(config CastConfig, onCastComplete CastSuccessFunc) CastSuccessFunc {
+func (spell *Spell) wrapCastFuncCDsReady(_ CastConfig, onCastComplete CastSuccessFunc) CastSuccessFunc {
 	if spell.Unit.PseudoStats.GracefulCastCDFailures {
 		return func(sim *Simulation, target *Unit) bool {
 			if spell.IsReady(sim) {
@@ -150,7 +150,7 @@ func (spell *Spell) wrapCastFuncCDsReady(config CastConfig, onCastComplete CastS
 	}
 }
 
-func (spell *Spell) wrapCastFuncResources(config CastConfig, onCastComplete CastFunc) CastSuccessFunc {
+func (spell *Spell) wrapCastFuncResources(_ CastConfig, onCastComplete CastFunc) CastSuccessFunc {
 	if spell.Cost == nil {
 		return func(sim *Simulation, target *Unit) bool {
 			onCastComplete(sim, target)
@@ -184,7 +184,7 @@ func (spell *Spell) wrapCastFuncHaste(config CastConfig, onCastComplete CastFunc
 	}
 }
 
-func (spell *Spell) wrapCastFuncGCD(config CastConfig, onCastComplete CastFunc) CastFunc {
+func (spell *Spell) wrapCastFuncGCD(_ CastConfig, onCastComplete CastFunc) CastFunc {
 	if spell.DefaultCast == emptyCast { // spells that are not actually cast (e.g. auto attacks, procs)
 		return onCastComplete
 	}

--- a/sim/core/environment.go
+++ b/sim/core/environment.go
@@ -36,6 +36,8 @@ type Environment struct {
 	Encounter Encounter
 	AllUnits  []*Unit
 
+	characters []*Character // "cached" in init(), for advance()
+
 	BaseDuration      time.Duration // base duration
 	DurationVariation time.Duration // variation per duration
 
@@ -154,8 +156,8 @@ func (env *Environment) finalize(raidProto *proto.Raid, _ *proto.Encounter, raid
 		for _, player := range party.Players {
 			character := player.GetCharacter()
 			character.Finalize()
-			for _, petAgent := range character.Pets {
-				petAgent.GetPet().Finalize()
+			for _, pet := range character.Pets {
+				pet.Finalize()
 			}
 		}
 	}
@@ -271,7 +273,7 @@ func (env *Environment) GetUnit(ref *proto.UnitReference, contextUnit *Unit) *Un
 		if ownerAgent == nil {
 			return nil
 		}
-		pets := ownerAgent.GetCharacter().Pets
+		pets := ownerAgent.GetCharacter().PetAgents
 		if int(ref.Index) < len(pets) {
 			return &pets[ref.Index].GetCharacter().Unit
 		} else {

--- a/sim/core/mana.go
+++ b/sim/core/mana.go
@@ -240,9 +240,8 @@ func (sim *Simulation) initManaTickAction() {
 				playersWithManaBars = append(playersWithManaBars, player)
 			}
 
-			for _, petAgent := range character.Pets {
-				pet := petAgent.GetPet()
-				if pet.HasManaBar() {
+			for _, petAgent := range character.PetAgents {
+				if petAgent.GetPet().HasManaBar() {
 					petsWithManaBars = append(petsWithManaBars, petAgent)
 				}
 			}
@@ -333,5 +332,4 @@ func (mc *ManaCost) SpendCost(sim *Simulation, spell *Spell) {
 		spell.Unit.PseudoStats.FiveSecondRuleRefreshTime = sim.CurrentTime + time.Second*5
 	}
 }
-func (mc *ManaCost) IssueRefund(sim *Simulation, spell *Spell) {
-}
+func (mc *ManaCost) IssueRefund(_ *Simulation, _ *Spell) {}

--- a/sim/core/pet.go
+++ b/sim/core/pet.go
@@ -86,8 +86,8 @@ func NewPet(name string, owner *Character, baseStats stats.Stats, statInheritanc
 	return pet
 }
 
-// Add a default base if pets dont need this
-func (pet *Pet) OwnerAttackSpeedChanged(sim *Simulation) {}
+// Add a default base if pets don't need this
+func (pet *Pet) OwnerAttackSpeedChanged(_ *Simulation) {}
 
 // Updates the stats for this pet in response to a stat change on the owner.
 // addedStats is the amount of stats added to the owner (will be negative if the
@@ -128,8 +128,8 @@ func (pet *Pet) reset(sim *Simulation, agent PetAgent) {
 		pet.Enable(sim, agent)
 	}
 }
-func (pet *Pet) advance(sim *Simulation, elapsedTime time.Duration) {
-	pet.Character.advance(sim, elapsedTime)
+func (pet *Pet) advance(sim *Simulation) {
+	pet.Character.advance(sim)
 }
 func (pet *Pet) doneIteration(sim *Simulation) {
 	pet.Character.doneIteration(sim)
@@ -248,6 +248,6 @@ func (pet *Pet) EnableWithTimeout(sim *Simulation, petAgent PetAgent, petDuratio
 func (pet *Pet) GetCharacter() *Character {
 	return &pet.Character
 }
-func (pet *Pet) AddRaidBuffs(raidBuffs *proto.RaidBuffs)    {}
-func (pet *Pet) AddPartyBuffs(partyBuffs *proto.PartyBuffs) {}
-func (pet *Pet) ApplyTalents()                              {}
+func (pet *Pet) AddRaidBuffs(_ *proto.RaidBuffs)   {}
+func (pet *Pet) AddPartyBuffs(_ *proto.PartyBuffs) {}
+func (pet *Pet) ApplyTalents()                     {}

--- a/sim/core/racials.go
+++ b/sim/core/racials.go
@@ -124,11 +124,8 @@ func applyRaceEffects(agent Agent) {
 		// TODO: Shadowmeld?
 	case proto.Race_RaceOrc:
 		// Command (Pet damage +5%)
-		if len(character.Pets) > 0 {
-			for _, petAgent := range character.Pets {
-				pet := petAgent.GetPet()
-				pet.PseudoStats.DamageDealtMultiplier *= 1.05
-			}
+		for _, pet := range character.Pets {
+			pet.PseudoStats.DamageDealtMultiplier *= 1.05
 		}
 
 		// Blood Fury

--- a/sim/core/raid.go
+++ b/sim/core/raid.go
@@ -353,13 +353,13 @@ func (raid *Raid) applyCharacterEffects(raidConfig *proto.Raid) *proto.RaidStats
 	return raidStats
 }
 
-func (raid Raid) AddStats(s stats.Stats) {
+func (raid *Raid) AddStats(s stats.Stats) {
 	for _, party := range raid.Parties {
 		party.AddStats(s)
 	}
 }
 
-func (raid Raid) GetPlayersOfClass(class proto.Class) []Agent {
+func (raid *Raid) GetPlayersOfClass(class proto.Class) []Agent {
 	classPlayers := []Agent{}
 	for _, party := range raid.Parties {
 		for _, agent := range party.Players {
@@ -371,7 +371,7 @@ func (raid Raid) GetPlayersOfClass(class proto.Class) []Agent {
 	return classPlayers
 }
 
-func (raid Raid) GetPlayerFromUnit(unit *Unit) Agent {
+func (raid *Raid) GetPlayerFromUnit(unit *Unit) Agent {
 	for _, party := range raid.Parties {
 		for _, agent := range party.PlayersAndPets {
 			if &agent.GetCharacter().Unit == unit {
@@ -382,7 +382,7 @@ func (raid Raid) GetPlayerFromUnit(unit *Unit) Agent {
 	return nil
 }
 
-func (raid Raid) GetFirstNPlayersOrPets(n int32) []*Unit {
+func (raid *Raid) GetFirstNPlayersOrPets(n int32) []*Unit {
 	return raid.AllUnits[:MinInt32(n, int32(len(raid.AllUnits)))]
 }
 

--- a/sim/core/raid.go
+++ b/sim/core/raid.go
@@ -288,7 +288,7 @@ func (raid *Raid) updatePlayersAndPets() {
 	for _, party := range raid.Parties {
 		party.Pets = []PetAgent{}
 		for _, player := range party.Players {
-			for _, petAgent := range player.GetCharacter().Pets {
+			for _, petAgent := range player.GetCharacter().PetAgents {
 				party.Pets = append(party.Pets, petAgent)
 				raidPets = append(raidPets, &petAgent.GetPet().Unit)
 			}
@@ -342,8 +342,8 @@ func (raid *Raid) applyCharacterEffects(raidConfig *proto.Raid) *proto.RaidStats
 			char.trackChanceOfDeath(playerConfig.HealingModel)
 			partyStats.Players[char.PartyIndex] = char.applyAllEffects(player, raidBuffs, partyBuffs, individualBuffs)
 
-			for _, petAgent := range char.Pets {
-				petAgent.GetCharacter().EnableHealthBar()
+			for _, pet := range char.Pets {
+				pet.EnableHealthBar()
 			}
 		}
 
@@ -441,18 +441,6 @@ func SinglePlayerRaidProto(player *proto.Player, partyBuffs *proto.PartyBuffs, r
 		Buffs:   raidBuffs,
 		Debuffs: debuffs,
 	}
-}
-
-func RaidPlayersWithSpec(raid *proto.Raid, spec proto.Spec) []*proto.Player {
-	var specPlayers []*proto.Player
-	for _, party := range raid.Parties {
-		for _, player := range party.Players {
-			if player != nil && player.GetSpec() != nil && PlayerProtoToSpec(player) == spec {
-				specPlayers = append(specPlayers, player)
-			}
-		}
-	}
-	return specPlayers
 }
 
 func RaidPlayersWithClass(raid *proto.Raid, class proto.Class) []*proto.Player {

--- a/sim/core/target.go
+++ b/sim/core/target.go
@@ -19,7 +19,7 @@ type Encounter struct {
 	ExecuteProportion_35 float64
 
 	EndFightAtHealth float64
-	// DamgeTaken is used to track health fights instead of duration fights.
+	// DamageTaken is used to track health fights instead of duration fights.
 	//  Once primary target has taken its health worth of damage, fight ends.
 	DamageTaken float64
 	// In health fight: set to true until we get something to base on
@@ -176,8 +176,8 @@ func (target *Target) Reset(sim *Simulation) {
 	}
 }
 
-func (target *Target) Advance(sim *Simulation, elapsedTime time.Duration) {
-	target.Unit.advance(sim, elapsedTime)
+func (target *Target) Advance(sim *Simulation) {
+	target.Unit.advance(sim)
 }
 
 func (target *Target) doneIteration(sim *Simulation) {

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -108,7 +108,7 @@ type Unit struct {
 	spellRegistrationHandlers []SpellRegisteredHandler
 
 	// Pets owned by this Unit.
-	Pets []PetAgent
+	PetAgents []PetAgent
 
 	// AutoAttacks is the manager for auto attack swings.
 	// Must be enabled to use, with "EnableAutoAttacks()".
@@ -256,10 +256,8 @@ func (unit *Unit) processDynamicBonus(sim *Simulation, bonus stats.Stats) {
 		unit.updateCastSpeed()
 	}
 
-	if len(unit.Pets) > 0 {
-		for _, petAgent := range unit.Pets {
-			petAgent.GetPet().addOwnerStats(sim, bonus)
-		}
+	for _, petAgent := range unit.PetAgents {
+		petAgent.GetPet().addOwnerStats(sim, bonus)
 	}
 }
 
@@ -467,7 +465,7 @@ func (unit *Unit) startPull(sim *Simulation) {
 }
 
 // Advance moves time forward counting down auras, CDs, mana regen, etc
-func (unit *Unit) advance(sim *Simulation, _ time.Duration) {
+func (unit *Unit) advance(sim *Simulation) {
 	unit.auraTracker.advance(sim)
 
 	if hc := &unit.Hardcast; hc.Expires != startingCDTime && hc.Expires <= sim.CurrentTime {

--- a/sim/hunter/pet_talents.go
+++ b/sim/hunter/pet_talents.go
@@ -136,7 +136,7 @@ func (hp *HunterPet) applyFeedingFrenzy() {
 	multiplier := 1.0 + 0.08*float64(hp.Talents().FeedingFrenzy)
 
 	hp.RegisterResetEffect(func(sim *core.Simulation) {
-		sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int) {
+		sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int32) {
 			if isExecute == 35 {
 				hp.PseudoStats.DamageDealtMultiplier *= multiplier
 			}

--- a/sim/mage/talents.go
+++ b/sim/mage/talents.go
@@ -620,7 +620,7 @@ func (mage *Mage) applyMoltenFury() {
 	multiplier := 1.0 + 0.06*float64(mage.Talents.MoltenFury)
 
 	mage.RegisterResetEffect(func(sim *core.Simulation) {
-		sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int) {
+		sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int32) {
 			mage.GetMajorCooldown(core.ActionID{SpellID: EvocationId}).Disable()
 			if isExecute == 35 {
 				mage.PseudoStats.DamageDealtMultiplier *= multiplier

--- a/sim/paladin/protection/protection.go
+++ b/sim/paladin/protection/protection.go
@@ -109,7 +109,7 @@ func (prot *ProtectionPaladin) Initialize() {
 func (prot *ProtectionPaladin) Reset(sim *core.Simulation) {
 	prot.Paladin.Reset(sim)
 
-	sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int) {
+	sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int32) {
 		if isExecute == 20 {
 			prot.OnGCDReady(sim)
 		}

--- a/sim/paladin/retribution/retribution.go
+++ b/sim/paladin/retribution/retribution.go
@@ -151,7 +151,7 @@ func (ret *RetributionPaladin) Reset(sim *core.Simulation) {
 		}
 	}
 
-	sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int) {
+	sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int32) {
 		if isExecute == 20 {
 			ret.OnGCDReady(sim)
 		}

--- a/sim/priest/shadow_word_death.go
+++ b/sim/priest/shadow_word_death.go
@@ -10,7 +10,7 @@ import (
 func (priest *Priest) registerShadowWordDeathSpell() {
 	if priest.HasMajorGlyph(proto.PriestMajorGlyph_GlyphOfShadowWordDeath) {
 		priest.RegisterResetEffect(func(sim *core.Simulation) {
-			sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int) {
+			sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int32) {
 				if isExecute == 35 {
 					priest.ShadowWordDeath.DamageMultiplier *= 1.1
 				}

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -178,7 +178,7 @@ func (rogue *Rogue) registerDirtyDeeds() {
 	actionID := core.ActionID{SpellID: 14083}
 
 	rogue.RegisterResetEffect(func(sim *core.Simulation) {
-		sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int) {
+		sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int32) {
 			if isExecute == 35 {
 				rogue.DirtyDeedsAura.Activate(sim)
 			}

--- a/sim/warlock/drain_soul.go
+++ b/sim/warlock/drain_soul.go
@@ -96,7 +96,7 @@ func (warlock *Warlock) registerDrainSoulSpell() {
 	})
 
 	warlock.RegisterResetEffect(func(sim *core.Simulation) {
-		sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int) {
+		sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int32) {
 			if isExecute == 25 {
 				mult := (4.0 + 0.04*float64(warlock.Talents.DeathsEmbrace)) / (1 + 0.04*float64(warlock.Talents.DeathsEmbrace))
 				warlock.DrainSoul.DamageMultiplier = mult

--- a/sim/warlock/shadowburn.go
+++ b/sim/warlock/shadowburn.go
@@ -16,7 +16,7 @@ func (warlock *Warlock) registerShadowBurnSpell() {
 
 	if warlock.HasMajorGlyph(proto.WarlockMajorGlyph_GlyphOfShadowburn) {
 		warlock.RegisterResetEffect(func(sim *core.Simulation) {
-			sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int) {
+			sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int32) {
 				if isExecute == 35 {
 					warlock.Shadowburn.BonusCritRating += 20 * core.CritRatingPerCritChance
 				}

--- a/sim/warlock/talents.go
+++ b/sim/warlock/talents.go
@@ -71,7 +71,7 @@ func (warlock *Warlock) applyDeathsEmbrace() {
 
 	multiplier := 1.0 + 0.04*float64(warlock.Talents.DeathsEmbrace)
 	warlock.RegisterResetEffect(func(sim *core.Simulation) {
-		sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int) {
+		sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int32) {
 			if isExecute == 35 {
 				warlock.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexShadow] *= multiplier
 			}
@@ -195,7 +195,7 @@ func (warlock *Warlock) setupDecimation() {
 	})
 
 	warlock.RegisterResetEffect(func(sim *core.Simulation) {
-		sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int) {
+		sim.RegisterExecutePhaseCallback(func(sim *core.Simulation, isExecute int32) {
 			if isExecute == 35 {
 				decimation.Activate(sim)
 			}


### PR DESCRIPTION
[core] rewrite execute phase handling to minimize the number of checks in advance()

[core] cache players and pets as *Character for use in advance()

[core] cleanup - cached pets are used instead of (renamed) PetAgents wherever applicable

[core] cleanup - change "isExecute" parameter from int to int32, for good measure

[core] cleanup - remove superfluous "not empty" check before iterating character.Pets in various places

[core] cleanup - remove unused parameters in init(), reset(), and advance() hierarchies