### PR TITLE
Fix druid nibelung

### DIFF
--- a/sim/common/wotlk/nibelung.go
+++ b/sim/common/wotlk/nibelung.go
@@ -118,7 +118,7 @@ func MakeNibelungTriggerAura(agent core.Agent, isHeroic bool) {
 		ICD:        time.Millisecond * 250,
 		ActionID:   core.ActionID{SpellID: procSpellId},
 		Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
-			for _, pet := range character.Pets {
+			for _, pet := range character.PetAgents {
 				valkyr, ok := pet.(*ValkyrPet)
 				if ok && !valkyr.IsEnabled() {
 					valkyr.registerSmite(isHeroic)

--- a/sim/common/wotlk/nibelung.go
+++ b/sim/common/wotlk/nibelung.go
@@ -117,7 +117,12 @@ func MakeNibelungTriggerAura(agent core.Agent, isHeroic bool) {
 		ProcChance: 0.02,
 		ICD:        time.Millisecond * 250,
 		ActionID:   core.ActionID{SpellID: procSpellId},
-		Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
+		Handler: func(sim *core.Simulation, spell *core.Spell, _ *core.SpellResult) {
+			// dummy proc spell can't proc nibelung
+			if spell == spell.Unit.GetDummyProcSpell() {
+				return
+			}
+
 			for _, pet := range character.PetAgents {
 				valkyr, ok := pet.(*ValkyrPet)
 				if ok && !valkyr.IsEnabled() {


### PR DESCRIPTION
Based on these logs:
https://classic.warcraftlogs.com/reports/a:HqayKwtz7LZFbhJV
https://classic.warcraftlogs.com/reports/a:HWhdDvjKwgrcfFG1

Based on those two logs it looks like Nibelung does not work like fetish:

first log
number of casts: 496+304+73+35+24+11+11+11+5
number of summons: 17
proc rate: 17/970 = 1.75%

second log
number of casts: 763+426+138+73+41+21+17+16+13
number of summons: 41
proc rate: 41/1508 = 2.7%

If it had double-proc chance on wrath and triple-proc on starfire we'd see a lot more
since for example at a 2% proc rate:
`496*2+304*3+73+35+24+11+11+11+5 = 2074`
expected summons = 2074 * 0.02 = 41.48

However, fetish definitely does double and triple-proc