### PR TITLE
downgrade sass to remove deprecation warning noise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "eslint-plugin-unused-imports": "^2.0.0",
                 "glob": "^8.0.3",
                 "http-server": "13.0.1",
-                "sass": "^1.39.0",
+                "sass": "^1.64.2",
                 "terser": "^5.14.2",
                 "typescript": "5.2.2",
                 "typescript-formatter": "^7.2.2",
@@ -2243,9 +2243,9 @@
             }
         },
         "node_modules/sass": {
-            "version": "1.65.1",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.65.1.tgz",
-            "integrity": "sha512-9DINwtHmA41SEd36eVPQ9BJKpn7eKDQmUHmpI0y5Zv2Rcorrh0zS+cFrt050hdNbmmCNKTW3hV5mWfuegNRsEA==",
+            "version": "1.64.2",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.64.2.tgz",
+            "integrity": "sha512-TnDlfc+CRnUAgLO9D8cQLFu/GIjJIzJCGkE7o4ekIGQOH7T3GetiRR/PsTWJUHhkzcSPrARkPI+gNWn5alCzDg==",
             "dev": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -4219,9 +4219,9 @@
             }
         },
         "sass": {
-            "version": "1.65.1",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.65.1.tgz",
-            "integrity": "sha512-9DINwtHmA41SEd36eVPQ9BJKpn7eKDQmUHmpI0y5Zv2Rcorrh0zS+cFrt050hdNbmmCNKTW3hV5mWfuegNRsEA==",
+            "version": "1.64.2",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.64.2.tgz",
+            "integrity": "sha512-TnDlfc+CRnUAgLO9D8cQLFu/GIjJIzJCGkE7o4ekIGQOH7T3GetiRR/PsTWJUHhkzcSPrARkPI+gNWn5alCzDg==",
             "dev": true,
             "requires": {
                 "chokidar": ">=3.0.0 <4.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "eslint-plugin-unused-imports": "^2.0.0",
         "glob": "^8.0.3",
         "http-server": "13.0.1",
-        "sass": "^1.39.0",
+        "sass": "^1.64.2",
         "terser": "^5.14.2",
         "typescript": "5.2.2",
         "typescript-formatter": "^7.2.2",


### PR DESCRIPTION
Until bootstrap addresses all the deprecation warnings, these are just annoying