### PR TITLE
fix army crit chance

### DIFF
--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -46,35 +46,35 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7278.96275
+  dps: 7273.99952
   tps: 3598.62553
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7190.56051
+  dps: 7185.56886
   tps: 3594.75963
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6978.77864
+  dps: 6973.86038
   tps: 3475.94382
   hps: 91.2816
  }
@@ -82,7 +82,7 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6978.77864
+  dps: 6973.86038
   tps: 3475.94382
   hps: 91.2816
  }
@@ -90,84 +90,84 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7296.84947
+  dps: 7291.88773
   tps: 3608.61081
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7081.12375
+  dps: 7076.56012
   tps: 3511.1774
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6129.20667
+  dps: 6125.11827
   tps: 3044.82886
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6046.85428
+  dps: 6042.8978
   tps: 3010.18705
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5756.7797
+  dps: 5752.86187
   tps: 2850.68623
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7273.87829
+  dps: 7268.91654
   tps: 3524.0708
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8671.24835
+  dps: 8665.88588
   tps: 4361.03988
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8770.66825
+  dps: 8765.31163
   tps: 4424.26482
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7418.98541
+  dps: 7414.02366
   tps: 3674.07843
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
   hps: 64
  }
@@ -175,266 +175,266 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7079.01098
+  dps: 7074.09272
   tps: 3529.54148
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7147.69389
+  dps: 7142.7402
   tps: 3570.88334
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7236.75443
+  dps: 7231.83617
   tps: 3583.05799
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7074.36607
+  dps: 7070.09917
   tps: 3514.64024
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 6174.20987
+  dps: 6169.90369
   tps: 3056.65868
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7612.7182
+  dps: 7607.74281
   tps: 3760.77339
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7046.00732
+  dps: 7041.08906
   tps: 3512.23511
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7459.24222
+  dps: 7454.61285
   tps: 3735.70616
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7486.47473
+  dps: 7481.6062
   tps: 3756.1399
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6995.13774
+  dps: 6990.2148
   tps: 3484.42795
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7301.1828
+  dps: 7296.22106
   tps: 3610.85138
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7114.11226
+  dps: 7109.31913
   tps: 3544.91622
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7138.81045
+  dps: 7134.1131
   tps: 3559.84999
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7273.87829
+  dps: 7268.91654
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7273.87829
+  dps: 7268.91654
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7296.84947
+  dps: 7291.88773
   tps: 3608.61081
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7293.2842
+  dps: 7288.32245
   tps: 3606.84727
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7090.13561
+  dps: 7085.89924
   tps: 3520.36863
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7273.87829
+  dps: 7268.91654
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7134.58519
+  dps: 7129.6315
   tps: 3565.38524
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7069.02478
+  dps: 7064.10652
   tps: 3524.60572
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7049.96495
+  dps: 7045.04669
   tps: 3514.55218
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7273.87829
+  dps: 7268.91654
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7273.87829
+  dps: 7268.91654
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7186.88185
+  dps: 7181.96359
   tps: 3586.21556
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7113.54257
+  dps: 7108.60627
   tps: 3551.08226
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7296.84947
+  dps: 7291.88773
   tps: 3608.61081
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7293.2842
+  dps: 7288.32245
   tps: 3606.84727
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7169.81897
+  dps: 7164.87136
   tps: 3582.22291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7273.87829
+  dps: 7268.91654
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7303.6118
+  dps: 7298.64172
   tps: 3610.85392
   hps: 12.53201
  }
@@ -442,483 +442,483 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50179"
  value: {
-  dps: 8330.82721
+  dps: 8326.37683
   tps: 4170.67943
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50708"
  value: {
-  dps: 8393.38812
+  dps: 8388.93775
   tps: 4205.21813
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7142.12799
+  dps: 7137.51225
   tps: 3555.64858
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7157.93933
+  dps: 7153.02107
   tps: 3551.19119
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6989.3614
+  dps: 6984.44011
   tps: 3481.43202
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7297.02212
+  dps: 7292.05362
   tps: 3607.98443
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7302.46772
+  dps: 7297.49764
   tps: 3610.80651
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7022.71016
+  dps: 7017.77933
   tps: 3498.72849
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7028.37098
+  dps: 7023.43852
   tps: 3501.6645
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7273.87829
+  dps: 7268.91654
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7273.87829
+  dps: 7268.91654
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7049.57039
+  dps: 7044.65213
   tps: 3521.51639
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7056.87804
+  dps: 7051.95978
   tps: 3525.90098
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7413.78698
+  dps: 7408.82498
   tps: 3671.42095
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7273.87829
+  dps: 7268.91654
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6736.06072
+  dps: 6732.03225
   tps: 3337.76372
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 6133.61883
+  dps: 6129.05279
   tps: 3038.44562
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7706.85504
+  dps: 7701.99524
   tps: 3874.37643
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6502.77316
+  dps: 6498.34794
   tps: 3220.11179
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6994.23349
+  dps: 6989.31524
   tps: 3483.6838
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 9646.58714
+  dps: 9641.13689
   tps: 4891.32675
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7071.80605
+  dps: 7066.88779
   tps: 3525.98808
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofLife-37657"
  value: {
-  dps: 7047.00459
+  dps: 7042.34259
   tps: 3508.14513
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7207.29305
+  dps: 7203.0961
   tps: 3576.86589
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 5696.37407
+  dps: 5692.43635
   tps: 2826.38251
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7302.46772
+  dps: 7297.49764
   tps: 3610.80651
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7297.02212
+  dps: 7292.05362
   tps: 3607.98443
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7287.49231
+  dps: 7282.52659
   tps: 3603.0458
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7208.59461
+  dps: 7204.25459
   tps: 3593.68409
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6327.19274
+  dps: 6322.54211
   tps: 3128.41375
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6318.59479
+  dps: 6314.08135
   tps: 3087.5745
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7291.35467
+  dps: 7286.54766
   tps: 3597.4399
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7246.36042
+  dps: 7241.89043
   tps: 3613.30958
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7254.20493
+  dps: 7249.76815
   tps: 3614.22271
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7273.87829
+  dps: 7268.91654
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7273.87829
+  dps: 7268.91654
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7030.38861
+  dps: 7025.72613
   tps: 3485.91413
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7273.87829
+  dps: 7268.91654
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7273.87829
+  dps: 7268.91654
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6033.85133
+  dps: 6029.88985
   tps: 2999.79378
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5594.38287
+  dps: 5589.35462
   tps: 2670.16304
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6978.77144
+  dps: 6973.85318
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 7430.15974
+  dps: 7425.79677
   tps: 3684.99695
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20068.12203
+  dps: 20063.56159
   tps: 10232.07493
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7314.83272
+  dps: 7309.87214
   tps: 3653.4153
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9445.74243
+  dps: 9420.93953
   tps: 4157.32843
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10602.4273
+  dps: 10599.68744
   tps: 5400.22368
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4132.25283
+  dps: 4129.50357
   tps: 2066.93188
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4988.61274
+  dps: 4974.86645
   tps: 2161.91396
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20363.17286
+  dps: 20358.61111
   tps: 10296.41535
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7413.78698
+  dps: 7408.82498
   tps: 3671.42095
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9643.04731
+  dps: 9618.23731
   tps: 4198.44359
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10785.7451
+  dps: 10783.00443
   tps: 5442.45068
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4204.13901
+  dps: 4201.38896
   tps: 2088.11648
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5099.30991
+  dps: 5085.55963
   tps: 2187.21186
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7038.3403
+  dps: 7033.95714
   tps: 3508.8017
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -46,7 +46,7 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7496.4837
+  dps: 7486.2719
   tps: 4821.53386
   hps: 369.59868
  }
@@ -54,7 +54,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7496.4837
+  dps: 7486.2719
   tps: 4821.53386
   hps: 383.43105
  }
@@ -62,7 +62,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8011.31759
+  dps: 8000.64059
   tps: 5089.57829
   hps: 270.31002
  }
@@ -70,7 +70,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7693.17915
+  dps: 7683.26572
   tps: 4992.13337
   hps: 264.72419
  }
@@ -78,7 +78,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7496.50821
+  dps: 7486.29641
   tps: 4821.50604
   hps: 354.03666
  }
@@ -86,7 +86,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7496.50821
+  dps: 7486.29641
   tps: 4821.50604
   hps: 354.03666
  }
@@ -94,7 +94,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8034.08422
+  dps: 8023.40722
   tps: 5109.17129
   hps: 265.35448
  }
@@ -102,7 +102,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7770.70297
+  dps: 7759.58116
   tps: 4920.9882
   hps: 257.00534
  }
@@ -110,7 +110,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6569.47756
+  dps: 6559.15567
   tps: 4216.61459
   hps: 232.68485
  }
@@ -118,7 +118,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6387.33292
+  dps: 6377.49389
   tps: 4137.17824
   hps: 224.48378
  }
@@ -126,7 +126,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6193.37563
+  dps: 6183.1721
   tps: 3966.21194
   hps: 224.07309
  }
@@ -134,7 +134,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8011.31759
+  dps: 8000.64059
   tps: 4987.78673
   hps: 265.35448
  }
@@ -142,7 +142,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8089.04883
+  dps: 8078.37183
   tps: 5161.19364
   hps: 265.35448
  }
@@ -150,7 +150,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8089.04883
+  dps: 8078.37183
   tps: 5161.19364
   hps: 265.35448
  }
@@ -158,7 +158,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8102.8959
+  dps: 8092.2189
   tps: 5175.16728
   hps: 265.35448
  }
@@ -166,7 +166,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -174,7 +174,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -182,7 +182,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 363.59146
  }
@@ -190,7 +190,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7590.71663
+  dps: 7580.50483
   tps: 4912.27372
   hps: 264.40904
  }
@@ -198,7 +198,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7614.32023
+  dps: 7604.25474
   tps: 4939.84833
   hps: 263.77874
  }
@@ -206,7 +206,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7846.29192
+  dps: 7835.71579
   tps: 5000.51817
   hps: 265.35448
  }
@@ -214,7 +214,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7650.22993
+  dps: 7640.34431
   tps: 4942.71555
   hps: 279.46859
  }
@@ -222,7 +222,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 6683.25242
+  dps: 6672.89598
   tps: 4276.86749
   hps: 296.98863
  }
@@ -230,7 +230,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8334.98278
+  dps: 8324.06593
   tps: 5327.14325
   hps: 265.35448
  }
@@ -238,7 +238,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7576.7571
+  dps: 7566.5453
   tps: 4899.77681
   hps: 264.40904
  }
@@ -246,7 +246,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7884.99892
+  dps: 7875.80268
   tps: 5188.60376
   hps: 272.60288
  }
@@ -254,7 +254,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7890.72945
+  dps: 7881.64984
   tps: 5223.22665
   hps: 272.28773
  }
@@ -262,7 +262,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -270,7 +270,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8036.01236
+  dps: 8025.33536
   tps: 5111.31429
   hps: 265.35448
  }
@@ -278,7 +278,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7713.66457
+  dps: 7702.76403
   tps: 4928.59166
   hps: 263.46359
  }
@@ -286,7 +286,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7685.15439
+  dps: 7674.42977
   tps: 4906.60879
   hps: 262.51815
  }
@@ -294,7 +294,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8011.31759
+  dps: 8000.64059
   tps: 5089.57829
   hps: 270.31002
  }
@@ -302,7 +302,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8011.31759
+  dps: 8000.64059
   tps: 5089.57829
   hps: 265.35448
  }
@@ -310,7 +310,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8034.08422
+  dps: 8023.40722
   tps: 5109.17129
   hps: 265.35448
  }
@@ -318,7 +318,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8030.73484
+  dps: 8020.05784
   tps: 5106.2296
   hps: 265.35448
  }
@@ -326,7 +326,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7647.35493
+  dps: 7636.56376
   tps: 4839.309
   hps: 266.61507
  }
@@ -334,7 +334,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 281.53732
  }
@@ -342,7 +342,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8011.31759
+  dps: 8000.64059
   tps: 5089.57829
   hps: 265.35448
  }
@@ -350,7 +350,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7646.13435
+  dps: 7636.07914
   tps: 4958.58648
   hps: 265.03933
  }
@@ -358,7 +358,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7579.60864
+  dps: 7569.39684
   tps: 4901.73682
   hps: 264.40904
  }
@@ -366,7 +366,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -374,7 +374,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -382,7 +382,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7560.36673
+  dps: 7550.15493
   tps: 4883.67609
   hps: 264.40904
  }
@@ -390,7 +390,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8011.31759
+  dps: 8000.64059
   tps: 5089.57829
   hps: 265.35448
  }
@@ -398,7 +398,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8011.31759
+  dps: 8000.64059
   tps: 5089.57829
   hps: 265.35448
  }
@@ -406,7 +406,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 8106.18293
+  dps: 8095.49646
   tps: 5174.72044
   hps: 265.35448
  }
@@ -414,7 +414,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7759.53833
+  dps: 7749.19584
   tps: 5034.05554
   hps: 264.40904
  }
@@ -422,7 +422,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -430,7 +430,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -438,7 +438,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -446,7 +446,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7602.15358
+  dps: 7592.57498
   tps: 4924.78139
   hps: 264.72419
  }
@@ -454,7 +454,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 8052.40176
+  dps: 8041.75862
   tps: 5132.84192
   hps: 265.35448
  }
@@ -462,7 +462,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -470,7 +470,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8034.08422
+  dps: 8023.40722
   tps: 5109.17129
   hps: 265.35448
  }
@@ -478,7 +478,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8030.73484
+  dps: 8020.05784
   tps: 5106.2296
   hps: 265.35448
  }
@@ -486,7 +486,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7662.58345
+  dps: 7652.31072
   tps: 4958.16485
   hps: 264.40904
  }
@@ -494,7 +494,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8011.31759
+  dps: 8000.64059
   tps: 5089.57829
   hps: 265.35448
  }
@@ -502,7 +502,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8046.29845
+  dps: 8035.60142
   tps: 5118.78399
   hps: 278.22315
  }
@@ -510,7 +510,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50179"
  value: {
-  dps: 8089.04883
+  dps: 8078.37183
   tps: 5161.19364
   hps: 265.35448
  }
@@ -518,7 +518,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50708"
  value: {
-  dps: 8089.04883
+  dps: 8078.37183
   tps: 5161.19364
   hps: 265.35448
  }
@@ -526,7 +526,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -534,7 +534,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -542,7 +542,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7578.1568
+  dps: 7567.945
   tps: 4907.41177
   hps: 264.40904
  }
@@ -550,7 +550,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -558,7 +558,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8039.45062
+  dps: 8028.75956
   tps: 5112.19294
   hps: 265.35448
  }
@@ -566,7 +566,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8046.07015
+  dps: 8035.37578
   tps: 5117.51403
   hps: 265.35448
  }
@@ -574,7 +574,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -582,7 +582,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -590,7 +590,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -598,7 +598,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8011.31759
+  dps: 8000.64059
   tps: 5089.57829
   hps: 269.38086
  }
@@ -606,7 +606,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8011.31759
+  dps: 8000.64059
   tps: 5089.57829
   hps: 270.31002
  }
@@ -614,7 +614,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -622,7 +622,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7547.51031
+  dps: 7537.27587
   tps: 4867.9732
   hps: 265.66963
  }
@@ -630,7 +630,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7556.79811
+  dps: 7546.56367
   tps: 4875.75366
   hps: 265.66963
  }
@@ -638,7 +638,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8089.04883
+  dps: 8078.37183
   tps: 5161.19364
   hps: 265.35448
  }
@@ -646,7 +646,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 8126.17272
+  dps: 8115.4752
   tps: 5190.50171
   hps: 265.35448
  }
@@ -654,7 +654,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8011.31759
+  dps: 8000.64059
   tps: 5089.57829
   hps: 265.35448
  }
@@ -662,7 +662,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -670,7 +670,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 8046.85193
+  dps: 8036.21032
   tps: 5128.39487
   hps: 265.35448
  }
@@ -678,7 +678,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7273.58983
+  dps: 7263.63083
   tps: 4683.02231
   hps: 255.62308
  }
@@ -686,7 +686,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6634.23544
+  dps: 6623.95362
   tps: 4228.54883
   hps: 270.24427
  }
@@ -694,7 +694,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8024.57071
+  dps: 8013.67517
   tps: 5321.84729
   hps: 297.77471
  }
@@ -702,7 +702,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7279.17455
+  dps: 7268.45891
   tps: 4777.27408
   hps: 308.77393
  }
@@ -710,7 +710,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -718,7 +718,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8089.04883
+  dps: 8078.37183
   tps: 5161.19364
   hps: 265.35448
  }
@@ -726,7 +726,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -734,7 +734,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 8003.37831
+  dps: 7992.74865
   tps: 5093.55962
   hps: 265.35448
  }
@@ -742,7 +742,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 8014.05015
+  dps: 8003.4205
   tps: 5104.33806
   hps: 265.35448
  }
@@ -750,7 +750,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 8003.37831
+  dps: 7992.74865
   tps: 5093.55962
   hps: 265.35448
  }
@@ -758,7 +758,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8207.09707
+  dps: 8196.40222
   tps: 5184.06066
   hps: 238.25177
  }
@@ -766,7 +766,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 8003.37831
+  dps: 7992.74865
   tps: 5093.55962
   hps: 265.35448
  }
@@ -774,7 +774,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 8003.37831
+  dps: 7992.74865
   tps: 5093.55962
   hps: 265.35448
  }
@@ -782,7 +782,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 8003.37831
+  dps: 7992.74865
   tps: 5093.55962
   hps: 265.35448
  }
@@ -790,7 +790,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 299.59146
  }
@@ -798,7 +798,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -806,7 +806,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -814,7 +814,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -822,7 +822,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7581.5191
+  dps: 7571.3073
   tps: 4903.62369
   hps: 264.40904
  }
@@ -830,7 +830,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 7576.90865
+  dps: 7566.30963
   tps: 4851.84607
   hps: 265.66963
  }
@@ -838,7 +838,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7694.51233
+  dps: 7684.34586
   tps: 4925.24482
   hps: 264.72419
  }
@@ -846,7 +846,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-StormshroudArmor"
  value: {
-  dps: 6069.92137
+  dps: 6060.79631
   tps: 3911.58651
   hps: 204.81996
  }
@@ -854,7 +854,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8046.07015
+  dps: 8035.37578
   tps: 5117.51403
   hps: 265.35448
  }
@@ -862,7 +862,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8039.45062
+  dps: 8028.75956
   tps: 5112.19294
   hps: 265.35448
  }
@@ -870,7 +870,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8027.86643
+  dps: 8017.18116
   tps: 5102.88102
   hps: 265.35448
  }
@@ -878,7 +878,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -886,7 +886,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -894,7 +894,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7835.61944
+  dps: 7826.08442
   tps: 5108.03978
   hps: 277.93737
  }
@@ -902,7 +902,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6782.06844
+  dps: 6771.87384
   tps: 4313.20341
   hps: 289.52451
  }
@@ -910,7 +910,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -918,7 +918,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7477.56519
+  dps: 7464.86408
   tps: 4731.67027
   hps: 251.95663
  }
@@ -926,7 +926,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8061.66081
+  dps: 8050.72634
   tps: 5107.97955
   hps: 263.46359
  }
@@ -934,7 +934,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7682.63654
+  dps: 7672.82466
   tps: 4963.43683
   hps: 267.87566
  }
@@ -942,7 +942,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7679.86807
+  dps: 7669.65053
   tps: 4977.51971
   hps: 264.72419
  }
@@ -950,7 +950,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8011.31759
+  dps: 8000.64059
   tps: 5089.57829
   hps: 265.35448
  }
@@ -958,7 +958,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8011.31759
+  dps: 8000.64059
   tps: 5089.57829
   hps: 265.35448
  }
@@ -966,7 +966,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7582.79238
+  dps: 7572.02695
   tps: 4836.49894
   hps: 263.46359
  }
@@ -974,7 +974,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8011.31759
+  dps: 8000.64059
   tps: 5089.57829
   hps: 265.35448
  }
@@ -982,7 +982,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8011.31759
+  dps: 8000.64059
   tps: 5089.57829
   hps: 265.35448
  }
@@ -990,7 +990,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6418.1415
+  dps: 6408.16323
   tps: 4164.15754
   hps: 230.2196
  }
@@ -998,7 +998,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7741.39269
+  dps: 7729.80562
   tps: 4916.95095
   hps: 264.74695
  }
@@ -1006,7 +1006,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7496.50696
+  dps: 7486.29516
   tps: 4821.49891
   hps: 264.40904
  }
@@ -1014,7 +1014,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 8149.01819
+  dps: 8138.30805
   tps: 5208.53745
   hps: 265.35448
  }
@@ -1022,7 +1022,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 8073.83508
+  dps: 8062.85337
   tps: 5161.15788
   hps: 265.34082
  }
@@ -1030,7 +1030,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36273.4182
+  dps: 36262.61329
   tps: 38806.87831
   hps: 261.42005
  }
@@ -1038,7 +1038,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7874.91822
+  dps: 7864.90906
   tps: 5123.77288
   hps: 264.56969
  }
@@ -1046,7 +1046,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11310.58228
+  dps: 11259.82823
   tps: 5671.76828
   hps: 231.49848
  }
@@ -1054,7 +1054,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 21904.76474
+  dps: 21899.41164
   tps: 24104.41002
   hps: 158.16236
  }
@@ -1062,7 +1062,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3884.00476
+  dps: 3878.71787
   tps: 2782.99681
   hps: 159.48827
  }
@@ -1070,7 +1070,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4968.70092
+  dps: 4940.67842
   tps: 2863.8087
   hps: 142.062
  }
@@ -1078,7 +1078,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 46692.32923
+  dps: 46680.37718
   tps: 50168.81961
   hps: 320.4671
  }
@@ -1086,7 +1086,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10304.99669
+  dps: 10292.68242
   tps: 6832.10793
   hps: 327.90162
  }
@@ -1094,7 +1094,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14386.20109
+  dps: 14324.2498
   tps: 7498.85252
   hps: 283.68577
  }
@@ -1102,7 +1102,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 29373.12258
+  dps: 29367.00937
   tps: 32420.54449
   hps: 210.32917
  }
@@ -1110,7 +1110,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5320.93998
+  dps: 5314.63289
   tps: 3892.91502
   hps: 211.33915
  }
@@ -1118,7 +1118,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6583.02626
+  dps: 6551.53668
   tps: 3961.61841
   hps: 180.53464
  }
@@ -1126,7 +1126,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36861.82424
+  dps: 36850.66571
   tps: 39310.28264
   hps: 261.88786
  }
@@ -1134,7 +1134,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8089.04883
+  dps: 8078.37183
   tps: 5161.19364
   hps: 265.35448
  }
@@ -1142,7 +1142,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11698.83465
+  dps: 11647.43451
   tps: 5732.02094
   hps: 231.63366
  }
@@ -1150,7 +1150,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 22117.20923
+  dps: 22111.77939
   tps: 24292.82052
   hps: 158.09971
  }
@@ -1158,7 +1158,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3966.09647
+  dps: 3960.62038
   tps: 2803.16899
   hps: 160.37453
  }
@@ -1166,7 +1166,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5145.98502
+  dps: 5117.63452
   tps: 2901.84378
   hps: 142.176
  }
@@ -1174,7 +1174,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 46763.68689
+  dps: 46751.45821
   tps: 49939.13248
   hps: 321.79215
  }
@@ -1182,7 +1182,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10455.01008
+  dps: 10442.2978
   tps: 6797.27018
   hps: 327.66427
  }
@@ -1190,7 +1190,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14825.7838
+  dps: 14761.66509
   tps: 7552.85592
   hps: 279.90437
  }
@@ -1198,7 +1198,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 29468.67437
+  dps: 29462.66686
   tps: 32479.5714
   hps: 209.69784
  }
@@ -1206,7 +1206,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5399.55862
+  dps: 5393.55375
   tps: 3891.01135
   hps: 211.97167
  }
@@ -1214,7 +1214,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6748.03707
+  dps: 6716.52851
   tps: 3960.19317
   hps: 175.59036
  }
@@ -1222,7 +1222,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7750.21797
+  dps: 7738.51736
   tps: 5013.1652
   hps: 262.8333
  }

--- a/sim/deathknight/ghoul_pet.go
+++ b/sim/deathknight/ghoul_pet.go
@@ -37,8 +37,6 @@ func (dk *Deathknight) NewArmyGhoulPet(_ int) *GhoulPet {
 
 		stats.MeleeHit:  -nocsHit,
 		stats.Expertise: -nocsHit * PetExpertiseScale,
-
-		stats.MeleeCrit: 3.2 * core.CritRatingPerCritChance,
 	}
 
 	ghoulPet := &GhoulPet{

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -13,7 +13,7 @@ character_stats_results: {
   final_stats: 221
   final_stats: 0
   final_stats: 5636.84
-  final_stats: 469.94994
+  final_stats: 469.94995
   final_stats: 2072.9756
   final_stats: 221
   final_stats: 94

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -13,7 +13,7 @@ character_stats_results: {
   final_stats: 221
   final_stats: 0
   final_stats: 5862.3136
-  final_stats: 469.94994
+  final_stats: 469.94995
   final_stats: 2164.78757
   final_stats: 221
   final_stats: 94


### PR DESCRIPTION
army ghouls crit about 8.5% of the time on logs which matches `856/83.3+3-4.8=8.47` (about 10% crit from 856 agility, 3% from heart of the crusader, 4.8% crit suppression)