### PR TITLE
ui: mobile fixes

### DIFF
--- a/ui/core/components/gear_picker.tsx
+++ b/ui/core/components/gear_picker.tsx
@@ -258,24 +258,10 @@ export class ItemPicker extends Component {
 				event.preventDefault();
 				this.openSelectorModal(SelectorModalTabs.Enchants, gearData);
 			};
-			const onClickEnd = (event: Event) => {
-				event.preventDefault();
-			};
 
-			// Make icon open gear selector
 			this.itemElem.iconElem.addEventListener('click', openGearSelector);
-			this.itemElem.iconElem.addEventListener('touchstart', openGearSelector);
-			this.itemElem.iconElem.addEventListener('touchend', onClickEnd);
-
-			// Make item name open gear selector
 			this.itemElem.nameElem.addEventListener('click', openGearSelector);
-			this.itemElem.nameElem.addEventListener('touchstart', openGearSelector);
-			this.itemElem.nameElem.addEventListener('touchend', onClickEnd);
-
-			// Make enchant name open enchant selector
 			this.itemElem.enchantElem.addEventListener('click', openEnchantSelector);
-			this.itemElem.enchantElem.addEventListener('touchstart', openEnchantSelector);
-			this.itemElem.enchantElem.addEventListener('touchend', onClickEnd);
 		});
 
 		player.gearChangeEmitter.on(() => {
@@ -370,7 +356,6 @@ export class IconItemSwapPicker<SpecType extends Spec, ValueType> extends Input<
 			};
 
 			this.iconAnchor.addEventListener('click', onClickStart);
-			this.iconAnchor.addEventListener('touchstart', onClickStart);
 		}).finally(() => this.init());
 
 	}

--- a/ui/core/components/gear_picker.tsx
+++ b/ui/core/components/gear_picker.tsx
@@ -190,11 +190,12 @@ export class ItemRenderer extends Component {
 			// Make enchant text hover have a tooltip.
 			if (newItem.enchant.spellId) {
 				this.enchantElem.href = ActionId.makeSpellUrl(newItem.enchant.spellId);
-				this.enchantElem.setAttribute('data-wowhead', `domain=wotlk&spell=${newItem.enchant.spellId}`);
+				this.enchantElem.dataset.wowhead = `domain=wotlk&spell=${newItem.enchant.spellId}`;
 			} else {
 				this.enchantElem.href = ActionId.makeItemUrl(newItem.enchant.itemId);
-				this.enchantElem.setAttribute('data-wowhead', `domain=wotlk&item=${newItem.enchant.itemId}`);
+				this.enchantElem.dataset.wowhead = `domain=wotlk&item=${newItem.enchant.itemId}`;
 			}
+			this.enchantElem.dataset.whtticon = 'false';
 		}
 
 		newItem.allSocketColors().forEach((socketColor, gemIdx) => {
@@ -1149,7 +1150,7 @@ export class ItemList<T> {
 		const listItemElem = (
 			<li className={`selector-modal-list-item ${equipdItemId == itemData.id ? 'active' : ''}`} dataset={{idx: item.idx.toString()}}>
 				<div className='selector-modal-list-label-cell'>
-					<a className='selector-modal-list-item-link' ref={anchorElem}>
+					<a className='selector-modal-list-item-link' ref={anchorElem} dataset={{whtticon:'false'}}>
 						<img className='selector-modal-list-item-icon' ref={iconElem}></img>
 						<label className='selector-modal-list-item-name' ref={nameElem}>
 							{itemData.name}

--- a/ui/core/components/icon_enum_picker.ts
+++ b/ui/core/components/icon_enum_picker.ts
@@ -71,6 +71,7 @@ export class IconEnumPicker<ModObject, T> extends Input<ModObject, T> {
 				data-bs-placement="bottom"
 				aria-expanded="false"
 				data-whtticon="false"
+				data-disable-wowhead-touch-tooltip='true'
 			>
 				<span class='icon-picker-label'></span>
 			</a>
@@ -90,6 +91,7 @@ export class IconEnumPicker<ModObject, T> extends Input<ModObject, T> {
 
 			const option = document.createElement('a');
 			option.classList.add('icon-picker-button');
+			option.dataset.disableWowheadTouchTooltip='true';
 			optionContainer.appendChild(option);
 			this.setImage(option, valueConfig);
 

--- a/ui/core/components/icon_enum_picker.ts
+++ b/ui/core/components/icon_enum_picker.ts
@@ -121,20 +121,6 @@ export class IconEnumPicker<ModObject, T> extends Input<ModObject, T> {
 				event.preventDefault();
 				this.currentValue = valueConfig.value;
 				this.inputChanged(TypedEvent.nextEventID());
-
-				// Wowhead tooltips can't seem to detect when an element is hidden while
-				// being moused over, and the tooltip doesn't disappear. Patch this by
-				// dispatching our own mouseout event.
-				option.dispatchEvent(new Event('mouseout'));
-			});
-			option.addEventListener('touchstart', event => {
-				event.preventDefault();
-			});
-			option.addEventListener('touchend', event => {
-				event.preventDefault();
-				this.currentValue = valueConfig.value;
-				this.inputChanged(TypedEvent.nextEventID());
-				dropdownMenu.style.display = "none";
 			});
 		});
 

--- a/ui/core/components/icon_enum_picker.ts
+++ b/ui/core/components/icon_enum_picker.ts
@@ -70,6 +70,7 @@ export class IconEnumPicker<ModObject, T> extends Input<ModObject, T> {
 				data-bs-toggle="dropdown"
 				data-bs-placement="bottom"
 				aria-expanded="false"
+				data-whtticon="false"
 			>
 				<span class='icon-picker-label'></span>
 			</a>

--- a/ui/core/components/icon_picker.tsx
+++ b/ui/core/components/icon_picker.tsx
@@ -89,8 +89,9 @@ export class IconPicker<ModObject, ValueType> extends Input<ModObject, ValueType
 		this.init();
 
 		this.rootAnchor.addEventListener('click', event => {
-			event.preventDefault();
-		});
+			this.handleLeftClick(event);
+		})
+
 		this.rootAnchor.addEventListener('contextmenu', event => {
 			event.preventDefault();
 		});
@@ -99,16 +100,8 @@ export class IconPicker<ModObject, ValueType> extends Input<ModObject, ValueType
 
 			if (rightClick) {
 				this.handleRightClick(event)
-			} else {
-				this.handleLeftClick(event)
+				event.preventDefault();
 			}
-		});
-
-		this.rootAnchor.addEventListener('touchstart', event => {
-			this.handleLeftClick(event)
-		});
-		this.rootAnchor.addEventListener('touchend', event => {
-			event.preventDefault();
 		});
 	}
 

--- a/ui/core/components/icon_picker.tsx
+++ b/ui/core/components/icon_picker.tsx
@@ -48,6 +48,7 @@ export class IconPicker<ModObject, ValueType> extends Input<ModObject, ValueType
 		this.rootAnchor = document.createElement('a');
 		this.rootAnchor.classList.add('icon-picker-button');
 		this.rootAnchor.dataset.whtticon = 'false';
+		this.rootAnchor.dataset.disableWowheadTouchTooltip = 'true';
 		this.rootAnchor.target = '_blank';
 		this.rootElem.prepend(this.rootAnchor);
 
@@ -67,8 +68,8 @@ export class IconPicker<ModObject, ValueType> extends Input<ModObject, ValueType
 		let ce = ref<HTMLSpanElement>();
 		this.rootAnchor.appendChild(
 			<div className='icon-input-level-container'>
-				<a ref={ia} className="icon-picker-button icon-input-improved icon-input-improved1"></a>
-				<a ref={ia2} className="icon-picker-button icon-input-improved icon-input-improved2"></a>
+				<a ref={ia} className="icon-picker-button icon-input-improved icon-input-improved1" dataset={{disableWowheadTouchTooltip:'true'}}></a>
+				<a ref={ia2} className="icon-picker-button icon-input-improved icon-input-improved2" dataset={{disableWowheadTouchTooltip:'true'}}></a>
 				<span ref={ce} className={`icon-picker-label ${this.config.states > 2 ? '' : 'hide'}`}></span>
 			</div>
 		);

--- a/ui/core/components/icon_picker.tsx
+++ b/ui/core/components/icon_picker.tsx
@@ -47,6 +47,7 @@ export class IconPicker<ModObject, ValueType> extends Input<ModObject, ValueType
 
 		this.rootAnchor = document.createElement('a');
 		this.rootAnchor.classList.add('icon-picker-button');
+		this.rootAnchor.dataset.whtticon = 'false';
 		this.rootAnchor.target = '_blank';
 		this.rootElem.prepend(this.rootAnchor);
 

--- a/ui/core/components/individual_sim_ui/bulk_tab.ts
+++ b/ui/core/components/individual_sim_ui/bulk_tab.ts
@@ -189,23 +189,9 @@ export class BulkItemPicker extends Component {
 				}
 			};
 
-			const onClickEnd = (event: Event) => {
-				event.preventDefault();
-			};
-
-			// Make icon open gear selector
 			this.itemElem.iconElem.addEventListener('click', openEnchantGemSelector);
-			this.itemElem.iconElem.addEventListener('touchstart', openEnchantGemSelector);
-			this.itemElem.iconElem.addEventListener('touchend', onClickEnd);
-
-			// Make item name open gear selector
 			this.itemElem.nameElem.addEventListener('click', openEnchantGemSelector);
-			this.itemElem.nameElem.addEventListener('touchstart', openEnchantGemSelector);
-			this.itemElem.nameElem.addEventListener('touchend', onClickEnd);
-
 			this.itemElem.enchantElem.addEventListener('click', openEnchantGemSelector);
-			this.itemElem.enchantElem.addEventListener('touchstart', openEnchantGemSelector);
-			this.itemElem.enchantElem.addEventListener('touchend', onClickEnd);
 		});
 	}
 

--- a/ui/core/components/multi_icon_picker.ts
+++ b/ui/core/components/multi_icon_picker.ts
@@ -43,6 +43,7 @@ export class MultiIconPicker<ModObject> extends Component {
 					role="button"
 					data-bs-toggle="dropdown"
 					aria-expanded="false"
+					data-disable-wowhead-touch-tooltip='true'
 					data-whtticon='false'
 				></a>
 				<ul class="dropdown-menu"></ul>

--- a/ui/core/components/multi_icon_picker.ts
+++ b/ui/core/components/multi_icon_picker.ts
@@ -43,6 +43,7 @@ export class MultiIconPicker<ModObject> extends Component {
 					role="button"
 					data-bs-toggle="dropdown"
 					aria-expanded="false"
+					data-whtticon='false'
 				></a>
 				<ul class="dropdown-menu"></ul>
 			</div>

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -912,7 +912,8 @@ export class Player<SpecType extends Spec> {
 			parts.push('sock');
 		}
 
-		elem.setAttribute('data-wowhead', parts.join('&'));
+		elem.dataset.wowhead = parts.join('&');
+		elem.dataset.whtticon = 'false';
 	}
 
 	static ARMOR_SLOTS: Array<ItemSlot> = [

--- a/ui/core/talents/glyphs_picker.ts
+++ b/ui/core/talents/glyphs_picker.ts
@@ -118,13 +118,6 @@ class GlyphPicker extends Input<Player<any>, number> {
 			event.preventDefault();
 			const selectorModal = new GlyphSelectorModal(this.rootElem.closest('.individual-sim-ui')!, this, this.glyphOptions);
 		});
-		this.iconElem.addEventListener('touchstart', event => {
-			event.preventDefault();
-			const selectorModal = new GlyphSelectorModal(this.rootElem.closest('.individual-sim-ui')!, this, this.glyphOptions);
-		});
-		this.iconElem.addEventListener('touchend', event => {
-			event.preventDefault();
-		});
 
 		this.init();
 	}

--- a/ui/core/talents/glyphs_picker.ts
+++ b/ui/core/talents/glyphs_picker.ts
@@ -111,7 +111,7 @@ class GlyphPicker extends Input<Player<any>, number> {
 		this.glyphOptions = glyphOptions;
 		this.selectedGlyph = emptyGlyphData;
 
-		this.rootElem.innerHTML = `<a class="glyph-picker-icon"></a>`;
+		this.rootElem.innerHTML = `<a class="glyph-picker-icon" data-whtticon='false'></a>`;
 
 		this.iconElem = this.rootElem.getElementsByClassName('glyph-picker-icon')[0] as HTMLAnchorElement;
 		this.iconElem.addEventListener('click', event => {

--- a/ui/core/talents/talents_picker.tsx
+++ b/ui/core/talents/talents_picker.tsx
@@ -346,7 +346,7 @@ class TalentPicker<TalentsProto> extends Component {
 		this.rootElem.style.gridColumn = String(this.config.location.colIdx + 1);
 
 		this.rootElem.dataset.maxPoints = String(this.config.maxPoints);
-		this.rootElem.dataset.wowhead = 'noimage';
+		this.rootElem.dataset.whtticon = 'false';
 
 		this.pointsDisplay = document.createElement('span');
 		this.pointsDisplay.classList.add('talent-picker-points');

--- a/ui/core/talents/talents_picker.tsx
+++ b/ui/core/talents/talents_picker.tsx
@@ -93,11 +93,7 @@ export class TalentsPicker<ModObject, TalentsProto> extends Input<ModObject, str
 		}
 
 		carouselPrevBtn.addEventListener('click', slidePrev);
-		carouselPrevBtn.addEventListener('touchstart', slidePrev);
-		carouselPrevBtn.addEventListener('touchend', (e) => e.preventDefault());
 		carouselNextBtn.addEventListener('click', slideNext);
-		carouselNextBtn.addEventListener('touchstart', slideNext);
-		carouselNextBtn.addEventListener('touchend', (e) => e.preventDefault());
 
 		this.init();
 	}
@@ -357,6 +353,12 @@ class TalentPicker<TalentsProto> extends Component {
 		});
 		this.rootElem.addEventListener('contextmenu', event => {
 			event.preventDefault();
+		});
+		this.rootElem.addEventListener('touchmove', event => {
+			if (this.longTouchTimer != undefined) {
+				clearTimeout(this.longTouchTimer);
+				this.longTouchTimer = undefined;
+			}
 		});
 		this.rootElem.addEventListener('touchstart', event => {
 			event.preventDefault();

--- a/ui/scss/core/components/_input.scss
+++ b/ui/scss/core/components/_input.scss
@@ -51,8 +51,6 @@
     flex-wrap: wrap;
 
     &> * {
-      flex-basis: 50%;
-
       &:nth-child(2n) {
         margin-right: 0 !important;
       }

--- a/ui/shared/bootstrap_overrides.ts
+++ b/ui/shared/bootstrap_overrides.ts
@@ -8,15 +8,23 @@ Tooltip.Default.trigger = "hover";
 
 let body = document.querySelector('body') as HTMLElement;
 
-// Custom dropdown event handlers for mouseover dropdowns
-body.addEventListener('mouseover', event => {
-	let target = event.target as HTMLElement;
-	let toggle = target.closest('[data-bs-toggle=dropdown]');
-	if (toggle && !toggle.classList.contains('open-on-click')) {
-		let dropdown = Dropdown.getOrCreateInstance(toggle);
-		dropdown.show();
-	}
-}, true);
+function isTouchDevice() {
+	return ('ontouchstart' in window) || (navigator.maxTouchPoints > 0);
+}
+
+// Disable 'mouseover' to avoid needed to double click on mobile
+// Leaving 'mouseleave', however still allows dropdown to close when clicking new box
+if (!isTouchDevice()) {
+	// Custom dropdown event handlers for mouseover dropdowns
+	body.addEventListener('mouseover', event => {
+		let target = event.target as HTMLElement;
+		let toggle = target.closest('[data-bs-toggle=dropdown]');
+		if (toggle && !toggle.classList.contains('open-on-click')) {
+			let dropdown = Dropdown.getOrCreateInstance(toggle);
+			dropdown.show();
+		}
+	}, true);
+}
 
 body.addEventListener('mouseleave', event => {
 	let e = event as MouseEvent;


### PR DESCRIPTION
 - removes icons from wowhead tooltips for less clutter
 - removes most 'touchstart' events
 - disables most wowhead tooltips on touch