### PR TITLE
vigo/dk-apl-fix

### DIFF
--- a/sim/deathknight/rotation.go
+++ b/sim/deathknight/rotation.go
@@ -6,7 +6,7 @@ import (
 	"github.com/wowsims/wotlk/sim/core"
 )
 
-func (dk *Deathknight) OnAutoAttack(sim *core.Simulation, spell *core.Spell) {
+func (dk *Deathknight) OnAutoAttack(_ *core.Simulation, _ *core.Spell) {
 }
 
 func (dk *Deathknight) OnGCDReady(sim *core.Simulation) {
@@ -218,12 +218,7 @@ func (dk *Deathknight) RotationActionCallback_RD(sim *core.Simulation, target *c
 	return -1
 }
 
-func (dk *Deathknight) RotationActionCallback_Reset(sim *core.Simulation, target *core.Unit, s *Sequence) time.Duration {
-	s.Reset()
-	return -1
-}
-
-func (s *Sequence) DoAction(sim *core.Simulation, target *core.Unit, dk *Deathknight) time.Duration {
+func (s *Sequence) DoAction(sim *core.Simulation, target *core.Unit, _ *Deathknight) time.Duration {
 	action := s.actions[s.idx]
 	return action(sim, target, s)
 }

--- a/sim/deathknight/rotation_helper.go
+++ b/sim/deathknight/rotation_helper.go
@@ -10,32 +10,15 @@ import (
 // return duration is an optional wait time
 type RotationAction func(sim *core.Simulation, target *core.Unit, s *Sequence) time.Duration
 
-func TernaryRotationAction(condition bool, t RotationAction, f RotationAction) RotationAction {
-	if condition {
-		return t
-	} else {
-		return f
-	}
-}
-
 // Add your UH rotation Actions here and then on the DoNext function
 
 type Sequence struct {
-	idx        int
-	numActions int
-	actions    []RotationAction
+	idx     int
+	actions []RotationAction
 }
 
 func (s *Sequence) IsOngoing() bool {
-	return s.idx < s.numActions
-}
-
-func (s *Sequence) RemainingActions() int {
-	return (s.numActions - 1) - s.idx
-}
-
-func (s *Sequence) Reset() {
-	s.idx = 0
+	return s.idx < len(s.actions)
 }
 
 func (s *Sequence) Advance() {
@@ -48,23 +31,13 @@ func (s *Sequence) ConditionalAdvance(condition bool) {
 	}
 }
 
-func (s *Sequence) GetNextAction() RotationAction {
-	if s.idx+1 < s.numActions {
-		return s.actions[s.idx+1]
-	} else {
-		return nil
-	}
-}
-
 func (s *Sequence) NewAction(action RotationAction) *Sequence {
 	s.actions = append(s.actions, action)
-	s.numActions += 1
 	return s
 }
 
 func (s *Sequence) Clear() *Sequence {
 	s.actions = s.actions[:0]
-	s.numActions = 0
 	s.idx = 0
 	return s
 }
@@ -72,8 +45,9 @@ func (s *Sequence) Clear() *Sequence {
 type RotationHelper struct {
 	RotationSequence *Sequence
 
-	LastOutcome           core.HitOutcome
-	LastCast              *core.Spell
-	NextCast              *core.Spell
+	LastOutcome core.HitOutcome
+	LastCast    *core.Spell
+	NextCast    *core.Spell
+
 	AoESpellNumTargetsHit int32
 }


### PR DESCRIPTION
[dk] prevent "resetEffects" leak when using APL rotations (plus refactoring for a little less reset() work)