### PR TITLE
ghoul crit is also too high

### DIFF
--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -46,35 +46,35 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7266.83557
+  dps: 7266.50661
   tps: 3598.62553
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7179.48687
+  dps: 7179.15841
   tps: 3594.75963
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6967.50666
+  dps: 6967.18072
   tps: 3475.94382
   hps: 91.2816
  }
@@ -82,7 +82,7 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6967.50666
+  dps: 6967.18072
   tps: 3475.94382
   hps: 91.2816
  }
@@ -90,84 +90,84 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7284.72378
+  dps: 7284.39492
   tps: 3608.61081
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7069.56007
+  dps: 7069.24078
   tps: 3511.1774
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6118.76649
+  dps: 6118.33695
   tps: 3044.82886
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6037.41625
+  dps: 6036.99048
   tps: 3010.18705
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5746.22202
+  dps: 5745.82373
   tps: 2850.68623
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7261.7526
+  dps: 7261.42374
   tps: 3524.0708
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8657.49801
+  dps: 8657.1518
   tps: 4361.03988
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8756.29999
+  dps: 8755.9314
   tps: 4424.26482
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7406.85972
+  dps: 7406.53086
   tps: 3674.07843
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
   hps: 64
  }
@@ -175,266 +175,266 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7067.739
+  dps: 7067.41307
   tps: 3529.54148
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7136.4655
+  dps: 7136.13957
   tps: 3570.88334
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7224.89111
+  dps: 7224.56518
   tps: 3583.05799
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7062.75194
+  dps: 7062.41932
   tps: 3514.64024
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 6162.13528
+  dps: 6161.72028
   tps: 3056.65868
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7600.39925
+  dps: 7600.06947
   tps: 3760.77339
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7034.73534
+  dps: 7034.40941
   tps: 3512.23511
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7447.70226
+  dps: 7447.27863
   tps: 3735.70616
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7474.10749
+  dps: 7473.74834
   tps: 3756.1399
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6983.86108
+  dps: 6983.53483
   tps: 3484.42795
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7289.05711
+  dps: 7288.72825
   tps: 3610.85138
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7102.03154
+  dps: 7101.72414
   tps: 3544.91622
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7126.4315
+  dps: 7126.14091
   tps: 3559.84999
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7261.7526
+  dps: 7261.42374
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7261.7526
+  dps: 7261.42374
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7284.72378
+  dps: 7284.39492
   tps: 3608.61081
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7281.1585
+  dps: 7280.82965
   tps: 3606.84727
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7078.30515
+  dps: 7077.97776
   tps: 3520.36863
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7261.7526
+  dps: 7261.42374
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7123.44803
+  dps: 7123.12209
   tps: 3565.38524
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7057.7528
+  dps: 7057.42687
   tps: 3524.60572
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7038.69297
+  dps: 7038.36703
   tps: 3514.55218
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7261.7526
+  dps: 7261.42374
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7261.7526
+  dps: 7261.42374
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7175.60987
+  dps: 7175.28394
   tps: 3586.21556
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7102.29318
+  dps: 7101.96725
   tps: 3551.08226
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7284.72378
+  dps: 7284.39492
   tps: 3608.61081
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7281.1585
+  dps: 7280.82965
   tps: 3606.84727
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7158.51763
+  dps: 7158.18973
   tps: 3582.22291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7261.7526
+  dps: 7261.42374
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7291.44884
+  dps: 7291.11942
   tps: 3610.85392
   hps: 12.53201
  }
@@ -442,483 +442,483 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50179"
  value: {
-  dps: 8317.62319
+  dps: 8317.27836
   tps: 4170.67943
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50708"
  value: {
-  dps: 8380.14186
+  dps: 8379.79703
   tps: 4205.21813
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7130.00606
+  dps: 7129.66362
   tps: 3555.64858
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7146.66735
+  dps: 7146.34142
   tps: 3551.19119
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6978.08639
+  dps: 6977.76025
   tps: 3481.43202
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7284.88968
+  dps: 7284.56037
   tps: 3607.98443
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7290.3337
+  dps: 7290.00428
   tps: 3610.80651
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7011.42561
+  dps: 7011.09883
   tps: 3498.72849
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7017.0848
+  dps: 7016.75792
   tps: 3501.6645
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7261.7526
+  dps: 7261.42374
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7261.7526
+  dps: 7261.42374
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7038.45414
+  dps: 7038.12821
   tps: 3521.51639
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7045.76179
+  dps: 7045.43585
   tps: 3525.90098
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7401.66104
+  dps: 7401.33216
   tps: 3671.42095
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7261.7526
+  dps: 7261.42374
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6723.87872
+  dps: 6723.53598
   tps: 3337.76372
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 6121.82534
+  dps: 6121.39325
   tps: 3038.44562
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7694.27084
+  dps: 7693.82602
   tps: 3874.37643
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6490.59555
+  dps: 6490.14682
   tps: 3220.11179
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6982.96151
+  dps: 6982.63558
   tps: 3483.6838
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 9629.82611
+  dps: 9629.43027
   tps: 4891.32675
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7060.53407
+  dps: 7060.20814
   tps: 3525.98808
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofLife-37657"
  value: {
-  dps: 7035.29396
+  dps: 7034.9072
   tps: 3508.14513
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7196.9623
+  dps: 7196.70533
   tps: 3576.86589
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 5686.41622
+  dps: 5686.12886
   tps: 2826.38251
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7290.3337
+  dps: 7290.00428
   tps: 3610.80651
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7284.88968
+  dps: 7284.56037
   tps: 3607.98443
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7275.36264
+  dps: 7275.03352
   tps: 3603.0458
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7196.06132
+  dps: 7195.67854
   tps: 3593.68409
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6314.64449
+  dps: 6314.37093
   tps: 3128.41375
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6305.6633
+  dps: 6305.30325
   tps: 3087.5745
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7279.30754
+  dps: 7278.99465
   tps: 3597.4399
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7234.28967
+  dps: 7233.93243
   tps: 3613.30958
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7242.41808
+  dps: 7242.06641
   tps: 3614.22271
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7261.7526
+  dps: 7261.42374
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7261.7526
+  dps: 7261.42374
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7018.34721
+  dps: 7018.05162
   tps: 3485.91413
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7261.7526
+  dps: 7261.42374
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7261.7526
+  dps: 7261.42374
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6024.07264
+  dps: 6023.66977
   tps: 2999.79378
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5581.4124
+  dps: 5581.02617
   tps: 2670.16304
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6967.49946
+  dps: 6967.17353
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 7418.40018
+  dps: 7418.04477
   tps: 3684.99695
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20055.8915
+  dps: 20055.52341
   tps: 10232.07493
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7303.05176
+  dps: 7302.72298
   tps: 3653.4153
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9403.61701
+  dps: 9401.97311
   tps: 4157.32843
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10595.16874
+  dps: 10595.0699
   tps: 5400.22368
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4125.7888
+  dps: 4125.62956
   tps: 2066.93188
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4966.88381
+  dps: 4966.08761
   tps: 2161.91396
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20350.64817
+  dps: 20350.27997
   tps: 10296.41535
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7401.66104
+  dps: 7401.33216
   tps: 3671.42095
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9600.04251
+  dps: 9598.39813
   tps: 4198.44359
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10778.278
+  dps: 10778.17913
   tps: 5442.45068
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4197.85028
+  dps: 4197.69099
   tps: 2088.11648
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5077.1693
+  dps: 5076.37287
   tps: 2187.21186
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7027.60155
+  dps: 7027.26061
   tps: 3508.8017
  }
 }

--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -46,35 +46,35 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7273.99952
+  dps: 7266.83557
   tps: 3598.62553
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7185.56886
+  dps: 7179.48687
   tps: 3594.75963
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6973.86038
+  dps: 6967.50666
   tps: 3475.94382
   hps: 91.2816
  }
@@ -82,7 +82,7 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6973.86038
+  dps: 6967.50666
   tps: 3475.94382
   hps: 91.2816
  }
@@ -90,84 +90,84 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7291.88773
+  dps: 7284.72378
   tps: 3608.61081
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7076.56012
+  dps: 7069.56007
   tps: 3511.1774
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6125.11827
+  dps: 6118.76649
   tps: 3044.82886
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6042.8978
+  dps: 6037.41625
   tps: 3010.18705
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5752.86187
+  dps: 5746.22202
   tps: 2850.68623
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7268.91654
+  dps: 7261.7526
   tps: 3524.0708
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8665.88588
+  dps: 8657.49801
   tps: 4361.03988
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8765.31163
+  dps: 8756.29999
   tps: 4424.26482
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7414.02366
+  dps: 7406.85972
   tps: 3674.07843
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
   hps: 64
  }
@@ -175,266 +175,266 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7074.09272
+  dps: 7067.739
   tps: 3529.54148
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7142.7402
+  dps: 7136.4655
   tps: 3570.88334
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7231.83617
+  dps: 7224.89111
   tps: 3583.05799
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7070.09917
+  dps: 7062.75194
   tps: 3514.64024
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 6169.90369
+  dps: 6162.13528
   tps: 3056.65868
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7607.74281
+  dps: 7600.39925
   tps: 3760.77339
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7041.08906
+  dps: 7034.73534
   tps: 3512.23511
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7454.61285
+  dps: 7447.70226
   tps: 3735.70616
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7481.6062
+  dps: 7474.10749
   tps: 3756.1399
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6990.2148
+  dps: 6983.86108
   tps: 3484.42795
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7296.22106
+  dps: 7289.05711
   tps: 3610.85138
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7109.31913
+  dps: 7102.03154
   tps: 3544.91622
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7134.1131
+  dps: 7126.4315
   tps: 3559.84999
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7268.91654
+  dps: 7261.7526
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7268.91654
+  dps: 7261.7526
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7291.88773
+  dps: 7284.72378
   tps: 3608.61081
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7288.32245
+  dps: 7281.1585
   tps: 3606.84727
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7085.89924
+  dps: 7078.30515
   tps: 3520.36863
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7268.91654
+  dps: 7261.7526
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7129.6315
+  dps: 7123.44803
   tps: 3565.38524
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7064.10652
+  dps: 7057.7528
   tps: 3524.60572
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7045.04669
+  dps: 7038.69297
   tps: 3514.55218
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7268.91654
+  dps: 7261.7526
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7268.91654
+  dps: 7261.7526
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7181.96359
+  dps: 7175.60987
   tps: 3586.21556
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7108.60627
+  dps: 7102.29318
   tps: 3551.08226
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7291.88773
+  dps: 7284.72378
   tps: 3608.61081
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7288.32245
+  dps: 7281.1585
   tps: 3606.84727
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7164.87136
+  dps: 7158.51763
   tps: 3582.22291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7268.91654
+  dps: 7261.7526
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7298.64172
+  dps: 7291.44884
   tps: 3610.85392
   hps: 12.53201
  }
@@ -442,483 +442,483 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50179"
  value: {
-  dps: 8326.37683
+  dps: 8317.62319
   tps: 4170.67943
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50708"
  value: {
-  dps: 8388.93775
+  dps: 8380.14186
   tps: 4205.21813
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7137.51225
+  dps: 7130.00606
   tps: 3555.64858
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7153.02107
+  dps: 7146.66735
   tps: 3551.19119
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6984.44011
+  dps: 6978.08639
   tps: 3481.43202
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7292.05362
+  dps: 7284.88968
   tps: 3607.98443
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7297.49764
+  dps: 7290.3337
   tps: 3610.80651
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7017.77933
+  dps: 7011.42561
   tps: 3498.72849
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7023.43852
+  dps: 7017.0848
   tps: 3501.6645
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7268.91654
+  dps: 7261.7526
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7268.91654
+  dps: 7261.7526
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7044.65213
+  dps: 7038.45414
   tps: 3521.51639
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7051.95978
+  dps: 7045.76179
   tps: 3525.90098
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7408.82498
+  dps: 7401.66104
   tps: 3671.42095
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7268.91654
+  dps: 7261.7526
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6732.03225
+  dps: 6723.87872
   tps: 3337.76372
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 6129.05279
+  dps: 6121.82534
   tps: 3038.44562
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7701.99524
+  dps: 7694.27084
   tps: 3874.37643
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6498.34794
+  dps: 6490.59555
   tps: 3220.11179
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6989.31524
+  dps: 6982.96151
   tps: 3483.6838
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 9641.13689
+  dps: 9629.82611
   tps: 4891.32675
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7066.88779
+  dps: 7060.53407
   tps: 3525.98808
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofLife-37657"
  value: {
-  dps: 7042.34259
+  dps: 7035.29396
   tps: 3508.14513
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7203.0961
+  dps: 7196.9623
   tps: 3576.86589
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 5692.43635
+  dps: 5686.41622
   tps: 2826.38251
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7297.49764
+  dps: 7290.3337
   tps: 3610.80651
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7292.05362
+  dps: 7284.88968
   tps: 3607.98443
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7282.52659
+  dps: 7275.36264
   tps: 3603.0458
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7204.25459
+  dps: 7196.06132
   tps: 3593.68409
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6322.54211
+  dps: 6314.64449
   tps: 3128.41375
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6314.08135
+  dps: 6305.6633
   tps: 3087.5745
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7286.54766
+  dps: 7279.30754
   tps: 3597.4399
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7241.89043
+  dps: 7234.28967
   tps: 3613.30958
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7249.76815
+  dps: 7242.41808
   tps: 3614.22271
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7268.91654
+  dps: 7261.7526
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7268.91654
+  dps: 7261.7526
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7025.72613
+  dps: 7018.34721
   tps: 3485.91413
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7268.91654
+  dps: 7261.7526
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7268.91654
+  dps: 7261.7526
   tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6029.88985
+  dps: 6024.07264
   tps: 2999.79378
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5589.35462
+  dps: 5581.4124
   tps: 2670.16304
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6973.85318
+  dps: 6967.49946
   tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 7425.79677
+  dps: 7418.40018
   tps: 3684.99695
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20063.56159
+  dps: 20055.8915
   tps: 10232.07493
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7309.87214
+  dps: 7303.05176
   tps: 3653.4153
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9420.93953
+  dps: 9403.61701
   tps: 4157.32843
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10599.68744
+  dps: 10595.16874
   tps: 5400.22368
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4129.50357
+  dps: 4125.7888
   tps: 2066.93188
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4974.86645
+  dps: 4966.88381
   tps: 2161.91396
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20358.61111
+  dps: 20350.64817
   tps: 10296.41535
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7408.82498
+  dps: 7401.66104
   tps: 3671.42095
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9618.23731
+  dps: 9600.04251
   tps: 4198.44359
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10783.00443
+  dps: 10778.278
   tps: 5442.45068
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4201.38896
+  dps: 4197.85028
   tps: 2088.11648
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5085.55963
+  dps: 5077.1693
   tps: 2187.21186
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7033.95714
+  dps: 7027.60155
   tps: 3508.8017
  }
 }

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -46,35 +46,35 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8054.08684
+  dps: 8049.05166
   tps: 4704.77841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8025.84044
+  dps: 8021.31251
   tps: 4703.32255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7815.53157
+  dps: 7811.05443
   tps: 4575.83784
   hps: 61.33921
  }
@@ -82,7 +82,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7815.53157
+  dps: 7811.05443
   tps: 4575.83784
   hps: 61.33921
  }
@@ -90,84 +90,84 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8069.5403
+  dps: 8064.50512
   tps: 4714.05048
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7786.992
+  dps: 7780.63189
   tps: 4547.2227
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6741.98054
+  dps: 6735.76558
   tps: 3938.21065
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6629.79755
+  dps: 6623.5446
   tps: 3874.95941
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6360.49523
+  dps: 6354.44319
   tps: 3713.79021
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8047.97007
+  dps: 8042.93489
   tps: 4607.08618
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8252.76995
+  dps: 8247.73477
   tps: 4823.98827
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8252.76995
+  dps: 8247.73477
   tps: 4823.98827
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8258.55416
+  dps: 8253.51898
   tps: 4827.4588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
   hps: 42.66667
  }
@@ -175,287 +175,287 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7927.88521
+  dps: 7923.40807
   tps: 4643.25003
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7981.75469
+  dps: 7977.06783
   tps: 4676.21305
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 8058.14751
+  dps: 8053.24111
   tps: 4710.49002
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7630.66463
+  dps: 7623.81429
   tps: 4459.86303
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 6769.37065
+  dps: 6762.75962
   tps: 3948.96128
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7710.14343
+  dps: 7705.10825
   tps: 4498.41236
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8451.03572
+  dps: 8445.82884
   tps: 4938.58079
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7912.81673
+  dps: 7908.33959
   tps: 4634.20894
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8238.62314
+  dps: 8233.66
   tps: 4821.82305
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8311.78023
+  dps: 8306.07605
   tps: 4868.99744
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7835.48516
+  dps: 7831.00802
   tps: 4587.81
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8076.60545
+  dps: 8071.57027
   tps: 4718.28957
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7966.25363
+  dps: 7960.45181
   tps: 4660.89476
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7977.49462
+  dps: 7971.95615
   tps: 4667.93261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8047.97007
+  dps: 8042.93489
   tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8047.97007
+  dps: 8042.93489
   tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8069.5403
+  dps: 8064.50512
   tps: 4714.05048
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8065.37547
+  dps: 8060.34029
   tps: 4711.55159
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7897.41873
+  dps: 7892.22007
   tps: 4618.16691
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8047.97007
+  dps: 8042.93489
   tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7945.73765
+  dps: 7940.68618
   tps: 4653.9849
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7913.95908
+  dps: 7909.48194
   tps: 4634.89434
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7898.55831
+  dps: 7894.08118
   tps: 4625.65389
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8047.97007
+  dps: 8042.93489
   tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8047.97007
+  dps: 8042.93489
   tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7710.96248
+  dps: 7705.9273
   tps: 4498.90379
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8058.5672
+  dps: 8054.09006
   tps: 4721.65922
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7939.50021
+  dps: 7934.27142
   tps: 4650.10754
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7708.25449
+  dps: 7703.21931
   tps: 4497.279
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8069.5403
+  dps: 8064.50512
   tps: 4714.05048
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8065.37547
+  dps: 8060.34029
   tps: 4711.55159
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8023.60339
+  dps: 8019.12625
   tps: 4700.68093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8047.97007
+  dps: 8042.93489
   tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8079.26287
+  dps: 8074.22769
   tps: 4719.88403
   hps: 12.97738
  }
@@ -463,805 +463,805 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50179"
  value: {
-  dps: 8252.76995
+  dps: 8247.73477
   tps: 4823.98827
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50708"
  value: {
-  dps: 8252.76995
+  dps: 8247.73477
   tps: 4823.98827
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8016.23024
+  dps: 8011.36298
   tps: 4693.82714
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7880.48757
+  dps: 7876.01043
   tps: 4614.81144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7828.49662
+  dps: 7824.01948
   tps: 4583.61687
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8073.53371
+  dps: 8068.49853
   tps: 4716.44653
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8079.54868
+  dps: 8074.5135
   tps: 4720.05551
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7868.84382
+  dps: 7864.36668
   tps: 4607.82519
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7875.6926
+  dps: 7871.21546
   tps: 4611.93446
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8047.97007
+  dps: 8042.93489
   tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8047.97007
+  dps: 8042.93489
   tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7841.0166
+  dps: 7836.37469
   tps: 4590.74123
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7842.80914
+  dps: 7838.16724
   tps: 4591.81676
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8252.76995
+  dps: 8247.73477
   tps: 4823.98827
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7711.91803
+  dps: 7706.88285
   tps: 4499.47712
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8047.97007
+  dps: 8042.93489
   tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7708.00472
+  dps: 7702.96955
   tps: 4497.12914
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7416.61591
+  dps: 7410.37312
   tps: 4336.00865
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 6691.64061
+  dps: 6684.94461
   tps: 3905.49874
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8443.64075
+  dps: 8436.30707
   tps: 4945.24259
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7069.39732
+  dps: 7062.92026
   tps: 4124.67709
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7829.16397
+  dps: 7824.68683
   tps: 4584.01728
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8252.76995
+  dps: 8247.73477
   tps: 4823.98827
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7706.04822
+  dps: 7701.01304
   tps: 4495.95523
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7713.13823
+  dps: 7708.10306
   tps: 4500.20925
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7706.04822
+  dps: 7701.01304
   tps: 4495.95523
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8128.96075
+  dps: 8123.6394
   tps: 4742.4245
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7706.04822
+  dps: 7701.01304
   tps: 4495.95523
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 8165.72978
+  dps: 8160.38124
   tps: 4763.79448
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7706.04822
+  dps: 7701.01304
   tps: 4495.95523
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7917.37154
+  dps: 7912.8944
   tps: 4636.94182
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 7894.61965
+  dps: 7888.26425
   tps: 4619.74272
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7987.33999
+  dps: 7981.67207
   tps: 4678.98998
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StormshroudArmor"
  value: {
-  dps: 6306.71293
+  dps: 6300.76975
   tps: 3684.89791
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8079.54868
+  dps: 8074.5135
   tps: 4720.05551
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8073.53371
+  dps: 8068.49853
   tps: 4716.44653
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8063.0075
+  dps: 8057.97233
   tps: 4710.13081
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7700.88779
+  dps: 7693.88019
   tps: 4503.12354
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6739.83854
+  dps: 6734.4304
   tps: 3936.12163
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7266.28054
+  dps: 7259.95609
   tps: 4236.50314
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8101.35501
+  dps: 8094.24489
   tps: 4729.81022
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7994.17733
+  dps: 7988.85003
   tps: 4684.26704
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8011.6793
+  dps: 8006.49493
   tps: 4692.26551
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8047.97007
+  dps: 8042.93489
   tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8047.97007
+  dps: 8042.93489
   tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7819.46099
+  dps: 7814.40577
   tps: 4574.01804
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8047.97007
+  dps: 8042.93489
   tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8047.97007
+  dps: 8042.93489
   tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6626.35287
+  dps: 6620.91778
   tps: 3873.65925
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7682.88576
+  dps: 7676.9397
   tps: 4481.27683
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7815.68428
+  dps: 7811.20715
   tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7713.01008
+  dps: 7707.97491
   tps: 4500.13236
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 8214.10748
+  dps: 8207.41354
   tps: 4801.74205
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26175.82396
+  dps: 26169.69375
   tps: 15586.28687
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8190.63619
+  dps: 8185.46773
   tps: 4793.27117
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9367.56466
+  dps: 9355.28157
   tps: 5335.77136
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13400.22379
+  dps: 13395.86689
   tps: 7963.37722
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4880.74092
+  dps: 4876.22625
   tps: 2850.01581
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5145.65155
+  dps: 5138.55986
   tps: 2930.78185
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Desync-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25386.92002
+  dps: 25381.17292
   tps: 15116.91668
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Desync-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8245.2366
+  dps: 8240.03315
   tps: 4830.55594
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Desync-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9211.56437
+  dps: 9199.2137
   tps: 5239.53361
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Desync-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13357.17488
+  dps: 13353.42381
   tps: 7940.30692
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Desync-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4914.06988
+  dps: 4909.36869
   tps: 2873.67962
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Desync-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5108.05403
+  dps: 5099.05025
   tps: 2906.44533
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30124.33986
+  dps: 30116.93744
   tps: 17937.30018
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9970.29163
+  dps: 9962.33382
   tps: 5844.69712
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11512.35584
+  dps: 11494.10471
   tps: 6587.45145
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16046.94986
+  dps: 16042.65065
   tps: 9541.62587
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5991.52613
+  dps: 5986.46807
   tps: 3506.66707
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6484.1384
+  dps: 6476.5195
   tps: 3713.44612
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Desync-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29718.02477
+  dps: 29710.35317
   tps: 17698.61004
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Desync-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10026.3513
+  dps: 10019.32736
   tps: 5885.19575
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Desync-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11337.5433
+  dps: 11320.16606
   tps: 6479.88819
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Desync-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16126.15329
+  dps: 16122.74612
   tps: 9593.16783
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Desync-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6032.64972
+  dps: 6027.40012
   tps: 3533.89824
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Desync-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6431.66506
+  dps: 6421.7701
   tps: 3681.67816
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25969.98262
+  dps: 25962.86421
   tps: 15456.68234
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8252.76995
+  dps: 8247.73477
   tps: 4823.98827
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9403.82134
+  dps: 9390.90572
   tps: 5343.67032
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13649.45665
+  dps: 13644.94907
   tps: 8107.65399
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4898.91518
+  dps: 4894.28064
   tps: 2858.52798
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5218.46646
+  dps: 5211.63559
   tps: 2968.53942
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Desync-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25814.03597
+  dps: 25806.96118
   tps: 15366.02637
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Desync-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8245.02636
+  dps: 8239.81182
   tps: 4825.11885
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Desync-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9294.13777
+  dps: 9281.43155
   tps: 5275.34054
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Desync-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13486.47945
+  dps: 13482.15526
   tps: 8013.77756
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Desync-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4896.13445
+  dps: 4891.40724
   tps: 2858.91461
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Desync-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5139.8316
+  dps: 5130.52958
   tps: 2918.70103
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30154.54213
+  dps: 30146.79454
   tps: 17952.29726
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10013.04225
+  dps: 10005.19286
   tps: 5863.41755
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11607.24501
+  dps: 11588.4308
   tps: 6626.71922
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15837.48523
+  dps: 15833.06919
   tps: 9413.23667
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6034.76588
+  dps: 6029.79858
   tps: 3529.23455
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6528.3911
+  dps: 6520.38779
   tps: 3732.26504
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Desync-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30043.04437
+  dps: 30035.8668
   tps: 17887.77545
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Desync-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10027.95251
+  dps: 10020.45538
   tps: 5878.5031
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Desync-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11420.71981
+  dps: 11403.65097
   tps: 6513.46362
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Desync-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16138.73928
+  dps: 16134.55915
   tps: 9596.23775
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Desync-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6067.60171
+  dps: 6062.57086
   tps: 3551.13488
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Desync-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6475.40812
+  dps: 6465.21765
   tps: 3700.27788
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7920.89243
+  dps: 7914.60639
   tps: 4637.8405
  }
 }

--- a/sim/deathknight/dps/TestFrostUH.results
+++ b/sim/deathknight/dps/TestFrostUH.results
@@ -46,35 +46,35 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8110.50841
+  dps: 8102.32676
   tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8025.15405
+  dps: 8018.08098
   tps: 5729.64573
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7812.57684
+  dps: 7805.50377
   tps: 5573.1889
   hps: 60.92312
  }
@@ -82,7 +82,7 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7812.57684
+  dps: 7805.50377
   tps: 5573.1889
   hps: 60.92312
  }
@@ -90,84 +90,84 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8131.94348
+  dps: 8123.76183
   tps: 5780.38812
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7816.43719
+  dps: 7808.31683
   tps: 5559.76199
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6608.88302
+  dps: 6601.66747
   tps: 4699.39067
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6549.70773
+  dps: 6543.48234
   tps: 4664.83982
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6338.2015
+  dps: 6331.34852
   tps: 4509.6772
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8110.50841
+  dps: 8102.32676
   tps: 5649.31967
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8293.87624
+  dps: 8285.69459
   tps: 5899.57063
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8293.87624
+  dps: 8285.69459
   tps: 5899.57063
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8297.72889
+  dps: 8289.54724
   tps: 5902.40618
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
   hps: 42.66667
  }
@@ -175,287 +175,287 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7939.8279
+  dps: 7932.75483
   tps: 5666.84568
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7987.36942
+  dps: 7980.29635
   tps: 5701.83624
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 8082.82261
+  dps: 8074.89678
   tps: 5750.66314
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7658.73742
+  dps: 7650.91269
   tps: 5447.5007
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkrunedPlate"
  value: {
-  dps: 6707.9101
+  dps: 6700.90641
   tps: 4758.8418
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7710.55736
+  dps: 7702.37571
   tps: 5470.24793
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8503.89807
+  dps: 8495.37531
   tps: 6045.57604
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7910.95149
+  dps: 7903.87842
   tps: 5645.59264
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8321.79222
+  dps: 8313.76207
   tps: 5937.69861
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8347.38551
+  dps: 8339.63252
   tps: 5959.06693
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8136.00039
+  dps: 8127.81874
   tps: 5783.374
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7995.14415
+  dps: 7988.28818
   tps: 5703.46795
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7952.53865
+  dps: 7945.6414
   tps: 5669.41185
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8110.50841
+  dps: 8102.32676
   tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8110.50841
+  dps: 8102.32676
   tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8131.94348
+  dps: 8123.76183
   tps: 5780.38812
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8128.51288
+  dps: 8120.33123
   tps: 5777.8632
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7902.4438
+  dps: 7894.59504
   tps: 5630.26517
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8110.50841
+  dps: 8102.32676
   tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7975.58302
+  dps: 7968.50995
   tps: 5693.16145
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7924.75441
+  dps: 7917.68134
   tps: 5655.75159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7903.83834
+  dps: 7896.76527
   tps: 5640.35736
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8110.50841
+  dps: 8102.32676
   tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8110.50841
+  dps: 8102.32676
   tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7711.40359
+  dps: 7703.22193
   tps: 5470.87076
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8065.85462
+  dps: 8058.78155
   tps: 5759.60134
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7929.37395
+  dps: 7922.30088
   tps: 5659.15157
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7708.66116
+  dps: 7700.47951
   tps: 5468.85233
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8131.94348
+  dps: 8123.76183
   tps: 5780.38812
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8128.51288
+  dps: 8120.33123
   tps: 5777.8632
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8020.03358
+  dps: 8012.96051
   tps: 5725.87706
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8110.50841
+  dps: 8102.32676
   tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8143.76338
+  dps: 8135.58173
   tps: 5789.08756
   hps: 12.85179
  }
@@ -463,637 +463,637 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-LastWord-50179"
  value: {
-  dps: 8293.87624
+  dps: 8285.69459
   tps: 5899.57063
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-LastWord-50708"
  value: {
-  dps: 8293.87624
+  dps: 8285.69459
   tps: 5899.57063
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7967.74629
+  dps: 7960.00684
   tps: 5681.79649
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7898.66805
+  dps: 7891.59498
   tps: 5636.55203
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8137.23315
+  dps: 8129.0515
   tps: 5784.28132
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8143.52133
+  dps: 8135.33967
   tps: 5788.90941
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8110.50841
+  dps: 8102.32676
   tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8110.50841
+  dps: 8102.32676
   tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7825.60988
+  dps: 7818.53681
   tps: 5582.78121
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7827.40245
+  dps: 7820.32938
   tps: 5584.10055
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8293.87624
+  dps: 8285.69459
   tps: 5899.57063
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7712.39085
+  dps: 7704.20919
   tps: 5471.59738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8110.50841
+  dps: 8102.32676
   tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7708.39683
+  dps: 7700.21518
   tps: 5468.65779
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7430.96859
+  dps: 7424.69989
   tps: 5290.68699
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ScourgebornePlate"
  value: {
-  dps: 6626.58038
+  dps: 6620.52943
   tps: 4703.59927
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8503.14856
+  dps: 8496.46907
   tps: 6063.20057
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7090.42677
+  dps: 7083.34116
   tps: 5026.96165
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8293.87624
+  dps: 8285.69459
   tps: 5899.57063
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7706.32624
+  dps: 7698.14459
   tps: 5467.13383
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7714.35458
+  dps: 7706.17293
   tps: 5473.04269
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7706.32624
+  dps: 7698.14459
   tps: 5467.13383
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8166.17666
+  dps: 8157.4265
   tps: 5791.29931
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7706.32624
+  dps: 7698.14459
   tps: 5467.13383
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 8205.7867
+  dps: 8196.98253
   tps: 5819.09528
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7706.32624
+  dps: 7698.14459
   tps: 5467.13383
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7928.14673
+  dps: 7921.07366
   tps: 5658.24834
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SparkofLife-37657"
  value: {
-  dps: 7776.48618
+  dps: 7769.73762
   tps: 5545.81107
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7884.30586
+  dps: 7876.75981
   tps: 5625.47153
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-StormshroudArmor"
  value: {
-  dps: 6281.02892
+  dps: 6274.38638
   tps: 4470.37359
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8143.52133
+  dps: 8135.33967
   tps: 5788.90941
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8137.23315
+  dps: 8129.0515
   tps: 5784.28132
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8126.22885
+  dps: 8118.04719
   tps: 5776.18215
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7684.57561
+  dps: 7676.09435
   tps: 5467.09135
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6664.64485
+  dps: 6657.25387
   tps: 4727.96221
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7286.78747
+  dps: 7278.4155
   tps: 5168.45552
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8182.93265
+  dps: 8173.79507
   tps: 5815.46073
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7952.59793
+  dps: 7945.20852
   tps: 5675.94109
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8025.38397
+  dps: 8017.88178
   tps: 5730.81623
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8110.50841
+  dps: 8102.32676
   tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8110.50841
+  dps: 8102.32676
   tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7784.54783
+  dps: 7777.71752
   tps: 5551.16867
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8110.50841
+  dps: 8102.32676
   tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8110.50841
+  dps: 8102.32676
   tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6564.40141
+  dps: 6558.03145
   tps: 4676.42434
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7753.58475
+  dps: 7745.86582
   tps: 5501.4791
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7812.64271
+  dps: 7805.56964
   tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7713.51915
+  dps: 7705.33749
   tps: 5472.42781
  }
 }
 dps_results: {
  key: "TestFrostUH-Average-Default"
  value: {
-  dps: 8219.25869
+  dps: 8210.43008
   tps: 5848.93951
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20719.36469
+  dps: 20712.38172
   tps: 15063.62953
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8202.73906
+  dps: 8194.95345
   tps: 5843.65919
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9459.30176
+  dps: 9438.57473
   tps: 6491.23599
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10416.54623
+  dps: 10410.89178
   tps: 7551.09001
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4714.85534
+  dps: 4709.61106
   tps: 3347.70186
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5187.76428
+  dps: 5179.01401
   tps: 3566.08499
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23979.14505
+  dps: 23970.06864
   tps: 17431.57839
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10037.57937
+  dps: 10026.4761
   tps: 7163.37912
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11789.8706
+  dps: 11761.80558
   tps: 8126.84999
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12456.51499
+  dps: 12450.85691
   tps: 9036.84098
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5859.29684
+  dps: 5852.89727
   tps: 4172.23866
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6546.06298
+  dps: 6534.09117
   tps: 4520.4282
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20082.57213
+  dps: 20075.02493
   tps: 14584.80108
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8293.87624
+  dps: 8285.69459
   tps: 5899.57063
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9573.90888
+  dps: 9554.80646
   tps: 6553.35516
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10242.21896
+  dps: 10236.22664
   tps: 7415.92515
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4665.07261
+  dps: 4659.82819
   tps: 3307.01917
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5200.92038
+  dps: 5191.42578
   tps: 3564.55079
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23893.54557
+  dps: 23884.16294
   tps: 17354.65556
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10144.30464
+  dps: 10132.51463
   tps: 7226.73598
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11887.40683
+  dps: 11857.98082
   tps: 8171.36393
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11924.02022
+  dps: 11918.75643
   tps: 8638.93311
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5840.49527
+  dps: 5833.83991
   tps: 4152.36994
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6604.08436
+  dps: 6589.69819
   tps: 4548.92752
  }
 }
 dps_results: {
  key: "TestFrostUH-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7386.32617
+  dps: 7377.97527
   tps: 5253.0538
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -46,7 +46,7 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7446.01996
+  dps: 7445.10075
   tps: 4821.53386
   hps: 369.59868
  }
@@ -54,7 +54,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7446.01996
+  dps: 7445.10075
   tps: 4821.53386
   hps: 383.43105
  }
@@ -62,7 +62,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7956.17793
+  dps: 7955.2242
   tps: 5089.57829
   hps: 270.31002
  }
@@ -70,7 +70,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7642.05203
+  dps: 7641.18695
   tps: 4992.13337
   hps: 264.72419
  }
@@ -78,7 +78,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7446.04447
+  dps: 7445.12527
   tps: 4821.50604
   hps: 354.03666
  }
@@ -86,7 +86,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7446.04447
+  dps: 7445.12527
   tps: 4821.50604
   hps: 354.03666
  }
@@ -94,7 +94,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7978.94456
+  dps: 7977.99083
   tps: 5109.17129
   hps: 265.35448
  }
@@ -102,7 +102,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7718.20573
+  dps: 7717.37292
   tps: 4920.9882
   hps: 257.00534
  }
@@ -110,7 +110,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6524.012
+  dps: 6523.37444
   tps: 4216.61459
   hps: 232.68485
  }
@@ -118,7 +118,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6342.44973
+  dps: 6341.91132
   tps: 4136.9408
   hps: 224.48378
  }
@@ -126,7 +126,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6149.79778
+  dps: 6149.11994
   tps: 3966.21194
   hps: 224.07309
  }
@@ -134,7 +134,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7956.17793
+  dps: 7955.2242
   tps: 4987.78673
   hps: 265.35448
  }
@@ -142,7 +142,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8033.90917
+  dps: 8032.95543
   tps: 5161.19364
   hps: 265.35448
  }
@@ -150,7 +150,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8033.90917
+  dps: 8032.95543
   tps: 5161.19364
   hps: 265.35448
  }
@@ -158,7 +158,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8047.75624
+  dps: 8046.80251
   tps: 5175.16728
   hps: 265.35448
  }
@@ -166,7 +166,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -174,7 +174,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -182,7 +182,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 363.59146
  }
@@ -190,7 +190,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7540.25289
+  dps: 7539.33369
   tps: 4912.27372
   hps: 264.40904
  }
@@ -198,7 +198,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7565.24916
+  dps: 7564.40539
   tps: 4939.84833
   hps: 263.77874
  }
@@ -206,7 +206,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7792.58763
+  dps: 7791.64281
   tps: 5000.51817
   hps: 265.35448
  }
@@ -214,7 +214,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7599.22646
+  dps: 7598.38862
   tps: 4942.71555
   hps: 279.46859
  }
@@ -222,7 +222,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 6636.84723
+  dps: 6636.23504
   tps: 4276.86749
   hps: 296.98863
  }
@@ -230,7 +230,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8279.93725
+  dps: 8278.96295
   tps: 5327.14325
   hps: 265.35448
  }
@@ -238,7 +238,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7526.29336
+  dps: 7525.37416
   tps: 4899.77681
   hps: 264.40904
  }
@@ -246,7 +246,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7831.0025
+  dps: 7830.26983
   tps: 5188.60376
   hps: 272.60288
  }
@@ -254,7 +254,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7842.50118
+  dps: 7841.68692
   tps: 5223.22665
   hps: 272.28773
  }
@@ -262,7 +262,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -270,7 +270,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7980.8727
+  dps: 7979.91896
   tps: 5111.31429
   hps: 265.35448
  }
@@ -278,7 +278,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7659.58658
+  dps: 7658.77297
   tps: 4928.59977
   hps: 263.46359
  }
@@ -286,7 +286,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7629.20082
+  dps: 7628.4107
   tps: 4906.60879
   hps: 262.51815
  }
@@ -294,7 +294,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7956.17793
+  dps: 7955.2242
   tps: 5089.57829
   hps: 270.31002
  }
@@ -302,7 +302,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7956.17793
+  dps: 7955.2242
   tps: 5089.57829
   hps: 265.35448
  }
@@ -310,7 +310,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7978.94456
+  dps: 7977.99083
   tps: 5109.17129
   hps: 265.35448
  }
@@ -318,7 +318,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7975.59518
+  dps: 7974.64145
   tps: 5106.2296
   hps: 265.35448
  }
@@ -326,7 +326,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7593.65438
+  dps: 7592.71519
   tps: 4839.309
   hps: 266.61507
  }
@@ -334,7 +334,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 281.53732
  }
@@ -342,7 +342,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7956.17793
+  dps: 7955.2242
   tps: 5089.57829
   hps: 265.35448
  }
@@ -350,7 +350,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7595.09414
+  dps: 7594.19847
   tps: 4958.58648
   hps: 265.03933
  }
@@ -358,7 +358,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7529.1449
+  dps: 7528.2257
   tps: 4901.73682
   hps: 264.40904
  }
@@ -366,7 +366,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -374,7 +374,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -382,7 +382,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7509.90299
+  dps: 7508.98379
   tps: 4883.67609
   hps: 264.40904
  }
@@ -390,7 +390,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7956.17793
+  dps: 7955.2242
   tps: 5089.57829
   hps: 265.35448
  }
@@ -398,7 +398,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7956.17793
+  dps: 7955.2242
   tps: 5089.57829
   hps: 265.35448
  }
@@ -406,7 +406,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 8051.03381
+  dps: 8050.07926
   tps: 5174.72044
   hps: 265.35448
  }
@@ -414,7 +414,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7708.9439
+  dps: 7708.01312
   tps: 5034.05554
   hps: 264.40904
  }
@@ -422,7 +422,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -430,7 +430,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -438,7 +438,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -446,7 +446,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7551.71058
+  dps: 7550.88546
   tps: 4924.78139
   hps: 264.72419
  }
@@ -454,7 +454,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7997.29596
+  dps: 7996.34525
   tps: 5132.84192
   hps: 265.35448
  }
@@ -462,7 +462,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -470,7 +470,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7978.94456
+  dps: 7977.99083
   tps: 5109.17129
   hps: 265.35448
  }
@@ -478,7 +478,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7975.59518
+  dps: 7974.64145
   tps: 5106.2296
   hps: 265.35448
  }
@@ -486,7 +486,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7612.05877
+  dps: 7611.13416
   tps: 4958.16485
   hps: 264.40904
  }
@@ -494,7 +494,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7956.17793
+  dps: 7955.2242
   tps: 5089.57829
   hps: 265.35448
  }
@@ -502,7 +502,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7991.91335
+  dps: 7990.95808
   tps: 5118.78399
   hps: 278.22315
  }
@@ -510,7 +510,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50179"
  value: {
-  dps: 8033.90917
+  dps: 8032.95543
   tps: 5161.19364
   hps: 265.35448
  }
@@ -518,7 +518,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50708"
  value: {
-  dps: 8033.90917
+  dps: 8032.95543
   tps: 5161.19364
   hps: 265.35448
  }
@@ -526,7 +526,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -534,7 +534,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -542,7 +542,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7527.69306
+  dps: 7526.77385
   tps: 4907.41177
   hps: 264.40904
  }
@@ -550,7 +550,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -558,7 +558,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7984.2969
+  dps: 7983.34192
   tps: 5112.19294
   hps: 265.35448
  }
@@ -566,7 +566,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7990.91313
+  dps: 7989.95786
   tps: 5117.51403
   hps: 265.35448
  }
@@ -574,7 +574,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -582,7 +582,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -590,7 +590,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -598,7 +598,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7956.17793
+  dps: 7955.2242
   tps: 5089.57829
   hps: 269.38086
  }
@@ -606,7 +606,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7956.17793
+  dps: 7955.2242
   tps: 5089.57829
   hps: 270.31002
  }
@@ -614,7 +614,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -622,7 +622,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7497.33331
+  dps: 7496.53761
   tps: 4867.98232
   hps: 265.66963
  }
@@ -630,7 +630,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7506.62111
+  dps: 7505.82541
   tps: 4875.76278
   hps: 265.66963
  }
@@ -638,7 +638,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8033.90917
+  dps: 8032.95543
   tps: 5161.19364
   hps: 265.35448
  }
@@ -646,7 +646,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 8071.01255
+  dps: 8070.05705
   tps: 5190.50171
   hps: 265.35448
  }
@@ -654,7 +654,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7956.17793
+  dps: 7955.2242
   tps: 5089.57829
   hps: 265.35448
  }
@@ -662,7 +662,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -670,7 +670,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7991.74767
+  dps: 7990.79707
   tps: 5128.39487
   hps: 265.35448
  }
@@ -678,7 +678,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7227.32105
+  dps: 7226.44045
   tps: 4683.04421
   hps: 255.62308
  }
@@ -686,7 +686,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6587.45639
+  dps: 6586.71076
   tps: 4228.55747
   hps: 270.24427
  }
@@ -694,7 +694,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7974.68507
+  dps: 7973.99309
   tps: 5321.84729
   hps: 297.77471
  }
@@ -702,7 +702,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7229.26559
+  dps: 7228.32658
   tps: 4777.27408
   hps: 308.77393
  }
@@ -710,7 +710,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -718,7 +718,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8033.90917
+  dps: 8032.95543
   tps: 5161.19364
   hps: 265.35448
  }
@@ -726,7 +726,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -734,7 +734,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7948.286
+  dps: 7947.33631
   tps: 5093.55962
   hps: 265.35448
  }
@@ -742,7 +742,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7958.95784
+  dps: 7958.00816
   tps: 5104.33806
   hps: 265.35448
  }
@@ -750,7 +750,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7948.286
+  dps: 7947.33631
   tps: 5093.55962
   hps: 265.35448
  }
@@ -758,7 +758,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8153.83576
+  dps: 8153.02192
   tps: 5184.06066
   hps: 238.25177
  }
@@ -766,7 +766,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7948.286
+  dps: 7947.33631
   tps: 5093.55962
   hps: 265.35448
  }
@@ -774,7 +774,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7948.286
+  dps: 7947.33631
   tps: 5093.55962
   hps: 265.35448
  }
@@ -782,7 +782,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7948.286
+  dps: 7947.33631
   tps: 5093.55962
   hps: 265.35448
  }
@@ -790,7 +790,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 299.59146
  }
@@ -798,7 +798,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -806,7 +806,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -814,7 +814,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -822,7 +822,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7531.05536
+  dps: 7530.13615
   tps: 4903.62369
   hps: 264.40904
  }
@@ -830,7 +830,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 7524.89653
+  dps: 7524.05289
   tps: 4851.84607
   hps: 265.66963
  }
@@ -838,7 +838,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7642.56919
+  dps: 7641.68644
   tps: 4925.24482
   hps: 264.72419
  }
@@ -846,7 +846,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-StormshroudArmor"
  value: {
-  dps: 6027.86305
+  dps: 6027.02866
   tps: 3911.58651
   hps: 204.81996
  }
@@ -854,7 +854,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7990.91313
+  dps: 7989.95786
   tps: 5117.51403
   hps: 265.35448
  }
@@ -862,7 +862,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7984.2969
+  dps: 7983.34192
   tps: 5112.19294
   hps: 265.35448
  }
@@ -870,7 +870,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7972.7185
+  dps: 7971.76404
   tps: 5102.88102
   hps: 265.35448
  }
@@ -878,7 +878,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -886,7 +886,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -894,7 +894,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7784.64182
+  dps: 7783.82464
   tps: 5108.03978
   hps: 277.93737
  }
@@ -902,7 +902,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6733.21143
+  dps: 6732.47421
   tps: 4313.20341
   hps: 289.52451
  }
@@ -910,7 +910,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -918,7 +918,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7425.62053
+  dps: 7424.66381
   tps: 4731.67027
   hps: 251.95663
  }
@@ -926,7 +926,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8006.2332
+  dps: 8005.43775
   tps: 5107.97955
   hps: 263.46359
  }
@@ -934,7 +934,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7631.42371
+  dps: 7630.5444
   tps: 4963.43683
   hps: 267.87566
  }
@@ -942,7 +942,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7632.24523
+  dps: 7631.37885
   tps: 4977.52883
   hps: 264.72419
  }
@@ -950,7 +950,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7956.17793
+  dps: 7955.2242
   tps: 5089.57829
   hps: 265.35448
  }
@@ -958,7 +958,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7956.17793
+  dps: 7955.2242
   tps: 5089.57829
   hps: 265.35448
  }
@@ -966,7 +966,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7527.65197
+  dps: 7526.94402
   tps: 4836.49894
   hps: 263.46359
  }
@@ -974,7 +974,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7956.17793
+  dps: 7955.2242
   tps: 5089.57829
   hps: 265.35448
  }
@@ -982,7 +982,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7956.17793
+  dps: 7955.2242
   tps: 5089.57829
   hps: 265.35448
  }
@@ -990,7 +990,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6374.68641
+  dps: 6374.13471
   tps: 4164.15754
   hps: 230.2196
  }
@@ -998,7 +998,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7688.69819
+  dps: 7687.78157
   tps: 4916.95095
   hps: 264.74695
  }
@@ -1006,7 +1006,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7446.04321
+  dps: 7445.12401
   tps: 4821.49891
   hps: 264.40904
  }
@@ -1014,7 +1014,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 8093.84539
+  dps: 8092.88882
   tps: 5208.53745
   hps: 265.35448
  }
@@ -1022,7 +1022,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 8018.73539
+  dps: 8017.83314
   tps: 5161.16075
   hps: 265.34082
  }
@@ -1030,7 +1030,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36222.94351
+  dps: 36222.16901
   tps: 38806.87831
   hps: 261.42005
  }
@@ -1038,7 +1038,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7822.21279
+  dps: 7821.32368
   tps: 5123.77288
   hps: 264.56969
  }
@@ -1046,7 +1046,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11201.55822
+  dps: 11197.08555
   tps: 5671.76828
   hps: 231.49848
  }
@@ -1054,7 +1054,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 21883.40085
+  dps: 21883.09234
   tps: 24104.41002
   hps: 158.16236
  }
@@ -1062,7 +1062,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3864.44757
+  dps: 3864.15784
   tps: 2782.99681
   hps: 159.48827
  }
@@ -1070,7 +1070,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4926.61699
+  dps: 4925.46991
   tps: 2863.8087
   hps: 142.062
  }
@@ -1078,7 +1078,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 46631.29175
+  dps: 46630.1848
   tps: 50168.81961
   hps: 320.4671
  }
@@ -1086,7 +1086,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10243.32141
+  dps: 10242.21918
   tps: 6832.10793
   hps: 327.90162
  }
@@ -1094,7 +1094,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14254.77477
+  dps: 14249.31176
   tps: 7498.85252
   hps: 283.68577
  }
@@ -1102,7 +1102,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 29347.94648
+  dps: 29347.45447
   tps: 32420.54449
   hps: 210.32917
  }
@@ -1110,7 +1110,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5297.27413
+  dps: 5296.84563
   tps: 3892.91502
   hps: 211.33915
  }
@@ -1118,7 +1118,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6532.30872
+  dps: 6530.03404
   tps: 3961.61841
   hps: 180.53464
  }
@@ -1126,7 +1126,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36806.66262
+  dps: 36805.89138
   tps: 39310.28264
   hps: 261.88786
  }
@@ -1134,7 +1134,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8033.90917
+  dps: 8032.95543
   tps: 5161.19364
   hps: 265.35448
  }
@@ -1142,7 +1142,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11585.24388
+  dps: 11580.71394
   tps: 5732.02094
   hps: 231.63366
  }
@@ -1150,7 +1150,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 22095.16543
+  dps: 22094.85284
   tps: 24292.82052
   hps: 158.09971
  }
@@ -1158,7 +1158,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3945.85507
+  dps: 3945.67933
   tps: 2803.16899
   hps: 160.37453
  }
@@ -1166,7 +1166,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5103.13561
+  dps: 5101.97353
   tps: 2901.84378
   hps: 142.176
  }
@@ -1174,7 +1174,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 46701.26542
+  dps: 46700.19374
   tps: 49939.13248
   hps: 321.79215
  }
@@ -1182,7 +1182,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10391.23186
+  dps: 10390.02013
   tps: 6797.27018
   hps: 327.66427
  }
@@ -1190,7 +1190,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14688.54028
+  dps: 14682.74307
   tps: 7552.85592
   hps: 279.90437
  }
@@ -1198,7 +1198,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 29444.07344
+  dps: 29443.58498
   tps: 32479.5714
   hps: 209.69784
  }
@@ -1206,7 +1206,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5375.16343
+  dps: 5374.6586
   tps: 3891.01135
   hps: 211.97167
  }
@@ -1214,7 +1214,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6695.72414
+  dps: 6693.30905
   tps: 3960.19317
   hps: 175.59036
  }
@@ -1222,7 +1222,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7697.25651
+  dps: 7696.31128
   tps: 5013.1652
   hps: 262.8333
  }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -46,7 +46,7 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7486.2719
+  dps: 7446.01996
   tps: 4821.53386
   hps: 369.59868
  }
@@ -54,7 +54,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7486.2719
+  dps: 7446.01996
   tps: 4821.53386
   hps: 383.43105
  }
@@ -62,7 +62,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8000.64059
+  dps: 7956.17793
   tps: 5089.57829
   hps: 270.31002
  }
@@ -70,7 +70,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7683.26572
+  dps: 7642.05203
   tps: 4992.13337
   hps: 264.72419
  }
@@ -78,7 +78,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7486.29641
+  dps: 7446.04447
   tps: 4821.50604
   hps: 354.03666
  }
@@ -86,7 +86,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7486.29641
+  dps: 7446.04447
   tps: 4821.50604
   hps: 354.03666
  }
@@ -94,7 +94,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8023.40722
+  dps: 7978.94456
   tps: 5109.17129
   hps: 265.35448
  }
@@ -102,7 +102,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7759.58116
+  dps: 7718.20573
   tps: 4920.9882
   hps: 257.00534
  }
@@ -110,7 +110,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6559.15567
+  dps: 6524.012
   tps: 4216.61459
   hps: 232.68485
  }
@@ -118,7 +118,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6377.19709
+  dps: 6342.44973
   tps: 4136.9408
   hps: 224.48378
  }
@@ -126,7 +126,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6183.1721
+  dps: 6149.79778
   tps: 3966.21194
   hps: 224.07309
  }
@@ -134,7 +134,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8000.64059
+  dps: 7956.17793
   tps: 4987.78673
   hps: 265.35448
  }
@@ -142,7 +142,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8078.37183
+  dps: 8033.90917
   tps: 5161.19364
   hps: 265.35448
  }
@@ -150,7 +150,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8078.37183
+  dps: 8033.90917
   tps: 5161.19364
   hps: 265.35448
  }
@@ -158,7 +158,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8092.2189
+  dps: 8047.75624
   tps: 5175.16728
   hps: 265.35448
  }
@@ -166,7 +166,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -174,7 +174,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -182,7 +182,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 363.59146
  }
@@ -190,7 +190,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7580.50483
+  dps: 7540.25289
   tps: 4912.27372
   hps: 264.40904
  }
@@ -198,7 +198,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7604.25474
+  dps: 7565.24916
   tps: 4939.84833
   hps: 263.77874
  }
@@ -206,7 +206,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7835.71579
+  dps: 7792.58763
   tps: 5000.51817
   hps: 265.35448
  }
@@ -214,7 +214,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7640.34431
+  dps: 7599.22646
   tps: 4942.71555
   hps: 279.46859
  }
@@ -222,7 +222,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 6672.89598
+  dps: 6636.84723
   tps: 4276.86749
   hps: 296.98863
  }
@@ -230,7 +230,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8324.06593
+  dps: 8279.93725
   tps: 5327.14325
   hps: 265.35448
  }
@@ -238,7 +238,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7566.5453
+  dps: 7526.29336
   tps: 4899.77681
   hps: 264.40904
  }
@@ -246,7 +246,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7875.80268
+  dps: 7831.0025
   tps: 5188.60376
   hps: 272.60288
  }
@@ -254,7 +254,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7881.64984
+  dps: 7842.50118
   tps: 5223.22665
   hps: 272.28773
  }
@@ -262,7 +262,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -270,7 +270,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8025.33536
+  dps: 7980.8727
   tps: 5111.31429
   hps: 265.35448
  }
@@ -278,7 +278,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7702.76936
+  dps: 7659.58658
   tps: 4928.59977
   hps: 263.46359
  }
@@ -286,7 +286,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7674.42977
+  dps: 7629.20082
   tps: 4906.60879
   hps: 262.51815
  }
@@ -294,7 +294,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8000.64059
+  dps: 7956.17793
   tps: 5089.57829
   hps: 270.31002
  }
@@ -302,7 +302,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8000.64059
+  dps: 7956.17793
   tps: 5089.57829
   hps: 265.35448
  }
@@ -310,7 +310,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8023.40722
+  dps: 7978.94456
   tps: 5109.17129
   hps: 265.35448
  }
@@ -318,7 +318,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8020.05784
+  dps: 7975.59518
   tps: 5106.2296
   hps: 265.35448
  }
@@ -326,7 +326,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7636.56376
+  dps: 7593.65438
   tps: 4839.309
   hps: 266.61507
  }
@@ -334,7 +334,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 281.53732
  }
@@ -342,7 +342,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8000.64059
+  dps: 7956.17793
   tps: 5089.57829
   hps: 265.35448
  }
@@ -350,7 +350,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7636.07914
+  dps: 7595.09414
   tps: 4958.58648
   hps: 265.03933
  }
@@ -358,7 +358,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7569.39684
+  dps: 7529.1449
   tps: 4901.73682
   hps: 264.40904
  }
@@ -366,7 +366,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -374,7 +374,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -382,7 +382,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7550.15493
+  dps: 7509.90299
   tps: 4883.67609
   hps: 264.40904
  }
@@ -390,7 +390,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8000.64059
+  dps: 7956.17793
   tps: 5089.57829
   hps: 265.35448
  }
@@ -398,7 +398,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8000.64059
+  dps: 7956.17793
   tps: 5089.57829
   hps: 265.35448
  }
@@ -406,7 +406,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 8095.49646
+  dps: 8051.03381
   tps: 5174.72044
   hps: 265.35448
  }
@@ -414,7 +414,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7749.19584
+  dps: 7708.9439
   tps: 5034.05554
   hps: 264.40904
  }
@@ -422,7 +422,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -430,7 +430,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -438,7 +438,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -446,7 +446,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7592.57498
+  dps: 7551.71058
   tps: 4924.78139
   hps: 264.72419
  }
@@ -454,7 +454,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 8041.75862
+  dps: 7997.29596
   tps: 5132.84192
   hps: 265.35448
  }
@@ -462,7 +462,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -470,7 +470,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8023.40722
+  dps: 7978.94456
   tps: 5109.17129
   hps: 265.35448
  }
@@ -478,7 +478,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8020.05784
+  dps: 7975.59518
   tps: 5106.2296
   hps: 265.35448
  }
@@ -486,7 +486,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7652.31072
+  dps: 7612.05877
   tps: 4958.16485
   hps: 264.40904
  }
@@ -494,7 +494,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8000.64059
+  dps: 7956.17793
   tps: 5089.57829
   hps: 265.35448
  }
@@ -502,7 +502,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8035.60142
+  dps: 7991.91335
   tps: 5118.78399
   hps: 278.22315
  }
@@ -510,7 +510,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50179"
  value: {
-  dps: 8078.37183
+  dps: 8033.90917
   tps: 5161.19364
   hps: 265.35448
  }
@@ -518,7 +518,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50708"
  value: {
-  dps: 8078.37183
+  dps: 8033.90917
   tps: 5161.19364
   hps: 265.35448
  }
@@ -526,7 +526,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -534,7 +534,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -542,7 +542,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7567.945
+  dps: 7527.69306
   tps: 4907.41177
   hps: 264.40904
  }
@@ -550,7 +550,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -558,7 +558,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8028.75956
+  dps: 7984.2969
   tps: 5112.19294
   hps: 265.35448
  }
@@ -566,7 +566,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8035.37578
+  dps: 7990.91313
   tps: 5117.51403
   hps: 265.35448
  }
@@ -574,7 +574,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -582,7 +582,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -590,7 +590,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -598,7 +598,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8000.64059
+  dps: 7956.17793
   tps: 5089.57829
   hps: 269.38086
  }
@@ -606,7 +606,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8000.64059
+  dps: 7956.17793
   tps: 5089.57829
   hps: 270.31002
  }
@@ -614,7 +614,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -622,7 +622,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7537.28187
+  dps: 7497.33331
   tps: 4867.98232
   hps: 265.66963
  }
@@ -630,7 +630,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7546.56968
+  dps: 7506.62111
   tps: 4875.76278
   hps: 265.66963
  }
@@ -638,7 +638,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8078.37183
+  dps: 8033.90917
   tps: 5161.19364
   hps: 265.35448
  }
@@ -646,7 +646,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 8115.4752
+  dps: 8071.01255
   tps: 5190.50171
   hps: 265.35448
  }
@@ -654,7 +654,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8000.64059
+  dps: 7956.17793
   tps: 5089.57829
   hps: 265.35448
  }
@@ -662,7 +662,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -670,7 +670,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 8036.21032
+  dps: 7991.74767
   tps: 5128.39487
   hps: 265.35448
  }
@@ -678,7 +678,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7263.64523
+  dps: 7227.32105
   tps: 4683.04421
   hps: 255.62308
  }
@@ -686,7 +686,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6623.9593
+  dps: 6587.45639
   tps: 4228.55747
   hps: 270.24427
  }
@@ -694,7 +694,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8013.67517
+  dps: 7974.68507
   tps: 5321.84729
   hps: 297.77471
  }
@@ -702,7 +702,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7268.45891
+  dps: 7229.26559
   tps: 4777.27408
   hps: 308.77393
  }
@@ -710,7 +710,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -718,7 +718,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8078.37183
+  dps: 8033.90917
   tps: 5161.19364
   hps: 265.35448
  }
@@ -726,7 +726,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -734,7 +734,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7992.74865
+  dps: 7948.286
   tps: 5093.55962
   hps: 265.35448
  }
@@ -742,7 +742,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 8003.4205
+  dps: 7958.95784
   tps: 5104.33806
   hps: 265.35448
  }
@@ -750,7 +750,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7992.74865
+  dps: 7948.286
   tps: 5093.55962
   hps: 265.35448
  }
@@ -758,7 +758,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8196.40222
+  dps: 8153.83576
   tps: 5184.06066
   hps: 238.25177
  }
@@ -766,7 +766,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7992.74865
+  dps: 7948.286
   tps: 5093.55962
   hps: 265.35448
  }
@@ -774,7 +774,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7992.74865
+  dps: 7948.286
   tps: 5093.55962
   hps: 265.35448
  }
@@ -782,7 +782,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7992.74865
+  dps: 7948.286
   tps: 5093.55962
   hps: 265.35448
  }
@@ -790,7 +790,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 299.59146
  }
@@ -798,7 +798,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -806,7 +806,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -814,7 +814,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -822,7 +822,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7571.3073
+  dps: 7531.05536
   tps: 4903.62369
   hps: 264.40904
  }
@@ -830,7 +830,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 7566.30963
+  dps: 7524.89653
   tps: 4851.84607
   hps: 265.66963
  }
@@ -838,7 +838,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7684.34586
+  dps: 7642.56919
   tps: 4925.24482
   hps: 264.72419
  }
@@ -846,7 +846,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-StormshroudArmor"
  value: {
-  dps: 6060.79631
+  dps: 6027.86305
   tps: 3911.58651
   hps: 204.81996
  }
@@ -854,7 +854,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8035.37578
+  dps: 7990.91313
   tps: 5117.51403
   hps: 265.35448
  }
@@ -862,7 +862,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8028.75956
+  dps: 7984.2969
   tps: 5112.19294
   hps: 265.35448
  }
@@ -870,7 +870,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8017.18116
+  dps: 7972.7185
   tps: 5102.88102
   hps: 265.35448
  }
@@ -878,7 +878,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -886,7 +886,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -894,7 +894,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7826.08442
+  dps: 7784.64182
   tps: 5108.03978
   hps: 277.93737
  }
@@ -902,7 +902,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6771.87384
+  dps: 6733.21143
   tps: 4313.20341
   hps: 289.52451
  }
@@ -910,7 +910,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -918,7 +918,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7464.86408
+  dps: 7425.62053
   tps: 4731.67027
   hps: 251.95663
  }
@@ -926,7 +926,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8050.72634
+  dps: 8006.2332
   tps: 5107.97955
   hps: 263.46359
  }
@@ -934,7 +934,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7672.82466
+  dps: 7631.42371
   tps: 4963.43683
   hps: 267.87566
  }
@@ -942,7 +942,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7669.65653
+  dps: 7632.24523
   tps: 4977.52883
   hps: 264.72419
  }
@@ -950,7 +950,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8000.64059
+  dps: 7956.17793
   tps: 5089.57829
   hps: 265.35448
  }
@@ -958,7 +958,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8000.64059
+  dps: 7956.17793
   tps: 5089.57829
   hps: 265.35448
  }
@@ -966,7 +966,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7572.02695
+  dps: 7527.65197
   tps: 4836.49894
   hps: 263.46359
  }
@@ -974,7 +974,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8000.64059
+  dps: 7956.17793
   tps: 5089.57829
   hps: 265.35448
  }
@@ -982,7 +982,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8000.64059
+  dps: 7956.17793
   tps: 5089.57829
   hps: 265.35448
  }
@@ -990,7 +990,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6408.16323
+  dps: 6374.68641
   tps: 4164.15754
   hps: 230.2196
  }
@@ -998,7 +998,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7729.80562
+  dps: 7688.69819
   tps: 4916.95095
   hps: 264.74695
  }
@@ -1006,7 +1006,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7486.29516
+  dps: 7446.04321
   tps: 4821.49891
   hps: 264.40904
  }
@@ -1014,7 +1014,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 8138.30805
+  dps: 8093.84539
   tps: 5208.53745
   hps: 265.35448
  }
@@ -1022,7 +1022,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 8062.85605
+  dps: 8018.73539
   tps: 5161.16075
   hps: 265.34082
  }
@@ -1030,7 +1030,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36262.61329
+  dps: 36222.94351
   tps: 38806.87831
   hps: 261.42005
  }
@@ -1038,7 +1038,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7864.90906
+  dps: 7822.21279
   tps: 5123.77288
   hps: 264.56969
  }
@@ -1046,7 +1046,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11259.82823
+  dps: 11201.55822
   tps: 5671.76828
   hps: 231.49848
  }
@@ -1054,7 +1054,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 21899.41164
+  dps: 21883.40085
   tps: 24104.41002
   hps: 158.16236
  }
@@ -1062,7 +1062,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3878.71787
+  dps: 3864.44757
   tps: 2782.99681
   hps: 159.48827
  }
@@ -1070,7 +1070,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4940.67842
+  dps: 4926.61699
   tps: 2863.8087
   hps: 142.062
  }
@@ -1078,7 +1078,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 46680.37718
+  dps: 46631.29175
   tps: 50168.81961
   hps: 320.4671
  }
@@ -1086,7 +1086,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10292.68242
+  dps: 10243.32141
   tps: 6832.10793
   hps: 327.90162
  }
@@ -1094,7 +1094,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14324.2498
+  dps: 14254.77477
   tps: 7498.85252
   hps: 283.68577
  }
@@ -1102,7 +1102,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 29367.00937
+  dps: 29347.94648
   tps: 32420.54449
   hps: 210.32917
  }
@@ -1110,7 +1110,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5314.63289
+  dps: 5297.27413
   tps: 3892.91502
   hps: 211.33915
  }
@@ -1118,7 +1118,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6551.53668
+  dps: 6532.30872
   tps: 3961.61841
   hps: 180.53464
  }
@@ -1126,7 +1126,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36850.66571
+  dps: 36806.66262
   tps: 39310.28264
   hps: 261.88786
  }
@@ -1134,7 +1134,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8078.37183
+  dps: 8033.90917
   tps: 5161.19364
   hps: 265.35448
  }
@@ -1142,7 +1142,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11647.43451
+  dps: 11585.24388
   tps: 5732.02094
   hps: 231.63366
  }
@@ -1150,7 +1150,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 22111.77939
+  dps: 22095.16543
   tps: 24292.82052
   hps: 158.09971
  }
@@ -1158,7 +1158,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3960.62038
+  dps: 3945.85507
   tps: 2803.16899
   hps: 160.37453
  }
@@ -1166,7 +1166,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5117.63452
+  dps: 5103.13561
   tps: 2901.84378
   hps: 142.176
  }
@@ -1174,7 +1174,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 46751.45821
+  dps: 46701.26542
   tps: 49939.13248
   hps: 321.79215
  }
@@ -1182,7 +1182,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10442.2978
+  dps: 10391.23186
   tps: 6797.27018
   hps: 327.66427
  }
@@ -1190,7 +1190,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14761.66509
+  dps: 14688.54028
   tps: 7552.85592
   hps: 279.90437
  }
@@ -1198,7 +1198,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 29462.66686
+  dps: 29444.07344
   tps: 32479.5714
   hps: 209.69784
  }
@@ -1206,7 +1206,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5393.55375
+  dps: 5375.16343
   tps: 3891.01135
   hps: 211.97167
  }
@@ -1214,7 +1214,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6716.52851
+  dps: 6695.72414
   tps: 3960.19317
   hps: 175.59036
  }
@@ -1222,7 +1222,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7738.51736
+  dps: 7697.25651
   tps: 5013.1652
   hps: 262.8333
  }

--- a/sim/deathknight/ghoul_pet.go
+++ b/sim/deathknight/ghoul_pet.go
@@ -89,8 +89,6 @@ func (dk *Deathknight) NewGhoulPet(permanent bool) *GhoulPet {
 
 		stats.MeleeHit:  -nocsHit,
 		stats.Expertise: -nocsHit * PetExpertiseScale,
-
-		stats.MeleeCrit: 3.2 * core.CritRatingPerCritChance,
 	}
 
 	ghoulPet := &GhoulPet{
@@ -117,7 +115,7 @@ func (dk *Deathknight) NewGhoulPet(permanent bool) *GhoulPet {
 
 	ghoulPet.AddStatDependency(stats.Strength, stats.AttackPower, 1)
 	ghoulPet.AddStatDependency(stats.Agility, stats.AttackPower, 1)
-	ghoulPet.AddStatDependency(stats.Agility, stats.MeleeCrit, core.CritRatingPerCritChance/83.3)
+	ghoulPet.AddStatDependency(stats.Agility, stats.MeleeCrit, core.CritRatingPerCritChance/85.5)
 
 	if permanent {
 		core.ApplyPetConsumeEffects(&ghoulPet.Character, dk.Consumes)

--- a/sim/deathknight/ghoul_pet.go
+++ b/sim/deathknight/ghoul_pet.go
@@ -62,7 +62,7 @@ func (dk *Deathknight) NewArmyGhoulPet(_ int) *GhoulPet {
 
 	ghoulPet.AddStatDependency(stats.Strength, stats.AttackPower, 1)
 	ghoulPet.AddStatDependency(stats.Agility, stats.AttackPower, 1)
-	ghoulPet.AddStatDependency(stats.Agility, stats.MeleeCrit, core.CritRatingPerCritChance/83.3)
+	ghoulPet.AddStatDependency(stats.Agility, stats.MeleeCrit, core.CritRatingPerCritChance/85.5)
 
 	// command doesn't apply to army ghoul
 	if dk.Race == proto.Race_RaceOrc {


### PR DESCRIPTION
In-game, you can view ghoul stats:

With 856 agility, gives 9.98% crit = 85.77 coefficient
With 1011 agility (HoW), gives 11.84% crit = 85.39 coefficient

Also, looking over numerous logs it's clear the ghoul is critting much less than in the sim (~17%, definitely not 20.5%)