### PR TITLE
vigo/cast

### DIFF
--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -28,13 +28,11 @@ type CastConfig struct {
 	ModifyCast func(*Simulation, *Spell, *Cast)
 
 	// Ignores haste when calculating the GCD and cast time for this cast.
+	// Automatically set if GCD and cast times are all 0, e.g. for empty casts.
 	IgnoreHaste bool
 
 	CD       Cooldown
 	SharedCD Cooldown
-
-	// Callbacks for providing additional custom behavior.
-	OnCastComplete func(*Simulation, *Spell)
 }
 
 type Cast struct {
@@ -56,7 +54,7 @@ type Cast struct {
 	AfterCastDelay time.Duration
 }
 
-func (cast Cast) EffectiveTime() time.Duration {
+func (cast *Cast) EffectiveTime() time.Duration {
 	gcd := cast.GCD
 	if cast.GCD != 0 {
 		// TODO: isn't this wrong for spells like shadowfury, that have a reduced GCD?
@@ -66,139 +64,75 @@ func (cast Cast) EffectiveTime() time.Duration {
 	return MaxDuration(gcd, fullCastTime)
 }
 
-var emptyCast Cast
-
 type CastFunc func(*Simulation, *Unit)
 type CastSuccessFunc func(*Simulation, *Unit) bool
 
-func (spell *Spell) makeCastFunc(config CastConfig, onCastComplete CastFunc) CastSuccessFunc {
-	return spell.wrapCastFuncInit(config,
-		spell.wrapCastFuncExtraCond(config,
-			spell.wrapCastFuncCDsReady(config,
-				spell.wrapCastFuncResources(config,
-					spell.wrapCastFuncHaste(config,
-						spell.wrapCastFuncGCD(config,
-							spell.wrapCastFuncCooldown(config,
-								spell.wrapCastFuncSharedCooldown(config,
-									spell.makeCastFuncWait(config, onCastComplete)))))))))
-}
+func (spell *Spell) makeCastFunc(config CastConfig) CastSuccessFunc {
+	return func(sim *Simulation, target *Unit) bool {
+		spell.CurCast = spell.DefaultCast
 
-func (spell *Spell) ApplyCostModifiers(cost float64) float64 {
-	cost -= spell.Unit.PseudoStats.CostReduction
-	cost = MaxFloat(0, cost*spell.Unit.PseudoStats.CostMultiplier)
-	return MaxFloat(0, cost*spell.CostMultiplier)
-}
-
-func (spell *Spell) wrapCastFuncInit(config CastConfig, onCastComplete CastSuccessFunc) CastSuccessFunc {
-	if spell.DefaultCast == emptyCast {
-		return onCastComplete
-	}
-
-	if config.ModifyCast == nil {
-		return func(sim *Simulation, target *Unit) bool {
-			spell.CurCast = spell.DefaultCast
-			return onCastComplete(sim, target)
-		}
-	} else {
-		modifyCast := config.ModifyCast
-		return func(sim *Simulation, target *Unit) bool {
-			spell.CurCast = spell.DefaultCast
-			cost := spell.CurCast.Cost
-			modifyCast(sim, spell, &spell.CurCast)
-			if cost != spell.CurCast.Cost {
+		if config.ModifyCast != nil {
+			config.ModifyCast(sim, spell, &spell.CurCast)
+			if spell.CurCast.Cost != spell.DefaultCast.Cost {
 				// Costs need to be modified using the unit and spell multipliers, so that
 				// their affects are also visible in the spell.CanCast() function, which
 				// does not invoke ModifyCast.
 				panic("May not modify cost in ModifyCast!")
 			}
-			return onCastComplete(sim, target)
 		}
-	}
-}
 
-func (spell *Spell) wrapCastFuncExtraCond(_ CastConfig, onCastComplete CastSuccessFunc) CastSuccessFunc {
-	if spell.ExtraCastCondition == nil {
-		return onCastComplete
-	} else {
-		return func(sim *Simulation, target *Unit) bool {
-			if spell.ExtraCastCondition(sim, target) {
-				return onCastComplete(sim, target)
-			} else {
+		if spell.ExtraCastCondition != nil {
+			if !spell.ExtraCastCondition(sim, target) {
 				if sim.Log != nil {
 					sim.Log("Failed cast because of extra condition")
 				}
 				return false
 			}
 		}
-	}
-}
 
-func (spell *Spell) wrapCastFuncCDsReady(_ CastConfig, onCastComplete CastSuccessFunc) CastSuccessFunc {
-	if spell.Unit.PseudoStats.GracefulCastCDFailures {
-		return func(sim *Simulation, target *Unit) bool {
-			if spell.IsReady(sim) {
-				return onCastComplete(sim, target)
-			} else {
-				if sim.Log != nil {
-					sim.Log("Failed cast because of CDs")
+		if spell.Cost != nil {
+			if !spell.Cost.MeetsRequirement(spell) {
+				if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
+					spell.Cost.LogCostFailure(sim, spell)
 				}
 				return false
 			}
 		}
-	} else {
-		return onCastComplete
-	}
-}
 
-func (spell *Spell) wrapCastFuncResources(_ CastConfig, onCastComplete CastFunc) CastSuccessFunc {
-	if spell.Cost == nil {
-		return func(sim *Simulation, target *Unit) bool {
-			onCastComplete(sim, target)
-			return true
+		if !config.IgnoreHaste {
+			spell.CurCast.GCD = spell.Unit.ApplyCastSpeed(spell.CurCast.GCD)
+			spell.CurCast.CastTime = spell.Unit.ApplyCastSpeedForSpell(spell.CurCast.CastTime, spell)
+			spell.CurCast.ChannelTime = spell.Unit.ApplyCastSpeedForSpell(spell.CurCast.ChannelTime, spell)
 		}
-	}
 
-	return func(sim *Simulation, target *Unit) bool {
-		if !spell.Cost.MeetsRequirement(spell) {
-			if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
-				spell.Cost.LogCostFailure(sim, spell)
+		if config.CD.Timer != nil {
+			// By panicking if spell is on CD, we force each sim to properly check for their own CDs.
+			if !spell.CD.IsReady(sim) {
+				if spell.Unit.PseudoStats.GracefulCastCDFailures {
+					if sim.Log != nil {
+						sim.Log("Failed cast because of CD")
+					}
+					return false
+				}
+				panic(fmt.Sprintf("Trying to cast %s but is still on cooldown for %s, curTime = %s", spell.ActionID, spell.CD.TimeToReady(sim), sim.CurrentTime))
 			}
-			return false
+			spell.CD.Set(sim.CurrentTime + spell.CurCast.CastTime + spell.CD.Duration)
 		}
-		onCastComplete(sim, target)
-		return true
-	}
-}
 
-func (spell *Spell) wrapCastFuncHaste(config CastConfig, onCastComplete CastFunc) CastFunc {
-	if config.IgnoreHaste || (spell.DefaultCast.GCD == 0 && spell.DefaultCast.CastTime == 0 && spell.DefaultCast.ChannelTime == 0) {
-		return onCastComplete
-	}
-
-	return func(sim *Simulation, target *Unit) {
-		spell.CurCast.GCD = spell.Unit.ApplyCastSpeed(spell.CurCast.GCD)
-		spell.CurCast.CastTime = spell.Unit.ApplyCastSpeedForSpell(spell.CurCast.CastTime, spell)
-		spell.CurCast.ChannelTime = spell.Unit.ApplyCastSpeedForSpell(spell.CurCast.ChannelTime, spell)
-
-		onCastComplete(sim, target)
-	}
-}
-
-func (spell *Spell) wrapCastFuncGCD(_ CastConfig, onCastComplete CastFunc) CastFunc {
-	if spell.DefaultCast == emptyCast { // spells that are not actually cast (e.g. auto attacks, procs)
-		return onCastComplete
-	}
-
-	if spell.DefaultCast.GCD == 0 { // mostly cooldowns (e.g. nature's swiftness, presence of mind)
-		return func(sim *Simulation, target *Unit) {
-			if hc := spell.Unit.Hardcast; hc.Expires > sim.CurrentTime {
-				panic(fmt.Sprintf("Trying to cast %s but casting/channeling %v for %s, curTime = %s", spell.ActionID, hc.ActionID, hc.Expires-sim.CurrentTime, sim.CurrentTime))
+		if config.SharedCD.Timer != nil {
+			// By panicking if spell is on CD, we force each sim to properly check for their own CDs.
+			if !spell.SharedCD.IsReady(sim) {
+				if spell.Unit.PseudoStats.GracefulCastCDFailures {
+					if sim.Log != nil {
+						sim.Log("Failed cast because of SharedCD")
+					}
+					return false
+				}
+				panic(fmt.Sprintf("Trying to cast %s but is still on shared cooldown for %s, curTime = %s", spell.ActionID, spell.SharedCD.TimeToReady(sim), sim.CurrentTime))
 			}
-			onCastComplete(sim, target)
+			spell.SharedCD.Set(sim.CurrentTime + spell.CurCast.CastTime + spell.SharedCD.Duration)
 		}
-	}
 
-	return func(sim *Simulation, target *Unit) {
 		// By panicking if spell is on CD, we force each sim to properly check for their own CDs.
 		if spell.CurCast.GCD != 0 && !spell.Unit.GCD.IsReady(sim) {
 			panic(fmt.Sprintf("Trying to cast %s but GCD on cooldown for %s, curTime = %s", spell.ActionID, spell.Unit.GCD.TimeToReady(sim), sim.CurrentTime))
@@ -208,137 +142,148 @@ func (spell *Spell) wrapCastFuncGCD(_ CastConfig, onCastComplete CastFunc) CastF
 			panic(fmt.Sprintf("Trying to cast %s but casting/channeling %v for %s, curTime = %s", spell.ActionID, hc.ActionID, hc.Expires-sim.CurrentTime, sim.CurrentTime))
 		}
 
-		effectiveTime := spell.CurCast.EffectiveTime()
-		if effectiveTime != 0 {
+		if effectiveTime := spell.CurCast.EffectiveTime(); effectiveTime != 0 {
 			spell.SpellMetrics[target.UnitIndex].TotalCastTime += effectiveTime
 			spell.Unit.SetGCDTimer(sim, sim.CurrentTime+effectiveTime)
 		}
 
-		onCastComplete(sim, target)
-	}
-}
-
-func (spell *Spell) wrapCastFuncCooldown(config CastConfig, onCastComplete CastFunc) CastFunc {
-	if config.CD.Timer == nil {
-		return onCastComplete
-	}
-
-	if config.CD.Duration == 0 {
-		panic("Cooldown specified but no duration!")
-	}
-
-	return func(sim *Simulation, target *Unit) {
-		// By panicking if spell is on CD, we force each sim to properly check for their own CDs.
-		if !spell.CD.IsReady(sim) {
-			panic(fmt.Sprintf("Trying to cast %s but is still on cooldown for %s, curTime = %s", spell.ActionID, spell.CD.TimeToReady(sim), sim.CurrentTime))
-		}
-
-		spell.CD.Set(sim.CurrentTime + spell.CurCast.CastTime + spell.CD.Duration)
-
-		onCastComplete(sim, target)
-	}
-}
-
-func (spell *Spell) wrapCastFuncSharedCooldown(config CastConfig, onCastComplete CastFunc) CastFunc {
-	if config.SharedCD.Timer == nil {
-		return onCastComplete
-	}
-
-	if config.SharedCD.Duration == 0 {
-		panic("SharedCooldown specified but no duration!")
-	}
-
-	return func(sim *Simulation, target *Unit) {
-		// By panicking if spell is on CD, we force each sim to properly check for their own CDs.
-		if !spell.SharedCD.IsReady(sim) {
-			panic(fmt.Sprintf("Trying to cast %s but is still on shared cooldown for %s, curTime = %s", spell.ActionID, spell.SharedCD.TimeToReady(sim), sim.CurrentTime))
-		}
-
-		spell.SharedCD.Set(sim.CurrentTime + spell.CurCast.CastTime + spell.SharedCD.Duration)
-
-		onCastComplete(sim, target)
-	}
-}
-
-func (spell *Spell) makeCastFuncWait(config CastConfig, onCastComplete CastFunc) CastFunc {
-	if !spell.Flags.Matches(SpellFlagNoOnCastComplete) {
-		oldOnCastComplete1 := onCastComplete
-		configOnCastComplete := config.OnCastComplete
-		onCastComplete = func(sim *Simulation, target *Unit) {
-			oldOnCastComplete1(sim, target)
-			if configOnCastComplete != nil {
-				configOnCastComplete(sim, spell)
+		// Hardcasts
+		if spell.CurCast.CastTime > 0 {
+			if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
+				spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s, Effective Time = %s)",
+					spell.ActionID, MaxFloat(0, spell.CurCast.Cost), spell.CurCast.CastTime, spell.CurCast.EffectiveTime())
 			}
+
+			spell.Unit.Hardcast = Hardcast{
+				Expires:  sim.CurrentTime + spell.CurCast.CastTime,
+				ActionID: spell.ActionID,
+				OnComplete: func(sim *Simulation, target *Unit) {
+					if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
+						spell.Unit.Log(sim, "Completed cast %s", spell.ActionID)
+					}
+
+					if spell.Cost != nil {
+						spell.Cost.SpendCost(sim, spell)
+					}
+
+					spell.applyEffects(sim, target)
+
+					if !spell.Flags.Matches(SpellFlagNoOnCastComplete) {
+						spell.Unit.OnCastComplete(sim, spell)
+					}
+				},
+				Target: target,
+			}
+
+			if spell.Unit.Hardcast.Expires != spell.Unit.NextGCDAt() {
+				spell.Unit.newHardcastAction(sim)
+			}
+
+			return true
+		}
+
+		// Instants/Channels
+		if spell.CurCast.ChannelTime > 0 {
+			spell.Unit.Hardcast = Hardcast{Expires: sim.CurrentTime + spell.CurCast.ChannelTime, ActionID: spell.ActionID}
+		}
+
+		if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
+			spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s, Effective Time = %s)",
+				spell.ActionID, MaxFloat(0, spell.CurCast.Cost), spell.CurCast.CastTime, spell.CurCast.EffectiveTime())
+			spell.Unit.Log(sim, "Completed cast %s", spell.ActionID)
+		}
+
+		if spell.Cost != nil {
+			spell.Cost.SpendCost(sim, spell)
+		}
+
+		spell.applyEffects(sim, target)
+
+		if !spell.Flags.Matches(SpellFlagNoOnCastComplete) {
 			spell.Unit.OnCastComplete(sim, spell)
 		}
-	}
 
-	if spell.Cost != nil {
-		oldOnCastComplete2 := onCastComplete
-		onCastComplete = func(sim *Simulation, target *Unit) {
-			spell.Cost.SpendCost(sim, spell)
-			oldOnCastComplete2(sim, target)
-		}
+		return true
 	}
+}
 
-	if spell.DefaultCast.ChannelTime > 0 {
-		return func(sim *Simulation, target *Unit) {
-			spell.Unit.Hardcast = Hardcast{Expires: sim.CurrentTime + spell.CurCast.ChannelTime, ActionID: spell.ActionID}
-			if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
-				spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s, Effective Time = %s)",
-					spell.ActionID, MaxFloat(0, spell.CurCast.Cost), spell.CurCast.CastTime, spell.CurCast.EffectiveTime())
-				spell.Unit.Log(sim, "Completed cast %s", spell.ActionID)
-			}
-			onCastComplete(sim, target)
-		}
-	}
-
-	if spell.DefaultCast.CastTime == 0 {
-		if spell.Flags.Matches(SpellFlagNoLogs) {
-			return onCastComplete
-		} else {
-			return func(sim *Simulation, target *Unit) {
+func (spell *Spell) makeCastFuncSimple() CastSuccessFunc {
+	return func(sim *Simulation, target *Unit) bool {
+		if spell.ExtraCastCondition != nil {
+			if !spell.ExtraCastCondition(sim, target) {
 				if sim.Log != nil {
-					spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s, Effective Time = %s)",
-						spell.ActionID, MaxFloat(0, spell.CurCast.Cost), spell.CurCast.CastTime, spell.CurCast.EffectiveTime())
-					spell.Unit.Log(sim, "Completed cast %s", spell.ActionID)
+					sim.Log("Failed cast because of extra condition")
 				}
-				onCastComplete(sim, target)
-			}
-		}
-	} else {
-		if !spell.Flags.Matches(SpellFlagNoLogs) {
-			oldOnCastComplete3 := onCastComplete
-			onCastComplete = func(sim *Simulation, target *Unit) {
-				if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
-					spell.Unit.Log(sim, "Completed cast %s", spell.ActionID)
-				}
-				oldOnCastComplete3(sim, target)
+				return false
 			}
 		}
 
-		return func(sim *Simulation, target *Unit) {
-			if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
-				spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s, Effective Time = %s)",
-					spell.ActionID, MaxFloat(0, spell.CurCast.Cost), spell.CurCast.CastTime, spell.CurCast.EffectiveTime())
+		if spell.CD.Timer != nil {
+			// By panicking if spell is on CD, we force each sim to properly check for their own CDs.
+			if !spell.CD.IsReady(sim) {
+				if spell.Unit.PseudoStats.GracefulCastCDFailures {
+					if sim.Log != nil {
+						sim.Log("Failed cast because of CD")
+					}
+					return false
+				}
+				panic(fmt.Sprintf("Trying to cast %s but is still on cooldown for %s, curTime = %s", spell.ActionID, spell.CD.TimeToReady(sim), sim.CurrentTime))
 			}
 
-			// For instant-cast spells we can skip creating an aura.
-			if spell.CurCast.CastTime == 0 {
-				onCastComplete(sim, target)
-			} else {
-				spell.Unit.Hardcast = Hardcast{
-					Expires:    sim.CurrentTime + spell.CurCast.CastTime,
-					ActionID:   spell.ActionID,
-					OnComplete: onCastComplete,
-					Target:     target,
-				}
-
-				// If hardcast and GCD happen at the same time then we don't need a separate action.
-				if spell.Unit.Hardcast.Expires != spell.Unit.NextGCDAt() {
-					spell.Unit.newHardcastAction(sim)
-				}
-			}
+			spell.CD.Set(sim.CurrentTime + spell.CD.Duration)
 		}
+
+		if spell.SharedCD.Timer != nil {
+			// By panicking if spell is on CD, we force each sim to properly check for their own CDs.
+			if !spell.SharedCD.IsReady(sim) {
+				if spell.Unit.PseudoStats.GracefulCastCDFailures {
+					if sim.Log != nil {
+						sim.Log("Failed cast because of SharedCD")
+					}
+					return false
+				}
+				panic(fmt.Sprintf("Trying to cast %s but is still on shared cooldown for %s, curTime = %s", spell.ActionID, spell.SharedCD.TimeToReady(sim), sim.CurrentTime))
+			}
+
+			spell.SharedCD.Set(sim.CurrentTime + spell.SharedCD.Duration)
+		}
+
+		if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
+			spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s, Effective Time = %s)",
+				spell.ActionID, 0, 0, 0)
+			spell.Unit.Log(sim, "Completed cast %s", spell.ActionID)
+		}
+
+		spell.applyEffects(sim, target)
+
+		if !spell.Flags.Matches(SpellFlagNoOnCastComplete) {
+			spell.Unit.OnCastComplete(sim, spell)
+		}
+
+		return true
 	}
+}
+
+func (spell *Spell) makeCastFuncAutosOrProcs() CastSuccessFunc {
+	return func(sim *Simulation, target *Unit) bool {
+		if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
+			spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s, Effective Time = %s)",
+				spell.ActionID, 0, 0, 0)
+			spell.Unit.Log(sim, "Completed cast %s", spell.ActionID)
+		}
+
+		spell.applyEffects(sim, target)
+
+		if !spell.Flags.Matches(SpellFlagNoOnCastComplete) {
+			spell.Unit.OnCastComplete(sim, spell)
+		}
+
+		return true
+	}
+}
+
+func (spell *Spell) ApplyCostModifiers(cost float64) float64 {
+	cost -= spell.Unit.PseudoStats.CostReduction
+	cost = MaxFloat(0, cost*spell.Unit.PseudoStats.CostMultiplier)
+	return MaxFloat(0, cost*spell.CostMultiplier)
 }

--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"log"
 	"math"
 	"math/rand"
 	"runtime"
@@ -230,6 +231,8 @@ func (sim *Simulation) Init() {
 // Run runs the simulation for the configured number of iterations, and
 // collects all the metrics together.
 func (sim *Simulation) run() *proto.RaidSimResult {
+	t0 := time.Now()
+
 	logsBuffer := &strings.Builder{}
 	if sim.Options.Debug || sim.Options.DebugFirstIteration {
 		sim.Log = func(message string, vals ...interface{}) {
@@ -288,6 +291,10 @@ func (sim *Simulation) run() *proto.RaidSimResult {
 	// Final progress report
 	if sim.ProgressReport != nil {
 		sim.ProgressReport(&proto.ProgressMetrics{TotalIterations: sim.Options.Iterations, CompletedIterations: sim.Options.Iterations, Dps: result.RaidMetrics.Dps.Avg, FinalRaidResult: result})
+	}
+
+	if d := sim.Options.Iterations; d > 3000 {
+		log.Printf("running %d iterations took %s", d, time.Since(t0))
 	}
 
 	return result

--- a/sim/core/spell.go
+++ b/sim/core/spell.go
@@ -168,14 +168,29 @@ func (unit *Unit) RegisterSpell(config SpellConfig) *Spell {
 	// Default the other damage multiplier to 1 if only one or the other is set.
 	if config.DamageMultiplier != 0 && config.DamageMultiplierAdditive == 0 {
 		config.DamageMultiplierAdditive = 1
-	}
-	if config.DamageMultiplierAdditive != 0 && config.DamageMultiplier == 0 {
+	} else if config.DamageMultiplierAdditive != 0 && config.DamageMultiplier == 0 {
 		config.DamageMultiplier = 1
 	}
 
 	if unit.IsUsingAPL {
 		config.Cast.DefaultCast.ChannelTime = 0
 		config.Cast.DefaultCast.AfterCastDelay = 0
+	}
+
+	if (config.DamageMultiplier != 0 || config.ThreatMultiplier != 0) && config.ProcMask == ProcMaskUnknown {
+		panic("ProcMask for spell " + config.ActionID.String() + " not set")
+	}
+
+	if (config.DamageMultiplier != 0 || config.ThreatMultiplier != 0) && config.SpellSchool == SpellSchoolNone {
+		panic("SpellSchool for spell " + config.ActionID.String() + " not set")
+	}
+
+	if config.Cast.CD.Timer != nil && config.Cast.CD.Duration == 0 {
+		panic("Cast.CD w/o Duration specified for spell " + config.ActionID.String())
+	}
+
+	if config.Cast.SharedCD.Timer != nil && config.Cast.SharedCD.Duration == 0 {
+		panic("Cast.SharedCD w/o Duration specified for spell " + config.ActionID.String())
 	}
 
 	spell := &Spell{
@@ -214,14 +229,6 @@ func (unit *Unit) RegisterSpell(config SpellConfig) *Spell {
 		RelatedAuras: config.RelatedAuras,
 	}
 
-	if (spell.DamageMultiplier != 0 || spell.ThreatMultiplier != 0) && spell.ProcMask == ProcMaskUnknown {
-		panic("Unknown proc mask on " + spell.ActionID.String())
-	}
-
-	if (spell.DamageMultiplier != 0 || spell.ThreatMultiplier != 0) && spell.SpellSchool == SpellSchoolNone {
-		panic("SpellSchool for spell " + spell.ActionID.String() + " not set")
-	}
-
 	switch {
 	case spell.SpellSchool.Matches(SpellSchoolPhysical):
 		spell.SchoolIndex = stats.SchoolIndexPhysical
@@ -239,6 +246,7 @@ func (unit *Unit) RegisterSpell(config SpellConfig) *Spell {
 		spell.SchoolIndex = stats.SchoolIndexShadow
 	}
 
+	// newXXXCost() all update spell.DefaultCast.Cost
 	if config.ManaCost.BaseCost != 0 || config.ManaCost.FlatCost != 0 {
 		spell.Cost = newManaCost(spell, config.ManaCost)
 	} else if config.EnergyCost.Cost != 0 {
@@ -255,7 +263,25 @@ func (unit *Unit) RegisterSpell(config SpellConfig) *Spell {
 	spell.createDots(config.Hot, true)
 	spell.createShields(config.Shield)
 
-	spell.castFn = spell.makeCastFunc(config.Cast, spell.applyEffects)
+	var emptyCast Cast
+
+	if spell.DefaultCast == emptyCast && spell.Cost != nil {
+		panic("Empty DefaultCast with a cost for spell " + config.ActionID.String())
+	}
+
+	if spell.DefaultCast.GCD == 0 && spell.DefaultCast.CastTime == 0 && spell.DefaultCast.ChannelTime == 0 {
+		config.Cast.IgnoreHaste = true
+	}
+
+	if spell.DefaultCast == emptyCast {
+		if config.ExtraCastCondition == nil && config.Cast.CD.Timer == nil && config.Cast.SharedCD.Timer == nil {
+			spell.castFn = spell.makeCastFuncAutosOrProcs()
+		} else {
+			spell.castFn = spell.makeCastFuncSimple()
+		}
+	} else {
+		spell.castFn = spell.makeCastFunc(config.Cast)
+	}
 
 	if spell.ApplyEffects == nil {
 		spell.ApplyEffects = func(*Simulation, *Unit, *Spell) {}
@@ -450,10 +476,10 @@ func (spell *Spell) CanCast(sim *Simulation, target *Unit) bool {
 		return false
 	}
 
-	// While casting, no other action is possible
+	// While casting or channeling, no other action is possible
 	if spell.Unit.Hardcast.Expires > sim.CurrentTime {
 		//if sim.Log != nil {
-		//	sim.Log("Cant cast because already casting")
+		//	sim.Log("Cant cast because already casting/channeling")
 		//}
 		return false
 	}
@@ -504,17 +530,9 @@ func (spell *Spell) SkipCastAndApplyEffects(sim *Simulation, target *Unit) {
 }
 
 func (spell *Spell) applyEffects(sim *Simulation, target *Unit) {
-	if spell.SpellMetrics == nil {
-		spell.reset(sim)
-	}
-	if target == nil {
-		target = spell.Unit.CurrentTarget
-	}
-	// target can still be null in individual sims when the caster is the enemy target
-	if target != nil {
-		spell.SpellMetrics[target.UnitIndex].Casts++
-		spell.casts++
-	}
+	spell.SpellMetrics[target.UnitIndex].Casts++
+	spell.casts++
+
 	spell.ApplyEffects(sim, target, spell)
 }
 

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -1022,8 +1022,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 8073.83508
-  tps: 5161.15788
+  dps: 8073.83747
+  tps: 5161.16036
   hps: 265.34082
  }
 }

--- a/sim/deathknight/summon_gargoyle.go
+++ b/sim/deathknight/summon_gargoyle.go
@@ -154,10 +154,6 @@ func (garg *GargoylePet) registerGargoyleStrikeSpell() {
 			DefaultCast: core.Cast{
 				CastTime: time.Millisecond * 2000,
 			},
-			OnCastComplete: func(sim *core.Simulation, spell *core.Spell) {
-				// Gargoyle doesn't use GCD, so we recast the spell over and over
-				garg.GargoyleStrike.Cast(sim, garg.CurrentTarget)
-			},
 		},
 
 		DamageMultiplier: 1,
@@ -168,6 +164,8 @@ func (garg *GargoylePet) registerGargoyleStrikeSpell() {
 			baseDamage := 2.05*sim.Roll(51, 69) + attackPowerModifier*spell.MeleeAttackPower()
 			result := spell.CalcDamage(sim, target, baseDamage, outcomeApplier)
 			spell.DealDamage(sim, result)
+
+			garg.GargoyleStrike.Cast(sim, garg.CurrentTarget)
 		},
 	})
 	outcomeApplier = garg.GargoyleStrike.OutcomeMagicCritFixedChance(0.05)


### PR DESCRIPTION
[core] makeCastFunc() outlined, but specialized for some common setups, plus some cleanups

[dk] gorgoyle now recasts in ApplyEffects() directly, removing the last Cast.OnCastComplete() use case

Contrary to intuition, this is actually a perf gain.

Question for a followup-PR: Is it ok to remove `PseudoStats.GracefulCastCDFailures`, or will this cause too many issues (crashes) with the legacy DK rotations? Just sprinkling two `Cast.CD.IsReady()` allows all DK tests to pass.