### PR TITLE
Removed CD on Chilled to the Bone spell

### DIFF
--- a/sim/encounters/icc/sindragosa25h_ai.go
+++ b/sim/encounters/icc/sindragosa25h_ai.go
@@ -93,18 +93,10 @@ func (ai *Sindragosa25HAI) Reset(sim *core.Simulation) {
 
 func (ai *Sindragosa25HAI) registerPermeatingChillAura(target *core.Target) {
 	ai.ChilledToTheBone = target.RegisterSpell(core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: 70106},
-		SpellSchool: core.SpellSchoolFrost,
-		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       core.SpellFlagNone,
-
-		Cast: core.CastConfig{
-			CD: core.Cooldown{
-				Timer:    target.NewTimer(),
-				Duration: time.Second * 2,
-			},
-		},
-
+		ActionID:         core.ActionID{SpellID: 70106},
+		SpellSchool:      core.SpellSchoolFrost,
+		ProcMask:         core.ProcMaskSpellDamage,
+		Flags:            core.SpellFlagNone,
 		DamageMultiplier: 1,
 		CritMultiplier:   1,
 		ThreatMultiplier: 0,


### PR DESCRIPTION
Removed CD on Chilled to the Bone spell, since it's redundant with the ICD on the player proc trigger and was causing crashes on DK sims with pets.

 Changes to be committed:
	modified:   sim/encounters/icc/sindragosa25h_ai.go