### PR TITLE
Add Spell crit suppression, Crit debuffs do stack

### DIFF
--- a/sim/common/wotlk/nibelung.go
+++ b/sim/common/wotlk/nibelung.go
@@ -39,7 +39,7 @@ func getSmiteConfig(valkyr *ValkyrPet, spellId int32, damageMin float64, damageM
 		ThreatMultiplier: 1,
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := sim.Roll(damageMin, damageMax)
-			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicCrit)
+			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeCritFixedChance(0.05))
 			spell.DealDamage(sim, result)
 			valkyr.GainHealth(sim, valkyr.MaxHealth()*0.25, valkyr.healthMetrics)
 		},

--- a/sim/common/wotlk/nibelung.go
+++ b/sim/common/wotlk/nibelung.go
@@ -39,7 +39,7 @@ func getSmiteConfig(valkyr *ValkyrPet, spellId int32, damageMin float64, damageM
 		ThreatMultiplier: 1,
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := sim.Roll(damageMin, damageMax)
-			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeCritFixedChance(0.05))
+			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicCrit)
 			spell.DealDamage(sim, result)
 			valkyr.GainHealth(sim, valkyr.MaxHealth()*0.25, valkyr.healthMetrics)
 		},

--- a/sim/core/spell_outcome.go
+++ b/sim/core/spell_outcome.go
@@ -126,44 +126,6 @@ func (spell *Spell) OutcomeHealingCrit(sim *Simulation, result *SpellResult, att
 	}
 }
 
-func (spell *Spell) OutcomeCritFixedChance(critChance float64) OutcomeApplier {
-	return func(sim *Simulation, result *SpellResult, attackTable *AttackTable) {
-		if spell.CritMultiplier == 0 {
-			panic("Spell " + spell.ActionID.String() + " missing CritMultiplier")
-		}
-		if spell.fixedCritCheck(sim, critChance) {
-			result.Outcome = OutcomeCrit
-			result.Damage *= spell.CritMultiplier
-			spell.SpellMetrics[result.Target.UnitIndex].Crits++
-		} else {
-			result.Outcome = OutcomeHit
-			spell.SpellMetrics[result.Target.UnitIndex].Hits++
-		}
-	}
-}
-
-func (spell *Spell) OutcomeMagicCritFixedChance(critChance float64) OutcomeApplier {
-	return func(sim *Simulation, result *SpellResult, attackTable *AttackTable) {
-		if spell.CritMultiplier == 0 {
-			panic("Spell " + spell.ActionID.String() + " missing CritMultiplier")
-		}
-		if spell.MagicHitCheck(sim, attackTable) {
-			if spell.fixedCritCheck(sim, critChance) {
-				result.Outcome = OutcomeCrit
-				result.Damage *= spell.CritMultiplier
-				spell.SpellMetrics[result.Target.UnitIndex].Crits++
-			} else {
-				result.Outcome = OutcomeHit
-				spell.SpellMetrics[result.Target.UnitIndex].Hits++
-			}
-		} else {
-			result.Outcome = OutcomeMiss
-			result.Damage = 0
-			spell.SpellMetrics[result.Target.UnitIndex].Misses++
-		}
-	}
-}
-
 func (spell *Spell) OutcomeTickMagicHit(sim *Simulation, result *SpellResult, attackTable *AttackTable) {
 	if spell.MagicHitCheck(sim, attackTable) {
 		result.Outcome = OutcomeHit

--- a/sim/core/spell_result.go
+++ b/sim/core/spell_result.go
@@ -102,7 +102,7 @@ func (spell *Spell) PhysicalCritChance(attackTable *AttackTable) float64 {
 	critRating := spell.Unit.stats[stats.MeleeCrit] +
 		spell.BonusCritRating +
 		attackTable.Defender.PseudoStats.BonusCritRatingTaken
-	return critRating/(CritRatingPerCritChance*100) - attackTable.CritSuppression
+	return critRating/(CritRatingPerCritChance*100) - attackTable.MeleeCritSuppression
 }
 func (spell *Spell) PhysicalCritCheck(sim *Simulation, attackTable *AttackTable) bool {
 	return sim.RandomFloat("Physical Crit Roll") < spell.PhysicalCritChance(attackTable)
@@ -135,7 +135,7 @@ func (spell *Spell) spellCritRating(target *Unit) float64 {
 		target.PseudoStats.BonusSpellCritRatingTaken
 }
 func (spell *Spell) SpellCritChance(target *Unit) float64 {
-	return spell.spellCritRating(target) / (CritRatingPerCritChance * 100)
+	return spell.spellCritRating(target)/(CritRatingPerCritChance*100) - spell.Unit.AttackTables[target.UnitIndex].SpellCritSuppression
 }
 func (spell *Spell) MagicCritCheck(sim *Simulation, target *Unit) bool {
 	critChance := spell.SpellCritChance(target)

--- a/sim/core/spell_result.go
+++ b/sim/core/spell_result.go
@@ -101,7 +101,7 @@ func (spell *Spell) PhysicalHitChance(attackTable *AttackTable) float64 {
 func (spell *Spell) PhysicalCritChance(attackTable *AttackTable) float64 {
 	critRating := spell.Unit.stats[stats.MeleeCrit] +
 		spell.BonusCritRating +
-		attackTable.Defender.PseudoStats.BonusMeleeCritRatingTaken
+		attackTable.Defender.PseudoStats.BonusCritRatingTaken
 	return critRating/(CritRatingPerCritChance*100) - attackTable.CritSuppression
 }
 func (spell *Spell) PhysicalCritCheck(sim *Simulation, attackTable *AttackTable) bool {
@@ -131,6 +131,7 @@ func (spell *Spell) MagicHitCheck(sim *Simulation, attackTable *AttackTable) boo
 func (spell *Spell) spellCritRating(target *Unit) float64 {
 	return spell.Unit.stats[stats.SpellCrit] +
 		spell.BonusCritRating +
+		target.PseudoStats.BonusCritRatingTaken +
 		target.PseudoStats.BonusSpellCritRatingTaken
 }
 func (spell *Spell) SpellCritChance(target *Unit) float64 {

--- a/sim/core/stats/stats.go
+++ b/sim/core/stats/stats.go
@@ -359,8 +359,8 @@ type PseudoStats struct {
 	ReducedCritTakenChance float64 // Reduces chance to be crit.
 
 	BonusRangedAttackPowerTaken float64 // Hunters mark
-	BonusSpellCritRatingTaken   float64 // Imp Shadow Bolt / Imp Scorch / Winter's Chill debuff + Totem of Wrath / Master Poisoner / Heart of the Crusader
-	BonusMeleeCritRatingTaken   float64 // Totem of Wrath / Master Poisoner / Heart of the Crusader
+	BonusSpellCritRatingTaken   float64 // Imp Shadow Bolt / Imp Scorch / Winter's Chill debuff
+	BonusCritRatingTaken        float64 // Totem of Wrath / Master Poisoner / Heart of the Crusader
 	BonusMeleeHitRatingTaken    float64 // Formerly Imp FF and SW Radiance;
 	BonusSpellHitRatingTaken    float64 // Imp FF
 

--- a/sim/core/target.go
+++ b/sim/core/target.go
@@ -247,7 +247,7 @@ func NewAttackTable(attacker *Unit, defender *Unit) *AttackTable {
 
 		table.GlanceMultiplier = UnitLevelFloat64(defender.Level, 0.95, 0.95, 0.85, 0.75)
 		table.MeleeCritSuppression = UnitLevelFloat64(defender.Level, 0, 0.01, 0.02, 0.048)
-		table.SpellCritSuppression = UnitLevelFloat64(defender.Level, 0, 0.01, 0.02, 0.03)
+		table.SpellCritSuppression = UnitLevelFloat64(defender.Level, 0, 0, 0.003, 0.021)
 	} else {
 		// Assumes defender (the Player) is level 80.
 		table.BaseSpellMissChance = 0.05

--- a/sim/core/target.go
+++ b/sim/core/target.go
@@ -213,8 +213,9 @@ type AttackTable struct {
 	BaseParryChance     float64
 	BaseGlanceChance    float64
 
-	GlanceMultiplier float64
-	CritSuppression  float64
+	GlanceMultiplier     float64
+	MeleeCritSuppression float64
+	SpellCritSuppression float64
 
 	DamageDealtMultiplier        float64 // attacker buff, applied in applyAttackerModifiers()
 	DamageTakenMultiplier        float64 // defender debuff, applied in applyTargetModifiers()
@@ -245,7 +246,8 @@ func NewAttackTable(attacker *Unit, defender *Unit) *AttackTable {
 		table.BaseGlanceChance = UnitLevelFloat64(defender.Level, 0.06, 0.12, 0.18, 0.24)
 
 		table.GlanceMultiplier = UnitLevelFloat64(defender.Level, 0.95, 0.95, 0.85, 0.75)
-		table.CritSuppression = UnitLevelFloat64(defender.Level, 0, 0.01, 0.02, 0.048)
+		table.MeleeCritSuppression = UnitLevelFloat64(defender.Level, 0, 0.01, 0.02, 0.048)
+		table.SpellCritSuppression = UnitLevelFloat64(defender.Level, 0, 0.01, 0.02, 0.03)
 	} else {
 		// Assumes defender (the Player) is level 80.
 		table.BaseSpellMissChance = 0.05

--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -46,879 +46,879 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7252.57861
-  tps: 3591.15044
+  dps: 7254.49949
+  tps: 3592.06493
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7163.41037
-  tps: 3585.91401
+  dps: 7165.61235
+  tps: 3586.98903
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6953.23111
-  tps: 3468.38072
+  dps: 6955.15432
+  tps: 3469.32296
   hps: 91.2816
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6953.23111
-  tps: 3468.38072
+  dps: 6955.15432
+  tps: 3469.32296
   hps: 91.2816
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7268.16669
-  tps: 3599.93184
+  dps: 7270.70319
+  tps: 3601.19975
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7057.3608
-  tps: 3504.71737
+  dps: 7061.44428
+  tps: 3507.02642
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6106.92554
-  tps: 3038.85004
+  dps: 6110.86035
+  tps: 3041.04376
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6025.95116
-  tps: 3004.12376
+  dps: 6029.80376
+  tps: 3006.27154
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5734.67243
-  tps: 2844.34337
+  dps: 5738.38546
+  tps: 2846.41166
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3516.75118
+  dps: 7249.42634
+  tps: 3517.64664
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8641.64139
-  tps: 4352.85242
+  dps: 8643.88056
+  tps: 4353.93653
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8740.22854
-  tps: 4415.63305
+  dps: 8742.4559
+  tps: 4416.72274
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7389.43473
-  tps: 3664.87872
+  dps: 7392.09802
+  tps: 3666.22271
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
   hps: 64
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7055.3852
-  tps: 3522.82918
+  dps: 7060.09821
+  tps: 3525.65698
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7120.91002
-  tps: 3562.32842
+  dps: 7125.98003
+  tps: 3565.25429
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7210.29116
-  tps: 3575.35207
+  dps: 7212.24797
+  tps: 3576.29432
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7052.28961
-  tps: 3509.06398
+  dps: 7055.44508
+  tps: 3510.95727
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 6148.86879
-  tps: 3050.12952
+  dps: 6151.69772
+  tps: 3051.35052
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7585.14825
-  tps: 3752.74168
+  dps: 7587.19169
+  tps: 3753.71492
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7019.99929
-  tps: 3504.1761
+  dps: 7022.82804
+  tps: 3505.53263
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7433.79045
-  tps: 3728.21833
+  dps: 7436.16972
+  tps: 3729.43422
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7461.25044
-  tps: 3749.56666
+  dps: 7463.47285
+  tps: 3750.57229
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6969.54763
-  tps: 3476.84445
+  dps: 6971.47602
+  tps: 3477.78924
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7272.84397
-  tps: 3602.37877
+  dps: 7275.03652
+  tps: 3603.44032
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7087.53723
-  tps: 3537.12647
+  dps: 7089.56569
+  tps: 3538.10697
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7112.0965
-  tps: 3552.37872
+  dps: 7114.25264
+  tps: 3553.56034
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7249.42634
+  tps: 3589.43535
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7249.42634
+  tps: 3589.43535
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7268.16669
-  tps: 3599.93184
+  dps: 7270.70319
+  tps: 3601.19975
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7266.07307
-  tps: 3598.90686
+  dps: 7268.60957
+  tps: 3600.17477
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7063.98871
-  tps: 3512.82447
+  dps: 7066.1656
+  tps: 3514.00609
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7249.42634
+  tps: 3589.43535
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7108.23002
-  tps: 3557.23556
+  dps: 7112.78642
+  tps: 3559.6433
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7044.49787
-  tps: 3517.60628
+  dps: 7049.27399
+  tps: 3520.2184
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7023.17819
-  tps: 3506.41375
+  dps: 7029.32211
+  tps: 3509.62963
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7249.42634
+  tps: 3589.43535
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7249.42634
+  tps: 3589.43535
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7160.82866
-  tps: 3578.376
+  dps: 7162.82199
+  tps: 3579.35268
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7086.94389
-  tps: 3542.95758
+  dps: 7091.42238
+  tps: 3545.42297
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7268.16669
-  tps: 3599.93184
+  dps: 7270.70319
+  tps: 3601.19975
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7266.07307
-  tps: 3598.90686
+  dps: 7268.60957
+  tps: 3600.17477
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7144.00451
-  tps: 3574.53195
+  dps: 7145.96015
+  tps: 3575.49012
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7249.42634
+  tps: 3589.43535
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7277.13926
-  tps: 3603.35068
+  dps: 7279.06736
+  tps: 3604.26868
   hps: 12.53201
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50179"
  value: {
-  dps: 8302.19087
-  tps: 4162.39109
+  dps: 8304.51946
+  tps: 4163.65409
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50708"
  value: {
-  dps: 8364.64391
-  tps: 4196.89347
+  dps: 8366.98267
+  tps: 4198.16207
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7114.2108
-  tps: 3547.32704
+  dps: 7119.82904
+  tps: 3550.3283
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7132.99356
-  tps: 3543.66149
+  dps: 7135.92013
+  tps: 3545.08962
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6963.78632
-  tps: 3473.85573
+  dps: 6965.71288
+  tps: 3474.79962
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7270.59229
-  tps: 3600.48772
+  dps: 7272.51872
+  tps: 3601.40491
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7276.02412
-  tps: 3603.30327
+  dps: 7277.95222
+  tps: 3604.22127
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6997.0483
-  tps: 3491.11063
+  dps: 6998.9854
+  tps: 3492.0597
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7002.69439
-  tps: 3494.03958
+  dps: 7004.63328
+  tps: 3494.98953
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7249.42634
+  tps: 3589.43535
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7249.42634
+  tps: 3589.43535
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7030.80029
-  tps: 3517.23238
+  dps: 7032.64174
+  tps: 3518.11312
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7037.2107
-  tps: 3521.07862
+  dps: 7039.14539
+  tps: 3522.01531
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7386.6665
-  tps: 3663.5027
+  dps: 7388.67747
+  tps: 3664.47139
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7249.42634
+  tps: 3589.43535
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6708.99133
-  tps: 3329.80214
+  dps: 6714.14074
+  tps: 3332.50768
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 6108.25996
-  tps: 3031.38863
+  dps: 6111.58936
+  tps: 3033.11719
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7677.37309
-  tps: 3865.13991
+  dps: 7680.78842
+  tps: 3867.18911
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6476.34934
-  tps: 3212.86032
+  dps: 6479.69318
+  tps: 3214.58474
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6968.65228
-  tps: 3476.10188
+  dps: 6970.58017
+  tps: 3477.04693
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 9613.20195
-  tps: 4882.35357
+  dps: 9619.89706
+  tps: 4886.37063
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7047.67387
-  tps: 3519.22549
+  dps: 7052.39046
+  tps: 3521.80189
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofLife-37657"
  value: {
-  dps: 7020.57905
-  tps: 3500.25811
+  dps: 7022.90369
+  tps: 3501.65289
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7182.06053
-  tps: 3568.45927
+  dps: 7184.46896
+  tps: 3569.90433
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 5671.18575
-  tps: 2818.45341
+  dps: 5676.14876
+  tps: 2820.83611
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7276.02412
-  tps: 3603.30327
+  dps: 7277.95222
+  tps: 3604.22127
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7270.59229
-  tps: 3600.48772
+  dps: 7272.51872
+  tps: 3601.40491
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7261.08659
-  tps: 3595.5605
+  dps: 7263.01009
+  tps: 3596.47626
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7172.27609
-  tps: 3580.86382
+  dps: 7180.33672
+  tps: 3585.25646
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6300.8513
-  tps: 3121.16012
+  dps: 6304.2692
+  tps: 3122.95067
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6291.58787
-  tps: 3079.70104
+  dps: 6297.18494
+  tps: 3082.81939
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7265.46986
-  tps: 3590.42044
+  dps: 7267.43446
+  tps: 3591.36134
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7219.18328
-  tps: 3604.95546
+  dps: 7221.52976
+  tps: 3606.36335
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7227.29784
-  tps: 3605.85695
+  dps: 7229.64432
+  tps: 3607.26483
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7249.42634
+  tps: 3589.43535
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7249.42634
+  tps: 3589.43535
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7004.07469
-  tps: 3478.27959
+  dps: 7006.03588
+  tps: 3479.20727
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7249.42634
+  tps: 3589.43535
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7249.42634
+  tps: 3589.43535
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6012.32983
-  tps: 2993.72538
+  dps: 6016.0907
+  tps: 2995.81386
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5566.35622
-  tps: 2662.39448
+  dps: 5572.2676
+  tps: 2665.54983
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6955.14712
+  tps: 3469.31864
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 7403.54527
-  tps: 3677.06011
+  dps: 7407.75036
+  tps: 3679.35209
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20037.91954
-  tps: 10222.86415
+  dps: 20042.2416
+  tps: 10225.23803
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7288.14712
-  tps: 3645.50397
+  dps: 7290.13746
+  tps: 3646.47181
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9387.69402
-  tps: 4149.42678
+  dps: 9389.51568
+  tps: 4150.51977
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10583.21016
-  tps: 5393.55368
+  dps: 10587.47794
+  tps: 5395.93411
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4116.13738
-  tps: 2061.57961
+  dps: 4119.74995
+  tps: 2063.67127
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4958.75535
-  tps: 2157.5146
+  dps: 4960.43121
+  tps: 2158.52011
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20329.86
-  tps: 10285.46854
+  dps: 20335.22812
+  tps: 10288.45122
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7386.6665
-  tps: 3663.5027
+  dps: 7388.67747
+  tps: 3664.47139
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9584.01352
-  tps: 4190.53508
+  dps: 9585.8367
+  tps: 4191.62899
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10766.29684
-  tps: 5435.80112
+  dps: 10770.6032
+  tps: 5438.19164
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4188.0905
-  tps: 2082.7085
+  dps: 4191.71974
+  tps: 2084.80319
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5068.9776
-  tps: 2182.7747
+  dps: 5070.65498
+  tps: 2183.78113
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7012.49963
-  tps: 3500.98662
+  dps: 7014.65967
+  tps: 3502.02386
  }
 }

--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -46,810 +46,810 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7252.57861
-  tps: 3591.15044
+  dps: 7266.50661
+  tps: 3598.62553
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7163.41037
-  tps: 3585.91401
+  dps: 7179.15841
+  tps: 3594.75963
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6953.23111
-  tps: 3468.38072
+  dps: 6967.18072
+  tps: 3475.94382
   hps: 91.2816
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6953.23111
-  tps: 3468.38072
+  dps: 6967.18072
+  tps: 3475.94382
   hps: 91.2816
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7268.16669
-  tps: 3599.93184
+  dps: 7284.39492
+  tps: 3608.61081
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7057.3608
-  tps: 3504.71737
+  dps: 7069.24078
+  tps: 3511.1774
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6106.92554
-  tps: 3038.85004
+  dps: 6118.33695
+  tps: 3044.82886
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6025.95116
-  tps: 3004.12376
+  dps: 6036.99048
+  tps: 3010.18705
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5734.67243
-  tps: 2844.34337
+  dps: 5745.82373
+  tps: 2850.68623
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3516.75118
+  dps: 7261.42374
+  tps: 3524.0708
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8641.64139
-  tps: 4352.85242
+  dps: 8657.1518
+  tps: 4361.03988
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8740.22854
-  tps: 4415.63305
+  dps: 8755.9314
+  tps: 4424.26482
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7389.43473
-  tps: 3664.87872
+  dps: 7406.53086
+  tps: 3674.07843
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
   hps: 64
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7055.3852
-  tps: 3522.82918
+  dps: 7067.41307
+  tps: 3529.54148
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7120.91002
-  tps: 3562.32842
+  dps: 7136.13957
+  tps: 3570.88334
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7210.29116
-  tps: 3575.35207
+  dps: 7224.56518
+  tps: 3583.05799
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7052.28961
-  tps: 3509.06398
+  dps: 7062.41932
+  tps: 3514.64024
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 6148.86879
-  tps: 3050.12952
+  dps: 6161.72028
+  tps: 3056.65868
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7585.14825
-  tps: 3752.74168
+  dps: 7600.06947
+  tps: 3760.77339
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7019.99929
-  tps: 3504.1761
+  dps: 7034.40941
+  tps: 3512.23511
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7433.79045
-  tps: 3728.21833
+  dps: 7447.27863
+  tps: 3735.70616
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7461.25044
-  tps: 3749.56666
+  dps: 7473.74834
+  tps: 3756.1399
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6969.54763
-  tps: 3476.84445
+  dps: 6983.53483
+  tps: 3484.42795
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7272.84397
-  tps: 3602.37877
+  dps: 7288.72825
+  tps: 3610.85138
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7087.53723
-  tps: 3537.12647
+  dps: 7101.72414
+  tps: 3544.91622
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7112.0965
-  tps: 3552.37872
+  dps: 7126.14091
+  tps: 3559.84999
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7261.42374
+  tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7261.42374
+  tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7268.16669
-  tps: 3599.93184
+  dps: 7284.39492
+  tps: 3608.61081
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7266.07307
-  tps: 3598.90686
+  dps: 7280.82965
+  tps: 3606.84727
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7063.98871
-  tps: 3512.82447
+  dps: 7077.97776
+  tps: 3520.36863
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7261.42374
+  tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7108.23002
-  tps: 3557.23556
+  dps: 7123.12209
+  tps: 3565.38524
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7044.49787
-  tps: 3517.60628
+  dps: 7057.42687
+  tps: 3524.60572
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7023.17819
-  tps: 3506.41375
+  dps: 7038.36703
+  tps: 3514.55218
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7261.42374
+  tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7261.42374
+  tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7160.82866
-  tps: 3578.376
+  dps: 7175.28394
+  tps: 3586.21556
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7086.94389
-  tps: 3542.95758
+  dps: 7101.96725
+  tps: 3551.08226
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7268.16669
-  tps: 3599.93184
+  dps: 7284.39492
+  tps: 3608.61081
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7266.07307
-  tps: 3598.90686
+  dps: 7280.82965
+  tps: 3606.84727
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7144.00451
-  tps: 3574.53195
+  dps: 7158.18973
+  tps: 3582.22291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7261.42374
+  tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7277.13926
-  tps: 3603.35068
+  dps: 7291.11942
+  tps: 3610.85392
   hps: 12.53201
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50179"
  value: {
-  dps: 8302.19087
-  tps: 4162.39109
+  dps: 8317.27836
+  tps: 4170.67943
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50708"
  value: {
-  dps: 8364.64391
-  tps: 4196.89347
+  dps: 8379.79703
+  tps: 4205.21813
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7114.2108
-  tps: 3547.32704
+  dps: 7129.66362
+  tps: 3555.64858
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7132.99356
-  tps: 3543.66149
+  dps: 7146.34142
+  tps: 3551.19119
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6963.78632
-  tps: 3473.85573
+  dps: 6977.76025
+  tps: 3481.43202
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7270.59229
-  tps: 3600.48772
+  dps: 7284.56037
+  tps: 3607.98443
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7276.02412
-  tps: 3603.30327
+  dps: 7290.00428
+  tps: 3610.80651
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6997.0483
-  tps: 3491.11063
+  dps: 7011.09883
+  tps: 3498.72849
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7002.69439
-  tps: 3494.03958
+  dps: 7016.75792
+  tps: 3501.6645
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7261.42374
+  tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7261.42374
+  tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7030.80029
-  tps: 3517.23238
+  dps: 7038.12821
+  tps: 3521.51639
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7037.2107
-  tps: 3521.07862
+  dps: 7045.43585
+  tps: 3525.90098
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7386.6665
-  tps: 3663.5027
+  dps: 7401.33216
+  tps: 3671.42095
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7261.42374
+  tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6708.99133
-  tps: 3329.80214
+  dps: 6723.53598
+  tps: 3337.76372
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 6108.25996
-  tps: 3031.38863
+  dps: 6121.39325
+  tps: 3038.44562
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7677.37309
-  tps: 3865.13991
+  dps: 7693.82602
+  tps: 3874.37643
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6476.34934
-  tps: 3212.86032
+  dps: 6490.14682
+  tps: 3220.11179
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6968.65228
-  tps: 3476.10188
+  dps: 6982.63558
+  tps: 3483.6838
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 9613.20195
-  tps: 4882.35357
+  dps: 9629.43027
+  tps: 4891.32675
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7047.67387
-  tps: 3519.22549
+  dps: 7060.20814
+  tps: 3525.98808
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofLife-37657"
  value: {
-  dps: 7020.57905
-  tps: 3500.25811
+  dps: 7034.9072
+  tps: 3508.14513
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7182.06053
-  tps: 3568.45927
+  dps: 7196.70533
+  tps: 3576.86589
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 5671.18575
-  tps: 2818.45341
+  dps: 5686.12886
+  tps: 2826.38251
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7276.02412
-  tps: 3603.30327
+  dps: 7290.00428
+  tps: 3610.80651
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7270.59229
-  tps: 3600.48772
+  dps: 7284.56037
+  tps: 3607.98443
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7261.08659
-  tps: 3595.5605
+  dps: 7275.03352
+  tps: 3603.0458
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7172.27609
-  tps: 3580.86382
+  dps: 7195.67854
+  tps: 3593.68409
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6300.8513
-  tps: 3121.16012
+  dps: 6314.37093
+  tps: 3128.41375
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6291.58787
-  tps: 3079.70104
+  dps: 6305.30325
+  tps: 3087.5745
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7265.46986
-  tps: 3590.42044
+  dps: 7278.99465
+  tps: 3597.4399
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7219.18328
-  tps: 3604.95546
+  dps: 7233.93243
+  tps: 3613.30958
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7227.29784
-  tps: 3605.85695
+  dps: 7242.06641
+  tps: 3614.22271
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7261.42374
+  tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7261.42374
+  tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7004.07469
-  tps: 3478.27959
+  dps: 7018.05162
+  tps: 3485.91413
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7261.42374
+  tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7247.50702
-  tps: 3588.52161
+  dps: 7261.42374
+  tps: 3595.99061
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6012.32983
-  tps: 2993.72538
+  dps: 6023.66977
+  tps: 2999.79378
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5566.35622
-  tps: 2662.39448
+  dps: 5581.02617
+  tps: 2670.16304
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6953.22391
-  tps: 3468.3764
+  dps: 6967.17353
+  tps: 3475.9395
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 7403.54527
-  tps: 3677.06011
+  dps: 7418.04477
+  tps: 3684.99695
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20041.03602
-  tps: 10224.25259
+  dps: 20055.52341
+  tps: 10232.07493
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7288.14712
-  tps: 3645.50397
+  dps: 7302.72298
+  tps: 3653.4153
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9387.69402
-  tps: 4149.42678
+  dps: 9401.97311
+  tps: 4157.32843
  }
 }
 dps_results: {
@@ -876,22 +876,22 @@ dps_results: {
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20334.09435
-  tps: 10287.49509
+  dps: 20350.27997
+  tps: 10296.41535
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7386.6665
-  tps: 3663.5027
+  dps: 7401.33216
+  tps: 3671.42095
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9584.01352
-  tps: 4190.53508
+  dps: 9598.39813
+  tps: 4198.44359
  }
 }
 dps_results: {
@@ -918,7 +918,7 @@ dps_results: {
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7012.49963
-  tps: 3500.98662
+  dps: 7027.26061
+  tps: 3508.8017
  }
 }

--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -46,879 +46,879 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7266.50661
-  tps: 3598.62553
+  dps: 7252.57861
+  tps: 3591.15044
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7179.15841
-  tps: 3594.75963
+  dps: 7163.41037
+  tps: 3585.91401
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6967.18072
-  tps: 3475.94382
+  dps: 6953.23111
+  tps: 3468.38072
   hps: 91.2816
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6967.18072
-  tps: 3475.94382
+  dps: 6953.23111
+  tps: 3468.38072
   hps: 91.2816
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7284.39492
-  tps: 3608.61081
+  dps: 7268.16669
+  tps: 3599.93184
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7069.24078
-  tps: 3511.1774
+  dps: 7057.3608
+  tps: 3504.71737
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6118.33695
-  tps: 3044.82886
+  dps: 6106.92554
+  tps: 3038.85004
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6036.99048
-  tps: 3010.18705
+  dps: 6025.95116
+  tps: 3004.12376
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5745.82373
-  tps: 2850.68623
+  dps: 5734.67243
+  tps: 2844.34337
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7261.42374
-  tps: 3524.0708
+  dps: 7247.50702
+  tps: 3516.75118
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8657.1518
-  tps: 4361.03988
+  dps: 8641.64139
+  tps: 4352.85242
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8755.9314
-  tps: 4424.26482
+  dps: 8740.22854
+  tps: 4415.63305
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7406.53086
-  tps: 3674.07843
+  dps: 7389.43473
+  tps: 3664.87872
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
   hps: 64
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7067.41307
-  tps: 3529.54148
+  dps: 7055.3852
+  tps: 3522.82918
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7136.13957
-  tps: 3570.88334
+  dps: 7120.91002
+  tps: 3562.32842
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7224.56518
-  tps: 3583.05799
+  dps: 7210.29116
+  tps: 3575.35207
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7062.41932
-  tps: 3514.64024
+  dps: 7052.28961
+  tps: 3509.06398
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 6161.72028
-  tps: 3056.65868
+  dps: 6148.86879
+  tps: 3050.12952
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7600.06947
-  tps: 3760.77339
+  dps: 7585.14825
+  tps: 3752.74168
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7034.40941
-  tps: 3512.23511
+  dps: 7019.99929
+  tps: 3504.1761
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7447.27863
-  tps: 3735.70616
+  dps: 7433.79045
+  tps: 3728.21833
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7473.74834
-  tps: 3756.1399
+  dps: 7461.25044
+  tps: 3749.56666
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6983.53483
-  tps: 3484.42795
+  dps: 6969.54763
+  tps: 3476.84445
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7288.72825
-  tps: 3610.85138
+  dps: 7272.84397
+  tps: 3602.37877
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7101.72414
-  tps: 3544.91622
+  dps: 7087.53723
+  tps: 3537.12647
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7126.14091
-  tps: 3559.84999
+  dps: 7112.0965
+  tps: 3552.37872
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7261.42374
-  tps: 3595.99061
+  dps: 7247.50702
+  tps: 3588.52161
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7261.42374
-  tps: 3595.99061
+  dps: 7247.50702
+  tps: 3588.52161
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7284.39492
-  tps: 3608.61081
+  dps: 7268.16669
+  tps: 3599.93184
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7280.82965
-  tps: 3606.84727
+  dps: 7266.07307
+  tps: 3598.90686
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7077.97776
-  tps: 3520.36863
+  dps: 7063.98871
+  tps: 3512.82447
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7261.42374
-  tps: 3595.99061
+  dps: 7247.50702
+  tps: 3588.52161
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7123.12209
-  tps: 3565.38524
+  dps: 7108.23002
+  tps: 3557.23556
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7057.42687
-  tps: 3524.60572
+  dps: 7044.49787
+  tps: 3517.60628
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7038.36703
-  tps: 3514.55218
+  dps: 7023.17819
+  tps: 3506.41375
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7261.42374
-  tps: 3595.99061
+  dps: 7247.50702
+  tps: 3588.52161
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7261.42374
-  tps: 3595.99061
+  dps: 7247.50702
+  tps: 3588.52161
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7175.28394
-  tps: 3586.21556
+  dps: 7160.82866
+  tps: 3578.376
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7101.96725
-  tps: 3551.08226
+  dps: 7086.94389
+  tps: 3542.95758
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7284.39492
-  tps: 3608.61081
+  dps: 7268.16669
+  tps: 3599.93184
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7280.82965
-  tps: 3606.84727
+  dps: 7266.07307
+  tps: 3598.90686
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7158.18973
-  tps: 3582.22291
+  dps: 7144.00451
+  tps: 3574.53195
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7261.42374
-  tps: 3595.99061
+  dps: 7247.50702
+  tps: 3588.52161
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7291.11942
-  tps: 3610.85392
+  dps: 7277.13926
+  tps: 3603.35068
   hps: 12.53201
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50179"
  value: {
-  dps: 8317.27836
-  tps: 4170.67943
+  dps: 8302.19087
+  tps: 4162.39109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50708"
  value: {
-  dps: 8379.79703
-  tps: 4205.21813
+  dps: 8364.64391
+  tps: 4196.89347
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7129.66362
-  tps: 3555.64858
+  dps: 7114.2108
+  tps: 3547.32704
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7146.34142
-  tps: 3551.19119
+  dps: 7132.99356
+  tps: 3543.66149
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6977.76025
-  tps: 3481.43202
+  dps: 6963.78632
+  tps: 3473.85573
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7284.56037
-  tps: 3607.98443
+  dps: 7270.59229
+  tps: 3600.48772
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7290.00428
-  tps: 3610.80651
+  dps: 7276.02412
+  tps: 3603.30327
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7011.09883
-  tps: 3498.72849
+  dps: 6997.0483
+  tps: 3491.11063
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7016.75792
-  tps: 3501.6645
+  dps: 7002.69439
+  tps: 3494.03958
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7261.42374
-  tps: 3595.99061
+  dps: 7247.50702
+  tps: 3588.52161
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7261.42374
-  tps: 3595.99061
+  dps: 7247.50702
+  tps: 3588.52161
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7038.12821
-  tps: 3521.51639
+  dps: 7030.80029
+  tps: 3517.23238
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7045.43585
-  tps: 3525.90098
+  dps: 7037.2107
+  tps: 3521.07862
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7401.33216
-  tps: 3671.42095
+  dps: 7386.6665
+  tps: 3663.5027
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7261.42374
-  tps: 3595.99061
+  dps: 7247.50702
+  tps: 3588.52161
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 6723.53598
-  tps: 3337.76372
+  dps: 6708.99133
+  tps: 3329.80214
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 6121.39325
-  tps: 3038.44562
+  dps: 6108.25996
+  tps: 3031.38863
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7693.82602
-  tps: 3874.37643
+  dps: 7677.37309
+  tps: 3865.13991
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 6490.14682
-  tps: 3220.11179
+  dps: 6476.34934
+  tps: 3212.86032
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6982.63558
-  tps: 3483.6838
+  dps: 6968.65228
+  tps: 3476.10188
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 9629.43027
-  tps: 4891.32675
+  dps: 9613.20195
+  tps: 4882.35357
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7060.20814
-  tps: 3525.98808
+  dps: 7047.67387
+  tps: 3519.22549
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofLife-37657"
  value: {
-  dps: 7034.9072
-  tps: 3508.14513
+  dps: 7020.57905
+  tps: 3500.25811
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7196.70533
-  tps: 3576.86589
+  dps: 7182.06053
+  tps: 3568.45927
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 5686.12886
-  tps: 2826.38251
+  dps: 5671.18575
+  tps: 2818.45341
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7290.00428
-  tps: 3610.80651
+  dps: 7276.02412
+  tps: 3603.30327
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7284.56037
-  tps: 3607.98443
+  dps: 7270.59229
+  tps: 3600.48772
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7275.03352
-  tps: 3603.0458
+  dps: 7261.08659
+  tps: 3595.5605
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7195.67854
-  tps: 3593.68409
+  dps: 7172.27609
+  tps: 3580.86382
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6314.37093
-  tps: 3128.41375
+  dps: 6300.8513
+  tps: 3121.16012
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6305.30325
-  tps: 3087.5745
+  dps: 6291.58787
+  tps: 3079.70104
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7278.99465
-  tps: 3597.4399
+  dps: 7265.46986
+  tps: 3590.42044
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7233.93243
-  tps: 3613.30958
+  dps: 7219.18328
+  tps: 3604.95546
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7242.06641
-  tps: 3614.22271
+  dps: 7227.29784
+  tps: 3605.85695
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7261.42374
-  tps: 3595.99061
+  dps: 7247.50702
+  tps: 3588.52161
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7261.42374
-  tps: 3595.99061
+  dps: 7247.50702
+  tps: 3588.52161
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7018.05162
-  tps: 3485.91413
+  dps: 7004.07469
+  tps: 3478.27959
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7261.42374
-  tps: 3595.99061
+  dps: 7247.50702
+  tps: 3588.52161
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7261.42374
-  tps: 3595.99061
+  dps: 7247.50702
+  tps: 3588.52161
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6023.66977
-  tps: 2999.79378
+  dps: 6012.32983
+  tps: 2993.72538
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5581.02617
-  tps: 2670.16304
+  dps: 5566.35622
+  tps: 2662.39448
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6967.17353
-  tps: 3475.9395
+  dps: 6953.22391
+  tps: 3468.3764
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 7418.04477
-  tps: 3684.99695
+  dps: 7403.54527
+  tps: 3677.06011
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20055.52341
-  tps: 10232.07493
+  dps: 20037.91954
+  tps: 10222.86415
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7302.72298
-  tps: 3653.4153
+  dps: 7288.14712
+  tps: 3645.50397
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9401.97311
-  tps: 4157.32843
+  dps: 9387.69402
+  tps: 4149.42678
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10595.0699
-  tps: 5400.22368
+  dps: 10583.21016
+  tps: 5393.55368
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4125.62956
-  tps: 2066.93188
+  dps: 4116.13738
+  tps: 2061.57961
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4966.08761
-  tps: 2161.91396
+  dps: 4958.75535
+  tps: 2157.5146
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20350.27997
-  tps: 10296.41535
+  dps: 20329.86
+  tps: 10285.46854
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7401.33216
-  tps: 3671.42095
+  dps: 7386.6665
+  tps: 3663.5027
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9598.39813
-  tps: 4198.44359
+  dps: 9584.01352
+  tps: 4190.53508
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10778.17913
-  tps: 5442.45068
+  dps: 10766.29684
+  tps: 5435.80112
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4197.69099
-  tps: 2088.11648
+  dps: 4188.0905
+  tps: 2082.7085
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5076.37287
-  tps: 2187.21186
+  dps: 5068.9776
+  tps: 2182.7747
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7027.26061
-  tps: 3508.8017
+  dps: 7012.49963
+  tps: 3500.98662
  }
 }

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -46,957 +46,957 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8049.05166
-  tps: 4704.77841
+  dps: 8043.54214
+  tps: 4701.4727
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8021.31251
-  tps: 4703.32255
+  dps: 8017.89008
+  tps: 4701.2691
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7811.05443
-  tps: 4575.83784
+  dps: 7805.54305
+  tps: 4572.53101
   hps: 61.33921
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7811.05443
-  tps: 4575.83784
+  dps: 7805.54305
+  tps: 4572.53101
   hps: 61.33921
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8064.50512
-  tps: 4714.05048
+  dps: 8057.78291
+  tps: 4710.01716
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7780.63189
-  tps: 4547.2227
+  dps: 7776.33163
+  tps: 4544.64255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6735.76558
-  tps: 3938.21065
+  dps: 6732.91724
+  tps: 3936.50165
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6623.5446
-  tps: 3874.95941
+  dps: 6621.70895
+  tps: 3873.85802
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6354.44319
-  tps: 3713.79021
+  dps: 6352.06953
+  tps: 3712.36601
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8042.93489
-  tps: 4607.08618
+  dps: 8037.43036
+  tps: 4603.84951
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8247.73477
-  tps: 4823.98827
+  dps: 8241.89905
+  tps: 4820.48684
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8247.73477
-  tps: 4823.98827
+  dps: 8241.89905
+  tps: 4820.48684
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8253.51898
-  tps: 4827.4588
+  dps: 8246.39344
+  tps: 4823.18348
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7923.40807
-  tps: 4643.25003
+  dps: 7919.67114
+  tps: 4641.00786
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7977.06783
-  tps: 4676.21305
+  dps: 7970.35212
+  tps: 4672.18363
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 8053.24111
-  tps: 4710.49002
+  dps: 8047.56391
+  tps: 4707.0837
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7623.81429
-  tps: 4459.86303
+  dps: 7621.72439
+  tps: 4458.60908
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 6762.75962
-  tps: 3948.96128
+  dps: 6758.13729
+  tps: 3946.18789
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7705.10825
-  tps: 4498.41236
+  dps: 7699.27254
+  tps: 4494.91093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8445.82884
-  tps: 4938.58079
+  dps: 8439.86396
+  tps: 4935.00186
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7908.33959
-  tps: 4634.20894
+  dps: 7900.42962
+  tps: 4629.46295
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8233.66
-  tps: 4821.82305
+  dps: 8230.30906
+  tps: 4819.81248
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8306.07605
-  tps: 4868.99744
+  dps: 8301.73082
+  tps: 4866.3903
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7831.00802
-  tps: 4587.81
+  dps: 7825.46038
+  tps: 4584.48141
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8071.57027
-  tps: 4718.28957
+  dps: 8064.84806
+  tps: 4714.25625
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7960.45181
-  tps: 4660.89476
+  dps: 7957.19481
+  tps: 4658.94056
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7971.95615
-  tps: 4667.93261
+  dps: 7967.11433
+  tps: 4665.02752
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8042.93489
-  tps: 4701.10835
+  dps: 8037.43036
+  tps: 4697.80563
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8042.93489
-  tps: 4701.10835
+  dps: 8037.43036
+  tps: 4697.80563
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8064.50512
-  tps: 4714.05048
+  dps: 8057.78291
+  tps: 4710.01716
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8060.34029
-  tps: 4711.55159
+  dps: 8053.61808
+  tps: 4707.51826
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7892.22007
-  tps: 4618.16691
+  dps: 7886.30309
+  tps: 4614.61671
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8042.93489
-  tps: 4701.10835
+  dps: 8037.43036
+  tps: 4697.80563
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7940.68618
-  tps: 4653.9849
+  dps: 7937.47712
+  tps: 4652.05946
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7909.48194
-  tps: 4634.89434
+  dps: 7906.03056
+  tps: 4632.82352
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7894.08118
-  tps: 4625.65389
+  dps: 7889.68485
+  tps: 4623.01609
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8042.93489
-  tps: 4701.10835
+  dps: 8037.43036
+  tps: 4697.80563
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8042.93489
-  tps: 4701.10835
+  dps: 8037.43036
+  tps: 4697.80563
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7705.9273
-  tps: 4498.90379
+  dps: 7700.09158
+  tps: 4495.40236
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8054.09006
-  tps: 4721.65922
+  dps: 8048.3647
+  tps: 4718.224
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7934.27142
-  tps: 4650.10754
+  dps: 7928.63904
+  tps: 4646.72811
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7703.21931
-  tps: 4497.279
+  dps: 7697.3836
+  tps: 4493.77757
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8064.50512
-  tps: 4714.05048
+  dps: 8057.78291
+  tps: 4710.01716
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8060.34029
-  tps: 4711.55159
+  dps: 8053.61808
+  tps: 4707.51826
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8019.12625
-  tps: 4700.68093
+  dps: 8013.50006
+  tps: 4697.30522
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8042.93489
-  tps: 4701.10835
+  dps: 8037.43036
+  tps: 4697.80563
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8074.22769
-  tps: 4719.88403
+  dps: 8068.61324
+  tps: 4716.51536
   hps: 12.97738
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50179"
  value: {
-  dps: 8247.73477
-  tps: 4823.98827
+  dps: 8241.89905
+  tps: 4820.48684
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50708"
  value: {
-  dps: 8247.73477
-  tps: 4823.98827
+  dps: 8241.89905
+  tps: 4820.48684
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8011.36298
-  tps: 4693.82714
+  dps: 8006.88319
+  tps: 4691.13926
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7876.01043
-  tps: 4614.81144
+  dps: 7870.76503
+  tps: 4611.6642
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7824.01948
-  tps: 4583.61687
+  dps: 7818.47772
+  tps: 4580.29181
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8068.49853
-  tps: 4716.44653
+  dps: 8062.97335
+  tps: 4713.13142
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8074.5135
-  tps: 4720.05551
+  dps: 8068.98347
+  tps: 4716.73749
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7864.36668
-  tps: 4607.82519
+  dps: 7858.79092
+  tps: 4604.47974
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7871.21546
-  tps: 4611.93446
+  dps: 7865.63393
+  tps: 4608.58554
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8042.93489
-  tps: 4701.10835
+  dps: 8037.43036
+  tps: 4697.80563
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8042.93489
-  tps: 4701.10835
+  dps: 8037.43036
+  tps: 4697.80563
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7836.37469
-  tps: 4590.74123
+  dps: 7832.78854
+  tps: 4588.57656
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7838.16724
-  tps: 4591.81676
+  dps: 7834.36811
+  tps: 4589.5243
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8247.73477
-  tps: 4823.98827
+  dps: 8241.89905
+  tps: 4820.48684
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7706.88285
-  tps: 4499.47712
+  dps: 7701.04713
+  tps: 4495.97569
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8042.93489
-  tps: 4701.10835
+  dps: 8037.43036
+  tps: 4697.80563
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7702.96955
-  tps: 4497.12914
+  dps: 7697.13383
+  tps: 4493.62771
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7410.37312
-  tps: 4336.00865
+  dps: 7406.15816
+  tps: 4333.47968
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 6684.94461
-  tps: 3905.49874
+  dps: 6680.05547
+  tps: 3902.56526
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8436.30707
-  tps: 4945.24259
+  dps: 8430.44902
+  tps: 4941.72776
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7062.92026
-  tps: 4124.67709
+  dps: 7056.45259
+  tps: 4120.79649
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7824.68683
-  tps: 4584.01728
+  dps: 7819.1365
+  tps: 4580.68708
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8247.73477
-  tps: 4823.98827
+  dps: 8241.89905
+  tps: 4820.48684
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7701.01304
-  tps: 4495.95523
+  dps: 7695.17732
+  tps: 4492.4538
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7708.10306
-  tps: 4500.20925
+  dps: 7702.26734
+  tps: 4496.70782
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7701.01304
-  tps: 4495.95523
+  dps: 7695.17732
+  tps: 4492.4538
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8123.6394
-  tps: 4742.4245
+  dps: 8117.46875
+  tps: 4738.72211
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7701.01304
-  tps: 4495.95523
+  dps: 7695.17732
+  tps: 4492.4538
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 8160.38124
-  tps: 4763.79448
+  dps: 8154.17877
+  tps: 4760.073
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7701.01304
-  tps: 4495.95523
+  dps: 7695.17732
+  tps: 4492.4538
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7912.8944
-  tps: 4636.94182
+  dps: 7909.44303
+  tps: 4634.871
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 7888.26425
-  tps: 4619.74272
+  dps: 7885.97822
+  tps: 4618.37111
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7981.67207
-  tps: 4678.98998
+  dps: 7976.96859
+  tps: 4676.1679
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StormshroudArmor"
  value: {
-  dps: 6300.76975
-  tps: 3684.89791
+  dps: 6295.19199
+  tps: 3681.55125
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8074.5135
-  tps: 4720.05551
+  dps: 8068.98347
+  tps: 4716.73749
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8068.49853
-  tps: 4716.44653
+  dps: 8062.97335
+  tps: 4713.13142
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8057.97233
-  tps: 4710.13081
+  dps: 8052.45565
+  tps: 4706.8208
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7693.88019
-  tps: 4503.12354
+  dps: 7681.34724
+  tps: 4495.60377
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6734.4304
-  tps: 3936.12163
+  dps: 6730.90132
+  tps: 3934.00418
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7259.95609
-  tps: 4236.50314
+  dps: 7254.83353
+  tps: 4233.4296
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8094.24489
-  tps: 4729.81022
+  dps: 8089.70259
+  tps: 4727.08484
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7988.85003
-  tps: 4684.26704
+  dps: 7984.22849
+  tps: 4681.49412
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8006.49493
-  tps: 4692.26551
+  dps: 8003.03606
+  tps: 4690.19018
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8042.93489
-  tps: 4701.10835
+  dps: 8037.43036
+  tps: 4697.80563
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8042.93489
-  tps: 4701.10835
+  dps: 8037.43036
+  tps: 4697.80563
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7814.40577
-  tps: 4574.01804
+  dps: 7809.85621
+  tps: 4571.28831
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8042.93489
-  tps: 4701.10835
+  dps: 8037.43036
+  tps: 4697.80563
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8042.93489
-  tps: 4701.10835
+  dps: 8037.43036
+  tps: 4697.80563
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6620.91778
-  tps: 3873.65925
+  dps: 6618.36398
+  tps: 3872.12697
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7676.9397
-  tps: 4481.27683
+  dps: 7673.86178
+  tps: 4479.43008
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7811.20715
-  tps: 4575.92947
+  dps: 7805.67618
+  tps: 4572.61089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7707.97491
-  tps: 4500.13236
+  dps: 7702.13919
+  tps: 4496.63093
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 8207.41354
-  tps: 4801.74205
+  dps: 8203.44285
+  tps: 4799.35964
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26169.69375
-  tps: 15586.28687
+  dps: 25987.39546
+  tps: 15476.90789
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8185.46773
-  tps: 4793.27117
+  dps: 8179.49066
+  tps: 4789.68493
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9355.28157
-  tps: 5335.77136
+  dps: 9342.12196
+  tps: 5327.87559
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13395.86689
-  tps: 7963.37722
+  dps: 13281.11867
+  tps: 7894.52829
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4876.22625
-  tps: 2850.01581
+  dps: 4872.56276
+  tps: 2847.81772
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5138.55986
-  tps: 2930.78185
+  dps: 5134.82537
+  tps: 2928.54115
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Desync-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25381.17292
-  tps: 15116.91668
+  dps: 25221.82181
+  tps: 15021.30601
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Desync-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8240.03315
-  tps: 4830.55594
+  dps: 8238.61553
+  tps: 4829.70537
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Desync-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9199.2137
-  tps: 5239.53361
+  dps: 9197.61833
+  tps: 5238.57638
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Desync-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13353.42381
-  tps: 7940.30692
+  dps: 13250.8694
+  tps: 7878.77428
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Desync-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4909.36869
-  tps: 2873.67962
+  dps: 4906.49929
+  tps: 2871.95798
  }
 }
 dps_results: {
@@ -1009,15 +1009,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30116.93744
-  tps: 17937.30018
+  dps: 29914.03005
+  tps: 17815.55575
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9962.33382
-  tps: 5844.69712
+  dps: 9956.74402
+  tps: 5841.34324
  }
 }
 dps_results: {
@@ -1030,15 +1030,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16042.65065
-  tps: 9541.62587
+  dps: 15926.23134
+  tps: 9471.77428
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5986.46807
-  tps: 3506.66707
+  dps: 5983.92264
+  tps: 3505.13982
  }
 }
 dps_results: {
@@ -1051,15 +1051,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Desync-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29710.35317
-  tps: 17698.61004
+  dps: 29540.13345
+  tps: 17596.4782
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Desync-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10019.32736
-  tps: 5885.19575
+  dps: 10014.28139
+  tps: 5882.16817
  }
 }
 dps_results: {
@@ -1072,15 +1072,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Desync-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16122.74612
-  tps: 9593.16783
+  dps: 16009.40663
+  tps: 9525.16413
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Desync-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6027.40012
-  tps: 3533.89824
+  dps: 6025.63272
+  tps: 3532.8378
  }
 }
 dps_results: {
@@ -1093,78 +1093,78 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25962.86421
-  tps: 15456.68234
+  dps: 25776.09022
+  tps: 15344.61794
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8247.73477
-  tps: 4823.98827
+  dps: 8241.89905
+  tps: 4820.48684
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9390.90572
-  tps: 5343.67032
+  dps: 9378.34776
+  tps: 5336.13555
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13644.94907
-  tps: 8107.65399
+  dps: 13526.04584
+  tps: 8036.31205
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4894.28064
-  tps: 2858.52798
+  dps: 4891.43017
+  tps: 2856.81769
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5211.63559
-  tps: 2968.53942
+  dps: 5207.8981
+  tps: 2966.29692
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Desync-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25806.96118
-  tps: 15366.02637
+  dps: 25650.80259
+  tps: 15272.33122
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Desync-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8239.81182
-  tps: 4825.11885
+  dps: 8236.11403
+  tps: 4822.90018
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Desync-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9281.43155
-  tps: 5275.34054
+  dps: 9279.83491
+  tps: 5274.38255
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Desync-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13482.15526
-  tps: 8013.77756
+  dps: 13384.85995
+  tps: 7955.40037
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Desync-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4891.40724
-  tps: 2858.91461
+  dps: 4888.05182
+  tps: 2856.90135
  }
 }
 dps_results: {
@@ -1177,15 +1177,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30146.79454
-  tps: 17952.29726
+  dps: 29948.68578
+  tps: 17833.43201
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10005.19286
-  tps: 5863.41755
+  dps: 9998.68616
+  tps: 5859.51354
  }
 }
 dps_results: {
@@ -1198,15 +1198,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15833.06919
-  tps: 9413.23667
+  dps: 15716.01403
+  tps: 9343.00357
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6029.79858
-  tps: 3529.23455
+  dps: 6027.88729
+  tps: 3528.08778
  }
 }
 dps_results: {
@@ -1219,15 +1219,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Desync-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30035.8668
-  tps: 17887.77545
+  dps: 29866.94293
+  tps: 17786.42113
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Desync-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10020.45538
-  tps: 5878.5031
+  dps: 10016.24627
+  tps: 5875.97764
  }
 }
 dps_results: {
@@ -1240,15 +1240,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Desync-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16134.55915
-  tps: 9596.23775
+  dps: 16019.87085
+  tps: 9527.42477
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Desync-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6062.57086
-  tps: 3551.13488
+  dps: 6061.73566
+  tps: 3550.63376
  }
 }
 dps_results: {
@@ -1261,7 +1261,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7914.60639
-  tps: 4637.8405
+  dps: 7910.81007
+  tps: 4635.5627
  }
 }

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -46,901 +46,901 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8043.54214
-  tps: 4701.4727
+  dps: 8049.05166
+  tps: 4704.77841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8017.89008
-  tps: 4701.2691
+  dps: 8021.31251
+  tps: 4703.32255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7805.54305
-  tps: 4572.53101
+  dps: 7811.05443
+  tps: 4575.83784
   hps: 61.33921
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7805.54305
-  tps: 4572.53101
+  dps: 7811.05443
+  tps: 4575.83784
   hps: 61.33921
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8057.78291
-  tps: 4710.01716
+  dps: 8064.50512
+  tps: 4714.05048
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7776.33163
-  tps: 4544.64255
+  dps: 7780.63189
+  tps: 4547.2227
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6732.91724
-  tps: 3936.50165
+  dps: 6735.76558
+  tps: 3938.21065
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6621.70895
-  tps: 3873.85802
+  dps: 6623.5446
+  tps: 3874.95941
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6352.06953
-  tps: 3712.36601
+  dps: 6354.44319
+  tps: 3713.79021
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4603.84951
+  dps: 8042.93489
+  tps: 4607.08618
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8241.89905
-  tps: 4820.48684
+  dps: 8247.73477
+  tps: 4823.98827
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8241.89905
-  tps: 4820.48684
+  dps: 8247.73477
+  tps: 4823.98827
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8246.39344
-  tps: 4823.18348
+  dps: 8253.51898
+  tps: 4827.4588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7919.67114
-  tps: 4641.00786
+  dps: 7923.40807
+  tps: 4643.25003
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7970.35212
-  tps: 4672.18363
+  dps: 7977.06783
+  tps: 4676.21305
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 8047.56391
-  tps: 4707.0837
+  dps: 8053.24111
+  tps: 4710.49002
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7621.72439
-  tps: 4458.60908
+  dps: 7623.81429
+  tps: 4459.86303
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 6758.13729
-  tps: 3946.18789
+  dps: 6762.75962
+  tps: 3948.96128
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7699.27254
-  tps: 4494.91093
+  dps: 7705.10825
+  tps: 4498.41236
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8439.86396
-  tps: 4935.00186
+  dps: 8445.82884
+  tps: 4938.58079
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7900.42962
-  tps: 4629.46295
+  dps: 7908.33959
+  tps: 4634.20894
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8230.30906
-  tps: 4819.81248
+  dps: 8233.66
+  tps: 4821.82305
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8301.73082
-  tps: 4866.3903
+  dps: 8306.07605
+  tps: 4868.99744
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7825.46038
-  tps: 4584.48141
+  dps: 7831.00802
+  tps: 4587.81
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8064.84806
-  tps: 4714.25625
+  dps: 8071.57027
+  tps: 4718.28957
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7957.19481
-  tps: 4658.94056
+  dps: 7960.45181
+  tps: 4660.89476
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7967.11433
-  tps: 4665.02752
+  dps: 7971.95615
+  tps: 4667.93261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8042.93489
+  tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8042.93489
+  tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8057.78291
-  tps: 4710.01716
+  dps: 8064.50512
+  tps: 4714.05048
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8053.61808
-  tps: 4707.51826
+  dps: 8060.34029
+  tps: 4711.55159
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7886.30309
-  tps: 4614.61671
+  dps: 7892.22007
+  tps: 4618.16691
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8042.93489
+  tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7937.47712
-  tps: 4652.05946
+  dps: 7940.68618
+  tps: 4653.9849
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7906.03056
-  tps: 4632.82352
+  dps: 7909.48194
+  tps: 4634.89434
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7889.68485
-  tps: 4623.01609
+  dps: 7894.08118
+  tps: 4625.65389
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8042.93489
+  tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8042.93489
+  tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7700.09158
-  tps: 4495.40236
+  dps: 7705.9273
+  tps: 4498.90379
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8048.3647
-  tps: 4718.224
+  dps: 8054.09006
+  tps: 4721.65922
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7928.63904
-  tps: 4646.72811
+  dps: 7934.27142
+  tps: 4650.10754
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7697.3836
-  tps: 4493.77757
+  dps: 7703.21931
+  tps: 4497.279
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8057.78291
-  tps: 4710.01716
+  dps: 8064.50512
+  tps: 4714.05048
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8053.61808
-  tps: 4707.51826
+  dps: 8060.34029
+  tps: 4711.55159
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8013.50006
-  tps: 4697.30522
+  dps: 8019.12625
+  tps: 4700.68093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8042.93489
+  tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8068.61324
-  tps: 4716.51536
+  dps: 8074.22769
+  tps: 4719.88403
   hps: 12.97738
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50179"
  value: {
-  dps: 8241.89905
-  tps: 4820.48684
+  dps: 8247.73477
+  tps: 4823.98827
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50708"
  value: {
-  dps: 8241.89905
-  tps: 4820.48684
+  dps: 8247.73477
+  tps: 4823.98827
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8006.88319
-  tps: 4691.13926
+  dps: 8011.36298
+  tps: 4693.82714
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7870.76503
-  tps: 4611.6642
+  dps: 7876.01043
+  tps: 4614.81144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7818.47772
-  tps: 4580.29181
+  dps: 7824.01948
+  tps: 4583.61687
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8062.97335
-  tps: 4713.13142
+  dps: 8068.49853
+  tps: 4716.44653
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8068.98347
-  tps: 4716.73749
+  dps: 8074.5135
+  tps: 4720.05551
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7858.79092
-  tps: 4604.47974
+  dps: 7864.36668
+  tps: 4607.82519
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7865.63393
-  tps: 4608.58554
+  dps: 7871.21546
+  tps: 4611.93446
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8042.93489
+  tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8042.93489
+  tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7832.78854
-  tps: 4588.57656
+  dps: 7836.37469
+  tps: 4590.74123
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7834.36811
-  tps: 4589.5243
+  dps: 7838.16724
+  tps: 4591.81676
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8241.89905
-  tps: 4820.48684
+  dps: 8247.73477
+  tps: 4823.98827
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7701.04713
-  tps: 4495.97569
+  dps: 7706.88285
+  tps: 4499.47712
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8042.93489
+  tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7697.13383
-  tps: 4493.62771
+  dps: 7702.96955
+  tps: 4497.12914
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7406.15816
-  tps: 4333.47968
+  dps: 7410.37312
+  tps: 4336.00865
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 6680.05547
-  tps: 3902.56526
+  dps: 6684.94461
+  tps: 3905.49874
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8430.44902
-  tps: 4941.72776
+  dps: 8436.30707
+  tps: 4945.24259
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7056.45259
-  tps: 4120.79649
+  dps: 7062.92026
+  tps: 4124.67709
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7819.1365
-  tps: 4580.68708
+  dps: 7824.68683
+  tps: 4584.01728
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8241.89905
-  tps: 4820.48684
+  dps: 8247.73477
+  tps: 4823.98827
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7695.17732
-  tps: 4492.4538
+  dps: 7701.01304
+  tps: 4495.95523
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7702.26734
-  tps: 4496.70782
+  dps: 7708.10306
+  tps: 4500.20925
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7695.17732
-  tps: 4492.4538
+  dps: 7701.01304
+  tps: 4495.95523
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8117.46875
-  tps: 4738.72211
+  dps: 8123.6394
+  tps: 4742.4245
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7695.17732
-  tps: 4492.4538
+  dps: 7701.01304
+  tps: 4495.95523
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 8154.17877
-  tps: 4760.073
+  dps: 8160.38124
+  tps: 4763.79448
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7695.17732
-  tps: 4492.4538
+  dps: 7701.01304
+  tps: 4495.95523
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7909.44303
-  tps: 4634.871
+  dps: 7912.8944
+  tps: 4636.94182
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 7885.97822
-  tps: 4618.37111
+  dps: 7888.26425
+  tps: 4619.74272
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7976.96859
-  tps: 4676.1679
+  dps: 7981.67207
+  tps: 4678.98998
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StormshroudArmor"
  value: {
-  dps: 6295.19199
-  tps: 3681.55125
+  dps: 6300.76975
+  tps: 3684.89791
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8068.98347
-  tps: 4716.73749
+  dps: 8074.5135
+  tps: 4720.05551
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8062.97335
-  tps: 4713.13142
+  dps: 8068.49853
+  tps: 4716.44653
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8052.45565
-  tps: 4706.8208
+  dps: 8057.97233
+  tps: 4710.13081
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7681.34724
-  tps: 4495.60377
+  dps: 7693.88019
+  tps: 4503.12354
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6730.90132
-  tps: 3934.00418
+  dps: 6734.4304
+  tps: 3936.12163
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7254.83353
-  tps: 4233.4296
+  dps: 7259.95609
+  tps: 4236.50314
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8089.70259
-  tps: 4727.08484
+  dps: 8094.24489
+  tps: 4729.81022
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7984.22849
-  tps: 4681.49412
+  dps: 7988.85003
+  tps: 4684.26704
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8003.03606
-  tps: 4690.19018
+  dps: 8006.49493
+  tps: 4692.26551
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8042.93489
+  tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8042.93489
+  tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7809.85621
-  tps: 4571.28831
+  dps: 7814.40577
+  tps: 4574.01804
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8042.93489
+  tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8042.93489
+  tps: 4701.10835
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6618.36398
-  tps: 3872.12697
+  dps: 6620.91778
+  tps: 3873.65925
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7673.86178
-  tps: 4479.43008
+  dps: 7676.9397
+  tps: 4481.27683
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7811.20715
+  tps: 4575.92947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7702.13919
-  tps: 4496.63093
+  dps: 7707.97491
+  tps: 4500.13236
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 8203.44285
-  tps: 4799.35964
+  dps: 8207.41354
+  tps: 4801.74205
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26156.37433
-  tps: 15578.29521
+  dps: 26169.69375
+  tps: 15586.28687
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8179.49066
-  tps: 4789.68493
+  dps: 8185.46773
+  tps: 4793.27117
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9342.12196
-  tps: 5327.87559
+  dps: 9355.28157
+  tps: 5335.77136
  }
 }
 dps_results: {
@@ -967,22 +967,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Desync-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25365.23192
-  tps: 15107.35208
+  dps: 25381.17292
+  tps: 15116.91668
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Desync-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8238.61553
-  tps: 4829.70537
+  dps: 8240.03315
+  tps: 4830.55594
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Desync-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9197.61833
-  tps: 5238.57638
+  dps: 9199.2137
+  tps: 5239.53361
  }
 }
 dps_results: {
@@ -1009,15 +1009,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30107.27683
-  tps: 17931.50381
+  dps: 30116.93744
+  tps: 17937.30018
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9956.74402
-  tps: 5841.34324
+  dps: 9962.33382
+  tps: 5844.69712
  }
 }
 dps_results: {
@@ -1051,15 +1051,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Desync-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29699.01278
-  tps: 17691.8058
+  dps: 29710.35317
+  tps: 17698.61004
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Desync-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10014.28139
-  tps: 5882.16817
+  dps: 10019.32736
+  tps: 5885.19575
  }
 }
 dps_results: {
@@ -1093,22 +1093,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25950.63694
-  tps: 15449.34597
+  dps: 25962.86421
+  tps: 15456.68234
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8241.89905
-  tps: 4820.48684
+  dps: 8247.73477
+  tps: 4823.98827
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9378.34776
-  tps: 5336.13555
+  dps: 9390.90572
+  tps: 5343.67032
  }
 }
 dps_results: {
@@ -1135,22 +1135,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Desync-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25796.81377
-  tps: 15359.93792
+  dps: 25806.96118
+  tps: 15366.02637
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Desync-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8236.11403
-  tps: 4822.90018
+  dps: 8239.81182
+  tps: 4825.11885
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Desync-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9279.83491
-  tps: 5274.38255
+  dps: 9281.43155
+  tps: 5275.34054
  }
 }
 dps_results: {
@@ -1177,15 +1177,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30135.99234
-  tps: 17945.81594
+  dps: 30146.79454
+  tps: 17952.29726
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9998.68616
-  tps: 5859.51354
+  dps: 10005.19286
+  tps: 5863.41755
  }
 }
 dps_results: {
@@ -1219,15 +1219,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Desync-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30026.95803
-  tps: 17882.43019
+  dps: 30035.8668
+  tps: 17887.77545
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Desync-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10016.24627
-  tps: 5875.97764
+  dps: 10020.45538
+  tps: 5878.5031
  }
 }
 dps_results: {
@@ -1261,7 +1261,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7910.81007
-  tps: 4635.5627
+  dps: 7914.60639
+  tps: 4637.8405
  }
 }

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -46,52 +46,52 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8043.54214
-  tps: 4701.4727
+  dps: 8044.63287
+  tps: 4702.12713
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8017.89008
-  tps: 4701.2691
+  dps: 8019.22811
+  tps: 4702.07192
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7805.54305
-  tps: 4572.53101
+  dps: 7806.67435
+  tps: 4573.20979
   hps: 61.33921
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7805.54305
-  tps: 4572.53101
+  dps: 7806.67435
+  tps: 4573.20979
   hps: 61.33921
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8057.78291
-  tps: 4710.01716
+  dps: 8060.03794
+  tps: 4711.37018
  }
 }
 dps_results: {
@@ -104,8 +104,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6732.91724
-  tps: 3936.50165
+  dps: 6733.96501
+  tps: 3937.13031
  }
 }
 dps_results: {
@@ -118,114 +118,114 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6352.06953
-  tps: 3712.36601
+  dps: 6352.93797
+  tps: 3712.88707
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4603.84951
+  dps: 8038.51998
+  tps: 4604.49021
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8241.89905
-  tps: 4820.48684
+  dps: 8243.05425
+  tps: 4821.17996
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8241.89905
-  tps: 4820.48684
+  dps: 8243.05425
+  tps: 4821.17996
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8246.39344
-  tps: 4823.18348
+  dps: 8248.78377
+  tps: 4824.61767
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7919.67114
-  tps: 4641.00786
+  dps: 7921.11839
+  tps: 4641.87622
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7970.35212
-  tps: 4672.18363
+  dps: 7970.57882
+  tps: 4672.31964
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 8047.56391
-  tps: 4707.0837
+  dps: 8048.68798
+  tps: 4707.75815
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7621.72439
-  tps: 4458.60908
+  dps: 7622.00029
+  tps: 4458.77463
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 6758.13729
-  tps: 3946.18789
+  dps: 6759.0187
+  tps: 3946.71673
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7699.27254
-  tps: 4494.91093
+  dps: 7700.42774
+  tps: 4495.60405
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8439.86396
-  tps: 4935.00186
+  dps: 8441.02431
+  tps: 4935.69807
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7900.42962
-  tps: 4629.46295
+  dps: 7901.67392
+  tps: 4630.20953
  }
 }
 dps_results: {
@@ -238,169 +238,169 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8301.73082
-  tps: 4866.3903
+  dps: 8302.7178
+  tps: 4866.98249
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7825.46038
-  tps: 4584.48141
+  dps: 7826.58817
+  tps: 4585.15808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8064.84806
-  tps: 4714.25625
+  dps: 8067.10309
+  tps: 4715.60926
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7957.19481
-  tps: 4658.94056
+  dps: 7958.27231
+  tps: 4659.58706
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7967.11433
-  tps: 4665.02752
+  dps: 7968.2384
+  tps: 4665.70196
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8038.51998
+  tps: 4698.4594
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8038.51998
+  tps: 4698.4594
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8057.78291
-  tps: 4710.01716
+  dps: 8060.03794
+  tps: 4711.37018
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8053.61808
-  tps: 4707.51826
+  dps: 8055.87311
+  tps: 4708.87128
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7886.30309
-  tps: 4614.61671
+  dps: 7887.42716
+  tps: 4615.29116
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8038.51998
+  tps: 4698.4594
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7937.47712
-  tps: 4652.05946
+  dps: 7937.77137
+  tps: 4652.23602
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7906.03056
-  tps: 4632.82352
+  dps: 7907.19225
+  tps: 4633.52053
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7889.68485
-  tps: 4623.01609
+  dps: 7890.6298
+  tps: 4623.58306
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8038.51998
+  tps: 4698.4594
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8038.51998
+  tps: 4698.4594
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7700.09158
-  tps: 4495.40236
+  dps: 7701.24678
+  tps: 4496.09548
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8048.3647
-  tps: 4718.224
+  dps: 8049.52908
+  tps: 4718.92263
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
@@ -413,79 +413,79 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7697.3836
-  tps: 4493.77757
+  dps: 7698.5388
+  tps: 4494.47069
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8057.78291
-  tps: 4710.01716
+  dps: 8060.03794
+  tps: 4711.37018
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8053.61808
-  tps: 4707.51826
+  dps: 8055.87311
+  tps: 4708.87128
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8013.50006
-  tps: 4697.30522
+  dps: 8014.64277
+  tps: 4697.99085
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8038.51998
+  tps: 4698.4594
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8068.61324
-  tps: 4716.51536
+  dps: 8069.70785
+  tps: 4717.17212
   hps: 12.97738
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50179"
  value: {
-  dps: 8241.89905
-  tps: 4820.48684
+  dps: 8243.05425
+  tps: 4821.17996
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50708"
  value: {
-  dps: 8241.89905
-  tps: 4820.48684
+  dps: 8243.05425
+  tps: 4821.17996
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
@@ -498,253 +498,253 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7870.76503
-  tps: 4611.6642
+  dps: 7871.8891
+  tps: 4612.33864
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7818.47772
-  tps: 4580.29181
+  dps: 7819.6042
+  tps: 4580.9677
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8062.97335
-  tps: 4713.13142
+  dps: 8064.06701
+  tps: 4713.78762
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8068.98347
-  tps: 4716.73749
+  dps: 8070.07808
+  tps: 4717.39426
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7858.79092
-  tps: 4604.47974
+  dps: 7859.92498
+  tps: 4605.16017
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7865.63393
-  tps: 4608.58554
+  dps: 7866.76927
+  tps: 4609.26674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8038.51998
+  tps: 4698.4594
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8038.51998
+  tps: 4698.4594
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7832.78854
-  tps: 4588.57656
+  dps: 7833.01059
+  tps: 4588.70979
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7834.36811
-  tps: 4589.5243
+  dps: 7834.61791
+  tps: 4589.67418
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8241.89905
-  tps: 4820.48684
+  dps: 8243.05425
+  tps: 4821.17996
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7701.04713
-  tps: 4495.97569
+  dps: 7702.20233
+  tps: 4496.66881
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8038.51998
+  tps: 4698.4594
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7697.13383
-  tps: 4493.62771
+  dps: 7698.28903
+  tps: 4494.32083
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7406.15816
-  tps: 4333.47968
+  dps: 7407.02776
+  tps: 4334.00144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 6680.05547
-  tps: 3902.56526
+  dps: 6680.92369
+  tps: 3903.08619
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8430.44902
-  tps: 4941.72776
+  dps: 8431.71541
+  tps: 4942.4876
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7056.45259
-  tps: 4120.79649
+  dps: 7057.52487
+  tps: 4121.43985
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7819.1365
-  tps: 4580.68708
+  dps: 7820.27619
+  tps: 4581.37089
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8241.89905
-  tps: 4820.48684
+  dps: 8243.05425
+  tps: 4821.17996
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7695.17732
-  tps: 4492.4538
+  dps: 7696.33252
+  tps: 4493.14692
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7702.26734
-  tps: 4496.70782
+  dps: 7703.42254
+  tps: 4497.40093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7695.17732
-  tps: 4492.4538
+  dps: 7696.33252
+  tps: 4493.14692
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8117.46875
-  tps: 4738.72211
+  dps: 8118.69311
+  tps: 4739.45673
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7695.17732
-  tps: 4492.4538
+  dps: 7696.33252
+  tps: 4493.14692
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 8154.17877
-  tps: 4760.073
+  dps: 8155.4097
+  tps: 4760.81156
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7695.17732
-  tps: 4492.4538
+  dps: 7696.33252
+  tps: 4493.14692
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7909.44303
-  tps: 4634.871
+  dps: 7910.60472
+  tps: 4635.56801
  }
 }
 dps_results: {
@@ -764,85 +764,85 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-StormshroudArmor"
  value: {
-  dps: 6295.19199
-  tps: 3681.55125
+  dps: 6297.37926
+  tps: 3682.86361
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8068.98347
-  tps: 4716.73749
+  dps: 8070.07808
+  tps: 4717.39426
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8062.97335
-  tps: 4713.13142
+  dps: 8064.06701
+  tps: 4713.78762
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8052.45565
-  tps: 4706.8208
+  dps: 8053.54764
+  tps: 4707.476
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7681.34724
-  tps: 4495.60377
+  dps: 7685.91749
+  tps: 4498.34592
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6730.90132
-  tps: 3934.00418
+  dps: 6731.81551
+  tps: 3934.55269
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7254.83353
-  tps: 4233.4296
+  dps: 7255.77247
+  tps: 4233.99297
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8089.70259
-  tps: 4727.08484
+  dps: 8090.79221
+  tps: 4727.73861
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7984.22849
-  tps: 4681.49412
+  dps: 7985.42571
+  tps: 4682.21245
  }
 }
 dps_results: {
@@ -855,85 +855,85 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8038.51998
+  tps: 4698.4594
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8038.51998
+  tps: 4698.4594
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7809.85621
-  tps: 4571.28831
+  dps: 7811.05343
+  tps: 4572.00664
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8038.51998
+  tps: 4698.4594
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8037.43036
-  tps: 4697.80563
+  dps: 8038.51998
+  tps: 4698.4594
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6618.36398
-  tps: 3872.12697
+  dps: 6619.26344
+  tps: 3872.66665
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7673.86178
-  tps: 4479.43008
+  dps: 7675.06471
+  tps: 4480.15184
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7805.67618
-  tps: 4572.61089
+  dps: 7806.80026
+  tps: 4573.28534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7702.13919
-  tps: 4496.63093
+  dps: 7703.29439
+  tps: 4497.32404
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 8203.44285
-  tps: 4799.35964
+  dps: 8204.67237
+  tps: 4800.09735
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25987.39546
-  tps: 15476.90789
+  dps: 26036.02639
+  tps: 15506.08645
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8179.49066
-  tps: 4789.68493
+  dps: 8180.68195
+  tps: 4790.3997
  }
 }
 dps_results: {
@@ -946,36 +946,36 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13281.11867
-  tps: 7894.52829
+  dps: 13316.56807
+  tps: 7915.79793
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4872.56276
-  tps: 2847.81772
+  dps: 4875.41056
+  tps: 2849.5264
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5134.82537
-  tps: 2928.54115
+  dps: 5138.55986
+  tps: 2930.78185
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Desync-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25221.82181
-  tps: 15021.30601
+  dps: 25268.52244
+  tps: 15049.32639
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Desync-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8238.61553
-  tps: 4829.70537
+  dps: 8239.71407
+  tps: 4830.36449
  }
 }
 dps_results: {
@@ -988,15 +988,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Desync-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13250.8694
-  tps: 7878.77428
+  dps: 13281.1632
+  tps: 7896.95056
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P1-Desync-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4906.49929
-  tps: 2871.95798
+  dps: 4907.92079
+  tps: 2872.81088
  }
 }
 dps_results: {
@@ -1009,8 +1009,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29914.03005
-  tps: 17815.55575
+  dps: 29978.6688
+  tps: 17854.33899
  }
 }
 dps_results: {
@@ -1030,15 +1030,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15926.23134
-  tps: 9471.77428
+  dps: 15967.56632
+  tps: 9496.57527
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5983.92264
-  tps: 3505.13982
+  dps: 5984.93357
+  tps: 3505.74637
  }
 }
 dps_results: {
@@ -1051,15 +1051,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Desync-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29540.13345
-  tps: 17596.4782
+  dps: 29591.98161
+  tps: 17627.5871
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Desync-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10014.28139
-  tps: 5882.16817
+  dps: 10015.47723
+  tps: 5882.88567
  }
 }
 dps_results: {
@@ -1072,8 +1072,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P2-Desync-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16009.40663
-  tps: 9525.16413
+  dps: 16044.76278
+  tps: 9546.37783
  }
 }
 dps_results: {
@@ -1093,15 +1093,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25776.09022
-  tps: 15344.61794
+  dps: 25827.51946
+  tps: 15375.47549
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8241.89905
-  tps: 4820.48684
+  dps: 8243.05425
+  tps: 4821.17996
  }
 }
 dps_results: {
@@ -1114,36 +1114,36 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13526.04584
-  tps: 8036.31205
+  dps: 13561.7895
+  tps: 8057.75824
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4891.43017
-  tps: 2856.81769
+  dps: 4894.28064
+  tps: 2858.52798
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5207.8981
-  tps: 2966.29692
+  dps: 5211.63559
+  tps: 2968.53942
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Desync-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25650.80259
-  tps: 15272.33122
+  dps: 25695.99308
+  tps: 15299.44551
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Desync-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8236.11403
-  tps: 4822.90018
+  dps: 8236.99353
+  tps: 4823.42788
  }
 }
 dps_results: {
@@ -1156,15 +1156,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Desync-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13384.85995
-  tps: 7955.40037
+  dps: 13415.27489
+  tps: 7973.64934
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P1-Desync-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4888.05182
-  tps: 2856.90135
+  dps: 4889.56363
+  tps: 2857.80844
  }
 }
 dps_results: {
@@ -1177,8 +1177,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29948.68578
-  tps: 17833.43201
+  dps: 30008.93774
+  tps: 17869.58318
  }
 }
 dps_results: {
@@ -1198,15 +1198,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15716.01403
-  tps: 9343.00357
+  dps: 15756.177
+  tps: 9367.10136
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6027.88729
-  tps: 3528.08778
+  dps: 6028.89905
+  tps: 3528.69483
  }
 }
 dps_results: {
@@ -1219,8 +1219,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Desync-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29866.94293
-  tps: 17786.42113
+  dps: 29918.87255
+  tps: 17817.5789
  }
 }
 dps_results: {
@@ -1240,8 +1240,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P2-Desync-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16019.87085
-  tps: 9527.42477
+  dps: 16053.35174
+  tps: 9547.51331
  }
 }
 dps_results: {
@@ -1261,7 +1261,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7910.81007
-  tps: 4635.5627
+  dps: 7912.27313
+  tps: 4636.44054
  }
 }

--- a/sim/deathknight/dps/TestFrostUH.results
+++ b/sim/deathknight/dps/TestFrostUH.results
@@ -46,523 +46,523 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8101.28005
-  tps: 5763.84153
+  dps: 8102.32676
+  tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8015.72903
-  tps: 5727.91469
+  dps: 8018.08098
+  tps: 5729.64573
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7804.42158
-  tps: 5572.39241
+  dps: 7805.50377
+  tps: 5573.1889
   hps: 60.92312
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7804.42158
-  tps: 5572.39241
+  dps: 7805.50377
+  tps: 5573.1889
   hps: 60.92312
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8122.51114
-  tps: 5779.46761
+  dps: 8123.76183
+  tps: 5780.38812
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7807.37147
-  tps: 5559.06621
+  dps: 7808.31683
+  tps: 5559.76199
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6599.2812
-  tps: 4697.63438
+  dps: 6601.66747
+  tps: 4699.39067
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6541.31794
-  tps: 4663.24682
+  dps: 6543.48234
+  tps: 4664.83982
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6328.17351
-  tps: 4507.3404
+  dps: 6331.34852
+  tps: 4509.6772
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8101.28005
-  tps: 5648.5647
+  dps: 8102.32676
+  tps: 5649.31967
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8284.58508
-  tps: 5898.75403
+  dps: 8285.69459
+  tps: 5899.57063
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8284.58508
-  tps: 5898.75403
+  dps: 8285.69459
+  tps: 5899.57063
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8288.22151
-  tps: 5901.43044
+  dps: 8289.54724
+  tps: 5902.40618
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7931.65054
-  tps: 5666.03292
+  dps: 7932.75483
+  tps: 5666.84568
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7978.10384
-  tps: 5700.22255
+  dps: 7980.29635
+  tps: 5701.83624
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 8073.82212
-  tps: 5749.8722
+  dps: 8074.89678
+  tps: 5750.66314
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7649.14899
-  tps: 5446.20261
+  dps: 7650.91269
+  tps: 5447.5007
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkrunedPlate"
  value: {
-  dps: 6696.96388
-  tps: 4755.94009
+  dps: 6700.90641
+  tps: 4758.8418
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7701.2662
-  tps: 5469.43133
+  dps: 7702.37571
+  tps: 5470.24793
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8494.26636
-  tps: 6044.75985
+  dps: 8495.37531
+  tps: 6045.57604
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7901.06319
-  tps: 5643.52063
+  dps: 7903.87842
+  tps: 5645.59264
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8312.42951
-  tps: 5936.71785
+  dps: 8313.76207
+  tps: 5937.69861
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8338.55787
-  tps: 5958.27598
+  dps: 8339.63252
+  tps: 5959.06693
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8126.56806
-  tps: 5782.4535
+  dps: 8127.81874
+  tps: 5783.374
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7986.27237
-  tps: 5701.98432
+  dps: 7988.28818
+  tps: 5703.46795
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7944.6961
-  tps: 5668.71611
+  dps: 7945.6414
+  tps: 5669.41185
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8101.28005
-  tps: 5763.84153
+  dps: 8102.32676
+  tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8101.28005
-  tps: 5763.84153
+  dps: 8102.32676
+  tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8122.51114
-  tps: 5779.46761
+  dps: 8123.76183
+  tps: 5780.38812
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8119.08054
-  tps: 5776.94269
+  dps: 8120.33123
+  tps: 5777.8632
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7892.79416
-  tps: 5628.93973
+  dps: 7894.59504
+  tps: 5630.26517
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8101.28005
-  tps: 5763.84153
+  dps: 8102.32676
+  tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7965.36016
-  tps: 5690.8432
+  dps: 7968.50995
+  tps: 5693.16145
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7916.57705
-  tps: 5654.93883
+  dps: 7917.68134
+  tps: 5655.75159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7895.66098
-  tps: 5639.5446
+  dps: 7896.76527
+  tps: 5640.35736
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8101.28005
-  tps: 5763.84153
+  dps: 8102.32676
+  tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8101.28005
-  tps: 5763.84153
+  dps: 8102.32676
+  tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7702.11242
-  tps: 5470.05416
+  dps: 7703.22193
+  tps: 5470.87076
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8057.66879
-  tps: 5758.78235
+  dps: 8058.78155
+  tps: 5759.60134
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7920.12227
-  tps: 5657.54811
+  dps: 7922.30088
+  tps: 5659.15157
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7699.37
-  tps: 5468.03573
+  dps: 7700.47951
+  tps: 5468.85233
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8122.51114
-  tps: 5779.46761
+  dps: 8123.76183
+  tps: 5780.38812
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8119.08054
-  tps: 5776.94269
+  dps: 8120.33123
+  tps: 5777.8632
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8011.86823
-  tps: 5725.07314
+  dps: 8012.96051
+  tps: 5725.87706
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8101.28005
-  tps: 5763.84153
+  dps: 8102.32676
+  tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8134.5303
-  tps: 5788.31371
+  dps: 8135.58173
+  tps: 5789.08756
   hps: 12.85179
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-LastWord-50179"
  value: {
-  dps: 8284.58508
-  tps: 5898.75403
+  dps: 8285.69459
+  tps: 5899.57063
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-LastWord-50708"
  value: {
-  dps: 8284.58508
-  tps: 5898.75403
+  dps: 8285.69459
+  tps: 5899.57063
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7958.90255
-  tps: 5680.98373
+  dps: 7960.00684
+  tps: 5681.79649
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7890.52033
-  tps: 5635.76109
+  dps: 7891.59498
+  tps: 5636.55203
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8128.00097
-  tps: 5783.50813
+  dps: 8129.0515
+  tps: 5784.28132
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8134.28825
-  tps: 5788.13556
+  dps: 8135.33967
+  tps: 5788.90941
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8101.28005
-  tps: 5763.84153
+  dps: 8102.32676
+  tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8101.28005
-  tps: 5763.84153
+  dps: 8102.32676
+  tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
@@ -582,351 +582,351 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8284.58508
-  tps: 5898.75403
+  dps: 8285.69459
+  tps: 5899.57063
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7703.09968
-  tps: 5470.78078
+  dps: 7704.20919
+  tps: 5471.59738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8101.28005
-  tps: 5763.84153
+  dps: 8102.32676
+  tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7699.10567
-  tps: 5467.84119
+  dps: 7700.21518
+  tps: 5468.65779
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7423.8507
-  tps: 5290.06198
+  dps: 7424.69989
+  tps: 5290.68699
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ScourgebornePlate"
  value: {
-  dps: 6616.11652
-  tps: 4700.35137
+  dps: 6620.52943
+  tps: 4703.59927
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8494.35049
-  tps: 6061.64129
+  dps: 8496.46907
+  tps: 6063.20057
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7079.55417
-  tps: 5024.17442
+  dps: 7083.34116
+  tps: 5026.96165
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8284.58508
-  tps: 5898.75403
+  dps: 8285.69459
+  tps: 5899.57063
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7697.03508
-  tps: 5466.31723
+  dps: 7698.14459
+  tps: 5467.13383
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7705.06342
-  tps: 5472.22609
+  dps: 7706.17293
+  tps: 5473.04269
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7697.03508
-  tps: 5466.31723
+  dps: 7698.14459
+  tps: 5467.13383
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8156.23953
-  tps: 5790.4257
+  dps: 8157.4265
+  tps: 5791.29931
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7697.03508
-  tps: 5466.31723
+  dps: 7698.14459
+  tps: 5467.13383
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 8195.78821
-  tps: 5818.21626
+  dps: 8196.98253
+  tps: 5819.09528
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7697.03508
-  tps: 5466.31723
+  dps: 7698.14459
+  tps: 5467.13383
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7919.96937
-  tps: 5657.43558
+  dps: 7921.07366
+  tps: 5658.24834
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SparkofLife-37657"
  value: {
-  dps: 7768.66296
-  tps: 5545.02013
+  dps: 7769.73762
+  tps: 5545.81107
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7875.60536
-  tps: 5624.62186
+  dps: 7876.75981
+  tps: 5625.47153
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-StormshroudArmor"
  value: {
-  dps: 6272.69401
-  tps: 4469.128
+  dps: 6274.38638
+  tps: 4470.37359
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8134.28825
-  tps: 5788.13556
+  dps: 8135.33967
+  tps: 5788.90941
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8128.00097
-  tps: 5783.50813
+  dps: 8129.0515
+  tps: 5784.28132
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8116.99824
-  tps: 5775.41011
+  dps: 8118.04719
+  tps: 5776.18215
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7664.49091
-  tps: 5458.55122
+  dps: 7676.09435
+  tps: 5467.09135
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6654.60061
-  tps: 4726.00941
+  dps: 6657.25387
+  tps: 4727.96221
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7276.74137
-  tps: 5167.22336
+  dps: 7278.4155
+  tps: 5168.45552
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8172.74836
-  tps: 5814.69036
+  dps: 8173.79507
+  tps: 5815.46073
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7943.32207
-  tps: 5674.55266
+  dps: 7945.20852
+  tps: 5675.94109
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8016.71285
-  tps: 5729.95589
+  dps: 8017.88178
+  tps: 5730.81623
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8101.28005
-  tps: 5763.84153
+  dps: 8102.32676
+  tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8101.28005
-  tps: 5763.84153
+  dps: 8102.32676
+  tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7775.62161
-  tps: 5549.62608
+  dps: 7777.71752
+  tps: 5551.16867
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8101.28005
-  tps: 5763.84153
+  dps: 8102.32676
+  tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8101.28005
-  tps: 5763.84153
+  dps: 8102.32676
+  tps: 5764.61191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6554.84711
-  tps: 4674.08066
+  dps: 6558.03145
+  tps: 4676.42434
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7743.62627
-  tps: 5499.8308
+  dps: 7745.86582
+  tps: 5501.4791
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7804.49499
-  tps: 5572.44644
+  dps: 7805.56964
+  tps: 5573.23738
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7704.22798
-  tps: 5471.61121
+  dps: 7705.33749
+  tps: 5472.42781
  }
 }
 dps_results: {
  key: "TestFrostUH-Average-Default"
  value: {
-  dps: 8206.27868
-  tps: 5845.88409
+  dps: 8210.43008
+  tps: 5848.93951
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20708.43375
-  tps: 15060.72382
+  dps: 20712.38172
+  tps: 15063.62953
  }
 }
 dps_results: {
@@ -967,22 +967,22 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23961.27442
-  tps: 17425.10585
+  dps: 23970.06864
+  tps: 17431.57839
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10023.90395
-  tps: 7161.48602
+  dps: 10026.4761
+  tps: 7163.37912
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11760.55987
-  tps: 8125.93315
+  dps: 11761.80558
+  tps: 8126.84999
  }
 }
 dps_results: {
@@ -1009,15 +1009,15 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20066.56388
-  tps: 14578.57375
+  dps: 20075.02493
+  tps: 14584.80108
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8284.58508
-  tps: 5898.75403
+  dps: 8285.69459
+  tps: 5899.57063
  }
 }
 dps_results: {
@@ -1051,22 +1051,22 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23873.02343
-  tps: 17346.45688
+  dps: 23884.16294
+  tps: 17354.65556
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10130.72104
-  tps: 7225.41589
+  dps: 10132.51463
+  tps: 7226.73598
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11856.73408
-  tps: 8170.44633
+  dps: 11857.98082
+  tps: 8171.36393
  }
 }
 dps_results: {
@@ -1093,7 +1093,7 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7377.36773
-  tps: 5252.60665
+  dps: 7377.97527
+  tps: 5253.0538
  }
 }

--- a/sim/deathknight/dps/TestFrostUH.results
+++ b/sim/deathknight/dps/TestFrostUH.results
@@ -46,523 +46,523 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8102.32676
-  tps: 5764.61191
+  dps: 8101.28005
+  tps: 5763.84153
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8018.08098
-  tps: 5729.64573
+  dps: 8015.72903
+  tps: 5727.91469
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7805.50377
-  tps: 5573.1889
+  dps: 7804.42158
+  tps: 5572.39241
   hps: 60.92312
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7805.50377
-  tps: 5573.1889
+  dps: 7804.42158
+  tps: 5572.39241
   hps: 60.92312
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8123.76183
-  tps: 5780.38812
+  dps: 8122.51114
+  tps: 5779.46761
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7808.31683
-  tps: 5559.76199
+  dps: 7807.37147
+  tps: 5559.06621
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6601.66747
-  tps: 4699.39067
+  dps: 6599.2812
+  tps: 4697.63438
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6543.48234
-  tps: 4664.83982
+  dps: 6541.31794
+  tps: 4663.24682
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6331.34852
-  tps: 4509.6772
+  dps: 6328.17351
+  tps: 4507.3404
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8102.32676
-  tps: 5649.31967
+  dps: 8101.28005
+  tps: 5648.5647
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8285.69459
-  tps: 5899.57063
+  dps: 8284.58508
+  tps: 5898.75403
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8285.69459
-  tps: 5899.57063
+  dps: 8284.58508
+  tps: 5898.75403
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8289.54724
-  tps: 5902.40618
+  dps: 8288.22151
+  tps: 5901.43044
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7932.75483
-  tps: 5666.84568
+  dps: 7931.65054
+  tps: 5666.03292
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7980.29635
-  tps: 5701.83624
+  dps: 7978.10384
+  tps: 5700.22255
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 8074.89678
-  tps: 5750.66314
+  dps: 8073.82212
+  tps: 5749.8722
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7650.91269
-  tps: 5447.5007
+  dps: 7649.14899
+  tps: 5446.20261
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkrunedPlate"
  value: {
-  dps: 6700.90641
-  tps: 4758.8418
+  dps: 6696.96388
+  tps: 4755.94009
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 7702.37571
-  tps: 5470.24793
+  dps: 7701.2662
+  tps: 5469.43133
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8495.37531
-  tps: 6045.57604
+  dps: 8494.26636
+  tps: 6044.75985
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7903.87842
-  tps: 5645.59264
+  dps: 7901.06319
+  tps: 5643.52063
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8313.76207
-  tps: 5937.69861
+  dps: 8312.42951
+  tps: 5936.71785
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8339.63252
-  tps: 5959.06693
+  dps: 8338.55787
+  tps: 5958.27598
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8127.81874
-  tps: 5783.374
+  dps: 8126.56806
+  tps: 5782.4535
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7988.28818
-  tps: 5703.46795
+  dps: 7986.27237
+  tps: 5701.98432
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7945.6414
-  tps: 5669.41185
+  dps: 7944.6961
+  tps: 5668.71611
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8102.32676
-  tps: 5764.61191
+  dps: 8101.28005
+  tps: 5763.84153
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8102.32676
-  tps: 5764.61191
+  dps: 8101.28005
+  tps: 5763.84153
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8123.76183
-  tps: 5780.38812
+  dps: 8122.51114
+  tps: 5779.46761
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8120.33123
-  tps: 5777.8632
+  dps: 8119.08054
+  tps: 5776.94269
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7894.59504
-  tps: 5630.26517
+  dps: 7892.79416
+  tps: 5628.93973
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8102.32676
-  tps: 5764.61191
+  dps: 8101.28005
+  tps: 5763.84153
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7968.50995
-  tps: 5693.16145
+  dps: 7965.36016
+  tps: 5690.8432
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7917.68134
-  tps: 5655.75159
+  dps: 7916.57705
+  tps: 5654.93883
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7896.76527
-  tps: 5640.35736
+  dps: 7895.66098
+  tps: 5639.5446
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8102.32676
-  tps: 5764.61191
+  dps: 8101.28005
+  tps: 5763.84153
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8102.32676
-  tps: 5764.61191
+  dps: 8101.28005
+  tps: 5763.84153
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 7703.22193
-  tps: 5470.87076
+  dps: 7702.11242
+  tps: 5470.05416
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8058.78155
-  tps: 5759.60134
+  dps: 8057.66879
+  tps: 5758.78235
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7922.30088
-  tps: 5659.15157
+  dps: 7920.12227
+  tps: 5657.54811
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7700.47951
-  tps: 5468.85233
+  dps: 7699.37
+  tps: 5468.03573
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8123.76183
-  tps: 5780.38812
+  dps: 8122.51114
+  tps: 5779.46761
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8120.33123
-  tps: 5777.8632
+  dps: 8119.08054
+  tps: 5776.94269
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8012.96051
-  tps: 5725.87706
+  dps: 8011.86823
+  tps: 5725.07314
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8102.32676
-  tps: 5764.61191
+  dps: 8101.28005
+  tps: 5763.84153
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8135.58173
-  tps: 5789.08756
+  dps: 8134.5303
+  tps: 5788.31371
   hps: 12.85179
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-LastWord-50179"
  value: {
-  dps: 8285.69459
-  tps: 5899.57063
+  dps: 8284.58508
+  tps: 5898.75403
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-LastWord-50708"
  value: {
-  dps: 8285.69459
-  tps: 5899.57063
+  dps: 8284.58508
+  tps: 5898.75403
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7960.00684
-  tps: 5681.79649
+  dps: 7958.90255
+  tps: 5680.98373
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7891.59498
-  tps: 5636.55203
+  dps: 7890.52033
+  tps: 5635.76109
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8129.0515
-  tps: 5784.28132
+  dps: 8128.00097
+  tps: 5783.50813
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8135.33967
-  tps: 5788.90941
+  dps: 8134.28825
+  tps: 5788.13556
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8102.32676
-  tps: 5764.61191
+  dps: 8101.28005
+  tps: 5763.84153
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8102.32676
-  tps: 5764.61191
+  dps: 8101.28005
+  tps: 5763.84153
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
@@ -582,351 +582,351 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8285.69459
-  tps: 5899.57063
+  dps: 8284.58508
+  tps: 5898.75403
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 7704.20919
-  tps: 5471.59738
+  dps: 7703.09968
+  tps: 5470.78078
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8102.32676
-  tps: 5764.61191
+  dps: 8101.28005
+  tps: 5763.84153
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7700.21518
-  tps: 5468.65779
+  dps: 7699.10567
+  tps: 5467.84119
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7424.69989
-  tps: 5290.68699
+  dps: 7423.8507
+  tps: 5290.06198
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ScourgebornePlate"
  value: {
-  dps: 6620.52943
-  tps: 4703.59927
+  dps: 6616.11652
+  tps: 4700.35137
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8496.46907
-  tps: 6063.20057
+  dps: 8494.35049
+  tps: 6061.64129
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7083.34116
-  tps: 5026.96165
+  dps: 7079.55417
+  tps: 5024.17442
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8285.69459
-  tps: 5899.57063
+  dps: 8284.58508
+  tps: 5898.75403
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7698.14459
-  tps: 5467.13383
+  dps: 7697.03508
+  tps: 5466.31723
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7706.17293
-  tps: 5473.04269
+  dps: 7705.06342
+  tps: 5472.22609
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7698.14459
-  tps: 5467.13383
+  dps: 7697.03508
+  tps: 5466.31723
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8157.4265
-  tps: 5791.29931
+  dps: 8156.23953
+  tps: 5790.4257
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7698.14459
-  tps: 5467.13383
+  dps: 7697.03508
+  tps: 5466.31723
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 8196.98253
-  tps: 5819.09528
+  dps: 8195.78821
+  tps: 5818.21626
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7698.14459
-  tps: 5467.13383
+  dps: 7697.03508
+  tps: 5466.31723
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7921.07366
-  tps: 5658.24834
+  dps: 7919.96937
+  tps: 5657.43558
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SparkofLife-37657"
  value: {
-  dps: 7769.73762
-  tps: 5545.81107
+  dps: 7768.66296
+  tps: 5545.02013
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7876.75981
-  tps: 5625.47153
+  dps: 7875.60536
+  tps: 5624.62186
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-StormshroudArmor"
  value: {
-  dps: 6274.38638
-  tps: 4470.37359
+  dps: 6272.69401
+  tps: 4469.128
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8135.33967
-  tps: 5788.90941
+  dps: 8134.28825
+  tps: 5788.13556
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8129.0515
-  tps: 5784.28132
+  dps: 8128.00097
+  tps: 5783.50813
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8118.04719
-  tps: 5776.18215
+  dps: 8116.99824
+  tps: 5775.41011
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7676.09435
-  tps: 5467.09135
+  dps: 7664.49091
+  tps: 5458.55122
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6657.25387
-  tps: 4727.96221
+  dps: 6654.60061
+  tps: 4726.00941
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7278.4155
-  tps: 5168.45552
+  dps: 7276.74137
+  tps: 5167.22336
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8173.79507
-  tps: 5815.46073
+  dps: 8172.74836
+  tps: 5814.69036
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7945.20852
-  tps: 5675.94109
+  dps: 7943.32207
+  tps: 5674.55266
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8017.88178
-  tps: 5730.81623
+  dps: 8016.71285
+  tps: 5729.95589
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8102.32676
-  tps: 5764.61191
+  dps: 8101.28005
+  tps: 5763.84153
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8102.32676
-  tps: 5764.61191
+  dps: 8101.28005
+  tps: 5763.84153
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7777.71752
-  tps: 5551.16867
+  dps: 7775.62161
+  tps: 5549.62608
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8102.32676
-  tps: 5764.61191
+  dps: 8101.28005
+  tps: 5763.84153
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8102.32676
-  tps: 5764.61191
+  dps: 8101.28005
+  tps: 5763.84153
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6558.03145
-  tps: 4676.42434
+  dps: 6554.84711
+  tps: 4674.08066
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7745.86582
-  tps: 5501.4791
+  dps: 7743.62627
+  tps: 5499.8308
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7805.56964
-  tps: 5573.23738
+  dps: 7804.49499
+  tps: 5572.44644
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 7705.33749
-  tps: 5472.42781
+  dps: 7704.22798
+  tps: 5471.61121
  }
 }
 dps_results: {
  key: "TestFrostUH-Average-Default"
  value: {
-  dps: 8210.43008
-  tps: 5848.93951
+  dps: 8206.27868
+  tps: 5845.88409
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20712.38172
-  tps: 15063.62953
+  dps: 20594.81292
+  tps: 14977.09889
  }
 }
 dps_results: {
@@ -946,15 +946,15 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10410.89178
-  tps: 7551.09001
+  dps: 10339.69301
+  tps: 7498.68771
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4709.61106
-  tps: 3347.70186
+  dps: 4706.91499
+  tps: 3345.71755
  }
 }
 dps_results: {
@@ -967,57 +967,57 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23970.06864
-  tps: 17431.57839
+  dps: 23831.29677
+  tps: 17329.4423
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10026.4761
-  tps: 7163.37912
+  dps: 10023.90395
+  tps: 7161.48602
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11761.80558
-  tps: 8126.84999
+  dps: 11760.55987
+  tps: 8125.93315
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12450.85691
-  tps: 9036.84098
+  dps: 12373.56065
+  tps: 8979.95093
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5852.89727
-  tps: 4172.23866
+  dps: 5849.74258
+  tps: 4169.91681
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6534.09117
-  tps: 4520.4282
+  dps: 6525.51789
+  tps: 4514.11826
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20075.02493
-  tps: 14584.80108
+  dps: 19950.58773
+  tps: 14493.2153
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8285.69459
-  tps: 5899.57063
+  dps: 8284.58508
+  tps: 5898.75403
  }
 }
 dps_results: {
@@ -1030,15 +1030,15 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10236.22664
-  tps: 7415.92515
+  dps: 10167.27916
+  tps: 7365.17981
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4659.82819
-  tps: 3307.01917
+  dps: 4657.93525
+  tps: 3305.62596
  }
 }
 dps_results: {
@@ -1051,49 +1051,49 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23884.16294
-  tps: 17354.65556
+  dps: 23745.02367
+  tps: 17252.24906
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10132.51463
-  tps: 7226.73598
+  dps: 10130.72104
+  tps: 7225.41589
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11857.98082
-  tps: 8171.36393
+  dps: 11856.73408
+  tps: 8170.44633
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11918.75643
-  tps: 8638.93311
+  dps: 11835.5414
+  tps: 8577.68685
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5833.83991
-  tps: 4152.36994
+  dps: 5830.69806
+  tps: 4150.05755
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6589.69819
-  tps: 4548.92752
+  dps: 6581.11765
+  tps: 4542.61224
  }
 }
 dps_results: {
  key: "TestFrostUH-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7377.97527
-  tps: 5253.0538
+  dps: 7377.36773
+  tps: 5252.60665
  }
 }

--- a/sim/deathknight/dps/TestFrostUH.results
+++ b/sim/deathknight/dps/TestFrostUH.results
@@ -67,8 +67,8 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8015.72903
-  tps: 5727.91469
+  dps: 8016.12167
+  tps: 5728.20367
  }
 }
 dps_results: {
@@ -90,8 +90,8 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8122.51114
-  tps: 5779.46761
+  dps: 8123.55785
+  tps: 5780.23799
  }
 }
 dps_results: {
@@ -104,22 +104,22 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6599.2812
-  tps: 4697.63438
+  dps: 6600.42287
+  tps: 4698.47465
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6541.31794
-  tps: 4663.24682
+  dps: 6541.62789
+  tps: 4663.47495
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6328.17351
-  tps: 4507.3404
+  dps: 6329.315
+  tps: 4508.18053
  }
 }
 dps_results: {
@@ -146,8 +146,8 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8288.22151
-  tps: 5901.43044
+  dps: 8289.33102
+  tps: 5902.24704
  }
 }
 dps_results: {
@@ -196,15 +196,15 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7649.14899
-  tps: 5446.20261
+  dps: 7650.91269
+  tps: 5447.5007
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkrunedPlate"
  value: {
-  dps: 6696.96388
-  tps: 4755.94009
+  dps: 6697.90512
+  tps: 4756.63285
  }
 }
 dps_results: {
@@ -224,8 +224,8 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7901.06319
-  tps: 5643.52063
+  dps: 7901.95746
+  tps: 5644.17882
  }
 }
 dps_results: {
@@ -252,15 +252,15 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8126.56806
-  tps: 5782.4535
+  dps: 8127.61476
+  tps: 5783.22388
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7986.27237
-  tps: 5701.98432
+  dps: 7987.21352
+  tps: 5702.677
  }
 }
 dps_results: {
@@ -287,22 +287,22 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8122.51114
-  tps: 5779.46761
+  dps: 8123.55785
+  tps: 5780.23799
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8119.08054
-  tps: 5776.94269
+  dps: 8120.12725
+  tps: 5777.71307
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7892.79416
-  tps: 5628.93973
+  dps: 7893.73532
+  tps: 5629.63242
  }
 }
 dps_results: {
@@ -427,15 +427,15 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8122.51114
-  tps: 5779.46761
+  dps: 8123.55785
+  tps: 5780.23799
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8119.08054
-  tps: 5776.94269
+  dps: 8120.12725
+  tps: 5777.71307
  }
 }
 dps_results: {
@@ -624,22 +624,22 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-ScourgebornePlate"
  value: {
-  dps: 6616.11652
-  tps: 4700.35137
+  dps: 6617.04589
+  tps: 4701.03538
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8494.35049
-  tps: 6061.64129
+  dps: 8496.26328
+  tps: 6063.04911
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7079.55417
-  tps: 5024.17442
+  dps: 7080.54748
+  tps: 5024.9055
  }
 }
 dps_results: {
@@ -764,8 +764,8 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-StormshroudArmor"
  value: {
-  dps: 6272.69401
-  tps: 4469.128
+  dps: 6274.36745
+  tps: 4470.35965
  }
 }
 dps_results: {
@@ -806,8 +806,8 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7664.49091
-  tps: 5458.55122
+  dps: 7667.6375
+  tps: 5460.86711
  }
 }
 dps_results: {
@@ -841,8 +841,8 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7943.32207
-  tps: 5674.55266
+  dps: 7944.26322
+  tps: 5675.24535
  }
 }
 dps_results: {
@@ -869,8 +869,8 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7775.62161
-  tps: 5549.62608
+  dps: 7776.46864
+  tps: 5550.2495
  }
 }
 dps_results: {
@@ -890,15 +890,15 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6554.84711
-  tps: 4674.08066
+  dps: 6556.02873
+  tps: 4674.95034
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7743.62627
-  tps: 5499.8308
+  dps: 7745.60392
+  tps: 5501.28635
  }
 }
 dps_results: {
@@ -918,15 +918,15 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Average-Default"
  value: {
-  dps: 8206.27868
-  tps: 5845.88409
+  dps: 8207.42606
+  tps: 5846.72856
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20594.81292
-  tps: 14977.09889
+  dps: 20628.68216
+  tps: 15002.02665
  }
 }
 dps_results: {
@@ -946,8 +946,8 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10339.69301
-  tps: 7498.68771
+  dps: 10360.28809
+  tps: 7513.84569
  }
 }
 dps_results: {
@@ -967,15 +967,15 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23831.29677
-  tps: 17329.4423
+  dps: 23873.56252
+  tps: 17360.54989
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10023.90395
-  tps: 7161.48602
+  dps: 10024.31076
+  tps: 7161.78543
  }
 }
 dps_results: {
@@ -988,29 +988,29 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12373.56065
-  tps: 8979.95093
+  dps: 12398.49471
+  tps: 8998.3024
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5849.74258
-  tps: 4169.91681
+  dps: 5852.03716
+  tps: 4171.60562
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6525.51789
-  tps: 4514.11826
+  dps: 6529.38004
+  tps: 4516.96081
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19950.58773
-  tps: 14493.2153
+  dps: 19982.73406
+  tps: 14516.875
  }
 }
 dps_results: {
@@ -1030,8 +1030,8 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10167.27916
-  tps: 7365.17981
+  dps: 10186.73465
+  tps: 7379.49905
  }
 }
 dps_results: {
@@ -1051,15 +1051,15 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23745.02367
-  tps: 17252.24906
+  dps: 23788.03345
+  tps: 17283.90426
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10130.72104
-  tps: 7225.41589
+  dps: 10131.12821
+  tps: 7225.71557
  }
 }
 dps_results: {
@@ -1072,22 +1072,22 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11835.5414
-  tps: 8577.68685
+  dps: 11861.49705
+  tps: 8596.79021
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5830.69806
-  tps: 4150.05755
+  dps: 5832.13804
+  tps: 4151.11737
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6581.11765
-  tps: 4542.61224
+  dps: 6584.98282
+  tps: 4545.45701
  }
 }
 dps_results: {

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -46,1184 +46,1184 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7445.10075
-  tps: 4821.53386
+  dps: 7404.36413
+  tps: 4775.20472
   hps: 369.59868
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7445.10075
-  tps: 4821.53386
+  dps: 7404.36413
+  tps: 4775.20472
   hps: 383.43105
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7955.2242
-  tps: 5089.57829
+  dps: 7915.07706
+  tps: 5043.62092
   hps: 270.31002
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7641.18695
-  tps: 4992.13337
+  dps: 7596.58501
+  tps: 4941.83029
   hps: 264.72419
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7445.12527
-  tps: 4821.50604
+  dps: 7404.38729
+  tps: 4775.17635
   hps: 354.03666
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7445.12527
-  tps: 4821.50604
+  dps: 7404.38729
+  tps: 4775.17635
   hps: 354.03666
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7977.99083
-  tps: 5109.17129
+  dps: 7932.6785
+  tps: 5058.05099
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7717.37292
-  tps: 4920.9882
+  dps: 7677.63184
+  tps: 4875.04156
   hps: 257.00534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6523.37444
-  tps: 4216.61459
+  dps: 6484.60977
+  tps: 4171.80676
   hps: 232.68485
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6341.91132
-  tps: 4136.9408
+  dps: 6303.17213
+  tps: 4092.56581
   hps: 224.48378
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6149.11994
-  tps: 3966.21194
+  dps: 6109.80272
+  tps: 3922.06412
   hps: 224.07309
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7955.2242
-  tps: 4987.78673
+  dps: 7915.07706
+  tps: 4942.7485
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8032.95543
-  tps: 5161.19364
+  dps: 7990.50391
+  tps: 5112.51596
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8032.95543
-  tps: 5161.19364
+  dps: 7990.50391
+  tps: 5112.51596
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8046.80251
-  tps: 5175.16728
+  dps: 7998.77144
+  tps: 5120.97977
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 363.59146
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7539.33369
-  tps: 4912.27372
+  dps: 7496.23671
+  tps: 4863.55381
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7564.40539
-  tps: 4939.84833
+  dps: 7516.52562
+  tps: 4887.35139
   hps: 263.77874
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7791.64281
-  tps: 5000.51817
+  dps: 7750.5313
+  tps: 4953.41647
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7598.38862
-  tps: 4942.71555
+  dps: 7556.52522
+  tps: 4894.24138
   hps: 279.46859
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 6636.23504
-  tps: 4276.86749
+  dps: 6597.34079
+  tps: 4232.77376
   hps: 296.98863
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8278.96295
-  tps: 5327.14325
+  dps: 8235.17732
+  tps: 5276.96283
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7525.37416
-  tps: 4899.77681
+  dps: 7479.52559
+  tps: 4848.10688
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7830.26983
-  tps: 5188.60376
+  dps: 7789.41441
+  tps: 5141.49336
   hps: 272.60288
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7841.68692
-  tps: 5223.22665
+  dps: 7798.96293
+  tps: 5173.71454
   hps: 272.28773
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7979.91896
-  tps: 5111.31429
+  dps: 7934.92546
+  tps: 5060.61293
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7658.77297
-  tps: 4928.59977
+  dps: 7619.83863
+  tps: 4883.28481
   hps: 263.46359
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7628.4107
-  tps: 4906.60879
+  dps: 7589.05379
+  tps: 4861.04035
   hps: 262.51815
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7955.2242
-  tps: 5089.57829
+  dps: 7915.07706
+  tps: 5043.62092
   hps: 270.31002
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7955.2242
-  tps: 5089.57829
+  dps: 7915.07706
+  tps: 5043.62092
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7977.99083
-  tps: 5109.17129
+  dps: 7932.6785
+  tps: 5058.05099
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7974.64145
-  tps: 5106.2296
+  dps: 7930.85824
+  tps: 5056.17436
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7592.71519
-  tps: 4839.309
+  dps: 7551.52074
+  tps: 4792.5856
   hps: 266.61507
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 281.53732
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7955.2242
-  tps: 5089.57829
+  dps: 7915.07706
+  tps: 5043.62092
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7594.19847
-  tps: 4958.58648
+  dps: 7547.27502
+  tps: 4906.71394
   hps: 265.03933
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7528.2257
-  tps: 4901.73682
+  dps: 7484.1879
+  tps: 4852.27823
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7508.98379
-  tps: 4883.67609
+  dps: 7467.17043
+  tps: 4835.48997
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7955.2242
-  tps: 5089.57829
+  dps: 7915.07706
+  tps: 5043.62092
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7955.2242
-  tps: 5089.57829
+  dps: 7915.07706
+  tps: 5043.62092
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 8050.07926
-  tps: 5174.72044
+  dps: 8007.51682
+  tps: 5125.91278
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7708.01312
-  tps: 5034.05554
+  dps: 7665.44745
+  tps: 4985.60344
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7550.88546
-  tps: 4924.78139
+  dps: 7503.00457
+  tps: 4872.3547
   hps: 264.72419
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7996.34525
-  tps: 5132.84192
+  dps: 7954.10908
+  tps: 5084.42681
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7977.99083
-  tps: 5109.17129
+  dps: 7932.6785
+  tps: 5058.05099
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7974.64145
-  tps: 5106.2296
+  dps: 7930.85824
+  tps: 5056.17436
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7611.13416
-  tps: 4958.16485
+  dps: 7569.53504
+  tps: 4910.83472
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7955.2242
-  tps: 5089.57829
+  dps: 7915.07706
+  tps: 5043.62092
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7990.95808
-  tps: 5118.78399
+  dps: 7950.64182
+  tps: 5072.63658
   hps: 278.22315
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50179"
  value: {
-  dps: 8032.95543
-  tps: 5161.19364
+  dps: 7990.50391
+  tps: 5112.51596
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50708"
  value: {
-  dps: 8032.95543
-  tps: 5161.19364
+  dps: 7990.50391
+  tps: 5112.51596
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7526.77385
-  tps: 4907.41177
+  dps: 7487.22944
+  tps: 4862.64101
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7983.34192
-  tps: 5112.19294
+  dps: 7943.01509
+  tps: 5066.02462
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7989.95786
-  tps: 5117.51403
+  dps: 7949.58874
+  tps: 5071.29608
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7955.2242
-  tps: 5089.57829
+  dps: 7915.07706
+  tps: 5043.62092
   hps: 269.38086
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7955.2242
-  tps: 5089.57829
+  dps: 7915.07706
+  tps: 5043.62092
   hps: 270.31002
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7496.53761
-  tps: 4867.98232
-  hps: 265.66963
+  dps: 7426.0672
+  tps: 4788.6912
+  hps: 263.77874
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7505.82541
-  tps: 4875.76278
-  hps: 265.66963
+  dps: 7434.69651
+  tps: 4795.90136
+  hps: 263.77874
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8032.95543
-  tps: 5161.19364
+  dps: 7990.50391
+  tps: 5112.51596
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 8070.05705
-  tps: 5190.50171
+  dps: 8027.36522
+  tps: 5141.54241
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7955.2242
-  tps: 5089.57829
+  dps: 7915.07706
+  tps: 5043.62092
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7990.79707
-  tps: 5128.39487
+  dps: 7948.5993
+  tps: 5080.02361
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7226.44045
-  tps: 4683.04421
+  dps: 7183.65126
+  tps: 4635.14064
   hps: 255.62308
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6586.71076
-  tps: 4228.55747
+  dps: 6551.51351
+  tps: 4187.48934
   hps: 270.24427
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7973.99309
-  tps: 5321.84729
+  dps: 7935.03739
+  tps: 5276.98883
   hps: 297.77471
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7228.32658
-  tps: 4777.27408
+  dps: 7186.95774
+  tps: 4727.72962
   hps: 308.77393
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 8032.95543
-  tps: 5161.19364
+  dps: 7990.50391
+  tps: 5112.51596
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7947.33631
-  tps: 5093.55962
+  dps: 7905.43935
+  tps: 5045.53186
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7958.00816
-  tps: 5104.33806
+  dps: 7914.92216
+  tps: 5055.70061
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7947.33631
-  tps: 5093.55962
+  dps: 7905.43935
+  tps: 5045.53186
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8153.02192
-  tps: 5184.06066
+  dps: 8111.80867
+  tps: 5137.03213
   hps: 238.25177
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7947.33631
-  tps: 5093.55962
+  dps: 7905.43935
+  tps: 5045.53186
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7947.33631
-  tps: 5093.55962
+  dps: 7905.43935
+  tps: 5045.53186
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7947.33631
-  tps: 5093.55962
+  dps: 7905.43935
+  tps: 5045.53186
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 299.59146
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7530.13615
-  tps: 4903.62369
+  dps: 7487.17675
+  tps: 4855.14039
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 7524.05289
-  tps: 4851.84607
+  dps: 7484.71043
+  tps: 4806.51829
   hps: 265.66963
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7641.68644
-  tps: 4925.24482
+  dps: 7601.26796
+  tps: 4878.57743
   hps: 264.72419
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StormshroudArmor"
  value: {
-  dps: 6027.02866
-  tps: 3911.58651
+  dps: 5995.22137
+  tps: 3873.89693
   hps: 204.81996
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7989.95786
-  tps: 5117.51403
+  dps: 7949.58874
+  tps: 5071.29608
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7983.34192
-  tps: 5112.19294
+  dps: 7943.01509
+  tps: 5066.02462
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7971.76404
-  tps: 5102.88102
+  dps: 7931.51119
+  tps: 5056.79957
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7783.82464
-  tps: 5108.03978
+  dps: 7727.96993
+  tps: 5049.12104
   hps: 277.93737
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6732.47421
-  tps: 4313.20341
+  dps: 6694.74984
+  tps: 4269.82203
   hps: 289.52451
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7424.66381
-  tps: 4731.67027
+  dps: 7379.69125
+  tps: 4681.19544
   hps: 251.95663
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8005.43775
-  tps: 5107.97955
+  dps: 7963.28032
+  tps: 5059.93719
   hps: 263.46359
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7630.5444
-  tps: 4963.43683
+  dps: 7589.08502
+  tps: 4916.37019
   hps: 267.87566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7631.37885
-  tps: 4977.52883
+  dps: 7590.24272
+  tps: 4930.56636
   hps: 264.72419
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7955.2242
-  tps: 5089.57829
+  dps: 7915.07706
+  tps: 5043.62092
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7955.2242
-  tps: 5089.57829
+  dps: 7915.07706
+  tps: 5043.62092
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7526.94402
-  tps: 4836.49894
+  dps: 7487.25612
+  tps: 4790.77541
   hps: 263.46359
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7955.2242
-  tps: 5089.57829
+  dps: 7915.07706
+  tps: 5043.62092
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7955.2242
-  tps: 5089.57829
+  dps: 7915.07706
+  tps: 5043.62092
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6374.13471
-  tps: 4164.15754
+  dps: 6336.00831
+  tps: 4120.49762
   hps: 230.2196
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7687.78157
-  tps: 4916.95095
+  dps: 7644.1096
+  tps: 4865.85616
   hps: 264.74695
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7445.12401
-  tps: 4821.49891
+  dps: 7404.37573
+  tps: 4775.16124
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 8092.88882
-  tps: 5208.53745
+  dps: 8050.0491
+  tps: 5159.40483
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 8017.83314
-  tps: 5161.16075
+  dps: 7974.37442
+  tps: 5111.30479
   hps: 265.34082
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36222.16901
-  tps: 38806.87831
+  dps: 35865.678
+  tps: 38253.39909
   hps: 261.42005
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7821.32368
-  tps: 5123.77288
+  dps: 7778.20427
+  tps: 5074.39422
   hps: 264.56969
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11197.08555
-  tps: 5671.76828
+  dps: 11156.80505
+  tps: 5619.92949
   hps: 231.49848
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 21883.09234
-  tps: 24104.41002
+  dps: 21636.5819
+  tps: 23720.56472
   hps: 158.16236
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3864.15784
-  tps: 2782.99681
+  dps: 3834.21906
+  tps: 2748.05288
   hps: 159.48827
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4925.46991
-  tps: 2863.8087
+  dps: 4892.67778
+  tps: 2823.33402
   hps: 142.062
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 46630.1848
-  tps: 50168.81961
+  dps: 46169.81295
+  tps: 49449.67001
   hps: 320.4671
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10242.21918
-  tps: 6832.10793
+  dps: 10190.64243
+  tps: 6773.16673
   hps: 327.90162
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14249.31176
-  tps: 7498.85252
+  dps: 14201.90775
+  tps: 7439.70267
   hps: 283.68577
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 29347.45447
-  tps: 32420.54449
+  dps: 29034.46406
+  tps: 31936.53859
   hps: 210.32917
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5296.84563
-  tps: 3892.91502
+  dps: 5257.31894
+  tps: 3848.5004
   hps: 211.33915
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6530.03404
-  tps: 3961.61841
+  dps: 6493.03979
+  tps: 3919.2043
   hps: 180.53464
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36805.89138
-  tps: 39310.28264
+  dps: 36446.01752
+  tps: 38752.14328
   hps: 261.88786
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8032.95543
-  tps: 5161.19364
+  dps: 7990.50391
+  tps: 5112.51596
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11580.71394
-  tps: 5732.02094
+  dps: 11540.23275
+  tps: 5679.93211
   hps: 231.63366
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 22094.85284
-  tps: 24292.82052
+  dps: 21846.76216
+  tps: 23906.28327
   hps: 158.09971
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3945.67933
-  tps: 2803.16899
+  dps: 3913.34648
+  tps: 2765.90819
   hps: 160.37453
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5101.97353
-  tps: 2901.84378
+  dps: 5068.5601
+  tps: 2860.62339
   hps: 142.176
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 46700.19374
-  tps: 49939.13248
+  dps: 46242.90748
+  tps: 49226.83396
   hps: 321.79215
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10390.02013
-  tps: 6797.27018
+  dps: 10337.4355
+  tps: 6737.30286
   hps: 327.66427
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14682.74307
-  tps: 7552.85592
+  dps: 14643.47326
+  tps: 7500.65844
   hps: 279.90437
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 29443.58498
-  tps: 32479.5714
+  dps: 29130.36566
+  tps: 31995.37655
   hps: 209.69784
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5374.6586
-  tps: 3891.01135
+  dps: 5337.09226
+  tps: 3848.40308
   hps: 211.97167
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6693.30905
-  tps: 3960.19317
+  dps: 6656.93612
+  tps: 3919.27089
   hps: 175.59036
  }
 }
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7696.31128
-  tps: 5013.1652
+  dps: 7653.91571
+  tps: 4964.29234
   hps: 262.8333
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -46,1184 +46,1184 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7396.15609
-  tps: 4766.79859
+  dps: 7445.10075
+  tps: 4821.53386
   hps: 369.59868
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7396.15609
-  tps: 4766.79859
+  dps: 7445.10075
+  tps: 4821.53386
   hps: 383.43105
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7912.79742
-  tps: 5039.39687
+  dps: 7955.2242
+  tps: 5089.57829
   hps: 270.31002
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7592.23117
-  tps: 4939.22712
+  dps: 7641.18695
+  tps: 4992.13337
   hps: 264.72419
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7396.17932
-  tps: 4766.76153
+  dps: 7445.12527
+  tps: 4821.50604
   hps: 354.03666
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7396.17932
-  tps: 4766.76153
+  dps: 7445.12527
+  tps: 4821.50604
   hps: 354.03666
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7931.35527
-  tps: 5054.76498
+  dps: 7977.99083
+  tps: 5109.17129
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7681.67609
-  tps: 4878.84152
+  dps: 7717.37292
+  tps: 4920.9882
   hps: 257.00534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6478.62175
-  tps: 4167.38887
+  dps: 6523.37444
+  tps: 4216.61459
   hps: 232.68485
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6299.3255
-  tps: 4088.68795
+  dps: 6341.91132
+  tps: 4136.9408
   hps: 224.48378
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6109.50781
-  tps: 3922.02692
+  dps: 6149.11994
+  tps: 3966.21194
   hps: 224.07309
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7912.79742
-  tps: 4938.60893
+  dps: 7955.2242
+  tps: 4987.78673
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7987.77382
-  tps: 5107.69737
+  dps: 8032.95543
+  tps: 5161.19364
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7987.77382
-  tps: 5107.69737
+  dps: 8032.95543
+  tps: 5161.19364
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7997.27056
-  tps: 5117.4966
+  dps: 8046.80251
+  tps: 5175.16728
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 363.59146
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7492.3607
-  tps: 4859.21385
+  dps: 7539.33369
+  tps: 4912.27372
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7520.09013
-  tps: 4889.84187
+  dps: 7564.40539
+  tps: 4939.84833
   hps: 263.77874
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7747.83666
-  tps: 4948.70508
+  dps: 7791.64281
+  tps: 5000.51817
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7547.51664
-  tps: 4888.70583
+  dps: 7598.38862
+  tps: 4942.71555
   hps: 279.46859
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 6591.02104
-  tps: 4229.79244
+  dps: 6636.23504
+  tps: 4276.86749
   hps: 296.98863
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8231.26762
-  tps: 5271.0201
+  dps: 8278.96295
+  tps: 5327.14325
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7476.23964
-  tps: 4844.7824
+  dps: 7525.37416
+  tps: 4899.77681
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7785.35944
-  tps: 5138.14179
+  dps: 7830.26983
+  tps: 5188.60376
   hps: 272.60288
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7794.41388
-  tps: 5168.47347
+  dps: 7841.68692
+  tps: 5223.22665
   hps: 272.28773
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7934.18808
-  tps: 5057.71915
+  dps: 7979.91896
+  tps: 5111.31429
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7613.51816
-  tps: 4878.3844
+  dps: 7658.77297
+  tps: 4928.59977
   hps: 263.46359
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7584.50629
-  tps: 4856.15552
+  dps: 7628.4107
+  tps: 4906.60879
   hps: 262.51815
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7912.79742
-  tps: 5039.39687
+  dps: 7955.2242
+  tps: 5089.57829
   hps: 270.31002
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7912.79742
-  tps: 5039.39687
+  dps: 7955.2242
+  tps: 5089.57829
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7931.35527
-  tps: 5054.76498
+  dps: 7977.99083
+  tps: 5109.17129
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7929.53149
-  tps: 5052.92938
+  dps: 7974.64145
+  tps: 5106.2296
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7548.39916
-  tps: 4788.12074
+  dps: 7592.71519
+  tps: 4839.309
   hps: 266.61507
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 281.53732
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7912.79742
-  tps: 5039.39687
+  dps: 7955.2242
+  tps: 5089.57829
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7544.29965
-  tps: 4907.49203
+  dps: 7594.19847
+  tps: 4958.58648
   hps: 265.03933
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7481.5898
-  tps: 4848.95079
+  dps: 7528.2257
+  tps: 4901.73682
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7463.96077
-  tps: 4831.6466
+  dps: 7508.98379
+  tps: 4883.67609
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7912.79742
-  tps: 5039.39687
+  dps: 7955.2242
+  tps: 5089.57829
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7912.79742
-  tps: 5039.39687
+  dps: 7955.2242
+  tps: 5089.57829
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 8004.78225
-  tps: 5121.08496
+  dps: 8050.07926
+  tps: 5174.72044
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7656.95475
-  tps: 4976.89046
+  dps: 7708.01312
+  tps: 5034.05554
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7505.81255
-  tps: 4875.70237
+  dps: 7550.88546
+  tps: 4924.78139
   hps: 264.72419
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7951.35962
-  tps: 5079.60547
+  dps: 7996.34525
+  tps: 5132.84192
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7931.35527
-  tps: 5054.76498
+  dps: 7977.99083
+  tps: 5109.17129
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7929.53149
-  tps: 5052.92938
+  dps: 7974.64145
+  tps: 5106.2296
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7561.21189
-  tps: 4902.30092
+  dps: 7611.13416
+  tps: 4958.16485
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7912.79742
-  tps: 5039.39687
+  dps: 7955.2242
+  tps: 5089.57829
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7948.30213
-  tps: 5068.45432
+  dps: 7990.95808
+  tps: 5118.78399
   hps: 278.22315
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50179"
  value: {
-  dps: 7987.77382
-  tps: 5107.69737
+  dps: 8032.95543
+  tps: 5161.19364
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50708"
  value: {
-  dps: 7987.77382
-  tps: 5107.69737
+  dps: 8032.95543
+  tps: 5161.19364
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7487.3722
-  tps: 4861.42124
+  dps: 7526.77385
+  tps: 4907.41177
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7940.73072
-  tps: 5061.78717
+  dps: 7983.34192
+  tps: 5112.19294
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7947.30326
-  tps: 5067.05548
+  dps: 7989.95786
+  tps: 5117.51403
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7912.79742
-  tps: 5039.39687
+  dps: 7955.2242
+  tps: 5089.57829
   hps: 269.38086
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7912.79742
-  tps: 5039.39687
+  dps: 7955.2242
+  tps: 5089.57829
   hps: 270.31002
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7449.60822
-  tps: 4815.7598
+  dps: 7496.53761
+  tps: 4867.98232
   hps: 265.66963
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7458.35181
-  tps: 4823.10604
+  dps: 7505.82541
+  tps: 4875.76278
   hps: 265.66963
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7987.77382
-  tps: 5107.69737
+  dps: 8032.95543
+  tps: 5161.19364
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 8024.62541
-  tps: 5136.70382
+  dps: 8070.05705
+  tps: 5190.50171
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7912.79742
-  tps: 5039.39687
+  dps: 7955.2242
+  tps: 5089.57829
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7945.85457
-  tps: 5075.20781
+  dps: 7990.79707
+  tps: 5128.39487
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7187.07389
-  tps: 4638.18637
+  dps: 7226.44045
+  tps: 4683.04421
   hps: 255.62308
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6546.72039
-  tps: 4185.19131
+  dps: 6586.71076
+  tps: 4228.55747
   hps: 270.24427
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7934.9471
-  tps: 5279.89667
+  dps: 7973.99309
+  tps: 5321.84729
   hps: 297.77471
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7174.528
-  tps: 4717.12046
+  dps: 7228.32658
+  tps: 4777.27408
   hps: 308.77393
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7987.77382
-  tps: 5107.69737
+  dps: 8032.95543
+  tps: 5161.19364
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7902.73169
-  tps: 5040.75942
+  dps: 7947.33631
+  tps: 5093.55962
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7911.52279
-  tps: 5050.18242
+  dps: 7958.00816
+  tps: 5104.33806
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7902.73169
-  tps: 5040.75942
+  dps: 7947.33631
+  tps: 5093.55962
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8109.57817
-  tps: 5136.1047
+  dps: 8153.02192
+  tps: 5184.06066
   hps: 238.25177
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7902.73169
-  tps: 5040.75942
+  dps: 7947.33631
+  tps: 5093.55962
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7902.73169
-  tps: 5040.75942
+  dps: 7947.33631
+  tps: 5093.55962
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7902.73169
-  tps: 5040.75942
+  dps: 7947.33631
+  tps: 5093.55962
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 299.59146
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7484.98936
-  tps: 4852.08639
+  dps: 7530.13615
+  tps: 4903.62369
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 7480.05266
-  tps: 4801.41676
+  dps: 7524.05289
+  tps: 4851.84607
   hps: 265.66963
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7599.51022
-  tps: 4876.03208
+  dps: 7641.68644
+  tps: 4925.24482
   hps: 264.72419
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StormshroudArmor"
  value: {
-  dps: 5992.38503
-  tps: 3872.82542
+  dps: 6027.02866
+  tps: 3911.58651
   hps: 204.81996
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7947.30326
-  tps: 5067.05548
+  dps: 7989.95786
+  tps: 5117.51403
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7940.73072
-  tps: 5061.78717
+  dps: 7983.34192
+  tps: 5112.19294
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7929.22877
-  tps: 5052.56764
+  dps: 7971.76404
+  tps: 5102.88102
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7724.89772
-  tps: 5048.98316
+  dps: 7783.82464
+  tps: 5108.03978
   hps: 277.93737
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6691.18112
-  tps: 4267.46118
+  dps: 6732.47421
+  tps: 4313.20341
   hps: 289.52451
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7378.19457
-  tps: 4678.83112
+  dps: 7424.66381
+  tps: 4731.67027
   hps: 251.95663
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7958.65181
-  tps: 5055.65486
+  dps: 8005.43775
+  tps: 5107.97955
   hps: 263.46359
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7579.80487
-  tps: 4908.43491
+  dps: 7630.5444
+  tps: 4963.43683
   hps: 267.87566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7586.4597
-  tps: 4927.36738
+  dps: 7631.37885
+  tps: 4977.52883
   hps: 264.72419
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7912.79742
-  tps: 5039.39687
+  dps: 7955.2242
+  tps: 5089.57829
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7912.79742
-  tps: 5039.39687
+  dps: 7955.2242
+  tps: 5089.57829
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7483.8836
-  tps: 4786.84318
+  dps: 7526.94402
+  tps: 4836.49894
   hps: 263.46359
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7912.79742
-  tps: 5039.39687
+  dps: 7955.2242
+  tps: 5089.57829
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7912.79742
-  tps: 5039.39687
+  dps: 7955.2242
+  tps: 5089.57829
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6333.12583
-  tps: 4118.36918
+  dps: 6374.13471
+  tps: 4164.15754
   hps: 230.2196
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7647.12397
-  tps: 4867.91669
+  dps: 7687.78157
+  tps: 4916.95095
   hps: 264.74695
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7396.20016
-  tps: 4766.7816
+  dps: 7445.12401
+  tps: 4821.49891
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 8047.30332
-  tps: 5154.55394
+  dps: 8092.88882
+  tps: 5208.53745
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 7974.78522
-  tps: 5111.29733
+  dps: 8017.83314
+  tps: 5161.16075
   hps: 265.34082
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36179.31505
-  tps: 38760.64257
+  dps: 36222.16901
+  tps: 38806.87831
   hps: 261.42005
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7779.11681
-  tps: 5075.87099
+  dps: 7821.32368
+  tps: 5123.77288
   hps: 264.56969
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11118.74767
-  tps: 5585.20045
+  dps: 11197.08555
+  tps: 5671.76828
   hps: 231.49848
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 21876.25786
-  tps: 24106.16443
+  dps: 21883.09234
+  tps: 24104.41002
   hps: 158.16236
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3855.54368
-  tps: 2782.78693
+  dps: 3864.15784
+  tps: 2782.99681
   hps: 159.48827
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4866.82648
-  tps: 2833.86938
+  dps: 4925.46991
+  tps: 2863.8087
   hps: 142.062
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 46558.3061
-  tps: 50091.62896
+  dps: 46630.1848
+  tps: 50168.81961
   hps: 320.4671
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10196.70287
-  tps: 6776.91034
+  dps: 10242.21918
+  tps: 6832.10793
   hps: 327.90162
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14215.03155
-  tps: 7459.36114
+  dps: 14249.31176
+  tps: 7498.85252
   hps: 283.68577
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 29330.47683
-  tps: 32416.30245
+  dps: 29347.45447
+  tps: 32420.54449
   hps: 210.32917
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5281.13115
-  tps: 3890.90892
+  dps: 5296.84563
+  tps: 3892.91502
   hps: 211.33915
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6483.45579
-  tps: 3955.828
+  dps: 6530.03404
+  tps: 3961.61841
   hps: 180.53464
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36757.79823
-  tps: 39258.12953
+  dps: 36805.89138
+  tps: 39310.28264
   hps: 261.88786
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7987.77382
-  tps: 5107.69737
+  dps: 8032.95543
+  tps: 5161.19364
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11501.1503
-  tps: 5644.52374
+  dps: 11580.71394
+  tps: 5732.02094
   hps: 231.63366
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 22087.25944
-  tps: 24294.45779
+  dps: 22094.85284
+  tps: 24292.82052
   hps: 158.09971
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3933.31549
-  tps: 2800.24593
+  dps: 3945.67933
+  tps: 2803.16899
   hps: 160.37453
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5038.532
-  tps: 2870.69471
+  dps: 5101.97353
+  tps: 2901.84378
   hps: 142.176
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 46631.38163
-  tps: 49864.90766
+  dps: 46700.19374
+  tps: 49939.13248
   hps: 321.79215
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10345.53605
-  tps: 6747.90355
+  dps: 10390.02013
+  tps: 6797.27018
   hps: 327.66427
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14674.25989
-  tps: 7527.53214
+  dps: 14682.74307
+  tps: 7552.85592
   hps: 279.90437
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 29433.82503
-  tps: 32482.48661
+  dps: 29443.58498
+  tps: 32479.5714
   hps: 209.69784
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5360.58125
-  tps: 3890.2795
+  dps: 5374.6586
+  tps: 3891.01135
   hps: 211.97167
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6647.8182
-  tps: 3959.05672
+  dps: 6693.30905
+  tps: 3960.19317
   hps: 175.59036
  }
 }
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7655.0955
-  tps: 4966.74089
+  dps: 7696.31128
+  tps: 5013.1652
   hps: 262.8333
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -46,1184 +46,1184 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7404.36413
-  tps: 4775.20472
+  dps: 7414.48195
+  tps: 4783.96802
   hps: 369.59868
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7404.36413
-  tps: 4775.20472
+  dps: 7414.48195
+  tps: 4783.96802
   hps: 383.43105
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7915.07706
-  tps: 5043.62092
+  dps: 7930.91456
+  tps: 5056.10193
   hps: 270.31002
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7596.58501
-  tps: 4941.83029
+  dps: 7607.91025
+  tps: 4955.64652
   hps: 264.72419
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7404.38729
-  tps: 4775.17635
+  dps: 7414.50365
+  tps: 4783.92678
   hps: 354.03666
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7404.38729
-  tps: 4775.17635
+  dps: 7414.50365
+  tps: 4783.92678
   hps: 354.03666
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7932.6785
-  tps: 5058.05099
+  dps: 7951.22896
+  tps: 5073.25695
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7677.63184
-  tps: 4875.04156
+  dps: 7695.79744
+  tps: 4892.00942
   hps: 257.00534
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 6484.60977
-  tps: 4171.80676
+  dps: 6493.44089
+  tps: 4181.19625
   hps: 232.68485
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6303.17213
-  tps: 4092.56581
+  dps: 6314.23983
+  tps: 4102.61461
   hps: 224.48378
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6109.80272
-  tps: 3922.06412
+  dps: 6123.65682
+  tps: 3935.00522
   hps: 224.07309
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7915.07706
-  tps: 4942.7485
+  dps: 7930.91456
+  tps: 4954.97989
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7990.50391
-  tps: 5112.51596
+  dps: 8006.77243
+  tps: 5125.30432
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7990.50391
-  tps: 5112.51596
+  dps: 8006.77243
+  tps: 5125.30432
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7998.77144
-  tps: 5120.97977
+  dps: 8018.14422
+  tps: 5137.09809
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 363.59146
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7496.23671
-  tps: 4863.55381
+  dps: 7511.1972
+  tps: 4875.98695
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7516.52562
-  tps: 4887.35139
+  dps: 7533.71043
+  tps: 4903.0983
   hps: 263.77874
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7750.5313
-  tps: 4953.41647
+  dps: 7766.2444
+  tps: 4965.75993
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 7556.52522
-  tps: 4894.24138
+  dps: 7565.41603
+  tps: 4905.68159
   hps: 279.46859
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 6597.34079
-  tps: 4232.77376
+  dps: 6603.3129
+  tps: 4241.52791
   hps: 296.98863
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8235.17732
-  tps: 5276.96283
+  dps: 8251.15184
+  tps: 5289.30094
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7479.52559
-  tps: 4848.10688
+  dps: 7495.87166
+  tps: 4863.42452
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7789.41441
-  tps: 5141.49336
+  dps: 7800.51844
+  tps: 5153.10702
   hps: 272.60288
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7798.96293
-  tps: 5173.71454
+  dps: 7809.43146
+  tps: 5182.73295
   hps: 272.28773
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7934.92546
-  tps: 5060.61293
+  dps: 7953.31638
+  tps: 5075.6568
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7619.83863
-  tps: 4883.28481
+  dps: 7628.19998
+  tps: 4892.84143
   hps: 263.46359
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7589.05379
-  tps: 4861.04035
+  dps: 7600.7134
+  tps: 4872.27609
   hps: 262.51815
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7915.07706
-  tps: 5043.62092
+  dps: 7930.91456
+  tps: 5056.10193
   hps: 270.31002
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7915.07706
-  tps: 5043.62092
+  dps: 7930.91456
+  tps: 5056.10193
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7932.6785
-  tps: 5058.05099
+  dps: 7951.22896
+  tps: 5073.25695
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7930.85824
-  tps: 5056.17436
+  dps: 7948.38397
+  tps: 5070.60399
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7551.52074
-  tps: 4792.5856
+  dps: 7562.36844
+  tps: 4801.365
   hps: 266.61507
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 281.53732
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7915.07706
-  tps: 5043.62092
+  dps: 7930.91456
+  tps: 5056.10193
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7547.27502
-  tps: 4906.71394
+  dps: 7556.49124
+  tps: 4919.14332
   hps: 265.03933
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7484.1879
-  tps: 4852.27823
+  dps: 7496.8647
+  tps: 4862.25005
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7467.17043
-  tps: 4835.48997
+  dps: 7478.05563
+  tps: 4844.48945
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7915.07706
-  tps: 5043.62092
+  dps: 7930.91456
+  tps: 5056.10193
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7915.07706
-  tps: 5043.62092
+  dps: 7930.91456
+  tps: 5056.10193
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 8007.51682
-  tps: 5125.91278
+  dps: 8023.83031
+  tps: 5138.73815
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7665.44745
-  tps: 4985.60344
+  dps: 7676.10181
+  tps: 4994.82223
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7503.00457
-  tps: 4872.3547
+  dps: 7519.5528
+  tps: 4889.05452
   hps: 264.72419
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 7954.10908
-  tps: 5084.42681
+  dps: 7970.25378
+  tps: 5097.10913
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7932.6785
-  tps: 5058.05099
+  dps: 7951.22896
+  tps: 5073.25695
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7930.85824
-  tps: 5056.17436
+  dps: 7948.38397
+  tps: 5070.60399
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7569.53504
-  tps: 4910.83472
+  dps: 7579.93374
+  tps: 4919.836
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7915.07706
-  tps: 5043.62092
+  dps: 7930.91456
+  tps: 5056.10193
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7950.64182
-  tps: 5072.63658
+  dps: 7966.22794
+  tps: 5084.93125
   hps: 278.22315
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50179"
  value: {
-  dps: 7990.50391
-  tps: 5112.51596
+  dps: 8006.77243
+  tps: 5125.30432
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50708"
  value: {
-  dps: 7990.50391
-  tps: 5112.51596
+  dps: 8006.77243
+  tps: 5125.30432
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7487.22944
-  tps: 4862.64101
+  dps: 7503.41375
+  tps: 4877.80279
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7943.01509
-  tps: 5066.02462
+  dps: 7958.92825
+  tps: 5078.56688
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7949.58874
-  tps: 5071.29608
+  dps: 7965.5197
+  tps: 5083.85276
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7915.07706
-  tps: 5043.62092
+  dps: 7930.91456
+  tps: 5056.10193
   hps: 269.38086
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7915.07706
-  tps: 5043.62092
+  dps: 7930.91456
+  tps: 5056.10193
   hps: 270.31002
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7426.0672
-  tps: 4788.6912
-  hps: 263.77874
+  dps: 7473.62595
+  tps: 4836.73617
+  hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7434.69651
-  tps: 4795.90136
-  hps: 263.77874
+  dps: 7482.62711
+  tps: 4844.32526
+  hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7990.50391
-  tps: 5112.51596
+  dps: 8006.77243
+  tps: 5125.30432
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 8027.36522
-  tps: 5141.54241
+  dps: 8043.73117
+  tps: 5154.41094
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7915.07706
-  tps: 5043.62092
+  dps: 7930.91456
+  tps: 5056.10193
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 7948.5993
-  tps: 5080.02361
+  dps: 7964.73257
+  tps: 5092.69699
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 7183.65126
-  tps: 4635.14064
+  dps: 7200.89044
+  tps: 4650.13363
   hps: 255.62308
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 6551.51351
-  tps: 4187.48934
+  dps: 6558.32811
+  tps: 4196.40212
   hps: 270.24427
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7935.03739
-  tps: 5276.98883
+  dps: 7950.8625
+  tps: 5295.51975
   hps: 297.77471
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 7186.95774
-  tps: 4727.72962
+  dps: 7188.21334
+  tps: 4730.44798
   hps: 308.77393
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7990.50391
-  tps: 5112.51596
+  dps: 8006.77243
+  tps: 5125.30432
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 7905.43935
-  tps: 5045.53186
+  dps: 7921.48303
+  tps: 5058.1352
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 7914.92216
-  tps: 5055.70061
+  dps: 7931.17487
+  tps: 5068.53106
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 7905.43935
-  tps: 5045.53186
+  dps: 7921.48303
+  tps: 5058.1352
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 8111.80867
-  tps: 5137.03213
+  dps: 8125.37063
+  tps: 5150.58475
   hps: 238.25177
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 7905.43935
-  tps: 5045.53186
+  dps: 7921.48303
+  tps: 5058.1352
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 7905.43935
-  tps: 5045.53186
+  dps: 7921.48303
+  tps: 5058.1352
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 7905.43935
-  tps: 5045.53186
+  dps: 7921.48303
+  tps: 5058.1352
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 299.59146
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7487.17675
-  tps: 4855.14039
+  dps: 7499.17266
+  tps: 4864.64157
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 7484.71043
-  tps: 4806.51829
+  dps: 7496.50604
+  tps: 4817.36718
   hps: 265.66963
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7601.26796
-  tps: 4878.57743
+  dps: 7616.43586
+  tps: 4892.2014
   hps: 264.72419
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StormshroudArmor"
  value: {
-  dps: 5995.22137
-  tps: 3873.89693
+  dps: 6004.47243
+  tps: 3885.85546
   hps: 204.81996
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7949.58874
-  tps: 5071.29608
+  dps: 7965.5197
+  tps: 5083.85276
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7943.01509
-  tps: 5066.02462
+  dps: 7958.92825
+  tps: 5078.56688
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7931.51119
-  tps: 5056.79957
+  dps: 7947.3932
+  tps: 5069.31661
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 7727.96993
-  tps: 5049.12104
+  dps: 7743.81167
+  tps: 5066.62197
   hps: 277.93737
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 6694.74984
-  tps: 4269.82203
+  dps: 6705.12504
+  tps: 4279.81442
   hps: 289.52451
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7379.69125
-  tps: 4681.19544
+  dps: 7398.49233
+  tps: 4697.9724
   hps: 251.95663
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7963.28032
-  tps: 5059.93719
+  dps: 7975.91081
+  tps: 5072.09354
   hps: 263.46359
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7589.08502
-  tps: 4916.37019
+  dps: 7597.78763
+  tps: 4925.19714
   hps: 267.87566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7590.24272
-  tps: 4930.56636
+  dps: 7601.95232
+  tps: 4941.83932
   hps: 264.72419
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7915.07706
-  tps: 5043.62092
+  dps: 7930.91456
+  tps: 5056.10193
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7915.07706
-  tps: 5043.62092
+  dps: 7930.91456
+  tps: 5056.10193
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7487.25612
-  tps: 4790.77541
+  dps: 7501.70717
+  tps: 4803.83275
   hps: 263.46359
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7915.07706
-  tps: 5043.62092
+  dps: 7930.91456
+  tps: 5056.10193
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7915.07706
-  tps: 5043.62092
+  dps: 7930.91456
+  tps: 5056.10193
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6336.00831
-  tps: 4120.49762
+  dps: 6347.51923
+  tps: 4132.10568
   hps: 230.2196
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7644.1096
-  tps: 4865.85616
+  dps: 7664.45769
+  tps: 4885.16685
   hps: 264.74695
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7404.37573
-  tps: 4775.16124
+  dps: 7414.53871
+  tps: 4783.96014
   hps: 264.40904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 8050.0491
-  tps: 5159.40483
+  dps: 8066.47501
+  tps: 5172.32271
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 7974.37442
-  tps: 5111.30479
+  dps: 7991.59054
+  tps: 5126.22255
   hps: 265.34082
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 35865.678
-  tps: 38253.39909
+  dps: 35968.66383
+  tps: 38412.81137
   hps: 261.42005
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7778.20427
-  tps: 5074.39422
+  dps: 7795.72355
+  tps: 5091.66639
   hps: 264.56969
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11156.80505
-  tps: 5619.92949
+  dps: 11135.48033
+  tps: 5602.22236
   hps: 231.49848
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 21636.5819
-  tps: 23720.56472
+  dps: 21706.5507
+  tps: 23841.66091
   hps: 158.16236
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3834.21906
-  tps: 2748.05288
+  dps: 3835.52191
+  tps: 2760.15078
   hps: 159.48827
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4892.67778
-  tps: 2823.33402
+  dps: 4846.79478
+  tps: 2809.23478
   hps: 142.062
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 46169.81295
-  tps: 49449.67001
+  dps: 46291.21235
+  tps: 49648.92161
   hps: 320.4671
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10190.64243
-  tps: 6773.16673
+  dps: 10221.03637
+  tps: 6801.01813
   hps: 327.90162
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14201.90775
-  tps: 7439.70267
+  dps: 14242.17848
+  tps: 7485.03166
   hps: 283.68577
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 29034.46406
-  tps: 31936.53859
+  dps: 29118.81955
+  tps: 32086.26534
   hps: 210.32917
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5257.31894
-  tps: 3848.5004
+  dps: 5249.22907
+  tps: 3856.35123
   hps: 211.33915
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6493.03979
-  tps: 3919.2043
+  dps: 6451.53316
+  tps: 3919.85304
   hps: 180.53464
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36446.01752
-  tps: 38752.14328
+  dps: 36548.78089
+  tps: 38910.76625
   hps: 261.88786
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7990.50391
-  tps: 5112.51596
+  dps: 8006.77243
+  tps: 5125.30432
   hps: 265.35448
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11540.23275
-  tps: 5679.93211
+  dps: 11518.6172
+  tps: 5661.83175
   hps: 231.63366
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 21846.76216
-  tps: 23906.28327
+  dps: 21915.68581
+  tps: 24027.33152
   hps: 158.09971
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3913.34648
-  tps: 2765.90819
+  dps: 3912.26789
+  tps: 2776.45458
   hps: 160.37453
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P1 -Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5068.5601
-  tps: 2860.62339
+  dps: 5018.19277
+  tps: 2845.68176
   hps: 142.176
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 46242.90748
-  tps: 49226.83396
+  dps: 46366.97977
+  tps: 49427.73421
   hps: 321.79215
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10337.4355
-  tps: 6737.30286
+  dps: 10365.93895
+  tps: 6769.32612
   hps: 327.66427
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14643.47326
-  tps: 7500.65844
+  dps: 14696.47552
+  tps: 7548.85246
   hps: 279.90437
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 29130.36566
-  tps: 31995.37655
+  dps: 29221.09804
+  tps: 32151.90593
   hps: 209.69784
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5337.09226
-  tps: 3848.40308
+  dps: 5333.2494
+  tps: 3859.94006
   hps: 211.97167
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P2-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6656.93612
-  tps: 3919.27089
+  dps: 6613.79953
+  tps: 3921.00791
   hps: 175.59036
  }
 }
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7653.91571
-  tps: 4964.29234
+  dps: 7671.25947
+  tps: 4982.74458
   hps: 262.8333
  }
 }

--- a/sim/deathknight/summon_gargoyle.go
+++ b/sim/deathknight/summon_gargoyle.go
@@ -143,7 +143,6 @@ func (garg *GargoylePet) OnGCDReady(_ *core.Simulation) {
 
 func (garg *GargoylePet) registerGargoyleStrikeSpell() {
 	attackPowerModifier := (1.0 + 0.04*float64(garg.dkOwner.Talents.Impurity)) / 3.0
-	var outcomeApplier core.OutcomeApplier
 
 	garg.GargoyleStrike = garg.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 51963},
@@ -162,11 +161,10 @@ func (garg *GargoylePet) registerGargoyleStrikeSpell() {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := 2.05*sim.Roll(51, 69) + attackPowerModifier*spell.MeleeAttackPower()
-			result := spell.CalcDamage(sim, target, baseDamage, outcomeApplier)
+			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
 			spell.DealDamage(sim, result)
 
 			garg.GargoyleStrike.Cast(sim, garg.CurrentTarget)
 		},
 	})
-	outcomeApplier = garg.GargoyleStrike.OutcomeMagicCritFixedChance(0.05)
 }

--- a/sim/deathknight/summon_gargoyle.go
+++ b/sim/deathknight/summon_gargoyle.go
@@ -143,6 +143,7 @@ func (garg *GargoylePet) OnGCDReady(_ *core.Simulation) {
 
 func (garg *GargoylePet) registerGargoyleStrikeSpell() {
 	attackPowerModifier := (1.0 + 0.04*float64(garg.dkOwner.Talents.Impurity)) / 3.0
+	var outcomeApplier core.OutcomeApplier
 
 	garg.GargoyleStrike = garg.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 51963},
@@ -161,10 +162,11 @@ func (garg *GargoylePet) registerGargoyleStrikeSpell() {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := 2.05*sim.Roll(51, 69) + attackPowerModifier*spell.MeleeAttackPower()
-			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
+			result := spell.CalcDamage(sim, target, baseDamage, outcomeApplier)
 			spell.DealDamage(sim, result)
 
 			garg.GargoyleStrike.Cast(sim, garg.CurrentTarget)
 		},
 	})
+	outcomeApplier = garg.GargoyleStrike.OutcomeMagicCritFixedChance(0.05)
 }

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -46,811 +46,811 @@ character_stats_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1478.39477
-  tps: 4467.18021
+  dps: 1483.10316
+  tps: 4527.01859
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 1404.93813
-  tps: 4274.06295
+  dps: 1408.69393
+  tps: 4326.14232
   hps: 83.17235
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 1404.93813
-  tps: 4274.06295
+  dps: 1408.69393
+  tps: 4326.14232
   hps: 83.17235
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1408.85779
-  tps: 4292.17939
+  dps: 1412.63947
+  tps: 4344.3789
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1377.54357
-  tps: 4197.16981
+  dps: 1381.20909
+  tps: 4248.03423
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1289.96043
-  tps: 3914.45553
+  dps: 1293.43074
+  tps: 3962.28554
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1255.88047
-  tps: 3803.82235
+  dps: 1259.2028
+  tps: 3850.2128
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1177.33798
-  tps: 3583.00443
+  dps: 1180.56341
+  tps: 3627.8996
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4181.1189
+  dps: 1406.10149
+  tps: 4231.93924
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 1804.73957
-  tps: 5191.49876
+  dps: 1808.67875
+  tps: 5247.87242
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 1857.69066
-  tps: 5286.89164
+  dps: 1861.57212
+  tps: 5342.41521
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1420.1532
-  tps: 4325.84918
+  dps: 1424.15072
+  tps: 4381.1577
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
   hps: 64
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1425.49243
-  tps: 4348.71544
+  dps: 1429.09932
+  tps: 4398.67134
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1476.70789
-  tps: 4463.04033
+  dps: 1481.39933
+  tps: 4516.89932
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 1455.43498
-  tps: 4433.92142
+  dps: 1459.32148
+  tps: 4487.71736
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 1609.51786
-  tps: 4878.74938
+  dps: 1611.651
+  tps: 4908.81735
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedPlate"
  value: {
-  dps: 1415.65176
-  tps: 4303.6036
+  dps: 1419.54536
+  tps: 4356.70782
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Death'sChoice-47464"
  value: {
-  dps: 1548.09145
-  tps: 4716.90254
+  dps: 1552.25479
+  tps: 4774.5167
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1417.34764
-  tps: 4319.81101
+  dps: 1421.69139
+  tps: 4380.22777
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 1499.39749
-  tps: 4525.86822
+  dps: 1502.96904
+  tps: 4573.92074
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 1509.2291
-  tps: 4548.8911
+  dps: 1512.81378
+  tps: 4599.76329
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1409.63255
-  tps: 4288.38915
+  dps: 1413.39156
+  tps: 4340.50806
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1410.11216
-  tps: 4297.17336
+  dps: 1413.7015
+  tps: 4346.58101
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 1456.36769
-  tps: 4380.88248
+  dps: 1460.11072
+  tps: 4432.30741
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 1453.44967
-  tps: 4378.35418
+  dps: 1457.20908
+  tps: 4430.49651
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1406.10149
+  tps: 4318.30535
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1406.10149
+  tps: 4318.30535
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1408.85779
-  tps: 4292.17939
+  dps: 1412.63947
+  tps: 4344.3789
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1408.39485
-  tps: 4286.13561
+  dps: 1412.63947
+  tps: 4344.3789
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 1431.41031
-  tps: 4345.80026
+  dps: 1435.13278
+  tps: 4396.66367
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1406.10149
+  tps: 4318.30535
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1458.22115
-  tps: 4431.99958
+  dps: 1461.85846
+  tps: 4469.68823
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1424.01663
-  tps: 4352.842
+  dps: 1427.63704
+  tps: 4403.28315
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1420.91927
-  tps: 4337.22596
+  dps: 1425.34414
+  tps: 4398.52881
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1406.10149
+  tps: 4318.30535
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1406.10149
+  tps: 4318.30535
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1463.71395
-  tps: 4442.25301
+  dps: 1467.58155
+  tps: 4495.92073
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 1453.10347
-  tps: 4427.26614
+  dps: 1457.15586
+  tps: 4474.7743
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1408.85779
-  tps: 4292.17939
+  dps: 1412.63947
+  tps: 4344.3789
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1408.39485
-  tps: 4286.13561
+  dps: 1412.63947
+  tps: 4344.3789
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1448.50388
-  tps: 4392.2661
+  dps: 1452.34065
+  tps: 4445.30081
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1406.10149
+  tps: 4318.30535
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1410.68693
-  tps: 4291.57074
+  dps: 1414.44866
+  tps: 4343.72756
   hps: 16.36114
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-LastWord-50179"
  value: {
-  dps: 1634.71373
-  tps: 4795.502
+  dps: 1638.47346
+  tps: 4849.54454
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-LastWord-50708"
  value: {
-  dps: 1654.58397
-  tps: 4842.10577
+  dps: 1658.35389
+  tps: 4896.29524
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1445.3466
-  tps: 4387.5869
+  dps: 1449.53441
+  tps: 4445.59626
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 1429.8888
-  tps: 4394.85096
+  dps: 1433.2598
+  tps: 4446.10699
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1407.98063
-  tps: 4283.40445
+  dps: 1411.73538
+  tps: 4335.46397
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1409.10108
-  tps: 4286.78543
+  dps: 1412.85872
+  tps: 4338.88523
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1410.68693
-  tps: 4291.57074
+  dps: 1414.44866
+  tps: 4343.72756
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 1417.51772
-  tps: 4312.18278
+  dps: 1421.29708
+  tps: 4364.58518
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 1419.13661
-  tps: 4317.06779
+  dps: 1422.92014
+  tps: 4369.52839
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1406.10149
+  tps: 4318.30535
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1406.10149
+  tps: 4318.30535
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1403.47639
-  tps: 4260.23644
+  dps: 1412.38809
+  tps: 4323.69302
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1404.00918
-  tps: 4261.34116
+  dps: 1413.23151
+  tps: 4325.44185
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1419.26935
-  tps: 4311.26174
+  dps: 1423.22474
+  tps: 4366.21973
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1406.10149
+  tps: 4318.30535
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 1524.86055
-  tps: 4642.76765
+  dps: 1527.37877
+  tps: 4678.65281
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgebornePlate"
  value: {
-  dps: 1383.99022
-  tps: 4224.21291
+  dps: 1387.69796
+  tps: 4275.60548
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 1699.75985
-  tps: 5161.68399
+  dps: 1702.21631
+  tps: 5196.91325
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 1491.82874
-  tps: 4545.63538
+  dps: 1496.12911
+  tps: 4602.01562
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1408.94946
-  tps: 4285.08069
+  dps: 1412.70034
+  tps: 4337.07515
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Shadowmourne-49623"
  value: {
-  dps: 2033.16397
-  tps: 5802.05357
+  dps: 2037.16335
+  tps: 5858.03018
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SoulPreserver-37111"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SouloftheDead-40382"
  value: {
-  dps: 1424.98791
-  tps: 4354.85595
+  dps: 1428.60832
+  tps: 4405.29709
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 1427.49694
-  tps: 4332.46615
+  dps: 1431.17986
+  tps: 4383.10724
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 1442.52147
-  tps: 4408.11473
+  dps: 1446.41469
+  tps: 4462.07222
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-StormshroudArmor"
  value: {
-  dps: 1144.48535
-  tps: 3528.76368
+  dps: 1147.87405
+  tps: 3574.70484
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1410.68693
-  tps: 4291.57074
+  dps: 1414.44866
+  tps: 4343.72756
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1409.10108
-  tps: 4286.78543
+  dps: 1412.85872
+  tps: 4338.88523
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1406.32585
-  tps: 4278.41114
+  dps: 1410.07633
+  tps: 4330.41116
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 1672.39983
-  tps: 5043.32932
+  dps: 1682.82064
+  tps: 5102.25806
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sPlate"
  value: {
-  dps: 1402.50661
-  tps: 4300.31858
+  dps: 1406.53396
+  tps: 4353.06439
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1395.14664
-  tps: 4288.22087
+  dps: 1398.80899
+  tps: 4340.64755
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1409.18772
-  tps: 4273.24365
+  dps: 1412.9283
+  tps: 4325.1021
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1443.84575
-  tps: 4377.20928
+  dps: 1447.86267
+  tps: 4431.1512
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1455.03694
-  tps: 4403.57171
+  dps: 1458.87751
+  tps: 4456.77784
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1406.10149
+  tps: 4318.30535
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1406.10149
+  tps: 4318.30535
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 1423.04798
-  tps: 4312.26902
+  dps: 1426.78917
+  tps: 4363.77872
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1406.10149
+  tps: 4318.30535
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1406.10149
+  tps: 4318.30535
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1248.58673
-  tps: 3782.19151
+  dps: 1251.94372
+  tps: 3829.08521
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 1191.11544
-  tps: 3824.71542
+  dps: 1194.53293
+  tps: 3872.99268
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-WingedTalisman-37844"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1408.69904
+  tps: 4326.21647
  }
 }
 dps_results: {
  key: "TestBloodTank-Average-Default"
  value: {
-  dps: 1786.21336
-  tps: 5979.18095
+  dps: 1789.23523
+  tps: 6019.62063
   dtps: 242.7252
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6391.46613
-  tps: 14590.34449
+  dps: 6395.067
+  tps: 14640.07803
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1428.67795
-  tps: 4300.84525
+  dps: 1432.34347
+  tps: 4351.51715
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1620.10574
-  tps: 5809.04798
+  dps: 1627.86566
+  tps: 5909.02331
  }
 }
 dps_results: {
@@ -877,22 +877,22 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6422.09913
-  tps: 14674.7747
+  dps: 6425.7703
+  tps: 14725.46441
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1440.9324
-  tps: 4347.30934
+  dps: 1444.6689
+  tps: 4398.94723
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1643.91596
-  tps: 5934.28992
+  dps: 1651.92712
+  tps: 6037.59018
  }
 }
 dps_results: {
@@ -919,8 +919,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1812.31035
-  tps: 5983.93196
+  dps: 1816.47681
+  tps: 6035.67207
   dtps: 242.59616
  }
 }

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -46,881 +46,881 @@ character_stats_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1478.39477
-  tps: 4467.18021
+  dps: 1480.96322
+  tps: 4498.57027
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 1404.93813
-  tps: 4274.06295
+  dps: 1406.89213
+  tps: 4300.80476
   hps: 83.17235
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 1404.93813
-  tps: 4274.06295
+  dps: 1406.89213
+  tps: 4300.80476
   hps: 83.17235
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1408.85779
-  tps: 4292.17939
+  dps: 1410.1169
+  tps: 4310.02073
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1377.54357
-  tps: 4197.16981
+  dps: 1379.45808
+  tps: 4223.4228
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1289.96043
-  tps: 3914.45553
+  dps: 1291.7696
+  tps: 3939.31543
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1255.88047
-  tps: 3803.82235
+  dps: 1257.59779
+  tps: 3827.45737
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1177.33798
-  tps: 3583.00443
+  dps: 1178.9901
+  tps: 3605.58253
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4181.1189
+  dps: 1404.30626
+  tps: 4207.20051
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 1804.73957
-  tps: 5191.49876
+  dps: 1806.71689
+  tps: 5219.84038
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 1857.69066
-  tps: 5286.89164
+  dps: 1859.64481
+  tps: 5314.89219
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1420.1532
-  tps: 4325.84918
+  dps: 1421.48607
+  tps: 4344.75728
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
   hps: 64
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1425.49243
-  tps: 4348.71544
+  dps: 1426.95356
+  tps: 4368.91751
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1476.70789
-  tps: 4463.04033
+  dps: 1477.50414
+  tps: 4474.59759
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 1455.43498
-  tps: 4433.92142
+  dps: 1457.49741
+  tps: 4462.10831
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 1609.51786
-  tps: 4878.74938
+  dps: 1610.04488
+  tps: 4886.39881
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedPlate"
  value: {
-  dps: 1415.65176
-  tps: 4303.6036
+  dps: 1417.69828
+  tps: 4330.72113
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Death'sChoice-47464"
  value: {
-  dps: 1548.09145
-  tps: 4716.90254
+  dps: 1550.31306
+  tps: 4747.25543
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1417.34764
-  tps: 4319.81101
+  dps: 1418.98793
+  tps: 4343.24787
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 1499.39749
-  tps: 4525.86822
+  dps: 1501.10432
+  tps: 4547.70391
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 1509.2291
-  tps: 4548.8911
+  dps: 1511.02588
+  tps: 4573.91884
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1409.63255
-  tps: 4288.38915
+  dps: 1411.58724
+  tps: 4315.13621
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1410.11216
-  tps: 4297.17336
+  dps: 1411.17893
+  tps: 4312.22284
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 1456.36769
-  tps: 4380.88248
+  dps: 1458.30372
+  tps: 4406.89693
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 1453.44967
-  tps: 4378.35418
+  dps: 1455.37967
+  tps: 4404.76063
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1404.30626
+  tps: 4293.06174
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1404.30626
+  tps: 4293.06174
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1408.85779
-  tps: 4292.17939
+  dps: 1410.1169
+  tps: 4310.02073
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1408.39485
-  tps: 4286.13561
+  dps: 1410.1169
+  tps: 4310.02073
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 1431.41031
-  tps: 4345.80026
+  dps: 1433.3884
+  tps: 4372.15854
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1404.30626
+  tps: 4293.06174
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1458.22115
-  tps: 4431.99958
+  dps: 1458.45423
+  tps: 4432.48286
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1424.01663
-  tps: 4352.842
+  dps: 1424.42942
+  tps: 4358.83342
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1420.91927
-  tps: 4337.22596
+  dps: 1421.93031
+  tps: 4351.08608
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1404.30626
+  tps: 4293.06174
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1404.30626
+  tps: 4293.06174
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1463.71395
-  tps: 4442.25301
+  dps: 1465.7123
+  tps: 4469.61769
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 1453.10347
-  tps: 4427.26614
+  dps: 1453.84806
+  tps: 4436.15889
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1408.85779
-  tps: 4292.17939
+  dps: 1410.1169
+  tps: 4310.02073
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1408.39485
-  tps: 4286.13561
+  dps: 1410.1169
+  tps: 4310.02073
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1448.50388
-  tps: 4392.2661
+  dps: 1450.50124
+  tps: 4419.48523
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1404.30626
+  tps: 4293.06174
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1410.68693
-  tps: 4291.57074
+  dps: 1412.64302
+  tps: 4318.33711
   hps: 16.36114
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-LastWord-50179"
  value: {
-  dps: 1634.71373
-  tps: 4795.502
+  dps: 1636.64896
+  tps: 4823.30778
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-LastWord-50708"
  value: {
-  dps: 1654.58397
-  tps: 4842.10577
+  dps: 1656.52094
+  tps: 4869.93964
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1445.3466
-  tps: 4387.5869
+  dps: 1446.38265
+  tps: 4401.80748
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 1429.8888
-  tps: 4394.85096
+  dps: 1431.05109
+  tps: 4411.72105
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1407.98063
-  tps: 4283.40445
+  dps: 1409.93312
+  tps: 4310.12125
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1409.10108
-  tps: 4286.78543
+  dps: 1411.05506
+  tps: 4313.52276
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1410.68693
-  tps: 4291.57074
+  dps: 1412.64302
+  tps: 4318.33711
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 1417.51772
-  tps: 4312.18278
+  dps: 1419.4829
+  tps: 4339.07426
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 1419.13661
-  tps: 4317.06779
+  dps: 1421.10394
+  tps: 4343.98891
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1404.30626
+  tps: 4293.06174
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1404.30626
+  tps: 4293.06174
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1403.47639
-  tps: 4260.23644
+  dps: 1409.08529
+  tps: 4295.82126
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1404.00918
-  tps: 4261.34116
+  dps: 1409.75491
+  tps: 4297.20973
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1419.26935
-  tps: 4311.26174
+  dps: 1421.3251
+  tps: 4339.46431
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1404.30626
+  tps: 4293.06174
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 1524.86055
-  tps: 4642.76765
+  dps: 1525.45161
+  tps: 4651.34646
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgebornePlate"
  value: {
-  dps: 1383.99022
-  tps: 4224.21291
+  dps: 1385.92905
+  tps: 4250.74164
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 1699.75985
-  tps: 5161.68399
+  dps: 1701.33305
+  tps: 5184.09317
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 1491.82874
-  tps: 4545.63538
+  dps: 1494.19278
+  tps: 4574.77868
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1408.94946
-  tps: 4285.08069
+  dps: 1410.90139
+  tps: 4311.78486
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Shadowmourne-49623"
  value: {
-  dps: 2033.16397
-  tps: 5802.05357
+  dps: 2034.6305
+  tps: 5821.77925
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SoulPreserver-37111"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SouloftheDead-40382"
  value: {
-  dps: 1424.98791
-  tps: 4354.85595
+  dps: 1425.4007
+  tps: 4360.84737
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 1427.49694
-  tps: 4332.46615
+  dps: 1429.41549
+  tps: 4358.31535
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 1442.52147
-  tps: 4408.11473
+  dps: 1444.56451
+  tps: 4436.0896
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-StormshroudArmor"
  value: {
-  dps: 1144.48535
-  tps: 3528.76368
+  dps: 1145.57784
+  tps: 3543.98738
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1410.68693
-  tps: 4291.57074
+  dps: 1412.64302
+  tps: 4318.33711
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1409.10108
-  tps: 4286.78543
+  dps: 1411.05506
+  tps: 4313.52276
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1406.32585
-  tps: 4278.41114
+  dps: 1408.27614
+  tps: 4305.09763
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 1672.39983
-  tps: 5043.32932
+  dps: 1674.5956
+  tps: 5055.07469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sPlate"
  value: {
-  dps: 1402.50661
-  tps: 4300.31858
+  dps: 1404.64785
+  tps: 4327.4419
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1395.14664
-  tps: 4288.22087
+  dps: 1396.36197
+  tps: 4305.76365
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1409.18772
-  tps: 4273.24365
+  dps: 1411.13121
+  tps: 4299.83158
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1443.84575
-  tps: 4377.20928
+  dps: 1445.91098
+  tps: 4404.96209
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1455.03694
-  tps: 4403.57171
+  dps: 1457.04136
+  tps: 4430.94163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1404.30626
+  tps: 4293.06174
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1404.30626
+  tps: 4293.06174
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 1423.04798
-  tps: 4312.26902
+  dps: 1424.97526
+  tps: 4338.6361
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1404.30626
+  tps: 4293.06174
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1402.36124
-  tps: 4266.44786
+  dps: 1404.30626
+  tps: 4293.06174
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1248.58673
-  tps: 3782.19151
+  dps: 1250.29916
+  tps: 3805.75423
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 1191.11544
-  tps: 3824.71542
+  dps: 1192.09899
+  tps: 3838.70724
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-WingedTalisman-37844"
  value: {
-  dps: 1404.95211
-  tps: 4274.26583
+  dps: 1406.90057
+  tps: 4300.92717
  }
 }
 dps_results: {
  key: "TestBloodTank-Average-Default"
  value: {
-  dps: 1786.21336
-  tps: 5979.18095
+  dps: 1787.11877
+  tps: 5991.13505
   dtps: 242.7252
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6391.46613
-  tps: 14590.34449
+  dps: 6393.32756
+  tps: 14615.56711
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1428.67795
-  tps: 4300.84525
+  dps: 1430.56047
+  tps: 4326.3739
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1620.10574
-  tps: 5809.04798
+  dps: 1625.81162
+  tps: 5882.89054
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3253.06357
-  tps: 7571.29146
+  dps: 3254.04349
+  tps: 7582.96022
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 805.68718
-  tps: 2493.22843
+  dps: 806.63371
+  tps: 2505.11855
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 830.4129
-  tps: 3248.34473
+  dps: 832.13872
+  tps: 3267.94989
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6422.09913
-  tps: 14674.7747
+  dps: 6424.01077
+  tps: 14700.68249
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1440.9324
-  tps: 4347.30934
+  dps: 1442.86576
+  tps: 4373.53226
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1643.91596
-  tps: 5934.28992
+  dps: 1649.82581
+  tps: 6010.87445
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3280.12832
-  tps: 7643.56044
+  dps: 3281.12903
+  tps: 7655.4622
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 813.57132
-  tps: 2525.59788
+  dps: 814.53719
+  tps: 2537.71832
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 846.23346
-  tps: 3339.09731
+  dps: 848.04574
+  tps: 3359.79471
  }
 }
 dps_results: {
  key: "TestBloodTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1812.31035
-  tps: 5983.93196
+  dps: 1814.33809
+  tps: 6009.7374
   dtps: 242.59616
  }
 }

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -46,881 +46,881 @@ character_stats_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1483.10316
-  tps: 4527.01859
+  dps: 1478.39477
+  tps: 4467.18021
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 1408.69393
-  tps: 4326.14232
+  dps: 1404.93813
+  tps: 4274.06295
   hps: 83.17235
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 1408.69393
-  tps: 4326.14232
+  dps: 1404.93813
+  tps: 4274.06295
   hps: 83.17235
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1412.63947
-  tps: 4344.3789
+  dps: 1408.85779
+  tps: 4292.17939
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1381.20909
-  tps: 4248.03423
+  dps: 1377.54357
+  tps: 4197.16981
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1293.43074
-  tps: 3962.28554
+  dps: 1289.96043
+  tps: 3914.45553
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1259.2028
-  tps: 3850.2128
+  dps: 1255.88047
+  tps: 3803.82235
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1180.56341
-  tps: 3627.8996
+  dps: 1177.33798
+  tps: 3583.00443
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1406.10149
-  tps: 4231.93924
+  dps: 1402.36124
+  tps: 4181.1189
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 1808.67875
-  tps: 5247.87242
+  dps: 1804.73957
+  tps: 5191.49876
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 1861.57212
-  tps: 5342.41521
+  dps: 1857.69066
+  tps: 5286.89164
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1424.15072
-  tps: 4381.1577
+  dps: 1420.1532
+  tps: 4325.84918
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
   hps: 64
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1429.09932
-  tps: 4398.67134
+  dps: 1425.49243
+  tps: 4348.71544
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1481.39933
-  tps: 4516.89932
+  dps: 1476.70789
+  tps: 4463.04033
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 1459.32148
-  tps: 4487.71736
+  dps: 1455.43498
+  tps: 4433.92142
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 1611.651
-  tps: 4908.81735
+  dps: 1609.51786
+  tps: 4878.74938
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedPlate"
  value: {
-  dps: 1419.54536
-  tps: 4356.70782
+  dps: 1415.65176
+  tps: 4303.6036
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Death'sChoice-47464"
  value: {
-  dps: 1552.25479
-  tps: 4774.5167
+  dps: 1548.09145
+  tps: 4716.90254
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1421.69139
-  tps: 4380.22777
+  dps: 1417.34764
+  tps: 4319.81101
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 1502.96904
-  tps: 4573.92074
+  dps: 1499.39749
+  tps: 4525.86822
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 1512.81378
-  tps: 4599.76329
+  dps: 1509.2291
+  tps: 4548.8911
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 1413.39156
-  tps: 4340.50806
+  dps: 1409.63255
+  tps: 4288.38915
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1413.7015
-  tps: 4346.58101
+  dps: 1410.11216
+  tps: 4297.17336
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 1460.11072
-  tps: 4432.30741
+  dps: 1456.36769
+  tps: 4380.88248
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 1457.20908
-  tps: 4430.49651
+  dps: 1453.44967
+  tps: 4378.35418
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1406.10149
-  tps: 4318.30535
+  dps: 1402.36124
+  tps: 4266.44786
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1406.10149
-  tps: 4318.30535
+  dps: 1402.36124
+  tps: 4266.44786
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1412.63947
-  tps: 4344.3789
+  dps: 1408.85779
+  tps: 4292.17939
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1412.63947
-  tps: 4344.3789
+  dps: 1408.39485
+  tps: 4286.13561
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 1435.13278
-  tps: 4396.66367
+  dps: 1431.41031
+  tps: 4345.80026
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1406.10149
-  tps: 4318.30535
+  dps: 1402.36124
+  tps: 4266.44786
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1461.85846
-  tps: 4469.68823
+  dps: 1458.22115
+  tps: 4431.99958
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1427.63704
-  tps: 4403.28315
+  dps: 1424.01663
+  tps: 4352.842
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1425.34414
-  tps: 4398.52881
+  dps: 1420.91927
+  tps: 4337.22596
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1406.10149
-  tps: 4318.30535
+  dps: 1402.36124
+  tps: 4266.44786
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1406.10149
-  tps: 4318.30535
+  dps: 1402.36124
+  tps: 4266.44786
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1467.58155
-  tps: 4495.92073
+  dps: 1463.71395
+  tps: 4442.25301
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 1457.15586
-  tps: 4474.7743
+  dps: 1453.10347
+  tps: 4427.26614
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1412.63947
-  tps: 4344.3789
+  dps: 1408.85779
+  tps: 4292.17939
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1412.63947
-  tps: 4344.3789
+  dps: 1408.39485
+  tps: 4286.13561
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1452.34065
-  tps: 4445.30081
+  dps: 1448.50388
+  tps: 4392.2661
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1406.10149
-  tps: 4318.30535
+  dps: 1402.36124
+  tps: 4266.44786
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1414.44866
-  tps: 4343.72756
+  dps: 1410.68693
+  tps: 4291.57074
   hps: 16.36114
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-LastWord-50179"
  value: {
-  dps: 1638.47346
-  tps: 4849.54454
+  dps: 1634.71373
+  tps: 4795.502
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-LastWord-50708"
  value: {
-  dps: 1658.35389
-  tps: 4896.29524
+  dps: 1654.58397
+  tps: 4842.10577
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1449.53441
-  tps: 4445.59626
+  dps: 1445.3466
+  tps: 4387.5869
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 1433.2598
-  tps: 4446.10699
+  dps: 1429.8888
+  tps: 4394.85096
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1411.73538
-  tps: 4335.46397
+  dps: 1407.98063
+  tps: 4283.40445
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1412.85872
-  tps: 4338.88523
+  dps: 1409.10108
+  tps: 4286.78543
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1414.44866
-  tps: 4343.72756
+  dps: 1410.68693
+  tps: 4291.57074
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 1421.29708
-  tps: 4364.58518
+  dps: 1417.51772
+  tps: 4312.18278
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 1422.92014
-  tps: 4369.52839
+  dps: 1419.13661
+  tps: 4317.06779
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1406.10149
-  tps: 4318.30535
+  dps: 1402.36124
+  tps: 4266.44786
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1406.10149
-  tps: 4318.30535
+  dps: 1402.36124
+  tps: 4266.44786
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1412.38809
-  tps: 4323.69302
+  dps: 1403.47639
+  tps: 4260.23644
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1413.23151
-  tps: 4325.44185
+  dps: 1404.00918
+  tps: 4261.34116
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1423.22474
-  tps: 4366.21973
+  dps: 1419.26935
+  tps: 4311.26174
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1406.10149
-  tps: 4318.30535
+  dps: 1402.36124
+  tps: 4266.44786
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 1527.37877
-  tps: 4678.65281
+  dps: 1524.86055
+  tps: 4642.76765
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgebornePlate"
  value: {
-  dps: 1387.69796
-  tps: 4275.60548
+  dps: 1383.99022
+  tps: 4224.21291
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 1702.21631
-  tps: 5196.91325
+  dps: 1699.75985
+  tps: 5161.68399
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 1496.12911
-  tps: 4602.01562
+  dps: 1491.82874
+  tps: 4545.63538
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1412.70034
-  tps: 4337.07515
+  dps: 1408.94946
+  tps: 4285.08069
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Shadowmourne-49623"
  value: {
-  dps: 2037.16335
-  tps: 5858.03018
+  dps: 2033.16397
+  tps: 5802.05357
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SoulPreserver-37111"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SouloftheDead-40382"
  value: {
-  dps: 1428.60832
-  tps: 4405.29709
+  dps: 1424.98791
+  tps: 4354.85595
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 1431.17986
-  tps: 4383.10724
+  dps: 1427.49694
+  tps: 4332.46615
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 1446.41469
-  tps: 4462.07222
+  dps: 1442.52147
+  tps: 4408.11473
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-StormshroudArmor"
  value: {
-  dps: 1147.87405
-  tps: 3574.70484
+  dps: 1144.48535
+  tps: 3528.76368
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1414.44866
-  tps: 4343.72756
+  dps: 1410.68693
+  tps: 4291.57074
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1412.85872
-  tps: 4338.88523
+  dps: 1409.10108
+  tps: 4286.78543
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1410.07633
-  tps: 4330.41116
+  dps: 1406.32585
+  tps: 4278.41114
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 1682.82064
-  tps: 5102.25806
+  dps: 1672.39983
+  tps: 5043.32932
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sPlate"
  value: {
-  dps: 1406.53396
-  tps: 4353.06439
+  dps: 1402.50661
+  tps: 4300.31858
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1398.80899
-  tps: 4340.64755
+  dps: 1395.14664
+  tps: 4288.22087
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1412.9283
-  tps: 4325.1021
+  dps: 1409.18772
+  tps: 4273.24365
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1447.86267
-  tps: 4431.1512
+  dps: 1443.84575
+  tps: 4377.20928
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1458.87751
-  tps: 4456.77784
+  dps: 1455.03694
+  tps: 4403.57171
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1406.10149
-  tps: 4318.30535
+  dps: 1402.36124
+  tps: 4266.44786
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1406.10149
-  tps: 4318.30535
+  dps: 1402.36124
+  tps: 4266.44786
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 1426.78917
-  tps: 4363.77872
+  dps: 1423.04798
+  tps: 4312.26902
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1406.10149
-  tps: 4318.30535
+  dps: 1402.36124
+  tps: 4266.44786
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1406.10149
-  tps: 4318.30535
+  dps: 1402.36124
+  tps: 4266.44786
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1251.94372
-  tps: 3829.08521
+  dps: 1248.58673
+  tps: 3782.19151
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 1194.53293
-  tps: 3872.99268
+  dps: 1191.11544
+  tps: 3824.71542
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-WingedTalisman-37844"
  value: {
-  dps: 1408.69904
-  tps: 4326.21647
+  dps: 1404.95211
+  tps: 4274.26583
  }
 }
 dps_results: {
  key: "TestBloodTank-Average-Default"
  value: {
-  dps: 1789.23523
-  tps: 6019.62063
+  dps: 1786.21336
+  tps: 5979.18095
   dtps: 242.7252
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6395.067
-  tps: 14640.07803
+  dps: 6391.46613
+  tps: 14590.34449
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1432.34347
-  tps: 4351.51715
+  dps: 1428.67795
+  tps: 4300.84525
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1627.86566
-  tps: 5909.02331
+  dps: 1620.10574
+  tps: 5809.04798
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3255.48509
-  tps: 7598.4336
+  dps: 3253.06357
+  tps: 7571.29146
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 808.00442
-  tps: 2521.73372
+  dps: 805.68718
+  tps: 2493.22843
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 833.83432
-  tps: 3289.29463
+  dps: 830.4129
+  tps: 3248.34473
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6425.7703
-  tps: 14725.46441
+  dps: 6422.09913
+  tps: 14674.7747
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1444.6689
-  tps: 4398.94723
+  dps: 1440.9324
+  tps: 4347.30934
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1651.92712
-  tps: 6037.59018
+  dps: 1643.91596
+  tps: 5934.28992
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3282.58199
-  tps: 7671.07276
+  dps: 3280.12832
+  tps: 7643.56044
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 815.91903
-  tps: 2554.4717
+  dps: 813.57132
+  tps: 2525.59788
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 849.7866
-  tps: 3381.75065
+  dps: 846.23346
+  tps: 3339.09731
  }
 }
 dps_results: {
  key: "TestBloodTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1816.47681
-  tps: 6035.67207
+  dps: 1812.31035
+  tps: 5983.93196
   dtps: 242.59616
  }
 }

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -46,1583 +46,1583 @@ character_stats_results: {
 dps_results: {
  key: "TestBalance-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 8059.50683
-  tps: 7880.9798
+  dps: 7792.86548
+  tps: 7611.29752
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 8098.72706
-  tps: 7919.2726
+  dps: 7830.7487
+  tps: 7648.2533
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 7838.05561
-  tps: 7664.66673
+  dps: 7579.00923
+  tps: 7402.92065
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7837.75557
-  tps: 7665.59279
+  dps: 7587.20126
+  tps: 7411.67145
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7741.35122
-  tps: 7662.87683
+  dps: 7485.66001
+  tps: 7404.25025
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7741.35122
-  tps: 7662.87683
+  dps: 7485.66001
+  tps: 7404.25025
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7858.74163
-  tps: 7687.06926
+  dps: 7608.0239
+  tps: 7433.20687
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6153.51491
-  tps: 5974.00883
+  dps: 5855.8573
+  tps: 5670.20906
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7880.94009
-  tps: 7555.93074
+  dps: 7628.96227
+  tps: 7305.62552
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 7979.09519
-  tps: 7803.87445
+  dps: 7713.72732
+  tps: 7535.46565
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8085.12785
-  tps: 7909.90711
+  dps: 7817.27857
+  tps: 7639.0169
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
   hps: 64
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7851.68994
-  tps: 7682.38398
+  dps: 7676.51589
+  tps: 7505.05382
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7865.50011
-  tps: 7696.50265
+  dps: 7710.51489
+  tps: 7540.74877
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7878.62857
-  tps: 7716.50406
+  dps: 7664.42303
+  tps: 7499.48504
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 7979.09519
-  tps: 7803.87445
+  dps: 7713.72732
+  tps: 7535.46565
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7766.34047
-  tps: 7595.82015
+  dps: 7529.16205
+  tps: 7356.47981
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7864.94594
-  tps: 7692.89303
+  dps: 7631.02953
+  tps: 7456.49386
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 8341.30109
-  tps: 8168.64074
+  dps: 8117.97348
+  tps: 7943.22472
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 8308.12864
-  tps: 8138.45474
+  dps: 8095.9742
+  tps: 7922.8876
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 4477.80016
-  tps: 4292.62214
+  dps: 4252.05918
+  tps: 4063.61289
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DreamwalkerGarb"
  value: {
-  dps: 6991.27577
-  tps: 6828.37535
+  dps: 6791.00105
+  tps: 6626.38451
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7837.75557
-  tps: 7665.59279
+  dps: 7587.20126
+  tps: 7411.67145
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7896.11346
-  tps: 7723.26898
+  dps: 7641.73827
+  tps: 7465.49306
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7858.74163
-  tps: 7686.6769
+  dps: 7608.0239
+  tps: 7432.91572
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7853.83121
-  tps: 7681.69103
+  dps: 7600.14232
+  tps: 7424.82117
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7791.50443
-  tps: 7620.21809
+  dps: 7610.01127
+  tps: 7438.38098
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7837.75557
-  tps: 7665.59279
+  dps: 7587.20126
+  tps: 7411.67145
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7848.60482
-  tps: 7680.56662
+  dps: 7723.05023
+  tps: 7552.03533
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 8072.2763
-  tps: 7900.1378
+  dps: 7884.83111
+  tps: 7710.32801
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7754.90158
-  tps: 7585.23958
+  dps: 7536.71398
+  tps: 7365.02641
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7938.28064
-  tps: 7762.62024
+  dps: 7675.77192
+  tps: 7497.07059
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForgeEmber-37660"
  value: {
-  dps: 8006.80956
-  tps: 7833.45226
+  dps: 7772.54968
+  tps: 7597.42603
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7880.94009
-  tps: 7707.73478
+  dps: 7628.96227
+  tps: 7452.38993
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7872.30319
-  tps: 7699.30638
+  dps: 7620.61007
+  tps: 7444.24623
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 7979.09519
-  tps: 7803.87445
+  dps: 7713.72732
+  tps: 7535.46565
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7876.16628
-  tps: 7701.26938
+  dps: 7615.83258
+  tps: 7437.89475
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 4758.01211
-  tps: 4574.90991
+  dps: 4448.21756
+  tps: 4263.05627
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 7396.96314
-  tps: 7212.90671
+  dps: 7225.08492
+  tps: 7037.51387
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 8079.11694
-  tps: 7900.1262
+  dps: 7811.80709
+  tps: 7629.77541
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 8123.6854
-  tps: 7943.64074
+  dps: 7854.85619
+  tps: 7671.77061
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7859.91834
-  tps: 7691.84891
+  dps: 7636.80044
+  tps: 7464.72724
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 7979.09519
-  tps: 7803.87445
+  dps: 7713.72732
+  tps: 7535.46565
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Heartpierce-49982"
  value: {
-  dps: 8085.12785
-  tps: 7909.90711
+  dps: 7817.27857
+  tps: 7639.0169
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Heartpierce-50641"
  value: {
-  dps: 8085.12785
-  tps: 7909.90711
+  dps: 7817.27857
+  tps: 7639.0169
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdolofLunarFury-47670"
  value: {
-  dps: 8158.50746
-  tps: 7985.74321
+  dps: 7944.07338
+  tps: 7768.55634
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 7979.09519
-  tps: 7803.87445
+  dps: 7713.72732
+  tps: 7535.46565
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 7979.09519
-  tps: 7803.87445
+  dps: 7713.72732
+  tps: 7535.46565
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 7979.09519
-  tps: 7803.87445
+  dps: 7713.72732
+  tps: 7535.46565
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 8273.84951
-  tps: 8102.76556
+  dps: 8065.45003
+  tps: 7891.60052
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 8020.55973
-  tps: 7845.92334
+  dps: 7774.07182
+  tps: 7596.8992
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 8003.98606
-  tps: 7828.62243
+  dps: 7738.28936
+  tps: 7560.02768
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 7979.09519
-  tps: 7803.87445
+  dps: 7713.72732
+  tps: 7535.46565
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7858.74163
-  tps: 7686.6769
+  dps: 7608.0239
+  tps: 7432.91572
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7853.83121
-  tps: 7681.69103
+  dps: 7600.14232
+  tps: 7424.82117
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7852.87957
-  tps: 7683.16883
+  dps: 7599.93738
+  tps: 7426.82471
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7837.75557
-  tps: 7665.59279
+  dps: 7587.20126
+  tps: 7411.67145
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 4477.766
-  tps: 4291.29096
+  dps: 4284.65834
+  tps: 4095.9625
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LasherweaveRegalia"
  value: {
-  dps: 8292.35477
-  tps: 8125.9311
+  dps: 8022.2352
+  tps: 7852.29285
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LastWord-50179"
  value: {
-  dps: 8085.12785
-  tps: 7909.90711
+  dps: 7817.27857
+  tps: 7639.0169
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LastWord-50708"
  value: {
-  dps: 8085.12785
-  tps: 7909.90711
+  dps: 7817.27857
+  tps: 7639.0169
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7846.39114
-  tps: 7674.0933
+  dps: 7586.95044
+  tps: 7411.61572
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 4952.91321
-  tps: 4774.281
+  dps: 4673.1354
+  tps: 4487.92629
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 7337.89244
-  tps: 7166.50367
+  dps: 7180.48294
+  tps: 7006.26391
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7828.81248
-  tps: 7659.16162
+  dps: 7606.78103
+  tps: 7435.09812
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7985.7745
-  tps: 7811.19786
+  dps: 7716.1113
+  tps: 7538.14019
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Nibelung-49992"
  value: {
-  dps: 8085.12785
-  tps: 7909.90711
+  dps: 7817.27857
+  tps: 7639.0169
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Nibelung-50648"
  value: {
-  dps: 8085.12785
-  tps: 7909.90711
+  dps: 7817.27857
+  tps: 7639.0169
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NightsongBattlegear"
  value: {
-  dps: 4760.05661
-  tps: 4578.36313
+  dps: 4477.02524
+  tps: 4290.18048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NightsongGarb"
  value: {
-  dps: 7298.92805
-  tps: 7128.67495
+  dps: 7112.0856
+  tps: 6939.37718
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7837.75557
-  tps: 7665.59279
+  dps: 7587.20126
+  tps: 7411.67145
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7837.75557
-  tps: 7665.59279
+  dps: 7587.20126
+  tps: 7411.67145
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7837.75557
-  tps: 7665.59279
+  dps: 7587.20126
+  tps: 7411.67145
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7837.75557
-  tps: 7665.59279
+  dps: 7587.20126
+  tps: 7411.67145
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 8180.72583
-  tps: 8003.97868
+  dps: 7963.53878
+  tps: 7785.31951
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 8241.95521
-  tps: 8064.44926
+  dps: 8022.80185
+  tps: 7843.82377
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8062.76851
-  tps: 7887.44972
+  dps: 7795.26416
+  tps: 7616.58085
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 7979.09519
-  tps: 7803.87445
+  dps: 7713.72732
+  tps: 7535.46565
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7837.75557
-  tps: 7664.97034
+  dps: 7587.20126
+  tps: 7411.00133
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 7979.09519
-  tps: 7803.87445
+  dps: 7713.72732
+  tps: 7535.46565
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 8022.06933
-  tps: 7846.97188
+  dps: 7756.70424
+  tps: 7578.70368
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 8057.72409
-  tps: 7882.081
+  dps: 7791.14352
+  tps: 7612.63698
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7874.10207
-  tps: 7699.9593
+  dps: 7613.78121
+  tps: 7436.59751
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7845.12868
-  tps: 7678.73433
+  dps: 7668.87723
+  tps: 7500.19494
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SparkofLife-37657"
  value: {
-  dps: 7819.68775
-  tps: 7646.61783
+  dps: 7611.33964
+  tps: 7434.97242
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-StormshroudArmor"
  value: {
-  dps: 5228.80412
-  tps: 5043.16574
+  dps: 4854.01086
+  tps: 4661.93652
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7837.75557
-  tps: 7665.59279
+  dps: 7587.20126
+  tps: 7411.67145
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7837.75557
-  tps: 7665.59279
+  dps: 7587.20126
+  tps: 7411.67145
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7837.75557
-  tps: 7665.59279
+  dps: 7587.20126
+  tps: 7411.67145
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7784.2018
-  tps: 7612.17175
+  dps: 7526.94566
+  tps: 7351.87632
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7784.61286
-  tps: 7614.77019
+  dps: 7546.94318
+  tps: 7374.91013
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartHarness"
  value: {
-  dps: 3597.09718
-  tps: 3417.73262
+  dps: 3394.20322
+  tps: 3210.55542
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartRegalia"
  value: {
-  dps: 5543.02836
-  tps: 5371.94748
+  dps: 5285.82141
+  tps: 5108.93482
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7837.75557
-  tps: 7665.59279
+  dps: 7587.20126
+  tps: 7411.67145
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7740.39672
-  tps: 7569.41567
+  dps: 7484.6339
+  tps: 7310.61192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7880.94009
-  tps: 7707.73478
+  dps: 7628.96227
+  tps: 7452.38993
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7872.30319
-  tps: 7699.30638
+  dps: 7620.61007
+  tps: 7444.24623
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7934.1665
-  tps: 7762.18959
+  dps: 7681.52533
+  tps: 7507.05495
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7872.30319
-  tps: 7699.30638
+  dps: 7620.61007
+  tps: 7444.24623
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7880.94009
-  tps: 7707.73478
+  dps: 7628.96227
+  tps: 7452.38993
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5195.43758
-  tps: 5007.13625
+  dps: 4900.89907
+  tps: 4708.69097
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 8370.50473
-  tps: 8192.90514
+  dps: 8140.94664
+  tps: 7961.26176
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 7979.09519
-  tps: 7803.87445
+  dps: 7713.72732
+  tps: 7535.46565
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7881.40027
-  tps: 7703.1678
+  dps: 7621.15201
+  tps: 7439.87861
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 7979.09519
-  tps: 7803.87445
+  dps: 7713.72732
+  tps: 7535.46565
  }
 }
 dps_results: {
  key: "TestBalance-Average-Default"
  value: {
-  dps: 8149.50453
-  tps: 7976.56069
+  dps: 7950.64092
+  tps: 7775.12942
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11526.60968
-  tps: 13647.85752
+  dps: 11194.57877
+  tps: 13231.65908
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8085.12785
-  tps: 7909.90711
+  dps: 7817.27857
+  tps: 7639.0169
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8992.04978
-  tps: 8402.66657
+  dps: 8789.4628
+  tps: 8197.76198
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4280.66809
-  tps: 4527.30148
+  dps: 4076.3738
+  tps: 4282.06403
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2383.47311
-  tps: 2274.54014
+  dps: 2280.86651
+  tps: 2169.86872
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5360.49427
-  tps: 5093.30441
+  dps: 5159.94352
+  tps: 4888.28496
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotBoth-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12716.89312
-  tps: 13252.98437
+  dps: 12624.43177
+  tps: 13160.52302
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotBoth-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8082.97131
-  tps: 7909.66978
+  dps: 7916.23663
+  tps: 7741.84335
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotBoth-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9013.56435
-  tps: 8423.88254
+  dps: 8808.85504
+  tps: 8215.61188
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotBoth-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4303.77422
-  tps: 4176.44029
+  dps: 4259.17649
+  tps: 4131.84256
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotBoth-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2298.55284
-  tps: 2188.33772
+  dps: 2233.57591
+  tps: 2121.86606
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotBoth-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5256.46082
-  tps: 4985.79531
+  dps: 5153.46733
+  tps: 4879.32617
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotIs-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12716.89312
-  tps: 13252.98437
+  dps: 12624.43177
+  tps: 13160.52302
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotIs-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8090.72863
-  tps: 7915.24291
+  dps: 7898.96784
+  tps: 7720.74372
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotIs-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9015.21323
-  tps: 8424.08086
+  dps: 8803.14713
+  tps: 8209.06638
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotIs-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4303.77422
-  tps: 4176.44029
+  dps: 4259.17649
+  tps: 4131.84256
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotIs-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2358.07879
-  tps: 2248.29509
+  dps: 2274.37279
+  tps: 2163.16338
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotIs-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5212.1088
-  tps: 4940.78125
+  dps: 5102.64465
+  tps: 4828.33798
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotMf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7670.51061
-  tps: 8975.24123
+  dps: 7512.63385
+  tps: 8761.73962
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotMf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8073.9094
-  tps: 7901.65795
+  dps: 7880.95466
+  tps: 7707.08939
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotMf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8997.91405
-  tps: 8409.79393
+  dps: 8779.65474
+  tps: 8188.57767
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotMf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3195.99575
-  tps: 3230.99446
+  dps: 3127.91189
+  tps: 3147.27383
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotMf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2325.25244
-  tps: 2216.07563
+  dps: 2208.90896
+  tps: 2097.41936
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotMf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5365.17979
-  tps: 5097.82442
+  dps: 5213.71212
+  tps: 4942.21907
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13898.60913
-  tps: 16213.22241
+  dps: 13616.01196
+  tps: 15896.29681
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9668.19517
-  tps: 9472.54508
+  dps: 9499.13661
+  tps: 9303.81314
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11000.01252
-  tps: 10341.88441
+  dps: 10734.95179
+  tps: 10074.3613
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6311.88778
-  tps: 6866.90083
+  dps: 5963.20333
+  tps: 6432.48922
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3496.53748
-  tps: 3380.5883
+  dps: 3290.28031
+  tps: 3169.92927
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6574.07132
-  tps: 6270.27224
+  dps: 6436.40614
+  tps: 6128.20363
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotBoth-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14710.68951
-  tps: 15334.44599
+  dps: 14592.21359
+  tps: 15214.23267
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotBoth-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9794.21743
-  tps: 9598.74971
+  dps: 9594.89313
+  tps: 9395.7556
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotBoth-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10976.63803
-  tps: 10319.50463
+  dps: 10745.64479
+  tps: 10086.89356
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotBoth-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5731.47331
-  tps: 5586.46637
+  dps: 5648.7188
+  tps: 5503.75586
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotBoth-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3462.89789
-  tps: 3347.1573
+  dps: 3236.21147
+  tps: 3116.13261
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotBoth-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6578.64729
-  tps: 6274.84821
+  dps: 6437.58283
+  tps: 6129.95468
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotIs-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14710.68951
-  tps: 15334.44599
+  dps: 14592.21359
+  tps: 15214.23267
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotIs-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9730.69781
-  tps: 9532.7958
+  dps: 9569.36231
+  tps: 9368.98327
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotIs-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11086.20205
-  tps: 10428.28743
+  dps: 10896.60912
+  tps: 10237.3792
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotIs-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5731.47331
-  tps: 5586.46637
+  dps: 5648.7188
+  tps: 5503.75586
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotIs-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3496.53748
-  tps: 3380.5883
+  dps: 3290.28031
+  tps: 3169.92927
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotIs-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6574.07132
-  tps: 6270.27224
+  dps: 6436.40614
+  tps: 6128.20363
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotMf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9865.58715
-  tps: 11828.94008
+  dps: 9646.80496
+  tps: 11500.91786
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotMf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9743.41358
-  tps: 9550.78505
+  dps: 9536.91305
+  tps: 9340.95577
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotMf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11004.32923
-  tps: 10348.23961
+  dps: 10763.63436
+  tps: 10105.84332
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotMf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4519.75712
-  tps: 4696.68259
+  dps: 4354.24472
+  tps: 4494.41816
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotMf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3462.89789
-  tps: 3347.1573
+  dps: 3236.21147
+  tps: 3116.13261
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotMf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6578.64729
-  tps: 6274.84821
+  dps: 6437.58283
+  tps: 6129.95468
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14263.73838
-  tps: 16602.97957
+  dps: 13881.33523
+  tps: 16137.86883
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9808.726
-  tps: 9609.36036
+  dps: 9611.89264
+  tps: 9410.99834
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11089.40333
-  tps: 10422.89489
+  dps: 10909.4365
+  tps: 10240.68627
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6758.96049
-  tps: 7405.57185
+  dps: 6494.70413
+  tps: 7098.14267
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3981.57009
-  tps: 3871.5503
+  dps: 3720.24983
+  tps: 3606.08322
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6614.96003
-  tps: 6312.68823
+  dps: 6355.64366
+  tps: 6045.74656
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotBoth-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14972.57836
-  tps: 15598.54403
+  dps: 14852.36146
+  tps: 15478.32713
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotBoth-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9834.59776
-  tps: 9632.99676
+  dps: 9623.21774
+  tps: 9420.92874
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotBoth-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11023.44921
-  tps: 10356.45252
+  dps: 10891.79326
+  tps: 10223.51259
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotBoth-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6012.50525
-  tps: 5864.27402
+  dps: 5949.52057
+  tps: 5801.28935
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotBoth-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3818.63293
-  tps: 3706.04759
+  dps: 3528.40818
+  tps: 3410.11001
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotBoth-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6647.40139
-  tps: 6343.56543
+  dps: 6447.88113
+  tps: 6137.98402
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotIs-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14972.57836
-  tps: 15598.54403
+  dps: 14852.36146
+  tps: 15478.32713
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotIs-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9775.12774
-  tps: 9572.64325
+  dps: 9625.46138
+  tps: 9421.53525
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotIs-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11104.56187
-  tps: 10436.99448
+  dps: 10971.82346
+  tps: 10302.70626
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotIs-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6012.50525
-  tps: 5864.27402
+  dps: 5949.52057
+  tps: 5801.28935
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotIs-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3842.74365
-  tps: 3729.686
+  dps: 3585.11805
+  tps: 3467.37279
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotIs-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6555.14668
-  tps: 6250.13759
+  dps: 6358.273
+  tps: 6047.20277
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotMf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10220.34689
-  tps: 12318.35554
+  dps: 9871.11402
+  tps: 11810.24457
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotMf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9805.89401
-  tps: 9610.27794
+  dps: 9571.17489
+  tps: 9372.44481
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotMf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11016.15302
-  tps: 10349.85306
+  dps: 10890.32473
+  tps: 10222.92209
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotMf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4663.34639
-  tps: 4890.64581
+  dps: 4609.09242
+  tps: 4806.78329
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotMf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3886.87817
-  tps: 3775.94741
+  dps: 3573.98993
+  tps: 3457.24152
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotMf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6644.01154
-  tps: 6342.13079
+  dps: 6371.22159
+  tps: 6061.52001
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16032.40775
-  tps: 18498.70034
+  dps: 15703.46815
+  tps: 18116.46802
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11236.57786
-  tps: 11038.02733
+  dps: 10957.51831
+  tps: 10756.60984
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12233.60154
-  tps: 11547.82181
+  dps: 11946.48002
+  tps: 11258.68738
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8537.04078
-  tps: 9590.75971
+  dps: 8063.77763
+  tps: 8967.56426
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5577.9187
-  tps: 5479.45502
+  dps: 5219.48365
+  tps: 5116.42131
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7636.84992
-  tps: 7330.39248
+  dps: 7472.71472
+  tps: 7163.05097
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotBoth-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16432.82492
-  tps: 17373.44851
+  dps: 16288.50731
+  tps: 17227.19726
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotBoth-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11371.42362
-  tps: 11164.30316
+  dps: 11127.74432
+  tps: 10922.55099
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotBoth-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12372.39525
-  tps: 11660.97868
+  dps: 12142.03239
+  tps: 11428.73575
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotBoth-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6198.85391
-  tps: 6170.45561
+  dps: 6014.48847
+  tps: 5974.55576
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotBoth-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5577.91692
-  tps: 5481.46405
+  dps: 5187.20613
+  tps: 5084.43924
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotBoth-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7843.24465
-  tps: 7534.9118
+  dps: 7641.01222
+  tps: 7327.76305
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotIs-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16304.27926
-  tps: 16999.80488
+  dps: 16170.41409
+  tps: 16866.93454
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotIs-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11223.99456
-  tps: 11021.65189
+  dps: 10963.68947
+  tps: 10759.24404
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotIs-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12309.79694
-  tps: 11625.52709
+  dps: 12042.87029
+  tps: 11356.68881
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotIs-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6597.86985
-  tps: 6442.27232
+  dps: 6524.90297
+  tps: 6369.66427
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotIs-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5419.22031
-  tps: 5318.6909
+  dps: 5036.05976
+  tps: 4930.78045
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotIs-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7741.6518
-  tps: 7434.5531
+  dps: 7550.19379
+  tps: 7239.24753
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotMf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14864.22032
-  tps: 17909.73274
+  dps: 14254.84514
+  tps: 17099.35713
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotMf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11504.09353
-  tps: 11302.54634
+  dps: 11161.55104
+  tps: 10958.95368
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotMf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12415.10593
-  tps: 11703.36311
+  dps: 12157.23365
+  tps: 11443.89435
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotMf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5238.81912
-  tps: 5636.28114
+  dps: 5016.35453
+  tps: 5356.2391
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotMf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5619.21663
-  tps: 5523.70984
+  dps: 5126.4868
+  tps: 5023.41838
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotMf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7792.62158
-  tps: 7485.99875
+  dps: 7629.33218
+  tps: 7316.93802
  }
 }
 dps_results: {
  key: "TestBalance-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 8052.19698
-  tps: 7909.90711
+  dps: 7784.36774
+  tps: 7639.0169
  }
 }

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -46,1583 +46,1583 @@ character_stats_results: {
 dps_results: {
  key: "TestBalance-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7792.86548
-  tps: 7611.29752
+  dps: 7855.25375
+  tps: 7674.82423
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7830.7487
-  tps: 7648.2533
+  dps: 7893.43386
+  tps: 7712.0769
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 7579.00923
-  tps: 7402.92065
+  dps: 7641.90922
+  tps: 7466.46475
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7645.06757
+  tps: 7471.2505
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7485.66001
-  tps: 7404.25025
+  dps: 7545.53806
+  tps: 7464.83243
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7485.66001
-  tps: 7404.25025
+  dps: 7545.53806
+  tps: 7464.83243
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7608.0239
-  tps: 7433.20687
+  dps: 7666.10567
+  tps: 7492.42732
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5855.8573
-  tps: 5670.20906
+  dps: 5995.13208
+  tps: 5812.46927
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7628.96227
-  tps: 7305.62552
+  dps: 7687.15361
+  tps: 7364.35078
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7774.75351
+  tps: 7597.63028
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7817.27857
-  tps: 7639.0169
+  dps: 7879.94404
+  tps: 7702.82081
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
   hps: 64
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7676.51589
-  tps: 7505.05382
+  dps: 7743.18594
+  tps: 7572.34832
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7710.51489
-  tps: 7540.74877
+  dps: 7729.92852
+  tps: 7559.34138
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7664.42303
-  tps: 7499.48504
+  dps: 7717.8636
+  tps: 7552.28316
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7774.75351
+  tps: 7597.63028
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7529.16205
-  tps: 7356.47981
+  dps: 7598.40916
+  tps: 7426.48644
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7631.02953
-  tps: 7456.49386
+  dps: 7674.29957
+  tps: 7500.42624
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 8117.97348
-  tps: 7943.22472
+  dps: 8182.05792
+  tps: 8008.71166
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 8095.9742
-  tps: 7922.8876
+  dps: 8161.27102
+  tps: 7990.99599
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 4252.05918
-  tps: 4063.61289
+  dps: 4301.21451
+  tps: 4113.5842
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DreamwalkerGarb"
  value: {
-  dps: 6791.00105
-  tps: 6626.38451
+  dps: 6869.90372
+  tps: 6705.975
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7645.06757
+  tps: 7471.2505
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7641.73827
-  tps: 7465.49306
+  dps: 7694.64528
+  tps: 7519.97075
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7608.0239
-  tps: 7432.91572
+  dps: 7666.10567
+  tps: 7492.12962
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7600.14232
-  tps: 7424.82117
+  dps: 7663.0499
+  tps: 7488.98674
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7610.01127
-  tps: 7438.38098
+  dps: 7667.15502
+  tps: 7495.49109
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7645.06757
+  tps: 7471.2505
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7723.05023
-  tps: 7552.03533
+  dps: 7756.52956
+  tps: 7585.86526
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7884.83111
-  tps: 7710.32801
+  dps: 7963.1183
+  tps: 7789.30599
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7536.71398
-  tps: 7365.02641
+  dps: 7577.80418
+  tps: 7406.52193
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7675.77192
-  tps: 7497.07059
+  dps: 7737.24249
+  tps: 7559.6796
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7772.54968
-  tps: 7597.42603
+  dps: 7877.91331
+  tps: 7703.40472
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7628.96227
-  tps: 7452.38993
+  dps: 7687.15361
+  tps: 7512.29401
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7620.61007
-  tps: 7444.24623
+  dps: 7678.7364
+  tps: 7504.08531
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7774.75351
+  tps: 7597.63028
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7615.83258
-  tps: 7437.89475
+  dps: 7676.69003
+  tps: 7499.89065
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 4448.21756
-  tps: 4263.05627
+  dps: 4544.25702
+  tps: 4359.73672
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 7225.08492
-  tps: 7037.51387
+  dps: 7282.10923
+  tps: 7095.48681
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7811.80709
-  tps: 7629.77541
+  dps: 7874.34381
+  tps: 7693.45057
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7854.85619
-  tps: 7671.77061
+  dps: 7917.7303
+  tps: 7735.78315
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7636.80044
-  tps: 7464.72724
+  dps: 7700.71303
+  tps: 7528.9997
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7774.75351
+  tps: 7597.63028
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Heartpierce-49982"
  value: {
-  dps: 7817.27857
-  tps: 7639.0169
+  dps: 7879.94404
+  tps: 7702.82081
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Heartpierce-50641"
  value: {
-  dps: 7817.27857
-  tps: 7639.0169
+  dps: 7879.94404
+  tps: 7702.82081
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdolofLunarFury-47670"
  value: {
-  dps: 7944.07338
-  tps: 7768.55634
+  dps: 7991.15288
+  tps: 7815.73843
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7774.75351
+  tps: 7597.63028
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7774.75351
+  tps: 7597.63028
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7774.75351
+  tps: 7597.63028
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 8065.45003
-  tps: 7891.60052
+  dps: 8105.6583
+  tps: 7932.10987
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 7774.07182
-  tps: 7596.8992
+  dps: 7867.38675
+  tps: 7691.9212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 7738.28936
-  tps: 7560.02768
+  dps: 7800.19254
+  tps: 7623.0693
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7774.75351
+  tps: 7597.63028
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7608.0239
-  tps: 7432.91572
+  dps: 7666.10567
+  tps: 7492.12962
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7600.14232
-  tps: 7424.82117
+  dps: 7663.0499
+  tps: 7488.98674
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7599.93738
-  tps: 7426.82471
+  dps: 7652.54862
+  tps: 7481.03147
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7645.06757
+  tps: 7471.2505
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 4284.65834
-  tps: 4095.9625
+  dps: 4336.87367
+  tps: 4148.12874
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LasherweaveRegalia"
  value: {
-  dps: 8022.2352
-  tps: 7852.29285
+  dps: 8054.83505
+  tps: 7885.58448
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LastWord-50179"
  value: {
-  dps: 7817.27857
-  tps: 7639.0169
+  dps: 7879.94404
+  tps: 7702.82081
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LastWord-50708"
  value: {
-  dps: 7817.27857
-  tps: 7639.0169
+  dps: 7879.94404
+  tps: 7702.82081
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7586.95044
-  tps: 7411.61572
+  dps: 7647.74066
+  tps: 7473.53629
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 4673.1354
-  tps: 4487.92629
+  dps: 4694.74118
+  tps: 4509.92567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 7180.48294
-  tps: 7006.26391
+  dps: 7232.24941
+  tps: 7058.45402
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7606.78103
-  tps: 7435.09812
+  dps: 7703.63662
+  tps: 7532.31187
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7716.1113
-  tps: 7538.14019
+  dps: 7784.46233
+  tps: 7608.12964
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Nibelung-49992"
  value: {
-  dps: 7817.27857
-  tps: 7639.0169
+  dps: 7879.94404
+  tps: 7702.82081
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Nibelung-50648"
  value: {
-  dps: 7817.27857
-  tps: 7639.0169
+  dps: 7879.94404
+  tps: 7702.82081
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NightsongBattlegear"
  value: {
-  dps: 4477.02524
-  tps: 4290.18048
+  dps: 4564.92487
+  tps: 4380.67882
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NightsongGarb"
  value: {
-  dps: 7112.0856
-  tps: 6939.37718
+  dps: 7163.21194
+  tps: 6991.61914
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7645.06757
+  tps: 7471.2505
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7645.06757
+  tps: 7471.2505
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7645.06757
+  tps: 7471.2505
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7645.06757
+  tps: 7471.2505
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7963.53878
-  tps: 7785.31951
+  dps: 8056.60456
+  tps: 7879.59836
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 8022.80185
-  tps: 7843.82377
+  dps: 8116.4891
+  tps: 7938.72408
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7795.26416
-  tps: 7616.58085
+  dps: 7857.52934
+  tps: 7680.56509
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7774.75351
+  tps: 7597.63028
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.00133
+  dps: 7645.06757
+  tps: 7470.57474
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7774.75351
+  tps: 7597.63028
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7756.70424
-  tps: 7578.70368
+  dps: 7818.80909
+  tps: 7641.84388
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7791.14352
-  tps: 7612.63698
+  dps: 7853.51829
+  tps: 7676.04039
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7613.78121
-  tps: 7436.59751
+  dps: 7674.76594
+  tps: 7498.72067
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7668.87723
-  tps: 7500.19494
+  dps: 7735.90498
+  tps: 7567.74342
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SparkofLife-37657"
  value: {
-  dps: 7611.33964
-  tps: 7434.97242
+  dps: 7678.44078
+  tps: 7503.67695
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-StormshroudArmor"
  value: {
-  dps: 4854.01086
-  tps: 4661.93652
+  dps: 4920.04477
+  tps: 4729.30013
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7645.06757
+  tps: 7471.2505
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7645.06757
+  tps: 7471.2505
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7645.06757
+  tps: 7471.2505
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7526.94566
-  tps: 7351.87632
+  dps: 7587.24983
+  tps: 7413.31564
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7546.94318
-  tps: 7374.91013
+  dps: 7617.07697
+  tps: 7445.64561
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartHarness"
  value: {
-  dps: 3394.20322
-  tps: 3210.55542
+  dps: 3424.40716
+  tps: 3241.34042
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartRegalia"
  value: {
-  dps: 5285.82141
-  tps: 5108.93482
+  dps: 5393.22849
+  tps: 5218.24137
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7645.06757
+  tps: 7471.2505
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7544.60646
+  tps: 7371.72291
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7628.96227
-  tps: 7452.38993
+  dps: 7687.15361
+  tps: 7512.29401
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7620.61007
-  tps: 7444.24623
+  dps: 7678.7364
+  tps: 7504.08531
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7681.52533
-  tps: 7507.05495
+  dps: 7739.79357
+  tps: 7566.01914
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7620.61007
-  tps: 7444.24623
+  dps: 7678.7364
+  tps: 7504.08531
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7628.96227
-  tps: 7452.38993
+  dps: 7687.15361
+  tps: 7512.29401
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 4900.89907
-  tps: 4708.69097
+  dps: 4929.29003
+  tps: 4737.61962
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 8140.94664
-  tps: 7961.26176
+  dps: 8261.02519
+  tps: 8082.34259
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7774.75351
+  tps: 7597.63028
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7621.15201
-  tps: 7439.87861
+  dps: 7681.39369
+  tps: 7501.25873
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7774.75351
+  tps: 7597.63028
  }
 }
 dps_results: {
  key: "TestBalance-Average-Default"
  value: {
-  dps: 7950.64092
-  tps: 7775.12942
+  dps: 8010.32942
+  tps: 7835.60792
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11194.57877
-  tps: 13231.65908
+  dps: 11295.39606
+  tps: 13358.28631
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7817.27857
-  tps: 7639.0169
+  dps: 7879.94404
+  tps: 7702.82081
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8789.4628
-  tps: 8197.76198
+  dps: 8813.93324
+  tps: 8223.09808
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4076.3738
-  tps: 4282.06403
+  dps: 4083.39194
+  tps: 4294.10188
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2280.86651
-  tps: 2169.86872
+  dps: 2293.49452
+  tps: 2182.87026
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5159.94352
-  tps: 4888.28496
+  dps: 5251.81921
+  tps: 4982.14674
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotBoth-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12624.43177
-  tps: 13160.52302
+  dps: 12651.80575
+  tps: 13187.897
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotBoth-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7916.23663
-  tps: 7741.84335
+  dps: 7970.80249
+  tps: 7797.37325
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotBoth-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8808.85504
-  tps: 8215.61188
+  dps: 8867.2419
+  tps: 8275.04359
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotBoth-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4259.17649
-  tps: 4131.84256
+  dps: 4271.23948
+  tps: 4143.92755
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotBoth-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2233.57591
-  tps: 2121.86606
+  dps: 2249.38303
+  tps: 2138.6416
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotBoth-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5153.46733
-  tps: 4879.32617
+  dps: 5213.37156
+  tps: 4941.05098
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotIs-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12624.43177
-  tps: 13160.52302
+  dps: 12651.80575
+  tps: 13187.897
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotIs-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7898.96784
-  tps: 7720.74372
+  dps: 7932.20496
+  tps: 7754.91203
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotIs-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8803.14713
-  tps: 8209.06638
+  dps: 8833.04708
+  tps: 8239.75313
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotIs-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4259.17649
-  tps: 4131.84256
+  dps: 4271.23948
+  tps: 4143.92755
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotIs-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2274.37279
-  tps: 2163.16338
+  dps: 2297.10085
+  tps: 2186.59032
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotIs-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5102.64465
-  tps: 4828.33798
+  dps: 5156.92481
+  tps: 4883.77669
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotMf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7512.63385
-  tps: 8761.73962
+  dps: 7531.37377
+  tps: 8779.08699
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotMf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7880.95466
-  tps: 7707.08939
+  dps: 7927.4621
+  tps: 7753.95467
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotMf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8779.65474
-  tps: 8188.57767
+  dps: 8838.6203
+  tps: 8248.73232
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotMf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3127.91189
-  tps: 3147.27383
+  dps: 3194.56772
+  tps: 3211.93272
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotMf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2208.90896
-  tps: 2097.41936
+  dps: 2247.35041
+  tps: 2136.80501
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotMf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5213.71212
-  tps: 4942.21907
+  dps: 5277.76868
+  tps: 5008.09621
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13616.01196
-  tps: 15896.29681
+  dps: 13702.58423
+  tps: 15988.92785
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9499.13661
-  tps: 9303.81314
+  dps: 9569.34716
+  tps: 9373.75909
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10734.95179
-  tps: 10074.3613
+  dps: 10870.82366
+  tps: 10211.52736
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5963.20333
-  tps: 6432.48922
+  dps: 6070.89374
+  tps: 6563.91986
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3290.28031
-  tps: 3169.92927
+  dps: 3326.95115
+  tps: 3208.12446
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6436.40614
-  tps: 6128.20363
+  dps: 6443.99935
+  tps: 6136.56266
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotBoth-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14592.21359
-  tps: 15214.23267
+  dps: 14627.63004
+  tps: 15249.64912
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotBoth-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9594.89313
-  tps: 9395.7556
+  dps: 9651.15727
+  tps: 9454.2753
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotBoth-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10745.64479
-  tps: 10086.89356
+  dps: 10867.85802
+  tps: 10209.83089
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotBoth-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5648.7188
-  tps: 5503.75586
+  dps: 5668.05605
+  tps: 5523.0931
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotBoth-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3236.21147
-  tps: 3116.13261
+  dps: 3311.87283
+  tps: 3193.11786
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotBoth-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6437.58283
-  tps: 6129.95468
+  dps: 6464.57
+  tps: 6157.70767
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotIs-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14592.21359
-  tps: 15214.23267
+  dps: 14627.63004
+  tps: 15249.64912
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotIs-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9569.36231
-  tps: 9368.98327
+  dps: 9650.73877
+  tps: 9451.52467
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotIs-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10896.60912
-  tps: 10237.3792
+  dps: 10992.07777
+  tps: 10333.80918
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotIs-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5648.7188
-  tps: 5503.75586
+  dps: 5668.05605
+  tps: 5523.0931
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotIs-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3290.28031
-  tps: 3169.92927
+  dps: 3326.95115
+  tps: 3208.12446
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotIs-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6436.40614
-  tps: 6128.20363
+  dps: 6443.99935
+  tps: 6136.56266
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotMf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9646.80496
-  tps: 11500.91786
+  dps: 9691.70704
+  tps: 11571.58526
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotMf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9536.91305
-  tps: 9340.95577
+  dps: 9615.74449
+  tps: 9422.141
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotMf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10763.63436
-  tps: 10105.84332
+  dps: 10868.64228
+  tps: 10211.55852
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotMf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4354.24472
-  tps: 4494.41816
+  dps: 4406.302
+  tps: 4560.9819
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotMf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3236.21147
-  tps: 3116.13261
+  dps: 3311.87283
+  tps: 3193.11786
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotMf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6437.58283
-  tps: 6129.95468
+  dps: 6464.57
+  tps: 6157.70767
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13881.33523
-  tps: 16137.86883
+  dps: 13970.52558
+  tps: 16246.15635
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9611.89264
-  tps: 9410.99834
+  dps: 9640.28651
+  tps: 9441.25261
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10909.4365
-  tps: 10240.68627
+  dps: 10976.46116
+  tps: 10308.22105
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6494.70413
-  tps: 7098.14267
+  dps: 6556.93231
+  tps: 7179.87893
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3720.24983
-  tps: 3606.08322
+  dps: 3790.24303
+  tps: 3677.34486
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6355.64366
-  tps: 6045.74656
+  dps: 6429.3618
+  tps: 6121.61542
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotBoth-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14852.36146
-  tps: 15478.32713
+  dps: 14888.09381
+  tps: 15514.05948
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotBoth-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9623.21774
-  tps: 9420.92874
+  dps: 9686.81625
+  tps: 9484.60932
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotBoth-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10891.79326
-  tps: 10223.51259
+  dps: 10920.51434
+  tps: 10252.43978
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotBoth-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5949.52057
-  tps: 5801.28935
+  dps: 5975.27664
+  tps: 5827.04541
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotBoth-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3528.40818
-  tps: 3410.11001
+  dps: 3630.64439
+  tps: 3514.27943
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotBoth-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6447.88113
-  tps: 6137.98402
+  dps: 6506.72374
+  tps: 6198.58632
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotIs-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14852.36146
-  tps: 15478.32713
+  dps: 14888.09381
+  tps: 15514.05948
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotIs-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9625.46138
-  tps: 9421.53525
+  dps: 9674.34739
+  tps: 9469.90346
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotIs-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10971.82346
-  tps: 10302.70626
+  dps: 11004.82058
+  tps: 10335.7686
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotIs-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5949.52057
-  tps: 5801.28935
+  dps: 5975.27664
+  tps: 5827.04541
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotIs-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3585.11805
-  tps: 3467.37279
+  dps: 3657.55131
+  tps: 3540.00638
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotIs-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6358.273
-  tps: 6047.20277
+  dps: 6394.50703
+  tps: 6084.60992
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotMf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9871.11402
-  tps: 11810.24457
+  dps: 9965.34491
+  tps: 11942.59915
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotMf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9571.17489
-  tps: 9372.44481
+  dps: 9605.8015
+  tps: 9407.32585
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotMf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10890.32473
-  tps: 10222.92209
+  dps: 10932.47749
+  tps: 10265.51701
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotMf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4609.09242
-  tps: 4806.78329
+  dps: 4643.53056
+  tps: 4853.86556
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotMf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3573.98993
-  tps: 3457.24152
+  dps: 3644.99756
+  tps: 3530.40812
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotMf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6371.22159
-  tps: 6061.52001
+  dps: 6437.65157
+  tps: 6130.29624
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15703.46815
-  tps: 18116.46802
+  dps: 15844.39927
+  tps: 18272.69519
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10957.51831
-  tps: 10756.60984
+  dps: 11072.1281
+  tps: 10871.47827
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11946.48002
-  tps: 11258.68738
+  dps: 11998.11645
+  tps: 11310.46603
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8063.77763
-  tps: 8967.56426
+  dps: 8198.65775
+  tps: 9160.80869
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5219.48365
-  tps: 5116.42131
+  dps: 5284.53466
+  tps: 5182.78566
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7472.71472
-  tps: 7163.05097
+  dps: 7435.88569
+  tps: 7125.15318
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotBoth-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16288.50731
-  tps: 17227.19726
+  dps: 16335.19054
+  tps: 17275.81414
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotBoth-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11127.74432
-  tps: 10922.55099
+  dps: 11242.65811
+  tps: 11036.92881
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotBoth-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12142.03239
-  tps: 11428.73575
+  dps: 12204.99946
+  tps: 11492.56812
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotBoth-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6014.48847
-  tps: 5974.55576
+  dps: 6093.01942
+  tps: 6057.15681
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotBoth-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5187.20613
-  tps: 5084.43924
+  dps: 5280.99437
+  tps: 5178.93006
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotBoth-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7641.01222
-  tps: 7327.76305
+  dps: 7714.16006
+  tps: 7402.19341
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotIs-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16170.41409
-  tps: 16866.93454
+  dps: 16217.59171
+  tps: 16914.11215
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotIs-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10963.68947
-  tps: 10759.24404
+  dps: 11073.57955
+  tps: 10869.24162
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotIs-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12042.87029
-  tps: 11356.68881
+  dps: 12139.98171
+  tps: 11454.22515
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotIs-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6524.90297
-  tps: 6369.66427
+  dps: 6553.67043
+  tps: 6398.43173
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotIs-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5036.05976
-  tps: 4930.78045
+  dps: 5053.66613
+  tps: 4946.79008
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotIs-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7550.19379
-  tps: 7239.24753
+  dps: 7545.25053
+  tps: 7233.66301
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotMf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14254.84514
-  tps: 17099.35713
+  dps: 14401.21956
+  tps: 17283.21119
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotMf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11161.55104
-  tps: 10958.95368
+  dps: 11271.20518
+  tps: 11069.15969
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotMf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12157.23365
-  tps: 11443.89435
+  dps: 12222.60441
+  tps: 11510.05046
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotMf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5016.35453
-  tps: 5356.2391
+  dps: 5170.26413
+  tps: 5537.92439
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotMf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5126.4868
-  tps: 5023.41838
+  dps: 5198.21144
+  tps: 5095.70073
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotMf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7629.33218
-  tps: 7316.93802
+  dps: 7691.01143
+  tps: 7380.11354
  }
 }
 dps_results: {
  key: "TestBalance-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7784.36774
-  tps: 7639.0169
+  dps: 7847.0963
+  tps: 7702.82081
  }
 }

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -46,926 +46,926 @@ character_stats_results: {
 dps_results: {
  key: "TestBalance-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7792.86548
-  tps: 7611.29752
+  dps: 8059.50683
+  tps: 7880.9798
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7830.7487
-  tps: 7648.2533
+  dps: 8098.72706
+  tps: 7919.2726
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 7579.00923
-  tps: 7402.92065
+  dps: 7838.05561
+  tps: 7664.66673
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7837.75557
+  tps: 7665.59279
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7485.66001
-  tps: 7404.25025
+  dps: 7741.35122
+  tps: 7662.87683
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7485.66001
-  tps: 7404.25025
+  dps: 7741.35122
+  tps: 7662.87683
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7608.0239
-  tps: 7433.20687
+  dps: 7858.74163
+  tps: 7687.06926
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5855.8573
-  tps: 5670.20906
+  dps: 6153.51491
+  tps: 5974.00883
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7628.96227
-  tps: 7305.62552
+  dps: 7880.94009
+  tps: 7555.93074
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7979.09519
+  tps: 7803.87445
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7817.27857
-  tps: 7639.0169
+  dps: 8085.12785
+  tps: 7909.90711
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
   hps: 64
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7676.51589
-  tps: 7505.05382
+  dps: 7851.68994
+  tps: 7682.38398
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7710.51489
-  tps: 7540.74877
+  dps: 7865.50011
+  tps: 7696.50265
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7664.42303
-  tps: 7499.48504
+  dps: 7878.62857
+  tps: 7716.50406
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7979.09519
+  tps: 7803.87445
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7529.16205
-  tps: 7356.47981
+  dps: 7766.34047
+  tps: 7595.82015
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7631.02953
-  tps: 7456.49386
+  dps: 7864.94594
+  tps: 7692.89303
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 8117.97348
-  tps: 7943.22472
+  dps: 8341.30109
+  tps: 8168.64074
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 8095.9742
-  tps: 7922.8876
+  dps: 8308.12864
+  tps: 8138.45474
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 4252.05918
-  tps: 4063.61289
+  dps: 4477.80016
+  tps: 4292.62214
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DreamwalkerGarb"
  value: {
-  dps: 6791.00105
-  tps: 6626.38451
+  dps: 6991.27577
+  tps: 6828.37535
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7837.75557
+  tps: 7665.59279
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7641.73827
-  tps: 7465.49306
+  dps: 7896.11346
+  tps: 7723.26898
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7608.0239
-  tps: 7432.91572
+  dps: 7858.74163
+  tps: 7686.6769
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7600.14232
-  tps: 7424.82117
+  dps: 7853.83121
+  tps: 7681.69103
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7610.01127
-  tps: 7438.38098
+  dps: 7791.50443
+  tps: 7620.21809
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7837.75557
+  tps: 7665.59279
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7723.05023
-  tps: 7552.03533
+  dps: 7848.60482
+  tps: 7680.56662
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7884.83111
-  tps: 7710.32801
+  dps: 8072.2763
+  tps: 7900.1378
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7536.71398
-  tps: 7365.02641
+  dps: 7754.90158
+  tps: 7585.23958
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7675.77192
-  tps: 7497.07059
+  dps: 7938.28064
+  tps: 7762.62024
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7772.54968
-  tps: 7597.42603
+  dps: 8006.80956
+  tps: 7833.45226
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7628.96227
-  tps: 7452.38993
+  dps: 7880.94009
+  tps: 7707.73478
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7620.61007
-  tps: 7444.24623
+  dps: 7872.30319
+  tps: 7699.30638
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7979.09519
+  tps: 7803.87445
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7615.83258
-  tps: 7437.89475
+  dps: 7876.16628
+  tps: 7701.26938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 4448.21756
-  tps: 4263.05627
+  dps: 4758.01211
+  tps: 4574.90991
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 7225.08492
-  tps: 7037.51387
+  dps: 7396.96314
+  tps: 7212.90671
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7811.80709
-  tps: 7629.77541
+  dps: 8079.11694
+  tps: 7900.1262
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7854.85619
-  tps: 7671.77061
+  dps: 8123.6854
+  tps: 7943.64074
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7636.80044
-  tps: 7464.72724
+  dps: 7859.91834
+  tps: 7691.84891
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7979.09519
+  tps: 7803.87445
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Heartpierce-49982"
  value: {
-  dps: 7817.27857
-  tps: 7639.0169
+  dps: 8085.12785
+  tps: 7909.90711
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Heartpierce-50641"
  value: {
-  dps: 7817.27857
-  tps: 7639.0169
+  dps: 8085.12785
+  tps: 7909.90711
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdolofLunarFury-47670"
  value: {
-  dps: 7944.07338
-  tps: 7768.55634
+  dps: 8158.50746
+  tps: 7985.74321
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7979.09519
+  tps: 7803.87445
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7979.09519
+  tps: 7803.87445
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7979.09519
+  tps: 7803.87445
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 8065.45003
-  tps: 7891.60052
+  dps: 8273.84951
+  tps: 8102.76556
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 7774.07182
-  tps: 7596.8992
+  dps: 8020.55973
+  tps: 7845.92334
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 7738.28936
-  tps: 7560.02768
+  dps: 8003.98606
+  tps: 7828.62243
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7979.09519
+  tps: 7803.87445
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7608.0239
-  tps: 7432.91572
+  dps: 7858.74163
+  tps: 7686.6769
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7600.14232
-  tps: 7424.82117
+  dps: 7853.83121
+  tps: 7681.69103
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7599.93738
-  tps: 7426.82471
+  dps: 7852.87957
+  tps: 7683.16883
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7837.75557
+  tps: 7665.59279
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 4284.65834
-  tps: 4095.9625
+  dps: 4477.766
+  tps: 4291.29096
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LasherweaveRegalia"
  value: {
-  dps: 8022.2352
-  tps: 7852.29285
+  dps: 8292.35477
+  tps: 8125.9311
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LastWord-50179"
  value: {
-  dps: 7817.27857
-  tps: 7639.0169
+  dps: 8085.12785
+  tps: 7909.90711
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LastWord-50708"
  value: {
-  dps: 7817.27857
-  tps: 7639.0169
+  dps: 8085.12785
+  tps: 7909.90711
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7586.95044
-  tps: 7411.61572
+  dps: 7846.39114
+  tps: 7674.0933
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 4673.1354
-  tps: 4487.92629
+  dps: 4952.91321
+  tps: 4774.281
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 7180.48294
-  tps: 7006.26391
+  dps: 7337.89244
+  tps: 7166.50367
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7606.78103
-  tps: 7435.09812
+  dps: 7828.81248
+  tps: 7659.16162
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7716.1113
-  tps: 7538.14019
+  dps: 7985.7745
+  tps: 7811.19786
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Nibelung-49992"
  value: {
-  dps: 7817.27857
-  tps: 7639.0169
+  dps: 8085.12785
+  tps: 7909.90711
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Nibelung-50648"
  value: {
-  dps: 7817.27857
-  tps: 7639.0169
+  dps: 8085.12785
+  tps: 7909.90711
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NightsongBattlegear"
  value: {
-  dps: 4477.02524
-  tps: 4290.18048
+  dps: 4760.05661
+  tps: 4578.36313
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NightsongGarb"
  value: {
-  dps: 7112.0856
-  tps: 6939.37718
+  dps: 7298.92805
+  tps: 7128.67495
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7837.75557
+  tps: 7665.59279
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7837.75557
+  tps: 7665.59279
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7837.75557
+  tps: 7665.59279
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7837.75557
+  tps: 7665.59279
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7963.53878
-  tps: 7785.31951
+  dps: 8180.72583
+  tps: 8003.97868
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 8022.80185
-  tps: 7843.82377
+  dps: 8241.95521
+  tps: 8064.44926
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7795.26416
-  tps: 7616.58085
+  dps: 8062.76851
+  tps: 7887.44972
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7979.09519
+  tps: 7803.87445
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.00133
+  dps: 7837.75557
+  tps: 7664.97034
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7979.09519
+  tps: 7803.87445
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7756.70424
-  tps: 7578.70368
+  dps: 8022.06933
+  tps: 7846.97188
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7791.14352
-  tps: 7612.63698
+  dps: 8057.72409
+  tps: 7882.081
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7613.78121
-  tps: 7436.59751
+  dps: 7874.10207
+  tps: 7699.9593
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7668.87723
-  tps: 7500.19494
+  dps: 7845.12868
+  tps: 7678.73433
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SparkofLife-37657"
  value: {
-  dps: 7611.33964
-  tps: 7434.97242
+  dps: 7819.68775
+  tps: 7646.61783
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-StormshroudArmor"
  value: {
-  dps: 4854.01086
-  tps: 4661.93652
+  dps: 5228.80412
+  tps: 5043.16574
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7837.75557
+  tps: 7665.59279
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7837.75557
+  tps: 7665.59279
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7837.75557
+  tps: 7665.59279
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7526.94566
-  tps: 7351.87632
+  dps: 7784.2018
+  tps: 7612.17175
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7546.94318
-  tps: 7374.91013
+  dps: 7784.61286
+  tps: 7614.77019
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartHarness"
  value: {
-  dps: 3394.20322
-  tps: 3210.55542
+  dps: 3597.09718
+  tps: 3417.73262
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartRegalia"
  value: {
-  dps: 5285.82141
-  tps: 5108.93482
+  dps: 5543.02836
+  tps: 5371.94748
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7587.20126
-  tps: 7411.67145
+  dps: 7837.75557
+  tps: 7665.59279
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7484.6339
-  tps: 7310.61192
+  dps: 7740.39672
+  tps: 7569.41567
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7628.96227
-  tps: 7452.38993
+  dps: 7880.94009
+  tps: 7707.73478
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7620.61007
-  tps: 7444.24623
+  dps: 7872.30319
+  tps: 7699.30638
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7681.52533
-  tps: 7507.05495
+  dps: 7934.1665
+  tps: 7762.18959
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7620.61007
-  tps: 7444.24623
+  dps: 7872.30319
+  tps: 7699.30638
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7628.96227
-  tps: 7452.38993
+  dps: 7880.94009
+  tps: 7707.73478
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 4900.89907
-  tps: 4708.69097
+  dps: 5195.43758
+  tps: 5007.13625
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 8140.94664
-  tps: 7961.26176
+  dps: 8370.50473
+  tps: 8192.90514
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7979.09519
+  tps: 7803.87445
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7621.15201
-  tps: 7439.87861
+  dps: 7881.40027
+  tps: 7703.1678
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 7713.72732
-  tps: 7535.46565
+  dps: 7979.09519
+  tps: 7803.87445
  }
 }
 dps_results: {
  key: "TestBalance-Average-Default"
  value: {
-  dps: 7950.64092
-  tps: 7775.12942
+  dps: 8149.50453
+  tps: 7976.56069
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11265.89849
-  tps: 13302.97881
+  dps: 11526.60968
+  tps: 13647.85752
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7817.27857
-  tps: 7639.0169
+  dps: 8085.12785
+  tps: 7909.90711
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8789.4628
-  tps: 8197.76198
+  dps: 8992.04978
+  tps: 8402.66657
  }
 }
 dps_results: {
@@ -992,22 +992,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotBoth-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12696.82191
-  tps: 13232.91317
+  dps: 12716.89312
+  tps: 13252.98437
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotBoth-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7916.23663
-  tps: 7741.84335
+  dps: 8082.97131
+  tps: 7909.66978
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotBoth-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8808.85504
-  tps: 8215.61188
+  dps: 9013.56435
+  tps: 8423.88254
  }
 }
 dps_results: {
@@ -1034,22 +1034,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotIs-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12696.82191
-  tps: 13232.91317
+  dps: 12716.89312
+  tps: 13252.98437
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotIs-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7898.96784
-  tps: 7720.74372
+  dps: 8090.72863
+  tps: 7915.24291
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotIs-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8803.14713
-  tps: 8209.06638
+  dps: 9015.21323
+  tps: 8424.08086
  }
 }
 dps_results: {
@@ -1076,22 +1076,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotMf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7631.39843
-  tps: 8929.33821
+  dps: 7670.51061
+  tps: 8975.24123
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotMf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7880.95466
-  tps: 7707.08939
+  dps: 8073.9094
+  tps: 7901.65795
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-MultidotMf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8779.65474
-  tps: 8188.57767
+  dps: 8997.91405
+  tps: 8409.79393
  }
 }
 dps_results: {
@@ -1118,22 +1118,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13693.1272
-  tps: 15973.41205
+  dps: 13898.60913
+  tps: 16213.22241
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9499.13661
-  tps: 9303.81314
+  dps: 9668.19517
+  tps: 9472.54508
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10734.95179
-  tps: 10074.3613
+  dps: 11000.01252
+  tps: 10341.88441
  }
 }
 dps_results: {
@@ -1160,22 +1160,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotBoth-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14667.82057
-  tps: 15289.83965
+  dps: 14710.68951
+  tps: 15334.44599
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotBoth-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9594.89313
-  tps: 9395.7556
+  dps: 9794.21743
+  tps: 9598.74971
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotBoth-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10745.64479
-  tps: 10086.89356
+  dps: 10976.63803
+  tps: 10319.50463
  }
 }
 dps_results: {
@@ -1202,22 +1202,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotIs-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14667.82057
-  tps: 15289.83965
+  dps: 14710.68951
+  tps: 15334.44599
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotIs-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9569.36231
-  tps: 9368.98327
+  dps: 9730.69781
+  tps: 9532.7958
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotIs-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10896.60912
-  tps: 10237.3792
+  dps: 11086.20205
+  tps: 10428.28743
  }
 }
 dps_results: {
@@ -1244,22 +1244,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotMf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9847.99458
-  tps: 11809.61011
+  dps: 9865.58715
+  tps: 11828.94008
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotMf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9536.91305
-  tps: 9340.95577
+  dps: 9743.41358
+  tps: 9550.78505
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-MultidotMf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10763.63436
-  tps: 10105.84332
+  dps: 11004.32923
+  tps: 10348.23961
  }
 }
 dps_results: {
@@ -1286,22 +1286,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13965.85159
-  tps: 16222.3852
+  dps: 14263.73838
+  tps: 16602.97957
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9611.89264
-  tps: 9410.99834
+  dps: 9808.726
+  tps: 9609.36036
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10909.4365
-  tps: 10240.68627
+  dps: 11089.40333
+  tps: 10422.89489
  }
 }
 dps_results: {
@@ -1328,22 +1328,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotBoth-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14935.52842
-  tps: 15561.49409
+  dps: 14972.57836
+  tps: 15598.54403
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotBoth-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9623.21774
-  tps: 9420.92874
+  dps: 9834.59776
+  tps: 9632.99676
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotBoth-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10891.79326
-  tps: 10223.51259
+  dps: 11023.44921
+  tps: 10356.45252
  }
 }
 dps_results: {
@@ -1370,22 +1370,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotIs-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14935.52842
-  tps: 15561.49409
+  dps: 14972.57836
+  tps: 15598.54403
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotIs-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9625.46138
-  tps: 9421.53525
+  dps: 9775.12774
+  tps: 9572.64325
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotIs-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10971.82346
-  tps: 10302.70626
+  dps: 11104.56187
+  tps: 10436.99448
  }
 }
 dps_results: {
@@ -1412,22 +1412,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotMf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10181.36556
-  tps: 12270.39171
+  dps: 10220.34689
+  tps: 12318.35554
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotMf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9571.17489
-  tps: 9372.44481
+  dps: 9805.89401
+  tps: 9610.27794
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-MultidotMf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 10890.32473
-  tps: 10222.92209
+  dps: 11016.15302
+  tps: 10349.85306
  }
 }
 dps_results: {
@@ -1454,22 +1454,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15790.48572
-  tps: 18203.48558
+  dps: 16032.40775
+  tps: 18498.70034
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10957.51831
-  tps: 10756.60984
+  dps: 11236.57786
+  tps: 11038.02733
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11946.48002
-  tps: 11258.68738
+  dps: 12233.60154
+  tps: 11547.82181
  }
 }
 dps_results: {
@@ -1496,22 +1496,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotBoth-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16378.87966
-  tps: 17317.56961
+  dps: 16432.82492
+  tps: 17373.44851
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotBoth-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11127.74432
-  tps: 10922.55099
+  dps: 11371.42362
+  tps: 11164.30316
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotBoth-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12142.03239
-  tps: 11428.73575
+  dps: 12372.39525
+  tps: 11660.97868
  }
 }
 dps_results: {
@@ -1538,22 +1538,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotIs-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16258.69704
-  tps: 16955.21748
+  dps: 16304.27926
+  tps: 16999.80488
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotIs-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10963.68947
-  tps: 10759.24404
+  dps: 11223.99456
+  tps: 11021.65189
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotIs-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12042.87029
-  tps: 11356.68881
+  dps: 12309.79694
+  tps: 11625.52709
  }
 }
 dps_results: {
@@ -1580,22 +1580,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotMf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14769.26952
-  tps: 17816.05436
+  dps: 14864.22032
+  tps: 17909.73274
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotMf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11161.55104
-  tps: 10958.95368
+  dps: 11504.09353
+  tps: 11302.54634
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-MultidotMf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12157.23365
-  tps: 11443.89435
+  dps: 12415.10593
+  tps: 11703.36311
  }
 }
 dps_results: {
@@ -1622,7 +1622,7 @@ dps_results: {
 dps_results: {
  key: "TestBalance-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7784.36774
-  tps: 7639.0169
+  dps: 8052.19698
+  tps: 7909.90711
  }
 }

--- a/sim/druid/balance/TestBalancePhase3.results
+++ b/sim/druid/balance/TestBalancePhase3.results
@@ -46,926 +46,926 @@ character_stats_results: {
 dps_results: {
  key: "TestBalancePhase3-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 11048.46671
-  tps: 10805.55991
+  dps: 11336.70754
+  tps: 11097.64077
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 11093.28535
-  tps: 10849.312
+  dps: 11382.68872
+  tps: 11142.5554
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 10797.9618
-  tps: 10563.00291
+  dps: 11081.98079
+  tps: 10849.97125
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 11163.70902
+  tps: 10929.22032
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10682.21656
-  tps: 10547.69579
+  dps: 10961.70369
+  tps: 10831.4404
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10682.21656
-  tps: 10547.69579
+  dps: 10961.70369
+  tps: 10831.4404
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 10946.33618
-  tps: 10708.94339
+  dps: 11198.52514
+  tps: 10963.47577
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8327.311
-  tps: 8099.92456
+  dps: 8505.96192
+  tps: 8280.12576
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 10922.02012
-  tps: 10468.91503
+  dps: 11213.66343
+  tps: 10761.56717
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 11153.03279
+  tps: 10915.45915
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11324.87689
-  tps: 11082.39742
+  dps: 11595.72394
+  tps: 11355.66931
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
   hps: 64
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 10892.44155
-  tps: 10661.07484
+  dps: 11091.38093
+  tps: 10862.09816
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 10856.24212
-  tps: 10625.36954
+  dps: 11118.49397
+  tps: 10890.79832
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 10866.57498
-  tps: 10643.61308
+  dps: 11129.44262
+  tps: 10908.98664
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 11153.03279
+  tps: 10915.45915
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Death'sChoice-47464"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10772.01759
-  tps: 10538.91589
+  dps: 11004.28523
+  tps: 10774.22699
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 10952.91362
-  tps: 10714.95369
+  dps: 11204.45462
+  tps: 10968.8336
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11455.07591
-  tps: 11218.82865
+  dps: 11700.6057
+  tps: 11468.41977
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11352.75374
-  tps: 11118.53258
+  dps: 11610.09357
+  tps: 11381.07753
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 6847.41492
-  tps: 6626.50454
+  dps: 7141.19326
+  tps: 6926.26382
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DreamwalkerGarb"
  value: {
-  dps: 8668.76781
-  tps: 8452.3858
+  dps: 8912.54387
+  tps: 8698.00147
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 11163.70902
+  tps: 10929.22032
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 10939.27648
-  tps: 10698.98189
+  dps: 11238.06977
+  tps: 11001.228
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 10946.33618
-  tps: 10708.1473
+  dps: 11198.52514
+  tps: 10962.7611
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 10930.37182
-  tps: 10691.91119
+  dps: 11189.24316
+  tps: 10952.81676
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10831.45971
-  tps: 10599.41185
+  dps: 11047.16195
+  tps: 10820.96178
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 11163.70902
+  tps: 10929.22032
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 10959.91115
-  tps: 10731.05008
+  dps: 11126.24017
+  tps: 10896.45219
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 11134.49187
-  tps: 10899.11362
+  dps: 11364.20898
+  tps: 11130.90917
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10708.78889
-  tps: 10477.97459
+  dps: 10991.56081
+  tps: 10763.16246
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10909.93636
-  tps: 10670.32618
+  dps: 11194.58389
+  tps: 10958.81374
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForgeEmber-37660"
  value: {
-  dps: 11058.3154
-  tps: 10821.90263
+  dps: 11259.76748
+  tps: 11027.08291
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 10922.02012
-  tps: 10679.42775
+  dps: 11213.66343
+  tps: 10977.97582
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 10912.28873
-  tps: 10669.93615
+  dps: 11203.67255
+  tps: 10968.22472
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 11153.03279
+  tps: 10915.45915
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10838.75145
-  tps: 10600.02407
+  dps: 11121.57139
+  tps: 10886.68404
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 7168.51137
-  tps: 6955.68902
+  dps: 7370.47983
+  tps: 7159.7439
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 9266.27009
-  tps: 9022.27041
+  dps: 9537.38671
+  tps: 9295.42334
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 11070.87603
-  tps: 10827.43596
+  dps: 11359.69813
+  tps: 11120.09808
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 11121.80631
-  tps: 10877.15424
+  dps: 11411.94947
+  tps: 11171.13743
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 10845.48071
-  tps: 10616.51491
+  dps: 11129.54448
+  tps: 10896.87991
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 11153.03279
+  tps: 10915.45915
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Heartpierce-49982"
  value: {
-  dps: 11324.87689
-  tps: 11082.39742
+  dps: 11595.72394
+  tps: 11355.66931
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Heartpierce-50641"
  value: {
-  dps: 11324.87689
-  tps: 11082.39742
+  dps: 11595.72394
+  tps: 11355.66931
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 11153.03279
+  tps: 10915.45915
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 11153.03279
+  tps: 10915.45915
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 11153.03279
+  tps: 10915.45915
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 11334.0292
-  tps: 11100.29747
+  dps: 11583.6039
+  tps: 11351.24153
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 10962.96914
-  tps: 10722.84395
+  dps: 11254.04065
+  tps: 11017.13825
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 10925.02032
-  tps: 10685.65614
+  dps: 11203.20017
+  tps: 10965.11372
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 11153.03279
+  tps: 10915.45915
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 11077.18076
-  tps: 10837.59416
+  dps: 11366.46076
+  tps: 11130.71418
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 10946.33618
-  tps: 10708.1473
+  dps: 11198.52514
+  tps: 10962.7611
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 10930.37182
-  tps: 10691.91119
+  dps: 11189.24316
+  tps: 10952.81676
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IncisorFragment-37723"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 10883.18845
-  tps: 10645.1165
+  dps: 11178.45129
+  tps: 10944.59932
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 11163.70902
+  tps: 10929.22032
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 6850.62419
-  tps: 6628.61676
+  dps: 7232.50971
+  tps: 7020.6027
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LasherweaveRegalia"
  value: {
-  dps: 9962.59336
-  tps: 9743.68378
+  dps: 10122.42199
+  tps: 9903.28923
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LastWord-50179"
  value: {
-  dps: 11324.87689
-  tps: 11082.39742
+  dps: 11595.72394
+  tps: 11355.66931
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LastWord-50708"
  value: {
-  dps: 11324.87689
-  tps: 11082.39742
+  dps: 11595.72394
+  tps: 11355.66931
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10804.71457
-  tps: 10568.8626
+  dps: 11086.68544
+  tps: 10854.67349
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 7486.11683
-  tps: 7270.70616
+  dps: 7685.58519
+  tps: 7474.54498
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 9408.77243
-  tps: 9180.91737
+  dps: 9634.28552
+  tps: 9408.50664
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 10851.08371
-  tps: 10619.60202
+  dps: 11052.02987
+  tps: 10822.48867
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 10965.92145
-  tps: 10727.67473
+  dps: 11246.14057
+  tps: 11011.22973
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Nibelung-49992"
  value: {
-  dps: 11324.87689
-  tps: 11082.39742
+  dps: 11595.72394
+  tps: 11355.66931
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Nibelung-50648"
  value: {
-  dps: 11324.87689
-  tps: 11082.39742
+  dps: 11595.72394
+  tps: 11355.66931
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-NightsongBattlegear"
  value: {
-  dps: 7176.78921
-  tps: 6957.8656
+  dps: 7487.8432
+  tps: 7273.87027
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-NightsongGarb"
  value: {
-  dps: 8978.95386
-  tps: 8750.8476
+  dps: 9178.96537
+  tps: 8950.20057
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 11163.70902
+  tps: 10929.22032
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 11163.70902
+  tps: 10929.22032
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 11163.70902
+  tps: 10929.22032
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 11163.70902
+  tps: 10929.22032
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 11251.73153
-  tps: 11010.12469
+  dps: 11520.73229
+  tps: 11281.55029
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 11324.87689
-  tps: 11082.39742
+  dps: 11595.72394
+  tps: 11355.66931
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11246.50307
-  tps: 11000.80279
+  dps: 11558.18855
+  tps: 11319.43066
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 11153.03279
+  tps: 10915.45915
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.51746
+  dps: 11163.70902
+  tps: 10928.76399
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 11153.03279
+  tps: 10915.45915
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 11005.68528
-  tps: 10765.55159
+  dps: 11292.81641
+  tps: 11056.1073
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 11046.4295
-  tps: 10805.42134
+  dps: 11334.61749
+  tps: 11096.99352
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10836.59676
-  tps: 10598.73186
+  dps: 11119.34196
+  tps: 10885.31708
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SouloftheDead-40382"
  value: {
-  dps: 10884.09914
-  tps: 10655.48503
+  dps: 11099.78825
+  tps: 10872.87929
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SparkofLife-37657"
  value: {
-  dps: 10807.45258
-  tps: 10574.27943
+  dps: 11032.50053
+  tps: 10802.11195
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 10846.17001
-  tps: 10612.00163
+  dps: 11046.02273
+  tps: 10817.42332
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-StormshroudArmor"
  value: {
-  dps: 7869.88289
-  tps: 7648.03901
+  dps: 8006.15923
+  tps: 7785.31459
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 11163.70902
+  tps: 10929.22032
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 11163.70902
+  tps: 10929.22032
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 11163.70902
+  tps: 10929.22032
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10733.86387
-  tps: 10498.44371
+  dps: 11013.94431
+  tps: 10782.36418
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10795.60438
-  tps: 10564.0818
+  dps: 11022.47933
+  tps: 10793.4807
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10962.58793
+  tps: 10732.19903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ThunderheartHarness"
  value: {
-  dps: 4438.92815
-  tps: 4212.25261
+  dps: 4715.24515
+  tps: 4494.26998
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ThunderheartRegalia"
  value: {
-  dps: 6814.97761
-  tps: 6598.31879
+  dps: 6992.80536
+  tps: 6780.09369
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 11163.70902
+  tps: 10929.22032
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 10846.17001
-  tps: 10612.00163
+  dps: 11046.02273
+  tps: 10817.42332
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 10846.17001
-  tps: 10612.00163
+  dps: 11046.02273
+  tps: 10817.42332
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 10922.02012
-  tps: 10679.42775
+  dps: 11213.66343
+  tps: 10977.97582
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 10912.28873
-  tps: 10669.93615
+  dps: 11203.67255
+  tps: 10968.22472
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 11002.44636
-  tps: 10768.13718
+  dps: 11191.71116
+  tps: 10962.25017
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 10912.28873
-  tps: 10669.93615
+  dps: 11203.67255
+  tps: 10968.22472
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 10922.02012
-  tps: 10679.42775
+  dps: 11213.66343
+  tps: 10977.97582
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 7964.57939
-  tps: 7743.73566
+  dps: 8107.21051
+  tps: 7888.46531
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 11193.99141
-  tps: 10955.35712
+  dps: 11491.93659
+  tps: 11255.79555
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 11153.03279
+  tps: 10915.45915
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10843.79618
-  tps: 10601.22813
+  dps: 11126.83343
+  tps: 10888.10541
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 11153.03279
+  tps: 10915.45915
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Average-Default"
  value: {
-  dps: 11436.82321
-  tps: 11201.56087
+  dps: 11681.44882
+  tps: 11448.97776
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-P3-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16034.64442
-  tps: 18765.61042
+  dps: 16268.29629
+  tps: 19059.08231
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-P3-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11324.87689
-  tps: 11082.39742
+  dps: 11595.72394
+  tps: 11355.66931
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-P3-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12294.70062
-  tps: 11471.56054
+  dps: 12477.70954
+  tps: 11655.99038
  }
 }
 dps_results: {
@@ -992,7 +992,7 @@ dps_results: {
 dps_results: {
  key: "TestBalancePhase3-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 11280.52948
-  tps: 11082.39742
+  dps: 11551.37653
+  tps: 11355.66931
  }
 }

--- a/sim/druid/balance/TestBalancePhase3.results
+++ b/sim/druid/balance/TestBalancePhase3.results
@@ -46,953 +46,953 @@ character_stats_results: {
 dps_results: {
  key: "TestBalancePhase3-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 11048.46671
-  tps: 10805.55991
+  dps: 11171.591
+  tps: 10930.05933
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 11093.28535
-  tps: 10849.312
+  dps: 11216.85652
+  tps: 10974.2583
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 10797.9618
-  tps: 10563.00291
+  dps: 10919.16185
+  tps: 10685.39485
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 10981.96255
+  tps: 10744.05328
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10682.21656
-  tps: 10547.69579
+  dps: 10803.246
+  tps: 10670.01223
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10682.21656
-  tps: 10547.69579
+  dps: 10803.246
+  tps: 10670.01223
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 10946.33618
-  tps: 10708.94339
+  dps: 11008.03564
+  tps: 10771.34878
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8327.311
-  tps: 8099.92456
+  dps: 8384.36293
+  tps: 8156.74691
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 10922.02012
-  tps: 10468.91503
+  dps: 11031.1316
+  tps: 10579.29752
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 10969.81125
+  tps: 10729.84682
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11324.87689
-  tps: 11082.39742
+  dps: 11391.85625
+  tps: 11150.10043
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
   hps: 64
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 10892.44155
-  tps: 10661.07484
+  dps: 10962.5087
+  tps: 10732.25541
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 10856.24212
-  tps: 10625.36954
+  dps: 10919.12041
+  tps: 10689.34955
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 10866.57498
-  tps: 10643.61308
+  dps: 10941.77648
+  tps: 10720.16436
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 10969.81125
+  tps: 10729.84682
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Death'sChoice-47464"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10772.01759
-  tps: 10538.91589
+  dps: 10850.2303
+  tps: 10618.74861
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 10952.91362
-  tps: 10714.95369
+  dps: 11012.75719
+  tps: 10775.38146
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11455.07591
-  tps: 11218.82865
+  dps: 11562.28247
+  tps: 11327.2299
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11352.75374
-  tps: 11118.53258
+  dps: 11475.2324
+  tps: 11242.36666
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 6847.41492
-  tps: 6626.50454
+  dps: 6908.51535
+  tps: 6687.19975
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DreamwalkerGarb"
  value: {
-  dps: 8668.76781
-  tps: 8452.3858
+  dps: 8746.14099
+  tps: 8530.3224
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 10981.96255
+  tps: 10744.05328
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 10939.27648
-  tps: 10698.98189
+  dps: 11048.22836
+  tps: 10809.71961
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 10946.33618
-  tps: 10708.1473
+  dps: 11008.03564
+  tps: 10770.57041
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 10930.37182
-  tps: 10691.91119
+  dps: 11007.15851
+  tps: 10769.55742
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10831.45971
-  tps: 10599.41185
+  dps: 10926.00801
+  tps: 10695.90559
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 10981.96255
+  tps: 10744.05328
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 10959.91115
-  tps: 10731.05008
+  dps: 11037.3943
+  tps: 10809.07746
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 11134.49187
-  tps: 10899.11362
+  dps: 11230.63041
+  tps: 10996.04926
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10708.78889
-  tps: 10477.97459
+  dps: 10833.60582
+  tps: 10603.36459
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10909.93636
-  tps: 10670.32618
+  dps: 11031.67939
+  tps: 10793.44434
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForgeEmber-37660"
  value: {
-  dps: 11058.3154
-  tps: 10821.90263
+  dps: 11118.05147
+  tps: 10882.93307
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 10922.02012
-  tps: 10679.42775
+  dps: 11031.1316
+  tps: 10792.02342
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 10912.28873
-  tps: 10669.93615
+  dps: 11021.29779
+  tps: 10782.4294
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 10969.81125
+  tps: 10729.84682
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10838.75145
-  tps: 10600.02407
+  dps: 10959.89115
+  tps: 10722.5389
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 7168.51137
-  tps: 6955.68902
+  dps: 7306.70673
+  tps: 7095.40483
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 9266.27009
-  tps: 9022.27041
+  dps: 9381.55842
+  tps: 9137.57465
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 11070.87603
-  tps: 10827.43596
+  dps: 11194.22376
+  tps: 10952.15881
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 11121.80631
-  tps: 10877.15424
+  dps: 11245.66185
+  tps: 11002.38491
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 10845.48071
-  tps: 10616.51491
+  dps: 10951.70114
+  tps: 10721.56325
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 10969.81125
+  tps: 10729.84682
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Heartpierce-49982"
  value: {
-  dps: 11324.87689
-  tps: 11082.39742
+  dps: 11391.85625
+  tps: 11150.10043
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Heartpierce-50641"
  value: {
-  dps: 11324.87689
-  tps: 11082.39742
+  dps: 11391.85625
+  tps: 11150.10043
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 10969.81125
+  tps: 10729.84682
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 10969.81125
+  tps: 10729.84682
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 10969.81125
+  tps: 10729.84682
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 11334.0292
-  tps: 11100.29747
+  dps: 11460.65594
+  tps: 11230.59328
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 10962.96914
-  tps: 10722.84395
+  dps: 11051.90585
+  tps: 10812.38214
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 10925.02032
-  tps: 10685.65614
+  dps: 11019.00025
+  tps: 10778.34361
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 10969.81125
+  tps: 10729.84682
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 11077.18076
-  tps: 10837.59416
+  dps: 11200.71393
+  tps: 10962.50246
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 10946.33618
-  tps: 10708.1473
+  dps: 11008.03564
+  tps: 10770.57041
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 10930.37182
-  tps: 10691.91119
+  dps: 11007.15851
+  tps: 10769.55742
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IncisorFragment-37723"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 10883.18845
-  tps: 10645.1165
+  dps: 10994.91233
+  tps: 10759.59594
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 10981.96255
+  tps: 10744.05328
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 6850.62419
-  tps: 6628.61676
+  dps: 6915.16343
+  tps: 6692.75783
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LasherweaveRegalia"
  value: {
-  dps: 9962.59336
-  tps: 9743.68378
+  dps: 10018.10353
+  tps: 9799.20773
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LastWord-50179"
  value: {
-  dps: 11324.87689
-  tps: 11082.39742
+  dps: 11391.85625
+  tps: 11150.10043
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LastWord-50708"
  value: {
-  dps: 11324.87689
-  tps: 11082.39742
+  dps: 11391.85625
+  tps: 11150.10043
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10804.71457
-  tps: 10568.8626
+  dps: 10925.43037
+  tps: 10690.95352
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 7486.11683
-  tps: 7270.70616
+  dps: 7585.25902
+  tps: 7370.21407
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 9408.77243
-  tps: 9180.91737
+  dps: 9425.6778
+  tps: 9197.31711
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 10851.08371
-  tps: 10619.60202
+  dps: 10913.80336
+  tps: 10683.03653
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 10965.92145
-  tps: 10727.67473
+  dps: 11095.64531
+  tps: 10858.77537
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Nibelung-49992"
  value: {
-  dps: 11324.87689
-  tps: 11082.39742
+  dps: 11391.85625
+  tps: 11150.10043
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Nibelung-50648"
  value: {
-  dps: 11324.87689
-  tps: 11082.39742
+  dps: 11391.85625
+  tps: 11150.10043
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-NightsongBattlegear"
  value: {
-  dps: 7176.78921
-  tps: 6957.8656
+  dps: 7269.27311
+  tps: 7052.89198
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-NightsongGarb"
  value: {
-  dps: 8978.95386
-  tps: 8750.8476
+  dps: 9026.26895
+  tps: 8798.46221
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 10981.96255
+  tps: 10744.05328
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 10981.96255
+  tps: 10744.05328
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 10981.96255
+  tps: 10744.05328
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 10981.96255
+  tps: 10744.05328
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 11251.73153
-  tps: 11010.12469
+  dps: 11318.94561
+  tps: 11078.06242
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 11324.87689
-  tps: 11082.39742
+  dps: 11391.85625
+  tps: 11150.10043
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11246.50307
-  tps: 11000.80279
+  dps: 11363.6244
+  tps: 11121.42453
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 10969.81125
+  tps: 10729.84682
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.51746
+  dps: 10981.96255
+  tps: 10743.58738
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 10969.81125
+  tps: 10729.84682
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 11005.68528
-  tps: 10765.55159
+  dps: 11128.383
+  tps: 10889.43358
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 11046.4295
-  tps: 10805.42134
+  dps: 11169.53347
+  tps: 10929.68629
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10836.59676
-  tps: 10598.73186
+  dps: 10957.60854
+  tps: 10721.11876
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SouloftheDead-40382"
  value: {
-  dps: 10884.09914
-  tps: 10655.48503
+  dps: 10957.83655
+  tps: 10729.86701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SparkofLife-37657"
  value: {
-  dps: 10807.45258
-  tps: 10574.27943
+  dps: 10918.70219
+  tps: 10688.12426
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 10846.17001
-  tps: 10612.00163
+  dps: 10898.11723
+  tps: 10667.14466
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-StormshroudArmor"
  value: {
-  dps: 7869.88289
-  tps: 7648.03901
+  dps: 7925.87426
+  tps: 7706.26825
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 10981.96255
+  tps: 10744.05328
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 10981.96255
+  tps: 10744.05328
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 10981.96255
+  tps: 10744.05328
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10733.86387
-  tps: 10498.44371
+  dps: 10853.85132
+  tps: 10619.80629
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10795.60438
-  tps: 10564.0818
+  dps: 10865.80182
+  tps: 10635.51009
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10683.80593
-  tps: 10449.57701
+  dps: 10803.29426
+  tps: 10570.44047
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ThunderheartHarness"
  value: {
-  dps: 4438.92815
-  tps: 4212.25261
+  dps: 4561.21796
+  tps: 4336.05753
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ThunderheartRegalia"
  value: {
-  dps: 6814.97761
-  tps: 6598.31879
+  dps: 6912.54255
+  tps: 6698.08076
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 10873.36317
-  tps: 10631.96971
+  dps: 10981.96255
+  tps: 10744.05328
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 10846.17001
-  tps: 10612.00163
+  dps: 10898.11723
+  tps: 10667.14466
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 10846.17001
-  tps: 10612.00163
+  dps: 10898.11723
+  tps: 10667.14466
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 10922.02012
-  tps: 10679.42775
+  dps: 11031.1316
+  tps: 10792.02342
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 10912.28873
-  tps: 10669.93615
+  dps: 11021.29779
+  tps: 10782.4294
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 11002.44636
-  tps: 10768.13718
+  dps: 11057.78497
+  tps: 10824.08987
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 10912.28873
-  tps: 10669.93615
+  dps: 11021.29779
+  tps: 10782.4294
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 10922.02012
-  tps: 10679.42775
+  dps: 11031.1316
+  tps: 10792.02342
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 7964.57939
-  tps: 7743.73566
+  dps: 7988.91349
+  tps: 7768.78493
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 11193.99141
-  tps: 10955.35712
+  dps: 11277.83501
+  tps: 11038.33216
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 10969.81125
+  tps: 10729.84682
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10843.79618
-  tps: 10601.22813
+  dps: 10965.47435
+  tps: 10724.28143
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 10877.12422
-  tps: 10638.1149
+  dps: 10969.81125
+  tps: 10729.84682
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Average-Default"
  value: {
-  dps: 11436.82321
-  tps: 11201.56087
+  dps: 11509.58823
+  tps: 11275.10971
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-P3-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15946.67004
-  tps: 18677.63604
+  dps: 16061.45221
+  tps: 18811.78812
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-P3-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11324.87689
-  tps: 11082.39742
+  dps: 11391.85625
+  tps: 11150.10043
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-P3-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12294.70062
-  tps: 11471.56054
+  dps: 12343.88023
+  tps: 11521.03069
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-P3-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7173.07763
-  tps: 8028.16316
+  dps: 7391.73183
+  tps: 8294.71074
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-P3-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4495.19313
-  tps: 4362.48958
+  dps: 4614.25456
+  tps: 4484.506
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-P3-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7678.11799
-  tps: 7310.79684
+  dps: 7746.92403
+  tps: 7381.52666
  }
 }
 dps_results: {
  key: "TestBalancePhase3-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 11280.52948
-  tps: 11082.39742
+  dps: 11347.50883
+  tps: 11150.10043
  }
 }

--- a/sim/druid/balance/TestBalancePhase3.results
+++ b/sim/druid/balance/TestBalancePhase3.results
@@ -46,953 +46,953 @@ character_stats_results: {
 dps_results: {
  key: "TestBalancePhase3-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 11336.70754
-  tps: 11097.64077
+  dps: 11048.46671
+  tps: 10805.55991
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 11382.68872
-  tps: 11142.5554
+  dps: 11093.28535
+  tps: 10849.312
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 11081.98079
-  tps: 10849.97125
+  dps: 10797.9618
+  tps: 10563.00291
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 11163.70902
-  tps: 10929.22032
+  dps: 10873.36317
+  tps: 10631.96971
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10961.70369
-  tps: 10831.4404
+  dps: 10682.21656
+  tps: 10547.69579
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10961.70369
-  tps: 10831.4404
+  dps: 10682.21656
+  tps: 10547.69579
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 11198.52514
-  tps: 10963.47577
+  dps: 10946.33618
+  tps: 10708.94339
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8505.96192
-  tps: 8280.12576
+  dps: 8327.311
+  tps: 8099.92456
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 11213.66343
-  tps: 10761.56717
+  dps: 10922.02012
+  tps: 10468.91503
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 11153.03279
-  tps: 10915.45915
+  dps: 10877.12422
+  tps: 10638.1149
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11595.72394
-  tps: 11355.66931
+  dps: 11324.87689
+  tps: 11082.39742
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
   hps: 64
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 11091.38093
-  tps: 10862.09816
+  dps: 10892.44155
+  tps: 10661.07484
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 11118.49397
-  tps: 10890.79832
+  dps: 10856.24212
+  tps: 10625.36954
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 11129.44262
-  tps: 10908.98664
+  dps: 10866.57498
+  tps: 10643.61308
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 11153.03279
-  tps: 10915.45915
+  dps: 10877.12422
+  tps: 10638.1149
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Death'sChoice-47464"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 11004.28523
-  tps: 10774.22699
+  dps: 10772.01759
+  tps: 10538.91589
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 11204.45462
-  tps: 10968.8336
+  dps: 10952.91362
+  tps: 10714.95369
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11700.6057
-  tps: 11468.41977
+  dps: 11455.07591
+  tps: 11218.82865
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11610.09357
-  tps: 11381.07753
+  dps: 11352.75374
+  tps: 11118.53258
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 7141.19326
-  tps: 6926.26382
+  dps: 6847.41492
+  tps: 6626.50454
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DreamwalkerGarb"
  value: {
-  dps: 8912.54387
-  tps: 8698.00147
+  dps: 8668.76781
+  tps: 8452.3858
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 11163.70902
-  tps: 10929.22032
+  dps: 10873.36317
+  tps: 10631.96971
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 11238.06977
-  tps: 11001.228
+  dps: 10939.27648
+  tps: 10698.98189
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 11198.52514
-  tps: 10962.7611
+  dps: 10946.33618
+  tps: 10708.1473
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 11189.24316
-  tps: 10952.81676
+  dps: 10930.37182
+  tps: 10691.91119
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 11047.16195
-  tps: 10820.96178
+  dps: 10831.45971
+  tps: 10599.41185
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 11163.70902
-  tps: 10929.22032
+  dps: 10873.36317
+  tps: 10631.96971
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 11126.24017
-  tps: 10896.45219
+  dps: 10959.91115
+  tps: 10731.05008
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 11364.20898
-  tps: 11130.90917
+  dps: 11134.49187
+  tps: 10899.11362
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10991.56081
-  tps: 10763.16246
+  dps: 10708.78889
+  tps: 10477.97459
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 11194.58389
-  tps: 10958.81374
+  dps: 10909.93636
+  tps: 10670.32618
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForgeEmber-37660"
  value: {
-  dps: 11259.76748
-  tps: 11027.08291
+  dps: 11058.3154
+  tps: 10821.90263
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 11213.66343
-  tps: 10977.97582
+  dps: 10922.02012
+  tps: 10679.42775
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 11203.67255
-  tps: 10968.22472
+  dps: 10912.28873
+  tps: 10669.93615
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 11153.03279
-  tps: 10915.45915
+  dps: 10877.12422
+  tps: 10638.1149
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-FuturesightRune-38763"
  value: {
-  dps: 11121.57139
-  tps: 10886.68404
+  dps: 10838.75145
+  tps: 10600.02407
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 7370.47983
-  tps: 7159.7439
+  dps: 7168.51137
+  tps: 6955.68902
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 9537.38671
-  tps: 9295.42334
+  dps: 9266.27009
+  tps: 9022.27041
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 11359.69813
-  tps: 11120.09808
+  dps: 11070.87603
+  tps: 10827.43596
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 11411.94947
-  tps: 11171.13743
+  dps: 11121.80631
+  tps: 10877.15424
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 11129.54448
-  tps: 10896.87991
+  dps: 10845.48071
+  tps: 10616.51491
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 11153.03279
-  tps: 10915.45915
+  dps: 10877.12422
+  tps: 10638.1149
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Heartpierce-49982"
  value: {
-  dps: 11595.72394
-  tps: 11355.66931
+  dps: 11324.87689
+  tps: 11082.39742
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Heartpierce-50641"
  value: {
-  dps: 11595.72394
-  tps: 11355.66931
+  dps: 11324.87689
+  tps: 11082.39742
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 11153.03279
-  tps: 10915.45915
+  dps: 10877.12422
+  tps: 10638.1149
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 11153.03279
-  tps: 10915.45915
+  dps: 10877.12422
+  tps: 10638.1149
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 11153.03279
-  tps: 10915.45915
+  dps: 10877.12422
+  tps: 10638.1149
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 11583.6039
-  tps: 11351.24153
+  dps: 11334.0292
+  tps: 11100.29747
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 11254.04065
-  tps: 11017.13825
+  dps: 10962.96914
+  tps: 10722.84395
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 11203.20017
-  tps: 10965.11372
+  dps: 10925.02032
+  tps: 10685.65614
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 11153.03279
-  tps: 10915.45915
+  dps: 10877.12422
+  tps: 10638.1149
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 11366.46076
-  tps: 11130.71418
+  dps: 11077.18076
+  tps: 10837.59416
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 11198.52514
-  tps: 10962.7611
+  dps: 10946.33618
+  tps: 10708.1473
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 11189.24316
-  tps: 10952.81676
+  dps: 10930.37182
+  tps: 10691.91119
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IncisorFragment-37723"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 11178.45129
-  tps: 10944.59932
+  dps: 10883.18845
+  tps: 10645.1165
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 11163.70902
-  tps: 10929.22032
+  dps: 10873.36317
+  tps: 10631.96971
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 7232.50971
-  tps: 7020.6027
+  dps: 6850.62419
+  tps: 6628.61676
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LasherweaveRegalia"
  value: {
-  dps: 10122.42199
-  tps: 9903.28923
+  dps: 9962.59336
+  tps: 9743.68378
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LastWord-50179"
  value: {
-  dps: 11595.72394
-  tps: 11355.66931
+  dps: 11324.87689
+  tps: 11082.39742
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LastWord-50708"
  value: {
-  dps: 11595.72394
-  tps: 11355.66931
+  dps: 11324.87689
+  tps: 11082.39742
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 11086.68544
-  tps: 10854.67349
+  dps: 10804.71457
+  tps: 10568.8626
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 7685.58519
-  tps: 7474.54498
+  dps: 7486.11683
+  tps: 7270.70616
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 9634.28552
-  tps: 9408.50664
+  dps: 9408.77243
+  tps: 9180.91737
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 11052.02987
-  tps: 10822.48867
+  dps: 10851.08371
+  tps: 10619.60202
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 11246.14057
-  tps: 11011.22973
+  dps: 10965.92145
+  tps: 10727.67473
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Nibelung-49992"
  value: {
-  dps: 11595.72394
-  tps: 11355.66931
+  dps: 11324.87689
+  tps: 11082.39742
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Nibelung-50648"
  value: {
-  dps: 11595.72394
-  tps: 11355.66931
+  dps: 11324.87689
+  tps: 11082.39742
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-NightsongBattlegear"
  value: {
-  dps: 7487.8432
-  tps: 7273.87027
+  dps: 7176.78921
+  tps: 6957.8656
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-NightsongGarb"
  value: {
-  dps: 9178.96537
-  tps: 8950.20057
+  dps: 8978.95386
+  tps: 8750.8476
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 11163.70902
-  tps: 10929.22032
+  dps: 10873.36317
+  tps: 10631.96971
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 11163.70902
-  tps: 10929.22032
+  dps: 10873.36317
+  tps: 10631.96971
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 11163.70902
-  tps: 10929.22032
+  dps: 10873.36317
+  tps: 10631.96971
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 11163.70902
-  tps: 10929.22032
+  dps: 10873.36317
+  tps: 10631.96971
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 11520.73229
-  tps: 11281.55029
+  dps: 11251.73153
+  tps: 11010.12469
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 11595.72394
-  tps: 11355.66931
+  dps: 11324.87689
+  tps: 11082.39742
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11558.18855
-  tps: 11319.43066
+  dps: 11246.50307
+  tps: 11000.80279
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 11153.03279
-  tps: 10915.45915
+  dps: 10877.12422
+  tps: 10638.1149
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 11163.70902
-  tps: 10928.76399
+  dps: 10873.36317
+  tps: 10631.51746
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 11153.03279
-  tps: 10915.45915
+  dps: 10877.12422
+  tps: 10638.1149
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 11292.81641
-  tps: 11056.1073
+  dps: 11005.68528
+  tps: 10765.55159
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 11334.61749
-  tps: 11096.99352
+  dps: 11046.4295
+  tps: 10805.42134
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SoulPreserver-37111"
  value: {
-  dps: 11119.34196
-  tps: 10885.31708
+  dps: 10836.59676
+  tps: 10598.73186
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SouloftheDead-40382"
  value: {
-  dps: 11099.78825
-  tps: 10872.87929
+  dps: 10884.09914
+  tps: 10655.48503
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SparkofLife-37657"
  value: {
-  dps: 11032.50053
-  tps: 10802.11195
+  dps: 10807.45258
+  tps: 10574.27943
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 11046.02273
-  tps: 10817.42332
+  dps: 10846.17001
+  tps: 10612.00163
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-StormshroudArmor"
  value: {
-  dps: 8006.15923
-  tps: 7785.31459
+  dps: 7869.88289
+  tps: 7648.03901
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 11163.70902
-  tps: 10929.22032
+  dps: 10873.36317
+  tps: 10631.96971
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 11163.70902
-  tps: 10929.22032
+  dps: 10873.36317
+  tps: 10631.96971
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 11163.70902
-  tps: 10929.22032
+  dps: 10873.36317
+  tps: 10631.96971
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 11013.94431
-  tps: 10782.36418
+  dps: 10733.86387
+  tps: 10498.44371
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 11022.47933
-  tps: 10793.4807
+  dps: 10795.60438
+  tps: 10564.0818
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10962.58793
-  tps: 10732.19903
+  dps: 10683.80593
+  tps: 10449.57701
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ThunderheartHarness"
  value: {
-  dps: 4715.24515
-  tps: 4494.26998
+  dps: 4438.92815
+  tps: 4212.25261
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ThunderheartRegalia"
  value: {
-  dps: 6992.80536
-  tps: 6780.09369
+  dps: 6814.97761
+  tps: 6598.31879
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 11163.70902
-  tps: 10929.22032
+  dps: 10873.36317
+  tps: 10631.96971
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 11046.02273
-  tps: 10817.42332
+  dps: 10846.17001
+  tps: 10612.00163
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 11046.02273
-  tps: 10817.42332
+  dps: 10846.17001
+  tps: 10612.00163
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 11213.66343
-  tps: 10977.97582
+  dps: 10922.02012
+  tps: 10679.42775
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 11203.67255
-  tps: 10968.22472
+  dps: 10912.28873
+  tps: 10669.93615
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 11191.71116
-  tps: 10962.25017
+  dps: 11002.44636
+  tps: 10768.13718
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 11203.67255
-  tps: 10968.22472
+  dps: 10912.28873
+  tps: 10669.93615
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 11213.66343
-  tps: 10977.97582
+  dps: 10922.02012
+  tps: 10679.42775
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 8107.21051
-  tps: 7888.46531
+  dps: 7964.57939
+  tps: 7743.73566
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 11491.93659
-  tps: 11255.79555
+  dps: 11193.99141
+  tps: 10955.35712
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 11153.03279
-  tps: 10915.45915
+  dps: 10877.12422
+  tps: 10638.1149
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-WingedTalisman-37844"
  value: {
-  dps: 11126.83343
-  tps: 10888.10541
+  dps: 10843.79618
+  tps: 10601.22813
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 11153.03279
-  tps: 10915.45915
+  dps: 10877.12422
+  tps: 10638.1149
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Average-Default"
  value: {
-  dps: 11681.44882
-  tps: 11448.97776
+  dps: 11436.82321
+  tps: 11201.56087
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-P3-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16268.29629
-  tps: 19059.08231
+  dps: 15946.67004
+  tps: 18677.63604
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-P3-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11595.72394
-  tps: 11355.66931
+  dps: 11324.87689
+  tps: 11082.39742
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-P3-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12477.70954
-  tps: 11655.99038
+  dps: 12294.70062
+  tps: 11471.56054
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-P3-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7581.49561
-  tps: 8542.14929
+  dps: 7173.07763
+  tps: 8028.16316
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-P3-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4866.60447
-  tps: 4740.51292
+  dps: 4495.19313
+  tps: 4362.48958
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-P3-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7922.54853
-  tps: 7563.35001
+  dps: 7678.11799
+  tps: 7310.79684
  }
 }
 dps_results: {
  key: "TestBalancePhase3-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 11551.37653
-  tps: 11355.66931
+  dps: 11280.52948
+  tps: 11082.39742
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -74,8 +74,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7598.58633
-  tps: 5458.11624
+  dps: 7598.90291
+  tps: 5458.34101
  }
 }
 dps_results: {
@@ -161,8 +161,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7579.68258
-  tps: 5444.32065
+  dps: 7579.8911
+  tps: 5444.46869
  }
 }
 dps_results: {
@@ -301,8 +301,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7577.05762
-  tps: 5442.30735
+  dps: 7577.15477
+  tps: 5442.37633
  }
 }
 dps_results: {
@@ -399,8 +399,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7556.47487
-  tps: 5427.84317
+  dps: 7556.65261
+  tps: 5427.96937
  }
 }
 dps_results: {
@@ -799,8 +799,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-StormshroudArmor"
  value: {
-  dps: 6281.09578
-  tps: 4520.97786
+  dps: 6281.1212
+  tps: 4520.99591
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -74,8 +74,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7598.90291
-  tps: 5458.34101
+  dps: 7598.58633
+  tps: 5458.11624
  }
 }
 dps_results: {
@@ -161,8 +161,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7579.8911
-  tps: 5444.46869
+  dps: 7579.68258
+  tps: 5444.32065
  }
 }
 dps_results: {
@@ -301,8 +301,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7577.15477
-  tps: 5442.37633
+  dps: 7577.05762
+  tps: 5442.30735
  }
 }
 dps_results: {
@@ -399,8 +399,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7556.65261
-  tps: 5427.96937
+  dps: 7556.47487
+  tps: 5427.84317
  }
 }
 dps_results: {
@@ -799,8 +799,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-StormshroudArmor"
  value: {
-  dps: 6281.1212
-  tps: 4520.99591
+  dps: 6281.09578
+  tps: 4520.97786
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -74,8 +74,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7598.58633
-  tps: 5458.11624
+  dps: 7598.7356
+  tps: 5458.22222
  }
 }
 dps_results: {
@@ -799,8 +799,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-StormshroudArmor"
  value: {
-  dps: 6281.09578
-  tps: 4520.97786
+  dps: 6281.10861
+  tps: 4520.98696
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeralDoubleArmorPenTrinketsNoDesync.results
+++ b/sim/druid/feral/TestFeralDoubleArmorPenTrinketsNoDesync.results
@@ -74,8 +74,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 9845.26137
-  tps: 7053.70424
+  dps: 9845.43629
+  tps: 7053.82843
  }
 }
 dps_results: {
@@ -161,8 +161,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 9840.58524
-  tps: 7050.38419
+  dps: 9841.34878
+  tps: 7050.9263
  }
 }
 dps_results: {
@@ -301,8 +301,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 9841.14556
-  tps: 7050.40808
+  dps: 9841.60921
+  tps: 7050.73727
  }
 }
 dps_results: {
@@ -399,8 +399,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 9818.48807
-  tps: 7034.39605
+  dps: 9819.03563
+  tps: 7034.78481
  }
 }
 dps_results: {
@@ -799,8 +799,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-StormshroudArmor"
  value: {
-  dps: 7731.2044
-  tps: 5553.92038
+  dps: 7731.20763
+  tps: 5553.92267
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeralDoubleArmorPenTrinketsNoDesync.results
+++ b/sim/druid/feral/TestFeralDoubleArmorPenTrinketsNoDesync.results
@@ -74,8 +74,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 9845.26137
-  tps: 7053.70424
+  dps: 9846.21547
+  tps: 7054.38165
  }
 }
 dps_results: {
@@ -161,8 +161,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 9840.58524
-  tps: 7050.38419
+  dps: 9842.15127
+  tps: 7051.49607
  }
 }
 dps_results: {
@@ -301,8 +301,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 9841.14556
-  tps: 7050.40808
+  dps: 9842.0556
+  tps: 7051.05421
  }
 }
 dps_results: {
@@ -399,8 +399,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 9818.48807
-  tps: 7034.39605
+  dps: 9819.52613
+  tps: 7035.13307
  }
 }
 dps_results: {
@@ -799,8 +799,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-StormshroudArmor"
  value: {
-  dps: 7731.2044
-  tps: 5553.92038
+  dps: 7731.2327
+  tps: 5553.94047
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeralDoubleArmorPenTrinketsNoDesync.results
+++ b/sim/druid/feral/TestFeralDoubleArmorPenTrinketsNoDesync.results
@@ -74,8 +74,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 9846.21547
-  tps: 7054.38165
+  dps: 9845.26137
+  tps: 7053.70424
  }
 }
 dps_results: {
@@ -161,8 +161,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 9842.15127
-  tps: 7051.49607
+  dps: 9840.58524
+  tps: 7050.38419
  }
 }
 dps_results: {
@@ -301,8 +301,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 9842.0556
-  tps: 7051.05421
+  dps: 9841.14556
+  tps: 7050.40808
  }
 }
 dps_results: {
@@ -399,8 +399,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 9819.52613
-  tps: 7035.13307
+  dps: 9818.48807
+  tps: 7034.39605
  }
 }
 dps_results: {
@@ -799,8 +799,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-StormshroudArmor"
  value: {
-  dps: 7731.2327
-  tps: 5553.94047
+  dps: 7731.2044
+  tps: 5553.92038
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeralDoubleArmorPenTrinketsWithDesync.results
+++ b/sim/druid/feral/TestFeralDoubleArmorPenTrinketsWithDesync.results
@@ -74,8 +74,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 9841.88317
-  tps: 7051.53008
+  dps: 9842.80494
+  tps: 7052.18453
  }
 }
 dps_results: {
@@ -161,8 +161,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 9840.72966
-  tps: 7050.18758
+  dps: 9842.08506
+  tps: 7051.14991
  }
 }
 dps_results: {
@@ -301,8 +301,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 9840.96541
-  tps: 7050.28017
+  dps: 9841.90308
+  tps: 7050.94592
  }
 }
 dps_results: {
@@ -399,8 +399,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 9818.48807
-  tps: 7034.39605
+  dps: 9819.52613
+  tps: 7035.13307
  }
 }
 dps_results: {
@@ -799,8 +799,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-StormshroudArmor"
  value: {
-  dps: 7804.10957
-  tps: 5605.23433
+  dps: 7804.1374
+  tps: 5605.25408
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeralDoubleArmorPenTrinketsWithDesync.results
+++ b/sim/druid/feral/TestFeralDoubleArmorPenTrinketsWithDesync.results
@@ -74,8 +74,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 9841.88317
-  tps: 7051.53008
+  dps: 9842.05809
+  tps: 7051.65427
  }
 }
 dps_results: {
@@ -161,8 +161,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 9840.72966
-  tps: 7050.18758
+  dps: 9841.31767
+  tps: 7050.60506
  }
 }
 dps_results: {
@@ -301,8 +301,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 9840.96541
-  tps: 7050.28017
+  dps: 9841.45669
+  tps: 7050.62898
  }
 }
 dps_results: {
@@ -399,8 +399,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 9818.48807
-  tps: 7034.39605
+  dps: 9819.03563
+  tps: 7034.78481
  }
 }
 dps_results: {
@@ -799,8 +799,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-StormshroudArmor"
  value: {
-  dps: 7804.10957
-  tps: 5605.23433
+  dps: 7804.11298
+  tps: 5605.23675
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeralDoubleArmorPenTrinketsWithDesync.results
+++ b/sim/druid/feral/TestFeralDoubleArmorPenTrinketsWithDesync.results
@@ -74,8 +74,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 9842.80494
-  tps: 7052.18453
+  dps: 9841.88317
+  tps: 7051.53008
  }
 }
 dps_results: {
@@ -161,8 +161,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 9842.08506
-  tps: 7051.14991
+  dps: 9840.72966
+  tps: 7050.18758
  }
 }
 dps_results: {
@@ -301,8 +301,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 9841.90308
-  tps: 7050.94592
+  dps: 9840.96541
+  tps: 7050.28017
  }
 }
 dps_results: {
@@ -399,8 +399,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 9819.52613
-  tps: 7035.13307
+  dps: 9818.48807
+  tps: 7034.39605
  }
 }
 dps_results: {
@@ -799,8 +799,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-StormshroudArmor"
  value: {
-  dps: 7804.1374
-  tps: 5605.25408
+  dps: 7804.10957
+  tps: 5605.23433
  }
 }
 dps_results: {

--- a/sim/druid/restoration/TestRestoration.results
+++ b/sim/druid/restoration/TestRestoration.results
@@ -252,8 +252,8 @@ dps_results: {
 dps_results: {
  key: "TestRestoration-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 37.44777
-  tps: 37.44777
+  dps: 36.87363
+  tps: 36.87363
  }
 }
 dps_results: {

--- a/sim/druid/restoration/TestRestoration.results
+++ b/sim/druid/restoration/TestRestoration.results
@@ -252,8 +252,8 @@ dps_results: {
 dps_results: {
  key: "TestRestoration-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 36.87363
-  tps: 36.87363
+  dps: 37.44777
+  tps: 37.44777
  }
 }
 dps_results: {

--- a/sim/druid/restoration/TestRestoration.results
+++ b/sim/druid/restoration/TestRestoration.results
@@ -252,8 +252,8 @@ dps_results: {
 dps_results: {
  key: "TestRestoration-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 36.87363
-  tps: 36.87363
+  dps: 37.01833
+  tps: 37.01833
  }
 }
 dps_results: {

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -46,48 +46,48 @@ character_stats_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 2614.49541
-  tps: 5516.74692
+  dps: 2624.07718
+  tps: 5539.82256
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2669.91111
-  tps: 5633.59525
+  dps: 2664.71359
+  tps: 5631.21058
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 2572.56258
-  tps: 5440.37628
+  dps: 2564.32186
+  tps: 5416.21154
   dtps: 6.41606
   hps: 85.38358
  }
@@ -95,8 +95,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 2572.56258
-  tps: 5440.37628
+  dps: 2564.32186
+  tps: 5416.21154
   dtps: 6.41606
   hps: 85.38358
  }
@@ -104,64 +104,64 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 2557.49877
-  tps: 5405.84981
+  dps: 2548.69952
+  tps: 5396.66581
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 2072.85453
-  tps: 4406.69491
+  dps: 2080.67698
+  tps: 4426.72866
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5274.11672
+  dps: 2542.4148
+  tps: 5278.91915
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 2506.35143
-  tps: 5304.27078
+  dps: 2507.53591
+  tps: 5302.38688
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2604.11155
-  tps: 5494.02277
+  dps: 2597.84402
+  tps: 5483.3436
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
   hps: 64
  }
@@ -169,937 +169,937 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2602.87788
-  tps: 5505.56618
+  dps: 2613.10439
+  tps: 5521.55227
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2667.03726
-  tps: 5638.19147
+  dps: 2669.48542
+  tps: 5645.04173
   dtps: 6.51435
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 2568.13788
-  tps: 5432.02094
+  dps: 2563.95499
+  tps: 5420.78633
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 2535.51527
-  tps: 5352.62409
+  dps: 2529.46293
+  tps: 5343.277
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Death'sChoice-47464"
  value: {
-  dps: 2702.32485
-  tps: 5707.72115
+  dps: 2720.78868
+  tps: 5740.72278
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 2577.04027
-  tps: 5440.17628
+  dps: 2598.00834
+  tps: 5486.51393
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 2756.84713
-  tps: 5831.82171
+  dps: 2761.48739
+  tps: 5837.99045
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 2782.30537
-  tps: 5870.4651
+  dps: 2787.60244
+  tps: 5884.85294
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2557.94672
-  tps: 5409.27862
+  dps: 2555.06478
+  tps: 5411.251
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 2640.68285
-  tps: 5600.45871
+  dps: 2656.44512
+  tps: 5634.59844
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 2643.07892
-  tps: 5606.9453
+  dps: 2661.88223
+  tps: 5642.1906
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 2440.12024
-  tps: 5144.67389
+  dps: 2441.8044
+  tps: 5154.43098
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerGarb"
  value: {
-  dps: 2093.45272
-  tps: 4473.09948
+  dps: 2106.9088
+  tps: 4501.45382
   dtps: 6.91076
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.53093
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2543.11245
+  tps: 5388.04363
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 2557.49877
-  tps: 5405.84981
+  dps: 2548.69952
+  tps: 5396.66581
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2557.578
-  tps: 5405.81151
+  dps: 2548.91328
+  tps: 5396.90501
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 2596.18149
-  tps: 5506.31367
+  dps: 2610.00382
+  tps: 5528.03522
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2648.03716
-  tps: 5602.30892
+  dps: 2638.27056
+  tps: 5579.72948
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2606.33642
-  tps: 5510.77487
+  dps: 2618.81058
+  tps: 5533.0202
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 2565.90809
-  tps: 5427.24715
+  dps: 2563.85717
+  tps: 5419.79145
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2599.64184
-  tps: 5500.27094
+  dps: 2598.17216
+  tps: 5491.15326
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 2551.17415
-  tps: 5395.61086
+  dps: 2540.94973
+  tps: 5370.10878
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2655.1666
-  tps: 5600.33268
+  dps: 2656.99581
+  tps: 5612.24281
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 2614.9211
-  tps: 5491.99564
+  dps: 2627.47254
+  tps: 5521.67313
   dtps: 7.20775
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 2063.66669
-  tps: 4397.02596
+  dps: 2086.96108
+  tps: 4439.92105
   dtps: 7.20775
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 2649.13892
-  tps: 5601.10632
+  dps: 2649.21582
+  tps: 5597.8656
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 2531.25372
-  tps: 5343.67015
+  dps: 2537.45153
+  tps: 5364.3171
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Heartpierce-49982"
  value: {
-  dps: 2620.64736
-  tps: 5541.24874
+  dps: 2619.79841
+  tps: 5540.03715
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Heartpierce-50641"
  value: {
-  dps: 2605.59691
-  tps: 5519.39866
+  dps: 2608.32031
+  tps: 5530.83941
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdolofLunarFury-47670"
  value: {
-  dps: 2506.35143
-  tps: 5304.27078
+  dps: 2507.53591
+  tps: 5302.38688
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 2506.35143
-  tps: 5304.27078
+  dps: 2507.53591
+  tps: 5302.38688
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 2544.53373
-  tps: 5376.90961
+  dps: 2552.4729
+  tps: 5396.49003
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 2550.96918
-  tps: 5394.21195
+  dps: 2556.3877
+  tps: 5408.71385
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 2506.92923
-  tps: 5299.60867
+  dps: 2507.31137
+  tps: 5300.6412
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 2542.07015
-  tps: 5376.5092
+  dps: 2527.28911
+  tps: 5345.30357
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 2506.35143
-  tps: 5304.27078
+  dps: 2507.53591
+  tps: 5302.38688
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 2521.11514
-  tps: 5324.30672
+  dps: 2529.84199
+  tps: 5340.68945
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 2557.49877
-  tps: 5405.84981
+  dps: 2548.69952
+  tps: 5396.66581
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2557.578
-  tps: 5405.81151
+  dps: 2548.91328
+  tps: 5396.90501
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2654.79915
-  tps: 5608.18562
+  dps: 2662.83281
+  tps: 5628.31682
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 2544.74203
-  tps: 5382.42621
+  dps: 2541.20194
+  tps: 5381.21507
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2566.57682
-  tps: 5429.06277
+  dps: 2565.44916
+  tps: 5422.06178
   dtps: 6.66421
-  hps: 23.14146
+  hps: 23.79294
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 2862.90859
-  tps: 5951.41759
+  dps: 2864.12734
+  tps: 5952.05533
   dtps: 5.8645
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveRegalia"
  value: {
-  dps: 2283.30215
-  tps: 4905.04384
+  dps: 2283.67267
+  tps: 4908.90637
   dtps: 7.20775
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LastWord-50179"
  value: {
-  dps: 2608.28634
-  tps: 5508.21431
+  dps: 2629.90458
+  tps: 5556.20767
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LastWord-50708"
  value: {
-  dps: 2621.73816
-  tps: 5529.98634
+  dps: 2626.40328
+  tps: 5542.72441
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 2626.41213
-  tps: 5542.79507
+  dps: 2620.06704
+  tps: 5522.83905
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 2118.29885
-  tps: 4546.33741
+  dps: 2132.96209
+  tps: 4576.98525
   dtps: 6.91076
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2645.41481
-  tps: 5603.41132
+  dps: 2651.68069
+  tps: 5617.87878
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 2642.40127
-  tps: 5549.62652
+  dps: 2653.86667
+  tps: 5576.53274
   dtps: 8.03899
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Nibelung-49992"
  value: {
-  dps: 2565.19498
-  tps: 5424.82408
+  dps: 2564.12228
+  tps: 5421.28947
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Nibelung-50648"
  value: {
-  dps: 2565.06198
-  tps: 5424.5445
+  dps: 2564.12228
+  tps: 5421.28947
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NightsongBattlegear"
  value: {
-  dps: 2596.6671
-  tps: 5482.59344
+  dps: 2597.53564
+  tps: 5485.73535
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NightsongGarb"
  value: {
-  dps: 2088.27063
-  tps: 4477.26765
+  dps: 2081.16829
+  tps: 4469.30811
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 2546.90078
-  tps: 5389.49204
+  dps: 2559.2542
+  tps: 5415.5703
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 2561.9697
-  tps: 5421.18645
+  dps: 2560.46476
+  tps: 5412.25734
   dtps: 5.50054
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 2557.56523
-  tps: 5418.55842
+  dps: 2569.0486
+  tps: 5436.13105
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 2558.98559
-  tps: 5421.54417
+  dps: 2570.90687
+  tps: 5440.03732
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2599.92738
-  tps: 5485.04134
+  dps: 2594.7435
+  tps: 5473.75285
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 2555.83132
-  tps: 5396.01832
+  dps: 2573.2495
+  tps: 5434.9965
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 2521.68637
-  tps: 5325.51988
+  dps: 2527.37
+  tps: 5337.78252
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2552.17544
-  tps: 5396.60909
+  dps: 2553.7119
+  tps: 5400.21968
   dtps: 4.4102
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SoulPreserver-37111"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SouloftheDead-40382"
  value: {
-  dps: 2600.12854
-  tps: 5496.87872
+  dps: 2613.14433
+  tps: 5520.45198
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 2587.00554
-  tps: 5481.71139
+  dps: 2594.0366
+  tps: 5492.8449
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 2632.47716
-  tps: 5564.77089
+  dps: 2631.68498
+  tps: 5560.81448
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-StormshroudArmor"
  value: {
-  dps: 2041.96377
-  tps: 4325.55925
+  dps: 2042.04562
+  tps: 4333.24819
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 2546.90078
-  tps: 5389.49204
+  dps: 2559.2542
+  tps: 5415.5703
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2532.08063
-  tps: 5353.48101
+  dps: 2542.87187
+  tps: 5386.38507
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 2568.13788
-  tps: 5432.02094
+  dps: 2563.95499
+  tps: 5420.78633
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartHarness"
  value: {
-  dps: 2064.63808
-  tps: 4504.95471
+  dps: 2074.17964
+  tps: 4524.56074
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartRegalia"
  value: {
-  dps: 1826.48099
-  tps: 3912.83073
+  dps: 1830.99036
+  tps: 3925.34006
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 2545.60916
-  tps: 5379.61755
+  dps: 2540.6341
+  tps: 5376.26344
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2641.58581
-  tps: 5592.81432
+  dps: 2658.84389
+  tps: 5628.73875
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2682.59484
-  tps: 5686.01757
+  dps: 2680.73182
+  tps: 5682.0938
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 2581.37223
-  tps: 5459.59282
+  dps: 2575.52955
+  tps: 5445.03158
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2542.4148
+  tps: 5386.41605
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 2182.8082
-  tps: 4620.19292
+  dps: 2191.05103
+  tps: 4642.01675
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 2025.04958
-  tps: 4337.01329
+  dps: 2034.86879
+  tps: 4358.78889
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 2506.35143
-  tps: 5304.27078
+  dps: 2507.53591
+  tps: 5302.38688
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WingedTalisman-37844"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.69079
+  tps: 5418.32796
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 2554.47256
-  tps: 5399.97443
+  dps: 2576.13369
+  tps: 5442.62454
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-Average-Default"
  value: {
-  dps: 2656.61413
-  tps: 5646.96656
-  dtps: 57.69135
+  dps: 2661.31728
+  tps: 5657.78091
+  dtps: 57.06483
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4763.1607
-  tps: 10864.88563
+  dps: 4800.03952
+  tps: 10952.49591
   dtps: 6.22692
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2642.7197
-  tps: 5593.60478
+  dps: 2664.80993
+  tps: 5638.79149
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2804.84549
-  tps: 6127.95373
+  dps: 2810.68757
+  tps: 6141.7009
   dtps: 33.32105
  }
 }
@@ -1127,8 +1127,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2772.23308
-  tps: 5900.37371
-  dtps: 48.36597
+  dps: 2773.95677
+  tps: 5900.8136
+  dtps: 47.66603
  }
 }

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -46,48 +46,48 @@ character_stats_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 2624.07718
-  tps: 5539.82256
+  dps: 2614.49541
+  tps: 5516.74692
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 2542.4148
-  tps: 5386.41605
+  dps: 2544.32845
+  tps: 5381.51928
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2664.71359
-  tps: 5631.21058
+  dps: 2669.91111
+  tps: 5633.59525
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 2564.32186
-  tps: 5416.21154
+  dps: 2572.56258
+  tps: 5440.37628
   dtps: 6.41606
   hps: 85.38358
  }
@@ -95,8 +95,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 2564.32186
-  tps: 5416.21154
+  dps: 2572.56258
+  tps: 5440.37628
   dtps: 6.41606
   hps: 85.38358
  }
@@ -104,64 +104,64 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 2548.69952
-  tps: 5396.66581
+  dps: 2557.49877
+  tps: 5405.84981
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 2080.67698
-  tps: 4426.72866
+  dps: 2072.85453
+  tps: 4406.69491
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2542.4148
-  tps: 5278.91915
+  dps: 2544.32845
+  tps: 5274.11672
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 2507.53591
-  tps: 5302.38688
+  dps: 2506.35143
+  tps: 5304.27078
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2597.84402
-  tps: 5483.3436
+  dps: 2604.11155
+  tps: 5494.02277
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
   hps: 64
  }
@@ -169,966 +169,966 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2613.10439
-  tps: 5521.55227
+  dps: 2602.87788
+  tps: 5505.56618
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2669.48542
-  tps: 5645.04173
+  dps: 2667.03726
+  tps: 5638.19147
   dtps: 6.51435
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 2563.95499
-  tps: 5420.78633
+  dps: 2568.13788
+  tps: 5432.02094
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 2529.46293
-  tps: 5343.277
+  dps: 2535.51527
+  tps: 5352.62409
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Death'sChoice-47464"
  value: {
-  dps: 2720.78868
-  tps: 5740.72278
+  dps: 2702.32485
+  tps: 5707.72115
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 2598.00834
-  tps: 5486.51393
+  dps: 2577.04027
+  tps: 5440.17628
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 2761.48739
-  tps: 5837.99045
+  dps: 2756.84713
+  tps: 5831.82171
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 2787.60244
-  tps: 5884.85294
+  dps: 2782.30537
+  tps: 5870.4651
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2555.06478
-  tps: 5411.251
+  dps: 2557.94672
+  tps: 5409.27862
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 2656.44512
-  tps: 5634.59844
+  dps: 2640.68285
+  tps: 5600.45871
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 2661.88223
-  tps: 5642.1906
+  dps: 2643.07892
+  tps: 5606.9453
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 2441.8044
-  tps: 5154.43098
+  dps: 2440.12024
+  tps: 5144.67389
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerGarb"
  value: {
-  dps: 2106.9088
-  tps: 4501.45382
+  dps: 2093.45272
+  tps: 4473.09948
   dtps: 6.91076
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 2542.4148
-  tps: 5386.41605
+  dps: 2544.32845
+  tps: 5381.51928
   dtps: 6.53093
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2543.11245
-  tps: 5388.04363
+  dps: 2544.32845
+  tps: 5381.51928
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 2548.69952
-  tps: 5396.66581
+  dps: 2557.49877
+  tps: 5405.84981
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2548.91328
-  tps: 5396.90501
+  dps: 2557.578
+  tps: 5405.81151
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 2610.00382
-  tps: 5528.03522
+  dps: 2596.18149
+  tps: 5506.31367
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 2542.4148
-  tps: 5386.41605
+  dps: 2544.32845
+  tps: 5381.51928
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2638.27056
-  tps: 5579.72948
+  dps: 2648.03716
+  tps: 5602.30892
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2618.81058
-  tps: 5533.0202
+  dps: 2606.33642
+  tps: 5510.77487
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 2563.85717
-  tps: 5419.79145
+  dps: 2565.90809
+  tps: 5427.24715
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2598.17216
-  tps: 5491.15326
+  dps: 2599.64184
+  tps: 5500.27094
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2542.4148
-  tps: 5386.41605
+  dps: 2544.32845
+  tps: 5381.51928
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2542.4148
-  tps: 5386.41605
+  dps: 2544.32845
+  tps: 5381.51928
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 2540.94973
-  tps: 5370.10878
+  dps: 2551.17415
+  tps: 5395.61086
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2656.99581
-  tps: 5612.24281
+  dps: 2655.1666
+  tps: 5600.33268
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 2627.47254
-  tps: 5521.67313
+  dps: 2614.9211
+  tps: 5491.99564
   dtps: 7.20775
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 2086.96108
-  tps: 4439.92105
+  dps: 2063.66669
+  tps: 4397.02596
   dtps: 7.20775
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 2649.21582
-  tps: 5597.8656
+  dps: 2649.13892
+  tps: 5601.10632
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 2537.45153
-  tps: 5364.3171
+  dps: 2531.25372
+  tps: 5343.67015
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Heartpierce-49982"
  value: {
-  dps: 2619.79841
-  tps: 5540.03715
+  dps: 2620.64736
+  tps: 5541.24874
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Heartpierce-50641"
  value: {
-  dps: 2608.32031
-  tps: 5530.83941
+  dps: 2605.59691
+  tps: 5519.39866
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdolofLunarFury-47670"
  value: {
-  dps: 2507.53591
-  tps: 5302.38688
+  dps: 2506.35143
+  tps: 5304.27078
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 2507.53591
-  tps: 5302.38688
+  dps: 2506.35143
+  tps: 5304.27078
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 2552.4729
-  tps: 5396.49003
+  dps: 2544.53373
+  tps: 5376.90961
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 2556.3877
-  tps: 5408.71385
+  dps: 2550.96918
+  tps: 5394.21195
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 2507.31137
-  tps: 5300.6412
+  dps: 2506.92923
+  tps: 5299.60867
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 2527.28911
-  tps: 5345.30357
+  dps: 2542.07015
+  tps: 5376.5092
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 2507.53591
-  tps: 5302.38688
+  dps: 2506.35143
+  tps: 5304.27078
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 2529.84199
-  tps: 5340.68945
+  dps: 2521.11514
+  tps: 5324.30672
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 2548.69952
-  tps: 5396.66581
+  dps: 2557.49877
+  tps: 5405.84981
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2548.91328
-  tps: 5396.90501
+  dps: 2557.578
+  tps: 5405.81151
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2662.83281
-  tps: 5628.31682
+  dps: 2654.79915
+  tps: 5608.18562
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 2541.20194
-  tps: 5381.21507
+  dps: 2544.74203
+  tps: 5382.42621
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2565.44916
-  tps: 5422.06178
+  dps: 2566.57682
+  tps: 5429.06277
   dtps: 6.66421
-  hps: 23.79294
+  hps: 23.14146
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 2864.12734
-  tps: 5952.05533
+  dps: 2862.90859
+  tps: 5951.41759
   dtps: 5.8645
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveRegalia"
  value: {
-  dps: 2283.67267
-  tps: 4908.90637
+  dps: 2283.30215
+  tps: 4905.04384
   dtps: 7.20775
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LastWord-50179"
  value: {
-  dps: 2629.90458
-  tps: 5556.20767
+  dps: 2608.28634
+  tps: 5508.21431
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LastWord-50708"
  value: {
-  dps: 2626.40328
-  tps: 5542.72441
+  dps: 2621.73816
+  tps: 5529.98634
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 2620.06704
-  tps: 5522.83905
+  dps: 2626.41213
+  tps: 5542.79507
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 2132.96209
-  tps: 4576.98525
+  dps: 2118.29885
+  tps: 4546.33741
   dtps: 6.91076
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2651.68069
-  tps: 5617.87878
+  dps: 2645.41481
+  tps: 5603.41132
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 2653.86667
-  tps: 5576.53274
+  dps: 2642.40127
+  tps: 5549.62652
   dtps: 8.03899
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Nibelung-49992"
  value: {
-  dps: 2564.12228
-  tps: 5421.28947
+  dps: 2565.19498
+  tps: 5424.82408
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Nibelung-50648"
  value: {
-  dps: 2564.12228
-  tps: 5421.28947
+  dps: 2565.06198
+  tps: 5424.5445
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NightsongBattlegear"
  value: {
-  dps: 2597.53564
-  tps: 5485.73535
+  dps: 2596.6671
+  tps: 5482.59344
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NightsongGarb"
  value: {
-  dps: 2081.16829
-  tps: 4469.30811
+  dps: 2088.27063
+  tps: 4477.26765
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 2559.2542
-  tps: 5415.5703
+  dps: 2546.90078
+  tps: 5389.49204
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 2560.46476
-  tps: 5412.25734
+  dps: 2561.9697
+  tps: 5421.18645
   dtps: 5.50054
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 2542.4148
-  tps: 5386.41605
+  dps: 2544.32845
+  tps: 5381.51928
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 2542.4148
-  tps: 5386.41605
+  dps: 2544.32845
+  tps: 5381.51928
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 2569.0486
-  tps: 5436.13105
+  dps: 2557.56523
+  tps: 5418.55842
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 2570.90687
-  tps: 5440.03732
+  dps: 2558.98559
+  tps: 5421.54417
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2594.7435
-  tps: 5473.75285
+  dps: 2599.92738
+  tps: 5485.04134
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 2573.2495
-  tps: 5434.9965
+  dps: 2555.83132
+  tps: 5396.01832
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2542.4148
-  tps: 5386.41605
+  dps: 2544.32845
+  tps: 5381.51928
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 2527.37
-  tps: 5337.78252
+  dps: 2521.68637
+  tps: 5325.51988
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2553.7119
-  tps: 5400.21968
+  dps: 2552.17544
+  tps: 5396.60909
   dtps: 4.4102
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SoulPreserver-37111"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SouloftheDead-40382"
  value: {
-  dps: 2613.14433
-  tps: 5520.45198
+  dps: 2600.12854
+  tps: 5496.87872
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 2594.0366
-  tps: 5492.8449
+  dps: 2587.00554
+  tps: 5481.71139
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 2631.68498
-  tps: 5560.81448
+  dps: 2632.47716
+  tps: 5564.77089
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-StormshroudArmor"
  value: {
-  dps: 2042.04562
-  tps: 4333.24819
+  dps: 2041.96377
+  tps: 4325.55925
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 2559.2542
-  tps: 5415.5703
+  dps: 2546.90078
+  tps: 5389.49204
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2542.87187
-  tps: 5386.38507
+  dps: 2532.08063
+  tps: 5353.48101
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 2563.95499
-  tps: 5420.78633
+  dps: 2568.13788
+  tps: 5432.02094
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartHarness"
  value: {
-  dps: 2074.17964
-  tps: 4524.56074
+  dps: 2064.63808
+  tps: 4504.95471
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartRegalia"
  value: {
-  dps: 1830.99036
-  tps: 3925.34006
+  dps: 1826.48099
+  tps: 3912.83073
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 2540.6341
-  tps: 5376.26344
+  dps: 2545.60916
+  tps: 5379.61755
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2658.84389
-  tps: 5628.73875
+  dps: 2641.58581
+  tps: 5592.81432
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2680.73182
-  tps: 5682.0938
+  dps: 2682.59484
+  tps: 5686.01757
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2542.4148
-  tps: 5386.41605
+  dps: 2544.32845
+  tps: 5381.51928
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2542.4148
-  tps: 5386.41605
+  dps: 2544.32845
+  tps: 5381.51928
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 2575.52955
-  tps: 5445.03158
+  dps: 2581.37223
+  tps: 5459.59282
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2542.4148
-  tps: 5386.41605
+  dps: 2544.32845
+  tps: 5381.51928
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2542.4148
-  tps: 5386.41605
+  dps: 2544.32845
+  tps: 5381.51928
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 2191.05103
-  tps: 4642.01675
+  dps: 2182.8082
+  tps: 4620.19292
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 2034.86879
-  tps: 4358.78889
+  dps: 2025.04958
+  tps: 4337.01329
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 2507.53591
-  tps: 5302.38688
+  dps: 2506.35143
+  tps: 5304.27078
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WingedTalisman-37844"
  value: {
-  dps: 2562.69079
-  tps: 5418.32796
+  dps: 2561.88808
+  tps: 5421.01437
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 2576.13369
-  tps: 5442.62454
+  dps: 2554.47256
+  tps: 5399.97443
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-Average-Default"
  value: {
-  dps: 2661.31728
-  tps: 5657.78091
-  dtps: 57.06483
+  dps: 2656.61413
+  tps: 5646.96656
+  dtps: 57.69135
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4800.03952
-  tps: 10952.49591
+  dps: 4748.32382
+  tps: 10828.06913
   dtps: 6.22692
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2664.80993
-  tps: 5638.79149
+  dps: 2642.7197
+  tps: 5593.60478
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2810.68757
-  tps: 6141.7009
+  dps: 2804.84549
+  tps: 6127.95373
   dtps: 33.32105
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1646.28
-  tps: 4007.99728
+  dps: 1662.79225
+  tps: 4043.93086
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1249.79542
-  tps: 2665.74497
+  dps: 1244.72565
+  tps: 2657.00206
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1053.80282
-  tps: 2353.66624
+  dps: 1052.77442
+  tps: 2350.82969
  }
 }
 dps_results: {
  key: "TestFeralTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2773.95677
-  tps: 5900.8136
-  dtps: 47.66603
+  dps: 2772.23308
+  tps: 5900.37371
+  dtps: 48.36597
  }
 }

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -46,48 +46,48 @@ character_stats_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 2614.49541
-  tps: 5516.74692
+  dps: 2614.82405
+  tps: 5520.16725
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2544.20528
+  tps: 5381.50581
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2669.91111
-  tps: 5633.59525
+  dps: 2670.45839
+  tps: 5635.28926
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 2572.56258
-  tps: 5440.37628
+  dps: 2570.70219
+  tps: 5436.33388
   dtps: 6.41606
   hps: 85.38358
  }
@@ -95,8 +95,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 2572.56258
-  tps: 5440.37628
+  dps: 2570.70219
+  tps: 5436.33388
   dtps: 6.41606
   hps: 85.38358
  }
@@ -104,64 +104,64 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 2557.49877
-  tps: 5405.84981
+  dps: 2538.21212
+  tps: 5367.14658
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 2072.85453
-  tps: 4406.69491
+  dps: 2076.21196
+  tps: 4419.01074
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5274.11672
+  dps: 2544.20528
+  tps: 5274.10377
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 2506.35143
-  tps: 5304.27078
+  dps: 2507.09919
+  tps: 5302.32314
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2604.11155
-  tps: 5494.02277
+  dps: 2604.81592
+  tps: 5499.42852
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
   hps: 64
  }
@@ -169,416 +169,416 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2602.87788
-  tps: 5505.56618
+  dps: 2595.05996
+  tps: 5489.55093
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2667.03726
-  tps: 5638.19147
+  dps: 2658.44282
+  tps: 5623.52369
   dtps: 6.51435
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 2568.13788
-  tps: 5432.02094
+  dps: 2562.19202
+  tps: 5421.84349
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 2535.51527
-  tps: 5352.62409
+  dps: 2535.20443
+  tps: 5351.19316
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Death'sChoice-47464"
  value: {
-  dps: 2702.32485
-  tps: 5707.72115
+  dps: 2710.38062
+  tps: 5721.56528
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 2577.04027
-  tps: 5440.17628
+  dps: 2577.9892
+  tps: 5445.83581
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 2756.84713
-  tps: 5831.82171
+  dps: 2757.60683
+  tps: 5830.45004
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 2782.30537
-  tps: 5870.4651
+  dps: 2789.0766
+  tps: 5887.3875
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2557.94672
-  tps: 5409.27862
+  dps: 2538.66007
+  tps: 5370.57539
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 2640.68285
-  tps: 5600.45871
+  dps: 2647.51512
+  tps: 5614.64546
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 2643.07892
-  tps: 5606.9453
+  dps: 2655.73546
+  tps: 5634.8312
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 2440.12024
-  tps: 5144.67389
+  dps: 2437.52419
+  tps: 5145.02246
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerGarb"
  value: {
-  dps: 2093.45272
-  tps: 4473.09948
+  dps: 2094.56719
+  tps: 4474.95276
   dtps: 6.91076
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2544.20528
+  tps: 5381.50581
   dtps: 6.53093
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2545.1524
+  tps: 5384.09945
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 2557.49877
-  tps: 5405.84981
+  dps: 2538.21212
+  tps: 5367.14658
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2557.578
-  tps: 5405.81151
+  dps: 2536.93412
+  tps: 5365.21077
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 2596.18149
-  tps: 5506.31367
+  dps: 2601.61461
+  tps: 5517.58447
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2544.20528
+  tps: 5381.50581
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2648.03716
-  tps: 5602.30892
+  dps: 2643.32641
+  tps: 5591.08686
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2606.33642
-  tps: 5510.77487
+  dps: 2607.96226
+  tps: 5513.49625
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 2565.90809
-  tps: 5427.24715
+  dps: 2565.18938
+  tps: 5428.66176
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2599.64184
-  tps: 5500.27094
+  dps: 2596.94745
+  tps: 5492.53871
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2544.20528
+  tps: 5381.50581
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2544.20528
+  tps: 5381.50581
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 2551.17415
-  tps: 5395.61086
+  dps: 2548.81789
+  tps: 5388.37205
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2655.1666
-  tps: 5600.33268
+  dps: 2651.39771
+  tps: 5597.57246
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 2614.9211
-  tps: 5491.99564
+  dps: 2621.37284
+  tps: 5509.2466
   dtps: 7.20775
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 2063.66669
-  tps: 4397.02596
+  dps: 2076.49303
+  tps: 4416.20499
   dtps: 7.20775
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 2649.13892
-  tps: 5601.10632
+  dps: 2642.14886
+  tps: 5583.48247
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 2531.25372
-  tps: 5343.67015
+  dps: 2529.22007
+  tps: 5334.28871
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Heartpierce-49982"
  value: {
-  dps: 2620.64736
-  tps: 5541.24874
+  dps: 2605.30334
+  tps: 5505.66322
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Heartpierce-50641"
  value: {
-  dps: 2605.59691
-  tps: 5519.39866
+  dps: 2607.79248
+  tps: 5526.54529
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdolofLunarFury-47670"
  value: {
-  dps: 2506.35143
-  tps: 5304.27078
+  dps: 2507.09919
+  tps: 5302.32314
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 2506.35143
-  tps: 5304.27078
+  dps: 2507.09919
+  tps: 5302.32314
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 2544.53373
-  tps: 5376.90961
+  dps: 2544.07137
+  tps: 5372.80237
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 2550.96918
-  tps: 5394.21195
+  dps: 2555.25167
+  tps: 5401.90265
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 2506.92923
-  tps: 5299.60867
+  dps: 2501.40497
+  tps: 5288.99804
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 2542.07015
-  tps: 5376.5092
+  dps: 2533.45025
+  tps: 5354.32567
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 2506.35143
-  tps: 5304.27078
+  dps: 2507.09919
+  tps: 5302.32314
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 2521.11514
-  tps: 5324.30672
+  dps: 2518.70829
+  tps: 5318.62864
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 2557.49877
-  tps: 5405.84981
+  dps: 2538.21212
+  tps: 5367.14658
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2557.578
-  tps: 5405.81151
+  dps: 2536.93412
+  tps: 5365.21077
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2654.79915
-  tps: 5608.18562
+  dps: 2664.73732
+  tps: 5630.94743
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 2544.74203
-  tps: 5382.42621
+  dps: 2541.67255
+  tps: 5377.29507
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2566.57682
-  tps: 5429.06277
+  dps: 2567.4026
+  tps: 5427.42767
   dtps: 6.66421
   hps: 23.14146
  }
@@ -586,535 +586,535 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 2862.90859
-  tps: 5951.41759
+  dps: 2864.33479
+  tps: 5956.0141
   dtps: 5.8645
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveRegalia"
  value: {
-  dps: 2283.30215
-  tps: 4905.04384
+  dps: 2281.02903
+  tps: 4904.02833
   dtps: 7.20775
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LastWord-50179"
  value: {
-  dps: 2608.28634
-  tps: 5508.21431
+  dps: 2612.29113
+  tps: 5514.72903
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LastWord-50708"
  value: {
-  dps: 2621.73816
-  tps: 5529.98634
+  dps: 2623.32357
+  tps: 5534.00001
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 2626.41213
-  tps: 5542.79507
+  dps: 2625.28914
+  tps: 5540.84729
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 2118.29885
-  tps: 4546.33741
+  dps: 2117.89775
+  tps: 4543.88662
   dtps: 6.91076
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2645.41481
-  tps: 5603.41132
+  dps: 2643.36425
+  tps: 5599.70458
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 2642.40127
-  tps: 5549.62652
+  dps: 2644.40355
+  tps: 5553.48457
   dtps: 8.03899
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Nibelung-49992"
  value: {
-  dps: 2565.19498
-  tps: 5424.82408
+  dps: 2562.19202
+  tps: 5421.84349
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Nibelung-50648"
  value: {
-  dps: 2565.06198
-  tps: 5424.5445
+  dps: 2562.19202
+  tps: 5421.84349
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NightsongBattlegear"
  value: {
-  dps: 2596.6671
-  tps: 5482.59344
+  dps: 2597.58498
+  tps: 5484.99438
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NightsongGarb"
  value: {
-  dps: 2088.27063
-  tps: 4477.26765
+  dps: 2081.62602
+  tps: 4465.52949
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 2546.90078
-  tps: 5389.49204
+  dps: 2547.40637
+  tps: 5392.80752
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 2561.9697
-  tps: 5421.18645
+  dps: 2558.48543
+  tps: 5413.32691
   dtps: 5.50054
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2544.20528
+  tps: 5381.50581
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2544.20528
+  tps: 5381.50581
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 2557.56523
-  tps: 5418.55842
+  dps: 2559.22556
+  tps: 5420.18249
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 2558.98559
-  tps: 5421.54417
+  dps: 2560.79514
+  tps: 5423.4819
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2599.92738
-  tps: 5485.04134
+  dps: 2595.68411
+  tps: 5477.36153
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 2555.83132
-  tps: 5396.01832
+  dps: 2557.86335
+  tps: 5399.80792
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2544.20528
+  tps: 5381.50581
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 2521.68637
-  tps: 5325.51988
+  dps: 2517.618
+  tps: 5317.79911
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2552.17544
-  tps: 5396.60909
+  dps: 2553.1926
+  tps: 5397.56275
   dtps: 4.4102
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SoulPreserver-37111"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SouloftheDead-40382"
  value: {
-  dps: 2600.12854
-  tps: 5496.87872
+  dps: 2601.75438
+  tps: 5499.6001
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 2587.00554
-  tps: 5481.71139
+  dps: 2588.64466
+  tps: 5483.93263
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 2632.47716
-  tps: 5564.77089
+  dps: 2633.03095
+  tps: 5564.89563
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-StormshroudArmor"
  value: {
-  dps: 2041.96377
-  tps: 4325.55925
+  dps: 2041.06192
+  tps: 4331.10781
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 2546.90078
-  tps: 5389.49204
+  dps: 2547.40637
+  tps: 5392.80752
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2532.08063
-  tps: 5353.48101
+  dps: 2536.32012
+  tps: 5368.80475
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 2568.13788
-  tps: 5432.02094
+  dps: 2562.19202
+  tps: 5421.84349
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartHarness"
  value: {
-  dps: 2064.63808
-  tps: 4504.95471
+  dps: 2072.49121
+  tps: 4526.94904
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartRegalia"
  value: {
-  dps: 1826.48099
-  tps: 3912.83073
+  dps: 1833.30709
+  tps: 3928.49251
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 2545.60916
-  tps: 5379.61755
+  dps: 2554.50281
+  tps: 5398.40853
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2641.58581
-  tps: 5592.81432
+  dps: 2654.40062
+  tps: 5622.24005
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2682.59484
-  tps: 5686.01757
+  dps: 2678.67892
+  tps: 5674.62151
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2544.20528
+  tps: 5381.50581
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2544.20528
+  tps: 5381.50581
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 2581.37223
-  tps: 5459.59282
+  dps: 2571.03112
+  tps: 5434.73449
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2544.20528
+  tps: 5381.50581
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2544.32845
-  tps: 5381.51928
+  dps: 2544.20528
+  tps: 5381.50581
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 2182.8082
-  tps: 4620.19292
+  dps: 2188.38619
+  tps: 4632.31426
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 2025.04958
-  tps: 4337.01329
+  dps: 2030.62697
+  tps: 4347.16765
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 2506.35143
-  tps: 5304.27078
+  dps: 2507.09919
+  tps: 5302.32314
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WingedTalisman-37844"
  value: {
-  dps: 2561.88808
-  tps: 5421.01437
+  dps: 2562.39217
+  tps: 5418.55452
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 2554.47256
-  tps: 5399.97443
+  dps: 2557.27302
+  tps: 5402.51118
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-Average-Default"
  value: {
-  dps: 2656.61413
-  tps: 5646.96656
-  dtps: 57.69135
+  dps: 2657.90942
+  tps: 5649.82496
+  dtps: 57.55786
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4748.32382
-  tps: 10828.06913
+  dps: 4807.26918
+  tps: 10975.28059
   dtps: 6.22692
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2642.7197
-  tps: 5593.60478
+  dps: 2650.41738
+  tps: 5609.21618
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2804.84549
-  tps: 6127.95373
+  dps: 2807.5672
+  tps: 6132.96087
   dtps: 33.32105
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1662.79225
-  tps: 4043.93086
+  dps: 1657.76809
+  tps: 4031.51855
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-P1-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1244.72565
-  tps: 2657.00206
+  dps: 1248.75204
+  tps: 2662.63771
  }
 }
 dps_results: {
@@ -1127,8 +1127,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2772.23308
-  tps: 5900.37371
-  dtps: 48.36597
+  dps: 2773.38928
+  tps: 5902.79618
+  dtps: 48.05603
  }
 }

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -46,866 +46,866 @@ character_stats_results: {
 dps_results: {
  key: "TestBM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 6448.76597
-  tps: 4476.67255
+  dps: 6448.78777
+  tps: 4476.69435
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 6168.19674
-  tps: 4062.85168
+  dps: 6168.22137
+  tps: 4062.87631
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6178.94316
+  tps: 4073.69559
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6259.20618
-  tps: 4145.77931
+  dps: 6259.42697
+  tps: 4146.0001
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6106.02951
-  tps: 4017.78105
+  dps: 6106.05414
+  tps: 4017.80568
   hps: 92.00776
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6106.02951
-  tps: 4017.78105
+  dps: 6106.05414
+  tps: 4017.80568
   hps: 92.00776
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6199.57685
-  tps: 4086.78522
+  dps: 6199.62101
+  tps: 4086.82938
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6073.40626
-  tps: 4021.51574
+  dps: 6073.42611
+  tps: 4021.53559
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 5754.00631
-  tps: 3662.60701
+  dps: 5754.02119
+  tps: 3662.62189
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBruise-50035"
  value: {
-  dps: 5991.73328
-  tps: 3928.70586
+  dps: 5991.75894
+  tps: 3928.73152
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBruise-50692"
  value: {
-  dps: 5981.74957
-  tps: 3921.49137
+  dps: 5981.77523
+  tps: 3921.51703
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5202.42541
-  tps: 3452.31932
+  dps: 5202.44999
+  tps: 3452.3439
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5037.87491
-  tps: 3322.03682
+  dps: 5037.89873
+  tps: 3322.06063
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6178.9207
-  tps: 3993.32474
+  dps: 6178.94316
+  tps: 3993.34675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6274.31128
-  tps: 4160.34538
+  dps: 6274.33576
+  tps: 4160.36986
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6274.31128
-  tps: 4160.34538
+  dps: 6274.33576
+  tps: 4160.36986
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6269.64731
-  tps: 4158.15632
+  dps: 6269.69544
+  tps: 4158.20445
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
   hps: 64
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 5728.7241
-  tps: 3760.0111
+  dps: 5728.73305
+  tps: 3760.02005
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6165.32322
-  tps: 4080.23868
+  dps: 6165.35036
+  tps: 4080.26582
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6219.68158
-  tps: 4137.59934
+  dps: 6219.97936
+  tps: 4137.89712
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6269.56057
-  tps: 4152.08797
+  dps: 6269.59404
+  tps: 4152.12143
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6404.77337
-  tps: 4252.43638
+  dps: 6404.798
+  tps: 4252.46101
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6163.2387
-  tps: 4074.56045
+  dps: 6163.27226
+  tps: 4074.59401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6432.03117
-  tps: 4312.27726
+  dps: 6432.05169
+  tps: 4312.29779
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6456.46697
-  tps: 4344.00374
+  dps: 6456.50186
+  tps: 4344.03864
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6195.48559
-  tps: 4083.75431
+  dps: 6195.52128
+  tps: 4083.78999
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6172.06587
-  tps: 4101.33944
+  dps: 6172.08947
+  tps: 4101.36304
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6170.41296
-  tps: 4087.40075
+  dps: 6170.43708
+  tps: 4087.42487
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6178.94316
+  tps: 4073.69559
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6187.11855
-  tps: 4079.75386
+  dps: 6187.14515
+  tps: 4079.78046
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6190.14459
-  tps: 4078.6536
+  dps: 6190.18875
+  tps: 4078.69776
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6187.09911
-  tps: 4075.7356
+  dps: 6187.14327
+  tps: 4075.77976
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6139.24144
-  tps: 4077.84273
+  dps: 6139.26607
+  tps: 4077.86736
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6178.94316
+  tps: 4073.69559
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6194.52908
-  tps: 4111.73813
+  dps: 6194.56376
+  tps: 4111.77282
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6159.33164
-  tps: 4077.61013
+  dps: 6159.36276
+  tps: 4077.64124
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6143.08533
-  tps: 4046.90611
+  dps: 6143.12957
+  tps: 4046.95035
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6150.19965
-  tps: 4068.13941
+  dps: 6150.22358
+  tps: 4068.16334
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6178.94316
+  tps: 4073.69559
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6178.94316
+  tps: 4073.69559
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6255.62809
-  tps: 4126.18754
+  dps: 6255.65272
+  tps: 4126.21217
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 6036.29197
-  tps: 4112.60018
+  dps: 6036.3108
+  tps: 4112.61901
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6196.00401
-  tps: 4113.94675
+  dps: 6196.24268
+  tps: 4114.18542
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 4895.16111
-  tps: 3209.6675
+  dps: 4895.16488
+  tps: 3209.67127
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Heartpierce-49982"
  value: {
-  dps: 6319.52753
-  tps: 4193.26606
+  dps: 6319.55201
+  tps: 4193.29054
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Heartpierce-50641"
  value: {
-  dps: 6320.49992
-  tps: 4193.97403
+  dps: 6320.5244
+  tps: 4193.99851
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6190.14459
-  tps: 4078.6536
+  dps: 6190.18875
+  tps: 4078.69776
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6187.09911
-  tps: 4075.7356
+  dps: 6187.14327
+  tps: 4075.77976
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6247.30246
-  tps: 4139.39508
+  dps: 6247.3271
+  tps: 4139.41971
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6217.56762
-  tps: 4111.49801
+  dps: 6217.59894
+  tps: 4111.52932
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6199.83824
-  tps: 4088.79731
+  dps: 6199.8607
+  tps: 4088.81977
   hps: 11.27139
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LastWord-50179"
  value: {
-  dps: 6274.31128
-  tps: 4160.34538
+  dps: 6274.33576
+  tps: 4160.36986
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LastWord-50708"
  value: {
-  dps: 6274.31128
-  tps: 4160.34538
+  dps: 6274.33576
+  tps: 4160.36986
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6194.65413
-  tps: 4120.65752
+  dps: 6194.68231
+  tps: 4120.68569
  }
 }
 dps_results: {
  key: "TestBM-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6197.52347
-  tps: 4118.26964
+  dps: 6197.53758
+  tps: 4118.28375
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Nibelung-49992"
  value: {
-  dps: 6359.07033
-  tps: 4224.52705
+  dps: 6359.10409
+  tps: 4224.56082
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Nibelung-50648"
  value: {
-  dps: 6364.62148
-  tps: 4228.57413
+  dps: 6364.65524
+  tps: 4228.6079
  }
 }
 dps_results: {
  key: "TestBM-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6195.22346
-  tps: 4085.49368
+  dps: 6195.24592
+  tps: 4085.51614
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6199.05941
-  tps: 4088.27499
+  dps: 6199.08187
+  tps: 4088.29745
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6178.94316
+  tps: 4073.69559
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6178.94316
+  tps: 4073.69559
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6274.31128
-  tps: 4160.34538
+  dps: 6274.33576
+  tps: 4160.36986
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6187.95662
-  tps: 4081.11149
+  dps: 6187.97908
+  tps: 4081.13395
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 6136.41048
-  tps: 4097.62445
+  dps: 6136.4368
+  tps: 4097.65077
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6481.72595
-  tps: 4370.57578
+  dps: 6481.75315
+  tps: 4370.60298
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6133.99552
-  tps: 4046.35716
+  dps: 6134.02015
+  tps: 4046.38179
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6133.99552
-  tps: 4047.04049
+  dps: 6134.02015
+  tps: 4047.06513
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6163.2786
-  tps: 4080.59478
+  dps: 6163.30972
+  tps: 4080.6259
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SparkofLife-37657"
  value: {
-  dps: 6146.05303
-  tps: 4061.22841
+  dps: 6146.07818
+  tps: 4061.25355
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6225.45355
-  tps: 4099.43104
+  dps: 6225.47813
+  tps: 4099.45562
  }
 }
 dps_results: {
  key: "TestBM-AllItems-StormshroudArmor"
  value: {
-  dps: 4947.63531
-  tps: 3247.14336
+  dps: 4947.65994
+  tps: 3247.16799
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6199.05941
-  tps: 4088.27499
+  dps: 6199.08187
+  tps: 4088.29745
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6195.22346
-  tps: 4085.49368
+  dps: 6195.24592
+  tps: 4085.51614
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6188.51056
-  tps: 4080.62639
+  dps: 6188.53302
+  tps: 4080.64885
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6173.26837
-  tps: 4068.63148
+  dps: 6173.30697
+  tps: 4068.67008
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheFistsofFury"
  value: {
-  dps: 6016.86695
-  tps: 3952.72688
+  dps: 6016.89261
+  tps: 3952.75253
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6131.10629
-  tps: 4055.50875
+  dps: 6131.13605
+  tps: 4055.53851
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6205.09504
-  tps: 4095.75372
+  dps: 6205.11797
+  tps: 4095.77665
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6145.78025
-  tps: 4042.1638
+  dps: 6145.80483
+  tps: 4042.18838
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6145.78025
-  tps: 4042.1638
+  dps: 6145.80483
+  tps: 4042.18838
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6178.94316
+  tps: 4073.69559
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6178.94316
+  tps: 4073.69559
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6123.85852
-  tps: 4046.21281
+  dps: 6123.88315
+  tps: 4046.23744
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6178.94316
+  tps: 4073.69559
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6178.94316
+  tps: 4073.69559
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5169.14897
-  tps: 3423.34814
+  dps: 5169.17925
+  tps: 3423.37842
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6069.88838
-  tps: 4012.04454
+  dps: 6069.9379
+  tps: 4012.09407
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 6277.51295
-  tps: 4234.40996
+  dps: 6277.5492
+  tps: 4234.44621
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.11859
+  tps: 4017.80568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 6678.8793
-  tps: 4603.32567
+  dps: 6678.8947
+  tps: 4603.34107
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 6871.91466
-  tps: 4796.88934
+  dps: 6871.93005
+  tps: 4796.90474
  }
 }
 dps_results: {
  key: "TestBM-Average-Default"
  value: {
-  dps: 6207.26875
-  tps: 4114.48972
+  dps: 6207.29177
+  tps: 4114.51274
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6644.87205
-  tps: 5614.15751
+  dps: 6644.89657
+  tps: 5614.18203
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5986.46143
-  tps: 3973.37832
+  dps: 5986.48555
+  tps: 3973.40244
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7163.39
-  tps: 4690.43078
+  dps: 7163.43362
+  tps: 4690.47439
  }
 }
 dps_results: {
@@ -932,22 +932,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6747.09523
-  tps: 5599.78898
+  dps: 6747.11976
+  tps: 5599.81351
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6084.14337
-  tps: 3956.53183
+  dps: 6084.16735
+  tps: 3956.55582
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7321.50034
-  tps: 4708.44304
+  dps: 7321.54396
+  tps: 4708.48665
  }
 }
 dps_results: {
@@ -974,7 +974,7 @@ dps_results: {
 dps_results: {
  key: "TestBM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6105.86525
-  tps: 4172.02759
+  dps: 6105.88988
+  tps: 4172.05222
  }
 }

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -46,866 +46,866 @@ character_stats_results: {
 dps_results: {
  key: "TestBM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 6448.84165
-  tps: 4476.74824
+  dps: 6448.76597
+  tps: 4476.67255
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 6168.29622
-  tps: 4062.95115
+  dps: 6168.19674
+  tps: 4062.85168
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6179.0121
-  tps: 4073.76453
+  dps: 6178.9207
+  tps: 4073.67313
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6259.8055
-  tps: 4146.37864
+  dps: 6259.20618
+  tps: 4145.77931
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6106.12899
-  tps: 4017.88052
+  dps: 6106.02951
+  tps: 4017.78105
   hps: 92.00776
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6106.12899
-  tps: 4017.88052
+  dps: 6106.02951
+  tps: 4017.78105
   hps: 92.00776
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6199.66791
-  tps: 4086.87629
+  dps: 6199.57685
+  tps: 4086.78522
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6073.49939
-  tps: 4021.60887
+  dps: 6073.40626
+  tps: 4021.51574
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 5754.09914
-  tps: 3662.69984
+  dps: 5754.00631
+  tps: 3662.60701
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBruise-50035"
  value: {
-  dps: 5991.83283
-  tps: 3928.80541
+  dps: 5991.73328
+  tps: 3928.70586
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBruise-50692"
  value: {
-  dps: 5981.84912
-  tps: 3921.59092
+  dps: 5981.74957
+  tps: 3921.49137
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5202.4887
-  tps: 3452.38261
+  dps: 5202.42541
+  tps: 3452.31932
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5037.93757
-  tps: 3322.09948
+  dps: 5037.87491
+  tps: 3322.03682
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6179.0121
-  tps: 3993.41431
+  dps: 6178.9207
+  tps: 3993.32474
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6274.4109
-  tps: 4160.445
+  dps: 6274.31128
+  tps: 4160.34538
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6274.4109
-  tps: 4160.445
+  dps: 6274.31128
+  tps: 4160.34538
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6269.74657
-  tps: 4158.25558
+  dps: 6269.64731
+  tps: 4158.15632
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
   hps: 64
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 5728.76714
-  tps: 3760.05413
+  dps: 5728.7241
+  tps: 3760.0111
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6165.42015
-  tps: 4080.33561
+  dps: 6165.32322
+  tps: 4080.23868
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6221.28374
-  tps: 4139.2015
+  dps: 6219.68158
+  tps: 4137.59934
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6269.64517
-  tps: 4152.17256
+  dps: 6269.56057
+  tps: 4152.08797
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6404.87314
-  tps: 4252.53615
+  dps: 6404.77337
+  tps: 4252.43638
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6163.33217
-  tps: 4074.65391
+  dps: 6163.2387
+  tps: 4074.56045
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6432.12301
-  tps: 4312.36911
+  dps: 6432.03117
+  tps: 4312.27726
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6456.57817
-  tps: 4344.11495
+  dps: 6456.46697
+  tps: 4344.00374
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6195.56818
-  tps: 4083.8369
+  dps: 6195.48559
+  tps: 4083.75431
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6172.16475
-  tps: 4101.43832
+  dps: 6172.06587
+  tps: 4101.33944
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6170.51221
-  tps: 4087.5
+  dps: 6170.41296
+  tps: 4087.40075
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6179.0121
-  tps: 4073.76453
+  dps: 6178.9207
+  tps: 4073.67313
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6187.20995
-  tps: 4079.84526
+  dps: 6187.11855
+  tps: 4079.75386
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6190.23566
-  tps: 4078.74467
+  dps: 6190.14459
+  tps: 4078.6536
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6187.19489
-  tps: 4075.83137
+  dps: 6187.09911
+  tps: 4075.7356
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6139.34083
-  tps: 4077.94212
+  dps: 6139.24144
+  tps: 4077.84273
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6179.0121
-  tps: 4073.76453
+  dps: 6178.9207
+  tps: 4073.67313
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6194.9086
-  tps: 4112.11765
+  dps: 6194.52908
+  tps: 4111.73813
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6159.42331
-  tps: 4077.70179
+  dps: 6159.33164
+  tps: 4077.61013
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6143.18942
-  tps: 4047.0102
+  dps: 6143.08533
+  tps: 4046.90611
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6150.27797
-  tps: 4068.21773
+  dps: 6150.19965
+  tps: 4068.13941
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6179.0121
-  tps: 4073.76453
+  dps: 6178.9207
+  tps: 4073.67313
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6179.0121
-  tps: 4073.76453
+  dps: 6178.9207
+  tps: 4073.67313
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6255.72757
-  tps: 4126.28702
+  dps: 6255.62809
+  tps: 4126.18754
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 6036.34696
-  tps: 4112.65517
+  dps: 6036.29197
+  tps: 4112.60018
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6196.50308
-  tps: 4114.44582
+  dps: 6196.00401
+  tps: 4113.94675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 4895.20867
-  tps: 3209.71506
+  dps: 4895.16111
+  tps: 3209.6675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Heartpierce-49982"
  value: {
-  dps: 6319.62715
-  tps: 4193.36569
+  dps: 6319.52753
+  tps: 4193.26606
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Heartpierce-50641"
  value: {
-  dps: 6320.59955
-  tps: 4194.07366
+  dps: 6320.49992
+  tps: 4193.97403
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6190.23566
-  tps: 4078.74467
+  dps: 6190.14459
+  tps: 4078.6536
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6187.19489
-  tps: 4075.83137
+  dps: 6187.09911
+  tps: 4075.7356
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6247.40194
-  tps: 4139.49455
+  dps: 6247.30246
+  tps: 4139.39508
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6217.66326
-  tps: 4111.59364
+  dps: 6217.56762
+  tps: 4111.49801
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6199.92964
-  tps: 4088.88871
+  dps: 6199.83824
+  tps: 4088.79731
   hps: 11.27139
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LastWord-50179"
  value: {
-  dps: 6274.4109
-  tps: 4160.445
+  dps: 6274.31128
+  tps: 4160.34538
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LastWord-50708"
  value: {
-  dps: 6274.4109
-  tps: 4160.445
+  dps: 6274.31128
+  tps: 4160.34538
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6194.73398
-  tps: 4120.73737
+  dps: 6194.65413
+  tps: 4120.65752
  }
 }
 dps_results: {
  key: "TestBM-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6197.60159
-  tps: 4118.34776
+  dps: 6197.52347
+  tps: 4118.26964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Nibelung-49992"
  value: {
-  dps: 6359.16856
-  tps: 4224.62529
+  dps: 6359.07033
+  tps: 4224.52705
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Nibelung-50648"
  value: {
-  dps: 6364.72433
-  tps: 4228.67699
+  dps: 6364.62148
+  tps: 4228.57413
  }
 }
 dps_results: {
  key: "TestBM-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6195.31486
-  tps: 4085.58508
+  dps: 6195.22346
+  tps: 4085.49368
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6199.15081
-  tps: 4088.36638
+  dps: 6199.05941
+  tps: 4088.27499
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6179.0121
-  tps: 4073.76453
+  dps: 6178.9207
+  tps: 4073.67313
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6179.0121
-  tps: 4073.76453
+  dps: 6178.9207
+  tps: 4073.67313
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6274.4109
-  tps: 4160.445
+  dps: 6274.31128
+  tps: 4160.34538
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6188.04802
-  tps: 4081.20289
+  dps: 6187.95662
+  tps: 4081.11149
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 6136.49607
-  tps: 4097.71004
+  dps: 6136.41048
+  tps: 4097.62445
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6481.82345
-  tps: 4370.67328
+  dps: 6481.72595
+  tps: 4370.57578
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6134.095
-  tps: 4046.45664
+  dps: 6133.99552
+  tps: 4046.35716
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6134.095
-  tps: 4047.13997
+  dps: 6133.99552
+  tps: 4047.04049
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6163.37489
-  tps: 4080.69107
+  dps: 6163.2786
+  tps: 4080.59478
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SparkofLife-37657"
  value: {
-  dps: 6146.15243
-  tps: 4061.32781
+  dps: 6146.05303
+  tps: 4061.22841
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6225.55685
-  tps: 4099.53434
+  dps: 6225.45355
+  tps: 4099.43104
  }
 }
 dps_results: {
  key: "TestBM-AllItems-StormshroudArmor"
  value: {
-  dps: 4947.6938
-  tps: 3247.20185
+  dps: 4947.63531
+  tps: 3247.14336
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6199.15081
-  tps: 4088.36638
+  dps: 6199.05941
+  tps: 4088.27499
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6195.31486
-  tps: 4085.58508
+  dps: 6195.22346
+  tps: 4085.49368
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6188.60196
-  tps: 4080.71779
+  dps: 6188.51056
+  tps: 4080.62639
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6173.3581
-  tps: 4068.7212
+  dps: 6173.26837
+  tps: 4068.63148
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheFistsofFury"
  value: {
-  dps: 6016.9665
-  tps: 3952.82643
+  dps: 6016.86695
+  tps: 3952.72688
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6131.20825
-  tps: 4055.61072
+  dps: 6131.10629
+  tps: 4055.50875
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6205.18703
-  tps: 4095.84572
+  dps: 6205.09504
+  tps: 4095.75372
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6145.88356
-  tps: 4042.26711
+  dps: 6145.78025
+  tps: 4042.1638
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6145.88356
-  tps: 4042.26711
+  dps: 6145.78025
+  tps: 4042.1638
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6179.0121
-  tps: 4073.76453
+  dps: 6178.9207
+  tps: 4073.67313
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6179.0121
-  tps: 4073.76453
+  dps: 6178.9207
+  tps: 4073.67313
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6123.95676
-  tps: 4046.31105
+  dps: 6123.85852
+  tps: 4046.21281
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6179.0121
-  tps: 4073.76453
+  dps: 6178.9207
+  tps: 4073.67313
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6179.0121
-  tps: 4073.76453
+  dps: 6178.9207
+  tps: 4073.67313
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5169.21763
-  tps: 3423.4168
+  dps: 5169.14897
+  tps: 3423.34814
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6069.99313
-  tps: 4012.1493
+  dps: 6069.88838
+  tps: 4012.04454
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 6277.60094
-  tps: 4234.49795
+  dps: 6277.51295
+  tps: 4234.40996
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6106.19343
-  tps: 4017.88052
+  dps: 6106.09396
+  tps: 4017.78105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 6678.98126
-  tps: 4603.42764
+  dps: 6678.8793
+  tps: 4603.32567
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 6872.01651
-  tps: 4796.9912
+  dps: 6871.91466
+  tps: 4796.88934
  }
 }
 dps_results: {
  key: "TestBM-Average-Default"
  value: {
-  dps: 6207.3495
-  tps: 4114.57047
+  dps: 6207.26875
+  tps: 4114.48972
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6644.9874
-  tps: 5614.27286
+  dps: 6644.87205
+  tps: 5614.15751
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5986.5656
-  tps: 3973.48249
+  dps: 5986.46143
+  tps: 3973.37832
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7163.68763
-  tps: 4690.7284
+  dps: 7163.39
+  tps: 4690.43078
  }
 }
 dps_results: {
@@ -932,22 +932,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6747.21059
-  tps: 5599.90433
+  dps: 6747.09523
+  tps: 5599.78898
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6084.2474
-  tps: 3956.63587
+  dps: 6084.14337
+  tps: 3956.53183
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7321.79796
-  tps: 4708.74066
+  dps: 7321.50034
+  tps: 4708.44304
  }
 }
 dps_results: {
@@ -974,7 +974,7 @@ dps_results: {
 dps_results: {
  key: "TestBM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6105.96567
-  tps: 4172.12801
+  dps: 6105.86525
+  tps: 4172.02759
  }
 }

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -46,866 +46,866 @@ character_stats_results: {
 dps_results: {
  key: "TestBM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 6448.76597
-  tps: 4476.67255
+  dps: 6448.84165
+  tps: 4476.74824
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 6168.19674
-  tps: 4062.85168
+  dps: 6168.29622
+  tps: 4062.95115
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6179.0121
+  tps: 4073.76453
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6259.20618
-  tps: 4145.77931
+  dps: 6259.8055
+  tps: 4146.37864
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6106.02951
-  tps: 4017.78105
+  dps: 6106.12899
+  tps: 4017.88052
   hps: 92.00776
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6106.02951
-  tps: 4017.78105
+  dps: 6106.12899
+  tps: 4017.88052
   hps: 92.00776
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6199.57685
-  tps: 4086.78522
+  dps: 6199.66791
+  tps: 4086.87629
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6073.40626
-  tps: 4021.51574
+  dps: 6073.49939
+  tps: 4021.60887
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 5754.00631
-  tps: 3662.60701
+  dps: 5754.09914
+  tps: 3662.69984
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBruise-50035"
  value: {
-  dps: 5991.73328
-  tps: 3928.70586
+  dps: 5991.83283
+  tps: 3928.80541
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBruise-50692"
  value: {
-  dps: 5981.74957
-  tps: 3921.49137
+  dps: 5981.84912
+  tps: 3921.59092
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5202.42541
-  tps: 3452.31932
+  dps: 5202.4887
+  tps: 3452.38261
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5037.87491
-  tps: 3322.03682
+  dps: 5037.93757
+  tps: 3322.09948
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6178.9207
-  tps: 3993.32474
+  dps: 6179.0121
+  tps: 3993.41431
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6274.31128
-  tps: 4160.34538
+  dps: 6274.4109
+  tps: 4160.445
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6274.31128
-  tps: 4160.34538
+  dps: 6274.4109
+  tps: 4160.445
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6269.64731
-  tps: 4158.15632
+  dps: 6269.74657
+  tps: 4158.25558
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
   hps: 64
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 5728.7241
-  tps: 3760.0111
+  dps: 5728.76714
+  tps: 3760.05413
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6165.32322
-  tps: 4080.23868
+  dps: 6165.42015
+  tps: 4080.33561
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6219.68158
-  tps: 4137.59934
+  dps: 6221.28374
+  tps: 4139.2015
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6269.56057
-  tps: 4152.08797
+  dps: 6269.64517
+  tps: 4152.17256
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6404.77337
-  tps: 4252.43638
+  dps: 6404.87314
+  tps: 4252.53615
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6163.2387
-  tps: 4074.56045
+  dps: 6163.33217
+  tps: 4074.65391
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6432.03117
-  tps: 4312.27726
+  dps: 6432.12301
+  tps: 4312.36911
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6456.46697
-  tps: 4344.00374
+  dps: 6456.57817
+  tps: 4344.11495
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6195.48559
-  tps: 4083.75431
+  dps: 6195.56818
+  tps: 4083.8369
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6172.06587
-  tps: 4101.33944
+  dps: 6172.16475
+  tps: 4101.43832
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6170.41296
-  tps: 4087.40075
+  dps: 6170.51221
+  tps: 4087.5
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6179.0121
+  tps: 4073.76453
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6187.11855
-  tps: 4079.75386
+  dps: 6187.20995
+  tps: 4079.84526
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6190.14459
-  tps: 4078.6536
+  dps: 6190.23566
+  tps: 4078.74467
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6187.09911
-  tps: 4075.7356
+  dps: 6187.19489
+  tps: 4075.83137
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6139.24144
-  tps: 4077.84273
+  dps: 6139.34083
+  tps: 4077.94212
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6179.0121
+  tps: 4073.76453
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6194.52908
-  tps: 4111.73813
+  dps: 6194.9086
+  tps: 4112.11765
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6159.33164
-  tps: 4077.61013
+  dps: 6159.42331
+  tps: 4077.70179
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6143.08533
-  tps: 4046.90611
+  dps: 6143.18942
+  tps: 4047.0102
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6150.19965
-  tps: 4068.13941
+  dps: 6150.27797
+  tps: 4068.21773
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6179.0121
+  tps: 4073.76453
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6179.0121
+  tps: 4073.76453
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6255.62809
-  tps: 4126.18754
+  dps: 6255.72757
+  tps: 4126.28702
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 6036.29197
-  tps: 4112.60018
+  dps: 6036.34696
+  tps: 4112.65517
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6196.00401
-  tps: 4113.94675
+  dps: 6196.50308
+  tps: 4114.44582
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 4895.16111
-  tps: 3209.6675
+  dps: 4895.20867
+  tps: 3209.71506
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Heartpierce-49982"
  value: {
-  dps: 6319.52753
-  tps: 4193.26606
+  dps: 6319.62715
+  tps: 4193.36569
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Heartpierce-50641"
  value: {
-  dps: 6320.49992
-  tps: 4193.97403
+  dps: 6320.59955
+  tps: 4194.07366
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6190.14459
-  tps: 4078.6536
+  dps: 6190.23566
+  tps: 4078.74467
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6187.09911
-  tps: 4075.7356
+  dps: 6187.19489
+  tps: 4075.83137
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6247.30246
-  tps: 4139.39508
+  dps: 6247.40194
+  tps: 4139.49455
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6217.56762
-  tps: 4111.49801
+  dps: 6217.66326
+  tps: 4111.59364
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6199.83824
-  tps: 4088.79731
+  dps: 6199.92964
+  tps: 4088.88871
   hps: 11.27139
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LastWord-50179"
  value: {
-  dps: 6274.31128
-  tps: 4160.34538
+  dps: 6274.4109
+  tps: 4160.445
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LastWord-50708"
  value: {
-  dps: 6274.31128
-  tps: 4160.34538
+  dps: 6274.4109
+  tps: 4160.445
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6194.65413
-  tps: 4120.65752
+  dps: 6194.73398
+  tps: 4120.73737
  }
 }
 dps_results: {
  key: "TestBM-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6197.52347
-  tps: 4118.26964
+  dps: 6197.60159
+  tps: 4118.34776
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Nibelung-49992"
  value: {
-  dps: 6359.07033
-  tps: 4224.52705
+  dps: 6359.16856
+  tps: 4224.62529
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Nibelung-50648"
  value: {
-  dps: 6364.62148
-  tps: 4228.57413
+  dps: 6364.72433
+  tps: 4228.67699
  }
 }
 dps_results: {
  key: "TestBM-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6195.22346
-  tps: 4085.49368
+  dps: 6195.31486
+  tps: 4085.58508
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6199.05941
-  tps: 4088.27499
+  dps: 6199.15081
+  tps: 4088.36638
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6179.0121
+  tps: 4073.76453
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6179.0121
+  tps: 4073.76453
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6274.31128
-  tps: 4160.34538
+  dps: 6274.4109
+  tps: 4160.445
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6187.95662
-  tps: 4081.11149
+  dps: 6188.04802
+  tps: 4081.20289
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 6136.41048
-  tps: 4097.62445
+  dps: 6136.49607
+  tps: 4097.71004
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6481.72595
-  tps: 4370.57578
+  dps: 6481.82345
+  tps: 4370.67328
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6133.99552
-  tps: 4046.35716
+  dps: 6134.095
+  tps: 4046.45664
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6133.99552
-  tps: 4047.04049
+  dps: 6134.095
+  tps: 4047.13997
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6163.2786
-  tps: 4080.59478
+  dps: 6163.37489
+  tps: 4080.69107
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SparkofLife-37657"
  value: {
-  dps: 6146.05303
-  tps: 4061.22841
+  dps: 6146.15243
+  tps: 4061.32781
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6225.45355
-  tps: 4099.43104
+  dps: 6225.55685
+  tps: 4099.53434
  }
 }
 dps_results: {
  key: "TestBM-AllItems-StormshroudArmor"
  value: {
-  dps: 4947.63531
-  tps: 3247.14336
+  dps: 4947.6938
+  tps: 3247.20185
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6199.05941
-  tps: 4088.27499
+  dps: 6199.15081
+  tps: 4088.36638
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6195.22346
-  tps: 4085.49368
+  dps: 6195.31486
+  tps: 4085.58508
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6188.51056
-  tps: 4080.62639
+  dps: 6188.60196
+  tps: 4080.71779
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6173.26837
-  tps: 4068.63148
+  dps: 6173.3581
+  tps: 4068.7212
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheFistsofFury"
  value: {
-  dps: 6016.86695
-  tps: 3952.72688
+  dps: 6016.9665
+  tps: 3952.82643
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6131.10629
-  tps: 4055.50875
+  dps: 6131.20825
+  tps: 4055.61072
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6205.09504
-  tps: 4095.75372
+  dps: 6205.18703
+  tps: 4095.84572
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6145.78025
-  tps: 4042.1638
+  dps: 6145.88356
+  tps: 4042.26711
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6145.78025
-  tps: 4042.1638
+  dps: 6145.88356
+  tps: 4042.26711
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6179.0121
+  tps: 4073.76453
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6179.0121
+  tps: 4073.76453
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6123.85852
-  tps: 4046.21281
+  dps: 6123.95676
+  tps: 4046.31105
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6179.0121
+  tps: 4073.76453
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6178.9207
-  tps: 4073.67313
+  dps: 6179.0121
+  tps: 4073.76453
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5169.14897
-  tps: 3423.34814
+  dps: 5169.21763
+  tps: 3423.4168
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6069.88838
-  tps: 4012.04454
+  dps: 6069.99313
+  tps: 4012.1493
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 6277.51295
-  tps: 4234.40996
+  dps: 6277.60094
+  tps: 4234.49795
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6106.09396
-  tps: 4017.78105
+  dps: 6106.19343
+  tps: 4017.88052
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 6678.8793
-  tps: 4603.32567
+  dps: 6678.98126
+  tps: 4603.42764
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 6871.91466
-  tps: 4796.88934
+  dps: 6872.01651
+  tps: 4796.9912
  }
 }
 dps_results: {
  key: "TestBM-Average-Default"
  value: {
-  dps: 6207.26875
-  tps: 4114.48972
+  dps: 6207.3495
+  tps: 4114.57047
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6644.87205
-  tps: 5614.15751
+  dps: 6644.9874
+  tps: 5614.27286
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5986.46143
-  tps: 3973.37832
+  dps: 5986.5656
+  tps: 3973.48249
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7163.39
-  tps: 4690.43078
+  dps: 7163.68763
+  tps: 4690.7284
  }
 }
 dps_results: {
@@ -932,22 +932,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6747.09523
-  tps: 5599.78898
+  dps: 6747.21059
+  tps: 5599.90433
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6084.14337
-  tps: 3956.53183
+  dps: 6084.2474
+  tps: 3956.63587
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7321.50034
-  tps: 4708.44304
+  dps: 7321.79796
+  tps: 4708.74066
  }
 }
 dps_results: {
@@ -974,7 +974,7 @@ dps_results: {
 dps_results: {
  key: "TestBM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6105.86525
-  tps: 4172.02759
+  dps: 6105.96567
+  tps: 4172.12801
  }
 }

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -46,866 +46,866 @@ character_stats_results: {
 dps_results: {
  key: "TestMM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 7806.26697
-  tps: 6913.74705
+  dps: 7806.17382
+  tps: 6913.6539
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 7110.15864
-  tps: 6192.45938
+  dps: 7110.05327
+  tps: 6192.354
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7125.83
-  tps: 6203.51889
+  dps: 7125.73323
+  tps: 6203.42211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7206.66603
-  tps: 6284.8081
+  dps: 7205.26032
+  tps: 6283.40239
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7039.23333
-  tps: 6128.13381
+  dps: 7039.12795
+  tps: 6128.02844
   hps: 91.85693
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7039.23333
-  tps: 6128.13381
+  dps: 7039.12795
+  tps: 6128.02844
   hps: 91.85693
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7148.47276
-  tps: 6227.31069
+  dps: 7148.39225
+  tps: 6227.23017
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7108.83961
-  tps: 6196.69952
+  dps: 7108.73818
+  tps: 6196.5981
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 6635.90335
-  tps: 5719.36597
+  dps: 6635.80578
+  tps: 5719.2684
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50035"
  value: {
-  dps: 6946.67586
-  tps: 6046.10624
+  dps: 6946.57841
+  tps: 6046.00879
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50692"
  value: {
-  dps: 6933.89887
-  tps: 6034.52118
+  dps: 6933.80142
+  tps: 6034.42373
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6108.57251
-  tps: 5320.78925
+  dps: 6108.50229
+  tps: 5320.71903
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5906.66833
-  tps: 5131.26057
+  dps: 5906.59619
+  tps: 5131.18844
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7125.83
-  tps: 6080.68931
+  dps: 7125.73323
+  tps: 6080.59447
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7289.03205
-  tps: 6365.92618
+  dps: 7288.92656
+  tps: 6365.82069
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7289.03205
-  tps: 6365.92618
+  dps: 7288.92656
+  tps: 6365.82069
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7284.97528
-  tps: 6364.57188
+  dps: 7284.88752
+  tps: 6364.48412
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
   hps: 64
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 6701.25007
-  tps: 5809.02851
+  dps: 6701.19242
+  tps: 5808.97086
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7136.3086
-  tps: 6225.58609
+  dps: 7136.21543
+  tps: 6225.49292
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7176.55964
-  tps: 6266.48775
+  dps: 7176.05109
+  tps: 6265.97919
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7272.91066
-  tps: 6345.57427
+  dps: 7272.80482
+  tps: 6345.46843
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7451.73689
-  tps: 6512.50475
+  dps: 7451.6314
+  tps: 6512.39926
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7122.70901
-  tps: 6213.01949
+  dps: 7122.63021
+  tps: 6212.94069
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7435.32776
-  tps: 6512.1507
+  dps: 7435.24453
+  tps: 6512.06747
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7482.71021
-  tps: 6558.11107
+  dps: 7482.60979
+  tps: 6558.01064
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7039.51859
-  tps: 6128.34541
+  dps: 7039.41321
+  tps: 6128.24003
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7143.7907
-  tps: 6223.66883
+  dps: 7143.69734
+  tps: 6223.57547
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7161.67859
-  tps: 6248.4746
+  dps: 7161.56731
+  tps: 6248.36332
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7149.2089
-  tps: 6239.62565
+  dps: 7149.09822
+  tps: 6239.51497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7125.83
-  tps: 6203.51889
+  dps: 7125.73323
+  tps: 6203.42211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7138.33582
-  tps: 6214.84431
+  dps: 7138.23905
+  tps: 6214.74753
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7142.98347
-  tps: 6222.58007
+  dps: 7142.90296
+  tps: 6222.49956
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7140.94973
-  tps: 6220.54633
+  dps: 7140.86152
+  tps: 6220.45811
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7092.87981
-  tps: 6187.35272
+  dps: 7092.76883
+  tps: 6187.24174
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7125.83
-  tps: 6203.51889
+  dps: 7125.73323
+  tps: 6203.42211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7186.01548
-  tps: 6275.47344
+  dps: 7185.18301
+  tps: 6274.64097
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7122.45223
-  tps: 6212.22888
+  dps: 7122.35579
+  tps: 6212.13245
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7086.95395
-  tps: 6171.5938
+  dps: 7086.84858
+  tps: 6171.48842
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7102.54092
-  tps: 6192.55011
+  dps: 7102.45748
+  tps: 6192.46667
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7125.83
-  tps: 6203.51889
+  dps: 7125.73323
+  tps: 6203.42211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7125.83
-  tps: 6203.51889
+  dps: 7125.73323
+  tps: 6203.42211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7229.36112
-  tps: 6300.36887
+  dps: 7229.25574
+  tps: 6300.26349
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7039.51859
-  tps: 6128.34541
+  dps: 7039.41321
+  tps: 6128.24003
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 7249.05623
-  tps: 6376.09385
+  dps: 7249.00193
+  tps: 6376.03956
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7150.82886
-  tps: 6240.67776
+  dps: 7150.73154
+  tps: 6240.58043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5571.71325
-  tps: 4823.19575
+  dps: 5571.66435
+  tps: 4823.14685
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-49982"
  value: {
-  dps: 7346.61323
-  tps: 6418.21293
+  dps: 7346.50774
+  tps: 6418.10744
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-50641"
  value: {
-  dps: 7347.85153
-  tps: 6419.33738
+  dps: 7347.74605
+  tps: 6419.23189
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7039.50503
-  tps: 6128.33185
+  dps: 7039.39965
+  tps: 6128.22647
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7142.98347
-  tps: 6222.58007
+  dps: 7142.90296
+  tps: 6222.49956
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7140.94973
-  tps: 6220.54633
+  dps: 7140.86152
+  tps: 6220.45811
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7199.03345
-  tps: 6279.42371
+  dps: 7198.92807
+  tps: 6279.31833
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7180.75614
-  tps: 6259.59841
+  dps: 7180.65936
+  tps: 6259.50163
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7148.6555
-  tps: 6223.96266
+  dps: 7148.55872
+  tps: 6223.86588
   hps: 11.15979
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LastWord-50179"
  value: {
-  dps: 7289.03205
-  tps: 6365.92618
+  dps: 7288.92656
+  tps: 6365.82069
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LastWord-50708"
  value: {
-  dps: 7289.03205
-  tps: 6365.92618
+  dps: 7288.92656
+  tps: 6365.82069
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7187.48209
-  tps: 6270.80096
+  dps: 7187.39919
+  tps: 6270.71806
  }
 }
 dps_results: {
  key: "TestMM-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7194.62115
-  tps: 6283.26717
+  dps: 7194.53955
+  tps: 6283.18557
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Nibelung-49992"
  value: {
-  dps: 7401.85333
-  tps: 6467.26458
+  dps: 7401.74749
+  tps: 6467.15874
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Nibelung-50648"
  value: {
-  dps: 7408.68046
-  tps: 6473.36101
+  dps: 7408.57463
+  tps: 6473.25518
  }
 }
 dps_results: {
  key: "TestMM-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7146.4464
-  tps: 6222.19817
+  dps: 7146.34962
+  tps: 6222.10139
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7151.29731
-  tps: 6226.59329
+  dps: 7151.20054
+  tps: 6226.49651
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7125.83
-  tps: 6203.51889
+  dps: 7125.73323
+  tps: 6203.42211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7125.83
-  tps: 6203.51889
+  dps: 7125.73323
+  tps: 6203.42211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7048.65175
-  tps: 6137.47386
+  dps: 7048.3748
+  tps: 6137.19691
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7049.86388
-  tps: 6138.68599
+  dps: 7049.5662
+  tps: 6138.38831
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7289.03205
-  tps: 6365.92618
+  dps: 7288.92656
+  tps: 6365.82069
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7133.17599
-  tps: 6209.80841
+  dps: 7133.07921
+  tps: 6209.71164
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7039.51859
-  tps: 6128.34541
+  dps: 7039.41321
+  tps: 6128.24003
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 7085.16295
-  tps: 6206.76154
+  dps: 7085.07916
+  tps: 6206.67775
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7039.51859
-  tps: 6128.34541
+  dps: 7039.41321
+  tps: 6128.24003
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7523.90217
-  tps: 6604.07758
+  dps: 7523.81259
+  tps: 6603.988
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7079.35313
-  tps: 6168.86356
+  dps: 7079.24775
+  tps: 6168.75819
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7080.43153
-  tps: 6170.49032
+  dps: 7080.32616
+  tps: 6170.38494
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7140.77887
-  tps: 6230.11118
+  dps: 7140.6815
+  tps: 6230.01381
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SparkofLife-37657"
  value: {
-  dps: 7101.30649
-  tps: 6191.25195
+  dps: 7101.19521
+  tps: 6191.14067
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7138.26932
-  tps: 6217.38206
+  dps: 7138.16255
+  tps: 6217.27528
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StormshroudArmor"
  value: {
-  dps: 5747.89276
-  tps: 4982.98695
+  dps: 5747.82478
+  tps: 4982.91898
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7151.29731
-  tps: 6226.59329
+  dps: 7151.20054
+  tps: 6226.49651
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7146.4464
-  tps: 6222.19817
+  dps: 7146.34962
+  tps: 6222.10139
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7137.95729
-  tps: 6214.5067
+  dps: 7137.86052
+  tps: 6214.40992
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7039.51859
-  tps: 6128.34541
+  dps: 7039.41321
+  tps: 6128.24003
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7125.69188
-  tps: 6205.40447
+  dps: 7125.59023
+  tps: 6205.30283
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheFistsofFury"
  value: {
-  dps: 6980.56521
-  tps: 6079.19973
+  dps: 6980.4679
+  tps: 6079.10242
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7039.512
-  tps: 6128.33882
+  dps: 7039.40663
+  tps: 6128.23345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7121.1151
-  tps: 6219.90303
+  dps: 7121.0179
+  tps: 6219.80582
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7166.43989
-  tps: 6247.83712
+  dps: 7166.33938
+  tps: 6247.73662
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7039.7296
-  tps: 6128.55642
+  dps: 7039.61829
+  tps: 6128.44511
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7039.7296
-  tps: 6128.55642
+  dps: 7039.61829
+  tps: 6128.44511
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7125.83
-  tps: 6203.51889
+  dps: 7125.73323
+  tps: 6203.42211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7125.83
-  tps: 6203.51889
+  dps: 7125.73323
+  tps: 6203.42211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7064.13602
-  tps: 6155.05274
+  dps: 7064.02657
+  tps: 6154.9433
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7125.83
-  tps: 6203.51889
+  dps: 7125.73323
+  tps: 6203.42211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7125.83
-  tps: 6203.51889
+  dps: 7125.73323
+  tps: 6203.42211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6066.87836
-  tps: 5285.43806
+  dps: 6066.80144
+  tps: 5285.36114
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7029.34664
-  tps: 6123.46382
+  dps: 7029.25142
+  tps: 6123.36859
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 7318.21177
-  tps: 6398.9946
+  dps: 7318.12407
+  tps: 6398.90689
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7039.51859
-  tps: 6128.34541
+  dps: 7039.41321
+  tps: 6128.24003
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7779.76491
-  tps: 6862.6882
+  dps: 7779.66176
+  tps: 6862.58505
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 8048.10992
-  tps: 7130.67432
+  dps: 8048.0078
+  tps: 7130.57219
  }
 }
 dps_results: {
  key: "TestMM-Average-Default"
  value: {
-  dps: 7285.56113
-  tps: 6369.70008
+  dps: 7285.48173
+  tps: 6369.62068
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6856.8672
-  tps: 7002.04398
+  dps: 6856.75971
+  tps: 7001.9365
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6186.98246
-  tps: 5302.2022
+  dps: 6186.88386
+  tps: 5302.1036
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7126.57511
-  tps: 6102.06963
+  dps: 7126.29704
+  tps: 6101.79157
  }
 }
 dps_results: {
@@ -932,22 +932,22 @@ dps_results: {
 dps_results: {
  key: "TestMM-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6867.35934
-  tps: 6962.733
+  dps: 6867.25198
+  tps: 6962.62564
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6221.67823
-  tps: 5285.2419
+  dps: 6221.57963
+  tps: 5285.14329
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7208.08663
-  tps: 6121.3929
+  dps: 7207.80857
+  tps: 6121.11483
  }
 }
 dps_results: {
@@ -974,7 +974,7 @@ dps_results: {
 dps_results: {
  key: "TestMM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7241.4931
-  tps: 6379.58708
+  dps: 7241.38756
+  tps: 6379.48154
  }
 }

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -46,866 +46,866 @@ character_stats_results: {
 dps_results: {
  key: "TestMM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 7806.17382
-  tps: 6913.6539
+  dps: 7806.26697
+  tps: 6913.74705
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 7110.05327
-  tps: 6192.354
+  dps: 7110.15864
+  tps: 6192.45938
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.83
+  tps: 6203.51889
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7205.26032
-  tps: 6283.40239
+  dps: 7206.66603
+  tps: 6284.8081
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7039.12795
-  tps: 6128.02844
+  dps: 7039.23333
+  tps: 6128.13381
   hps: 91.85693
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7039.12795
-  tps: 6128.02844
+  dps: 7039.23333
+  tps: 6128.13381
   hps: 91.85693
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7148.39225
-  tps: 6227.23017
+  dps: 7148.47276
+  tps: 6227.31069
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7108.73818
-  tps: 6196.5981
+  dps: 7108.83961
+  tps: 6196.69952
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 6635.80578
-  tps: 5719.2684
+  dps: 6635.90335
+  tps: 5719.36597
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50035"
  value: {
-  dps: 6946.57841
-  tps: 6046.00879
+  dps: 6946.67586
+  tps: 6046.10624
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50692"
  value: {
-  dps: 6933.80142
-  tps: 6034.42373
+  dps: 6933.89887
+  tps: 6034.52118
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6108.50229
-  tps: 5320.71903
+  dps: 6108.57251
+  tps: 5320.78925
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5906.59619
-  tps: 5131.18844
+  dps: 5906.66833
+  tps: 5131.26057
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6080.59447
+  dps: 7125.83
+  tps: 6080.68931
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7288.92656
-  tps: 6365.82069
+  dps: 7289.03205
+  tps: 6365.92618
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7288.92656
-  tps: 6365.82069
+  dps: 7289.03205
+  tps: 6365.92618
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7284.88752
-  tps: 6364.48412
+  dps: 7284.97528
+  tps: 6364.57188
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
   hps: 64
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 6701.19242
-  tps: 5808.97086
+  dps: 6701.25007
+  tps: 5809.02851
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7136.21543
-  tps: 6225.49292
+  dps: 7136.3086
+  tps: 6225.58609
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7176.05109
-  tps: 6265.97919
+  dps: 7176.55964
+  tps: 6266.48775
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7272.80482
-  tps: 6345.46843
+  dps: 7272.91066
+  tps: 6345.57427
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7451.6314
-  tps: 6512.39926
+  dps: 7451.73689
+  tps: 6512.50475
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7122.63021
-  tps: 6212.94069
+  dps: 7122.70901
+  tps: 6213.01949
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7435.24453
-  tps: 6512.06747
+  dps: 7435.32776
+  tps: 6512.1507
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7482.60979
-  tps: 6558.01064
+  dps: 7482.71021
+  tps: 6558.11107
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7039.41321
-  tps: 6128.24003
+  dps: 7039.51859
+  tps: 6128.34541
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7143.69734
-  tps: 6223.57547
+  dps: 7143.7907
+  tps: 6223.66883
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7161.56731
-  tps: 6248.36332
+  dps: 7161.67859
+  tps: 6248.4746
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7149.09822
-  tps: 6239.51497
+  dps: 7149.2089
+  tps: 6239.62565
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.83
+  tps: 6203.51889
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7138.23905
-  tps: 6214.74753
+  dps: 7138.33582
+  tps: 6214.84431
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7142.90296
-  tps: 6222.49956
+  dps: 7142.98347
+  tps: 6222.58007
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7140.86152
-  tps: 6220.45811
+  dps: 7140.94973
+  tps: 6220.54633
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7092.76883
-  tps: 6187.24174
+  dps: 7092.87981
+  tps: 6187.35272
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.83
+  tps: 6203.51889
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7185.18301
-  tps: 6274.64097
+  dps: 7186.01548
+  tps: 6275.47344
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7122.35579
-  tps: 6212.13245
+  dps: 7122.45223
+  tps: 6212.22888
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7086.84858
-  tps: 6171.48842
+  dps: 7086.95395
+  tps: 6171.5938
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7102.45748
-  tps: 6192.46667
+  dps: 7102.54092
+  tps: 6192.55011
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.83
+  tps: 6203.51889
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.83
+  tps: 6203.51889
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7229.25574
-  tps: 6300.26349
+  dps: 7229.36112
+  tps: 6300.36887
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7039.41321
-  tps: 6128.24003
+  dps: 7039.51859
+  tps: 6128.34541
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 7249.00193
-  tps: 6376.03956
+  dps: 7249.05623
+  tps: 6376.09385
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7150.73154
-  tps: 6240.58043
+  dps: 7150.82886
+  tps: 6240.67776
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5571.66435
-  tps: 4823.14685
+  dps: 5571.71325
+  tps: 4823.19575
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-49982"
  value: {
-  dps: 7346.50774
-  tps: 6418.10744
+  dps: 7346.61323
+  tps: 6418.21293
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-50641"
  value: {
-  dps: 7347.74605
-  tps: 6419.23189
+  dps: 7347.85153
+  tps: 6419.33738
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7039.39965
-  tps: 6128.22647
+  dps: 7039.50503
+  tps: 6128.33185
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7142.90296
-  tps: 6222.49956
+  dps: 7142.98347
+  tps: 6222.58007
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7140.86152
-  tps: 6220.45811
+  dps: 7140.94973
+  tps: 6220.54633
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7198.92807
-  tps: 6279.31833
+  dps: 7199.03345
+  tps: 6279.42371
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7180.65936
-  tps: 6259.50163
+  dps: 7180.75614
+  tps: 6259.59841
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7148.55872
-  tps: 6223.86588
+  dps: 7148.6555
+  tps: 6223.96266
   hps: 11.15979
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LastWord-50179"
  value: {
-  dps: 7288.92656
-  tps: 6365.82069
+  dps: 7289.03205
+  tps: 6365.92618
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LastWord-50708"
  value: {
-  dps: 7288.92656
-  tps: 6365.82069
+  dps: 7289.03205
+  tps: 6365.92618
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7187.39919
-  tps: 6270.71806
+  dps: 7187.48209
+  tps: 6270.80096
  }
 }
 dps_results: {
  key: "TestMM-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7194.53955
-  tps: 6283.18557
+  dps: 7194.62115
+  tps: 6283.26717
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Nibelung-49992"
  value: {
-  dps: 7401.74749
-  tps: 6467.15874
+  dps: 7401.85333
+  tps: 6467.26458
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Nibelung-50648"
  value: {
-  dps: 7408.57463
-  tps: 6473.25518
+  dps: 7408.68046
+  tps: 6473.36101
  }
 }
 dps_results: {
  key: "TestMM-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7146.34962
-  tps: 6222.10139
+  dps: 7146.4464
+  tps: 6222.19817
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7151.20054
-  tps: 6226.49651
+  dps: 7151.29731
+  tps: 6226.59329
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.83
+  tps: 6203.51889
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.83
+  tps: 6203.51889
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7048.3748
-  tps: 6137.19691
+  dps: 7048.65175
+  tps: 6137.47386
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7049.5662
-  tps: 6138.38831
+  dps: 7049.86388
+  tps: 6138.68599
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7288.92656
-  tps: 6365.82069
+  dps: 7289.03205
+  tps: 6365.92618
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7133.07921
-  tps: 6209.71164
+  dps: 7133.17599
+  tps: 6209.80841
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7039.41321
-  tps: 6128.24003
+  dps: 7039.51859
+  tps: 6128.34541
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 7085.07916
-  tps: 6206.67775
+  dps: 7085.16295
+  tps: 6206.76154
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7039.41321
-  tps: 6128.24003
+  dps: 7039.51859
+  tps: 6128.34541
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7523.81259
-  tps: 6603.988
+  dps: 7523.90217
+  tps: 6604.07758
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7079.24775
-  tps: 6168.75819
+  dps: 7079.35313
+  tps: 6168.86356
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7080.32616
-  tps: 6170.38494
+  dps: 7080.43153
+  tps: 6170.49032
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7140.6815
-  tps: 6230.01381
+  dps: 7140.77887
+  tps: 6230.11118
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SparkofLife-37657"
  value: {
-  dps: 7101.19521
-  tps: 6191.14067
+  dps: 7101.30649
+  tps: 6191.25195
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7138.16255
-  tps: 6217.27528
+  dps: 7138.26932
+  tps: 6217.38206
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StormshroudArmor"
  value: {
-  dps: 5747.82478
-  tps: 4982.91898
+  dps: 5747.89276
+  tps: 4982.98695
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7151.20054
-  tps: 6226.49651
+  dps: 7151.29731
+  tps: 6226.59329
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7146.34962
-  tps: 6222.10139
+  dps: 7146.4464
+  tps: 6222.19817
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7137.86052
-  tps: 6214.40992
+  dps: 7137.95729
+  tps: 6214.5067
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7039.41321
-  tps: 6128.24003
+  dps: 7039.51859
+  tps: 6128.34541
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7125.59023
-  tps: 6205.30283
+  dps: 7125.69188
+  tps: 6205.40447
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheFistsofFury"
  value: {
-  dps: 6980.4679
-  tps: 6079.10242
+  dps: 6980.56521
+  tps: 6079.19973
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.512
+  tps: 6128.33882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7121.0179
-  tps: 6219.80582
+  dps: 7121.1151
+  tps: 6219.90303
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7166.33938
-  tps: 6247.73662
+  dps: 7166.43989
+  tps: 6247.83712
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7039.61829
-  tps: 6128.44511
+  dps: 7039.7296
+  tps: 6128.55642
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7039.61829
-  tps: 6128.44511
+  dps: 7039.7296
+  tps: 6128.55642
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.83
+  tps: 6203.51889
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.83
+  tps: 6203.51889
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7064.02657
-  tps: 6154.9433
+  dps: 7064.13602
+  tps: 6155.05274
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.83
+  tps: 6203.51889
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.83
+  tps: 6203.51889
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6066.80144
-  tps: 5285.36114
+  dps: 6066.87836
+  tps: 5285.43806
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7029.25142
-  tps: 6123.36859
+  dps: 7029.34664
+  tps: 6123.46382
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 7318.12407
-  tps: 6398.90689
+  dps: 7318.21177
+  tps: 6398.9946
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7039.41321
-  tps: 6128.24003
+  dps: 7039.51859
+  tps: 6128.34541
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7779.66176
-  tps: 6862.58505
+  dps: 7779.76491
+  tps: 6862.6882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 8048.0078
-  tps: 7130.57219
+  dps: 8048.10992
+  tps: 7130.67432
  }
 }
 dps_results: {
  key: "TestMM-Average-Default"
  value: {
-  dps: 7285.48173
-  tps: 6369.62068
+  dps: 7285.56113
+  tps: 6369.70008
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6856.77217
-  tps: 7001.94896
+  dps: 6856.8672
+  tps: 7002.04398
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6186.88386
-  tps: 5302.1036
+  dps: 6186.98246
+  tps: 5302.2022
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7126.29704
-  tps: 6101.79157
+  dps: 7126.57511
+  tps: 6102.06963
  }
 }
 dps_results: {
@@ -932,22 +932,22 @@ dps_results: {
 dps_results: {
  key: "TestMM-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6867.26444
-  tps: 6962.6381
+  dps: 6867.35934
+  tps: 6962.733
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6221.57963
-  tps: 5285.14329
+  dps: 6221.67823
+  tps: 5285.2419
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7207.80857
-  tps: 6121.11483
+  dps: 7208.08663
+  tps: 6121.3929
  }
 }
 dps_results: {
@@ -974,7 +974,7 @@ dps_results: {
 dps_results: {
  key: "TestMM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7241.38756
-  tps: 6379.48154
+  dps: 7241.4931
+  tps: 6379.58708
  }
 }

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -46,866 +46,866 @@ character_stats_results: {
 dps_results: {
  key: "TestMM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 7806.17382
-  tps: 6913.6539
+  dps: 7806.20179
+  tps: 6913.68187
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 7110.05327
-  tps: 6192.354
+  dps: 7110.08499
+  tps: 6192.38572
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.76233
+  tps: 6203.45122
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7205.26032
-  tps: 6283.40239
+  dps: 7205.74309
+  tps: 6283.88516
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7039.12795
-  tps: 6128.02844
+  dps: 7039.15968
+  tps: 6128.06016
   hps: 91.85693
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7039.12795
-  tps: 6128.02844
+  dps: 7039.15968
+  tps: 6128.06016
   hps: 91.85693
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7148.39225
-  tps: 6227.23017
+  dps: 7148.42538
+  tps: 6227.26331
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7108.73818
-  tps: 6196.5981
+  dps: 7108.76757
+  tps: 6196.62748
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 6635.80578
-  tps: 5719.2684
+  dps: 6635.8277
+  tps: 5719.29032
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50035"
  value: {
-  dps: 6946.57841
-  tps: 6046.00879
+  dps: 6946.60382
+  tps: 6046.0342
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50692"
  value: {
-  dps: 6933.80142
-  tps: 6034.42373
+  dps: 6933.82683
+  tps: 6034.44914
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6108.50229
-  tps: 5320.71903
+  dps: 6108.53072
+  tps: 5320.74746
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5906.59619
-  tps: 5131.18844
+  dps: 5906.62567
+  tps: 5131.21791
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6080.59447
+  dps: 7125.76233
+  tps: 6080.62299
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7288.92656
-  tps: 6365.82069
+  dps: 7288.95829
+  tps: 6365.85241
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7288.92656
-  tps: 6365.82069
+  dps: 7288.95829
+  tps: 6365.85241
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7284.88752
-  tps: 6364.48412
+  dps: 7284.92364
+  tps: 6364.52023
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
   hps: 64
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 6701.19242
-  tps: 5808.97086
+  dps: 6701.20911
+  tps: 5808.98755
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7136.21543
-  tps: 6225.49292
+  dps: 7136.23768
+  tps: 6225.51518
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7176.05109
-  tps: 6265.97919
+  dps: 7176.08734
+  tps: 6266.01544
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7272.80482
-  tps: 6345.46843
+  dps: 7272.84467
+  tps: 6345.50828
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7451.6314
-  tps: 6512.39926
+  dps: 7451.66312
+  tps: 6512.43098
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7122.63021
-  tps: 6212.94069
+  dps: 7122.66482
+  tps: 6212.97529
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7435.24453
-  tps: 6512.06747
+  dps: 7435.26739
+  tps: 6512.09033
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7482.60979
-  tps: 6558.01064
+  dps: 7482.64498
+  tps: 6558.04584
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7039.41321
-  tps: 6128.24003
+  dps: 7039.44493
+  tps: 6128.27175
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7143.69734
-  tps: 6223.57547
+  dps: 7143.7339
+  tps: 6223.61203
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7161.56731
-  tps: 6248.36332
+  dps: 7161.60296
+  tps: 6248.39897
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7149.09822
-  tps: 6239.51497
+  dps: 7149.13401
+  tps: 6239.55075
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.76233
+  tps: 6203.45122
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7138.23905
-  tps: 6214.74753
+  dps: 7138.2723
+  tps: 6214.78079
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7142.90296
-  tps: 6222.49956
+  dps: 7142.93609
+  tps: 6222.53269
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7140.86152
-  tps: 6220.45811
+  dps: 7140.89807
+  tps: 6220.49467
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7092.76883
-  tps: 6187.24174
+  dps: 7092.80601
+  tps: 6187.27892
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.76233
+  tps: 6203.45122
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7185.18301
-  tps: 6274.64097
+  dps: 7185.49423
+  tps: 6274.95218
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7122.35579
-  tps: 6212.13245
+  dps: 7122.38551
+  tps: 6212.16217
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7086.84858
-  tps: 6171.48842
+  dps: 7086.89322
+  tps: 6171.53307
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7102.45748
-  tps: 6192.46667
+  dps: 7102.49153
+  tps: 6192.50072
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.76233
+  tps: 6203.45122
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.76233
+  tps: 6203.45122
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7229.25574
-  tps: 6300.26349
+  dps: 7229.28746
+  tps: 6300.29521
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7039.41321
-  tps: 6128.24003
+  dps: 7039.44493
+  tps: 6128.27175
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 7249.00193
-  tps: 6376.03956
+  dps: 7249.01349
+  tps: 6376.05111
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7150.73154
-  tps: 6240.58043
+  dps: 7150.76641
+  tps: 6240.61531
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5571.66435
-  tps: 4823.14685
+  dps: 5571.67248
+  tps: 4823.15498
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-49982"
  value: {
-  dps: 7346.50774
-  tps: 6418.10744
+  dps: 7346.53946
+  tps: 6418.13916
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-50641"
  value: {
-  dps: 7347.74605
-  tps: 6419.23189
+  dps: 7347.77777
+  tps: 6419.26361
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7039.39965
-  tps: 6128.22647
+  dps: 7039.43137
+  tps: 6128.25819
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7142.90296
-  tps: 6222.49956
+  dps: 7142.93609
+  tps: 6222.53269
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7140.86152
-  tps: 6220.45811
+  dps: 7140.89807
+  tps: 6220.49467
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7198.92807
-  tps: 6279.31833
+  dps: 7198.95979
+  tps: 6279.35005
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7180.65936
-  tps: 6259.50163
+  dps: 7180.69647
+  tps: 6259.53874
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7148.55872
-  tps: 6223.86588
+  dps: 7148.58783
+  tps: 6223.89498
   hps: 11.15979
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LastWord-50179"
  value: {
-  dps: 7288.92656
-  tps: 6365.82069
+  dps: 7288.95829
+  tps: 6365.85241
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LastWord-50708"
  value: {
-  dps: 7288.92656
-  tps: 6365.82069
+  dps: 7288.95829
+  tps: 6365.85241
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7187.39919
-  tps: 6270.71806
+  dps: 7187.42811
+  tps: 6270.74698
  }
 }
 dps_results: {
  key: "TestMM-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7194.53955
-  tps: 6283.18557
+  dps: 7194.55622
+  tps: 6283.20224
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Nibelung-49992"
  value: {
-  dps: 7401.74749
-  tps: 6467.15874
+  dps: 7401.79201
+  tps: 6467.20326
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Nibelung-50648"
  value: {
-  dps: 7408.57463
-  tps: 6473.25518
+  dps: 7408.61914
+  tps: 6473.29969
  }
 }
 dps_results: {
  key: "TestMM-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7146.34962
-  tps: 6222.10139
+  dps: 7146.37872
+  tps: 6222.13049
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7151.20054
-  tps: 6226.49651
+  dps: 7151.22964
+  tps: 6226.52562
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.76233
+  tps: 6203.45122
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.76233
+  tps: 6203.45122
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7048.3748
-  tps: 6137.19691
+  dps: 7048.41025
+  tps: 6137.23236
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7049.5662
-  tps: 6138.38831
+  dps: 7049.60165
+  tps: 6138.42376
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7288.92656
-  tps: 6365.82069
+  dps: 7288.95829
+  tps: 6365.85241
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7133.07921
-  tps: 6209.71164
+  dps: 7133.10832
+  tps: 6209.74074
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7039.41321
-  tps: 6128.24003
+  dps: 7039.44493
+  tps: 6128.27175
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 7085.07916
-  tps: 6206.67775
+  dps: 7085.10784
+  tps: 6206.70643
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7039.41321
-  tps: 6128.24003
+  dps: 7039.44493
+  tps: 6128.27175
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7523.81259
-  tps: 6603.988
+  dps: 7523.83112
+  tps: 6604.00652
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7079.24775
-  tps: 6168.75819
+  dps: 7079.27947
+  tps: 6168.78991
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7080.32616
-  tps: 6170.38494
+  dps: 7080.35788
+  tps: 6170.41666
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7140.6815
-  tps: 6230.01381
+  dps: 7140.71216
+  tps: 6230.04446
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SparkofLife-37657"
  value: {
-  dps: 7101.19521
-  tps: 6191.14067
+  dps: 7101.23085
+  tps: 6191.17632
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7138.16255
-  tps: 6217.27528
+  dps: 7138.19473
+  tps: 6217.30747
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StormshroudArmor"
  value: {
-  dps: 5747.82478
-  tps: 4982.91898
+  dps: 5747.85124
+  tps: 4982.94543
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7151.20054
-  tps: 6226.49651
+  dps: 7151.22964
+  tps: 6226.52562
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7146.34962
-  tps: 6222.10139
+  dps: 7146.37872
+  tps: 6222.13049
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7137.86052
-  tps: 6214.40992
+  dps: 7137.88962
+  tps: 6214.43903
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7039.41321
-  tps: 6128.24003
+  dps: 7039.44493
+  tps: 6128.27175
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7125.59023
-  tps: 6205.30283
+  dps: 7125.62997
+  tps: 6205.34256
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheFistsofFury"
  value: {
-  dps: 6980.4679
-  tps: 6079.10242
+  dps: 6980.49331
+  tps: 6079.12783
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7039.40663
-  tps: 6128.23345
+  dps: 7039.43835
+  tps: 6128.26517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7121.0179
-  tps: 6219.80582
+  dps: 7121.03083
+  tps: 6219.81875
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7166.33938
-  tps: 6247.73662
+  dps: 7166.37252
+  tps: 6247.76975
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7039.61829
-  tps: 6128.44511
+  dps: 7039.65048
+  tps: 6128.4773
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7039.61829
-  tps: 6128.44511
+  dps: 7039.65048
+  tps: 6128.4773
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.76233
+  tps: 6203.45122
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.76233
+  tps: 6203.45122
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7064.02657
-  tps: 6154.9433
+  dps: 7064.0621
+  tps: 6154.97883
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.76233
+  tps: 6203.45122
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7125.73323
-  tps: 6203.42211
+  dps: 7125.76233
+  tps: 6203.45122
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6066.80144
-  tps: 5285.36114
+  dps: 6066.82279
+  tps: 5285.38249
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7029.25142
-  tps: 6123.36859
+  dps: 7029.29094
+  tps: 6123.40811
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 7318.12407
-  tps: 6398.90689
+  dps: 7318.16034
+  tps: 6398.94316
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7039.41321
-  tps: 6128.24003
+  dps: 7039.44493
+  tps: 6128.27175
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7779.66176
-  tps: 6862.58505
+  dps: 7779.68401
+  tps: 6862.60731
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 8048.0078
-  tps: 7130.57219
+  dps: 8048.03065
+  tps: 7130.59505
  }
 }
 dps_results: {
  key: "TestMM-Average-Default"
  value: {
-  dps: 7285.48173
-  tps: 6369.62068
+  dps: 7285.50562
+  tps: 6369.64457
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6856.75971
-  tps: 7001.9365
+  dps: 6856.79096
+  tps: 7001.96775
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6186.88386
-  tps: 5302.1036
+  dps: 6186.91465
+  tps: 5302.13439
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7126.29704
-  tps: 6101.79157
+  dps: 7126.36235
+  tps: 6101.85688
  }
 }
 dps_results: {
@@ -932,22 +932,22 @@ dps_results: {
 dps_results: {
  key: "TestMM-Settings-Orc-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6867.25198
-  tps: 6962.62564
+  dps: 6867.2831
+  tps: 6962.65676
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6221.57963
-  tps: 5285.14329
+  dps: 6221.61042
+  tps: 5285.17408
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7207.80857
-  tps: 6121.11483
+  dps: 7207.87388
+  tps: 6121.18014
  }
 }
 dps_results: {
@@ -974,7 +974,7 @@ dps_results: {
 dps_results: {
  key: "TestMM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7241.38756
-  tps: 6379.48154
+  dps: 7241.41928
+  tps: 6379.51326
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -46,866 +46,866 @@ character_stats_results: {
 dps_results: {
  key: "TestSV-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 7887.95855
-  tps: 6897.37084
+  dps: 7887.89804
+  tps: 6897.31033
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7383.20413
-  tps: 6348.82218
+  dps: 7383.1284
+  tps: 6348.74644
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7383.20413
-  tps: 6348.82218
+  dps: 7383.1284
+  tps: 6348.74644
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 7434.40295
-  tps: 6395.67993
+  dps: 7434.32722
+  tps: 6395.6042
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7549.04078
-  tps: 6495.32085
+  dps: 7548.9713
+  tps: 6495.25137
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7560.93614
-  tps: 6515.87294
+  dps: 7560.59624
+  tps: 6515.53304
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7384.37841
-  tps: 6349.81391
+  dps: 7384.30268
+  tps: 6349.73817
   hps: 91.41974
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7384.37841
-  tps: 6349.81391
+  dps: 7384.30268
+  tps: 6349.73817
   hps: 91.41974
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7559.28626
-  tps: 6508.52862
+  dps: 7559.21289
+  tps: 6508.45525
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7502.02544
-  tps: 6466.17609
+  dps: 7501.95277
+  tps: 6466.10342
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 7281.25026
-  tps: 6237.11084
+  dps: 7281.18189
+  tps: 6237.04247
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50035"
  value: {
-  dps: 7325.73499
-  tps: 6299.99082
+  dps: 7325.6576
+  tps: 6299.91343
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50692"
  value: {
-  dps: 7315.08806
-  tps: 6289.68178
+  dps: 7315.01068
+  tps: 6289.60439
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6225.84635
-  tps: 5361.46751
+  dps: 6225.80691
+  tps: 5361.42807
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5977.4598
-  tps: 5138.21263
+  dps: 5977.41955
+  tps: 5138.17237
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7539.39249
-  tps: 6360.11902
+  dps: 7539.32301
+  tps: 6360.05093
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7767.48528
-  tps: 6700.15077
+  dps: 7767.40955
+  tps: 6700.07504
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7771.16337
-  tps: 6702.72859
+  dps: 7771.08763
+  tps: 6702.65285
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7707.14152
-  tps: 6656.44107
+  dps: 7707.06155
+  tps: 6656.3611
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7383.20413
-  tps: 6348.82218
+  dps: 7383.1284
+  tps: 6348.74644
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7383.20413
-  tps: 6348.82218
+  dps: 7383.1284
+  tps: 6348.74644
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7452.13786
-  tps: 6396.87681
+  dps: 7452.06213
+  tps: 6396.80108
   hps: 64
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 6802.17227
-  tps: 5824.70387
+  dps: 6802.13943
+  tps: 5824.67103
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7483.81503
-  tps: 6449.57298
+  dps: 7483.74059
+  tps: 6449.49854
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7533.21366
-  tps: 6498.8366
+  dps: 7532.43767
+  tps: 6498.06061
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7633.89358
-  tps: 6583.4726
+  dps: 7633.82222
+  tps: 6583.40124
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7880.76138
-  tps: 6814.49343
+  dps: 7880.68565
+  tps: 6814.4177
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7461.88066
-  tps: 6427.66753
+  dps: 7461.80436
+  tps: 6427.59123
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7727.89358
-  tps: 6681.37007
+  dps: 7727.83143
+  tps: 6681.30791
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7772.84569
-  tps: 6725.42758
+  dps: 7772.77084
+  tps: 6725.35273
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7383.21418
-  tps: 6348.83222
+  dps: 7383.13844
+  tps: 6348.75649
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7562.20269
-  tps: 6511.49271
+  dps: 7562.13344
+  tps: 6511.42346
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7485.38325
-  tps: 6448.28633
+  dps: 7485.30979
+  tps: 6448.21287
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7477.73948
-  tps: 6439.99777
+  dps: 7477.66603
+  tps: 6439.92431
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7549.04078
-  tps: 6495.32085
+  dps: 7548.9713
+  tps: 6495.25137
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7546.862
-  tps: 6495.38654
+  dps: 7546.79252
+  tps: 6495.31706
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7559.28626
-  tps: 6508.58581
+  dps: 7559.21289
+  tps: 6508.51244
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7553.50561
-  tps: 6502.80778
+  dps: 7553.42792
+  tps: 6502.73009
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7432.27281
-  tps: 6402.22955
+  dps: 7432.19602
+  tps: 6402.15277
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7416.75957
-  tps: 6372.2128
+  dps: 7416.68384
+  tps: 6372.13706
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7539.39249
-  tps: 6488.60663
+  dps: 7539.32301
+  tps: 6488.53715
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7541.5073
-  tps: 6506.97844
+  dps: 7540.85402
+  tps: 6506.32516
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7474.14383
-  tps: 6439.8529
+  dps: 7474.07351
+  tps: 6439.78257
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7412.58594
-  tps: 6376.13029
+  dps: 7412.5055
+  tps: 6376.04985
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7383.20413
-  tps: 6348.82218
+  dps: 7383.1284
+  tps: 6348.74644
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7458.23261
-  tps: 6423.82854
+  dps: 7458.17548
+  tps: 6423.7714
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7539.39249
-  tps: 6488.60663
+  dps: 7539.32301
+  tps: 6488.53715
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7539.39249
-  tps: 6488.60663
+  dps: 7539.32301
+  tps: 6488.53715
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7578.01982
-  tps: 6526.669
+  dps: 7577.94409
+  tps: 6526.59327
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7383.21418
-  tps: 6348.83222
+  dps: 7383.13844
+  tps: 6348.75649
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 7518.4746
-  tps: 6533.26076
+  dps: 7518.42508
+  tps: 6533.21125
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7383.21344
-  tps: 6348.83149
+  dps: 7383.13771
+  tps: 6348.75575
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7383.21344
-  tps: 6348.83149
+  dps: 7383.13771
+  tps: 6348.75575
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7514.55274
-  tps: 6480.04229
+  dps: 7514.09213
+  tps: 6479.58168
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5571.3156
-  tps: 4758.39502
+  dps: 5571.28197
+  tps: 4758.3614
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-49982"
  value: {
-  dps: 7799.47695
-  tps: 6735.4235
+  dps: 7799.40122
+  tps: 6735.34776
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-50641"
  value: {
-  dps: 7803.52994
-  tps: 6738.54043
+  dps: 7803.4542
+  tps: 6738.46469
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7383.19562
-  tps: 6348.81367
+  dps: 7383.11989
+  tps: 6348.73793
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7559.28626
-  tps: 6508.58581
+  dps: 7559.21289
+  tps: 6508.51244
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7553.50561
-  tps: 6502.80778
+  dps: 7553.42792
+  tps: 6502.73009
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7531.92176
-  tps: 6489.3473
+  dps: 7531.84603
+  tps: 6489.27157
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7554.02924
-  tps: 6508.48519
+  dps: 7553.95544
+  tps: 6508.41138
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7564.17656
-  tps: 6511.06097
+  dps: 7564.10708
+  tps: 6510.99149
   hps: 12.062
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LastWord-50179"
  value: {
-  dps: 7750.01437
-  tps: 6687.90616
+  dps: 7749.93863
+  tps: 6687.83043
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LastWord-50708"
  value: {
-  dps: 7746.9493
-  tps: 6685.75798
+  dps: 7746.87356
+  tps: 6685.68225
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7383.20413
-  tps: 6348.82218
+  dps: 7383.1284
+  tps: 6348.74644
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7383.20413
-  tps: 6348.82218
+  dps: 7383.1284
+  tps: 6348.74644
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7492.54164
-  tps: 6456.01692
+  dps: 7492.48661
+  tps: 6455.96188
  }
 }
 dps_results: {
  key: "TestSV-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7501.50082
-  tps: 6468.49487
+  dps: 7501.4302
+  tps: 6468.42425
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Nibelung-49992"
  value: {
-  dps: 7824.67187
-  tps: 6756.15604
+  dps: 7824.59579
+  tps: 6756.07997
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Nibelung-50648"
  value: {
-  dps: 7831.59757
-  tps: 6762.20112
+  dps: 7831.51725
+  tps: 6762.12081
  }
 }
 dps_results: {
  key: "TestSV-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7383.19379
-  tps: 6348.81183
+  dps: 7383.11805
+  tps: 6348.7361
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7560.9294
-  tps: 6508.25913
+  dps: 7560.85992
+  tps: 6508.18965
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7565.99691
-  tps: 6512.88325
+  dps: 7565.92742
+  tps: 6512.81377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7383.19379
-  tps: 6348.81183
+  dps: 7383.11805
+  tps: 6348.7361
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7383.20413
-  tps: 6348.82218
+  dps: 7383.1284
+  tps: 6348.74644
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7383.20413
-  tps: 6348.82218
+  dps: 7383.1284
+  tps: 6348.74644
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7547.23172
-  tps: 6494.06193
+  dps: 7547.16224
+  tps: 6493.99245
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7549.04078
-  tps: 6495.32085
+  dps: 7548.9713
+  tps: 6495.25137
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7383.20413
-  tps: 6348.82218
+  dps: 7383.1284
+  tps: 6348.74644
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7399.46693
-  tps: 6365.02827
+  dps: 7398.9819
+  tps: 6364.54325
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7401.46407
-  tps: 6367.02541
+  dps: 7400.92747
+  tps: 6366.48881
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7718.13761
-  tps: 6665.56511
+  dps: 7718.06188
+  tps: 6665.48938
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7539.39249
-  tps: 6488.36625
+  dps: 7539.32301
+  tps: 6488.29677
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7383.21418
-  tps: 6348.83222
+  dps: 7383.13844
+  tps: 6348.75649
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 7401.41625
-  tps: 6403.38894
+  dps: 7401.36217
+  tps: 6403.33486
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7383.21418
-  tps: 6348.83222
+  dps: 7383.13844
+  tps: 6348.75649
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7966.87945
-  tps: 6897.35944
+  dps: 7966.80515
+  tps: 6897.28513
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7383.20413
-  tps: 6348.82218
+  dps: 7383.1284
+  tps: 6348.74644
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7452.14717
-  tps: 6396.88612
+  dps: 7452.07144
+  tps: 6396.81039
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7383.20413
-  tps: 6353.95761
+  dps: 7383.1284
+  tps: 6353.88187
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7383.20413
-  tps: 6354.43385
+  dps: 7383.1284
+  tps: 6354.35812
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7383.20413
-  tps: 6348.82218
+  dps: 7383.1284
+  tps: 6348.74644
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7478.36541
-  tps: 6445.65425
+  dps: 7478.29097
+  tps: 6445.57981
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SparkofLife-37657"
  value: {
-  dps: 7437.64403
-  tps: 6398.36787
+  dps: 7437.56845
+  tps: 6398.2923
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7482.94307
-  tps: 6439.19451
+  dps: 7482.86735
+  tps: 6439.11879
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StormshroudArmor"
  value: {
-  dps: 5772.61132
-  tps: 4946.12509
+  dps: 5772.58008
+  tps: 4946.09385
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7565.99691
-  tps: 6512.88325
+  dps: 7565.92742
+  tps: 6512.81377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7560.9294
-  tps: 6508.25913
+  dps: 7560.85992
+  tps: 6508.18965
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7552.06126
-  tps: 6500.16693
+  dps: 7551.99178
+  tps: 6500.09744
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7383.21418
-  tps: 6348.83222
+  dps: 7383.13844
+  tps: 6348.75649
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7441.96729
-  tps: 6402.18976
+  dps: 7441.89181
+  tps: 6402.11428
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheFistsofFury"
  value: {
-  dps: 7374.4699
-  tps: 6347.32817
+  dps: 7374.39252
+  tps: 6347.25078
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7383.20413
-  tps: 6348.82218
+  dps: 7383.1284
+  tps: 6348.74644
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7518.30357
-  tps: 6489.69766
+  dps: 7518.22516
+  tps: 6489.61925
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7579.37421
-  tps: 6529.1633
+  dps: 7579.30622
+  tps: 6529.09531
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7383.34652
-  tps: 6348.96457
+  dps: 7383.2708
+  tps: 6348.88884
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7383.34652
-  tps: 6348.96457
+  dps: 7383.2708
+  tps: 6348.88884
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7539.39249
-  tps: 6488.60663
+  dps: 7539.32301
+  tps: 6488.53715
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7539.39249
-  tps: 6488.60663
+  dps: 7539.32301
+  tps: 6488.53715
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7392.65196
-  tps: 6360.30778
+  dps: 7392.57724
+  tps: 6360.23306
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7539.39249
-  tps: 6488.60663
+  dps: 7539.32301
+  tps: 6488.53715
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7539.39249
-  tps: 6488.60663
+  dps: 7539.32301
+  tps: 6488.53715
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6183.24271
-  tps: 5325.38792
+  dps: 6183.19209
+  tps: 5325.33731
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7357.24155
-  tps: 6329.17776
+  dps: 7357.16038
+  tps: 6329.0966
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 7512.97004
-  tps: 6492.49108
+  dps: 7512.89867
+  tps: 6492.41971
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7383.21418
-  tps: 6348.83222
+  dps: 7383.13844
+  tps: 6348.75649
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7968.34114
-  tps: 6915.0533
+  dps: 7968.27069
+  tps: 6914.98285
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 8107.73938
-  tps: 7061.0234
+  dps: 8107.66871
+  tps: 7060.95272
  }
 }
 dps_results: {
  key: "TestSV-Average-Default"
  value: {
-  dps: 7677.28347
-  tps: 6628.88924
+  dps: 7677.22183
+  tps: 6628.8276
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7549.34166
-  tps: 7921.78644
+  dps: 7549.25052
+  tps: 7921.6953
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6910.34199
-  tps: 5914.87171
+  dps: 6910.26158
+  tps: 5914.7913
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7712.15925
-  tps: 6567.57831
+  dps: 7711.91448
+  tps: 6567.33353
  }
 }
 dps_results: {
@@ -932,22 +932,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7549.34166
-  tps: 7921.78644
+  dps: 7549.25052
+  tps: 7921.6953
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6910.34199
-  tps: 5914.87171
+  dps: 6910.26158
+  tps: 5914.7913
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-SV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7712.15925
-  tps: 6567.57831
+  dps: 7711.91448
+  tps: 6567.33353
  }
 }
 dps_results: {
@@ -974,22 +974,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7595.48367
-  tps: 7907.6924
+  dps: 7595.39253
+  tps: 7907.60125
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6957.05112
-  tps: 5905.23194
+  dps: 6956.97071
+  tps: 5905.15153
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7794.04909
-  tps: 6581.84848
+  dps: 7793.80432
+  tps: 6581.60371
  }
 }
 dps_results: {
@@ -1016,22 +1016,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7595.48367
-  tps: 7907.6924
+  dps: 7595.39253
+  tps: 7907.60125
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6957.05112
-  tps: 5905.23194
+  dps: 6956.97071
+  tps: 5905.15153
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-SV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7794.04909
-  tps: 6581.84848
+  dps: 7793.80432
+  tps: 6581.60371
  }
 }
 dps_results: {
@@ -1058,7 +1058,7 @@ dps_results: {
 dps_results: {
  key: "TestSV-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7612.30541
-  tps: 6640.55061
+  dps: 7612.22982
+  tps: 6640.47502
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -46,866 +46,866 @@ character_stats_results: {
 dps_results: {
  key: "TestSV-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 7887.89804
-  tps: 6897.31033
+  dps: 7887.91777
+  tps: 6897.33006
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.14172
+  tps: 6348.75977
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.14172
+  tps: 6348.75977
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 7434.32722
-  tps: 6395.6042
+  dps: 7434.34054
+  tps: 6395.61752
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7548.9713
-  tps: 6495.25137
+  dps: 7548.98352
+  tps: 6495.26359
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7560.59624
-  tps: 6515.53304
+  dps: 7560.61898
+  tps: 6515.55578
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7384.30268
-  tps: 6349.73817
+  dps: 7384.316
+  tps: 6349.7515
   hps: 91.41974
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7384.30268
-  tps: 6349.73817
+  dps: 7384.316
+  tps: 6349.7515
   hps: 91.41974
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7559.21289
-  tps: 6508.45525
+  dps: 7559.24983
+  tps: 6508.49219
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7501.95277
-  tps: 6466.10342
+  dps: 7501.97139
+  tps: 6466.12204
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 7281.18189
-  tps: 6237.04247
+  dps: 7281.19084
+  tps: 6237.05142
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50035"
  value: {
-  dps: 7325.6576
-  tps: 6299.91343
+  dps: 7325.67609
+  tps: 6299.93192
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50692"
  value: {
-  dps: 7315.01068
-  tps: 6289.60439
+  dps: 7315.02916
+  tps: 6289.62288
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6225.80691
-  tps: 5361.42807
+  dps: 6225.82044
+  tps: 5361.4416
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5977.41955
-  tps: 5138.17237
+  dps: 5977.43321
+  tps: 5138.18604
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7539.32301
-  tps: 6360.05093
+  dps: 7539.33523
+  tps: 6360.0629
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7767.40955
-  tps: 6700.07504
+  dps: 7767.42287
+  tps: 6700.08836
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7771.08763
-  tps: 6702.65285
+  dps: 7771.10096
+  tps: 6702.66617
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7707.06155
-  tps: 6656.3611
+  dps: 7707.10181
+  tps: 6656.40136
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.14172
+  tps: 6348.75977
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.14172
+  tps: 6348.75977
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7452.06213
-  tps: 6396.80108
+  dps: 7452.07545
+  tps: 6396.8144
   hps: 64
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 6802.13943
-  tps: 5824.67103
+  dps: 6802.14795
+  tps: 5824.67954
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7483.74059
-  tps: 6449.49854
+  dps: 7483.76664
+  tps: 6449.52458
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7532.43767
-  tps: 6498.06061
+  dps: 7532.46892
+  tps: 6498.09186
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7633.82222
-  tps: 6583.40124
+  dps: 7633.85387
+  tps: 6583.43289
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7880.68565
-  tps: 6814.4177
+  dps: 7880.69897
+  tps: 6814.43102
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7461.80436
-  tps: 6427.59123
+  dps: 7461.83586
+  tps: 6427.62273
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7727.83143
-  tps: 6681.30791
+  dps: 7727.84026
+  tps: 6681.31674
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7772.77084
-  tps: 6725.35273
+  dps: 7772.7931
+  tps: 6725.37498
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7383.13844
-  tps: 6348.75649
+  dps: 7383.15176
+  tps: 6348.76981
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7562.13344
-  tps: 6511.42346
+  dps: 7562.16626
+  tps: 6511.45628
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7485.30979
-  tps: 6448.21287
+  dps: 7485.32324
+  tps: 6448.22632
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7477.66603
-  tps: 6439.92431
+  dps: 7477.67947
+  tps: 6439.93776
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7548.9713
-  tps: 6495.25137
+  dps: 7548.98352
+  tps: 6495.26359
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7546.79252
-  tps: 6495.31706
+  dps: 7546.80932
+  tps: 6495.33387
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7559.21289
-  tps: 6508.51244
+  dps: 7559.24983
+  tps: 6508.54938
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7553.42792
-  tps: 6502.73009
+  dps: 7553.46499
+  tps: 6502.76716
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7432.19602
-  tps: 6402.15277
+  dps: 7432.20966
+  tps: 6402.16641
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7416.68384
-  tps: 6372.13706
+  dps: 7416.69716
+  tps: 6372.15038
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7539.32301
-  tps: 6488.53715
+  dps: 7539.33523
+  tps: 6488.54937
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7540.85402
-  tps: 6506.32516
+  dps: 7540.99556
+  tps: 6506.4667
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7474.07351
-  tps: 6439.78257
+  dps: 7474.09484
+  tps: 6439.80391
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7412.5055
-  tps: 6376.04985
+  dps: 7412.53662
+  tps: 6376.08097
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.14172
+  tps: 6348.75977
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7458.17548
-  tps: 6423.7714
+  dps: 7458.18975
+  tps: 6423.78567
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7539.32301
-  tps: 6488.53715
+  dps: 7539.33523
+  tps: 6488.54937
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7539.32301
-  tps: 6488.53715
+  dps: 7539.33523
+  tps: 6488.54937
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7577.94409
-  tps: 6526.59327
+  dps: 7577.95741
+  tps: 6526.60659
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7383.13844
-  tps: 6348.75649
+  dps: 7383.15176
+  tps: 6348.76981
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 7518.42508
-  tps: 6533.21125
+  dps: 7518.44138
+  tps: 6533.22755
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7383.13771
-  tps: 6348.75575
+  dps: 7383.15103
+  tps: 6348.76908
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7383.13771
-  tps: 6348.75575
+  dps: 7383.15103
+  tps: 6348.76908
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7514.09213
-  tps: 6479.58168
+  dps: 7514.1229
+  tps: 6479.61246
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5571.28197
-  tps: 4758.3614
+  dps: 5571.28617
+  tps: 4758.3656
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-49982"
  value: {
-  dps: 7799.40122
-  tps: 6735.34776
+  dps: 7799.41454
+  tps: 6735.36108
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-50641"
  value: {
-  dps: 7803.4542
-  tps: 6738.46469
+  dps: 7803.46752
+  tps: 6738.47801
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7383.11989
-  tps: 6348.73793
+  dps: 7383.13321
+  tps: 6348.75126
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7559.21289
-  tps: 6508.51244
+  dps: 7559.24983
+  tps: 6508.54938
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7553.42792
-  tps: 6502.73009
+  dps: 7553.46499
+  tps: 6502.76716
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7531.84603
-  tps: 6489.27157
+  dps: 7531.85935
+  tps: 6489.28489
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7553.95544
-  tps: 6508.41138
+  dps: 7553.97602
+  tps: 6508.43196
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7564.10708
-  tps: 6510.99149
+  dps: 7564.1193
+  tps: 6511.00371
   hps: 12.062
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LastWord-50179"
  value: {
-  dps: 7749.93863
-  tps: 6687.83043
+  dps: 7749.95196
+  tps: 6687.84375
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LastWord-50708"
  value: {
-  dps: 7746.87356
-  tps: 6685.68225
+  dps: 7746.88688
+  tps: 6685.69557
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.14172
+  tps: 6348.75977
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.14172
+  tps: 6348.75977
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7492.48661
-  tps: 6455.96188
+  dps: 7492.50265
+  tps: 6455.97793
  }
 }
 dps_results: {
  key: "TestSV-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7501.4302
-  tps: 6468.42425
+  dps: 7501.44874
+  tps: 6468.44278
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Nibelung-49992"
  value: {
-  dps: 7824.59579
-  tps: 6756.07997
+  dps: 7824.62745
+  tps: 6756.11163
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Nibelung-50648"
  value: {
-  dps: 7831.51725
-  tps: 6762.12081
+  dps: 7831.54891
+  tps: 6762.15247
  }
 }
 dps_results: {
  key: "TestSV-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7383.11805
-  tps: 6348.7361
+  dps: 7383.13138
+  tps: 6348.74942
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7560.85992
-  tps: 6508.18965
+  dps: 7560.87214
+  tps: 6508.20187
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7565.92742
-  tps: 6512.81377
+  dps: 7565.93965
+  tps: 6512.82599
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7383.11805
-  tps: 6348.7361
+  dps: 7383.13138
+  tps: 6348.74942
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.14172
+  tps: 6348.75977
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.14172
+  tps: 6348.75977
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7547.16224
-  tps: 6493.99245
+  dps: 7547.17446
+  tps: 6494.00467
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7548.9713
-  tps: 6495.25137
+  dps: 7548.98352
+  tps: 6495.26359
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.14172
+  tps: 6348.75977
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7398.9819
-  tps: 6364.54325
+  dps: 7399.22331
+  tps: 6364.78465
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7400.92747
-  tps: 6366.48881
+  dps: 7401.19725
+  tps: 6366.7586
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7718.06188
-  tps: 6665.48938
+  dps: 7718.0752
+  tps: 6665.5027
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7539.32301
-  tps: 6488.29677
+  dps: 7539.33523
+  tps: 6488.30899
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7383.13844
-  tps: 6348.75649
+  dps: 7383.15176
+  tps: 6348.76981
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 7401.36217
-  tps: 6403.33486
+  dps: 7401.37841
+  tps: 6403.3511
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7383.13844
-  tps: 6348.75649
+  dps: 7383.15176
+  tps: 6348.76981
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7966.80515
-  tps: 6897.28513
+  dps: 7966.83059
+  tps: 6897.31057
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.14172
+  tps: 6348.75977
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7452.07144
-  tps: 6396.81039
+  dps: 7452.08476
+  tps: 6396.82371
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7383.1284
-  tps: 6353.88187
+  dps: 7383.14172
+  tps: 6353.8952
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7383.1284
-  tps: 6354.35812
+  dps: 7383.14172
+  tps: 6354.37144
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.14172
+  tps: 6348.75977
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7478.29097
-  tps: 6445.57981
+  dps: 7478.31231
+  tps: 6445.60115
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SparkofLife-37657"
  value: {
-  dps: 7437.56845
-  tps: 6398.2923
+  dps: 7437.5819
+  tps: 6398.30574
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7482.86735
-  tps: 6439.11879
+  dps: 7482.88079
+  tps: 6439.13223
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StormshroudArmor"
  value: {
-  dps: 5772.58008
-  tps: 4946.09385
+  dps: 5772.58917
+  tps: 4946.10294
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7565.92742
-  tps: 6512.81377
+  dps: 7565.93965
+  tps: 6512.82599
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7560.85992
-  tps: 6508.18965
+  dps: 7560.87214
+  tps: 6508.20187
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7551.99178
-  tps: 6500.09744
+  dps: 7552.004
+  tps: 6500.10967
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7383.13844
-  tps: 6348.75649
+  dps: 7383.15176
+  tps: 6348.76981
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7441.89181
-  tps: 6402.11428
+  dps: 7441.92758
+  tps: 6402.15005
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheFistsofFury"
  value: {
-  dps: 7374.39252
-  tps: 6347.25078
+  dps: 7374.41101
+  tps: 6347.26927
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.14172
+  tps: 6348.75977
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7518.22516
-  tps: 6489.61925
+  dps: 7518.24858
+  tps: 6489.64266
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7579.30622
-  tps: 6529.09531
+  dps: 7579.31769
+  tps: 6529.10678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7383.2708
-  tps: 6348.88884
+  dps: 7383.28424
+  tps: 6348.90229
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7383.2708
-  tps: 6348.88884
+  dps: 7383.28424
+  tps: 6348.90229
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7539.32301
-  tps: 6488.53715
+  dps: 7539.33523
+  tps: 6488.54937
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7539.32301
-  tps: 6488.53715
+  dps: 7539.33523
+  tps: 6488.54937
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7392.57724
-  tps: 6360.23306
+  dps: 7392.59055
+  tps: 6360.24637
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7539.32301
-  tps: 6488.53715
+  dps: 7539.33523
+  tps: 6488.54937
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7539.32301
-  tps: 6488.53715
+  dps: 7539.33523
+  tps: 6488.54937
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6183.19209
-  tps: 5325.33731
+  dps: 6183.21565
+  tps: 5325.36086
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7357.16038
-  tps: 6329.0966
+  dps: 7357.19693
+  tps: 6329.13314
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 7512.89867
-  tps: 6492.41971
+  dps: 7512.93209
+  tps: 6492.45313
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7383.13844
-  tps: 6348.75649
+  dps: 7383.15176
+  tps: 6348.76981
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7968.27069
-  tps: 6914.98285
+  dps: 7968.27964
+  tps: 6914.9918
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 8107.66871
-  tps: 7060.95272
+  dps: 8107.67813
+  tps: 7060.96214
  }
 }
 dps_results: {
  key: "TestSV-Average-Default"
  value: {
-  dps: 7677.22183
-  tps: 6628.8276
+  dps: 7677.23945
+  tps: 6628.84521
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7549.25052
-  tps: 7921.6953
+  dps: 7549.27159
+  tps: 7921.71637
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6910.26158
-  tps: 5914.7913
+  dps: 6910.27949
+  tps: 5914.8092
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7711.91448
-  tps: 6567.33353
+  dps: 7711.9593
+  tps: 6567.37835
  }
 }
 dps_results: {
@@ -932,22 +932,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7549.25052
-  tps: 7921.6953
+  dps: 7549.27159
+  tps: 7921.71637
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6910.26158
-  tps: 5914.7913
+  dps: 6910.27949
+  tps: 5914.8092
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-SV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7711.91448
-  tps: 6567.33353
+  dps: 7711.9593
+  tps: 6567.37835
  }
 }
 dps_results: {
@@ -974,22 +974,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7595.39253
-  tps: 7907.60125
+  dps: 7595.41361
+  tps: 7907.62233
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6956.97071
-  tps: 5905.15153
+  dps: 6956.98861
+  tps: 5905.16943
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7793.80432
-  tps: 6581.60371
+  dps: 7793.84914
+  tps: 6581.64853
  }
 }
 dps_results: {
@@ -1016,22 +1016,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7595.39253
-  tps: 7907.60125
+  dps: 7595.41361
+  tps: 7907.62233
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6956.97071
-  tps: 5905.15153
+  dps: 6956.98861
+  tps: 5905.16943
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-SV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7793.80432
-  tps: 6581.60371
+  dps: 7793.84914
+  tps: 6581.64853
  }
 }
 dps_results: {
@@ -1058,7 +1058,7 @@ dps_results: {
 dps_results: {
  key: "TestSV-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7612.22982
-  tps: 6640.47502
+  dps: 7612.24326
+  tps: 6640.48847
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -46,866 +46,866 @@ character_stats_results: {
 dps_results: {
  key: "TestSV-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 7887.89804
-  tps: 6897.31033
+  dps: 7887.95855
+  tps: 6897.37084
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.20413
+  tps: 6348.82218
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.20413
+  tps: 6348.82218
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 7434.32722
-  tps: 6395.6042
+  dps: 7434.40295
+  tps: 6395.67993
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7548.9713
-  tps: 6495.25137
+  dps: 7549.04078
+  tps: 6495.32085
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7560.59624
-  tps: 6515.53304
+  dps: 7560.93614
+  tps: 6515.87294
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7384.30268
-  tps: 6349.73817
+  dps: 7384.37841
+  tps: 6349.81391
   hps: 91.41974
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7384.30268
-  tps: 6349.73817
+  dps: 7384.37841
+  tps: 6349.81391
   hps: 91.41974
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7559.21289
-  tps: 6508.45525
+  dps: 7559.28626
+  tps: 6508.52862
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7501.95277
-  tps: 6466.10342
+  dps: 7502.02544
+  tps: 6466.17609
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 7281.18189
-  tps: 6237.04247
+  dps: 7281.25026
+  tps: 6237.11084
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50035"
  value: {
-  dps: 7325.6576
-  tps: 6299.91343
+  dps: 7325.73499
+  tps: 6299.99082
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50692"
  value: {
-  dps: 7315.01068
-  tps: 6289.60439
+  dps: 7315.08806
+  tps: 6289.68178
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6225.80691
-  tps: 5361.42807
+  dps: 6225.84635
+  tps: 5361.46751
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5977.41955
-  tps: 5138.17237
+  dps: 5977.4598
+  tps: 5138.21263
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7539.32301
-  tps: 6360.05093
+  dps: 7539.39249
+  tps: 6360.11902
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7767.40955
-  tps: 6700.07504
+  dps: 7767.48528
+  tps: 6700.15077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7771.08763
-  tps: 6702.65285
+  dps: 7771.16337
+  tps: 6702.72859
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7707.06155
-  tps: 6656.3611
+  dps: 7707.14152
+  tps: 6656.44107
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.20413
+  tps: 6348.82218
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.20413
+  tps: 6348.82218
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7452.06213
-  tps: 6396.80108
+  dps: 7452.13786
+  tps: 6396.87681
   hps: 64
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 6802.13943
-  tps: 5824.67103
+  dps: 6802.17227
+  tps: 5824.70387
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7483.74059
-  tps: 6449.49854
+  dps: 7483.81503
+  tps: 6449.57298
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7532.43767
-  tps: 6498.06061
+  dps: 7533.21366
+  tps: 6498.8366
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7633.82222
-  tps: 6583.40124
+  dps: 7633.89358
+  tps: 6583.4726
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7880.68565
-  tps: 6814.4177
+  dps: 7880.76138
+  tps: 6814.49343
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7461.80436
-  tps: 6427.59123
+  dps: 7461.88066
+  tps: 6427.66753
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7727.83143
-  tps: 6681.30791
+  dps: 7727.89358
+  tps: 6681.37007
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7772.77084
-  tps: 6725.35273
+  dps: 7772.84569
+  tps: 6725.42758
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7383.13844
-  tps: 6348.75649
+  dps: 7383.21418
+  tps: 6348.83222
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7562.13344
-  tps: 6511.42346
+  dps: 7562.20269
+  tps: 6511.49271
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7485.30979
-  tps: 6448.21287
+  dps: 7485.38325
+  tps: 6448.28633
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7477.66603
-  tps: 6439.92431
+  dps: 7477.73948
+  tps: 6439.99777
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7548.9713
-  tps: 6495.25137
+  dps: 7549.04078
+  tps: 6495.32085
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7546.79252
-  tps: 6495.31706
+  dps: 7546.862
+  tps: 6495.38654
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7559.21289
-  tps: 6508.51244
+  dps: 7559.28626
+  tps: 6508.58581
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7553.42792
-  tps: 6502.73009
+  dps: 7553.50561
+  tps: 6502.80778
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7432.19602
-  tps: 6402.15277
+  dps: 7432.27281
+  tps: 6402.22955
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7416.68384
-  tps: 6372.13706
+  dps: 7416.75957
+  tps: 6372.2128
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7539.32301
-  tps: 6488.53715
+  dps: 7539.39249
+  tps: 6488.60663
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7540.85402
-  tps: 6506.32516
+  dps: 7541.5073
+  tps: 6506.97844
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7474.07351
-  tps: 6439.78257
+  dps: 7474.14383
+  tps: 6439.8529
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7412.5055
-  tps: 6376.04985
+  dps: 7412.58594
+  tps: 6376.13029
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.20413
+  tps: 6348.82218
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7458.17548
-  tps: 6423.7714
+  dps: 7458.23261
+  tps: 6423.82854
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7539.32301
-  tps: 6488.53715
+  dps: 7539.39249
+  tps: 6488.60663
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7539.32301
-  tps: 6488.53715
+  dps: 7539.39249
+  tps: 6488.60663
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7577.94409
-  tps: 6526.59327
+  dps: 7578.01982
+  tps: 6526.669
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7383.13844
-  tps: 6348.75649
+  dps: 7383.21418
+  tps: 6348.83222
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 7518.42508
-  tps: 6533.21125
+  dps: 7518.4746
+  tps: 6533.26076
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7383.13771
-  tps: 6348.75575
+  dps: 7383.21344
+  tps: 6348.83149
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7383.13771
-  tps: 6348.75575
+  dps: 7383.21344
+  tps: 6348.83149
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7514.09213
-  tps: 6479.58168
+  dps: 7514.55274
+  tps: 6480.04229
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5571.28197
-  tps: 4758.3614
+  dps: 5571.3156
+  tps: 4758.39502
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-49982"
  value: {
-  dps: 7799.40122
-  tps: 6735.34776
+  dps: 7799.47695
+  tps: 6735.4235
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-50641"
  value: {
-  dps: 7803.4542
-  tps: 6738.46469
+  dps: 7803.52994
+  tps: 6738.54043
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7383.11989
-  tps: 6348.73793
+  dps: 7383.19562
+  tps: 6348.81367
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7559.21289
-  tps: 6508.51244
+  dps: 7559.28626
+  tps: 6508.58581
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7553.42792
-  tps: 6502.73009
+  dps: 7553.50561
+  tps: 6502.80778
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7531.84603
-  tps: 6489.27157
+  dps: 7531.92176
+  tps: 6489.3473
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7553.95544
-  tps: 6508.41138
+  dps: 7554.02924
+  tps: 6508.48519
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7564.10708
-  tps: 6510.99149
+  dps: 7564.17656
+  tps: 6511.06097
   hps: 12.062
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LastWord-50179"
  value: {
-  dps: 7749.93863
-  tps: 6687.83043
+  dps: 7750.01437
+  tps: 6687.90616
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LastWord-50708"
  value: {
-  dps: 7746.87356
-  tps: 6685.68225
+  dps: 7746.9493
+  tps: 6685.75798
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.20413
+  tps: 6348.82218
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.20413
+  tps: 6348.82218
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7492.48661
-  tps: 6455.96188
+  dps: 7492.54164
+  tps: 6456.01692
  }
 }
 dps_results: {
  key: "TestSV-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7501.4302
-  tps: 6468.42425
+  dps: 7501.50082
+  tps: 6468.49487
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Nibelung-49992"
  value: {
-  dps: 7824.59579
-  tps: 6756.07997
+  dps: 7824.67187
+  tps: 6756.15604
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Nibelung-50648"
  value: {
-  dps: 7831.51725
-  tps: 6762.12081
+  dps: 7831.59757
+  tps: 6762.20112
  }
 }
 dps_results: {
  key: "TestSV-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7383.11805
-  tps: 6348.7361
+  dps: 7383.19379
+  tps: 6348.81183
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7560.85992
-  tps: 6508.18965
+  dps: 7560.9294
+  tps: 6508.25913
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7565.92742
-  tps: 6512.81377
+  dps: 7565.99691
+  tps: 6512.88325
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7383.11805
-  tps: 6348.7361
+  dps: 7383.19379
+  tps: 6348.81183
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.20413
+  tps: 6348.82218
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.20413
+  tps: 6348.82218
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7547.16224
-  tps: 6493.99245
+  dps: 7547.23172
+  tps: 6494.06193
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7548.9713
-  tps: 6495.25137
+  dps: 7549.04078
+  tps: 6495.32085
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.20413
+  tps: 6348.82218
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7398.9819
-  tps: 6364.54325
+  dps: 7399.46693
+  tps: 6365.02827
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7400.92747
-  tps: 6366.48881
+  dps: 7401.46407
+  tps: 6367.02541
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7718.06188
-  tps: 6665.48938
+  dps: 7718.13761
+  tps: 6665.56511
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7539.32301
-  tps: 6488.29677
+  dps: 7539.39249
+  tps: 6488.36625
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7383.13844
-  tps: 6348.75649
+  dps: 7383.21418
+  tps: 6348.83222
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 7401.36217
-  tps: 6403.33486
+  dps: 7401.41625
+  tps: 6403.38894
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7383.13844
-  tps: 6348.75649
+  dps: 7383.21418
+  tps: 6348.83222
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7966.80515
-  tps: 6897.28513
+  dps: 7966.87945
+  tps: 6897.35944
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.20413
+  tps: 6348.82218
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7452.07144
-  tps: 6396.81039
+  dps: 7452.14717
+  tps: 6396.88612
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7383.1284
-  tps: 6353.88187
+  dps: 7383.20413
+  tps: 6353.95761
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7383.1284
-  tps: 6354.35812
+  dps: 7383.20413
+  tps: 6354.43385
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.20413
+  tps: 6348.82218
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7478.29097
-  tps: 6445.57981
+  dps: 7478.36541
+  tps: 6445.65425
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SparkofLife-37657"
  value: {
-  dps: 7437.56845
-  tps: 6398.2923
+  dps: 7437.64403
+  tps: 6398.36787
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7482.86735
-  tps: 6439.11879
+  dps: 7482.94307
+  tps: 6439.19451
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StormshroudArmor"
  value: {
-  dps: 5772.58008
-  tps: 4946.09385
+  dps: 5772.61132
+  tps: 4946.12509
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7565.92742
-  tps: 6512.81377
+  dps: 7565.99691
+  tps: 6512.88325
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7560.85992
-  tps: 6508.18965
+  dps: 7560.9294
+  tps: 6508.25913
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7551.99178
-  tps: 6500.09744
+  dps: 7552.06126
+  tps: 6500.16693
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7383.13844
-  tps: 6348.75649
+  dps: 7383.21418
+  tps: 6348.83222
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7441.89181
-  tps: 6402.11428
+  dps: 7441.96729
+  tps: 6402.18976
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheFistsofFury"
  value: {
-  dps: 7374.39252
-  tps: 6347.25078
+  dps: 7374.4699
+  tps: 6347.32817
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7383.1284
-  tps: 6348.74644
+  dps: 7383.20413
+  tps: 6348.82218
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7518.22516
-  tps: 6489.61925
+  dps: 7518.30357
+  tps: 6489.69766
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7579.30622
-  tps: 6529.09531
+  dps: 7579.37421
+  tps: 6529.1633
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7383.2708
-  tps: 6348.88884
+  dps: 7383.34652
+  tps: 6348.96457
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7383.2708
-  tps: 6348.88884
+  dps: 7383.34652
+  tps: 6348.96457
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7539.32301
-  tps: 6488.53715
+  dps: 7539.39249
+  tps: 6488.60663
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7539.32301
-  tps: 6488.53715
+  dps: 7539.39249
+  tps: 6488.60663
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7392.57724
-  tps: 6360.23306
+  dps: 7392.65196
+  tps: 6360.30778
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7539.32301
-  tps: 6488.53715
+  dps: 7539.39249
+  tps: 6488.60663
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7539.32301
-  tps: 6488.53715
+  dps: 7539.39249
+  tps: 6488.60663
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6183.19209
-  tps: 5325.33731
+  dps: 6183.24271
+  tps: 5325.38792
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7357.16038
-  tps: 6329.0966
+  dps: 7357.24155
+  tps: 6329.17776
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 7512.89867
-  tps: 6492.41971
+  dps: 7512.97004
+  tps: 6492.49108
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7383.13844
-  tps: 6348.75649
+  dps: 7383.21418
+  tps: 6348.83222
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7968.27069
-  tps: 6914.98285
+  dps: 7968.34114
+  tps: 6915.0533
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 8107.66871
-  tps: 7060.95272
+  dps: 8107.73938
+  tps: 7061.0234
  }
 }
 dps_results: {
  key: "TestSV-Average-Default"
  value: {
-  dps: 7677.22183
-  tps: 6628.8276
+  dps: 7677.28347
+  tps: 6628.88924
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7549.25863
-  tps: 7921.70341
+  dps: 7549.34166
+  tps: 7921.78644
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6910.26158
-  tps: 5914.7913
+  dps: 6910.34199
+  tps: 5914.87171
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7711.91448
-  tps: 6567.33353
+  dps: 7712.15925
+  tps: 6567.57831
  }
 }
 dps_results: {
@@ -932,22 +932,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7549.25863
-  tps: 7921.70341
+  dps: 7549.34166
+  tps: 7921.78644
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6910.26158
-  tps: 5914.7913
+  dps: 6910.34199
+  tps: 5914.87171
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-SV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7711.91448
-  tps: 6567.33353
+  dps: 7712.15925
+  tps: 6567.57831
  }
 }
 dps_results: {
@@ -974,22 +974,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7595.40064
-  tps: 7907.60937
+  dps: 7595.48367
+  tps: 7907.6924
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6956.97071
-  tps: 5905.15153
+  dps: 6957.05112
+  tps: 5905.23194
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7793.80432
-  tps: 6581.60371
+  dps: 7794.04909
+  tps: 6581.84848
  }
 }
 dps_results: {
@@ -1016,22 +1016,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-SV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7595.40064
-  tps: 7907.60937
+  dps: 7595.48367
+  tps: 7907.6924
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-SV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6956.97071
-  tps: 5905.15153
+  dps: 6957.05112
+  tps: 5905.23194
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-SV-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7793.80432
-  tps: 6581.60371
+  dps: 7794.04909
+  tps: 6581.84848
  }
 }
 dps_results: {
@@ -1058,7 +1058,7 @@ dps_results: {
 dps_results: {
  key: "TestSV-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7612.22982
-  tps: 6640.47502
+  dps: 7612.30541
+  tps: 6640.55061
  }
 }

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -46,815 +46,815 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7262.75725
-  tps: 4372.10285
+  dps: 7127.29456
+  tps: 4291.54782
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7297.48136
-  tps: 4392.61405
+  dps: 7161.36092
+  tps: 4311.66767
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7202.18891
-  tps: 4335.9026
+  dps: 7088.41023
+  tps: 4268.04144
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6961.78746
-  tps: 4194.59495
+  dps: 6831.29047
+  tps: 4117.02618
   hps: 97.53276
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6961.78746
-  tps: 4194.59495
+  dps: 6831.29047
+  tps: 4117.02618
   hps: 97.53276
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7253.09969
-  tps: 4366.55557
+  dps: 7133.0087
+  tps: 4294.9613
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5885.73462
-  tps: 3545.79842
+  dps: 5773.45252
+  tps: 3479.26681
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 7933.61563
-  tps: 4773.54829
+  dps: 7787.31196
+  tps: 4686.72985
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7241.61772
-  tps: 4273.70224
+  dps: 7127.21698
+  tps: 4206.83469
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7410.63457
-  tps: 4460.81569
+  dps: 7272.81374
+  tps: 4378.68354
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
   hps: 64
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7077.53578
-  tps: 4263.30874
+  dps: 6945.32491
+  tps: 4184.59482
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7083.47514
-  tps: 4287.02366
+  dps: 6952.46949
+  tps: 4209.31601
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7213.87012
-  tps: 4347.73676
+  dps: 7078.50076
+  tps: 4267.43841
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7009.89788
-  tps: 4222.94027
+  dps: 6878.69727
+  tps: 4144.87593
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7238.64026
-  tps: 4357.6191
+  dps: 7108.84928
+  tps: 4280.30487
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7540.3207
-  tps: 4540.35033
+  dps: 7394.78971
+  tps: 4453.62724
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7459.85004
-  tps: 4494.61448
+  dps: 7320.05329
+  tps: 4411.27443
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7202.18891
-  tps: 4335.9026
+  dps: 7088.41023
+  tps: 4268.04144
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7286.17392
-  tps: 4386.12747
+  dps: 7170.37545
+  tps: 4317.04944
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7232.30105
-  tps: 4353.81558
+  dps: 7105.7828
+  tps: 4278.46498
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7226.99591
-  tps: 4350.63249
+  dps: 7100.90433
+  tps: 4275.5379
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7055.52599
-  tps: 4252.76348
+  dps: 6930.14163
+  tps: 4178.12739
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7202.18891
-  tps: 4335.9026
+  dps: 7088.41023
+  tps: 4268.04144
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7074.41145
-  tps: 4261.26353
+  dps: 6935.40246
+  tps: 4178.46103
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7274.20496
-  tps: 4380.121
+  dps: 7131.57998
+  tps: 4295.16004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7014.08994
-  tps: 4230.71058
+  dps: 6879.97231
+  tps: 4151.01044
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7155.42817
-  tps: 4308.70458
+  dps: 7021.99855
+  tps: 4229.35918
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7185.59126
-  tps: 4327.66663
+  dps: 7049.07267
+  tps: 4246.2572
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7241.61772
-  tps: 4359.18459
+  dps: 7127.21698
+  tps: 4290.9524
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7233.73195
-  tps: 4354.52819
+  dps: 7119.45563
+  tps: 4286.3702
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FrostfireGarb"
  value: {
-  dps: 6672.51099
-  tps: 4020.47921
+  dps: 6561.63115
+  tps: 3954.44362
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7117.4729
-  tps: 4288.13673
+  dps: 6983.87583
+  tps: 4208.49655
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 7010.33897
-  tps: 4212.68266
+  dps: 6894.46437
+  tps: 4144.60308
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7280.11931
-  tps: 4382.35845
+  dps: 7144.32774
+  tps: 4301.60775
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7319.57853
-  tps: 4405.66664
+  dps: 7183.03951
+  tps: 4324.47122
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7060.32431
-  tps: 4267.84141
+  dps: 6931.70291
+  tps: 4191.55358
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Heartpierce-49982"
  value: {
-  dps: 7410.63457
-  tps: 4460.81569
+  dps: 7272.81374
+  tps: 4378.68354
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Heartpierce-50641"
  value: {
-  dps: 7410.63457
-  tps: 4460.81569
+  dps: 7272.81374
+  tps: 4378.68354
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7283.39516
-  tps: 4385.56125
+  dps: 7147.49909
+  tps: 4304.73844
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7232.30105
-  tps: 4353.81558
+  dps: 7105.7828
+  tps: 4278.46498
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7226.99591
-  tps: 4350.63249
+  dps: 7100.90433
+  tps: 4275.5379
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7324.40238
-  tps: 4415.40239
+  dps: 7204.89346
+  tps: 4344.01875
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7202.18891
-  tps: 4335.9026
+  dps: 7088.41023
+  tps: 4268.04144
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 7165.07605
-  tps: 4311.55161
+  dps: 7043.58927
+  tps: 4239.24255
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KirinTorGarb"
  value: {
-  dps: 7072.92883
-  tps: 4253.2668
+  dps: 6963.9626
+  tps: 4188.33224
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7205.85329
-  tps: 4340.84148
+  dps: 7076.02516
+  tps: 4263.71746
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7048.70022
-  tps: 4245.91394
+  dps: 6914.16675
+  tps: 4165.71961
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7215.07559
-  tps: 4344.49303
+  dps: 7080.36496
+  tps: 4264.37903
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Nibelung-49992"
  value: {
-  dps: 7410.63457
-  tps: 4460.81569
+  dps: 7272.81374
+  tps: 4378.68354
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Nibelung-50648"
  value: {
-  dps: 7410.63457
-  tps: 4460.81569
+  dps: 7272.81374
+  tps: 4378.68354
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7202.18891
-  tps: 4335.9026
+  dps: 7088.41023
+  tps: 4268.04144
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7202.18891
-  tps: 4335.9026
+  dps: 7088.41023
+  tps: 4268.04144
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7202.18891
-  tps: 4335.9026
+  dps: 7088.41023
+  tps: 4268.04144
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7202.18891
-  tps: 4335.9026
+  dps: 7088.41023
+  tps: 4268.04144
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7401.40778
-  tps: 4530.7438
+  dps: 7248.94506
+  tps: 4436.79961
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7453.06559
-  tps: 4570.78817
+  dps: 7298.8227
+  tps: 4475.2953
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7377.83548
-  tps: 4441.29054
+  dps: 7253.87764
+  tps: 4367.32189
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7228.02718
-  tps: 4351.29722
+  dps: 7112.60854
+  tps: 4282.5332
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7297.01565
-  tps: 4401.03645
+  dps: 7157.75624
+  tps: 4318.10637
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7342.41554
-  tps: 4426.84874
+  dps: 7202.61298
+  tps: 4343.56032
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7098.6069
-  tps: 4275.1408
+  dps: 6966.2536
+  tps: 4196.43578
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7144.7136
-  tps: 4312.65245
+  dps: 7008.07811
+  tps: 4231.07805
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SparkofLife-37657"
  value: {
-  dps: 7095.56639
-  tps: 4275.10679
+  dps: 6975.41324
+  tps: 4203.6017
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7167.0499
-  tps: 4316.48973
+  dps: 7036.47478
+  tps: 4239.11591
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7202.18891
-  tps: 4335.9026
+  dps: 7088.41023
+  tps: 4268.04144
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7202.18891
-  tps: 4335.9026
+  dps: 7088.41023
+  tps: 4268.04144
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7202.18891
-  tps: 4335.9026
+  dps: 7088.41023
+  tps: 4268.04144
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7049.69773
-  tps: 4248.87462
+  dps: 6910.76106
+  tps: 4165.9989
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7107.94262
-  tps: 4286.99927
+  dps: 6973.34024
+  tps: 4207.10736
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TempestRegalia"
  value: {
-  dps: 5383.6804
-  tps: 3253.99727
+  dps: 5286.32098
+  tps: 3196.50813
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6980.22924
-  tps: 4205.21624
+  dps: 6850.11829
+  tps: 4127.84537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6102.39604
-  tps: 3684.17223
+  dps: 5991.74618
+  tps: 3618.28976
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7202.18891
-  tps: 4335.9026
+  dps: 7088.41023
+  tps: 4268.04144
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7164.87258
-  tps: 4313.78083
+  dps: 7035.81501
+  tps: 4236.91435
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7164.87258
-  tps: 4313.78083
+  dps: 7035.81501
+  tps: 4236.91435
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7241.61772
-  tps: 4359.18459
+  dps: 7127.21698
+  tps: 4290.9524
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7233.73195
-  tps: 4354.52819
+  dps: 7119.45563
+  tps: 4286.3702
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7102.24972
-  tps: 4277.81155
+  dps: 6975.78999
+  tps: 4202.73249
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7233.73195
-  tps: 4354.52819
+  dps: 7119.45563
+  tps: 4286.3702
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7241.61772
-  tps: 4359.18459
+  dps: 7127.21698
+  tps: 4290.9524
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7114.80914
-  tps: 4285.96418
+  dps: 6981.97968
+  tps: 4206.96221
  }
 }
 dps_results: {
  key: "TestArcane-Average-Default"
  value: {
-  dps: 7451.90236
-  tps: 4484.70324
+  dps: 7311.7435
+  tps: 4401.47285
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22479.10874
-  tps: 13520.13019
+  dps: 22121.19013
+  tps: 13306.35821
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1415.44271
-  tps: 861.93669
+  dps: 1393.77238
+  tps: 849.73154
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2477.32135
-  tps: 1402.19696
+  dps: 2444.45212
+  tps: 1384.54424
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15462.3806
-  tps: 9503.71339
+  dps: 15202.17614
+  tps: 9348.08538
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 710.21571
-  tps: 446.69995
+  dps: 695.52592
+  tps: 438.47642
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1529.46713
-  tps: 932.88919
+  dps: 1501.38455
+  tps: 917.5828
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7410.63457
-  tps: 6077.08827
+  dps: 7272.81374
+  tps: 5994.95612
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7410.63457
-  tps: 4460.81569
+  dps: 7272.81374
+  tps: 4378.68354
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9833.20595
-  tps: 5815.53698
+  dps: 9667.26182
+  tps: 5716.74204
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3460.41391
-  tps: 3298.15262
+  dps: 3387.66422
+  tps: 3255.0033
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3460.41391
-  tps: 2091.79716
+  dps: 3387.66422
+  tps: 2048.64783
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5017.0646
-  tps: 2931.92428
+  dps: 4893.36568
+  tps: 2859.53759
  }
 }
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7410.63457
-  tps: 4460.81569
+  dps: 7272.81374
+  tps: 4378.68354
  }
 }

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -46,746 +46,746 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7127.29456
-  tps: 4291.54782
+  dps: 7262.75725
+  tps: 4372.10285
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7161.36092
-  tps: 4311.66767
+  dps: 7297.48136
+  tps: 4392.61405
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7202.18891
+  tps: 4335.9026
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6831.29047
-  tps: 4117.02618
+  dps: 6961.78746
+  tps: 4194.59495
   hps: 97.53276
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6831.29047
-  tps: 4117.02618
+  dps: 6961.78746
+  tps: 4194.59495
   hps: 97.53276
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7133.0087
-  tps: 4294.9613
+  dps: 7253.09969
+  tps: 4366.55557
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5773.45252
-  tps: 3479.26681
+  dps: 5885.73462
+  tps: 3545.79842
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 7787.31196
-  tps: 4686.72985
+  dps: 7933.61563
+  tps: 4773.54829
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7127.21698
-  tps: 4206.83469
+  dps: 7241.61772
+  tps: 4273.70224
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7272.81374
-  tps: 4378.68354
+  dps: 7410.63457
+  tps: 4460.81569
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
   hps: 64
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6945.32491
-  tps: 4184.59482
+  dps: 7077.53578
+  tps: 4263.30874
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6952.46949
-  tps: 4209.31601
+  dps: 7083.47514
+  tps: 4287.02366
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7078.50076
-  tps: 4267.43841
+  dps: 7213.87012
+  tps: 4347.73676
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6878.69727
-  tps: 4144.87593
+  dps: 7009.89788
+  tps: 4222.94027
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7108.84928
-  tps: 4280.30487
+  dps: 7238.64026
+  tps: 4357.6191
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7394.78971
-  tps: 4453.62724
+  dps: 7540.3207
+  tps: 4540.35033
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7320.05329
-  tps: 4411.27443
+  dps: 7459.85004
+  tps: 4494.61448
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7202.18891
+  tps: 4335.9026
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7170.37545
-  tps: 4317.04944
+  dps: 7286.17392
+  tps: 4386.12747
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7105.7828
-  tps: 4278.46498
+  dps: 7232.30105
+  tps: 4353.81558
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7100.90433
-  tps: 4275.5379
+  dps: 7226.99591
+  tps: 4350.63249
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6930.14163
-  tps: 4178.12739
+  dps: 7055.52599
+  tps: 4252.76348
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7202.18891
+  tps: 4335.9026
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6935.40246
-  tps: 4178.46103
+  dps: 7074.41145
+  tps: 4261.26353
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7131.57998
-  tps: 4295.16004
+  dps: 7274.20496
+  tps: 4380.121
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6879.97231
-  tps: 4151.01044
+  dps: 7014.08994
+  tps: 4230.71058
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7021.99855
-  tps: 4229.35918
+  dps: 7155.42817
+  tps: 4308.70458
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7049.07267
-  tps: 4246.2572
+  dps: 7185.59126
+  tps: 4327.66663
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7127.21698
-  tps: 4290.9524
+  dps: 7241.61772
+  tps: 4359.18459
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7119.45563
-  tps: 4286.3702
+  dps: 7233.73195
+  tps: 4354.52819
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FrostfireGarb"
  value: {
-  dps: 6561.63115
-  tps: 3954.44362
+  dps: 6672.51099
+  tps: 4020.47921
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6983.87583
-  tps: 4208.49655
+  dps: 7117.4729
+  tps: 4288.13673
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 6894.46437
-  tps: 4144.60308
+  dps: 7010.33897
+  tps: 4212.68266
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7144.32774
-  tps: 4301.60775
+  dps: 7280.11931
+  tps: 4382.35845
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7183.03951
-  tps: 4324.47122
+  dps: 7319.57853
+  tps: 4405.66664
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6931.70291
-  tps: 4191.55358
+  dps: 7060.32431
+  tps: 4267.84141
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Heartpierce-49982"
  value: {
-  dps: 7272.81374
-  tps: 4378.68354
+  dps: 7410.63457
+  tps: 4460.81569
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Heartpierce-50641"
  value: {
-  dps: 7272.81374
-  tps: 4378.68354
+  dps: 7410.63457
+  tps: 4460.81569
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7147.49909
-  tps: 4304.73844
+  dps: 7283.39516
+  tps: 4385.56125
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7105.7828
-  tps: 4278.46498
+  dps: 7232.30105
+  tps: 4353.81558
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7100.90433
-  tps: 4275.5379
+  dps: 7226.99591
+  tps: 4350.63249
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7204.89346
-  tps: 4344.01875
+  dps: 7324.40238
+  tps: 4415.40239
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7202.18891
+  tps: 4335.9026
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 7043.58927
-  tps: 4239.24255
+  dps: 7165.07605
+  tps: 4311.55161
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KirinTorGarb"
  value: {
-  dps: 6963.9626
-  tps: 4188.33224
+  dps: 7072.92883
+  tps: 4253.2668
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7076.02516
-  tps: 4263.71746
+  dps: 7205.85329
+  tps: 4340.84148
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6914.16675
-  tps: 4165.71961
+  dps: 7048.70022
+  tps: 4245.91394
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7080.36496
-  tps: 4264.37903
+  dps: 7215.07559
+  tps: 4344.49303
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Nibelung-49992"
  value: {
-  dps: 7272.81374
-  tps: 4378.68354
+  dps: 7410.63457
+  tps: 4460.81569
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Nibelung-50648"
  value: {
-  dps: 7272.81374
-  tps: 4378.68354
+  dps: 7410.63457
+  tps: 4460.81569
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7202.18891
+  tps: 4335.9026
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7202.18891
+  tps: 4335.9026
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7202.18891
+  tps: 4335.9026
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7202.18891
+  tps: 4335.9026
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7248.94506
-  tps: 4436.79961
+  dps: 7401.40778
+  tps: 4530.7438
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7298.8227
-  tps: 4475.2953
+  dps: 7453.06559
+  tps: 4570.78817
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7253.87764
-  tps: 4367.32189
+  dps: 7377.83548
+  tps: 4441.29054
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7112.60854
-  tps: 4282.5332
+  dps: 7228.02718
+  tps: 4351.29722
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7157.75624
-  tps: 4318.10637
+  dps: 7297.01565
+  tps: 4401.03645
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7202.61298
-  tps: 4343.56032
+  dps: 7342.41554
+  tps: 4426.84874
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6966.2536
-  tps: 4196.43578
+  dps: 7098.6069
+  tps: 4275.1408
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7008.07811
-  tps: 4231.07805
+  dps: 7144.7136
+  tps: 4312.65245
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SparkofLife-37657"
  value: {
-  dps: 6975.41324
-  tps: 4203.6017
+  dps: 7095.56639
+  tps: 4275.10679
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7036.47478
-  tps: 4239.11591
+  dps: 7167.0499
+  tps: 4316.48973
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7202.18891
+  tps: 4335.9026
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7202.18891
+  tps: 4335.9026
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7202.18891
+  tps: 4335.9026
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6910.76106
-  tps: 4165.9989
+  dps: 7049.69773
+  tps: 4248.87462
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6973.34024
-  tps: 4207.10736
+  dps: 7107.94262
+  tps: 4286.99927
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TempestRegalia"
  value: {
-  dps: 5286.32098
-  tps: 3196.50813
+  dps: 5383.6804
+  tps: 3253.99727
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6980.22924
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5991.74618
-  tps: 3618.28976
+  dps: 6102.39604
+  tps: 3684.17223
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7202.18891
+  tps: 4335.9026
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7035.81501
-  tps: 4236.91435
+  dps: 7164.87258
+  tps: 4313.78083
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7035.81501
-  tps: 4236.91435
+  dps: 7164.87258
+  tps: 4313.78083
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7127.21698
-  tps: 4290.9524
+  dps: 7241.61772
+  tps: 4359.18459
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7119.45563
-  tps: 4286.3702
+  dps: 7233.73195
+  tps: 4354.52819
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6975.78999
-  tps: 4202.73249
+  dps: 7102.24972
+  tps: 4277.81155
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7119.45563
-  tps: 4286.3702
+  dps: 7233.73195
+  tps: 4354.52819
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7127.21698
-  tps: 4290.9524
+  dps: 7241.61772
+  tps: 4359.18459
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6981.97968
-  tps: 4206.96221
+  dps: 7114.80914
+  tps: 4285.96418
  }
 }
 dps_results: {
  key: "TestArcane-Average-Default"
  value: {
-  dps: 7311.7435
-  tps: 4401.47285
+  dps: 7451.90236
+  tps: 4484.70324
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22457.96911
-  tps: 13508.4256
+  dps: 22479.10874
+  tps: 13520.13019
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1393.77238
-  tps: 849.73154
+  dps: 1415.44271
+  tps: 861.93669
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2444.45212
-  tps: 1384.54424
+  dps: 2477.32135
+  tps: 1402.19696
  }
 }
 dps_results: {
@@ -812,22 +812,22 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7272.81374
-  tps: 5994.95612
+  dps: 7410.63457
+  tps: 6077.08827
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7272.81374
-  tps: 4378.68354
+  dps: 7410.63457
+  tps: 4460.81569
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9667.26182
-  tps: 5716.74204
+  dps: 9833.20595
+  tps: 5815.53698
  }
 }
 dps_results: {
@@ -854,7 +854,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7272.81374
-  tps: 4378.68354
+  dps: 7410.63457
+  tps: 4460.81569
  }
 }

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -46,815 +46,815 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7127.29456
-  tps: 4291.54782
+  dps: 7164.7152
+  tps: 4313.64641
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7161.36092
-  tps: 4311.66767
+  dps: 7198.9601
+  tps: 4333.87176
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7123.02877
+  tps: 4288.81256
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6831.29047
-  tps: 4117.02618
+  dps: 6869.69762
+  tps: 4139.7299
   hps: 97.53276
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6831.29047
-  tps: 4117.02618
+  dps: 6869.69762
+  tps: 4139.7299
   hps: 97.53276
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7133.0087
-  tps: 4294.9613
+  dps: 7165.00451
+  tps: 4314.08164
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5773.45252
-  tps: 3479.26681
+  dps: 5804.40456
+  tps: 3497.66377
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 7787.31196
-  tps: 4686.72985
+  dps: 7826.42899
+  tps: 4709.80914
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7127.21698
-  tps: 4206.83469
+  dps: 7162.02047
+  tps: 4227.29914
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7272.81374
-  tps: 4378.68354
+  dps: 7306.1053
+  tps: 4398.58133
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
   hps: 64
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6945.32491
-  tps: 4184.59482
+  dps: 6984.75776
+  tps: 4208.10794
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6952.46949
-  tps: 4209.31601
+  dps: 6989.28104
+  tps: 4231.10812
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7078.50076
-  tps: 4267.43841
+  dps: 7121.49583
+  tps: 4292.90136
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6878.69727
-  tps: 4144.87593
+  dps: 6912.78706
+  tps: 4164.89179
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7108.84928
-  tps: 4280.30487
+  dps: 7139.4366
+  tps: 4298.58011
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7394.78971
-  tps: 4453.62724
+  dps: 7438.24035
+  tps: 4479.62047
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7320.05329
-  tps: 4411.27443
+  dps: 7360.24593
+  tps: 4435.31582
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7123.02877
+  tps: 4288.81256
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7170.37545
-  tps: 4317.04944
+  dps: 7204.13092
+  tps: 4337.30272
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7105.7828
-  tps: 4278.46498
+  dps: 7136.33614
+  tps: 4296.71983
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7100.90433
-  tps: 4275.5379
+  dps: 7133.40504
+  tps: 4294.96117
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6930.14163
-  tps: 4178.12739
+  dps: 6964.4055
+  tps: 4198.50341
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7123.02877
+  tps: 4288.81256
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6935.40246
-  tps: 4178.46103
+  dps: 6980.11351
+  tps: 4205.21624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7131.57998
-  tps: 4295.16004
+  dps: 7179.51756
+  tps: 4323.85018
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6879.97231
-  tps: 4151.01044
+  dps: 6918.48949
+  tps: 4173.82706
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7021.99855
-  tps: 4229.35918
+  dps: 7058.86734
+  tps: 4251.13169
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7049.07267
-  tps: 4246.2572
+  dps: 7092.6274
+  tps: 4272.31862
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7127.21698
-  tps: 4290.9524
+  dps: 7162.02047
+  tps: 4311.83449
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7119.45563
-  tps: 4286.3702
+  dps: 7154.22213
+  tps: 4307.2301
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FrostfireGarb"
  value: {
-  dps: 6561.63115
-  tps: 3954.44362
+  dps: 6592.95452
+  tps: 3973.23764
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6983.87583
-  tps: 4208.49655
+  dps: 7023.50418
+  tps: 4232.03898
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 6894.46437
-  tps: 4144.60308
+  dps: 6929.51269
+  tps: 4164.84382
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7144.32774
-  tps: 4301.60775
+  dps: 7181.83765
+  tps: 4323.75909
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7183.03951
-  tps: 4324.47122
+  dps: 7220.7523
+  tps: 4346.74244
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6931.70291
-  tps: 4191.55358
+  dps: 6965.09563
+  tps: 4211.24973
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Heartpierce-49982"
  value: {
-  dps: 7272.81374
-  tps: 4378.68354
+  dps: 7306.1053
+  tps: 4398.58133
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Heartpierce-50641"
  value: {
-  dps: 7272.81374
-  tps: 4378.68354
+  dps: 7306.1053
+  tps: 4398.58133
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7147.49909
-  tps: 4304.73844
+  dps: 7185.05807
+  tps: 4326.92184
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7105.7828
-  tps: 4278.46498
+  dps: 7136.33614
+  tps: 4296.71983
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7100.90433
-  tps: 4275.5379
+  dps: 7133.40504
+  tps: 4294.96117
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7204.89346
-  tps: 4344.01875
+  dps: 7238.25674
+  tps: 4364.03673
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7123.02877
+  tps: 4288.81256
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 7043.58927
-  tps: 4239.24255
+  dps: 7085.12339
+  tps: 4264.08756
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KirinTorGarb"
  value: {
-  dps: 6963.9626
-  tps: 4188.33224
+  dps: 6995.60777
+  tps: 4207.31935
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7076.02516
-  tps: 4263.71746
+  dps: 7122.38893
+  tps: 4291.38913
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6914.16675
-  tps: 4165.71961
+  dps: 6956.61666
+  tps: 4191.11813
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7080.36496
-  tps: 4264.37903
+  dps: 7119.59958
+  tps: 4287.57103
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Nibelung-49992"
  value: {
-  dps: 7272.81374
-  tps: 4378.68354
+  dps: 7306.1053
+  tps: 4398.58133
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Nibelung-50648"
  value: {
-  dps: 7272.81374
-  tps: 4378.68354
+  dps: 7306.1053
+  tps: 4398.58133
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7123.02877
+  tps: 4288.81256
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7123.02877
+  tps: 4288.81256
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7123.02877
+  tps: 4288.81256
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7123.02877
+  tps: 4288.81256
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7248.94506
-  tps: 4436.79961
+  dps: 7278.50202
+  tps: 4454.63044
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7298.8227
-  tps: 4475.2953
+  dps: 7328.51816
+  tps: 4493.21952
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7253.87764
-  tps: 4367.32189
+  dps: 7291.61184
+  tps: 4389.96241
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7112.60854
-  tps: 4282.5332
+  dps: 7147.41898
+  tps: 4303.34231
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7157.75624
-  tps: 4318.10637
+  dps: 7195.67874
+  tps: 4340.58743
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7202.61298
-  tps: 4343.56032
+  dps: 7240.76823
+  tps: 4366.21496
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6966.2536
-  tps: 4196.43578
+  dps: 7002.83024
+  tps: 4218.03566
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7008.07811
-  tps: 4231.07805
+  dps: 7056.37989
+  tps: 4260.12613
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SparkofLife-37657"
  value: {
-  dps: 6975.41324
-  tps: 4203.6017
+  dps: 7015.17222
+  tps: 4227.27082
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7036.47478
-  tps: 4239.11591
+  dps: 7073.5523
+  tps: 4261.14639
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7123.02877
+  tps: 4288.81256
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7123.02877
+  tps: 4288.81256
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7123.02877
+  tps: 4288.81256
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6910.76106
-  tps: 4165.9989
+  dps: 6952.36272
+  tps: 4190.73792
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6973.34024
-  tps: 4207.10736
+  dps: 7006.18587
+  tps: 4226.40331
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TempestRegalia"
  value: {
-  dps: 5286.32098
-  tps: 3196.50813
+  dps: 5321.34235
+  tps: 3217.26774
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6850.11829
-  tps: 4127.84537
+  dps: 6886.08628
+  tps: 4149.08559
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5991.74618
-  tps: 3618.28976
+  dps: 6031.3273
+  tps: 3642.03844
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7088.41023
-  tps: 4268.04144
+  dps: 7123.02877
+  tps: 4288.81256
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7035.81501
-  tps: 4236.91435
+  dps: 7067.67885
+  tps: 4255.95551
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7035.81501
-  tps: 4236.91435
+  dps: 7067.67885
+  tps: 4255.95551
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7127.21698
-  tps: 4290.9524
+  dps: 7162.02047
+  tps: 4311.83449
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7119.45563
-  tps: 4286.3702
+  dps: 7154.22213
+  tps: 4307.2301
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6975.78999
-  tps: 4202.73249
+  dps: 7010.69682
+  tps: 4223.50727
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7119.45563
-  tps: 4286.3702
+  dps: 7154.22213
+  tps: 4307.2301
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7127.21698
-  tps: 4290.9524
+  dps: 7162.02047
+  tps: 4311.83449
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6981.97968
-  tps: 4206.96221
+  dps: 7018.787
+  tps: 4228.70602
  }
 }
 dps_results: {
  key: "TestArcane-Average-Default"
  value: {
-  dps: 7311.7435
-  tps: 4401.47285
+  dps: 7353.9788
+  tps: 4426.56841
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22121.19013
-  tps: 13306.35821
+  dps: 22227.35027
+  tps: 13369.69167
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1393.77238
-  tps: 849.73154
+  dps: 1400.12513
+  tps: 853.38504
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2444.45212
-  tps: 1384.54424
+  dps: 2449.67139
+  tps: 1387.29003
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15202.17614
-  tps: 9348.08538
+  dps: 15279.13245
+  tps: 9394.06731
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 695.52592
-  tps: 438.47642
+  dps: 700.19775
+  tps: 441.12154
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1501.38455
-  tps: 917.5828
+  dps: 1510.7017
+  tps: 922.79284
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7272.81374
-  tps: 5994.95612
+  dps: 7306.1053
+  tps: 6014.8539
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7272.81374
-  tps: 4378.68354
+  dps: 7306.1053
+  tps: 4398.58133
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9667.26182
-  tps: 5716.74204
+  dps: 9716.59183
+  tps: 5746.34004
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3387.66422
-  tps: 3255.0033
+  dps: 3411.47147
+  tps: 3269.14133
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3387.66422
-  tps: 2048.64783
+  dps: 3411.47147
+  tps: 2062.78587
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P1Arcane-ArcaneRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4893.36568
-  tps: 2859.53759
+  dps: 4932.40033
+  tps: 2882.34652
  }
 }
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7272.81374
-  tps: 4378.68354
+  dps: 7306.1053
+  tps: 4398.58133
  }
 }

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -46,815 +46,815 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6534.80126
-  tps: 5225.15489
+  dps: 6290.24452
+  tps: 5027.95692
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6570.21466
-  tps: 5253.07024
+  dps: 6324.35766
+  tps: 5054.83101
  }
 }
 dps_results: {
  key: "TestFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6469.64646
-  tps: 5173.84469
+  dps: 6271.62155
+  tps: 5013.18422
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6268.82247
-  tps: 5015.79289
-  hps: 94.61364
+  dps: 6011.83514
+  tps: 4808.35379
+  hps: 94.5738
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6268.82247
-  tps: 5015.79289
-  hps: 94.61364
+  dps: 6011.83514
+  tps: 4808.35379
+  hps: 94.5738
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6566.07434
-  tps: 5252.22713
+  dps: 6377.13192
+  tps: 5100.35695
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4951.42201
-  tps: 3954.87837
+  dps: 4817.53058
+  tps: 3849.51341
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 7179.31923
-  tps: 5739.36838
+  dps: 6933.23584
+  tps: 5541.51692
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6509.82709
-  tps: 5103.08693
+  dps: 6310.48158
+  tps: 4944.57108
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6666.04192
-  tps: 5331.42606
+  dps: 6470.1591
+  tps: 5172.94354
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
   hps: 64
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6418.06693
-  tps: 5136.23828
+  dps: 6158.2637
+  tps: 4925.83939
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6436.57447
-  tps: 5161.00385
+  dps: 6253.12281
+  tps: 5012.64946
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6482.54159
-  tps: 5189.63965
+  dps: 6257.2894
+  tps: 5008.11842
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6313.10352
-  tps: 5051.56077
+  dps: 6086.38548
+  tps: 4867.94313
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6498.19343
-  tps: 5197.41833
+  dps: 6302.28787
+  tps: 5038.58432
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6525.07439
-  tps: 5218.41386
+  dps: 6349.25553
+  tps: 5077.4512
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6493.41712
-  tps: 5193.82707
+  dps: 6296.96037
+  tps: 5035.51914
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6469.64646
-  tps: 5173.84469
+  dps: 6271.62155
+  tps: 5013.18422
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6573.03147
-  tps: 5256.7686
+  dps: 6381.93787
+  tps: 5103.4822
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6486.77937
-  tps: 5188.01602
+  dps: 6300.94774
+  tps: 5037.57446
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6484.87639
-  tps: 5186.38771
+  dps: 6287.3771
+  tps: 5026.44338
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6300.84311
-  tps: 5040.92179
+  dps: 6038.68866
+  tps: 4828.58828
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6469.64646
-  tps: 5173.84469
+  dps: 6271.62155
+  tps: 5013.18422
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6458.50754
-  tps: 5176.42806
+  dps: 6290.41991
+  tps: 5041.55012
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6628.39668
-  tps: 5302.10882
+  dps: 6363.19226
+  tps: 5088.48183
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6377.03608
-  tps: 5106.76787
+  dps: 6187.50394
+  tps: 4955.3394
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6425.34166
-  tps: 5138.87107
+  dps: 6184.80391
+  tps: 4944.89157
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6548.68197
-  tps: 5239.62416
+  dps: 6266.6399
+  tps: 5011.84705
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6509.82709
-  tps: 5205.50379
+  dps: 6310.48158
+  tps: 5043.78195
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6501.79096
-  tps: 5199.17197
+  dps: 6302.70958
+  tps: 5037.6624
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FrostfireGarb"
  value: {
-  dps: 5996.06798
-  tps: 4798.72185
+  dps: 5835.90001
+  tps: 4670.21431
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6465.43615
-  tps: 5171.18705
+  dps: 6226.60756
+  tps: 4981.02852
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 6495.36616
-  tps: 5185.04376
+  dps: 6293.66606
+  tps: 5025.15339
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6552.50796
-  tps: 5239.11256
+  dps: 6307.30109
+  tps: 5041.39397
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6592.75046
-  tps: 5270.83456
+  dps: 6346.06602
+  tps: 5071.9327
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6441.46881
-  tps: 5161.35445
+  dps: 6253.55974
+  tps: 5011.17269
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-49982"
  value: {
-  dps: 6666.04192
-  tps: 5331.42606
+  dps: 6470.1591
+  tps: 5172.94354
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 6666.04192
-  tps: 5331.42606
+  dps: 6470.1591
+  tps: 5172.94354
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6554.53588
-  tps: 5242.43111
+  dps: 6309.23062
+  tps: 5044.61856
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6486.77937
-  tps: 5188.01602
+  dps: 6300.94774
+  tps: 5037.57446
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6484.87639
-  tps: 5186.38771
+  dps: 6287.3771
+  tps: 5026.44338
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6579.34651
-  tps: 5268.08179
+  dps: 6417.65418
+  tps: 5137.9682
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6469.64646
-  tps: 5173.84469
+  dps: 6271.62155
+  tps: 5013.18422
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 6749.14423
-  tps: 5396.25085
+  dps: 6513.64497
+  tps: 5206.22787
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KirinTorGarb"
  value: {
-  dps: 6766.27832
-  tps: 5405.06664
+  dps: 6536.18577
+  tps: 5221.2947
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6545.12
-  tps: 5237.55258
+  dps: 6304.71359
+  tps: 5042.61949
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6394.70575
-  tps: 5116.70294
+  dps: 6118.90089
+  tps: 4894.52797
  }
 }
 dps_results: {
  key: "TestFire-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6513.04565
-  tps: 5209.19051
+  dps: 6289.1915
+  tps: 5030.35858
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Nibelung-49992"
  value: {
-  dps: 6666.04192
-  tps: 5331.42606
+  dps: 6470.1591
+  tps: 5172.94354
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Nibelung-50648"
  value: {
-  dps: 6666.04192
-  tps: 5331.42606
+  dps: 6470.1591
+  tps: 5172.94354
  }
 }
 dps_results: {
  key: "TestFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6469.64646
-  tps: 5173.84469
+  dps: 6271.62155
+  tps: 5013.18422
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6469.64646
-  tps: 5173.84469
+  dps: 6271.62155
+  tps: 5013.18422
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6469.64646
-  tps: 5173.84469
+  dps: 6271.62155
+  tps: 5013.18422
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6469.64646
-  tps: 5173.84469
+  dps: 6271.62155
+  tps: 5013.18422
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6704.10608
-  tps: 5391.31764
+  dps: 6453.35892
+  tps: 5188.22676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6752.76713
-  tps: 5433.783
+  dps: 6500.0032
+  tps: 5228.89416
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6647.74768
-  tps: 5316.32566
+  dps: 6439.23518
+  tps: 5147.27513
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6500.86746
-  tps: 5198.82769
+  dps: 6343.8858
+  tps: 5073.2536
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6596.47425
-  tps: 5279.36391
+  dps: 6408.36154
+  tps: 5130.23797
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6637.50554
-  tps: 5311.73404
+  dps: 6432.00939
+  tps: 5148.84476
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6367.39246
-  tps: 5093.1914
+  dps: 6128.98241
+  tps: 4900.91579
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6524.32793
-  tps: 5227.33539
+  dps: 6310.41257
+  tps: 5056.7087
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 6428.49085
-  tps: 5142.6259
+  dps: 6183.68525
+  tps: 4945.60578
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6361.39158
-  tps: 5087.69759
+  dps: 6165.89707
+  tps: 4930.34156
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6469.64646
-  tps: 5173.84469
+  dps: 6271.62155
+  tps: 5013.18422
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6469.64646
-  tps: 5173.84469
+  dps: 6271.62155
+  tps: 5013.18422
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6469.64646
-  tps: 5173.84469
+  dps: 6271.62155
+  tps: 5013.18422
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6371.27917
-  tps: 5096.39657
+  dps: 6143.73698
+  tps: 4913.73916
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6437.73852
-  tps: 5153.00247
+  dps: 6211.37298
+  tps: 4971.6296
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TempestRegalia"
  value: {
-  dps: 4623.11492
-  tps: 3697.33974
+  dps: 4495.8556
+  tps: 3595.9508
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6246.66496
-  tps: 4998.02543
+  dps: 6012.68762
+  tps: 4809.29959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5299.33808
-  tps: 4245.17635
+  dps: 5158.51199
+  tps: 4132.9619
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6469.64646
-  tps: 5173.84469
+  dps: 6271.62155
+  tps: 5013.18422
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6476.68751
-  tps: 5180.35503
+  dps: 6287.01731
+  tps: 5027.45683
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6476.68751
-  tps: 5180.35503
+  dps: 6287.01731
+  tps: 5027.45683
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6509.82709
-  tps: 5205.50379
+  dps: 6310.48158
+  tps: 5043.78195
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6501.79096
-  tps: 5199.17197
+  dps: 6302.70958
+  tps: 5037.6624
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6400.77673
-  tps: 5121.16941
+  dps: 6167.73528
+  tps: 4932.09453
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6501.79096
-  tps: 5199.17197
+  dps: 6302.70958
+  tps: 5037.6624
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6509.82709
-  tps: 5205.50379
+  dps: 6310.48158
+  tps: 5043.78195
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6381.58571
-  tps: 5105.96202
+  dps: 6140.6766
+  tps: 4911.69078
  }
 }
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
-  dps: 6841.95828
-  tps: 5471.46232
+  dps: 6640.99481
+  tps: 5310.70678
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22668.84493
-  tps: 24108.36901
+  dps: 22166.75512
+  tps: 23611.6076
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1856.19748
-  tps: 1629.23894
+  dps: 1829.61279
+  tps: 1607.32011
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2581.51745
-  tps: 2165.97677
+  dps: 2544.50565
+  tps: 2134.86119
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14446.79738
-  tps: 16154.91987
+  dps: 14135.97415
+  tps: 15780.25661
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 855.85503
-  tps: 745.79357
+  dps: 838.0569
+  tps: 730.65356
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1463.20066
-  tps: 1191.68976
+  dps: 1442.03515
+  tps: 1173.76053
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9891.21129
-  tps: 10074.24546
+  dps: 9623.06423
+  tps: 9793.53131
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6666.04192
-  tps: 5331.42606
+  dps: 6470.1591
+  tps: 5172.94354
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8151.46347
-  tps: 6425.40612
+  dps: 7985.57343
+  tps: 6290.24419
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4759.88064
-  tps: 5449.2759
+  dps: 4523.57862
+  tps: 5184.69177
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2483.31099
-  tps: 1980.21442
+  dps: 2418.82722
+  tps: 1928.44034
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3799.50796
-  tps: 2943.10154
+  dps: 3706.53285
+  tps: 2870.90394
  }
 }
 dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6666.04192
-  tps: 5331.42606
+  dps: 6470.1591
+  tps: 5172.94354
  }
 }

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -46,746 +46,746 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6290.24452
-  tps: 5027.95692
+  dps: 6534.80126
+  tps: 5225.15489
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6324.35766
-  tps: 5054.83101
+  dps: 6570.21466
+  tps: 5253.07024
  }
 }
 dps_results: {
  key: "TestFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6469.64646
+  tps: 5173.84469
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6011.83514
-  tps: 4808.35379
-  hps: 94.5738
+  dps: 6268.82247
+  tps: 5015.79289
+  hps: 94.61364
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6011.83514
-  tps: 4808.35379
-  hps: 94.5738
+  dps: 6268.82247
+  tps: 5015.79289
+  hps: 94.61364
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6377.13192
-  tps: 5100.35695
+  dps: 6566.07434
+  tps: 5252.22713
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4817.53058
-  tps: 3849.51341
+  dps: 4951.42201
+  tps: 3954.87837
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 6933.23584
-  tps: 5541.51692
+  dps: 7179.31923
+  tps: 5739.36838
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6310.48158
-  tps: 4944.57108
+  dps: 6509.82709
+  tps: 5103.08693
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6470.1591
-  tps: 5172.94354
+  dps: 6666.04192
+  tps: 5331.42606
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
   hps: 64
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6158.2637
-  tps: 4925.83939
+  dps: 6418.06693
+  tps: 5136.23828
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6253.12281
-  tps: 5012.64946
+  dps: 6436.57447
+  tps: 5161.00385
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6257.2894
-  tps: 5008.11842
+  dps: 6482.54159
+  tps: 5189.63965
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6086.38548
-  tps: 4867.94313
+  dps: 6313.10352
+  tps: 5051.56077
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6302.28787
-  tps: 5038.58432
+  dps: 6498.19343
+  tps: 5197.41833
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6349.25553
-  tps: 5077.4512
+  dps: 6525.07439
+  tps: 5218.41386
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6296.96037
-  tps: 5035.51914
+  dps: 6493.41712
+  tps: 5193.82707
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6469.64646
+  tps: 5173.84469
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6381.93787
-  tps: 5103.4822
+  dps: 6573.03147
+  tps: 5256.7686
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6300.94774
-  tps: 5037.57446
+  dps: 6486.77937
+  tps: 5188.01602
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6287.3771
-  tps: 5026.44338
+  dps: 6484.87639
+  tps: 5186.38771
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6038.68866
-  tps: 4828.58828
+  dps: 6300.84311
+  tps: 5040.92179
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6469.64646
+  tps: 5173.84469
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6290.41991
-  tps: 5041.55012
+  dps: 6458.50754
+  tps: 5176.42806
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6363.19226
-  tps: 5088.48183
+  dps: 6628.39668
+  tps: 5302.10882
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6187.50394
-  tps: 4955.3394
+  dps: 6377.03608
+  tps: 5106.76787
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6184.80391
-  tps: 4944.89157
+  dps: 6425.34166
+  tps: 5138.87107
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6266.6399
-  tps: 5011.84705
+  dps: 6548.68197
+  tps: 5239.62416
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6310.48158
-  tps: 5043.78195
+  dps: 6509.82709
+  tps: 5205.50379
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6302.70958
-  tps: 5037.6624
+  dps: 6501.79096
+  tps: 5199.17197
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FrostfireGarb"
  value: {
-  dps: 5835.90001
-  tps: 4670.21431
+  dps: 5996.06798
+  tps: 4798.72185
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6226.60756
-  tps: 4981.02852
+  dps: 6465.43615
+  tps: 5171.18705
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 6293.66606
-  tps: 5025.15339
+  dps: 6495.36616
+  tps: 5185.04376
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6307.30109
-  tps: 5041.39397
+  dps: 6552.50796
+  tps: 5239.11256
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6346.06602
-  tps: 5071.9327
+  dps: 6592.75046
+  tps: 5270.83456
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6253.55974
-  tps: 5011.17269
+  dps: 6441.46881
+  tps: 5161.35445
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-49982"
  value: {
-  dps: 6470.1591
-  tps: 5172.94354
+  dps: 6666.04192
+  tps: 5331.42606
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 6470.1591
-  tps: 5172.94354
+  dps: 6666.04192
+  tps: 5331.42606
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6309.23062
-  tps: 5044.61856
+  dps: 6554.53588
+  tps: 5242.43111
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6300.94774
-  tps: 5037.57446
+  dps: 6486.77937
+  tps: 5188.01602
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6287.3771
-  tps: 5026.44338
+  dps: 6484.87639
+  tps: 5186.38771
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6417.65418
-  tps: 5137.9682
+  dps: 6579.34651
+  tps: 5268.08179
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6469.64646
+  tps: 5173.84469
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 6513.64497
-  tps: 5206.22787
+  dps: 6749.14423
+  tps: 5396.25085
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KirinTorGarb"
  value: {
-  dps: 6536.18577
-  tps: 5221.2947
+  dps: 6766.27832
+  tps: 5405.06664
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6304.71359
-  tps: 5042.61949
+  dps: 6545.12
+  tps: 5237.55258
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6118.90089
-  tps: 4894.52797
+  dps: 6394.70575
+  tps: 5116.70294
  }
 }
 dps_results: {
  key: "TestFire-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6289.1915
-  tps: 5030.35858
+  dps: 6513.04565
+  tps: 5209.19051
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Nibelung-49992"
  value: {
-  dps: 6470.1591
-  tps: 5172.94354
+  dps: 6666.04192
+  tps: 5331.42606
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Nibelung-50648"
  value: {
-  dps: 6470.1591
-  tps: 5172.94354
+  dps: 6666.04192
+  tps: 5331.42606
  }
 }
 dps_results: {
  key: "TestFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6469.64646
+  tps: 5173.84469
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6469.64646
+  tps: 5173.84469
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6469.64646
+  tps: 5173.84469
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6469.64646
+  tps: 5173.84469
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6453.35892
-  tps: 5188.22676
+  dps: 6704.10608
+  tps: 5391.31764
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6500.0032
-  tps: 5228.89416
+  dps: 6752.76713
+  tps: 5433.783
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6439.23518
-  tps: 5147.27513
+  dps: 6647.74768
+  tps: 5316.32566
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6343.8858
-  tps: 5073.2536
+  dps: 6500.86746
+  tps: 5198.82769
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6408.36154
-  tps: 5130.23797
+  dps: 6596.47425
+  tps: 5279.36391
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6432.00939
-  tps: 5148.84476
+  dps: 6637.50554
+  tps: 5311.73404
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6128.98241
-  tps: 4900.91579
+  dps: 6367.39246
+  tps: 5093.1914
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6310.41257
-  tps: 5056.7087
+  dps: 6524.32793
+  tps: 5227.33539
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 6183.68525
-  tps: 4945.60578
+  dps: 6428.49085
+  tps: 5142.6259
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6165.89707
-  tps: 4930.34156
+  dps: 6361.39158
+  tps: 5087.69759
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6469.64646
+  tps: 5173.84469
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6469.64646
+  tps: 5173.84469
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6469.64646
+  tps: 5173.84469
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6143.73698
-  tps: 4913.73916
+  dps: 6371.27917
+  tps: 5096.39657
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6211.37298
-  tps: 4971.6296
+  dps: 6437.73852
+  tps: 5153.00247
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TempestRegalia"
  value: {
-  dps: 4495.8556
-  tps: 3595.9508
+  dps: 4623.11492
+  tps: 3697.33974
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6246.66496
+  tps: 4998.02543
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5158.51199
-  tps: 4132.9619
+  dps: 5299.33808
+  tps: 4245.17635
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6469.64646
+  tps: 5173.84469
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6287.01731
-  tps: 5027.45683
+  dps: 6476.68751
+  tps: 5180.35503
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6287.01731
-  tps: 5027.45683
+  dps: 6476.68751
+  tps: 5180.35503
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6310.48158
-  tps: 5043.78195
+  dps: 6509.82709
+  tps: 5205.50379
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6302.70958
-  tps: 5037.6624
+  dps: 6501.79096
+  tps: 5199.17197
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6167.73528
-  tps: 4932.09453
+  dps: 6400.77673
+  tps: 5121.16941
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6302.70958
-  tps: 5037.6624
+  dps: 6501.79096
+  tps: 5199.17197
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6310.48158
-  tps: 5043.78195
+  dps: 6509.82709
+  tps: 5205.50379
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6140.6766
-  tps: 4911.69078
+  dps: 6381.58571
+  tps: 5105.96202
  }
 }
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
-  dps: 6640.99481
-  tps: 5310.70678
+  dps: 6841.95828
+  tps: 5471.46232
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22638.70688
-  tps: 24083.26283
+  dps: 22668.84493
+  tps: 24108.36901
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1829.61279
-  tps: 1607.32011
+  dps: 1856.19748
+  tps: 1629.23894
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2544.50565
-  tps: 2134.86119
+  dps: 2581.51745
+  tps: 2165.97677
  }
 }
 dps_results: {
@@ -812,22 +812,22 @@ dps_results: {
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9724.62464
-  tps: 9885.71066
+  dps: 9891.21129
+  tps: 10074.24546
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6470.1591
-  tps: 5172.94354
+  dps: 6666.04192
+  tps: 5331.42606
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7985.57343
-  tps: 6290.24419
+  dps: 8151.46347
+  tps: 6425.40612
  }
 }
 dps_results: {
@@ -854,7 +854,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6470.1591
-  tps: 5172.94354
+  dps: 6666.04192
+  tps: 5331.42606
  }
 }

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -46,815 +46,815 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6290.24452
-  tps: 5027.95692
+  dps: 6376.41823
+  tps: 5095.6999
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6324.35766
-  tps: 5054.83101
+  dps: 6411.00525
+  tps: 5122.94473
  }
 }
 dps_results: {
  key: "TestFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6345.80093
+  tps: 5073.47999
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6011.83514
-  tps: 4808.35379
-  hps: 94.5738
+  dps: 6093.91076
+  tps: 4872.99417
+  hps: 94.45005
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6011.83514
-  tps: 4808.35379
-  hps: 94.5738
+  dps: 6093.91076
+  tps: 4872.99417
+  hps: 94.45005
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6377.13192
-  tps: 5100.35695
+  dps: 6410.37582
+  tps: 5126.57042
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4817.53058
-  tps: 3849.51341
+  dps: 4882.05337
+  tps: 3900.24838
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 6933.23584
-  tps: 5541.51692
+  dps: 6968.98188
+  tps: 5570.1686
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6310.48158
-  tps: 4944.57108
+  dps: 6385.14508
+  tps: 5004.05663
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6470.1591
-  tps: 5172.94354
+  dps: 6562.05243
+  tps: 5247.44633
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
   hps: 64
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6158.2637
-  tps: 4925.83939
+  dps: 6272.36319
+  tps: 5018.63149
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6253.12281
-  tps: 5012.64946
+  dps: 6313.78989
+  tps: 5061.05439
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6257.2894
-  tps: 5008.11842
+  dps: 6310.22781
+  tps: 5050.67173
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6086.38548
-  tps: 4867.94313
+  dps: 6118.72091
+  tps: 4893.78945
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6302.28787
-  tps: 5038.58432
+  dps: 6388.79699
+  tps: 5108.87811
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6349.25553
-  tps: 5077.4512
+  dps: 6367.8205
+  tps: 5092.29145
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6296.96037
-  tps: 5035.51914
+  dps: 6354.89819
+  tps: 5081.61347
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6345.80093
+  tps: 5073.47999
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6381.93787
-  tps: 5103.4822
+  dps: 6442.66036
+  tps: 5152.11742
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6300.94774
-  tps: 5037.57446
+  dps: 6388.15908
+  tps: 5108.33165
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6287.3771
-  tps: 5026.44338
+  dps: 6383.49359
+  tps: 5104.50421
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6038.68866
-  tps: 4828.58828
+  dps: 6114.85645
+  tps: 4890.22704
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6345.80093
+  tps: 5073.47999
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6290.41991
-  tps: 5041.55012
+  dps: 6294.39701
+  tps: 5045.15493
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6363.19226
-  tps: 5088.48183
+  dps: 6420.85296
+  tps: 5135.34798
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6187.50394
-  tps: 4955.3394
+  dps: 6243.245
+  tps: 4999.15789
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6184.80391
-  tps: 4944.89157
+  dps: 6269.5129
+  tps: 5011.48863
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6266.6399
-  tps: 5011.84705
+  dps: 6344.17543
+  tps: 5074.4174
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6310.48158
-  tps: 5043.78195
+  dps: 6385.14508
+  tps: 5104.46862
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6302.70958
-  tps: 5037.6624
+  dps: 6377.27625
+  tps: 5098.2709
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FrostfireGarb"
  value: {
-  dps: 5835.90001
-  tps: 4670.21431
+  dps: 5880.74307
+  tps: 4706.70469
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6226.60756
-  tps: 4981.02852
+  dps: 6252.38914
+  tps: 5001.09761
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 6293.66606
-  tps: 5025.15339
+  dps: 6362.31219
+  tps: 5079.21839
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6307.30109
-  tps: 5041.39397
+  dps: 6393.71174
+  tps: 5109.32232
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6346.06602
-  tps: 5071.9327
+  dps: 6433.01517
+  tps: 5140.28234
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6253.55974
-  tps: 5011.17269
+  dps: 6279.57078
+  tps: 5031.13904
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-49982"
  value: {
-  dps: 6470.1591
-  tps: 5172.94354
+  dps: 6562.05243
+  tps: 5247.44633
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 6470.1591
-  tps: 5172.94354
+  dps: 6562.05243
+  tps: 5247.44633
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6309.23062
-  tps: 5044.61856
+  dps: 6395.79077
+  tps: 5112.68686
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6300.94774
-  tps: 5037.57446
+  dps: 6388.15908
+  tps: 5108.33165
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6287.3771
-  tps: 5026.44338
+  dps: 6383.49359
+  tps: 5104.50421
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6417.65418
-  tps: 5137.9682
+  dps: 6467.39942
+  tps: 5178.17962
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6345.80093
+  tps: 5073.47999
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 6513.64497
-  tps: 5206.22787
+  dps: 6598.55617
+  tps: 5276.55184
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KirinTorGarb"
  value: {
-  dps: 6536.18577
-  tps: 5221.2947
+  dps: 6596.16248
+  tps: 5269.61354
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6304.71359
-  tps: 5042.61949
+  dps: 6375.43961
+  tps: 5099.54751
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6118.90089
-  tps: 4894.52797
+  dps: 6199.93967
+  tps: 4959.4285
  }
 }
 dps_results: {
  key: "TestFire-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6289.1915
-  tps: 5030.35858
+  dps: 6388.51788
+  tps: 5109.08038
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Nibelung-49992"
  value: {
-  dps: 6470.1591
-  tps: 5172.94354
+  dps: 6562.05243
+  tps: 5247.44633
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Nibelung-50648"
  value: {
-  dps: 6470.1591
-  tps: 5172.94354
+  dps: 6562.05243
+  tps: 5247.44633
  }
 }
 dps_results: {
  key: "TestFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6345.80093
+  tps: 5073.47999
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6345.80093
+  tps: 5073.47999
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6345.80093
+  tps: 5073.47999
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6345.80093
+  tps: 5073.47999
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6453.35892
-  tps: 5188.22676
+  dps: 6540.94635
+  tps: 5260.81667
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6500.0032
-  tps: 5228.89416
+  dps: 6588.52662
+  tps: 5302.3485
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6439.23518
-  tps: 5147.27513
+  dps: 6517.43965
+  tps: 5210.79097
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6343.8858
-  tps: 5073.2536
+  dps: 6387.47013
+  tps: 5107.90406
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6408.36154
-  tps: 5130.23797
+  dps: 6459.91709
+  tps: 5169.92887
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6432.00939
-  tps: 5148.84476
+  dps: 6489.93387
+  tps: 5194.28048
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6128.98241
-  tps: 4900.91579
+  dps: 6212.91596
+  tps: 4966.9062
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6310.41257
-  tps: 5056.7087
+  dps: 6371.34138
+  tps: 5105.18789
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 6183.68525
-  tps: 4945.60578
+  dps: 6279.75871
+  tps: 5022.58077
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6165.89707
-  tps: 4930.34156
+  dps: 6243.27093
+  tps: 4992.76799
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6345.80093
+  tps: 5073.47999
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6345.80093
+  tps: 5073.47999
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6345.80093
+  tps: 5073.47999
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6143.73698
-  tps: 4913.73916
+  dps: 6226.92508
+  tps: 4981.18874
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6211.37298
-  tps: 4971.6296
+  dps: 6262.58139
+  tps: 5011.95333
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TempestRegalia"
  value: {
-  dps: 4495.8556
-  tps: 3595.9508
+  dps: 4550.42774
+  tps: 3639.47607
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6012.68762
-  tps: 4809.29959
+  dps: 6095.00567
+  tps: 4874.02612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5158.51199
-  tps: 4132.9619
+  dps: 5214.11871
+  tps: 4177.02571
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6271.62155
-  tps: 5013.18422
+  dps: 6345.80093
+  tps: 5073.47999
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6287.01731
-  tps: 5027.45683
+  dps: 6358.55239
+  tps: 5085.44091
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6287.01731
-  tps: 5027.45683
+  dps: 6358.55239
+  tps: 5085.44091
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6310.48158
-  tps: 5043.78195
+  dps: 6385.14508
+  tps: 5104.46862
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6302.70958
-  tps: 5037.6624
+  dps: 6377.27625
+  tps: 5098.2709
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6167.73528
-  tps: 4932.09453
+  dps: 6275.07039
+  tps: 5018.0826
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6302.70958
-  tps: 5037.6624
+  dps: 6377.27625
+  tps: 5098.2709
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6310.48158
-  tps: 5043.78195
+  dps: 6385.14508
+  tps: 5104.46862
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6140.6766
-  tps: 4911.69078
+  dps: 6225.0893
+  tps: 4978.09303
  }
 }
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
-  dps: 6640.99481
-  tps: 5310.70678
+  dps: 6700.70372
+  tps: 5358.52055
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22166.75512
-  tps: 23611.6076
+  dps: 22320.73055
+  tps: 23758.55456
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1829.61279
-  tps: 1607.32011
+  dps: 1839.95235
+  tps: 1615.56867
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2544.50565
-  tps: 2134.86119
+  dps: 2556.05555
+  tps: 2144.17213
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14135.97415
-  tps: 15780.25661
+  dps: 14231.19584
+  tps: 15899.21555
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 838.0569
-  tps: 730.65356
+  dps: 838.49327
+  tps: 731.09609
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1442.03515
-  tps: 1173.76053
+  dps: 1443.67748
+  tps: 1175.26449
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9623.06423
-  tps: 9793.53131
+  dps: 9735.97221
+  tps: 9925.44464
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6470.1591
-  tps: 5172.94354
+  dps: 6562.05243
+  tps: 5247.44633
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7985.57343
-  tps: 6290.24419
+  dps: 8052.65959
+  tps: 6343.40853
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4523.57862
-  tps: 5184.69177
+  dps: 4583.12363
+  tps: 5251.67418
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2418.82722
-  tps: 1928.44034
+  dps: 2425.23303
+  tps: 1934.67136
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P1Fire-FireRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3706.53285
-  tps: 2870.90394
+  dps: 3728.29169
+  tps: 2887.90026
  }
 }
 dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6470.1591
-  tps: 5172.94354
+  dps: 6562.05243
+  tps: 5247.44633
  }
 }

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -46,815 +46,815 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 5309.59117
-  tps: 4210.19665
+  dps: 5344.78531
+  tps: 4239.25055
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 5338.40878
-  tps: 4233.5405
+  dps: 5373.79662
+  tps: 4262.75757
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5221.71305
-  tps: 4145.86338
+  dps: 5255.37254
+  tps: 4174.144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 5075.35935
-  tps: 4020.52349
+  dps: 5108.98039
+  tps: 4048.27052
   hps: 93.60355
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 5075.35935
-  tps: 4020.52349
+  dps: 5108.98039
+  tps: 4048.27052
   hps: 93.60355
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5239.56033
-  tps: 4161.50436
+  dps: 5268.86404
+  tps: 4186.0391
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4452.33802
-  tps: 3498.98595
+  dps: 4487.69067
+  tps: 3528.01222
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 5749.85885
-  tps: 4614.07836
+  dps: 5783.00916
+  tps: 4641.75897
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5254.31588
-  tps: 4089.45783
+  dps: 5288.19186
+  tps: 4117.35377
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 5359.49872
-  tps: 4269.31469
+  dps: 5391.25398
+  tps: 4296.05755
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
   hps: 64
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5155.22743
-  tps: 4091.71862
+  dps: 5186.89207
+  tps: 4117.8009
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5172.9764
-  tps: 4119.18853
+  dps: 5213.17061
+  tps: 4152.66444
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 5129.06822
-  tps: 4072.6493
+  dps: 5156.58735
+  tps: 4094.54353
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Death'sChoice-47464"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5101.53715
-  tps: 4043.87131
+  dps: 5128.20097
+  tps: 4064.95746
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5242.07617
-  tps: 4163.89637
+  dps: 5270.86105
+  tps: 4187.96751
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 5559.53243
-  tps: 4454.83909
+  dps: 5597.92858
+  tps: 4486.71918
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 5472.10277
-  tps: 4380.0779
+  dps: 5510.83183
+  tps: 4411.85964
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5221.71305
-  tps: 4145.86338
+  dps: 5255.37254
+  tps: 4174.144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5259.18198
-  tps: 4176.33225
+  dps: 5291.51382
+  tps: 4203.29851
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5239.7279
-  tps: 4161.78293
+  dps: 5269.0279
+  tps: 4186.31767
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5234.98439
-  tps: 4157.52972
+  dps: 5269.0279
+  tps: 4186.31767
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 5152.77856
-  tps: 4094.69523
+  dps: 5186.98468
+  tps: 4122.985
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5221.71305
-  tps: 4145.86338
+  dps: 5255.37254
+  tps: 4174.144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5146.73515
-  tps: 4081.98466
+  dps: 5186.54337
+  tps: 4115.53753
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5290.84055
-  tps: 4211.89677
+  dps: 5340.28992
+  tps: 4253.75163
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 5073.69291
-  tps: 4016.46672
+  dps: 5107.75403
+  tps: 4044.44818
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 5220.51857
-  tps: 4138.04291
+  dps: 5255.11399
+  tps: 4166.59252
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5236.11867
-  tps: 4163.00538
+  dps: 5281.59273
+  tps: 4201.47572
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5254.31588
-  tps: 4172.24332
+  dps: 5288.19186
+  tps: 4200.70857
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5247.79531
-  tps: 4166.96734
+  dps: 5281.628
+  tps: 4195.39566
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FrostfireGarb"
  value: {
-  dps: 4797.80734
-  tps: 3787.35322
+  dps: 4820.6916
+  tps: 3806.59715
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5154.88638
-  tps: 4083.41282
+  dps: 5189.11643
+  tps: 4111.65046
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 5286.8373
-  tps: 4173.73424
+  dps: 5317.06925
+  tps: 4198.30056
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 5323.99997
-  tps: 4221.86858
+  dps: 5359.29097
+  tps: 4251.00406
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 5356.74726
-  tps: 4248.39569
+  dps: 5392.25837
+  tps: 4277.71657
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 5170.31131
-  tps: 4110.25091
+  dps: 5210.69759
+  tps: 4144.54207
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Heartpierce-49982"
  value: {
-  dps: 5359.49872
-  tps: 4269.31469
+  dps: 5391.25398
+  tps: 4296.05755
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Heartpierce-50641"
  value: {
-  dps: 5359.49872
-  tps: 4269.31469
+  dps: 5391.25398
+  tps: 4296.05755
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5307.27533
-  tps: 4226.73775
+  dps: 5342.55612
+  tps: 4255.94739
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5239.7279
-  tps: 4161.78293
+  dps: 5269.0279
+  tps: 4186.31767
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5234.98439
-  tps: 4157.52972
+  dps: 5269.0279
+  tps: 4186.31767
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5218.16185
-  tps: 4143.22049
+  dps: 5250.25176
+  tps: 4169.98313
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5221.71305
-  tps: 4145.86338
+  dps: 5255.37254
+  tps: 4174.144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 5176.0477
-  tps: 4112.09757
+  dps: 5196.61597
+  tps: 4128.47777
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KirinTorGarb"
  value: {
-  dps: 5211.55923
-  tps: 4144.55947
+  dps: 5241.45047
+  tps: 4169.66003
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5066.83538
-  tps: 4007.83608
+  dps: 5100.39872
+  tps: 4035.51792
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5125.71657
-  tps: 4064.95746
+  dps: 5170.00443
+  tps: 4102.3763
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 5260.84497
-  tps: 4174.30092
+  dps: 5300.49373
+  tps: 4207.39853
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Nibelung-49992"
  value: {
-  dps: 5359.49872
-  tps: 4269.31469
+  dps: 5391.25398
+  tps: 4296.05755
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Nibelung-50648"
  value: {
-  dps: 5359.49872
-  tps: 4269.31469
+  dps: 5391.25398
+  tps: 4296.05755
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5221.71305
-  tps: 4145.86338
+  dps: 5255.37254
+  tps: 4174.144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5221.71305
-  tps: 4145.86338
+  dps: 5255.37254
+  tps: 4174.144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 5075.88688
-  tps: 4021.09884
+  dps: 5109.50499
+  tps: 4048.82526
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5221.71305
-  tps: 4145.86338
+  dps: 5255.37254
+  tps: 4174.144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5221.71305
-  tps: 4145.86338
+  dps: 5255.37254
+  tps: 4174.144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 5384.78508
-  tps: 4287.13005
+  dps: 5408.68833
+  tps: 4303.73301
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 5423.3698
-  tps: 4321.21489
+  dps: 5447.60576
+  tps: 4338.12459
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5339.89031
-  tps: 4251.96237
+  dps: 5376.38125
+  tps: 4282.78825
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5221.32407
-  tps: 4144.76807
+  dps: 5254.95253
+  tps: 4173.01742
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 5274.16308
-  tps: 4182.12
+  dps: 5309.11755
+  tps: 4210.9736
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 5299.82953
-  tps: 4203.67103
+  dps: 5335.01723
+  tps: 4232.72438
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulPreserver-37111"
  value: {
-  dps: 5173.36248
-  tps: 4099.84387
+  dps: 5207.64094
+  tps: 4128.1265
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 5131.44495
-  tps: 4070.88218
+  dps: 5175.87368
+  tps: 4108.39993
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 5178.00256
-  tps: 4113.14145
+  dps: 5214.23605
+  tps: 4142.40174
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 5175.95257
-  tps: 4108.33347
+  dps: 5209.32128
+  tps: 4136.53509
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5221.71305
-  tps: 4145.86338
+  dps: 5255.37254
+  tps: 4174.144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5221.71305
-  tps: 4145.86338
+  dps: 5255.37254
+  tps: 4174.144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5221.71305
-  tps: 4145.86338
+  dps: 5255.37254
+  tps: 4174.144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 5072.3751
-  tps: 4015.09669
+  dps: 5106.05643
+  tps: 4042.87453
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 5089.03321
-  tps: 4030.27489
+  dps: 5121.54169
+  tps: 4056.62862
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TempestRegalia"
  value: {
-  dps: 4246.41372
-  tps: 3344.4641
+  dps: 4278.57559
+  tps: 3371.63716
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 5075.12064
-  tps: 4020.26255
+  dps: 5108.73875
+  tps: 4047.98896
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 4365.96447
-  tps: 3453.17104
+  dps: 4395.96899
+  tps: 3478.74577
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5221.71305
-  tps: 4145.86338
+  dps: 5255.37254
+  tps: 4174.144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5204.8238
-  tps: 4134.49567
+  dps: 5235.63772
+  tps: 4160.16451
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5204.8238
-  tps: 4134.49567
+  dps: 5235.63772
+  tps: 4160.16451
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5254.31588
-  tps: 4172.24332
+  dps: 5288.19186
+  tps: 4200.70857
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5247.79531
-  tps: 4166.96734
+  dps: 5281.628
+  tps: 4195.39566
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 5191.3898
-  tps: 4116.29854
+  dps: 5226.68336
+  tps: 4145.41546
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5247.79531
-  tps: 4166.96734
+  dps: 5281.628
+  tps: 4195.39566
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5254.31588
-  tps: 4172.24332
+  dps: 5288.19186
+  tps: 4200.70857
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 5164.75673
-  tps: 4100.80983
+  dps: 5198.94769
+  tps: 4129.04861
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 5443.5145
-  tps: 4346.09562
+  dps: 5478.5269
+  tps: 4375.24674
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12044.43627
+  dps: 12046.66242
   tps: 11280.31542
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1784.16469
+  dps: 1786.43021
   tps: 1078.13961
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2877.60541
+  dps: 2878.92231
   tps: 1949.98182
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5631.35078
+  dps: 5632.70837
   tps: 5372.07612
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 952.40334
+  dps: 953.68066
   tps: 502.28946
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1704.32262
+  dps: 1706.55508
   tps: 1062.80935
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5359.49872
-  tps: 4895.7175
+  dps: 5391.25398
+  tps: 4922.46037
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5359.49872
-  tps: 4269.31469
+  dps: 5391.25398
+  tps: 4296.05755
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6515.70666
-  tps: 5190.16064
+  dps: 6544.24856
+  tps: 5214.17329
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3158.29513
-  tps: 3221.53987
+  dps: 3183.07729
+  tps: 3242.72347
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3158.29513
-  tps: 2461.31678
+  dps: 3183.07729
+  tps: 2482.50038
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3628.50722
-  tps: 2783.96034
+  dps: 3645.42135
+  tps: 2798.00429
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5359.49872
-  tps: 4269.31469
+  dps: 5391.25398
+  tps: 4296.05755
  }
 }

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -46,815 +46,815 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 5432.15859
-  tps: 4311.38836
+  dps: 5309.59117
+  tps: 4210.19665
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 5461.64835
-  tps: 4335.29806
+  dps: 5338.40878
+  tps: 4233.5405
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5330.62959
-  tps: 4236.57613
+  dps: 5221.71305
+  tps: 4145.86338
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 5192.68308
-  tps: 4117.34451
+  dps: 5075.35935
+  tps: 4020.52349
   hps: 93.60355
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 5192.68308
-  tps: 4117.34451
+  dps: 5075.35935
+  tps: 4020.52349
   hps: 93.60355
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5344.3827
-  tps: 4248.75857
+  dps: 5239.56033
+  tps: 4161.50436
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4555.78155
-  tps: 3584.40162
+  dps: 4452.33802
+  tps: 3498.98595
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 5854.72477
-  tps: 4700.99365
+  dps: 5749.85885
+  tps: 4614.07836
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5363.92876
-  tps: 4178.93444
+  dps: 5254.31588
+  tps: 4089.45783
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 5473.04742
-  tps: 4364.42179
+  dps: 5359.49872
+  tps: 4269.31469
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
   hps: 64
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5275.08243
-  tps: 4191.03555
+  dps: 5155.22743
+  tps: 4091.71862
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5286.24375
-  tps: 4213.16941
+  dps: 5172.9764
+  tps: 4119.18853
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 5237.15783
-  tps: 4161.25173
+  dps: 5129.06822
+  tps: 4072.6493
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Death'sChoice-47464"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5208.0278
-  tps: 4130.85614
+  dps: 5101.53715
+  tps: 4043.87131
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5346.21697
-  tps: 4250.54052
+  dps: 5242.07617
+  tps: 4163.89637
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 5683.64834
-  tps: 4558.34478
+  dps: 5559.53243
+  tps: 4454.83909
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 5597.50546
-  tps: 4483.63325
+  dps: 5472.10277
+  tps: 4380.0779
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5330.62959
-  tps: 4236.57613
+  dps: 5221.71305
+  tps: 4145.86338
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5367.3737
-  tps: 4266.30102
+  dps: 5259.18198
+  tps: 4176.33225
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5344.54656
-  tps: 4249.03715
+  dps: 5239.7279
+  tps: 4161.78293
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5340.35134
-  tps: 4245.2745
+  dps: 5234.98439
+  tps: 4157.52972
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 5265.44597
-  tps: 4189.06901
+  dps: 5152.77856
+  tps: 4094.69523
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5330.62959
-  tps: 4236.57613
+  dps: 5221.71305
+  tps: 4145.86338
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5266.78468
-  tps: 4182.50035
+  dps: 5146.73515
+  tps: 4081.98466
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5427.31417
-  tps: 4326.0879
+  dps: 5290.84055
+  tps: 4211.89677
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 5188.32477
-  tps: 4110.97126
+  dps: 5073.69291
+  tps: 4016.46672
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 5341.00841
-  tps: 4237.48565
+  dps: 5220.51857
+  tps: 4138.04291
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5366.44195
-  tps: 4271.68102
+  dps: 5236.11867
+  tps: 4163.00538
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5363.92876
-  tps: 4263.54599
+  dps: 5254.31588
+  tps: 4172.24332
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5357.26892
-  tps: 4258.15202
+  dps: 5247.79531
+  tps: 4166.96734
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FrostfireGarb"
  value: {
-  dps: 4901.64878
-  tps: 3874.43276
+  dps: 4797.80734
+  tps: 3787.35322
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5273.9999
-  tps: 4181.69485
+  dps: 5154.88638
+  tps: 4083.41282
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 5393.58899
-  tps: 4261.14235
+  dps: 5286.8373
+  tps: 4173.73424
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 5446.90347
-  tps: 4323.34321
+  dps: 5323.99997
+  tps: 4221.86858
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 5480.41457
-  tps: 4350.51332
+  dps: 5356.74726
+  tps: 4248.39569
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 5294.29401
-  tps: 4215.05749
+  dps: 5170.31131
+  tps: 4110.25091
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Heartpierce-49982"
  value: {
-  dps: 5473.04742
-  tps: 4364.42179
+  dps: 5359.49872
+  tps: 4269.31469
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Heartpierce-50641"
  value: {
-  dps: 5473.04742
-  tps: 4364.42179
+  dps: 5359.49872
+  tps: 4269.31469
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5429.98983
-  tps: 4328.34295
+  dps: 5307.27533
+  tps: 4226.73775
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5344.54656
-  tps: 4249.03715
+  dps: 5239.7279
+  tps: 4161.78293
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5340.35134
-  tps: 4245.2745
+  dps: 5234.98439
+  tps: 4157.52972
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5325.81681
-  tps: 4232.77343
+  dps: 5218.16185
+  tps: 4143.22049
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5330.62959
-  tps: 4236.57613
+  dps: 5221.71305
+  tps: 4145.86338
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 5263.40827
-  tps: 4183.83589
+  dps: 5176.0477
+  tps: 4112.09757
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KirinTorGarb"
  value: {
-  dps: 5316.8425
-  tps: 4231.86358
+  dps: 5211.55923
+  tps: 4144.55947
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5183.9288
-  tps: 4104.43724
+  dps: 5066.83538
+  tps: 4007.83608
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5256.48313
-  tps: 4174.04813
+  dps: 5125.71657
+  tps: 4064.95746
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 5383.79252
-  tps: 4275.99135
+  dps: 5260.84497
+  tps: 4174.30092
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Nibelung-49992"
  value: {
-  dps: 5473.04742
-  tps: 4364.42179
+  dps: 5359.49872
+  tps: 4269.31469
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Nibelung-50648"
  value: {
-  dps: 5473.04742
-  tps: 4364.42179
+  dps: 5359.49872
+  tps: 4269.31469
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5330.62959
-  tps: 4236.57613
+  dps: 5221.71305
+  tps: 4145.86338
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5330.62959
-  tps: 4236.57613
+  dps: 5221.71305
+  tps: 4145.86338
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 5192.9683
-  tps: 4117.68329
+  dps: 5075.88688
+  tps: 4021.09884
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5330.62959
-  tps: 4236.57613
+  dps: 5221.71305
+  tps: 4145.86338
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5330.62959
-  tps: 4236.57613
+  dps: 5221.71305
+  tps: 4145.86338
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 5461.40319
-  tps: 4348.24648
+  dps: 5384.78508
+  tps: 4287.13005
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 5501.22079
-  tps: 4383.50471
+  dps: 5423.3698
+  tps: 4321.21489
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5457.88305
-  tps: 4350.83927
+  dps: 5339.89031
+  tps: 4251.96237
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5330.20958
-  tps: 4235.44954
+  dps: 5221.32407
+  tps: 4144.76807
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 5395.97569
-  tps: 4282.68723
+  dps: 5274.16308
+  tps: 4182.12
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 5422.1989
-  tps: 4304.70498
+  dps: 5299.82953
+  tps: 4203.67103
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulPreserver-37111"
  value: {
-  dps: 5292.75243
-  tps: 4198.36069
+  dps: 5173.36248
+  tps: 4099.84387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 5263.91521
-  tps: 4181.86121
+  dps: 5131.44495
+  tps: 4070.88218
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 5287.85482
-  tps: 4202.62386
+  dps: 5178.00256
+  tps: 4113.14145
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 5288.83134
-  tps: 4203.17699
+  dps: 5175.95257
+  tps: 4108.33347
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5330.62959
-  tps: 4236.57613
+  dps: 5221.71305
+  tps: 4145.86338
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5330.62959
-  tps: 4236.57613
+  dps: 5221.71305
+  tps: 4145.86338
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5330.62959
-  tps: 4236.57613
+  dps: 5221.71305
+  tps: 4145.86338
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 5189.75926
-  tps: 4111.93321
+  dps: 5072.3751
+  tps: 4015.09669
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 5202.79591
-  tps: 4123.87694
+  dps: 5089.03321
+  tps: 4030.27489
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TempestRegalia"
  value: {
-  dps: 4340.73276
-  tps: 3422.83712
+  dps: 4246.41372
+  tps: 3344.4641
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 5192.21914
-  tps: 4116.85036
+  dps: 5075.12064
+  tps: 4020.26255
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 4466.85163
-  tps: 3538.27722
+  dps: 4365.96447
+  tps: 3453.17104
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5330.62959
-  tps: 4236.57613
+  dps: 5221.71305
+  tps: 4145.86338
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5316.93918
-  tps: 4228.42332
+  dps: 5204.8238
+  tps: 4134.49567
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5316.93918
-  tps: 4228.42332
+  dps: 5204.8238
+  tps: 4134.49567
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5363.92876
-  tps: 4263.54599
+  dps: 5254.31588
+  tps: 4172.24332
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5357.26892
-  tps: 4258.15202
+  dps: 5247.79531
+  tps: 4166.96734
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 5317.50834
-  tps: 4221.61266
+  dps: 5191.3898
+  tps: 4116.29854
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5357.26892
-  tps: 4258.15202
+  dps: 5247.79531
+  tps: 4166.96734
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5363.92876
-  tps: 4263.54599
+  dps: 5254.31588
+  tps: 4172.24332
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 5283.97969
-  tps: 4199.30477
+  dps: 5164.75673
+  tps: 4100.80983
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 5562.13805
-  tps: 4444.71531
+  dps: 5443.5145
+  tps: 4346.09562
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12052.57938
+  dps: 12044.43627
   tps: 11280.31542
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1792.42689
+  dps: 1784.16469
   tps: 1078.13961
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2884.37127
+  dps: 2877.60541
   tps: 1949.98182
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5636.29226
+  dps: 5631.35078
   tps: 5372.07612
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 957.22024
+  dps: 952.40334
   tps: 502.28946
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1711.13491
+  dps: 1704.32262
   tps: 1062.80935
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5473.04742
-  tps: 4990.8246
+  dps: 5359.49872
+  tps: 4895.7175
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5473.04742
-  tps: 4364.42179
+  dps: 5359.49872
+  tps: 4269.31469
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6666.47075
-  tps: 5318.65811
+  dps: 6515.70666
+  tps: 5190.16064
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3225.34806
-  tps: 3276.9822
+  dps: 3158.29513
+  tps: 3221.53987
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3225.34806
-  tps: 2516.75911
+  dps: 3158.29513
+  tps: 2461.31678
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3715.47655
-  tps: 2856.11816
+  dps: 3628.50722
+  tps: 2783.96034
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5473.04742
-  tps: 4364.42179
+  dps: 5359.49872
+  tps: 4269.31469
  }
 }

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -46,745 +46,745 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 5303.32924
-  tps: 4204.68615
+  dps: 5432.15859
+  tps: 4311.38836
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 5332.11154
-  tps: 4227.99894
+  dps: 5461.64835
+  tps: 4335.29806
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5213.45431
-  tps: 4138.59569
+  dps: 5330.62959
+  tps: 4236.57613
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 5069.34672
-  tps: 4015.23238
+  dps: 5192.68308
+  tps: 4117.34451
   hps: 93.60355
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 5069.34672
-  tps: 4015.23238
+  dps: 5192.68308
+  tps: 4117.34451
   hps: 93.60355
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5232.9724
-  tps: 4155.70698
+  dps: 5344.3827
+  tps: 4248.75857
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4450.22228
-  tps: 3497.12409
+  dps: 4555.78155
+  tps: 3584.40162
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 5745.58258
-  tps: 4610.31524
+  dps: 5854.72477
+  tps: 4700.99365
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5246.00472
-  tps: 4082.29029
+  dps: 5363.92876
+  tps: 4178.93444
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 5352.31789
-  tps: 4262.99555
+  dps: 5473.04742
+  tps: 4364.42179
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
   hps: 64
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5150.7795
-  tps: 4087.80444
+  dps: 5275.08243
+  tps: 4191.03555
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5165.06059
-  tps: 4112.22261
+  dps: 5286.24375
+  tps: 4213.16941
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 5124.68423
-  tps: 4068.79139
+  dps: 5237.15783
+  tps: 4161.25173
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Death'sChoice-47464"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5097.30195
-  tps: 4040.14433
+  dps: 5208.0278
+  tps: 4130.85614
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5235.48825
-  tps: 4158.099
+  dps: 5346.21697
+  tps: 4250.54052
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 5553.6538
-  tps: 4449.6659
+  dps: 5683.64834
+  tps: 4558.34478
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 5464.60189
-  tps: 4373.47712
+  dps: 5597.50546
+  tps: 4483.63325
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5213.45431
-  tps: 4138.59569
+  dps: 5330.62959
+  tps: 4236.57613
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5250.87083
-  tps: 4169.01843
+  dps: 5367.3737
+  tps: 4266.30102
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5233.13998
-  tps: 4155.98556
+  dps: 5344.54656
+  tps: 4249.03715
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5228.40293
-  tps: 4151.73803
+  dps: 5340.35134
+  tps: 4245.2745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 5151.11277
-  tps: 4093.22934
+  dps: 5265.44597
+  tps: 4189.06901
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5213.45431
-  tps: 4138.59569
+  dps: 5330.62959
+  tps: 4236.57613
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5143.13886
-  tps: 4078.81993
+  dps: 5266.78468
+  tps: 4182.50035
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5286.29672
-  tps: 4207.89819
+  dps: 5427.31417
+  tps: 4326.0879
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 5066.71816
-  tps: 4010.32894
+  dps: 5188.32477
+  tps: 4110.97126
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 5214.36576
-  tps: 4132.62844
+  dps: 5341.00841
+  tps: 4237.48565
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5230.91631
-  tps: 4158.4273
+  dps: 5366.44195
+  tps: 4271.68102
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5246.00472
-  tps: 4164.92951
+  dps: 5363.92876
+  tps: 4263.54599
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5239.49464
-  tps: 4159.66274
+  dps: 5357.26892
+  tps: 4258.15202
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FrostfireGarb"
  value: {
-  dps: 4792.84177
-  tps: 3782.98352
+  dps: 4901.64878
+  tps: 3874.43276
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5148.81221
-  tps: 4078.06755
+  dps: 5273.9999
+  tps: 4181.69485
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 5277.73193
-  tps: 4165.72152
+  dps: 5393.58899
+  tps: 4261.14235
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 5317.72039
-  tps: 4216.34254
+  dps: 5446.90347
+  tps: 4323.34321
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 5350.42755
-  tps: 4242.83435
+  dps: 5480.41457
+  tps: 4350.51332
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 5165.19695
-  tps: 4105.75027
+  dps: 5294.29401
+  tps: 4215.05749
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Heartpierce-49982"
  value: {
-  dps: 5352.31789
-  tps: 4262.99555
+  dps: 5473.04742
+  tps: 4364.42179
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Heartpierce-50641"
  value: {
-  dps: 5352.31789
-  tps: 4262.99555
+  dps: 5473.04742
+  tps: 4364.42179
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5301.00596
-  tps: 4221.2207
+  dps: 5429.98983
+  tps: 4328.34295
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5233.13998
-  tps: 4155.98556
+  dps: 5344.54656
+  tps: 4249.03715
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5228.40293
-  tps: 4151.73803
+  dps: 5340.35134
+  tps: 4245.2745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5209.90662
-  tps: 4135.95589
+  dps: 5325.81681
+  tps: 4232.77343
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5213.45431
-  tps: 4138.59569
+  dps: 5330.62959
+  tps: 4236.57613
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 5169.03861
-  tps: 4105.92957
+  dps: 5263.40827
+  tps: 4183.83589
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KirinTorGarb"
  value: {
-  dps: 5205.68947
-  tps: 4139.39409
+  dps: 5316.8425
+  tps: 4231.86358
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5060.86071
-  tps: 4002.57836
+  dps: 5183.9288
+  tps: 4104.43724
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5120.61381
-  tps: 4060.46703
+  dps: 5256.48313
+  tps: 4174.04813
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 5255.57373
-  tps: 4169.66223
+  dps: 5383.79252
+  tps: 4275.99135
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Nibelung-49992"
  value: {
-  dps: 5352.31789
-  tps: 4262.99555
+  dps: 5473.04742
+  tps: 4364.42179
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Nibelung-50648"
  value: {
-  dps: 5352.31789
-  tps: 4262.99555
+  dps: 5473.04742
+  tps: 4364.42179
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5213.45431
-  tps: 4138.59569
+  dps: 5330.62959
+  tps: 4236.57613
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5213.45431
-  tps: 4138.59569
+  dps: 5330.62959
+  tps: 4236.57613
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 5070.86221
-  tps: 4016.67714
+  dps: 5192.9683
+  tps: 4117.68329
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5213.45431
-  tps: 4138.59569
+  dps: 5330.62959
+  tps: 4236.57613
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5213.45431
-  tps: 4138.59569
+  dps: 5330.62959
+  tps: 4236.57613
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 5379.54478
-  tps: 4281.27792
+  dps: 5461.40319
+  tps: 4348.24648
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 5417.96644
-  tps: 4315.19834
+  dps: 5501.22079
+  tps: 4383.50471
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5330.88829
-  tps: 4244.04059
+  dps: 5457.88305
+  tps: 4350.83927
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5213.06533
-  tps: 4137.50038
+  dps: 5330.20958
+  tps: 4235.44954
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 5267.93485
-  tps: 4176.63916
+  dps: 5395.97569
+  tps: 4282.68723
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 5293.5692
-  tps: 4198.16194
+  dps: 5422.1989
+  tps: 4304.70498
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulPreserver-37111"
  value: {
-  dps: 5167.26745
-  tps: 4094.48025
+  dps: 5292.75243
+  tps: 4198.36069
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 5127.03661
-  tps: 4067.01708
+  dps: 5263.91521
+  tps: 4181.86121
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 5169.96105
-  tps: 4106.06492
+  dps: 5287.85482
+  tps: 4202.62386
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 5169.73975
-  tps: 4102.8662
+  dps: 5288.83134
+  tps: 4203.17699
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5213.45431
-  tps: 4138.59569
+  dps: 5330.62959
+  tps: 4236.57613
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5213.45431
-  tps: 4138.59569
+  dps: 5330.62959
+  tps: 4236.57613
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5213.45431
-  tps: 4138.59569
+  dps: 5330.62959
+  tps: 4236.57613
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 5066.40043
-  tps: 4009.83897
+  dps: 5189.75926
+  tps: 4111.93321
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 5084.79801
-  tps: 4026.54792
+  dps: 5202.79591
+  tps: 4123.87694
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TempestRegalia"
  value: {
-  dps: 4245.56744
-  tps: 3343.71937
+  dps: 4340.73276
+  tps: 3422.83712
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 5069.14596
-  tps: 4015.00483
+  dps: 5192.21914
+  tps: 4116.85036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 4360.28931
-  tps: 3448.1769
+  dps: 4466.85163
+  tps: 3538.27722
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5213.45431
-  tps: 4138.59569
+  dps: 5330.62959
+  tps: 4236.57613
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5200.55414
-  tps: 4130.73837
+  dps: 5316.93918
+  tps: 4228.42332
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5200.55414
-  tps: 4130.73837
+  dps: 5316.93918
+  tps: 4228.42332
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5246.00472
-  tps: 4164.92951
+  dps: 5363.92876
+  tps: 4263.54599
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5239.49464
-  tps: 4159.66274
+  dps: 5357.26892
+  tps: 4258.15202
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 5183.78905
-  tps: 4109.60988
+  dps: 5317.50834
+  tps: 4221.61266
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5239.49464
-  tps: 4159.66274
+  dps: 5357.26892
+  tps: 4258.15202
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5246.00472
-  tps: 4164.92951
+  dps: 5363.92876
+  tps: 4263.54599
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 5158.55491
-  tps: 4095.35223
+  dps: 5283.97969
+  tps: 4199.30477
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 5437.61979
-  tps: 4340.90827
+  dps: 5562.13805
+  tps: 4444.71531
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12044.43627
+  dps: 12052.57938
   tps: 11280.31542
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1784.16469
+  dps: 1792.42689
   tps: 1078.13961
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2877.60541
+  dps: 2884.37127
   tps: 1949.98182
  }
 }
@@ -812,22 +812,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5352.31789
-  tps: 4889.39837
+  dps: 5473.04742
+  tps: 4990.8246
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5352.31789
-  tps: 4262.99555
+  dps: 5473.04742
+  tps: 4364.42179
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Troll-P1Frost-FrostRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6511.4203
-  tps: 5186.38864
+  dps: 6666.47075
+  tps: 5318.65811
  }
 }
 dps_results: {
@@ -854,7 +854,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5352.31789
-  tps: 4262.99555
+  dps: 5473.04742
+  tps: 4364.42179
  }
 }

--- a/sim/mage/TestFrostFire.results
+++ b/sim/mage/TestFrostFire.results
@@ -46,773 +46,773 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostFire-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6205.65443
-  tps: 4950.69643
+  dps: 6006.01632
+  tps: 4790.02558
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6239.91272
-  tps: 4977.68398
+  dps: 6039.17596
+  tps: 4816.14307
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6160.08095
-  tps: 4911.38507
+  dps: 5984.68974
+  tps: 4766.61114
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 5925.05863
-  tps: 4729.66537
-  hps: 94.63921
+  dps: 5732.715
+  tps: 4574.76305
+  hps: 95.13126
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 5925.05863
-  tps: 4729.66537
-  hps: 94.63921
+  dps: 5732.715
+  tps: 4574.76305
+  hps: 95.13126
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6213.63521
-  tps: 4951.43655
+  dps: 6021.43575
+  tps: 4797.27362
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4995.36165
-  tps: 3991.40916
+  dps: 4875.79753
+  tps: 3897.28201
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 6938.52225
-  tps: 5544.05221
+  dps: 6752.12839
+  tps: 5394.95157
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6198.94292
-  tps: 4844.56311
+  dps: 6022.38827
+  tps: 4701.69242
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6376.09828
-  tps: 5084.23177
+  dps: 6189.76046
+  tps: 4933.74001
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
   hps: 64
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6047.11096
-  tps: 4828.94902
+  dps: 5898.05824
+  tps: 4709.32149
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6107.47026
-  tps: 4886.86219
+  dps: 5909.98023
+  tps: 4725.61134
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6100.70046
-  tps: 4861.73742
+  dps: 5897.05596
+  tps: 4698.3996
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Death'sChoice-47464"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5963.10172
-  tps: 4763.25959
+  dps: 5772.91796
+  tps: 4609.13923
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6192.14412
-  tps: 4938.20929
+  dps: 6025.87981
+  tps: 4802.5724
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6408.43838
-  tps: 5123.81963
+  dps: 6148.19224
+  tps: 4915.02463
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6347.18054
-  tps: 5075.32968
+  dps: 6155.17133
+  tps: 4919.86384
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6160.08095
-  tps: 4911.38507
+  dps: 5984.68974
+  tps: 4766.61114
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6230.53788
-  tps: 4964.44838
+  dps: 6032.5651
+  tps: 4803.65247
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6193.78146
-  tps: 4938.37832
+  dps: 6017.59885
+  tps: 4796.01073
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6190.30879
-  tps: 4935.59065
+  dps: 6014.68326
+  tps: 4793.63435
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6035.577
-  tps: 4822.63064
+  dps: 5824.46838
+  tps: 4656.83497
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6160.08095
-  tps: 4911.38507
+  dps: 5984.68974
+  tps: 4766.61114
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6123.00201
-  tps: 4896.05112
+  dps: 5862.78269
+  tps: 4684.47218
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6253.99284
-  tps: 4993.02063
+  dps: 6071.96915
+  tps: 4846.94353
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 5986.85985
-  tps: 4774.56007
+  dps: 5799.54379
+  tps: 4622.31305
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6099.76514
-  tps: 4867.28035
+  dps: 5903.52289
+  tps: 4709.29879
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6164.71687
-  tps: 4923.73457
+  dps: 5995.94961
+  tps: 4787.22502
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6198.94292
-  tps: 4941.9816
+  dps: 6022.38827
+  tps: 4796.27673
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6191.17052
-  tps: 4935.8623
+  dps: 6014.84857
+  tps: 4790.34361
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FrostfireGarb"
  value: {
-  dps: 5629.25226
-  tps: 4482.67758
+  dps: 5442.31867
+  tps: 4330.53289
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6057.35518
-  tps: 4833.35556
+  dps: 5889.87929
+  tps: 4693.95935
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 6116.12394
-  tps: 4872.28139
+  dps: 5986.67938
+  tps: 4767.56294
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6222.78357
-  tps: 4964.1902
+  dps: 6022.59614
+  tps: 4803.08432
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6261.71346
-  tps: 4994.85788
+  dps: 6060.27755
+  tps: 4832.76329
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6089.52943
-  tps: 4867.77966
+  dps: 5925.85738
+  tps: 4738.35092
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Heartpierce-49982"
  value: {
-  dps: 6376.09828
-  tps: 5084.23177
+  dps: 6189.76046
+  tps: 4933.74001
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 6376.09828
-  tps: 5084.23177
+  dps: 6189.76046
+  tps: 4933.74001
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6225.5701
-  tps: 4968.0683
+  dps: 6025.08685
+  tps: 4806.713
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6193.78146
-  tps: 4938.37832
+  dps: 6017.59885
+  tps: 4796.01073
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6190.30879
-  tps: 4935.59065
+  dps: 6014.68326
+  tps: 4793.63435
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6204.274
-  tps: 4944.55527
+  dps: 6012.18939
+  tps: 4789.55026
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6160.08095
-  tps: 4911.38507
+  dps: 5984.68974
+  tps: 4766.61114
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 6295.70339
-  tps: 5017.52267
+  dps: 6083.07982
+  tps: 4841.96414
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-KirinTorGarb"
  value: {
-  dps: 6361.49024
-  tps: 5063.1764
+  dps: 6192.41809
+  tps: 4925.88678
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6113.78406
-  tps: 4871.5147
+  dps: 5963.18235
+  tps: 4749.64285
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6023.2804
-  tps: 4809.83255
+  dps: 5853.30718
+  tps: 4673.38485
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6179.28982
-  tps: 4933.52186
+  dps: 5956.99214
+  tps: 4753.61716
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Nibelung-49992"
  value: {
-  dps: 6376.09828
-  tps: 5084.23177
+  dps: 6189.76046
+  tps: 4933.74001
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Nibelung-50648"
  value: {
-  dps: 6376.09828
-  tps: 5084.23177
+  dps: 6189.76046
+  tps: 4933.74001
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6160.08095
-  tps: 4911.38507
+  dps: 5984.68974
+  tps: 4766.61114
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6160.08095
-  tps: 4911.38507
+  dps: 5984.68974
+  tps: 4766.61114
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6160.08095
-  tps: 4911.38507
+  dps: 5984.68974
+  tps: 4766.61114
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6160.08095
-  tps: 4911.38507
+  dps: 5984.68974
+  tps: 4766.61114
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6361.4927
-  tps: 5117.31133
+  dps: 6137.96293
+  tps: 4929.63506
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6412.17766
-  tps: 5162.04155
+  dps: 6186.23182
+  tps: 4972.13966
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6340.59607
-  tps: 5055.79716
+  dps: 6155.22744
+  tps: 4903.0413
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6160.60819
-  tps: 4911.83964
+  dps: 5983.55921
+  tps: 4763.64003
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6236.71052
-  tps: 4970.64061
+  dps: 6019.81805
+  tps: 4798.26046
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6268.17768
-  tps: 4996.11669
+  dps: 6050.21018
+  tps: 4822.88457
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6043.70611
-  tps: 4823.1189
+  dps: 5849.26166
+  tps: 4666.56108
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6108.24956
-  tps: 4874.58762
+  dps: 5923.15097
+  tps: 4725.90433
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 6057.1386
-  tps: 4826.53585
+  dps: 5837.28105
+  tps: 4650.25919
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6081.23105
-  tps: 4851.8242
+  dps: 5867.15619
+  tps: 4681.56126
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6160.08095
-  tps: 4911.38507
+  dps: 5984.68974
+  tps: 4766.61114
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6160.08095
-  tps: 4911.38507
+  dps: 5984.68974
+  tps: 4766.61114
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6160.08095
-  tps: 4911.38507
+  dps: 5984.68974
+  tps: 4766.61114
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6031.43997
-  tps: 4808.98782
+  dps: 5824.33076
+  tps: 4642.60982
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6033.58152
-  tps: 4807.68526
+  dps: 5843.67285
+  tps: 4655.30413
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TempestRegalia"
  value: {
-  dps: 4500.6622
-  tps: 3600.3356
+  dps: 4359.31939
+  tps: 3487.51234
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 5926.91647
-  tps: 4731.11587
+  dps: 5736.21743
+  tps: 4577.52418
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5082.56654
-  tps: 4067.98952
+  dps: 4956.24794
+  tps: 3966.65262
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6160.08095
-  tps: 4911.38507
+  dps: 5984.68974
+  tps: 4766.61114
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6155.59586
-  tps: 4910.26942
+  dps: 5935.01048
+  tps: 4731.84954
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6155.59586
-  tps: 4910.26942
+  dps: 5935.01048
+  tps: 4731.84954
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6198.94292
-  tps: 4941.9816
+  dps: 6022.38827
+  tps: 4796.27673
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6191.17052
-  tps: 4935.8623
+  dps: 6014.84857
+  tps: 4790.34361
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6127.45071
-  tps: 4896.90824
+  dps: 5928.41105
+  tps: 4732.52068
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6191.17052
-  tps: 4935.8623
+  dps: 6014.84857
+  tps: 4790.34361
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6198.94292
-  tps: 4941.9816
+  dps: 6022.38827
+  tps: 4796.27673
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6047.48439
-  tps: 4827.57021
+  dps: 5858.56123
+  tps: 4675.39922
  }
 }
 dps_results: {
  key: "TestFrostFire-Average-Default"
  value: {
-  dps: 6412.6051
-  tps: 5115.59318
+  dps: 6220.74927
+  tps: 4960.59589
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9232.12928
-  tps: 9183.60979
+  dps: 8987.79706
+  tps: 9006.35515
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6376.09828
-  tps: 5084.23177
+  dps: 6189.76046
+  tps: 4933.74001
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7375.01249
-  tps: 5793.70003
+  dps: 7214.29918
+  tps: 5664.42826
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4902.58444
-  tps: 5583.14731
+  dps: 4692.00525
+  tps: 5335.98137
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2605.84408
-  tps: 2078.22412
+  dps: 2544.08289
+  tps: 2030.1774
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3154.73621
-  tps: 2423.42337
+  dps: 3067.37484
+  tps: 2356.84879
  }
 }
 dps_results: {
  key: "TestFrostFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6376.09828
-  tps: 5084.23177
+  dps: 6189.76046
+  tps: 4933.74001
  }
 }

--- a/sim/mage/TestFrostFire.results
+++ b/sim/mage/TestFrostFire.results
@@ -46,746 +46,746 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostFire-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 5833.65523
-  tps: 4646.33296
+  dps: 6205.65443
+  tps: 4950.69643
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 5865.84997
-  tps: 4671.67038
+  dps: 6239.91272
+  tps: 4977.68398
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5778.2685
-  tps: 4603.53879
+  dps: 6160.08095
+  tps: 4911.38507
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 5579.84323
-  tps: 4444.58084
-  hps: 94.85875
+  dps: 5925.05863
+  tps: 4729.66537
+  hps: 94.63921
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 5579.84323
-  tps: 4444.58084
-  hps: 94.85875
+  dps: 5925.05863
+  tps: 4729.66537
+  hps: 94.63921
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 5828.74955
-  tps: 4639.48648
+  dps: 6213.63521
+  tps: 4951.43655
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4733.86976
-  tps: 3782.12163
+  dps: 4995.36165
+  tps: 3991.40916
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 6538.78347
-  tps: 5219.69872
+  dps: 6938.52225
+  tps: 5544.05221
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 5814.67784
-  tps: 4540.90971
+  dps: 6198.94292
+  tps: 4844.56311
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 5986.74008
-  tps: 4767.71219
+  dps: 6376.09828
+  tps: 5084.23177
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
   hps: 64
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5724.91575
-  tps: 4565.25876
+  dps: 6047.11096
+  tps: 4828.94902
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5774.34267
-  tps: 4612.48207
+  dps: 6107.47026
+  tps: 4886.86219
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 5714.1435
-  tps: 4551.02477
+  dps: 6100.70046
+  tps: 4861.73742
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Death'sChoice-47464"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5633.6514
-  tps: 4488.09789
+  dps: 5963.10172
+  tps: 4763.25959
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 5852.40394
-  tps: 4661.7419
+  dps: 6192.14412
+  tps: 4938.20929
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6033.27694
-  tps: 4821.44101
+  dps: 6408.43838
+  tps: 5123.81963
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 5990.41498
-  tps: 4785.73141
+  dps: 6347.18054
+  tps: 5075.32968
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5778.2685
-  tps: 4603.53879
+  dps: 6160.08095
+  tps: 4911.38507
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 5847.79472
-  tps: 4653.50145
+  dps: 6230.53788
+  tps: 4964.44838
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 5823.666
-  tps: 4637.25293
+  dps: 6193.78146
+  tps: 4938.37832
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 5813.20744
-  tps: 4628.98392
+  dps: 6190.30879
+  tps: 4935.59065
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 5681.28331
-  tps: 4530.76233
+  dps: 6035.577
+  tps: 4822.63064
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5778.2685
-  tps: 4603.53879
+  dps: 6160.08095
+  tps: 4911.38507
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5756.40405
-  tps: 4598.79024
+  dps: 6123.00201
+  tps: 4896.05112
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 5943.10922
-  tps: 4735.4804
+  dps: 6253.99284
+  tps: 4993.02063
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 5618.5459
-  tps: 4476.51694
+  dps: 5986.85985
+  tps: 4774.56007
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 5734.14423
-  tps: 4568.0173
+  dps: 6099.76514
+  tps: 4867.28035
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5853.00244
-  tps: 4664.96901
+  dps: 6164.71687
+  tps: 4923.73457
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 5814.67784
-  tps: 4632.16992
+  dps: 6198.94292
+  tps: 4941.9816
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 5807.39597
-  tps: 4626.44369
+  dps: 6191.17052
+  tps: 4935.8623
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FrostfireGarb"
  value: {
-  dps: 5320.73902
-  tps: 4232.60488
+  dps: 5629.25226
+  tps: 4482.67758
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5748.59439
-  tps: 4576.9408
+  dps: 6057.35518
+  tps: 4833.35556
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 5854.89766
-  tps: 4662.11692
+  dps: 6116.12394
+  tps: 4872.28139
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 5849.7526
-  tps: 4659.00167
+  dps: 6222.78357
+  tps: 4964.1902
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 5886.33753
-  tps: 4687.7942
+  dps: 6261.71346
+  tps: 4994.85788
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 5757.80964
-  tps: 4601.04695
+  dps: 6089.52943
+  tps: 4867.77966
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Heartpierce-49982"
  value: {
-  dps: 5986.74008
-  tps: 4767.71219
+  dps: 6376.09828
+  tps: 5084.23177
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 5986.74008
-  tps: 4767.71219
+  dps: 6376.09828
+  tps: 5084.23177
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 5851.9081
-  tps: 4662.42606
+  dps: 6225.5701
+  tps: 4968.0683
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 5823.666
-  tps: 4637.25293
+  dps: 6193.78146
+  tps: 4938.37832
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 5813.20744
-  tps: 4628.98392
+  dps: 6190.30879
+  tps: 4935.59065
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 5819.60786
-  tps: 4634.11337
+  dps: 6204.274
+  tps: 4944.55527
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5778.2685
-  tps: 4603.53879
+  dps: 6160.08095
+  tps: 4911.38507
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 5991.42295
-  tps: 4769.37739
+  dps: 6295.70339
+  tps: 5017.52267
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-KirinTorGarb"
  value: {
-  dps: 6040.70693
-  tps: 4801.66149
+  dps: 6361.49024
+  tps: 5063.1764
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5792.57045
-  tps: 4612.14192
+  dps: 6113.78406
+  tps: 4871.5147
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5713.64485
-  tps: 4553.75672
+  dps: 6023.2804
+  tps: 4809.83255
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 5805.34753
-  tps: 4626.04503
+  dps: 6179.28982
+  tps: 4933.52186
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Nibelung-49992"
  value: {
-  dps: 5986.74008
-  tps: 4767.71219
+  dps: 6376.09828
+  tps: 5084.23177
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Nibelung-50648"
  value: {
-  dps: 5986.74008
-  tps: 4767.71219
+  dps: 6376.09828
+  tps: 5084.23177
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5778.2685
-  tps: 4603.53879
+  dps: 6160.08095
+  tps: 4911.38507
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5778.2685
-  tps: 4603.53879
+  dps: 6160.08095
+  tps: 4911.38507
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5778.2685
-  tps: 4603.53879
+  dps: 6160.08095
+  tps: 4911.38507
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5778.2685
-  tps: 4603.53879
+  dps: 6160.08095
+  tps: 4911.38507
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 5997.61557
-  tps: 4813.73687
+  dps: 6361.4927
+  tps: 5117.31133
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6045.21432
-  tps: 4855.69604
+  dps: 6412.17766
+  tps: 5162.04155
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 5939.34856
-  tps: 4732.40284
+  dps: 6340.59607
+  tps: 5055.79716
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5804.51833
-  tps: 4619.38528
+  dps: 6160.60819
+  tps: 4911.83964
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 5840.44389
-  tps: 4651.97912
+  dps: 6236.71052
+  tps: 4970.64061
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 5869.90907
-  tps: 4675.85426
+  dps: 6268.17768
+  tps: 4996.11669
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SoulPreserver-37111"
  value: {
-  dps: 5681.46193
-  tps: 4526.55607
+  dps: 6043.70611
+  tps: 4823.1189
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SouloftheDead-40382"
  value: {
-  dps: 5776.40731
-  tps: 4607.29351
+  dps: 6108.24956
+  tps: 4874.58762
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 5691.22219
-  tps: 4530.17253
+  dps: 6057.1386
+  tps: 4826.53585
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 5705.29063
-  tps: 4544.36604
+  dps: 6081.23105
+  tps: 4851.8242
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5778.2685
-  tps: 4603.53879
+  dps: 6160.08095
+  tps: 4911.38507
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5778.2685
-  tps: 4603.53879
+  dps: 6160.08095
+  tps: 4911.38507
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5778.2685
-  tps: 4603.53879
+  dps: 6160.08095
+  tps: 4911.38507
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 5694.33352
-  tps: 4534.72381
+  dps: 6031.43997
+  tps: 4808.98782
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 5640.61011
-  tps: 4490.15854
+  dps: 6033.58152
+  tps: 4807.68526
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TempestRegalia"
  value: {
-  dps: 4237.57159
-  tps: 3389.03574
+  dps: 4500.6622
+  tps: 3600.3356
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 5571.70715
-  tps: 4440.1785
+  dps: 5926.91647
+  tps: 4731.11587
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 4841.32015
-  tps: 3872.6816
+  dps: 5082.56654
+  tps: 4067.98952
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5778.2685
-  tps: 4603.53879
+  dps: 6160.08095
+  tps: 4911.38507
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5773.69542
-  tps: 4597.5881
+  dps: 6155.59586
+  tps: 4910.26942
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5773.69542
-  tps: 4597.5881
+  dps: 6155.59586
+  tps: 4910.26942
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 5814.67784
-  tps: 4632.16992
+  dps: 6198.94292
+  tps: 4941.9816
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 5807.39597
-  tps: 4626.44369
+  dps: 6191.17052
+  tps: 4935.8623
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 5717.08139
-  tps: 4555.27845
+  dps: 6127.45071
+  tps: 4896.90824
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 5807.39597
-  tps: 4626.44369
+  dps: 6191.17052
+  tps: 4935.8623
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 5814.67784
-  tps: 4632.16992
+  dps: 6198.94292
+  tps: 4941.9816
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-WingedTalisman-37844"
  value: {
-  dps: 5689.37426
-  tps: 4534.31219
+  dps: 6047.48439
+  tps: 4827.57021
  }
 }
 dps_results: {
  key: "TestFrostFire-Average-Default"
  value: {
-  dps: 6100.46258
-  tps: 4861.87612
+  dps: 6412.6051
+  tps: 5115.59318
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8898.63177
-  tps: 8903.5853
+  dps: 9232.12928
+  tps: 9183.60979
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5986.74008
-  tps: 4767.71219
+  dps: 6376.09828
+  tps: 5084.23177
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6883.40006
-  tps: 5390.50358
+  dps: 7375.01249
+  tps: 5793.70003
  }
 }
 dps_results: {
@@ -812,7 +812,7 @@ dps_results: {
 dps_results: {
  key: "TestFrostFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5986.74008
-  tps: 4767.71219
+  dps: 6376.09828
+  tps: 5084.23177
  }
 }

--- a/sim/mage/TestFrostFire.results
+++ b/sim/mage/TestFrostFire.results
@@ -46,773 +46,773 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostFire-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6006.01632
-  tps: 4790.02558
+  dps: 6045.8471
+  tps: 4822.50362
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6039.17596
-  tps: 4816.14307
+  dps: 6079.22784
+  tps: 4848.79513
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 5984.68974
-  tps: 4766.61114
+  dps: 6047.50807
+  tps: 4821.34004
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 5732.715
-  tps: 4574.76305
-  hps: 95.13126
+  dps: 5778.02458
+  tps: 4611.68083
+  hps: 94.68976
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 5732.715
-  tps: 4574.76305
-  hps: 95.13126
+  dps: 5778.02458
+  tps: 4611.68083
+  hps: 94.68976
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6021.43575
-  tps: 4797.27362
+  dps: 6086.89033
+  tps: 4851.02737
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4875.79753
-  tps: 3897.28201
+  dps: 4897.8637
+  tps: 3915.7493
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 6752.12839
-  tps: 5394.95157
+  dps: 6817.4668
+  tps: 5447.5327
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6022.38827
-  tps: 4701.69242
+  dps: 6085.68056
+  tps: 4755.77456
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6189.76046
-  tps: 4933.74001
+  dps: 6252.40356
+  tps: 4987.343
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
   hps: 64
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 5898.05824
-  tps: 4709.32149
+  dps: 5939.71659
+  tps: 4743.14247
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 5909.98023
-  tps: 4725.61134
+  dps: 5973.6726
+  tps: 4777.06654
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 5897.05596
-  tps: 4698.3996
+  dps: 5972.09119
+  tps: 4758.34203
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Death'sChoice-47464"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 5772.91796
-  tps: 4609.13923
+  dps: 5854.57904
+  tps: 4674.17559
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6025.87981
-  tps: 4802.5724
+  dps: 6081.4138
+  tps: 4850.49743
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6148.19224
-  tps: 4915.02463
+  dps: 6235.21645
+  tps: 4983.94835
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6155.17133
-  tps: 4919.86384
+  dps: 6206.29055
+  tps: 4961.40727
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 5984.68974
-  tps: 4766.61114
+  dps: 6047.50807
+  tps: 4821.34004
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6032.5651
-  tps: 4803.65247
+  dps: 6100.22098
+  tps: 4861.66876
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6017.59885
-  tps: 4796.01073
+  dps: 6076.1822
+  tps: 4846.36591
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6014.68326
-  tps: 4793.63435
+  dps: 6076.72316
+  tps: 4846.7532
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 5824.46838
-  tps: 4656.83497
+  dps: 5903.97054
+  tps: 4717.70226
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 5984.68974
-  tps: 4766.61114
+  dps: 6047.50807
+  tps: 4821.34004
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 5862.78269
-  tps: 4684.47218
+  dps: 5954.89115
+  tps: 4758.98636
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6071.96915
-  tps: 4846.94353
+  dps: 6125.10981
+  tps: 4888.33728
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 5799.54379
-  tps: 4622.31305
+  dps: 5839.9245
+  tps: 4655.2295
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 5903.52289
-  tps: 4709.29879
+  dps: 5942.67029
+  tps: 4741.23895
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 5995.94961
-  tps: 4787.22502
+  dps: 6055.22307
+  tps: 4834.8482
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6022.38827
-  tps: 4796.27673
+  dps: 6085.68056
+  tps: 4851.38974
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6014.84857
-  tps: 4790.34361
+  dps: 6078.04606
+  tps: 4845.3798
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FrostfireGarb"
  value: {
-  dps: 5442.31867
-  tps: 4330.53289
+  dps: 5512.77642
+  tps: 4387.42515
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 5889.87929
-  tps: 4693.95935
+  dps: 5919.13549
+  tps: 4718.61542
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 5986.67938
-  tps: 4767.56294
+  dps: 6022.58188
+  tps: 4796.7282
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6022.59614
-  tps: 4803.08432
+  dps: 6062.53747
+  tps: 4835.64938
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6060.27755
-  tps: 4832.76329
+  dps: 6100.47013
+  tps: 4865.52609
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 5925.85738
-  tps: 4738.35092
+  dps: 6019.40797
+  tps: 4810.86133
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Heartpierce-49982"
  value: {
-  dps: 6189.76046
-  tps: 4933.74001
+  dps: 6252.40356
+  tps: 4987.343
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 6189.76046
-  tps: 4933.74001
+  dps: 6252.40356
+  tps: 4987.343
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6025.08685
-  tps: 4806.713
+  dps: 6065.01271
+  tps: 4839.27289
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6017.59885
-  tps: 4796.01073
+  dps: 6076.1822
+  tps: 4846.36591
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6014.68326
-  tps: 4793.63435
+  dps: 6076.72316
+  tps: 4846.7532
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6012.18939
-  tps: 4789.55026
+  dps: 6095.07794
+  tps: 4857.5484
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 5984.68974
-  tps: 4766.61114
+  dps: 6047.50807
+  tps: 4821.34004
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 6083.07982
-  tps: 4841.96414
+  dps: 6179.62997
+  tps: 4918.80641
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-KirinTorGarb"
  value: {
-  dps: 6192.41809
-  tps: 4925.88678
+  dps: 6214.95227
+  tps: 4943.76374
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 5963.18235
-  tps: 4749.64285
+  dps: 6037.6416
+  tps: 4809.75738
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 5853.30718
-  tps: 4673.38485
+  dps: 5916.15464
+  tps: 4722.58046
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 5956.99214
-  tps: 4753.61716
+  dps: 6032.88698
+  tps: 4815.92389
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Nibelung-49992"
  value: {
-  dps: 6189.76046
-  tps: 4933.74001
+  dps: 6252.40356
+  tps: 4987.343
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Nibelung-50648"
  value: {
-  dps: 6189.76046
-  tps: 4933.74001
+  dps: 6252.40356
+  tps: 4987.343
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 5984.68974
-  tps: 4766.61114
+  dps: 6047.50807
+  tps: 4821.34004
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 5984.68974
-  tps: 4766.61114
+  dps: 6047.50807
+  tps: 4821.34004
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 5984.68974
-  tps: 4766.61114
+  dps: 6047.50807
+  tps: 4821.34004
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 5984.68974
-  tps: 4766.61114
+  dps: 6047.50807
+  tps: 4821.34004
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6137.96293
-  tps: 4929.63506
+  dps: 6206.90762
+  tps: 4989.86244
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6186.23182
-  tps: 4972.13966
+  dps: 6256.62843
+  tps: 5033.76166
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6155.22744
-  tps: 4903.0413
+  dps: 6221.96592
+  tps: 4960.90632
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 5983.55921
-  tps: 4763.64003
+  dps: 6050.88364
+  tps: 4820.93468
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6019.81805
-  tps: 4798.26046
+  dps: 6074.96923
+  tps: 4841.91716
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6050.21018
-  tps: 4822.88457
+  dps: 6105.63477
+  tps: 4866.7574
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SoulPreserver-37111"
  value: {
-  dps: 5849.26166
-  tps: 4666.56108
+  dps: 5888.04726
+  tps: 4698.21648
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SouloftheDead-40382"
  value: {
-  dps: 5923.15097
-  tps: 4725.90433
+  dps: 5986.13147
+  tps: 4775.50806
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 5837.28105
-  tps: 4650.25919
+  dps: 5874.76719
+  tps: 4681.44506
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 5867.15619
-  tps: 4681.56126
+  dps: 5979.09654
+  tps: 4771.20693
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 5984.68974
-  tps: 4766.61114
+  dps: 6047.50807
+  tps: 4821.34004
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 5984.68974
-  tps: 4766.61114
+  dps: 6047.50807
+  tps: 4821.34004
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 5984.68974
-  tps: 4766.61114
+  dps: 6047.50807
+  tps: 4821.34004
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 5824.33076
-  tps: 4642.60982
+  dps: 5894.83238
+  tps: 4700.21096
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 5843.67285
-  tps: 4655.30413
+  dps: 5895.08906
+  tps: 4696.33191
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TempestRegalia"
  value: {
-  dps: 4359.31939
-  tps: 3487.51234
+  dps: 4383.21106
+  tps: 3505.85913
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 5736.21743
-  tps: 4577.52418
+  dps: 5774.2493
+  tps: 4608.58633
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 4956.24794
-  tps: 3966.65262
+  dps: 4975.51002
+  tps: 3983.19696
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 5984.68974
-  tps: 4766.61114
+  dps: 6047.50807
+  tps: 4821.34004
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 5935.01048
-  tps: 4731.84954
+  dps: 6033.564
+  tps: 4809.30466
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 5935.01048
-  tps: 4731.84954
+  dps: 6033.564
+  tps: 4809.30466
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6022.38827
-  tps: 4796.27673
+  dps: 6085.68056
+  tps: 4851.38974
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6014.84857
-  tps: 4790.34361
+  dps: 6078.04606
+  tps: 4845.3798
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 5928.41105
-  tps: 4732.52068
+  dps: 6014.4949
+  tps: 4804.97446
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6014.84857
-  tps: 4790.34361
+  dps: 6078.04606
+  tps: 4845.3798
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6022.38827
-  tps: 4796.27673
+  dps: 6085.68056
+  tps: 4851.38974
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-WingedTalisman-37844"
  value: {
-  dps: 5858.56123
-  tps: 4675.39922
+  dps: 5894.57258
+  tps: 4704.84495
  }
 }
 dps_results: {
  key: "TestFrostFire-Average-Default"
  value: {
-  dps: 6220.74927
-  tps: 4960.59589
+  dps: 6278.85808
+  tps: 5007.65409
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8987.79706
-  tps: 9006.35515
+  dps: 9045.65395
+  tps: 9035.70502
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6189.76046
-  tps: 4933.74001
+  dps: 6252.40356
+  tps: 4987.343
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7214.29918
-  tps: 5664.42826
+  dps: 7261.81044
+  tps: 5701.9178
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4692.00525
-  tps: 5335.98137
+  dps: 4753.37511
+  tps: 5409.28803
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2544.08289
-  tps: 2030.1774
+  dps: 2562.20648
+  tps: 2043.63199
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P1FrostFire-FrostFireRotation-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3067.37484
-  tps: 2356.84879
+  dps: 3076.34919
+  tps: 2361.93694
  }
 }
 dps_results: {
  key: "TestFrostFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6189.76046
-  tps: 4933.74001
+  dps: 6252.40356
+  tps: 4987.343
  }
 }

--- a/sim/mage/frostfire_bolt.go
+++ b/sim/mage/frostfire_bolt.go
@@ -72,7 +72,7 @@ func (mage *Mage) registerFrostfireBoltSpell() {
 			//  2) Shadow Mastery / Improved Scorch / Winter's Chill
 			// Luckily, each of those effects has its own dedicated pseudostat, so we
 			// can implement this by modifying the crit of this spell before the calc.
-			doubleDipBonus := target.PseudoStats.BonusSpellCritRatingTaken
+			doubleDipBonus := target.PseudoStats.BonusCritRatingTaken + target.PseudoStats.BonusSpellCritRatingTaken
 			spell.BonusCritRating += doubleDipBonus
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
 			spell.BonusCritRating -= doubleDipBonus

--- a/sim/paladin/holy/TestHoly.results
+++ b/sim/paladin/holy/TestHoly.results
@@ -254,8 +254,8 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 39.47301
-  tps: 39.47301
+  dps: 38.5263
+  tps: 38.5263
  }
 }
 dps_results: {

--- a/sim/paladin/holy/TestHoly.results
+++ b/sim/paladin/holy/TestHoly.results
@@ -254,8 +254,8 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 38.5263
-  tps: 38.5263
+  dps: 38.66144
+  tps: 38.66144
  }
 }
 dps_results: {

--- a/sim/paladin/holy/TestHoly.results
+++ b/sim/paladin/holy/TestHoly.results
@@ -254,8 +254,8 @@ dps_results: {
 dps_results: {
  key: "TestHoly-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 38.5263
-  tps: 38.5263
+  dps: 39.47301
+  tps: 39.47301
  }
 }
 dps_results: {

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -88,8 +88,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 3196.58801
-  tps: 7608.65921
+  dps: 3197.68771
+  tps: 7610.23177
  }
 }
 dps_results: {
@@ -189,8 +189,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 3167.4671
-  tps: 7530.7703
+  dps: 3167.94289
+  tps: 7531.45069
  }
 }
 dps_results: {
@@ -308,8 +308,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 3167.55882
-  tps: 7539.67011
+  dps: 3168.19045
+  tps: 7540.57333
  }
 }
 dps_results: {
@@ -399,8 +399,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 3149.776
-  tps: 7512.0391
+  dps: 3149.94487
+  tps: 7512.28058
  }
 }
 dps_results: {
@@ -631,15 +631,15 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 3211.68118
-  tps: 7587.69039
+  dps: 3213.46747
+  tps: 7590.24478
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 3228.47521
-  tps: 7613.78162
+  dps: 3230.48456
+  tps: 7616.65499
  }
 }
 dps_results: {
@@ -743,8 +743,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-StormshroudArmor"
  value: {
-  dps: 2517.00739
-  tps: 6029.32051
+  dps: 2517.02504
+  tps: 6029.34574
  }
 }
 dps_results: {

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -88,8 +88,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 3197.68771
-  tps: 7610.23177
+  dps: 3196.58801
+  tps: 7608.65921
  }
 }
 dps_results: {
@@ -189,8 +189,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 3167.94289
-  tps: 7531.45069
+  dps: 3167.4671
+  tps: 7530.7703
  }
 }
 dps_results: {
@@ -308,8 +308,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 3168.19045
-  tps: 7540.57333
+  dps: 3167.55882
+  tps: 7539.67011
  }
 }
 dps_results: {
@@ -399,8 +399,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 3149.94487
-  tps: 7512.28058
+  dps: 3149.776
+  tps: 7512.0391
  }
 }
 dps_results: {
@@ -631,15 +631,15 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 3213.46747
-  tps: 7590.24478
+  dps: 3211.68118
+  tps: 7587.69039
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 3230.48456
-  tps: 7616.65499
+  dps: 3228.47521
+  tps: 7613.78162
  }
 }
 dps_results: {
@@ -743,8 +743,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-StormshroudArmor"
  value: {
-  dps: 2517.02504
-  tps: 6029.34574
+  dps: 2517.00739
+  tps: 6029.32051
  }
 }
 dps_results: {

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -88,8 +88,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 3196.58801
-  tps: 7608.65921
+  dps: 3196.96614
+  tps: 7609.19993
  }
 }
 dps_results: {
@@ -189,8 +189,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 3167.4671
-  tps: 7530.7703
+  dps: 3167.72092
+  tps: 7531.13327
  }
 }
 dps_results: {
@@ -308,8 +308,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 3167.55882
-  tps: 7539.67011
+  dps: 3167.93998
+  tps: 7540.21516
  }
 }
 dps_results: {
@@ -399,8 +399,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 3149.776
-  tps: 7512.0391
+  dps: 3149.94487
+  tps: 7512.28058
  }
 }
 dps_results: {
@@ -631,15 +631,15 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 3211.68118
-  tps: 7587.69039
+  dps: 3212.0549
+  tps: 7588.22482
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 3228.47521
-  tps: 7613.78162
+  dps: 3228.89564
+  tps: 7614.38283
  }
 }
 dps_results: {
@@ -743,8 +743,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-StormshroudArmor"
  value: {
-  dps: 2517.00739
-  tps: 6029.32051
+  dps: 2517.01233
+  tps: 6029.32757
  }
 }
 dps_results: {

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -46,64 +46,64 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AegisBattlegear"
  value: {
-  dps: 6210.379
-  tps: 6307.23551
+  dps: 6211.00334
+  tps: 6307.85985
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AegisPlate"
  value: {
-  dps: 5581.08286
-  tps: 5676.69435
+  dps: 5582.57326
+  tps: 5678.18475
   dtps: 8.90286
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6417.92617
-  tps: 6517.2386
+  dps: 6418.33628
+  tps: 6517.64871
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6424.18993
-  tps: 6523.50236
+  dps: 6424.6004
+  tps: 6523.91283
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AshtongueTalismanofZeal-32489"
  value: {
-  dps: 6393.35496
-  tps: 6492.66739
+  dps: 6393.71917
+  tps: 6493.0316
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6484.25123
-  tps: 6583.56366
+  dps: 6484.63164
+  tps: 6583.94407
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6562.52439
-  tps: 6661.51564
+  dps: 6563.70431
+  tps: 6662.69555
   dtps: 10.03858
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6367.0851
-  tps: 6466.39753
+  dps: 6367.48675
+  tps: 6466.79918
   dtps: 9.48456
   hps: 96.07729
  }
@@ -111,8 +111,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6367.0851
-  tps: 6466.39753
+  dps: 6367.48675
+  tps: 6466.79918
   dtps: 9.48456
   hps: 96.07729
  }
@@ -120,96 +120,96 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6492.23864
-  tps: 6591.15748
+  dps: 6492.81371
+  tps: 6591.73255
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6290.43351
-  tps: 6387.23964
+  dps: 6291.44635
+  tps: 6388.25248
   dtps: 9.56591
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 5311.66673
-  tps: 5408.20852
+  dps: 5313.2358
+  tps: 5409.7776
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5130.49241
-  tps: 5226.5957
+  dps: 5132.10599
+  tps: 5228.20928
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5060.8743
-  tps: 5156.55225
+  dps: 5062.14017
+  tps: 5157.81812
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6491.21999
-  tps: 6460.70802
+  dps: 6491.60077
+  tps: 6461.08119
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6965.24872
-  tps: 7064.56115
+  dps: 6965.6733
+  tps: 7064.98573
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6998.10794
-  tps: 7097.42037
+  dps: 6998.53347
+  tps: 7097.8459
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6619.02381
-  tps: 6718.33624
+  dps: 6619.65064
+  tps: 6718.96307
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6366.96193
-  tps: 6466.27436
+  dps: 6367.36914
+  tps: 6466.68157
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6366.96193
-  tps: 6466.27436
+  dps: 6367.36914
+  tps: 6466.68157
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6366.96193
-  tps: 6466.27436
+  dps: 6367.36914
+  tps: 6466.68157
   dtps: 9.92959
   hps: 64
  }
@@ -217,304 +217,304 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6456.71469
-  tps: 6556.02712
+  dps: 6458.3576
+  tps: 6557.67003
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6490.2354
-  tps: 6589.15885
+  dps: 6490.95779
+  tps: 6589.88124
   dtps: 9.77043
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6366.571
-  tps: 6463.15846
+  dps: 6366.98241
+  tps: 6463.56987
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6970.73274
-  tps: 7070.04517
+  dps: 6971.16085
+  tps: 7070.47328
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6428.14392
-  tps: 6527.45635
+  dps: 6429.22294
+  tps: 6528.53538
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6632.93693
-  tps: 6731.87189
+  dps: 6633.81386
+  tps: 6732.74882
   dtps: 10.29273
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6734.03114
-  tps: 6833.19807
+  dps: 6734.65702
+  tps: 6833.82395
   dtps: 10.29273
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6366.96193
-  tps: 6466.27436
+  dps: 6367.36914
+  tps: 6466.68157
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6499.07111
-  tps: 6598.38354
+  dps: 6499.66734
+  tps: 6598.97977
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6524.3693
-  tps: 6623.69174
+  dps: 6525.18881
+  tps: 6624.51125
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6493.79259
-  tps: 6593.32937
+  dps: 6494.42012
+  tps: 6593.95689
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6484.25123
-  tps: 6583.56366
+  dps: 6484.63164
+  tps: 6583.94407
   dtps: 9.731
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6489.6242
-  tps: 6588.80485
+  dps: 6490.00498
+  tps: 6589.18563
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6496.9654
-  tps: 6596.27784
+  dps: 6497.54047
+  tps: 6596.8529
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6495.19521
-  tps: 6594.50764
+  dps: 6495.57562
+  tps: 6594.88805
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6370.23954
-  tps: 6469.39153
+  dps: 6370.61252
+  tps: 6469.76451
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6366.96193
-  tps: 6466.27436
+  dps: 6367.36914
+  tps: 6466.68157
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6484.25123
-  tps: 6583.56366
+  dps: 6484.63164
+  tps: 6583.94407
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6510.89088
-  tps: 6609.62626
+  dps: 6512.25045
+  tps: 6610.98583
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6482.97416
-  tps: 6582.28659
+  dps: 6484.62585
+  tps: 6583.93828
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6374.40001
-  tps: 6472.21052
+  dps: 6374.60315
+  tps: 6472.41366
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6398.56545
-  tps: 6497.87789
+  dps: 6398.97446
+  tps: 6498.28689
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6441.10933
-  tps: 6540.42176
+  dps: 6442.75199
+  tps: 6542.06443
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6491.21999
-  tps: 6590.53242
+  dps: 6491.60077
+  tps: 6590.9132
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6489.82624
-  tps: 6589.13867
+  dps: 6490.20694
+  tps: 6589.51938
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuriousGladiator'sLibramofFortitude-42853"
  value: {
-  dps: 6637.50564
-  tps: 6736.81807
+  dps: 6637.92084
+  tps: 6737.23327
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6384.61435
-  tps: 6483.92678
+  dps: 6385.02256
+  tps: 6484.33499
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Gladiator'sVindication"
  value: {
-  dps: 6284.2714
-  tps: 6380.68578
+  dps: 6285.54841
+  tps: 6381.96279
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6421.05805
-  tps: 6520.37048
+  dps: 6421.46834
+  tps: 6520.78077
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6428.17596
-  tps: 6527.48839
+  dps: 6428.58666
+  tps: 6527.89909
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6465.81905
-  tps: 6564.77387
+  dps: 6466.82493
+  tps: 6565.77975
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HatefulGladiator'sLibramofFortitude-42851"
  value: {
-  dps: 6605.33503
-  tps: 6704.64746
+  dps: 6605.74935
+  tps: 6705.06178
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6384.85464
-  tps: 6484.16707
+  dps: 6385.26267
+  tps: 6484.5751
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6496.9654
-  tps: 6596.27784
+  dps: 6497.54047
+  tps: 6596.8529
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6495.19521
-  tps: 6594.50764
+  dps: 6495.57562
+  tps: 6594.88805
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6529.72444
-  tps: 6629.03687
+  dps: 6530.13508
+  tps: 6629.44751
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6471.33369
-  tps: 6570.45484
+  dps: 6471.52365
+  tps: 6570.6448
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6517.65483
-  tps: 6616.96726
+  dps: 6518.03614
+  tps: 6617.34857
   dtps: 9.92959
   hps: 11.51045
  }
@@ -522,552 +522,552 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-LastWord-50179"
  value: {
-  dps: 6823.17346
-  tps: 6922.48589
+  dps: 6823.59398
+  tps: 6922.90641
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LastWord-50708"
  value: {
-  dps: 6853.78539
-  tps: 6953.09782
+  dps: 6854.2068
+  tps: 6953.51923
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6366.96193
-  tps: 6466.27436
+  dps: 6367.36914
+  tps: 6466.68157
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofFuriousBlows-37574"
  value: {
-  dps: 6542.74426
-  tps: 6642.05669
+  dps: 6543.77037
+  tps: 6643.0828
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofObstruction-40707"
  value: {
-  dps: 6521.51078
-  tps: 6620.82321
+  dps: 6521.92263
+  tps: 6621.23506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofReciprocation-40706"
  value: {
-  dps: 6521.51078
-  tps: 6620.82321
+  dps: 6521.92263
+  tps: 6621.23506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofThreeTruths-50455"
  value: {
-  dps: 6953.41311
-  tps: 7052.72554
+  dps: 6953.8379
+  tps: 7053.15033
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofValiance-47661"
  value: {
-  dps: 6919.92854
-  tps: 7019.24097
+  dps: 6920.35215
+  tps: 7019.66459
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramoftheSacredShield-45145"
  value: {
-  dps: 6521.51078
-  tps: 6620.82321
+  dps: 6521.92263
+  tps: 6621.23506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerBattlegear"
  value: {
-  dps: 4859.6837
-  tps: 4953.84935
+  dps: 4860.55694
+  tps: 4954.72259
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornBattlegear"
  value: {
-  dps: 6839.69028
-  tps: 6941.48339
+  dps: 6840.9515
+  tps: 6942.74462
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornPlate"
  value: {
-  dps: 5705.12527
-  tps: 5800.87129
+  dps: 5706.46883
+  tps: 5802.21485
   dtps: 8.90286
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6366.96193
-  tps: 6466.27436
+  dps: 6367.36914
+  tps: 6466.68157
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6454.9888
-  tps: 6553.98145
+  dps: 6456.44013
+  tps: 6555.43278
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6495.54948
-  tps: 6594.86191
+  dps: 6496.77482
+  tps: 6596.08725
   dtps: 10.29273
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6366.96193
-  tps: 6466.27436
+  dps: 6367.36914
+  tps: 6466.68157
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6511.29689
-  tps: 6610.60932
+  dps: 6511.67802
+  tps: 6610.99046
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6517.66058
-  tps: 6616.97301
+  dps: 6518.04188
+  tps: 6617.35431
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6366.96193
-  tps: 6466.27436
+  dps: 6367.36914
+  tps: 6466.68157
   dtps: 8.19524
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6366.96193
-  tps: 6466.27436
+  dps: 6367.36914
+  tps: 6466.68157
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6366.96193
-  tps: 6466.27436
+  dps: 6367.36914
+  tps: 6466.68157
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6484.25123
-  tps: 6583.56366
+  dps: 6484.63164
+  tps: 6583.94407
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6484.25123
-  tps: 6583.56366
+  dps: 6484.63164
+  tps: 6583.94407
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6366.96193
-  tps: 6466.27436
+  dps: 6367.36914
+  tps: 6466.68157
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionBattlegear"
  value: {
-  dps: 5805.59312
-  tps: 5904.65962
+  dps: 5806.11305
+  tps: 5905.17956
   dtps: 9.56591
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionPlate"
  value: {
-  dps: 5318.96962
-  tps: 5414.5429
+  dps: 5319.91576
+  tps: 5415.48904
   dtps: 8.90286
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6634.78733
-  tps: 6733.63586
+  dps: 6637.62095
+  tps: 6736.46948
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6668.90382
-  tps: 6767.75235
+  dps: 6672.0107
+  tps: 6770.85924
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6618.17316
-  tps: 6717.48559
+  dps: 6618.5878
+  tps: 6717.90024
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessGladiator'sLibramofFortitude-42854"
  value: {
-  dps: 6660.06019
-  tps: 6759.37263
+  dps: 6660.47605
+  tps: 6759.78848
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6483.02408
-  tps: 6580.79533
+  dps: 6483.21405
+  tps: 6580.98529
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6366.96193
-  tps: 6466.27436
+  dps: 6367.36914
+  tps: 6466.68157
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SavageGladiator'sLibramofFortitude-42611"
  value: {
-  dps: 6595.84549
-  tps: 6695.15793
+  dps: 6596.25953
+  tps: 6695.57196
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6366.96193
-  tps: 6466.27436
+  dps: 6367.36914
+  tps: 6466.68157
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7867.40356
-  tps: 7966.35286
+  dps: 7868.80025
+  tps: 7967.74955
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6366.96193
-  tps: 6466.27436
+  dps: 6367.36914
+  tps: 6466.68157
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6366.96193
-  tps: 6466.27436
+  dps: 6367.36914
+  tps: 6466.68157
   dtps: 6.55074
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6405.74625
-  tps: 6504.57916
+  dps: 6406.33845
+  tps: 6505.17136
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6411.43065
-  tps: 6510.26356
+  dps: 6412.02331
+  tps: 6510.85622
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6388.31566
-  tps: 6487.62809
+  dps: 6388.72409
+  tps: 6488.03652
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6442.31541
-  tps: 6541.48393
+  dps: 6448.42566
+  tps: 6547.54803
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SparkofLife-37657"
  value: {
-  dps: 6398.19102
-  tps: 6492.5018
+  dps: 6398.58239
+  tps: 6492.89318
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6510.91808
-  tps: 6609.93109
+  dps: 6511.12123
+  tps: 6610.13424
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StormshroudArmor"
  value: {
-  dps: 5025.12492
-  tps: 5120.34575
+  dps: 5026.51344
+  tps: 5121.73427
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6517.66058
-  tps: 6616.97301
+  dps: 6518.04188
+  tps: 6617.35431
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6511.29689
-  tps: 6610.60932
+  dps: 6511.67802
+  tps: 6610.99046
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6500.16044
-  tps: 6599.47287
+  dps: 6500.54128
+  tps: 6599.85371
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6366.96193
-  tps: 6466.27436
+  dps: 6367.36914
+  tps: 6466.68157
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6366.44283
-  tps: 6463.30483
+  dps: 6366.85424
+  tps: 6463.71624
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6366.96193
-  tps: 6466.27436
+  dps: 6367.36914
+  tps: 6466.68157
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5365.08886
-  tps: 5463.82224
+  dps: 5365.70715
+  tps: 5464.44053
   dtps: 9.56591
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6515.30469
-  tps: 6613.94318
+  dps: 6515.49465
+  tps: 6614.13315
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6981.4101
-  tps: 7080.24613
+  dps: 6981.78503
+  tps: 7080.62106
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7050.11966
-  tps: 7148.73829
+  dps: 7050.32281
+  tps: 7148.94143
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6491.21999
-  tps: 6590.53242
+  dps: 6491.60077
+  tps: 6590.9132
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6489.82624
-  tps: 6589.13867
+  dps: 6490.20694
+  tps: 6589.51938
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6407.23023
-  tps: 6506.13932
+  dps: 6407.60126
+  tps: 6506.51035
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeoftheLightbringer-32368"
  value: {
-  dps: 6521.51078
-  tps: 6620.82321
+  dps: 6521.92263
+  tps: 6621.23506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6489.82624
-  tps: 6589.13867
+  dps: 6490.20694
+  tps: 6589.51938
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6491.21999
-  tps: 6590.53242
+  dps: 6491.60077
+  tps: 6590.9132
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sBattlegear"
  value: {
-  dps: 6235.72207
-  tps: 6331.93467
+  dps: 6236.10423
+  tps: 6332.31683
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sPlate"
  value: {
-  dps: 5651.70917
-  tps: 5747.44983
+  dps: 5653.06749
+  tps: 5748.80816
   dtps: 8.90286
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5168.79252
-  tps: 5265.56569
+  dps: 5170.40428
+  tps: 5267.17745
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5174.316
-  tps: 5271.81952
+  dps: 5174.54495
+  tps: 5272.04846
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6388.64367
-  tps: 6487.9561
+  dps: 6389.05088
+  tps: 6488.36331
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathfulGladiator'sLibramofFortitude-51478"
  value: {
-  dps: 6685.83683
-  tps: 6785.14926
+  dps: 6686.25343
+  tps: 6785.56586
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 6585.06522
-  tps: 6683.40481
+  dps: 6586.43458
+  tps: 6684.77417
   dtps: 13.13693
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21264.49075
-  tps: 23318.06238
+  dps: 21265.35826
+  tps: 23318.92989
   dtps: 8.81235
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5334.2953
-  tps: 5431.91723
+  dps: 5334.51615
+  tps: 5432.13808
   dtps: 9.85058
  }
 }
@@ -1103,16 +1103,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19430.55504
-  tps: 21482.60765
+  dps: 19431.61139
+  tps: 21483.664
   dtps: 8.61128
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5785.60254
-  tps: 5882.66534
+  dps: 5785.77597
+  tps: 5882.83877
   dtps: 9.85058
  }
 }
@@ -1148,16 +1148,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21662.62049
-  tps: 23700.81702
+  dps: 21663.22502
+  tps: 23701.42155
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6618.17316
-  tps: 6717.48559
+  dps: 6618.5878
+  tps: 6717.90024
   dtps: 9.92959
  }
 }
@@ -1193,16 +1193,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21503.66416
-  tps: 23556.60028
+  dps: 21504.45473
+  tps: 23557.39085
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6618.17316
-  tps: 6717.48559
+  dps: 6618.5878
+  tps: 6717.90024
   dtps: 9.92959
  }
 }
@@ -1238,16 +1238,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21492.88988
-  tps: 23526.99922
+  dps: 21493.37878
+  tps: 23527.48812
   dtps: 8.81235
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5325.03373
-  tps: 5421.48032
+  dps: 5325.23447
+  tps: 5421.68106
   dtps: 9.85058
  }
 }
@@ -1283,16 +1283,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19659.20823
-  tps: 21693.69686
+  dps: 19659.67035
+  tps: 21694.15898
   dtps: 8.61128
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5779.84605
-  tps: 5876.44888
+  dps: 5780.06909
+  tps: 5876.67192
   dtps: 9.85058
  }
 }
@@ -1328,16 +1328,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21842.79998
-  tps: 23860.9735
+  dps: 21843.41685
+  tps: 23861.59037
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6610.9127
-  tps: 6709.34781
+  dps: 6611.51224
+  tps: 6709.94736
   dtps: 9.92959
  }
 }
@@ -1373,16 +1373,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21613.04364
-  tps: 23647.85812
+  dps: 21614.06153
+  tps: 23648.876
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6610.9127
-  tps: 6709.34781
+  dps: 6611.51224
+  tps: 6709.94736
   dtps: 9.92959
  }
 }
@@ -1418,16 +1418,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21390.7291
-  tps: 23422.82663
+  dps: 21391.58803
+  tps: 23423.68556
   dtps: 8.81235
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5324.13367
-  tps: 5420.67164
+  dps: 5324.50443
+  tps: 5421.0424
   dtps: 9.85058
  }
 }
@@ -1463,16 +1463,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19536.11565
-  tps: 21569.14424
+  dps: 19536.72217
+  tps: 21569.75076
   dtps: 8.61128
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5783.64114
-  tps: 5880.1217
+  dps: 5784.0767
+  tps: 5880.55725
   dtps: 9.85058
  }
 }
@@ -1508,16 +1508,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21733.9785
-  tps: 23749.08854
+  dps: 21734.60475
+  tps: 23749.71478
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6614.63159
-  tps: 6713.17719
+  dps: 6615.01206
+  tps: 6713.55766
   dtps: 9.92959
  }
 }
@@ -1553,16 +1553,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21542.99325
-  tps: 23581.57078
+  dps: 21543.55808
+  tps: 23582.13561
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6614.63159
-  tps: 6713.17719
+  dps: 6615.01206
+  tps: 6713.55766
   dtps: 9.92959
  }
 }
@@ -1598,16 +1598,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21363.56553
-  tps: 23395.65477
+  dps: 21364.42385
+  tps: 23396.51309
   dtps: 8.81235
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5315.87813
-  tps: 5412.37793
+  dps: 5316.07884
+  tps: 5412.57864
   dtps: 9.85058
  }
 }
@@ -1643,16 +1643,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19507.24824
-  tps: 21540.31864
+  dps: 19507.85432
+  tps: 21540.92472
   dtps: 8.61128
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5766.78129
-  tps: 5863.3968
+  dps: 5767.00429
+  tps: 5863.6198
   dtps: 9.85058
  }
 }
@@ -1688,16 +1688,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21710.76323
-  tps: 23729.06456
+  dps: 21711.38902
+  tps: 23729.69035
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6604.52899
-  tps: 6702.94946
+  dps: 6604.90918
+  tps: 6703.32965
   dtps: 9.92959
  }
 }
@@ -1733,16 +1733,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21484.87173
-  tps: 23520.53073
+  dps: 21485.43614
+  tps: 23521.09514
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6604.52899
-  tps: 6702.94946
+  dps: 6604.90918
+  tps: 6703.32965
   dtps: 9.92959
  }
 }
@@ -1778,8 +1778,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6250.11693
-  tps: 6348.93632
+  dps: 6250.76169
+  tps: 6349.58108
   dtps: 9.92959
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -46,64 +46,64 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AegisBattlegear"
  value: {
-  dps: 6211.00334
-  tps: 6307.85985
+  dps: 6210.379
+  tps: 6307.23551
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AegisPlate"
  value: {
-  dps: 5582.57326
-  tps: 5678.18475
+  dps: 5581.08286
+  tps: 5676.69435
   dtps: 8.90286
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6418.33628
-  tps: 6517.64871
+  dps: 6417.92617
+  tps: 6517.2386
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6424.6004
-  tps: 6523.91283
+  dps: 6424.18993
+  tps: 6523.50236
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AshtongueTalismanofZeal-32489"
  value: {
-  dps: 6393.71917
-  tps: 6493.0316
+  dps: 6393.35496
+  tps: 6492.66739
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6484.63164
-  tps: 6583.94407
+  dps: 6484.25123
+  tps: 6583.56366
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6563.70431
-  tps: 6662.69555
+  dps: 6562.52439
+  tps: 6661.51564
   dtps: 10.03858
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6367.48675
-  tps: 6466.79918
+  dps: 6367.0851
+  tps: 6466.39753
   dtps: 9.48456
   hps: 96.07729
  }
@@ -111,8 +111,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6367.48675
-  tps: 6466.79918
+  dps: 6367.0851
+  tps: 6466.39753
   dtps: 9.48456
   hps: 96.07729
  }
@@ -120,96 +120,96 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6492.81371
-  tps: 6591.73255
+  dps: 6492.23864
+  tps: 6591.15748
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6291.44635
-  tps: 6388.25248
+  dps: 6290.43351
+  tps: 6387.23964
   dtps: 9.56591
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 5313.2358
-  tps: 5409.7776
+  dps: 5311.66673
+  tps: 5408.20852
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5132.10599
-  tps: 5228.20928
+  dps: 5130.49241
+  tps: 5226.5957
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5062.14017
-  tps: 5157.81812
+  dps: 5060.8743
+  tps: 5156.55225
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6491.60077
-  tps: 6461.08119
+  dps: 6491.21999
+  tps: 6460.70802
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6965.6733
-  tps: 7064.98573
+  dps: 6965.24872
+  tps: 7064.56115
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6998.53347
-  tps: 7097.8459
+  dps: 6998.10794
+  tps: 7097.42037
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6619.65064
-  tps: 6718.96307
+  dps: 6619.02381
+  tps: 6718.33624
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6367.36914
-  tps: 6466.68157
+  dps: 6366.96193
+  tps: 6466.27436
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6367.36914
-  tps: 6466.68157
+  dps: 6366.96193
+  tps: 6466.27436
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6367.36914
-  tps: 6466.68157
+  dps: 6366.96193
+  tps: 6466.27436
   dtps: 9.92959
   hps: 64
  }
@@ -217,304 +217,304 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6458.3576
-  tps: 6557.67003
+  dps: 6456.71469
+  tps: 6556.02712
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6490.95779
-  tps: 6589.88124
+  dps: 6490.2354
+  tps: 6589.15885
   dtps: 9.77043
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6366.98241
-  tps: 6463.56987
+  dps: 6366.571
+  tps: 6463.15846
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6971.16085
-  tps: 7070.47328
+  dps: 6970.73274
+  tps: 7070.04517
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6429.22294
-  tps: 6528.53538
+  dps: 6428.14392
+  tps: 6527.45635
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6633.81386
-  tps: 6732.74882
+  dps: 6632.93693
+  tps: 6731.87189
   dtps: 10.29273
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6734.65702
-  tps: 6833.82395
+  dps: 6734.03114
+  tps: 6833.19807
   dtps: 10.29273
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6367.36914
-  tps: 6466.68157
+  dps: 6366.96193
+  tps: 6466.27436
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6499.66734
-  tps: 6598.97977
+  dps: 6499.07111
+  tps: 6598.38354
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6525.18881
-  tps: 6624.51125
+  dps: 6524.3693
+  tps: 6623.69174
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6494.42012
-  tps: 6593.95689
+  dps: 6493.79259
+  tps: 6593.32937
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6484.63164
-  tps: 6583.94407
+  dps: 6484.25123
+  tps: 6583.56366
   dtps: 9.731
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6490.00498
-  tps: 6589.18563
+  dps: 6489.6242
+  tps: 6588.80485
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6497.54047
-  tps: 6596.8529
+  dps: 6496.9654
+  tps: 6596.27784
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6495.57562
-  tps: 6594.88805
+  dps: 6495.19521
+  tps: 6594.50764
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6370.61252
-  tps: 6469.76451
+  dps: 6370.23954
+  tps: 6469.39153
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6367.36914
-  tps: 6466.68157
+  dps: 6366.96193
+  tps: 6466.27436
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6484.63164
-  tps: 6583.94407
+  dps: 6484.25123
+  tps: 6583.56366
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6512.25045
-  tps: 6610.98583
+  dps: 6510.89088
+  tps: 6609.62626
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6484.62585
-  tps: 6583.93828
+  dps: 6482.97416
+  tps: 6582.28659
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6374.60315
-  tps: 6472.41366
+  dps: 6374.40001
+  tps: 6472.21052
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6398.97446
-  tps: 6498.28689
+  dps: 6398.56545
+  tps: 6497.87789
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6442.75199
-  tps: 6542.06443
+  dps: 6441.10933
+  tps: 6540.42176
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6491.60077
-  tps: 6590.9132
+  dps: 6491.21999
+  tps: 6590.53242
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6490.20694
-  tps: 6589.51938
+  dps: 6489.82624
+  tps: 6589.13867
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuriousGladiator'sLibramofFortitude-42853"
  value: {
-  dps: 6637.92084
-  tps: 6737.23327
+  dps: 6637.50564
+  tps: 6736.81807
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6385.02256
-  tps: 6484.33499
+  dps: 6384.61435
+  tps: 6483.92678
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Gladiator'sVindication"
  value: {
-  dps: 6285.54841
-  tps: 6381.96279
+  dps: 6284.2714
+  tps: 6380.68578
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6421.46834
-  tps: 6520.78077
+  dps: 6421.05805
+  tps: 6520.37048
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6428.58666
-  tps: 6527.89909
+  dps: 6428.17596
+  tps: 6527.48839
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6466.82493
-  tps: 6565.77975
+  dps: 6465.81905
+  tps: 6564.77387
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HatefulGladiator'sLibramofFortitude-42851"
  value: {
-  dps: 6605.74935
-  tps: 6705.06178
+  dps: 6605.33503
+  tps: 6704.64746
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6385.26267
-  tps: 6484.5751
+  dps: 6384.85464
+  tps: 6484.16707
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6497.54047
-  tps: 6596.8529
+  dps: 6496.9654
+  tps: 6596.27784
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6495.57562
-  tps: 6594.88805
+  dps: 6495.19521
+  tps: 6594.50764
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6530.13508
-  tps: 6629.44751
+  dps: 6529.72444
+  tps: 6629.03687
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6471.52365
-  tps: 6570.6448
+  dps: 6471.33369
+  tps: 6570.45484
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6518.03614
-  tps: 6617.34857
+  dps: 6517.65483
+  tps: 6616.96726
   dtps: 9.92959
   hps: 11.51045
  }
@@ -522,552 +522,552 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-LastWord-50179"
  value: {
-  dps: 6823.59398
-  tps: 6922.90641
+  dps: 6823.17346
+  tps: 6922.48589
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LastWord-50708"
  value: {
-  dps: 6854.2068
-  tps: 6953.51923
+  dps: 6853.78539
+  tps: 6953.09782
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6367.36914
-  tps: 6466.68157
+  dps: 6366.96193
+  tps: 6466.27436
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofFuriousBlows-37574"
  value: {
-  dps: 6543.77037
-  tps: 6643.0828
+  dps: 6542.74426
+  tps: 6642.05669
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofObstruction-40707"
  value: {
-  dps: 6521.92263
-  tps: 6621.23506
+  dps: 6521.51078
+  tps: 6620.82321
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofReciprocation-40706"
  value: {
-  dps: 6521.92263
-  tps: 6621.23506
+  dps: 6521.51078
+  tps: 6620.82321
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofThreeTruths-50455"
  value: {
-  dps: 6953.8379
-  tps: 7053.15033
+  dps: 6953.41311
+  tps: 7052.72554
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofValiance-47661"
  value: {
-  dps: 6920.35215
-  tps: 7019.66459
+  dps: 6919.92854
+  tps: 7019.24097
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramoftheSacredShield-45145"
  value: {
-  dps: 6521.92263
-  tps: 6621.23506
+  dps: 6521.51078
+  tps: 6620.82321
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerBattlegear"
  value: {
-  dps: 4860.55694
-  tps: 4954.72259
+  dps: 4859.6837
+  tps: 4953.84935
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornBattlegear"
  value: {
-  dps: 6840.9515
-  tps: 6942.74462
+  dps: 6839.69028
+  tps: 6941.48339
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornPlate"
  value: {
-  dps: 5706.46883
-  tps: 5802.21485
+  dps: 5705.12527
+  tps: 5800.87129
   dtps: 8.90286
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6367.36914
-  tps: 6466.68157
+  dps: 6366.96193
+  tps: 6466.27436
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6456.44013
-  tps: 6555.43278
+  dps: 6454.9888
+  tps: 6553.98145
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6496.77482
-  tps: 6596.08725
+  dps: 6495.54948
+  tps: 6594.86191
   dtps: 10.29273
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6367.36914
-  tps: 6466.68157
+  dps: 6366.96193
+  tps: 6466.27436
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6511.67802
-  tps: 6610.99046
+  dps: 6511.29689
+  tps: 6610.60932
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6518.04188
-  tps: 6617.35431
+  dps: 6517.66058
+  tps: 6616.97301
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6367.36914
-  tps: 6466.68157
+  dps: 6366.96193
+  tps: 6466.27436
   dtps: 8.19524
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6367.36914
-  tps: 6466.68157
+  dps: 6366.96193
+  tps: 6466.27436
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6367.36914
-  tps: 6466.68157
+  dps: 6366.96193
+  tps: 6466.27436
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6484.63164
-  tps: 6583.94407
+  dps: 6484.25123
+  tps: 6583.56366
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6484.63164
-  tps: 6583.94407
+  dps: 6484.25123
+  tps: 6583.56366
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6367.36914
-  tps: 6466.68157
+  dps: 6366.96193
+  tps: 6466.27436
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionBattlegear"
  value: {
-  dps: 5806.11305
-  tps: 5905.17956
+  dps: 5805.59312
+  tps: 5904.65962
   dtps: 9.56591
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionPlate"
  value: {
-  dps: 5319.91576
-  tps: 5415.48904
+  dps: 5318.96962
+  tps: 5414.5429
   dtps: 8.90286
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6637.62095
-  tps: 6736.46948
+  dps: 6634.78733
+  tps: 6733.63586
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6672.0107
-  tps: 6770.85924
+  dps: 6668.90382
+  tps: 6767.75235
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6618.5878
-  tps: 6717.90024
+  dps: 6618.17316
+  tps: 6717.48559
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessGladiator'sLibramofFortitude-42854"
  value: {
-  dps: 6660.47605
-  tps: 6759.78848
+  dps: 6660.06019
+  tps: 6759.37263
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6483.21405
-  tps: 6580.98529
+  dps: 6483.02408
+  tps: 6580.79533
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6367.36914
-  tps: 6466.68157
+  dps: 6366.96193
+  tps: 6466.27436
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SavageGladiator'sLibramofFortitude-42611"
  value: {
-  dps: 6596.25953
-  tps: 6695.57196
+  dps: 6595.84549
+  tps: 6695.15793
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6367.36914
-  tps: 6466.68157
+  dps: 6366.96193
+  tps: 6466.27436
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7868.80025
-  tps: 7967.74955
+  dps: 7867.40356
+  tps: 7966.35286
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6367.36914
-  tps: 6466.68157
+  dps: 6366.96193
+  tps: 6466.27436
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6367.36914
-  tps: 6466.68157
+  dps: 6366.96193
+  tps: 6466.27436
   dtps: 6.55074
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6406.33845
-  tps: 6505.17136
+  dps: 6405.74625
+  tps: 6504.57916
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6412.02331
-  tps: 6510.85622
+  dps: 6411.43065
+  tps: 6510.26356
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6388.72409
-  tps: 6488.03652
+  dps: 6388.31566
+  tps: 6487.62809
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6448.42566
-  tps: 6547.54803
+  dps: 6442.31541
+  tps: 6541.48393
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SparkofLife-37657"
  value: {
-  dps: 6398.58239
-  tps: 6492.89318
+  dps: 6398.19102
+  tps: 6492.5018
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6511.12123
-  tps: 6610.13424
+  dps: 6510.91808
+  tps: 6609.93109
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StormshroudArmor"
  value: {
-  dps: 5026.51344
-  tps: 5121.73427
+  dps: 5025.12492
+  tps: 5120.34575
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6518.04188
-  tps: 6617.35431
+  dps: 6517.66058
+  tps: 6616.97301
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6511.67802
-  tps: 6610.99046
+  dps: 6511.29689
+  tps: 6610.60932
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6500.54128
-  tps: 6599.85371
+  dps: 6500.16044
+  tps: 6599.47287
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6367.36914
-  tps: 6466.68157
+  dps: 6366.96193
+  tps: 6466.27436
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6366.85424
-  tps: 6463.71624
+  dps: 6366.44283
+  tps: 6463.30483
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6367.36914
-  tps: 6466.68157
+  dps: 6366.96193
+  tps: 6466.27436
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5365.70715
-  tps: 5464.44053
+  dps: 5365.08886
+  tps: 5463.82224
   dtps: 9.56591
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6515.49465
-  tps: 6614.13315
+  dps: 6515.30469
+  tps: 6613.94318
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6981.78503
-  tps: 7080.62106
+  dps: 6981.4101
+  tps: 7080.24613
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7050.32281
-  tps: 7148.94143
+  dps: 7050.11966
+  tps: 7148.73829
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6491.60077
-  tps: 6590.9132
+  dps: 6491.21999
+  tps: 6590.53242
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6490.20694
-  tps: 6589.51938
+  dps: 6489.82624
+  tps: 6589.13867
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6407.60126
-  tps: 6506.51035
+  dps: 6407.23023
+  tps: 6506.13932
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeoftheLightbringer-32368"
  value: {
-  dps: 6521.92263
-  tps: 6621.23506
+  dps: 6521.51078
+  tps: 6620.82321
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6490.20694
-  tps: 6589.51938
+  dps: 6489.82624
+  tps: 6589.13867
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6491.60077
-  tps: 6590.9132
+  dps: 6491.21999
+  tps: 6590.53242
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sBattlegear"
  value: {
-  dps: 6236.10423
-  tps: 6332.31683
+  dps: 6235.72207
+  tps: 6331.93467
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sPlate"
  value: {
-  dps: 5653.06749
-  tps: 5748.80816
+  dps: 5651.70917
+  tps: 5747.44983
   dtps: 8.90286
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5170.40428
-  tps: 5267.17745
+  dps: 5168.79252
+  tps: 5265.56569
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5174.54495
-  tps: 5272.04846
+  dps: 5174.316
+  tps: 5271.81952
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6389.05088
-  tps: 6488.36331
+  dps: 6388.64367
+  tps: 6487.9561
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathfulGladiator'sLibramofFortitude-51478"
  value: {
-  dps: 6686.25343
-  tps: 6785.56586
+  dps: 6685.83683
+  tps: 6785.14926
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 6586.43458
-  tps: 6684.77417
+  dps: 6585.06522
+  tps: 6683.40481
   dtps: 13.13693
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21265.35826
-  tps: 23318.92989
+  dps: 21234.6809
+  tps: 23288.25253
   dtps: 8.81235
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5334.51615
-  tps: 5432.13808
+  dps: 5334.2953
+  tps: 5431.91723
   dtps: 9.85058
  }
 }
@@ -1082,15 +1082,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12233.16628
-  tps: 14270.20975
+  dps: 12215.58733
+  tps: 14252.63079
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2966.04444
-  tps: 3069.84832
+  dps: 2965.46033
+  tps: 3069.26421
  }
 }
 dps_results: {
@@ -1103,16 +1103,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19431.61139
-  tps: 21483.664
+  dps: 19401.20272
+  tps: 21453.25533
   dtps: 8.61128
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5785.77597
-  tps: 5882.83877
+  dps: 5785.60254
+  tps: 5882.66534
   dtps: 9.85058
  }
 }
@@ -1127,15 +1127,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11123.23543
-  tps: 13167.23607
+  dps: 11105.26858
+  tps: 13149.26921
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3035.63542
-  tps: 3139.32713
+  dps: 3035.01142
+  tps: 3138.70313
  }
 }
 dps_results: {
@@ -1148,16 +1148,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21663.22502
-  tps: 23701.42155
+  dps: 21633.97789
+  tps: 23672.17443
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6618.5878
-  tps: 6717.90024
+  dps: 6618.17316
+  tps: 6717.48559
   dtps: 9.92959
  }
 }
@@ -1172,15 +1172,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11991.40508
-  tps: 13954.5876
+  dps: 11973.89741
+  tps: 13937.07993
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3611.9275
-  tps: 3715.71397
+  dps: 3611.29676
+  tps: 3715.08323
  }
 }
 dps_results: {
@@ -1193,16 +1193,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21504.45473
-  tps: 23557.39085
+  dps: 21474.44961
+  tps: 23527.38574
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6618.5878
-  tps: 6717.90024
+  dps: 6618.17316
+  tps: 6717.48559
   dtps: 9.92959
  }
 }
@@ -1217,15 +1217,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12229.82398
-  tps: 14273.75138
+  dps: 12211.58138
+  tps: 14255.50878
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3611.9275
-  tps: 3715.71397
+  dps: 3611.29676
+  tps: 3715.08323
  }
 }
 dps_results: {
@@ -1238,16 +1238,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21493.37878
-  tps: 23527.48812
+  dps: 21463.43995
+  tps: 23497.54929
   dtps: 8.81235
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5325.23447
-  tps: 5421.68106
+  dps: 5325.03373
+  tps: 5421.48032
   dtps: 9.85058
  }
 }
@@ -1262,15 +1262,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12230.21638
-  tps: 14241.24132
+  dps: 12212.53151
+  tps: 14223.55645
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2976.96126
-  tps: 3079.45917
+  dps: 2976.02792
+  tps: 3078.52583
  }
 }
 dps_results: {
@@ -1283,16 +1283,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19659.67035
-  tps: 21694.15898
+  dps: 19630.06938
+  tps: 21664.55801
   dtps: 8.61128
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5780.06909
-  tps: 5876.67192
+  dps: 5779.84605
+  tps: 5876.44888
   dtps: 9.85058
  }
 }
@@ -1307,15 +1307,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11092.12748
-  tps: 13096.12202
+  dps: 11074.77172
+  tps: 13078.76626
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3044.77426
-  tps: 3147.14148
+  dps: 3043.97552
+  tps: 3146.34273
  }
 }
 dps_results: {
@@ -1328,16 +1328,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21843.41685
-  tps: 23861.59037
+  dps: 21814.46681
+  tps: 23832.64034
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6611.51224
-  tps: 6709.94736
+  dps: 6610.9127
+  tps: 6709.34781
   dtps: 9.92959
  }
 }
@@ -1352,15 +1352,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11989.47836
-  tps: 13909.63756
+  dps: 11971.7092
+  tps: 13891.86841
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3615.70845
-  tps: 3718.31792
+  dps: 3614.88507
+  tps: 3717.49454
  }
 }
 dps_results: {
@@ -1373,16 +1373,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21614.06153
-  tps: 23648.876
+  dps: 21584.67872
+  tps: 23619.4932
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6611.51224
-  tps: 6709.94736
+  dps: 6610.9127
+  tps: 6709.34781
   dtps: 9.92959
  }
 }
@@ -1397,15 +1397,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12175.644
-  tps: 14188.4923
+  dps: 12158.03879
+  tps: 14170.88709
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3615.70845
-  tps: 3718.31792
+  dps: 3614.88507
+  tps: 3717.49454
  }
 }
 dps_results: {
@@ -1418,16 +1418,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21391.58803
-  tps: 23423.68556
+  dps: 21361.04076
+  tps: 23393.13829
   dtps: 8.81235
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5324.50443
-  tps: 5421.0424
+  dps: 5324.13367
+  tps: 5420.67164
   dtps: 9.85058
  }
 }
@@ -1442,15 +1442,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12128.58596
-  tps: 14133.28949
+  dps: 12110.49576
+  tps: 14115.1993
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2974.49469
-  tps: 3076.85916
+  dps: 2973.77867
+  tps: 3076.14314
  }
 }
 dps_results: {
@@ -1463,16 +1463,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19536.72217
-  tps: 21569.75076
+  dps: 19506.42588
+  tps: 21539.45448
   dtps: 8.61128
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5784.0767
-  tps: 5880.55725
+  dps: 5783.64114
+  tps: 5880.1217
   dtps: 9.85058
  }
 }
@@ -1487,15 +1487,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10990.70902
-  tps: 12979.05291
+  dps: 10972.98946
+  tps: 12961.33335
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3041.87106
-  tps: 3144.27429
+  dps: 3041.08228
+  tps: 3143.4855
  }
 }
 dps_results: {
@@ -1508,16 +1508,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21734.60475
-  tps: 23749.71478
+  dps: 21705.5184
+  tps: 23720.62843
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6615.01206
-  tps: 6713.55766
+  dps: 6614.63159
+  tps: 6713.17719
   dtps: 9.92959
  }
 }
@@ -1532,15 +1532,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11926.21583
-  tps: 13860.09922
+  dps: 11908.7536
+  tps: 13842.63699
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3611.04904
-  tps: 3713.60893
+  dps: 3610.41759
+  tps: 3712.97748
  }
 }
 dps_results: {
@@ -1553,16 +1553,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21543.55808
-  tps: 23582.13561
+  dps: 21514.33099
+  tps: 23552.90853
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6615.01206
-  tps: 6713.55766
+  dps: 6614.63159
+  tps: 6713.17719
   dtps: 9.92959
  }
 }
@@ -1577,15 +1577,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12124.51762
-  tps: 14138.37582
+  dps: 12106.72992
+  tps: 14120.58812
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3611.04904
-  tps: 3713.60893
+  dps: 3610.41759
+  tps: 3712.97748
  }
 }
 dps_results: {
@@ -1598,16 +1598,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21364.42385
-  tps: 23396.51309
+  dps: 21333.94724
+  tps: 23366.03648
   dtps: 8.81235
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5316.07884
-  tps: 5412.57864
+  dps: 5315.87813
+  tps: 5412.37793
   dtps: 9.85058
  }
 }
@@ -1622,15 +1622,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12147.65998
-  tps: 14157.73289
+  dps: 12130.31169
+  tps: 14140.3846
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2970.58868
-  tps: 3072.97248
+  dps: 2969.87315
+  tps: 3072.25696
  }
 }
 dps_results: {
@@ -1643,16 +1643,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19507.85432
-  tps: 21540.92472
+  dps: 19477.57697
+  tps: 21510.64737
   dtps: 8.61128
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5767.00429
-  tps: 5863.6198
+  dps: 5766.78129
+  tps: 5863.3968
   dtps: 9.85058
  }
 }
@@ -1667,15 +1667,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11015.75123
-  tps: 13018.64727
+  dps: 10998.37697
+  tps: 13001.27301
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3035.56423
-  tps: 3137.89626
+  dps: 3034.776
+  tps: 3137.10802
  }
 }
 dps_results: {
@@ -1688,16 +1688,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21711.38902
-  tps: 23729.69035
+  dps: 21682.45094
+  tps: 23700.75227
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6604.90918
-  tps: 6703.32965
+  dps: 6604.52899
+  tps: 6702.94946
   dtps: 9.92959
  }
 }
@@ -1712,15 +1712,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11912.65521
-  tps: 13832.70343
+  dps: 11895.103
+  tps: 13815.15122
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3608.00861
-  tps: 3710.58878
+  dps: 3607.3776
+  tps: 3709.95777
  }
 }
 dps_results: {
@@ -1733,16 +1733,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21485.43614
-  tps: 23521.09514
+  dps: 21455.89502
+  tps: 23491.55402
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6604.90918
-  tps: 6703.32965
+  dps: 6604.52899
+  tps: 6702.94946
   dtps: 9.92959
  }
 }
@@ -1757,15 +1757,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12088.90853
-  tps: 14103.4412
+  dps: 12071.53041
+  tps: 14086.06308
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3608.00861
-  tps: 3710.58878
+  dps: 3607.3776
+  tps: 3709.95777
  }
 }
 dps_results: {
@@ -1778,8 +1778,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6250.76169
-  tps: 6349.58108
+  dps: 6250.11693
+  tps: 6348.93632
   dtps: 9.92959
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -46,16 +46,16 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AegisBattlegear"
  value: {
-  dps: 6210.379
-  tps: 6307.23551
+  dps: 6210.55279
+  tps: 6307.4093
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AegisPlate"
  value: {
-  dps: 5581.08286
-  tps: 5676.69435
+  dps: 5581.2657
+  tps: 5676.87719
   dtps: 8.90286
  }
 }
@@ -94,8 +94,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6562.52439
-  tps: 6661.51564
+  dps: 6562.87574
+  tps: 6661.86699
   dtps: 10.03858
  }
 }
@@ -128,32 +128,32 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6290.43351
-  tps: 6387.23964
+  dps: 6290.80961
+  tps: 6387.61574
   dtps: 9.56591
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 5311.66673
-  tps: 5408.20852
+  dps: 5312.19249
+  tps: 5408.73429
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5130.49241
-  tps: 5226.5957
+  dps: 5130.88745
+  tps: 5226.99074
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5060.8743
-  tps: 5156.55225
+  dps: 5061.05382
+  tps: 5156.73177
   dtps: 9.23882
  }
 }
@@ -217,8 +217,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6456.71469
-  tps: 6556.02712
+  dps: 6456.91783
+  tps: 6556.23026
   dtps: 9.92959
  }
 }
@@ -249,24 +249,24 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6428.14392
-  tps: 6527.45635
+  dps: 6428.55678
+  tps: 6527.86921
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6632.93693
-  tps: 6731.87189
+  dps: 6633.14922
+  tps: 6732.08418
   dtps: 10.29273
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6734.03114
-  tps: 6833.19807
+  dps: 6734.45388
+  tps: 6833.62081
   dtps: 10.29273
  }
 }
@@ -289,16 +289,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6524.3693
-  tps: 6623.69174
+  dps: 6524.55699
+  tps: 6623.87943
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6493.79259
-  tps: 6593.32937
+  dps: 6494.21608
+  tps: 6593.75285
   dtps: 9.92959
  }
 }
@@ -337,8 +337,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6370.23954
-  tps: 6469.39153
+  dps: 6370.40937
+  tps: 6469.56136
   dtps: 9.92959
  }
 }
@@ -361,16 +361,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6510.89088
-  tps: 6609.62626
+  dps: 6511.12811
+  tps: 6609.86349
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6482.97416
-  tps: 6582.28659
+  dps: 6483.17842
+  tps: 6582.49085
   dtps: 9.92959
  }
 }
@@ -393,8 +393,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6441.10933
-  tps: 6540.42176
+  dps: 6441.33606
+  tps: 6540.64849
   dtps: 9.92959
  }
 }
@@ -457,8 +457,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6465.81905
-  tps: 6564.77387
+  dps: 6466.24296
+  tps: 6565.19777
   dtps: 9.92959
  }
 }
@@ -594,16 +594,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerBattlegear"
  value: {
-  dps: 4859.6837
-  tps: 4953.84935
+  dps: 4859.86855
+  tps: 4954.0342
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornBattlegear"
  value: {
-  dps: 6839.69028
-  tps: 6941.48339
+  dps: 6839.86875
+  tps: 6941.66186
   dtps: 9.92959
  }
 }
@@ -634,8 +634,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6495.54948
-  tps: 6594.86191
+  dps: 6495.82536
+  tps: 6595.13779
   dtps: 10.29273
  }
 }
@@ -714,8 +714,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionBattlegear"
  value: {
-  dps: 5805.59312
-  tps: 5904.65962
+  dps: 5805.96373
+  tps: 5905.03024
   dtps: 9.56591
  }
 }
@@ -730,16 +730,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6634.78733
-  tps: 6733.63586
+  dps: 6636.1444
+  tps: 6734.99293
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6668.90382
-  tps: 6767.75235
+  dps: 6670.38076
+  tps: 6769.22929
   dtps: 9.92959
  }
 }
@@ -818,16 +818,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6405.74625
-  tps: 6504.57916
+  dps: 6405.95149
+  tps: 6504.7844
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6411.43065
-  tps: 6510.26356
+  dps: 6411.63604
+  tps: 6510.46895
   dtps: 9.92959
  }
 }
@@ -842,16 +842,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6442.31541
-  tps: 6541.48393
+  dps: 6442.51856
+  tps: 6541.68708
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SparkofLife-37657"
  value: {
-  dps: 6398.19102
-  tps: 6492.5018
+  dps: 6398.39956
+  tps: 6492.71035
   dtps: 9.92959
  }
 }
@@ -866,8 +866,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-StormshroudArmor"
  value: {
-  dps: 5025.12492
-  tps: 5120.34575
+  dps: 5025.52394
+  tps: 5120.74478
   dtps: 9.23882
  }
 }
@@ -922,8 +922,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5365.08886
-  tps: 5463.82224
+  dps: 5365.70715
+  tps: 5464.44053
   dtps: 9.56591
  }
 }
@@ -938,8 +938,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6981.4101
-  tps: 7080.24613
+  dps: 6981.6022
+  tps: 7080.43823
   dtps: 9.92959
  }
 }
@@ -970,8 +970,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6407.23023
-  tps: 6506.13932
+  dps: 6407.39753
+  tps: 6506.30662
   dtps: 9.92959
  }
 }
@@ -1002,8 +1002,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sBattlegear"
  value: {
-  dps: 6235.72207
-  tps: 6331.93467
+  dps: 6235.89588
+  tps: 6332.10849
   dtps: 9.92959
  }
 }
@@ -1018,16 +1018,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5168.79252
-  tps: 5265.56569
+  dps: 5169.31559
+  tps: 5266.08876
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5174.316
-  tps: 5271.81952
+  dps: 5174.54495
+  tps: 5272.04846
   dtps: 9.92959
  }
 }
@@ -1050,16 +1050,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 6585.06522
-  tps: 6683.40481
+  dps: 6585.4259
+  tps: 6683.76548
   dtps: 13.13693
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21234.6809
-  tps: 23288.25253
+  dps: 21242.14248
+  tps: 23295.7141
   dtps: 8.81235
  }
 }
@@ -1082,15 +1082,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12215.58733
-  tps: 14252.63079
+  dps: 12221.24579
+  tps: 14258.28925
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2965.46033
-  tps: 3069.26421
+  dps: 2965.6171
+  tps: 3069.42098
  }
 }
 dps_results: {
@@ -1103,8 +1103,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19401.20272
-  tps: 21453.25533
+  dps: 19408.89813
+  tps: 21460.95074
   dtps: 8.61128
  }
 }
@@ -1127,15 +1127,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11105.26858
-  tps: 13149.26921
+  dps: 11110.88219
+  tps: 13154.88282
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3035.01142
-  tps: 3138.70313
+  dps: 3035.20737
+  tps: 3138.89908
  }
 }
 dps_results: {
@@ -1148,8 +1148,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21633.97789
-  tps: 23672.17443
+  dps: 21641.5794
+  tps: 23679.77594
   dtps: 8.80605
  }
 }
@@ -1172,15 +1172,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11973.89741
-  tps: 13937.07993
+  dps: 11979.25404
+  tps: 13942.43656
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3611.29676
-  tps: 3715.08323
+  dps: 3611.49271
+  tps: 3715.27918
  }
 }
 dps_results: {
@@ -1193,8 +1193,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21474.44961
-  tps: 23527.38574
+  dps: 21482.36659
+  tps: 23535.30272
   dtps: 8.80605
  }
 }
@@ -1217,15 +1217,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12211.58138
-  tps: 14255.50878
+  dps: 12217.44199
+  tps: 14261.36939
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-P1-Retribution Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3611.29676
-  tps: 3715.08323
+  dps: 3611.49271
+  tps: 3715.27918
  }
 }
 dps_results: {
@@ -1238,8 +1238,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21463.43995
-  tps: 23497.54929
+  dps: 21471.10815
+  tps: 23505.21749
   dtps: 8.81235
  }
 }
@@ -1262,15 +1262,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12212.53151
-  tps: 14223.55645
+  dps: 12217.6001
+  tps: 14228.62504
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2976.02792
-  tps: 3078.52583
+  dps: 2976.18477
+  tps: 3078.68268
  }
 }
 dps_results: {
@@ -1283,8 +1283,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19630.06938
-  tps: 21664.55801
+  dps: 19637.83016
+  tps: 21672.31879
   dtps: 8.61128
  }
 }
@@ -1307,15 +1307,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11074.77172
-  tps: 13078.76626
+  dps: 11079.77137
+  tps: 13083.76591
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3043.97552
-  tps: 3146.34273
+  dps: 3044.17158
+  tps: 3146.5388
  }
 }
 dps_results: {
@@ -1328,16 +1328,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21814.46681
-  tps: 23832.64034
+  dps: 21821.30986
+  tps: 23839.48338
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6610.9127
-  tps: 6709.34781
+  dps: 6611.30506
+  tps: 6709.74017
   dtps: 9.92959
  }
 }
@@ -1352,15 +1352,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11971.7092
-  tps: 13891.86841
+  dps: 11976.75459
+  tps: 13896.9138
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3614.88507
-  tps: 3717.49454
+  dps: 3615.42087
+  tps: 3718.03034
  }
 }
 dps_results: {
@@ -1373,16 +1373,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21584.67872
-  tps: 23619.4932
+  dps: 21591.93048
+  tps: 23626.74496
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6610.9127
-  tps: 6709.34781
+  dps: 6611.30506
+  tps: 6709.74017
   dtps: 9.92959
  }
 }
@@ -1397,15 +1397,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12158.03879
-  tps: 14170.88709
+  dps: 12162.90559
+  tps: 14175.75389
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-P1-Retribution Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3614.88507
-  tps: 3717.49454
+  dps: 3615.42087
+  tps: 3718.03034
  }
 }
 dps_results: {
@@ -1418,16 +1418,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21361.04076
-  tps: 23393.13829
+  dps: 21368.78202
+  tps: 23400.87955
   dtps: 8.81235
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5324.13367
-  tps: 5420.67164
+  dps: 5324.30358
+  tps: 5420.84155
   dtps: 9.85058
  }
 }
@@ -1442,15 +1442,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12110.49576
-  tps: 14115.1993
+  dps: 12115.86359
+  tps: 14120.56712
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2973.77867
-  tps: 3076.14314
+  dps: 2974.06687
+  tps: 3076.43135
  }
 }
 dps_results: {
@@ -1463,16 +1463,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19506.42588
-  tps: 21539.45448
+  dps: 19514.36158
+  tps: 21547.39017
   dtps: 8.61128
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5783.64114
-  tps: 5880.1217
+  dps: 5783.85354
+  tps: 5880.33409
   dtps: 9.85058
  }
 }
@@ -1487,15 +1487,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10972.98946
-  tps: 12961.33335
+  dps: 10978.39663
+  tps: 12966.74052
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3041.08228
-  tps: 3143.4855
+  dps: 3041.44254
+  tps: 3143.84577
  }
 }
 dps_results: {
@@ -1508,16 +1508,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21705.5184
-  tps: 23720.62843
+  dps: 21712.90083
+  tps: 23728.01087
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6614.63159
-  tps: 6713.17719
+  dps: 6614.80475
+  tps: 6713.35035
   dtps: 9.92959
  }
 }
@@ -1532,15 +1532,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11908.7536
-  tps: 13842.63699
+  dps: 11914.01502
+  tps: 13847.89841
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3610.41759
-  tps: 3712.97748
+  dps: 3610.61376
+  tps: 3713.17365
  }
 }
 dps_results: {
@@ -1553,16 +1553,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21514.33099
-  tps: 23552.90853
+  dps: 21521.91297
+  tps: 23560.4905
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6614.63159
-  tps: 6713.17719
+  dps: 6614.80475
+  tps: 6713.35035
   dtps: 9.92959
  }
 }
@@ -1577,15 +1577,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12106.72992
-  tps: 14120.58812
+  dps: 12112.28511
+  tps: 14126.14331
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-P1-Retribution Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3610.41759
-  tps: 3712.97748
+  dps: 3610.61376
+  tps: 3713.17365
  }
 }
 dps_results: {
@@ -1598,8 +1598,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21333.94724
-  tps: 23366.03648
+  dps: 21341.6564
+  tps: 23373.74564
   dtps: 8.81235
  }
 }
@@ -1622,15 +1622,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12130.31169
-  tps: 14140.3846
+  dps: 12135.28104
+  tps: 14145.35395
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOC-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2969.87315
-  tps: 3072.25696
+  dps: 2970.16116
+  tps: 3072.54497
  }
 }
 dps_results: {
@@ -1643,8 +1643,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19477.57697
-  tps: 21510.64737
+  dps: 19485.50759
+  tps: 21518.57799
   dtps: 8.61128
  }
 }
@@ -1667,15 +1667,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10998.37697
-  tps: 13001.27301
+  dps: 11003.53713
+  tps: 13006.43317
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOR-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3034.776
-  tps: 3137.10802
+  dps: 3035.13601
+  tps: 3137.46804
  }
 }
 dps_results: {
@@ -1688,16 +1688,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21682.45094
-  tps: 23700.75227
+  dps: 21689.77559
+  tps: 23708.07691
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6604.52899
-  tps: 6702.94946
+  dps: 6604.70203
+  tps: 6703.12249
   dtps: 9.92959
  }
 }
@@ -1712,15 +1712,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11895.103
-  tps: 13815.15122
+  dps: 11900.15924
+  tps: 13820.20746
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV 2 Target Swapping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3607.3776
-  tps: 3709.95777
+  dps: 3607.57363
+  tps: 3710.15381
  }
 }
 dps_results: {
@@ -1733,16 +1733,16 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21455.89502
-  tps: 23491.55402
+  dps: 21463.49456
+  tps: 23499.15356
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6604.52899
-  tps: 6702.94946
+  dps: 6604.70203
+  tps: 6703.12249
   dtps: 9.92959
  }
 }
@@ -1757,15 +1757,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12071.53041
-  tps: 14086.06308
+  dps: 12076.77016
+  tps: 14091.30283
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-P1-Retribution Paladin SOV-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3607.3776
-  tps: 3709.95777
+  dps: 3607.57363
+  tps: 3710.15381
  }
 }
 dps_results: {
@@ -1778,8 +1778,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6250.11693
-  tps: 6348.93632
+  dps: 6250.34264
+  tps: 6349.16203
   dtps: 9.92959
  }
 }

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -46,795 +46,795 @@ character_stats_results: {
 dps_results: {
  key: "TestShadow-AllItems-AbsolutionRegalia"
  value: {
-  dps: 5321.34619
-  tps: 5189.67548
+  dps: 5437.11928
+  tps: 5305.49786
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7217.34178
-  tps: 7157.63053
+  dps: 7335.16133
+  tps: 7287.86828
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7258.35832
-  tps: 7192.83663
+  dps: 7390.47799
+  tps: 7339.76974
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7191.86217
+  tps: 7146.75809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6903.35816
-  tps: 6858.3268
-  hps: 88.02155
+  dps: 7042.11481
+  tps: 6998.58174
+  hps: 87.65631
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6903.35816
-  tps: 6858.3268
-  hps: 88.02155
+  dps: 7042.11481
+  tps: 6998.58174
+  hps: 87.65631
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7128.24176
-  tps: 7061.75881
+  dps: 7277.21075
+  tps: 7212.05182
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5991.63473
-  tps: 5829.69385
+  dps: 6170.8237
+  tps: 6007.08774
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7095.28832
-  tps: 6899.23305
+  dps: 7232.03653
+  tps: 7043.71894
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7248.63052
-  tps: 7181.98824
+  dps: 7381.11362
+  tps: 7328.61165
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
   hps: 64
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 6850.76241
-  tps: 6765.04312
+  dps: 6980.52869
+  tps: 6893.35653
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 7900.10405
-  tps: 7824.85346
+  dps: 8076.34527
+  tps: 8001.00571
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7006.90129
-  tps: 6968.89221
+  dps: 7152.76072
+  tps: 7121.81398
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7054.54354
-  tps: 7018.46799
+  dps: 7239.35802
+  tps: 7193.88835
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7078.77484
-  tps: 7005.53408
+  dps: 7235.03535
+  tps: 7163.91902
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6937.90953
-  tps: 6887.02842
+  dps: 7087.07635
+  tps: 7047.54191
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7081.71081
-  tps: 7030.26443
+  dps: 7220.15955
+  tps: 7169.28701
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7549.32503
-  tps: 7477.83241
+  dps: 7710.54667
+  tps: 7632.24489
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7445.88175
-  tps: 7373.38429
+  dps: 7669.54151
+  tps: 7566.34034
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7191.86217
+  tps: 7146.75809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7149.67413
-  tps: 7085.51505
+  dps: 7300.70143
+  tps: 7235.15339
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7077.48416
-  tps: 7026.02105
+  dps: 7208.89347
+  tps: 7158.99824
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7073.33392
-  tps: 7021.90297
+  dps: 7206.08858
+  tps: 7155.40298
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7082.79612
-  tps: 6999.39425
+  dps: 7256.03285
+  tps: 7154.36137
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7191.86217
+  tps: 7146.75809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7055.94219
-  tps: 7011.98357
+  dps: 7223.99524
+  tps: 7183.77146
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7206.48052
-  tps: 7158.95217
+  dps: 7365.15711
+  tps: 7324.253
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7007.07321
-  tps: 6936.26581
+  dps: 7164.63374
+  tps: 7093.13824
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7081.24775
-  tps: 7033.77745
+  dps: 7223.22385
+  tps: 7177.39641
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7066.02953
-  tps: 7023.44469
+  dps: 7214.39529
+  tps: 7176.25332
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7095.28832
-  tps: 7039.01053
+  dps: 7232.03653
+  tps: 7186.43785
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7087.38556
-  tps: 7031.22409
+  dps: 7224.00166
+  tps: 7178.5019
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7088.83806
-  tps: 7017.48085
+  dps: 7243.00961
+  tps: 7168.42378
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GarbofFaith"
  value: {
-  dps: 6439.76077
-  tps: 6335.18339
+  dps: 6588.76801
+  tps: 6484.49351
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 6723.70592
-  tps: 6627.15785
+  dps: 6895.57112
+  tps: 6798.92543
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 6949.67959
-  tps: 6814.19991
+  dps: 7080.23481
+  tps: 6946.59731
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7235.18562
-  tps: 7175.19847
+  dps: 7353.26887
+  tps: 7305.73873
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7281.09014
-  tps: 7215.19748
+  dps: 7415.45165
+  tps: 7364.23207
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7014.74432
-  tps: 6973.69249
+  dps: 7178.18663
+  tps: 7133.6013
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-49982"
  value: {
-  dps: 7248.63052
-  tps: 7181.98824
+  dps: 7381.11362
+  tps: 7328.61165
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-50641"
  value: {
-  dps: 7248.63052
-  tps: 7181.98824
+  dps: 7381.11362
+  tps: 7328.61165
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7077.48416
-  tps: 7026.02105
+  dps: 7208.89347
+  tps: 7158.99824
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7073.33392
-  tps: 7021.90297
+  dps: 7206.08858
+  tps: 7155.40298
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7156.22873
-  tps: 7083.69802
+  dps: 7310.12374
+  tps: 7234.74334
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7191.86217
+  tps: 7146.75809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50179"
  value: {
-  dps: 7248.63052
-  tps: 7181.98824
+  dps: 7381.11362
+  tps: 7328.61165
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50708"
  value: {
-  dps: 7248.63052
-  tps: 7181.98824
+  dps: 7381.11362
+  tps: 7328.61165
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7057.43576
-  tps: 6981.14579
+  dps: 7232.60175
+  tps: 7155.53691
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6975.34611
-  tps: 6932.37915
+  dps: 7143.68235
+  tps: 7099.35358
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7292.3034
-  tps: 7244.43231
+  dps: 7431.47711
+  tps: 7394.95447
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Nibelung-49992"
  value: {
-  dps: 7248.63052
-  tps: 7181.98824
+  dps: 7381.11362
+  tps: 7328.61165
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Nibelung-50648"
  value: {
-  dps: 7248.63052
-  tps: 7181.98824
+  dps: 7381.11362
+  tps: 7328.61165
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7191.86217
+  tps: 7146.75809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7191.86217
+  tps: 7146.75809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7191.86217
+  tps: 7146.75809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7191.86217
+  tps: 7146.75809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RegaliaofFaith"
  value: {
-  dps: 6151.26184
-  tps: 6067.76034
+  dps: 6288.90913
+  tps: 6205.47251
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7291.10143
-  tps: 7248.10213
+  dps: 7485.07892
+  tps: 7431.65794
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7337.93741
-  tps: 7294.57852
+  dps: 7534.02479
+  tps: 7480.17948
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7205.47052
-  tps: 7149.1507
+  dps: 7371.5022
+  tps: 7307.2249
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7079.67963
-  tps: 7019.07928
+  dps: 7238.67848
+  tps: 7183.05711
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationGarb"
  value: {
-  dps: 6940.16845
-  tps: 6895.67795
+  dps: 7065.8714
+  tps: 7025.5407
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationRegalia"
  value: {
-  dps: 6577.63387
-  tps: 6490.33138
+  dps: 6733.34387
+  tps: 6645.25359
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7236.433
-  tps: 7168.24031
+  dps: 7399.32084
+  tps: 7335.07108
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7268.09944
-  tps: 7202.93199
+  dps: 7431.48913
+  tps: 7369.47963
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7023.12232
-  tps: 6976.4322
+  dps: 7163.96283
+  tps: 7118.91129
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7082.61931
-  tps: 7015.77421
+  dps: 7234.34936
+  tps: 7166.40469
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SparkofLife-37657"
  value: {
-  dps: 7067.37392
-  tps: 6991.34815
+  dps: 7250.5521
+  tps: 7173.97163
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6919.50612
-  tps: 6873.41783
+  dps: 7052.12465
+  tps: 7009.20662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7191.86217
+  tps: 7146.75809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7191.86217
+  tps: 7146.75809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7191.86217
+  tps: 7146.75809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7038.36088
-  tps: 6959.58111
+  dps: 7184.85972
+  tps: 7114.49272
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7017.23301
-  tps: 6945.89822
+  dps: 7176.87659
+  tps: 7103.33763
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 7041.21314
+  tps: 6997.77808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7191.86217
+  tps: 7146.75809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6919.50612
-  tps: 6873.41783
+  dps: 7052.12465
+  tps: 7009.20662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6919.50612
-  tps: 6873.41783
+  dps: 7052.12465
+  tps: 7009.20662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7095.28832
-  tps: 7039.01053
+  dps: 7232.03653
+  tps: 7186.43785
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7087.38556
-  tps: 7031.22409
+  dps: 7224.00166
+  tps: 7178.5019
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7117.96721
-  tps: 7057.5463
+  dps: 7295.06776
+  tps: 7231.89184
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7087.38556
-  tps: 7031.22409
+  dps: 7224.00166
+  tps: 7178.5019
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7095.28832
-  tps: 7039.01053
+  dps: 7232.03653
+  tps: 7186.43785
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7469.6876
-  tps: 7413.20331
+  dps: 7619.72747
+  tps: 7569.62682
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VestmentsofAbsolution"
  value: {
-  dps: 5125.34988
-  tps: 4986.29507
+  dps: 5237.38966
+  tps: 5098.18072
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7046.66063
-  tps: 6985.21115
+  dps: 7178.48013
+  tps: 7130.82072
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRaiment"
  value: {
-  dps: 6501.25334
-  tps: 6423.1212
+  dps: 6637.67071
+  tps: 6556.88402
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRegalia"
  value: {
-  dps: 6890.50373
-  tps: 6813.31105
+  dps: 7038.3981
+  tps: 6960.88663
  }
 }
 dps_results: {
  key: "TestShadow-Average-Default"
  value: {
-  dps: 7271.61363
-  tps: 7210.48699
+  dps: 7430.35258
+  tps: 7374.24596
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7232.65591
-  tps: 7982.30383
+  dps: 7406.7255
+  tps: 8149.81173
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7232.65591
-  tps: 7160.07902
+  dps: 7406.7255
+  tps: 7329.0255
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7842.16764
-  tps: 7920.16203
+  dps: 8016.49117
+  tps: 8095.24933
  }
 }
 dps_results: {
@@ -861,22 +861,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6829.52423
-  tps: 7690.82202
+  dps: 6987.56679
+  tps: 7910.35766
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6829.52423
-  tps: 6772.28791
+  dps: 6987.56679
+  tps: 6933.31474
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7584.48186
-  tps: 7663.52973
+  dps: 7768.68484
+  tps: 7847.73271
  }
 }
 dps_results: {
@@ -903,22 +903,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7229.77474
-  tps: 8118.84386
+  dps: 7381.54421
+  tps: 8314.04601
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7229.77474
-  tps: 7176.92194
+  dps: 7381.54421
+  tps: 7332.03073
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8013.13921
-  tps: 8092.57339
+  dps: 8191.88992
+  tps: 8271.32409
  }
 }
 dps_results: {
@@ -945,22 +945,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7223.76667
-  tps: 7984.85284
+  dps: 7397.74555
+  tps: 8137.92826
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7223.76667
-  tps: 7147.28578
+  dps: 7397.74555
+  tps: 7320.10053
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7836.38982
-  tps: 7914.4164
+  dps: 8016.64498
+  tps: 8095.43532
  }
 }
 dps_results: {
@@ -987,22 +987,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6820.09165
-  tps: 7697.51173
+  dps: 6988.54037
+  tps: 7889.95109
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6820.09165
-  tps: 6760.91583
+  dps: 6988.54037
+  tps: 6926.04976
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7575.42988
-  tps: 7654.47776
+  dps: 7764.84329
+  tps: 7843.89116
  }
 }
 dps_results: {
@@ -1029,22 +1029,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7228.56942
-  tps: 8101.10087
+  dps: 7375.53443
+  tps: 8303.38858
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7228.56942
-  tps: 7162.35647
+  dps: 7375.53443
+  tps: 7322.4474
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8000.84446
-  tps: 8080.27864
+  dps: 8180.8026
+  tps: 8260.23678
  }
 }
 dps_results: {
@@ -1071,22 +1071,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7226.17262
-  tps: 7979.78397
+  dps: 7402.11289
+  tps: 8141.05434
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7226.17262
-  tps: 7153.54157
+  dps: 7402.11289
+  tps: 7324.33035
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7838.62798
-  tps: 7916.58856
+  dps: 8021.23604
+  tps: 8099.96039
  }
 }
 dps_results: {
@@ -1113,22 +1113,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6826.73401
-  tps: 7700.23699
+  dps: 6994.73157
+  tps: 7886.99304
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6826.73401
-  tps: 6767.33673
+  dps: 6994.73157
+  tps: 6932.2259
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7579.70299
-  tps: 7658.68487
+  dps: 7769.2298
+  tps: 7848.21168
  }
 }
 dps_results: {
@@ -1155,22 +1155,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7248.63052
-  tps: 8113.86683
+  dps: 7381.11362
+  tps: 8320.09651
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7248.63052
-  tps: 7181.98824
+  dps: 7381.11362
+  tps: 7328.61165
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8005.40985
-  tps: 8084.77802
+  dps: 8185.47487
+  tps: 8264.84305
  }
 }
 dps_results: {
@@ -1197,7 +1197,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7235.44038
-  tps: 7181.98824
+  dps: 7371.08738
+  tps: 7328.61165
  }
 }

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -46,1158 +46,1158 @@ character_stats_results: {
 dps_results: {
  key: "TestShadow-AllItems-AbsolutionRegalia"
  value: {
-  dps: 5437.11928
-  tps: 5305.49786
+  dps: 5321.34619
+  tps: 5189.67548
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7335.16133
-  tps: 7287.86828
+  dps: 7217.34178
+  tps: 7157.63053
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7390.47799
-  tps: 7339.76974
+  dps: 7258.35832
+  tps: 7192.83663
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7191.86217
-  tps: 7146.75809
+  dps: 7042.90744
+  tps: 6991.86765
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7042.11481
-  tps: 6998.58174
-  hps: 87.65631
+  dps: 6903.35816
+  tps: 6858.3268
+  hps: 88.02155
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7042.11481
-  tps: 6998.58174
-  hps: 87.65631
+  dps: 6903.35816
+  tps: 6858.3268
+  hps: 88.02155
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7277.21075
-  tps: 7212.05182
+  dps: 7128.24176
+  tps: 7061.75881
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6170.8237
-  tps: 6007.08774
+  dps: 5991.63473
+  tps: 5829.69385
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7232.03653
-  tps: 7043.71894
+  dps: 7095.28832
+  tps: 6899.23305
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7381.11362
-  tps: 7328.61165
+  dps: 7248.63052
+  tps: 7181.98824
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
   hps: 64
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 6980.52869
-  tps: 6893.35653
+  dps: 6850.76241
+  tps: 6765.04312
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 8076.34527
-  tps: 8001.00571
+  dps: 7900.10405
+  tps: 7824.85346
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7152.76072
-  tps: 7121.81398
+  dps: 7006.90129
+  tps: 6968.89221
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7239.35802
-  tps: 7193.88835
+  dps: 7054.54354
+  tps: 7018.46799
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7235.03535
-  tps: 7163.91902
+  dps: 7078.77484
+  tps: 7005.53408
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7087.07635
-  tps: 7047.54191
+  dps: 6937.90953
+  tps: 6887.02842
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7220.15955
-  tps: 7169.28701
+  dps: 7081.71081
+  tps: 7030.26443
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7710.54667
-  tps: 7632.24489
+  dps: 7549.32503
+  tps: 7477.83241
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7669.54151
-  tps: 7566.34034
+  dps: 7445.88175
+  tps: 7373.38429
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7191.86217
-  tps: 7146.75809
+  dps: 7042.90744
+  tps: 6991.86765
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7300.70143
-  tps: 7235.15339
+  dps: 7149.67413
+  tps: 7085.51505
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7208.89347
-  tps: 7158.99824
+  dps: 7077.48416
+  tps: 7026.02105
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7206.08858
-  tps: 7155.40298
+  dps: 7073.33392
+  tps: 7021.90297
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7256.03285
-  tps: 7154.36137
+  dps: 7082.79612
+  tps: 6999.39425
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7191.86217
-  tps: 7146.75809
+  dps: 7042.90744
+  tps: 6991.86765
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7223.99524
-  tps: 7183.77146
+  dps: 7055.94219
+  tps: 7011.98357
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7365.15711
-  tps: 7324.253
+  dps: 7206.48052
+  tps: 7158.95217
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7164.63374
-  tps: 7093.13824
+  dps: 7007.07321
+  tps: 6936.26581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7223.22385
-  tps: 7177.39641
+  dps: 7081.24775
+  tps: 7033.77745
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7214.39529
-  tps: 7176.25332
+  dps: 7066.02953
+  tps: 7023.44469
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7232.03653
-  tps: 7186.43785
+  dps: 7095.28832
+  tps: 7039.01053
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7224.00166
-  tps: 7178.5019
+  dps: 7087.38556
+  tps: 7031.22409
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7243.00961
-  tps: 7168.42378
+  dps: 7088.83806
+  tps: 7017.48085
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GarbofFaith"
  value: {
-  dps: 6588.76801
-  tps: 6484.49351
+  dps: 6439.76077
+  tps: 6335.18339
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 6895.57112
-  tps: 6798.92543
+  dps: 6723.70592
+  tps: 6627.15785
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 7080.23481
-  tps: 6946.59731
+  dps: 6949.67959
+  tps: 6814.19991
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7353.26887
-  tps: 7305.73873
+  dps: 7235.18562
+  tps: 7175.19847
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7415.45165
-  tps: 7364.23207
+  dps: 7281.09014
+  tps: 7215.19748
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7178.18663
-  tps: 7133.6013
+  dps: 7014.74432
+  tps: 6973.69249
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-49982"
  value: {
-  dps: 7381.11362
-  tps: 7328.61165
+  dps: 7248.63052
+  tps: 7181.98824
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-50641"
  value: {
-  dps: 7381.11362
-  tps: 7328.61165
+  dps: 7248.63052
+  tps: 7181.98824
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7208.89347
-  tps: 7158.99824
+  dps: 7077.48416
+  tps: 7026.02105
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7206.08858
-  tps: 7155.40298
+  dps: 7073.33392
+  tps: 7021.90297
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7310.12374
-  tps: 7234.74334
+  dps: 7156.22873
+  tps: 7083.69802
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7191.86217
-  tps: 7146.75809
+  dps: 7042.90744
+  tps: 6991.86765
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50179"
  value: {
-  dps: 7381.11362
-  tps: 7328.61165
+  dps: 7248.63052
+  tps: 7181.98824
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50708"
  value: {
-  dps: 7381.11362
-  tps: 7328.61165
+  dps: 7248.63052
+  tps: 7181.98824
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7232.60175
-  tps: 7155.53691
+  dps: 7057.43576
+  tps: 6981.14579
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7143.68235
-  tps: 7099.35358
+  dps: 6975.34611
+  tps: 6932.37915
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7431.47711
-  tps: 7394.95447
+  dps: 7292.3034
+  tps: 7244.43231
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Nibelung-49992"
  value: {
-  dps: 7381.11362
-  tps: 7328.61165
+  dps: 7248.63052
+  tps: 7181.98824
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Nibelung-50648"
  value: {
-  dps: 7381.11362
-  tps: 7328.61165
+  dps: 7248.63052
+  tps: 7181.98824
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7191.86217
-  tps: 7146.75809
+  dps: 7042.90744
+  tps: 6991.86765
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7191.86217
-  tps: 7146.75809
+  dps: 7042.90744
+  tps: 6991.86765
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7191.86217
-  tps: 7146.75809
+  dps: 7042.90744
+  tps: 6991.86765
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7191.86217
-  tps: 7146.75809
+  dps: 7042.90744
+  tps: 6991.86765
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RegaliaofFaith"
  value: {
-  dps: 6288.90913
-  tps: 6205.47251
+  dps: 6151.26184
+  tps: 6067.76034
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7485.07892
-  tps: 7431.65794
+  dps: 7291.10143
+  tps: 7248.10213
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7534.02479
-  tps: 7480.17948
+  dps: 7337.93741
+  tps: 7294.57852
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7371.5022
-  tps: 7307.2249
+  dps: 7205.47052
+  tps: 7149.1507
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7238.67848
-  tps: 7183.05711
+  dps: 7079.67963
+  tps: 7019.07928
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationGarb"
  value: {
-  dps: 7065.8714
-  tps: 7025.5407
+  dps: 6940.16845
+  tps: 6895.67795
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationRegalia"
  value: {
-  dps: 6733.34387
-  tps: 6645.25359
+  dps: 6577.63387
+  tps: 6490.33138
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7399.32084
-  tps: 7335.07108
+  dps: 7236.433
+  tps: 7168.24031
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7431.48913
-  tps: 7369.47963
+  dps: 7268.09944
+  tps: 7202.93199
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7163.96283
-  tps: 7118.91129
+  dps: 7023.12232
+  tps: 6976.4322
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7234.34936
-  tps: 7166.40469
+  dps: 7082.61931
+  tps: 7015.77421
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SparkofLife-37657"
  value: {
-  dps: 7250.5521
-  tps: 7173.97163
+  dps: 7067.37392
+  tps: 6991.34815
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7052.12465
-  tps: 7009.20662
+  dps: 6919.50612
+  tps: 6873.41783
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7191.86217
-  tps: 7146.75809
+  dps: 7042.90744
+  tps: 6991.86765
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7191.86217
-  tps: 7146.75809
+  dps: 7042.90744
+  tps: 6991.86765
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7191.86217
-  tps: 7146.75809
+  dps: 7042.90744
+  tps: 6991.86765
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7184.85972
-  tps: 7114.49272
+  dps: 7038.36088
+  tps: 6959.58111
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7176.87659
-  tps: 7103.33763
+  dps: 7017.23301
+  tps: 6945.89822
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7041.21314
-  tps: 6997.77808
+  dps: 6903.56135
+  tps: 6858.49662
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7191.86217
-  tps: 7146.75809
+  dps: 7042.90744
+  tps: 6991.86765
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7052.12465
-  tps: 7009.20662
+  dps: 6919.50612
+  tps: 6873.41783
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7052.12465
-  tps: 7009.20662
+  dps: 6919.50612
+  tps: 6873.41783
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7232.03653
-  tps: 7186.43785
+  dps: 7095.28832
+  tps: 7039.01053
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7224.00166
-  tps: 7178.5019
+  dps: 7087.38556
+  tps: 7031.22409
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7295.06776
-  tps: 7231.89184
+  dps: 7117.96721
+  tps: 7057.5463
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7224.00166
-  tps: 7178.5019
+  dps: 7087.38556
+  tps: 7031.22409
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7232.03653
-  tps: 7186.43785
+  dps: 7095.28832
+  tps: 7039.01053
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7619.72747
-  tps: 7569.62682
+  dps: 7469.6876
+  tps: 7413.20331
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VestmentsofAbsolution"
  value: {
-  dps: 5237.38966
-  tps: 5098.18072
+  dps: 5125.34988
+  tps: 4986.29507
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7178.48013
-  tps: 7130.82072
+  dps: 7046.66063
+  tps: 6985.21115
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRaiment"
  value: {
-  dps: 6637.67071
-  tps: 6556.88402
+  dps: 6501.25334
+  tps: 6423.1212
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRegalia"
  value: {
-  dps: 7038.3981
-  tps: 6960.88663
+  dps: 6890.50373
+  tps: 6813.31105
  }
 }
 dps_results: {
  key: "TestShadow-Average-Default"
  value: {
-  dps: 7430.35258
-  tps: 7374.24596
+  dps: 7271.61363
+  tps: 7210.48699
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7406.7255
-  tps: 8149.81173
+  dps: 7232.65591
+  tps: 7982.30383
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7406.7255
-  tps: 7329.0255
+  dps: 7232.65591
+  tps: 7160.07902
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8016.49117
-  tps: 8095.24933
+  dps: 7842.16764
+  tps: 7920.16203
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3827.70514
-  tps: 4696.59221
+  dps: 3727.54113
+  tps: 4577.36799
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3827.70514
-  tps: 3752.067
+  dps: 3727.54113
+  tps: 3651.74474
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3873.63106
-  tps: 3862.8793
+  dps: 3737.70553
+  tps: 3727.76726
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6987.56679
-  tps: 7910.35766
+  dps: 6829.52423
+  tps: 7690.82202
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6987.56679
-  tps: 6933.31474
+  dps: 6829.52423
+  tps: 6772.28791
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7768.68484
-  tps: 7847.73271
+  dps: 7584.48186
+  tps: 7663.52973
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3631.82627
-  tps: 4589.33439
+  dps: 3527.07332
+  tps: 4487.6596
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3631.82627
-  tps: 3560.60954
+  dps: 3527.07332
+  tps: 3458.93475
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3962.56033
-  tps: 3783.57323
+  dps: 3804.72557
+  tps: 3638.01467
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7381.54421
-  tps: 8314.04601
+  dps: 7229.77474
+  tps: 8118.84386
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7381.54421
-  tps: 7332.03073
+  dps: 7229.77474
+  tps: 7176.92194
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8191.88992
-  tps: 8271.32409
+  dps: 8013.13921
+  tps: 8092.57339
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3757.53604
-  tps: 4705.22117
+  dps: 3614.03015
+  tps: 4575.27372
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3757.53604
-  tps: 3686.80648
+  dps: 3614.03015
+  tps: 3546.54887
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4242.1543
-  tps: 4024.48132
+  dps: 4091.62238
+  tps: 3890.77616
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7397.74555
-  tps: 8137.92826
+  dps: 7223.76667
+  tps: 7984.85284
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7397.74555
-  tps: 7320.10053
+  dps: 7223.76667
+  tps: 7147.28578
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8016.64498
-  tps: 8095.43532
+  dps: 7836.38982
+  tps: 7914.4164
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3823.98997
-  tps: 4705.46966
+  dps: 3713.42604
+  tps: 4552.53094
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3823.98997
-  tps: 3748.91593
+  dps: 3713.42604
+  tps: 3637.21784
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3864.81908
-  tps: 3855.28788
+  dps: 3728.64486
+  tps: 3720.89526
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6988.54037
-  tps: 7889.95109
+  dps: 6820.09165
+  tps: 7697.51173
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6988.54037
-  tps: 6926.04976
+  dps: 6820.09165
+  tps: 6760.91583
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7764.84329
-  tps: 7843.89116
+  dps: 7575.42988
+  tps: 7654.47776
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3622.8236
-  tps: 4595.8928
+  dps: 3503.55088
+  tps: 4463.6002
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3622.8236
-  tps: 3553.42107
+  dps: 3503.55088
+  tps: 3434.87534
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3954.18057
-  tps: 3776.61089
+  dps: 3796.49909
+  tps: 3631.19693
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7375.53443
-  tps: 8303.38858
+  dps: 7228.56942
+  tps: 8101.10087
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7375.53443
-  tps: 7322.4474
+  dps: 7228.56942
+  tps: 7162.35647
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8180.8026
-  tps: 8260.23678
+  dps: 8000.84446
+  tps: 8080.27864
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3712.698
-  tps: 4630.37909
+  dps: 3624.95131
+  tps: 4595.34283
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3712.698
-  tps: 3639.45816
+  dps: 3624.95131
+  tps: 3556.30781
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4242.30193
-  tps: 4024.59798
+  dps: 4086.88013
+  tps: 3887.25519
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7402.11289
-  tps: 8141.05434
+  dps: 7226.17262
+  tps: 7979.78397
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7402.11289
-  tps: 7324.33035
+  dps: 7226.17262
+  tps: 7153.54157
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8021.23604
-  tps: 8099.96039
+  dps: 7838.62798
+  tps: 7916.58856
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3835.20609
-  tps: 4696.70819
+  dps: 3722.78352
+  tps: 4570.76914
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3835.20609
-  tps: 3758.89606
+  dps: 3722.78352
+  tps: 3646.68108
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3867.08914
-  tps: 3857.35329
+  dps: 3730.71248
+  tps: 3722.77352
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6994.73157
-  tps: 7886.99304
+  dps: 6826.73401
+  tps: 7700.23699
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6994.73157
-  tps: 6932.2259
+  dps: 6826.73401
+  tps: 6767.33673
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7769.2298
-  tps: 7848.21168
+  dps: 7579.70299
+  tps: 7658.68487
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3619.07872
-  tps: 4590.09967
+  dps: 3509.23294
+  tps: 4478.43213
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3619.07872
-  tps: 3549.35693
+  dps: 3509.23294
+  tps: 3441.12042
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3956.48681
-  tps: 3778.60276
+  dps: 3798.5463
+  tps: 3632.95211
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7381.11362
-  tps: 8320.09651
+  dps: 7248.63052
+  tps: 8113.86683
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7381.11362
-  tps: 7328.61165
+  dps: 7248.63052
+  tps: 7181.98824
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8185.47487
-  tps: 8264.84305
+  dps: 8005.40985
+  tps: 8084.77802
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3729.55626
-  tps: 4660.00521
+  dps: 3619.94902
+  tps: 4577.63435
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3729.55626
-  tps: 3657.00369
+  dps: 3619.94902
+  tps: 3550.6157
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4244.77146
-  tps: 4026.71378
+  dps: 4089.10005
+  tps: 3889.15961
  }
 }
 dps_results: {
  key: "TestShadow-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7371.08738
-  tps: 7328.61165
+  dps: 7235.44038
+  tps: 7181.98824
  }
 }

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -46,1158 +46,1158 @@ character_stats_results: {
 dps_results: {
  key: "TestShadow-AllItems-AbsolutionRegalia"
  value: {
-  dps: 5321.34619
-  tps: 5189.67548
+  dps: 5361.15198
+  tps: 5229.55052
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7217.34178
-  tps: 7157.63053
+  dps: 7239.6256
+  tps: 7184.45689
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7258.35832
-  tps: 7192.83663
+  dps: 7309.7482
+  tps: 7246.60315
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7103.1458
+  tps: 7045.35855
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6903.35816
-  tps: 6858.3268
-  hps: 88.02155
+  dps: 6949.14206
+  tps: 6898.24552
+  hps: 88.09348
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6903.35816
-  tps: 6858.3268
-  hps: 88.02155
+  dps: 6949.14206
+  tps: 6898.24552
+  hps: 88.09348
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7128.24176
-  tps: 7061.75881
+  dps: 7181.44772
+  tps: 7112.8071
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5991.63473
-  tps: 5829.69385
+  dps: 6053.91017
+  tps: 5892.11366
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7095.28832
-  tps: 6899.23305
+  dps: 7175.23704
+  tps: 6973.47846
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7248.63052
-  tps: 7181.98824
+  dps: 7299.94354
+  tps: 7235.66473
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
   hps: 64
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 6850.76241
-  tps: 6765.04312
+  dps: 6889.25904
+  tps: 6802.72269
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 7900.10405
-  tps: 7824.85346
+  dps: 7960.18574
+  tps: 7884.52925
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7006.90129
-  tps: 6968.89221
+  dps: 7060.42568
+  tps: 7012.28519
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7054.54354
-  tps: 7018.46799
+  dps: 7110.92267
+  tps: 7060.50141
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7078.77484
-  tps: 7005.53408
+  dps: 7128.37228
+  tps: 7058.51049
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6937.90953
-  tps: 6887.02842
+  dps: 6972.32853
+  tps: 6929.36157
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7081.71081
-  tps: 7030.26443
+  dps: 7139.99609
+  tps: 7082.99659
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7549.32503
-  tps: 7477.83241
+  dps: 7574.98001
+  tps: 7510.18079
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7445.88175
-  tps: 7373.38429
+  dps: 7517.30187
+  tps: 7445.08656
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7103.1458
+  tps: 7045.35855
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7149.67413
-  tps: 7085.51505
+  dps: 7202.80038
+  tps: 7133.36361
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7077.48416
-  tps: 7026.02105
+  dps: 7121.76365
+  tps: 7064.35093
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7073.33392
-  tps: 7021.90297
+  dps: 7118.98625
+  tps: 7061.33748
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7082.79612
-  tps: 6999.39425
+  dps: 7115.64213
+  tps: 7041.71225
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7103.1458
+  tps: 7045.35855
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7055.94219
-  tps: 7011.98357
+  dps: 7101.29637
+  tps: 7063.00375
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7206.48052
-  tps: 7158.95217
+  dps: 7249.80988
+  tps: 7201.37011
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7007.07321
-  tps: 6936.26581
+  dps: 7058.94231
+  tps: 6988.80341
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7081.24775
-  tps: 7033.77745
+  dps: 7129.14926
+  tps: 7075.59082
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7066.02953
-  tps: 7023.44469
+  dps: 7122.9888
+  tps: 7080.10191
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7095.28832
-  tps: 7039.01053
+  dps: 7175.23704
+  tps: 7114.77503
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7087.38556
-  tps: 7031.22409
+  dps: 7134.91902
+  tps: 7076.65859
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7088.83806
-  tps: 7017.48085
+  dps: 7129.1241
+  tps: 7062.39926
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GarbofFaith"
  value: {
-  dps: 6439.76077
-  tps: 6335.18339
+  dps: 6481.26721
+  tps: 6377.07084
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 6723.70592
-  tps: 6627.15785
+  dps: 6777.75349
+  tps: 6681.73087
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 6949.67959
-  tps: 6814.19991
+  dps: 6995.087
+  tps: 6859.42614
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7235.18562
-  tps: 7175.19847
+  dps: 7292.11855
+  tps: 7234.49383
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7281.09014
-  tps: 7215.19748
+  dps: 7332.64
+  tps: 7269.12848
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7014.74432
-  tps: 6973.69249
+  dps: 7059.55234
+  tps: 7017.96153
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-49982"
  value: {
-  dps: 7248.63052
-  tps: 7181.98824
+  dps: 7299.94354
+  tps: 7235.66473
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-50641"
  value: {
-  dps: 7248.63052
-  tps: 7181.98824
+  dps: 7299.94354
+  tps: 7235.66473
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7077.48416
-  tps: 7026.02105
+  dps: 7121.76365
+  tps: 7064.35093
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7073.33392
-  tps: 7021.90297
+  dps: 7118.98625
+  tps: 7061.33748
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7156.22873
-  tps: 7083.69802
+  dps: 7199.08385
+  tps: 7125.15049
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7103.1458
+  tps: 7045.35855
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50179"
  value: {
-  dps: 7248.63052
-  tps: 7181.98824
+  dps: 7299.94354
+  tps: 7235.66473
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50708"
  value: {
-  dps: 7248.63052
-  tps: 7181.98824
+  dps: 7299.94354
+  tps: 7235.66473
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7057.43576
-  tps: 6981.14579
+  dps: 7108.94585
+  tps: 7032.47748
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6975.34611
-  tps: 6932.37915
+  dps: 7021.92397
+  tps: 6983.12454
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7292.3034
-  tps: 7244.43231
+  dps: 7356.0808
+  tps: 7307.96916
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Nibelung-49992"
  value: {
-  dps: 7248.63052
-  tps: 7181.98824
+  dps: 7299.94354
+  tps: 7235.66473
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Nibelung-50648"
  value: {
-  dps: 7248.63052
-  tps: 7181.98824
+  dps: 7299.94354
+  tps: 7235.66473
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7103.1458
+  tps: 7045.35855
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7103.1458
+  tps: 7045.35855
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7103.1458
+  tps: 7045.35855
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7103.1458
+  tps: 7045.35855
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RegaliaofFaith"
  value: {
-  dps: 6151.26184
-  tps: 6067.76034
+  dps: 6194.25209
+  tps: 6110.52339
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7291.10143
-  tps: 7248.10213
+  dps: 7330.2158
+  tps: 7289.23546
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7337.93741
-  tps: 7294.57852
+  dps: 7377.18804
+  tps: 7335.853
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7205.47052
-  tps: 7149.1507
+  dps: 7274.75658
+  tps: 7209.83122
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7079.67963
-  tps: 7019.07928
+  dps: 7134.17335
+  tps: 7072.29423
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationGarb"
  value: {
-  dps: 6940.16845
-  tps: 6895.67795
+  dps: 6987.90623
+  tps: 6935.99324
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationRegalia"
  value: {
-  dps: 6577.63387
-  tps: 6490.33138
+  dps: 6614.59733
+  tps: 6526.98023
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7236.433
-  tps: 7168.24031
+  dps: 7287.45339
+  tps: 7217.5803
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7268.09944
-  tps: 7202.93199
+  dps: 7322.51279
+  tps: 7251.8358
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7023.12232
-  tps: 6976.4322
+  dps: 7070.66178
+  tps: 7017.95584
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7082.61931
-  tps: 7015.77421
+  dps: 7133.52265
+  tps: 7064.95696
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SparkofLife-37657"
  value: {
-  dps: 7067.37392
-  tps: 6991.34815
+  dps: 7134.05121
+  tps: 7057.78587
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6919.50612
-  tps: 6873.41783
+  dps: 6955.11268
+  tps: 6904.1867
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7103.1458
+  tps: 7045.35855
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7103.1458
+  tps: 7045.35855
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7103.1458
+  tps: 7045.35855
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7038.36088
-  tps: 6959.58111
+  dps: 7089.79177
+  tps: 7011.19157
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7017.23301
-  tps: 6945.89822
+  dps: 7066.53756
+  tps: 6994.36798
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6903.56135
-  tps: 6858.49662
+  dps: 6949.24067
+  tps: 6898.31076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7042.90744
-  tps: 6991.86765
+  dps: 7103.1458
+  tps: 7045.35855
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6919.50612
-  tps: 6873.41783
+  dps: 6955.11268
+  tps: 6904.1867
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6919.50612
-  tps: 6873.41783
+  dps: 6955.11268
+  tps: 6904.1867
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7095.28832
-  tps: 7039.01053
+  dps: 7175.23704
+  tps: 7114.77503
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7087.38556
-  tps: 7031.22409
+  dps: 7134.91902
+  tps: 7076.65859
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7117.96721
-  tps: 7057.5463
+  dps: 7174.23038
+  tps: 7115.93063
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7087.38556
-  tps: 7031.22409
+  dps: 7134.91902
+  tps: 7076.65859
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7095.28832
-  tps: 7039.01053
+  dps: 7175.23704
+  tps: 7114.77503
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7469.6876
-  tps: 7413.20331
+  dps: 7506.51799
+  tps: 7460.78079
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VestmentsofAbsolution"
  value: {
-  dps: 5125.34988
-  tps: 4986.29507
+  dps: 5147.90749
+  tps: 5010.15025
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7046.66063
-  tps: 6985.21115
+  dps: 7086.05589
+  tps: 7032.25508
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRaiment"
  value: {
-  dps: 6501.25334
-  tps: 6423.1212
+  dps: 6532.34373
+  tps: 6452.67515
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRegalia"
  value: {
-  dps: 6890.50373
-  tps: 6813.31105
+  dps: 6939.21831
+  tps: 6861.87011
  }
 }
 dps_results: {
  key: "TestShadow-Average-Default"
  value: {
-  dps: 7271.61363
-  tps: 7210.48699
+  dps: 7322.55802
+  tps: 7262.27609
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7232.65591
-  tps: 7982.30383
+  dps: 7295.30456
+  tps: 8044.11229
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7232.65591
-  tps: 7160.07902
+  dps: 7295.30456
+  tps: 7217.81331
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7842.16764
-  tps: 7920.16203
+  dps: 7882.05762
+  tps: 7960.81577
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3727.54113
-  tps: 4577.36799
+  dps: 3756.14691
+  tps: 4630.56815
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3727.54113
-  tps: 3651.74474
+  dps: 3756.14691
+  tps: 3680.88786
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3737.70553
-  tps: 3727.76726
+  dps: 3767.13107
+  tps: 3757.52686
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6829.52423
-  tps: 7690.82202
+  dps: 6853.47779
+  tps: 7769.80172
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6829.52423
-  tps: 6772.28791
+  dps: 6853.47779
+  tps: 6816.59393
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7584.48186
-  tps: 7663.52973
+  dps: 7643.54562
+  tps: 7722.5935
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3527.07332
-  tps: 4487.6596
+  dps: 3544.07965
+  tps: 4496.91722
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3527.07332
-  tps: 3458.93475
+  dps: 3544.07965
+  tps: 3475.06581
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3804.72557
-  tps: 3638.01467
+  dps: 3866.32439
+  tps: 3673.34993
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7229.77474
-  tps: 8118.84386
+  dps: 7276.82912
+  tps: 8184.50902
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7229.77474
-  tps: 7176.92194
+  dps: 7276.82912
+  tps: 7219.48057
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8013.13921
-  tps: 8092.57339
+  dps: 8085.64572
+  tps: 8165.0799
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3614.03015
-  tps: 4575.27372
+  dps: 3656.97717
+  tps: 4612.28254
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3614.03015
-  tps: 3546.54887
+  dps: 3656.97717
+  tps: 3586.99441
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4091.62238
-  tps: 3890.77616
+  dps: 4116.35464
+  tps: 3914.8625
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7223.76667
-  tps: 7984.85284
+  dps: 7285.46672
+  tps: 8033.46445
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7223.76667
-  tps: 7147.28578
+  dps: 7285.46672
+  tps: 7208.43706
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7836.38982
-  tps: 7914.4164
+  dps: 7881.24864
+  tps: 7960.03899
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3713.42604
-  tps: 4552.53094
+  dps: 3744.17239
+  tps: 4608.24386
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3713.42604
-  tps: 3637.21784
+  dps: 3744.17239
+  tps: 3668.87372
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3728.64486
-  tps: 3720.89526
+  dps: 3758.37331
+  tps: 3750.12264
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6820.09165
-  tps: 7697.51173
+  dps: 6852.03204
+  tps: 7759.3767
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6820.09165
-  tps: 6760.91583
+  dps: 6852.03204
+  tps: 6809.47177
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7575.42988
-  tps: 7654.47776
+  dps: 7638.36121
+  tps: 7717.40908
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3503.55088
-  tps: 4463.6002
+  dps: 3546.92649
+  tps: 4520.96329
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3503.55088
-  tps: 3434.87534
+  dps: 3546.92649
+  tps: 3478.49156
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3796.49909
-  tps: 3631.19693
+  dps: 3858.06418
+  tps: 3666.50465
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7228.56942
-  tps: 8101.10087
+  dps: 7288.39974
+  tps: 8176.23169
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7228.56942
-  tps: 7162.35647
+  dps: 7288.39974
+  tps: 7224.12311
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8000.84446
-  tps: 8080.27864
+  dps: 8070.42799
+  tps: 8149.86217
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3624.95131
-  tps: 4595.34283
+  dps: 3658.30569
+  tps: 4621.00358
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3624.95131
-  tps: 3556.30781
+  dps: 3658.30569
+  tps: 3588.842
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4086.88013
-  tps: 3887.25519
+  dps: 4111.50989
+  tps: 3911.24107
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7226.17262
-  tps: 7979.78397
+  dps: 7290.05214
+  tps: 8026.11688
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7226.17262
-  tps: 7153.54157
+  dps: 7290.05214
+  tps: 7212.414
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7838.62798
-  tps: 7916.58856
+  dps: 7881.68817
+  tps: 7959.64875
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3722.78352
-  tps: 4570.76914
+  dps: 3743.33943
+  tps: 4598.28746
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3722.78352
-  tps: 3646.68108
+  dps: 3743.33943
+  tps: 3667.33737
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3730.71248
-  tps: 3722.77352
+  dps: 3760.48331
+  tps: 3752.03932
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6826.73401
-  tps: 7700.23699
+  dps: 6859.55335
+  tps: 7766.58264
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6826.73401
-  tps: 6767.33673
+  dps: 6859.55335
+  tps: 6816.83348
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7579.70299
-  tps: 7658.68487
+  dps: 7640.38248
+  tps: 7719.36436
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3509.23294
-  tps: 4478.43213
+  dps: 3551.38333
+  tps: 4523.70736
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3509.23294
-  tps: 3441.12042
+  dps: 3551.38333
+  tps: 3482.96462
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3798.5463
-  tps: 3632.95211
+  dps: 3860.1957
+  tps: 3668.32556
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7248.63052
-  tps: 8113.86683
+  dps: 7299.94354
+  tps: 8186.30318
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7248.63052
-  tps: 7181.98824
+  dps: 7299.94354
+  tps: 7235.66473
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8005.40985
-  tps: 8084.77802
+  dps: 8072.89263
+  tps: 8152.26081
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3619.94902
-  tps: 4577.63435
+  dps: 3658.03024
+  tps: 4629.97135
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3619.94902
-  tps: 3550.6157
+  dps: 3658.03024
+  tps: 3589.22862
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4089.10005
-  tps: 3889.15961
+  dps: 4113.76812
+  tps: 3913.1787
  }
 }
 dps_results: {
  key: "TestShadow-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7235.44038
-  tps: 7181.98824
+  dps: 7287.0436
+  tps: 7235.66473
  }
 }

--- a/sim/priest/smite/TestSmite.results
+++ b/sim/priest/smite/TestSmite.results
@@ -46,822 +46,822 @@ character_stats_results: {
 dps_results: {
  key: "TestSmite-AllItems-AbsolutionRegalia"
  value: {
-  dps: 2402.26445
-  tps: 2061.09294
+  dps: 2409.01271
+  tps: 2066.40495
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 3510.88826
-  tps: 2980.12973
+  dps: 3514.43896
+  tps: 2983.99036
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 3527.31127
-  tps: 2993.6734
+  dps: 3530.87468
+  tps: 2997.54815
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3465.81437
+  tps: 2943.40256
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3380.712
+  tps: 2873.67929
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 3381.54669
-  tps: 2873.8362
-  hps: 89.4188
+  dps: 3385.92139
+  tps: 2878.32231
+  hps: 89.55698
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 3381.54669
-  tps: 2873.8362
-  hps: 89.4188
+  dps: 3385.92139
+  tps: 2878.32231
+  hps: 89.55698
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 3493.40025
-  tps: 2966.09707
+  dps: 3500.32531
+  tps: 2972.29725
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 2654.7953
-  tps: 2268.02023
+  dps: 2661.67934
+  tps: 2273.4344
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 3478.582
-  tps: 2895.94331
+  dps: 3484.26041
+  tps: 2900.58559
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 3490.02325
-  tps: 2962.83642
+  dps: 3495.41331
+  tps: 2967.90154
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3380.712
+  tps: 2873.67929
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3380.712
+  tps: 2873.67929
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3380.712
+  tps: 2873.67929
   hps: 64
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 3528.12058
-  tps: 3005.64819
+  dps: 3547.21022
+  tps: 3019.79579
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 3520.80531
-  tps: 2993.64341
+  dps: 3525.17103
+  tps: 2996.57865
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 3401.09938
-  tps: 2891.30004
+  dps: 3407.02026
+  tps: 2896.15296
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 3442.76487
-  tps: 2937.00923
+  dps: 3448.76373
+  tps: 2941.80847
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 3427.73504
-  tps: 2914.54363
+  dps: 3433.1929
+  tps: 2917.89699
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Death'sChoice-47464"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3380.712
+  tps: 2873.67929
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DeathKnight'sAnguish-38212"
- value: {
-  dps: 3380.77099
-  tps: 2873.15593
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-Deathbringer'sWill-50362"
- value: {
-  dps: 3377.26469
-  tps: 2869.93348
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-Deathbringer'sWill-50363"
- value: {
-  dps: 3377.26469
-  tps: 2869.93348
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-Defender'sCode-40257"
- value: {
-  dps: 3377.26469
-  tps: 2869.93348
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-DestructiveSkyflareDiamond"
- value: {
-  dps: 3461.60947
-  tps: 2939.38917
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-DislodgedForeignObject-50348"
- value: {
-  dps: 3508.40797
-  tps: 2977.7217
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-DislodgedForeignObject-50353"
- value: {
-  dps: 3499.92239
-  tps: 2974.11581
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-EffulgentSkyflareDiamond"
- value: {
-  dps: 3460.1522
-  tps: 2938.67596
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-EmberSkyflareDiamond"
- value: {
-  dps: 3521.13465
-  tps: 2988.19334
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-EnigmaticSkyflareDiamond"
- value: {
-  dps: 3461.41042
-  tps: 2939.15169
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-EnigmaticStarflareDiamond"
- value: {
-  dps: 3461.19398
-  tps: 2938.93525
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-EphemeralSnowflake-50260"
- value: {
-  dps: 3349.36022
-  tps: 2849.56756
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-EssenceofGossamer-37220"
- value: {
-  dps: 3377.26469
-  tps: 2869.93348
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-EternalEarthsiegeDiamond"
- value: {
-  dps: 3460.1522
-  tps: 2938.67596
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-ExtractofNecromanticPower-40373"
- value: {
-  dps: 3435.38291
-  tps: 2928.66584
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-EyeoftheBroodmother-45308"
- value: {
-  dps: 3484.22401
-  tps: 2959.71909
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-Figurine-SapphireOwl-42413"
- value: {
-  dps: 3451.53154
-  tps: 2932.09187
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-ForethoughtTalisman-40258"
- value: {
-  dps: 3460.12624
-  tps: 2938.26747
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-ForgeEmber-37660"
- value: {
-  dps: 3446.25256
-  tps: 2930.09401
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-ForlornSkyflareDiamond"
- value: {
-  dps: 3478.582
-  tps: 2953.88338
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-ForlornStarflareDiamond"
- value: {
-  dps: 3474.89604
-  tps: 2950.8419
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-FuryoftheFiveFlights-40431"
- value: {
-  dps: 3377.26469
-  tps: 2869.93348
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-FuturesightRune-38763"
- value: {
-  dps: 3444.85055
-  tps: 2927.33459
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-GarbofFaith"
- value: {
-  dps: 3147.4946
-  tps: 2691.39927
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-Gladiator'sInvestiture"
- value: {
-  dps: 3553.82671
-  tps: 3029.87573
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-Gladiator'sRaiment"
- value: {
-  dps: 3315.08203
-  tps: 2830.27472
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-GlowingTwilightScale-54573"
- value: {
-  dps: 3519.09977
-  tps: 2986.90156
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-GlowingTwilightScale-54589"
- value: {
-  dps: 3537.76228
-  tps: 3002.2921
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-GnomishLightningGenerator-41121"
- value: {
-  dps: 3417.62322
-  tps: 2913.48634
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-Heartpierce-49982"
- value: {
-  dps: 3521.13465
-  tps: 2988.19334
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-Heartpierce-50641"
- value: {
-  dps: 3521.13465
-  tps: 2988.19334
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-ImpassiveSkyflareDiamond"
- value: {
-  dps: 3461.41042
-  tps: 2939.15169
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-ImpassiveStarflareDiamond"
- value: {
-  dps: 3461.19398
-  tps: 2938.93525
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-IncisorFragment-37723"
- value: {
-  dps: 3377.26469
-  tps: 2869.93348
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-InsightfulEarthsiegeDiamond"
- value: {
-  dps: 3580.75829
-  tps: 3045.11524
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-InvigoratingEarthsiegeDiamond"
- value: {
-  dps: 3460.1522
-  tps: 2938.67596
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-LastWord-50179"
- value: {
-  dps: 3521.13465
-  tps: 2988.19334
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-LastWord-50708"
- value: {
-  dps: 3521.13465
-  tps: 2988.19334
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-Lavanthor'sTalisman-37872"
- value: {
-  dps: 3377.26469
-  tps: 2869.93348
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-MajesticDragonFigurine-40430"
- value: {
-  dps: 3517.71282
-  tps: 2988.09051
- }
-}
-dps_results: {
- key: "TestSmite-AllItems-MeteoriteWhetstone-37390"
  value: {
   dps: 3385.99576
   tps: 2879.04861
  }
 }
 dps_results: {
+ key: "TestSmite-AllItems-Deathbringer'sWill-50362"
+ value: {
+  dps: 3380.712
+  tps: 2873.67929
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-Deathbringer'sWill-50363"
+ value: {
+  dps: 3380.712
+  tps: 2873.67929
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-Defender'sCode-40257"
+ value: {
+  dps: 3380.712
+  tps: 2873.67929
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-DestructiveSkyflareDiamond"
+ value: {
+  dps: 3468.50277
+  tps: 2945.72966
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-DislodgedForeignObject-50348"
+ value: {
+  dps: 3514.05017
+  tps: 2982.11452
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-DislodgedForeignObject-50353"
+ value: {
+  dps: 3500.2134
+  tps: 2974.97642
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-EffulgentSkyflareDiamond"
+ value: {
+  dps: 3465.81437
+  tps: 2943.40256
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-EmberSkyflareDiamond"
+ value: {
+  dps: 3524.69096
+  tps: 2992.06268
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-EnigmaticSkyflareDiamond"
+ value: {
+  dps: 3466.12423
+  tps: 2943.6781
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-EnigmaticStarflareDiamond"
+ value: {
+  dps: 3467.68057
+  tps: 2945.28011
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-EphemeralSnowflake-50260"
+ value: {
+  dps: 3367.58661
+  tps: 2864.4468
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-EssenceofGossamer-37220"
+ value: {
+  dps: 3380.712
+  tps: 2873.67929
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-EternalEarthsiegeDiamond"
+ value: {
+  dps: 3465.81437
+  tps: 2943.40256
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-ExtractofNecromanticPower-40373"
+ value: {
+  dps: 3452.65465
+  tps: 2944.14086
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-EyeoftheBroodmother-45308"
+ value: {
+  dps: 3499.22152
+  tps: 2972.32358
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-Figurine-SapphireOwl-42413"
+ value: {
+  dps: 3462.58074
+  tps: 2939.70477
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-ForethoughtTalisman-40258"
+ value: {
+  dps: 3463.63766
+  tps: 2942.08448
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-ForgeEmber-37660"
+ value: {
+  dps: 3466.29471
+  tps: 2946.93933
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-ForlornSkyflareDiamond"
+ value: {
+  dps: 3484.26041
+  tps: 2958.622
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-ForlornStarflareDiamond"
+ value: {
+  dps: 3480.5712
+  tps: 2955.57811
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-FuryoftheFiveFlights-40431"
+ value: {
+  dps: 3380.712
+  tps: 2873.67929
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-FuturesightRune-38763"
+ value: {
+  dps: 3456.33735
+  tps: 2937.8278
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-GarbofFaith"
+ value: {
+  dps: 3163.27028
+  tps: 2704.31758
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-Gladiator'sInvestiture"
+ value: {
+  dps: 3569.28467
+  tps: 3040.62595
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-Gladiator'sRaiment"
+ value: {
+  dps: 3326.44265
+  tps: 2838.1292
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-GlowingTwilightScale-54573"
+ value: {
+  dps: 3522.65682
+  tps: 2990.76926
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-GlowingTwilightScale-54589"
+ value: {
+  dps: 3541.33377
+  tps: 3006.17583
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-GnomishLightningGenerator-41121"
+ value: {
+  dps: 3431.31935
+  tps: 2924.76295
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-Heartpierce-49982"
+ value: {
+  dps: 3524.69096
+  tps: 2992.06268
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-Heartpierce-50641"
+ value: {
+  dps: 3524.69096
+  tps: 2992.06268
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-ImpassiveSkyflareDiamond"
+ value: {
+  dps: 3466.12423
+  tps: 2943.6781
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-ImpassiveStarflareDiamond"
+ value: {
+  dps: 3467.68057
+  tps: 2945.28011
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-IncisorFragment-37723"
+ value: {
+  dps: 3380.712
+  tps: 2873.67929
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-InsightfulEarthsiegeDiamond"
+ value: {
+  dps: 3587.10453
+  tps: 3050.35029
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-InvigoratingEarthsiegeDiamond"
+ value: {
+  dps: 3465.81437
+  tps: 2943.40256
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-LastWord-50179"
+ value: {
+  dps: 3524.69096
+  tps: 2992.06268
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-LastWord-50708"
+ value: {
+  dps: 3524.69096
+  tps: 2992.06268
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-Lavanthor'sTalisman-37872"
+ value: {
+  dps: 3380.712
+  tps: 2873.67929
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-MajesticDragonFigurine-40430"
+ value: {
+  dps: 3532.25553
+  tps: 3000.79219
+ }
+}
+dps_results: {
+ key: "TestSmite-AllItems-MeteoriteWhetstone-37390"
+ value: {
+  dps: 3405.1067
+  tps: 2895.01029
+ }
+}
+dps_results: {
  key: "TestSmite-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 3477.43672
-  tps: 2954.1345
+  dps: 3484.00534
+  tps: 2960.95878
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Nibelung-49992"
  value: {
-  dps: 3521.13465
-  tps: 2988.19334
+  dps: 3524.69096
+  tps: 2992.06268
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Nibelung-50648"
  value: {
-  dps: 3521.13465
-  tps: 2988.19334
+  dps: 3524.69096
+  tps: 2992.06268
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3380.712
+  tps: 2873.67929
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3465.81437
+  tps: 2943.40256
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3465.81437
+  tps: 2943.40256
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3380.712
+  tps: 2873.67929
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3380.712
+  tps: 2873.67929
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3380.712
+  tps: 2873.67929
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3465.81437
+  tps: 2943.40256
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3465.81437
+  tps: 2943.40256
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3380.712
+  tps: 2873.67929
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RegaliaofFaith"
  value: {
-  dps: 3096.84355
-  tps: 2645.90191
+  dps: 3109.73743
+  tps: 2657.49702
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 3579.42421
-  tps: 3056.15474
+  dps: 3595.75766
+  tps: 3071.59209
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 3605.47148
-  tps: 3079.85999
+  dps: 3622.29595
+  tps: 3095.78435
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 3488.53752
-  tps: 2962.17383
+  dps: 3494.67941
+  tps: 2967.2988
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 3472.91568
-  tps: 2950.54084
+  dps: 3485.54384
+  tps: 2960.82581
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3380.712
+  tps: 2873.67929
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SanctificationGarb"
  value: {
-  dps: 3315.86109
-  tps: 2828.60285
+  dps: 3318.39624
+  tps: 2830.52724
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SanctificationRegalia"
  value: {
-  dps: 3291.63138
-  tps: 2806.77974
+  dps: 3305.74982
+  tps: 2818.23541
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3380.712
+  tps: 2873.67929
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3380.712
+  tps: 2873.67929
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3380.712
+  tps: 2873.67929
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 3601.06998
-  tps: 3061.55386
+  dps: 3605.49766
+  tps: 3065.41272
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 3632.79749
-  tps: 3087.85153
+  dps: 3647.51634
+  tps: 3100.56975
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SoulPreserver-37111"
  value: {
-  dps: 3433.25222
-  tps: 2916.10509
+  dps: 3436.74285
+  tps: 2919.89901
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SouloftheDead-40382"
  value: {
-  dps: 3496.72362
-  tps: 2975.07326
+  dps: 3506.3743
+  tps: 2983.42997
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SparkofLife-37657"
  value: {
-  dps: 3465.20651
-  tps: 2943.35476
+  dps: 3475.54485
+  tps: 2951.64586
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 3398.62019
-  tps: 2888.26231
+  dps: 3403.51714
+  tps: 2892.83498
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3465.81437
+  tps: 2943.40256
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3465.81437
+  tps: 2943.40256
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3465.81437
+  tps: 2943.40256
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 3430.79785
-  tps: 2916.55095
+  dps: 3451.58755
+  tps: 2934.19273
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 3492.03531
-  tps: 2969.58071
+  dps: 3505.26471
+  tps: 2981.4815
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3380.712
+  tps: 2873.67929
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3465.81437
+  tps: 2943.40256
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 3398.62019
-  tps: 2888.26231
+  dps: 3403.51714
+  tps: 2892.83498
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 3398.62019
-  tps: 2888.26231
+  dps: 3403.51714
+  tps: 2892.83498
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 3478.582
-  tps: 2953.88338
+  dps: 3484.26041
+  tps: 2958.622
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 3474.89604
-  tps: 2950.8419
+  dps: 3480.5712
+  tps: 2955.57811
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 3412.85097
-  tps: 2901.25807
+  dps: 3427.14399
+  tps: 2913.02515
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 3474.89604
-  tps: 2950.8419
+  dps: 3480.5712
+  tps: 2955.57811
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 3478.582
-  tps: 2953.88338
+  dps: 3484.26041
+  tps: 2958.622
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 3603.93313
-  tps: 3056.45728
+  dps: 3618.09049
+  tps: 3068.28749
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-VestmentsofAbsolution"
  value: {
-  dps: 2315.85798
-  tps: 1983.44941
+  dps: 2327.12464
+  tps: 1993.93817
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-WingedTalisman-37844"
  value: {
-  dps: 3431.64443
-  tps: 2916.35584
+  dps: 3435.47218
+  tps: 2920.3906
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Zabra'sRaiment"
  value: {
-  dps: 3280.37854
-  tps: 2798.61095
+  dps: 3285.42589
+  tps: 2804.87351
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Zabra'sRegalia"
  value: {
-  dps: 3434.31972
-  tps: 2925.17496
+  dps: 3434.00921
+  tps: 2925.73013
  }
 }
 dps_results: {
  key: "TestSmite-Average-Default"
  value: {
-  dps: 3500.57187
-  tps: 2974.06528
+  dps: 3513.54707
+  tps: 2984.87813
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3521.13465
-  tps: 4080.94938
+  dps: 3524.69096
+  tps: 4084.80899
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3521.13465
-  tps: 2988.19334
+  dps: 3524.69096
+  tps: 2992.06268
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4786.61322
-  tps: 4145.34204
+  dps: 4802.98377
+  tps: 4160.03991
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1187.14605
-  tps: 1472.42547
+  dps: 1191.57542
+  tps: 1476.29994
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1187.14605
-  tps: 1020.5374
+  dps: 1191.57542
+  tps: 1024.41187
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2829.54064
-  tps: 2269.24498
+  dps: 2837.73254
+  tps: 2276.92561
  }
 }
 dps_results: {
  key: "TestSmite-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3505.07311
-  tps: 2988.19334
+  dps: 3508.56243
+  tps: 2992.06268
  }
 }

--- a/sim/priest/smite/TestSmite.results
+++ b/sim/priest/smite/TestSmite.results
@@ -46,795 +46,795 @@ character_stats_results: {
 dps_results: {
  key: "TestSmite-AllItems-AbsolutionRegalia"
  value: {
-  dps: 2402.26445
-  tps: 2061.09294
+  dps: 2436.12526
+  tps: 2088.59504
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 3510.88826
-  tps: 2980.12973
+  dps: 3541.81612
+  tps: 3007.74514
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 3527.31127
-  tps: 2993.6734
+  dps: 3558.37879
+  tps: 3021.41228
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3494.3727
+  tps: 2967.82463
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 3381.54669
-  tps: 2873.8362
-  hps: 89.4188
+  dps: 3412.05219
+  tps: 2900.68099
+  hps: 89.80483
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 3381.54669
-  tps: 2873.8362
-  hps: 89.4188
+  dps: 3412.05219
+  tps: 2900.68099
+  hps: 89.80483
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 3493.40025
-  tps: 2966.09707
+  dps: 3538.60107
+  tps: 3002.73881
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 2654.7953
-  tps: 2268.02023
+  dps: 2690.97024
+  tps: 2296.84702
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 3478.582
-  tps: 2895.94331
+  dps: 3512.98559
+  tps: 2924.65441
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 3490.02325
-  tps: 2962.83642
+  dps: 3528.41092
+  tps: 2995.80662
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
   hps: 64
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 3528.12058
-  tps: 3005.64819
+  dps: 3573.90456
+  tps: 3041.54017
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 3520.80531
-  tps: 2993.64341
+  dps: 3548.71192
+  tps: 3015.22866
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 3401.09938
-  tps: 2891.30004
+  dps: 3433.80224
+  tps: 2917.45655
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 3442.76487
-  tps: 2937.00923
+  dps: 3483.47258
+  tps: 2970.71949
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 3427.73504
-  tps: 2914.54363
+  dps: 3473.70556
+  tps: 2949.80827
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Death'sChoice-47464"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 3380.77099
-  tps: 2873.15593
+  dps: 3418.56271
+  tps: 2904.66608
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Defender'sCode-40257"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 3461.60947
-  tps: 2939.38917
+  dps: 3497.68693
+  tps: 2970.32303
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 3508.40797
-  tps: 2977.7217
+  dps: 3556.19723
+  tps: 3018.25905
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 3499.92239
-  tps: 2974.11581
+  dps: 3540.20385
+  tps: 3007.80649
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3494.3727
+  tps: 2967.82463
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 3521.13465
-  tps: 2988.19334
+  dps: 3552.18738
+  tps: 3015.91992
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 3461.41042
-  tps: 2939.15169
+  dps: 3497.31514
+  tps: 2970.0256
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 3461.19398
-  tps: 2938.93525
+  dps: 3495.86267
+  tps: 2968.80218
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 3349.36022
-  tps: 2849.56756
+  dps: 3393.66471
+  tps: 2887.08043
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3494.3727
+  tps: 2967.82463
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 3435.38291
-  tps: 2928.66584
+  dps: 3473.37252
+  tps: 2960.82456
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 3484.22401
-  tps: 2959.71909
+  dps: 3532.93884
+  tps: 2998.8261
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 3451.53154
-  tps: 2932.09187
+  dps: 3501.99885
+  tps: 2971.72868
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 3460.12624
-  tps: 2938.26747
+  dps: 3490.62243
+  tps: 2965.50124
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ForgeEmber-37660"
  value: {
-  dps: 3446.25256
-  tps: 2930.09401
+  dps: 3493.00858
+  tps: 2967.66586
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 3478.582
-  tps: 2953.88338
+  dps: 3512.98559
+  tps: 2983.18239
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 3474.89604
-  tps: 2950.8419
+  dps: 3509.26301
+  tps: 2980.11084
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-FuturesightRune-38763"
  value: {
-  dps: 3444.85055
-  tps: 2927.33459
+  dps: 3486.17858
+  tps: 2961.86024
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-GarbofFaith"
  value: {
-  dps: 3147.4946
-  tps: 2691.39927
+  dps: 3185.68008
+  tps: 2724.3421
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 3553.82671
-  tps: 3029.87573
+  dps: 3583.1564
+  tps: 3053.5424
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 3315.08203
-  tps: 2830.27472
+  dps: 3353.0545
+  tps: 2859.57421
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 3519.09977
-  tps: 2986.90156
+  dps: 3550.09746
+  tps: 3014.57871
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 3537.76228
-  tps: 3002.2921
+  dps: 3568.91867
+  tps: 3030.10956
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 3417.62322
-  tps: 2913.48634
+  dps: 3474.4892
+  tps: 2959.11086
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Heartpierce-49982"
  value: {
-  dps: 3521.13465
-  tps: 2988.19334
+  dps: 3552.18738
+  tps: 3015.91992
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Heartpierce-50641"
  value: {
-  dps: 3521.13465
-  tps: 2988.19334
+  dps: 3552.18738
+  tps: 3015.91992
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 3461.41042
-  tps: 2939.15169
+  dps: 3497.31514
+  tps: 2970.0256
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 3461.19398
-  tps: 2938.93525
+  dps: 3495.86267
+  tps: 2968.80218
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-IncisorFragment-37723"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 3580.75829
-  tps: 3045.11524
+  dps: 3611.48307
+  tps: 3070.92039
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3494.3727
+  tps: 2967.82463
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-LastWord-50179"
  value: {
-  dps: 3521.13465
-  tps: 2988.19334
+  dps: 3552.18738
+  tps: 3015.91992
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-LastWord-50708"
  value: {
-  dps: 3521.13465
-  tps: 2988.19334
+  dps: 3552.18738
+  tps: 3015.91992
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 3517.71282
-  tps: 2988.09051
+  dps: 3563.34129
+  tps: 3026.62632
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 3385.99576
-  tps: 2879.04861
+  dps: 3431.93046
+  tps: 2915.86344
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 3477.43672
-  tps: 2954.1345
+  dps: 3504.35518
+  tps: 2977.69769
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Nibelung-49992"
  value: {
-  dps: 3521.13465
-  tps: 2988.19334
+  dps: 3552.18738
+  tps: 3015.91992
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Nibelung-50648"
  value: {
-  dps: 3521.13465
-  tps: 2988.19334
+  dps: 3552.18738
+  tps: 3015.91992
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3494.3727
+  tps: 2967.82463
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3494.3727
+  tps: 2967.82463
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3494.3727
+  tps: 2967.82463
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3494.3727
+  tps: 2967.82463
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RegaliaofFaith"
  value: {
-  dps: 3096.84355
-  tps: 2645.90191
+  dps: 3135.74099
+  tps: 2679.33623
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 3579.42421
-  tps: 3056.15474
+  dps: 3637.66268
+  tps: 3105.31707
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 3605.47148
-  tps: 3079.85999
+  dps: 3665.11651
+  tps: 3130.39224
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 3488.53752
-  tps: 2962.17383
+  dps: 3525.12262
+  tps: 2993.33849
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 3472.91568
-  tps: 2950.54084
+  dps: 3514.81318
+  tps: 2985.18174
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SanctificationGarb"
  value: {
-  dps: 3315.86109
-  tps: 2828.60285
+  dps: 3342.30243
+  tps: 2850.59637
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SanctificationRegalia"
  value: {
-  dps: 3291.63138
-  tps: 2806.77974
+  dps: 3321.00964
+  tps: 2830.56977
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 3601.06998
-  tps: 3061.55386
+  dps: 3640.41945
+  tps: 3095.43918
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 3632.79749
-  tps: 3087.85153
+  dps: 3675.45965
+  tps: 3125.19918
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SoulPreserver-37111"
  value: {
-  dps: 3433.25222
-  tps: 2916.10509
+  dps: 3463.51988
+  tps: 2943.13683
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SouloftheDead-40382"
  value: {
-  dps: 3496.72362
-  tps: 2975.07326
+  dps: 3528.25274
+  tps: 3001.8088
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SparkofLife-37657"
  value: {
-  dps: 3465.20651
-  tps: 2943.35476
+  dps: 3501.1229
+  tps: 2974.34058
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 3398.62019
-  tps: 2888.26231
+  dps: 3438.22363
+  tps: 2922.64626
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3494.3727
+  tps: 2967.82463
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3494.3727
+  tps: 2967.82463
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3494.3727
+  tps: 2967.82463
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 3430.79785
-  tps: 2916.55095
+  dps: 3474.18883
+  tps: 2953.23326
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 3492.03531
-  tps: 2969.58071
+  dps: 3544.98952
+  tps: 3014.89414
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 3377.26469
-  tps: 2869.93348
+  dps: 3407.05625
+  tps: 2896.5443
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 3460.1522
-  tps: 2938.67596
+  dps: 3494.3727
+  tps: 2967.82463
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 3398.62019
-  tps: 2888.26231
+  dps: 3438.22363
+  tps: 2922.64626
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 3398.62019
-  tps: 2888.26231
+  dps: 3438.22363
+  tps: 2922.64626
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 3478.582
-  tps: 2953.88338
+  dps: 3512.98559
+  tps: 2983.18239
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 3474.89604
-  tps: 2950.8419
+  dps: 3509.26301
+  tps: 2980.11084
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 3412.85097
-  tps: 2901.25807
+  dps: 3455.98377
+  tps: 2937.66321
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 3474.89604
-  tps: 2950.8419
+  dps: 3509.26301
+  tps: 2980.11084
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 3478.582
-  tps: 2953.88338
+  dps: 3512.98559
+  tps: 2983.18239
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 3603.93313
-  tps: 3056.45728
+  dps: 3651.73987
+  tps: 3097.81938
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-VestmentsofAbsolution"
  value: {
-  dps: 2315.85798
-  tps: 1983.44941
+  dps: 2342.44152
+  tps: 2007.71395
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-WingedTalisman-37844"
  value: {
-  dps: 3431.64443
-  tps: 2916.35584
+  dps: 3462.1986
+  tps: 2943.51841
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Zabra'sRaiment"
  value: {
-  dps: 3280.37854
-  tps: 2798.61095
+  dps: 3304.55381
+  tps: 2822.55596
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Zabra'sRegalia"
  value: {
-  dps: 3434.31972
-  tps: 2925.17496
+  dps: 3462.07273
+  tps: 2949.18338
  }
 }
 dps_results: {
  key: "TestSmite-Average-Default"
  value: {
-  dps: 3500.57187
-  tps: 2974.06528
+  dps: 3547.064
+  tps: 3012.163
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3521.13465
-  tps: 4080.94938
+  dps: 3552.18738
+  tps: 4107.53864
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3521.13465
-  tps: 2988.19334
+  dps: 3552.18738
+  tps: 3015.91992
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4786.61322
-  tps: 4145.34204
+  dps: 4828.90007
+  tps: 4180.75956
  }
 }
 dps_results: {
@@ -861,7 +861,7 @@ dps_results: {
 dps_results: {
  key: "TestSmite-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3505.07311
-  tps: 2988.19334
+  dps: 3536.14408
+  tps: 3015.91992
  }
 }

--- a/sim/priest/smite/TestSmite.results
+++ b/sim/priest/smite/TestSmite.results
@@ -46,822 +46,822 @@ character_stats_results: {
 dps_results: {
  key: "TestSmite-AllItems-AbsolutionRegalia"
  value: {
-  dps: 2436.12526
-  tps: 2088.59504
+  dps: 2402.26445
+  tps: 2061.09294
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 3541.81612
-  tps: 3007.74514
+  dps: 3510.88826
+  tps: 2980.12973
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 3558.37879
-  tps: 3021.41228
+  dps: 3527.31127
+  tps: 2993.6734
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 3494.3727
-  tps: 2967.82463
+  dps: 3460.1522
+  tps: 2938.67596
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 3412.05219
-  tps: 2900.68099
-  hps: 89.80483
+  dps: 3381.54669
+  tps: 2873.8362
+  hps: 89.4188
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 3412.05219
-  tps: 2900.68099
-  hps: 89.80483
+  dps: 3381.54669
+  tps: 2873.8362
+  hps: 89.4188
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 3538.60107
-  tps: 3002.73881
+  dps: 3493.40025
+  tps: 2966.09707
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 2690.97024
-  tps: 2296.84702
+  dps: 2654.7953
+  tps: 2268.02023
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 3512.98559
-  tps: 2924.65441
+  dps: 3478.582
+  tps: 2895.94331
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 3528.41092
-  tps: 2995.80662
+  dps: 3490.02325
+  tps: 2962.83642
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
   hps: 64
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 3573.90456
-  tps: 3041.54017
+  dps: 3528.12058
+  tps: 3005.64819
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 3548.71192
-  tps: 3015.22866
+  dps: 3520.80531
+  tps: 2993.64341
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 3433.80224
-  tps: 2917.45655
+  dps: 3401.09938
+  tps: 2891.30004
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 3483.47258
-  tps: 2970.71949
+  dps: 3442.76487
+  tps: 2937.00923
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 3473.70556
-  tps: 2949.80827
+  dps: 3427.73504
+  tps: 2914.54363
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Death'sChoice-47464"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 3418.56271
-  tps: 2904.66608
+  dps: 3380.77099
+  tps: 2873.15593
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Defender'sCode-40257"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 3497.68693
-  tps: 2970.32303
+  dps: 3461.60947
+  tps: 2939.38917
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 3556.19723
-  tps: 3018.25905
+  dps: 3508.40797
+  tps: 2977.7217
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 3540.20385
-  tps: 3007.80649
+  dps: 3499.92239
+  tps: 2974.11581
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 3494.3727
-  tps: 2967.82463
+  dps: 3460.1522
+  tps: 2938.67596
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 3552.18738
-  tps: 3015.91992
+  dps: 3521.13465
+  tps: 2988.19334
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 3497.31514
-  tps: 2970.0256
+  dps: 3461.41042
+  tps: 2939.15169
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 3495.86267
-  tps: 2968.80218
+  dps: 3461.19398
+  tps: 2938.93525
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 3393.66471
-  tps: 2887.08043
+  dps: 3349.36022
+  tps: 2849.56756
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 3494.3727
-  tps: 2967.82463
+  dps: 3460.1522
+  tps: 2938.67596
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 3473.37252
-  tps: 2960.82456
+  dps: 3435.38291
+  tps: 2928.66584
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 3532.93884
-  tps: 2998.8261
+  dps: 3484.22401
+  tps: 2959.71909
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 3501.99885
-  tps: 2971.72868
+  dps: 3451.53154
+  tps: 2932.09187
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 3490.62243
-  tps: 2965.50124
+  dps: 3460.12624
+  tps: 2938.26747
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ForgeEmber-37660"
  value: {
-  dps: 3493.00858
-  tps: 2967.66586
+  dps: 3446.25256
+  tps: 2930.09401
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 3512.98559
-  tps: 2983.18239
+  dps: 3478.582
+  tps: 2953.88338
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 3509.26301
-  tps: 2980.11084
+  dps: 3474.89604
+  tps: 2950.8419
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-FuturesightRune-38763"
  value: {
-  dps: 3486.17858
-  tps: 2961.86024
+  dps: 3444.85055
+  tps: 2927.33459
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-GarbofFaith"
  value: {
-  dps: 3185.68008
-  tps: 2724.3421
+  dps: 3147.4946
+  tps: 2691.39927
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 3583.1564
-  tps: 3053.5424
+  dps: 3553.82671
+  tps: 3029.87573
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 3353.0545
-  tps: 2859.57421
+  dps: 3315.08203
+  tps: 2830.27472
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 3550.09746
-  tps: 3014.57871
+  dps: 3519.09977
+  tps: 2986.90156
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 3568.91867
-  tps: 3030.10956
+  dps: 3537.76228
+  tps: 3002.2921
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 3474.4892
-  tps: 2959.11086
+  dps: 3417.62322
+  tps: 2913.48634
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Heartpierce-49982"
  value: {
-  dps: 3552.18738
-  tps: 3015.91992
+  dps: 3521.13465
+  tps: 2988.19334
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Heartpierce-50641"
  value: {
-  dps: 3552.18738
-  tps: 3015.91992
+  dps: 3521.13465
+  tps: 2988.19334
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 3497.31514
-  tps: 2970.0256
+  dps: 3461.41042
+  tps: 2939.15169
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 3495.86267
-  tps: 2968.80218
+  dps: 3461.19398
+  tps: 2938.93525
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-IncisorFragment-37723"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 3611.48307
-  tps: 3070.92039
+  dps: 3580.75829
+  tps: 3045.11524
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 3494.3727
-  tps: 2967.82463
+  dps: 3460.1522
+  tps: 2938.67596
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-LastWord-50179"
  value: {
-  dps: 3552.18738
-  tps: 3015.91992
+  dps: 3521.13465
+  tps: 2988.19334
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-LastWord-50708"
  value: {
-  dps: 3552.18738
-  tps: 3015.91992
+  dps: 3521.13465
+  tps: 2988.19334
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 3563.34129
-  tps: 3026.62632
+  dps: 3517.71282
+  tps: 2988.09051
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 3431.93046
-  tps: 2915.86344
+  dps: 3385.99576
+  tps: 2879.04861
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 3504.35518
-  tps: 2977.69769
+  dps: 3477.43672
+  tps: 2954.1345
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Nibelung-49992"
  value: {
-  dps: 3552.18738
-  tps: 3015.91992
+  dps: 3521.13465
+  tps: 2988.19334
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Nibelung-50648"
  value: {
-  dps: 3552.18738
-  tps: 3015.91992
+  dps: 3521.13465
+  tps: 2988.19334
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 3494.3727
-  tps: 2967.82463
+  dps: 3460.1522
+  tps: 2938.67596
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 3494.3727
-  tps: 2967.82463
+  dps: 3460.1522
+  tps: 2938.67596
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 3494.3727
-  tps: 2967.82463
+  dps: 3460.1522
+  tps: 2938.67596
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 3494.3727
-  tps: 2967.82463
+  dps: 3460.1522
+  tps: 2938.67596
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RegaliaofFaith"
  value: {
-  dps: 3135.74099
-  tps: 2679.33623
+  dps: 3096.84355
+  tps: 2645.90191
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 3637.66268
-  tps: 3105.31707
+  dps: 3579.42421
+  tps: 3056.15474
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 3665.11651
-  tps: 3130.39224
+  dps: 3605.47148
+  tps: 3079.85999
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 3525.12262
-  tps: 2993.33849
+  dps: 3488.53752
+  tps: 2962.17383
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 3514.81318
-  tps: 2985.18174
+  dps: 3472.91568
+  tps: 2950.54084
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SanctificationGarb"
  value: {
-  dps: 3342.30243
-  tps: 2850.59637
+  dps: 3315.86109
+  tps: 2828.60285
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SanctificationRegalia"
  value: {
-  dps: 3321.00964
-  tps: 2830.56977
+  dps: 3291.63138
+  tps: 2806.77974
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 3640.41945
-  tps: 3095.43918
+  dps: 3601.06998
+  tps: 3061.55386
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 3675.45965
-  tps: 3125.19918
+  dps: 3632.79749
+  tps: 3087.85153
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SoulPreserver-37111"
  value: {
-  dps: 3463.51988
-  tps: 2943.13683
+  dps: 3433.25222
+  tps: 2916.10509
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SouloftheDead-40382"
  value: {
-  dps: 3528.25274
-  tps: 3001.8088
+  dps: 3496.72362
+  tps: 2975.07326
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SparkofLife-37657"
  value: {
-  dps: 3501.1229
-  tps: 2974.34058
+  dps: 3465.20651
+  tps: 2943.35476
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 3438.22363
-  tps: 2922.64626
+  dps: 3398.62019
+  tps: 2888.26231
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 3494.3727
-  tps: 2967.82463
+  dps: 3460.1522
+  tps: 2938.67596
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 3494.3727
-  tps: 2967.82463
+  dps: 3460.1522
+  tps: 2938.67596
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 3494.3727
-  tps: 2967.82463
+  dps: 3460.1522
+  tps: 2938.67596
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 3474.18883
-  tps: 2953.23326
+  dps: 3430.79785
+  tps: 2916.55095
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 3544.98952
-  tps: 3014.89414
+  dps: 3492.03531
+  tps: 2969.58071
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 3407.05625
-  tps: 2896.5443
+  dps: 3377.26469
+  tps: 2869.93348
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 3494.3727
-  tps: 2967.82463
+  dps: 3460.1522
+  tps: 2938.67596
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 3438.22363
-  tps: 2922.64626
+  dps: 3398.62019
+  tps: 2888.26231
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 3438.22363
-  tps: 2922.64626
+  dps: 3398.62019
+  tps: 2888.26231
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 3512.98559
-  tps: 2983.18239
+  dps: 3478.582
+  tps: 2953.88338
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 3509.26301
-  tps: 2980.11084
+  dps: 3474.89604
+  tps: 2950.8419
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 3455.98377
-  tps: 2937.66321
+  dps: 3412.85097
+  tps: 2901.25807
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 3509.26301
-  tps: 2980.11084
+  dps: 3474.89604
+  tps: 2950.8419
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 3512.98559
-  tps: 2983.18239
+  dps: 3478.582
+  tps: 2953.88338
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 3651.73987
-  tps: 3097.81938
+  dps: 3603.93313
+  tps: 3056.45728
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-VestmentsofAbsolution"
  value: {
-  dps: 2342.44152
-  tps: 2007.71395
+  dps: 2315.85798
+  tps: 1983.44941
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-WingedTalisman-37844"
  value: {
-  dps: 3462.1986
-  tps: 2943.51841
+  dps: 3431.64443
+  tps: 2916.35584
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Zabra'sRaiment"
  value: {
-  dps: 3304.55381
-  tps: 2822.55596
+  dps: 3280.37854
+  tps: 2798.61095
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Zabra'sRegalia"
  value: {
-  dps: 3462.07273
-  tps: 2949.18338
+  dps: 3434.31972
+  tps: 2925.17496
  }
 }
 dps_results: {
  key: "TestSmite-Average-Default"
  value: {
-  dps: 3547.064
-  tps: 3012.163
+  dps: 3500.57187
+  tps: 2974.06528
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3552.18738
-  tps: 4107.53864
+  dps: 3521.13465
+  tps: 4080.94938
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3552.18738
-  tps: 3015.91992
+  dps: 3521.13465
+  tps: 2988.19334
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4828.90007
-  tps: 4180.75956
+  dps: 4786.61322
+  tps: 4145.34204
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1207.0692
-  tps: 1488.40529
+  dps: 1187.14605
+  tps: 1472.42547
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1207.0692
-  tps: 1036.51722
+  dps: 1187.14605
+  tps: 1020.5374
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-P1-Basic-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2867.13794
-  tps: 2301.13513
+  dps: 2829.54064
+  tps: 2269.24498
  }
 }
 dps_results: {
  key: "TestSmite-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3536.14408
-  tps: 3015.91992
+  dps: 3505.07311
+  tps: 2988.19334
  }
 }

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -46,768 +46,768 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7428.44853
-  tps: 5274.19845
+  dps: 7463.92646
+  tps: 5299.38779
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7614.18016
+  tps: 5406.06792
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7636.55058
-  tps: 5421.95091
+  dps: 7673.74386
+  tps: 5448.35814
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7410.11323
-  tps: 5261.18039
+  dps: 7445.27677
+  tps: 5286.14651
   hps: 60.32296
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7410.11323
-  tps: 5261.18039
+  dps: 7445.27677
+  tps: 5286.14651
   hps: 60.32296
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7605.03417
-  tps: 5399.57426
+  dps: 7637.30377
+  tps: 5422.48567
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50035"
  value: {
-  dps: 4927.69622
-  tps: 3498.66431
+  dps: 4943.05297
+  tps: 3509.56761
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50692"
  value: {
-  dps: 4998.32747
-  tps: 3548.81251
+  dps: 5013.53816
+  tps: 3559.61209
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5783.10845
-  tps: 4106.007
+  dps: 5812.92214
+  tps: 4127.17472
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6948.75288
-  tps: 4933.61455
+  dps: 6978.84466
+  tps: 4954.97971
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5274.92361
+  dps: 7614.18016
+  tps: 5297.94656
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7725.86316
-  tps: 5485.36284
+  dps: 7761.03702
+  tps: 5510.33628
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7550.44097
-  tps: 5360.81309
+  dps: 7587.069
+  tps: 5386.81899
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7594.90405
-  tps: 5392.38188
+  dps: 7633.67534
+  tps: 5419.90949
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7603.99152
-  tps: 5398.83398
+  dps: 7639.85142
+  tps: 5424.29451
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7977.32441
-  tps: 5663.90033
+  dps: 8015.20257
+  tps: 5690.79382
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7510.89562
-  tps: 5332.73589
+  dps: 7546.50941
+  tps: 5358.02168
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7844.14317
-  tps: 5569.34165
+  dps: 7880.93908
+  tps: 5595.46675
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7905.16051
-  tps: 5612.66396
+  dps: 7941.57823
+  tps: 5638.52055
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7605.67814
-  tps: 5400.03148
+  dps: 7637.45312
+  tps: 5422.59172
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7624.66331
-  tps: 5413.51095
+  dps: 7661.81513
+  tps: 5439.88874
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7605.95317
-  tps: 5400.22675
+  dps: 7642.54771
+  tps: 5426.20887
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7614.18016
+  tps: 5406.06792
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7614.18016
+  tps: 5406.06792
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7605.03417
-  tps: 5399.57426
+  dps: 7637.30377
+  tps: 5422.48567
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7591.80662
-  tps: 5390.1827
+  dps: 7623.84522
+  tps: 5412.9301
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7481.42024
-  tps: 5311.80837
+  dps: 7517.25481
+  tps: 5337.25091
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7614.18016
+  tps: 5406.06792
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7573.94147
-  tps: 5377.49845
+  dps: 7611.72511
+  tps: 5404.32483
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7535.41111
-  tps: 5350.14189
+  dps: 7572.86844
+  tps: 5376.73659
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7408.59263
-  tps: 5260.10077
+  dps: 7443.65376
+  tps: 5284.99417
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7516.47401
-  tps: 5336.69654
+  dps: 7553.47069
+  tps: 5362.96419
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7614.18016
+  tps: 5406.06792
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7614.18016
+  tps: 5406.06792
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7689.70687
-  tps: 5459.69188
+  dps: 7726.04634
+  tps: 5485.4929
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7457.23884
-  tps: 5294.63957
+  dps: 7491.11839
+  tps: 5318.69406
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7545.45936
-  tps: 5357.27614
+  dps: 7583.43061
+  tps: 5384.23574
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-49982"
  value: {
-  dps: 7721.10761
-  tps: 5481.9864
+  dps: 7756.86034
+  tps: 5507.37084
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-50641"
  value: {
-  dps: 7721.10761
-  tps: 5481.9864
+  dps: 7756.86034
+  tps: 5507.37084
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7605.03417
-  tps: 5399.57426
+  dps: 7637.30377
+  tps: 5422.48567
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7591.80662
-  tps: 5390.1827
+  dps: 7623.84522
+  tps: 5412.9301
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7579.98184
-  tps: 5381.7871
+  dps: 7615.66173
+  tps: 5407.11983
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7614.18016
+  tps: 5406.06792
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7621.12239
-  tps: 5410.9969
+  dps: 7654.42039
+  tps: 5434.63848
   hps: 11.11293
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7624.83142
-  tps: 5413.63031
+  dps: 7662.54688
+  tps: 5440.40829
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7615.32579
-  tps: 5406.88131
+  dps: 7648.44014
+  tps: 5430.3925
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7611.12191
-  tps: 5403.89656
+  dps: 7644.33151
+  tps: 5427.47537
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7618.18784
-  tps: 5408.91337
+  dps: 7651.42595
+  tps: 5432.51242
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7614.18016
+  tps: 5406.06792
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7614.18016
+  tps: 5406.06792
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7600.08894
-  tps: 5396.06315
+  dps: 7650.12176
+  tps: 5431.58645
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7624.2655
-  tps: 5413.22851
+  dps: 7675.97335
+  tps: 5449.94108
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7721.10761
-  tps: 5481.9864
+  dps: 7756.86034
+  tps: 5507.37084
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7614.18016
+  tps: 5406.06792
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7738.71872
-  tps: 5494.49029
+  dps: 7772.83202
+  tps: 5518.71074
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 5695.66359
-  tps: 4043.92115
+  dps: 5723.38584
+  tps: 4063.60395
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7540.31878
-  tps: 5353.62633
+  dps: 7577.74486
+  tps: 5380.19885
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 7490.19507
-  tps: 5318.0385
+  dps: 7526.20661
+  tps: 5343.60669
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7561.33235
-  tps: 5368.54597
+  dps: 7597.57753
+  tps: 5394.28005
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StormshroudArmor"
  value: {
-  dps: 6056.58177
-  tps: 4300.17305
+  dps: 6088.65336
+  tps: 4322.94389
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7618.18784
-  tps: 5408.91337
+  dps: 7651.42595
+  tps: 5432.51242
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7611.12191
-  tps: 5403.89656
+  dps: 7644.33151
+  tps: 5427.47537
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7598.75653
-  tps: 5395.11714
+  dps: 7631.91625
+  tps: 5418.66054
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 7372.30958
-  tps: 5234.3398
+  dps: 7405.46441
+  tps: 5257.87973
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheFistsofFury"
  value: {
-  dps: 4236.4554
-  tps: 3007.88333
+  dps: 4252.13272
+  tps: 3019.01423
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7652.89683
-  tps: 5433.55675
+  dps: 7686.70071
+  tps: 5457.5575
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7831.31203
-  tps: 5560.23154
+  dps: 7870.40161
+  tps: 5587.98514
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7892.82683
-  tps: 5603.90705
+  dps: 7932.27894
+  tps: 5631.91805
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7614.18016
+  tps: 5406.06792
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7614.18016
+  tps: 5406.06792
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7430.23555
-  tps: 5275.46724
+  dps: 7465.38857
+  tps: 5300.42588
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7614.18016
+  tps: 5406.06792
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7614.18016
+  tps: 5406.06792
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6136.90509
-  tps: 4357.20261
+  dps: 6168.20488
+  tps: 4379.42547
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 7142.35816
-  tps: 5071.07429
+  dps: 7172.84607
+  tps: 5092.72071
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7444.98342
+  tps: 5285.93823
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 7739.15843
-  tps: 5494.80248
+  dps: 7777.49182
+  tps: 5522.0192
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28849.89914
-  tps: 20483.42839
+  dps: 28870.05946
+  tps: 20497.74222
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7721.10761
-  tps: 5481.9864
+  dps: 7756.86034
+  tps: 5507.37084
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8905.28677
-  tps: 6322.75361
+  dps: 8946.50088
+  tps: 6352.01562
  }
 }
 dps_results: {
@@ -876,22 +876,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27566.49461
-  tps: 19572.21117
+  dps: 27585.83579
+  tps: 19585.94341
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7308.86451
-  tps: 5189.2938
+  dps: 7339.95088
+  tps: 5211.36512
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8379.5869
-  tps: 5949.5067
+  dps: 8413.18311
+  tps: 5973.36001
  }
 }
 dps_results: {
@@ -918,22 +918,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18285.76227
-  tps: 12982.89121
+  dps: 18302.52243
+  tps: 12994.79093
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3590.40285
-  tps: 2549.18602
+  dps: 3606.38293
+  tps: 2560.53188
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4155.01488
-  tps: 2950.06057
+  dps: 4176.88196
+  tps: 2965.58619
  }
 }
 dps_results: {
@@ -960,22 +960,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28931.8185
-  tps: 20541.59113
+  dps: 28954.30187
+  tps: 20557.55433
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7757.547
-  tps: 5507.85837
+  dps: 7793.64979
+  tps: 5533.49135
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9007.69374
-  tps: 6395.46256
+  dps: 9049.38893
+  tps: 6425.06614
  }
 }
 dps_results: {
@@ -1044,22 +1044,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27673.89707
-  tps: 19648.46692
+  dps: 27692.01449
+  tps: 19661.33029
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7343.25643
-  tps: 5213.71207
+  dps: 7374.41231
+  tps: 5235.83274
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8478.20348
-  tps: 6019.52447
+  dps: 8512.20624
+  tps: 6043.66643
  }
 }
 dps_results: {
@@ -1086,22 +1086,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18389.74389
-  tps: 13056.71816
+  dps: 18406.15733
+  tps: 13068.37171
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3601.38272
-  tps: 2556.98173
+  dps: 3617.40913
+  tps: 2568.36048
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4193.49256
-  tps: 2977.37972
+  dps: 4215.505
+  tps: 2993.00855
  }
 }
 dps_results: {
@@ -1128,7 +1128,7 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7271.13797
-  tps: 5162.50796
+  dps: 7304.35676
+  tps: 5186.0933
  }
 }

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -46,789 +46,789 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7463.92646
-  tps: 5299.38779
+  dps: 7428.44853
+  tps: 5274.19845
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7614.18016
-  tps: 5406.06792
+  dps: 7581.0917
+  tps: 5382.57511
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7673.74386
-  tps: 5448.35814
+  dps: 7636.55058
+  tps: 5421.95091
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7445.27677
-  tps: 5286.14651
+  dps: 7410.11323
+  tps: 5261.18039
   hps: 60.32296
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7445.27677
-  tps: 5286.14651
+  dps: 7410.11323
+  tps: 5261.18039
   hps: 60.32296
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7637.30377
-  tps: 5422.48567
+  dps: 7605.03417
+  tps: 5399.57426
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50035"
  value: {
-  dps: 4943.05297
-  tps: 3509.56761
+  dps: 4927.69622
+  tps: 3498.66431
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50692"
  value: {
-  dps: 5013.53816
-  tps: 3559.61209
+  dps: 4998.32747
+  tps: 3548.81251
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5812.92214
-  tps: 4127.17472
+  dps: 5783.10845
+  tps: 4106.007
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6978.84466
-  tps: 4954.97971
+  dps: 6948.75288
+  tps: 4933.61455
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7614.18016
-  tps: 5297.94656
+  dps: 7581.0917
+  tps: 5274.92361
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7761.03702
-  tps: 5510.33628
+  dps: 7725.86316
+  tps: 5485.36284
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7587.069
-  tps: 5386.81899
+  dps: 7550.44097
+  tps: 5360.81309
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7633.67534
-  tps: 5419.90949
+  dps: 7594.90405
+  tps: 5392.38188
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7639.85142
-  tps: 5424.29451
+  dps: 7603.99152
+  tps: 5398.83398
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8015.20257
-  tps: 5690.79382
+  dps: 7977.32441
+  tps: 5663.90033
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7546.50941
-  tps: 5358.02168
+  dps: 7510.89562
+  tps: 5332.73589
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7880.93908
-  tps: 5595.46675
+  dps: 7844.14317
+  tps: 5569.34165
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7941.57823
-  tps: 5638.52055
+  dps: 7905.16051
+  tps: 5612.66396
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7637.45312
-  tps: 5422.59172
+  dps: 7605.67814
+  tps: 5400.03148
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7661.81513
-  tps: 5439.88874
+  dps: 7624.66331
+  tps: 5413.51095
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7642.54771
-  tps: 5426.20887
+  dps: 7605.95317
+  tps: 5400.22675
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7614.18016
-  tps: 5406.06792
+  dps: 7581.0917
+  tps: 5382.57511
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7614.18016
-  tps: 5406.06792
+  dps: 7581.0917
+  tps: 5382.57511
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7637.30377
-  tps: 5422.48567
+  dps: 7605.03417
+  tps: 5399.57426
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7623.84522
-  tps: 5412.9301
+  dps: 7591.80662
+  tps: 5390.1827
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7517.25481
-  tps: 5337.25091
+  dps: 7481.42024
+  tps: 5311.80837
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7614.18016
-  tps: 5406.06792
+  dps: 7581.0917
+  tps: 5382.57511
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7611.72511
-  tps: 5404.32483
+  dps: 7573.94147
+  tps: 5377.49845
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7572.86844
-  tps: 5376.73659
+  dps: 7535.41111
+  tps: 5350.14189
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7443.65376
-  tps: 5284.99417
+  dps: 7408.59263
+  tps: 5260.10077
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7553.47069
-  tps: 5362.96419
+  dps: 7516.47401
+  tps: 5336.69654
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7614.18016
-  tps: 5406.06792
+  dps: 7581.0917
+  tps: 5382.57511
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7614.18016
-  tps: 5406.06792
+  dps: 7581.0917
+  tps: 5382.57511
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7726.04634
-  tps: 5485.4929
+  dps: 7689.70687
+  tps: 5459.69188
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7491.11839
-  tps: 5318.69406
+  dps: 7457.23884
+  tps: 5294.63957
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7583.43061
-  tps: 5384.23574
+  dps: 7545.45936
+  tps: 5357.27614
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-49982"
  value: {
-  dps: 7756.86034
-  tps: 5507.37084
+  dps: 7721.10761
+  tps: 5481.9864
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-50641"
  value: {
-  dps: 7756.86034
-  tps: 5507.37084
+  dps: 7721.10761
+  tps: 5481.9864
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7637.30377
-  tps: 5422.48567
+  dps: 7605.03417
+  tps: 5399.57426
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7623.84522
-  tps: 5412.9301
+  dps: 7591.80662
+  tps: 5390.1827
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7615.66173
-  tps: 5407.11983
+  dps: 7579.98184
+  tps: 5381.7871
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7614.18016
-  tps: 5406.06792
+  dps: 7581.0917
+  tps: 5382.57511
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7654.42039
-  tps: 5434.63848
+  dps: 7621.12239
+  tps: 5410.9969
   hps: 11.11293
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7662.54688
-  tps: 5440.40829
+  dps: 7624.83142
+  tps: 5413.63031
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7648.44014
-  tps: 5430.3925
+  dps: 7615.32579
+  tps: 5406.88131
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7644.33151
-  tps: 5427.47537
+  dps: 7611.12191
+  tps: 5403.89656
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7651.42595
-  tps: 5432.51242
+  dps: 7618.18784
+  tps: 5408.91337
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7614.18016
-  tps: 5406.06792
+  dps: 7581.0917
+  tps: 5382.57511
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7614.18016
-  tps: 5406.06792
+  dps: 7581.0917
+  tps: 5382.57511
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7650.12176
-  tps: 5431.58645
+  dps: 7600.08894
+  tps: 5396.06315
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7675.97335
-  tps: 5449.94108
+  dps: 7624.2655
+  tps: 5413.22851
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7756.86034
-  tps: 5507.37084
+  dps: 7721.10761
+  tps: 5481.9864
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7614.18016
-  tps: 5406.06792
+  dps: 7581.0917
+  tps: 5382.57511
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7772.83202
-  tps: 5518.71074
+  dps: 7738.71872
+  tps: 5494.49029
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 5723.38584
-  tps: 4063.60395
+  dps: 5695.66359
+  tps: 4043.92115
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7577.74486
-  tps: 5380.19885
+  dps: 7540.31878
+  tps: 5353.62633
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 7526.20661
-  tps: 5343.60669
+  dps: 7490.19507
+  tps: 5318.0385
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7597.57753
-  tps: 5394.28005
+  dps: 7561.33235
+  tps: 5368.54597
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StormshroudArmor"
  value: {
-  dps: 6088.65336
-  tps: 4322.94389
+  dps: 6056.58177
+  tps: 4300.17305
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7651.42595
-  tps: 5432.51242
+  dps: 7618.18784
+  tps: 5408.91337
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7644.33151
-  tps: 5427.47537
+  dps: 7611.12191
+  tps: 5403.89656
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7631.91625
-  tps: 5418.66054
+  dps: 7598.75653
+  tps: 5395.11714
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 7405.46441
-  tps: 5257.87973
+  dps: 7372.30958
+  tps: 5234.3398
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheFistsofFury"
  value: {
-  dps: 4252.13272
-  tps: 3019.01423
+  dps: 4236.4554
+  tps: 3007.88333
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7686.70071
-  tps: 5457.5575
+  dps: 7652.89683
+  tps: 5433.55675
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7870.40161
-  tps: 5587.98514
+  dps: 7831.31203
+  tps: 5560.23154
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7932.27894
-  tps: 5631.91805
+  dps: 7892.82683
+  tps: 5603.90705
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7614.18016
-  tps: 5406.06792
+  dps: 7581.0917
+  tps: 5382.57511
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7614.18016
-  tps: 5406.06792
+  dps: 7581.0917
+  tps: 5382.57511
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7465.38857
-  tps: 5300.42588
+  dps: 7430.23555
+  tps: 5275.46724
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7614.18016
-  tps: 5406.06792
+  dps: 7581.0917
+  tps: 5382.57511
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7614.18016
-  tps: 5406.06792
+  dps: 7581.0917
+  tps: 5382.57511
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6168.20488
-  tps: 4379.42547
+  dps: 6136.90509
+  tps: 4357.20261
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 7172.84607
-  tps: 5092.72071
+  dps: 7142.35816
+  tps: 5071.07429
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7444.98342
-  tps: 5285.93823
+  dps: 7409.87377
+  tps: 5261.01037
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 7777.49182
-  tps: 5522.0192
+  dps: 7739.15843
+  tps: 5494.80248
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28870.05946
-  tps: 20497.74222
+  dps: 28738.14015
+  tps: 20404.0795
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7756.86034
-  tps: 5507.37084
+  dps: 7721.10761
+  tps: 5481.9864
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8946.50088
-  tps: 6352.01562
+  dps: 8905.28677
+  tps: 6322.75361
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15613.67494
-  tps: 11085.70921
+  dps: 15542.59342
+  tps: 11035.24133
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3750.67276
-  tps: 2662.97766
+  dps: 3733.16965
+  tps: 2650.55045
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3854.74934
-  tps: 2736.87203
+  dps: 3836.06829
+  tps: 2723.60848
  }
 }
 dps_results: {
@@ -876,127 +876,127 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27585.83579
-  tps: 19585.94341
+  dps: 27470.72551
+  tps: 19504.21511
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7339.95088
-  tps: 5211.36512
+  dps: 7308.86451
+  tps: 5189.2938
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8413.18311
-  tps: 5973.36001
+  dps: 8379.5869
+  tps: 5949.5067
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14939.10339
-  tps: 10606.76341
+  dps: 14880.18295
+  tps: 10564.92989
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3547.38434
-  tps: 2518.64288
+  dps: 3532.48477
+  tps: 2508.06419
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3623.04366
-  tps: 2572.361
+  dps: 3605.46112
+  tps: 2559.87739
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18302.52243
-  tps: 12994.79093
+  dps: 18174.15416
+  tps: 12903.64945
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3606.38293
-  tps: 2560.53188
+  dps: 3590.40285
+  tps: 2549.18602
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4176.88196
-  tps: 2965.58619
+  dps: 4155.01488
+  tps: 2950.06057
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9461.53586
-  tps: 6717.69046
+  dps: 9392.36407
+  tps: 6668.57849
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1619.88428
-  tps: 1150.11784
+  dps: 1611.75788
+  tps: 1144.34809
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1667.85944
-  tps: 1184.1802
+  dps: 1661.23906
+  tps: 1179.47973
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28954.30187
-  tps: 20557.55433
+  dps: 28820.57085
+  tps: 20462.6053
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7793.64979
-  tps: 5533.49135
+  dps: 7757.547
+  tps: 5507.85837
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9049.38893
-  tps: 6425.06614
+  dps: 9007.69374
+  tps: 6395.46256
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15688.20237
-  tps: 11138.62368
+  dps: 15617.30776
+  tps: 11088.28851
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3769.69619
-  tps: 2676.4843
+  dps: 3752.11499
+  tps: 2664.00164
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3892.59097
-  tps: 2763.73959
+  dps: 3873.67573
+  tps: 2750.30977
  }
 }
 dps_results: {
@@ -1044,91 +1044,91 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27692.01449
-  tps: 19661.33029
+  dps: 27577.62632
+  tps: 19580.11469
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7374.41231
-  tps: 5235.83274
+  dps: 7343.25643
+  tps: 5213.71207
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8512.20624
-  tps: 6043.66643
+  dps: 8478.20348
+  tps: 6019.52447
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15105.97399
-  tps: 10725.24154
+  dps: 15045.54649
+  tps: 10682.33801
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3565.94006
-  tps: 2531.81744
+  dps: 3550.83524
+  tps: 2521.09302
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3656.97416
-  tps: 2596.45165
+  dps: 3639.57133
+  tps: 2584.09564
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18406.15733
-  tps: 13068.37171
+  dps: 18277.78857
+  tps: 12977.22988
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3617.40913
-  tps: 2568.36048
+  dps: 3601.38272
+  tps: 2556.98173
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4215.505
-  tps: 2993.00855
+  dps: 4193.49256
+  tps: 2977.37972
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9493.57287
-  tps: 6740.43674
+  dps: 9424.00019
+  tps: 6691.04013
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1625.60592
-  tps: 1154.1802
+  dps: 1617.44864
+  tps: 1148.38853
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1685.25044
-  tps: 1196.52781
+  dps: 1678.60214
+  tps: 1191.80752
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7304.35676
-  tps: 5186.0933
+  dps: 7271.13797
+  tps: 5162.50796
  }
 }

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -46,789 +46,789 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7428.44853
-  tps: 5274.19845
+  dps: 7440.18796
+  tps: 5282.53345
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7592.05174
+  tps: 5390.35674
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7636.55058
-  tps: 5421.95091
+  dps: 7648.78225
+  tps: 5430.6354
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7410.11323
-  tps: 5261.18039
+  dps: 7421.58552
+  tps: 5269.32572
   hps: 60.32296
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7410.11323
-  tps: 5261.18039
+  dps: 7421.58552
+  tps: 5269.32572
   hps: 60.32296
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7605.03417
-  tps: 5399.57426
+  dps: 7614.37467
+  tps: 5406.20602
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50035"
  value: {
-  dps: 4927.69622
-  tps: 3498.66431
+  dps: 4932.31509
+  tps: 3501.94371
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50692"
  value: {
-  dps: 4998.32747
-  tps: 3548.81251
+  dps: 5002.87981
+  tps: 3552.04466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5783.10845
-  tps: 4106.007
+  dps: 5791.74451
+  tps: 4112.1386
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6948.75288
-  tps: 4933.61455
+  dps: 6957.99742
+  tps: 4940.17817
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5274.92361
+  dps: 7592.05174
+  tps: 5282.5496
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7725.86316
-  tps: 5485.36284
+  dps: 7736.04431
+  tps: 5492.59146
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7550.44097
-  tps: 5360.81309
+  dps: 7560.3582
+  tps: 5367.85432
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7594.90405
-  tps: 5392.38188
+  dps: 7605.91062
+  tps: 5400.19654
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7603.99152
-  tps: 5398.83398
+  dps: 7615.61818
+  tps: 5407.08891
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7977.32441
-  tps: 5663.90033
+  dps: 7989.75634
+  tps: 5672.727
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7510.89562
-  tps: 5332.73589
+  dps: 7522.33165
+  tps: 5340.85547
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7844.14317
-  tps: 5569.34165
+  dps: 7856.52676
+  tps: 5578.134
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7905.16051
-  tps: 5612.66396
+  dps: 7917.03602
+  tps: 5621.09557
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7605.67814
-  tps: 5400.03148
+  dps: 7615.19412
+  tps: 5406.78783
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7624.66331
-  tps: 5413.51095
+  dps: 7636.80461
+  tps: 5422.13127
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7605.95317
-  tps: 5400.22675
+  dps: 7618.0581
+  tps: 5408.82125
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7592.05174
+  tps: 5390.35674
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7592.05174
+  tps: 5390.35674
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7605.03417
-  tps: 5399.57426
+  dps: 7614.37467
+  tps: 5406.20602
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7591.80662
-  tps: 5390.1827
+  dps: 7601.16482
+  tps: 5396.82702
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7481.42024
-  tps: 5311.80837
+  dps: 7493.33497
+  tps: 5320.26783
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7592.05174
+  tps: 5390.35674
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7573.94147
-  tps: 5377.49845
+  dps: 7584.28521
+  tps: 5384.8425
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7535.41111
-  tps: 5350.14189
+  dps: 7545.58635
+  tps: 5357.36631
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7408.59263
-  tps: 5260.10077
+  dps: 7420.03817
+  tps: 5268.2271
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7516.47401
-  tps: 5336.69654
+  dps: 7526.02872
+  tps: 5343.48039
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7592.05174
+  tps: 5390.35674
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7592.05174
+  tps: 5390.35674
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7689.70687
-  tps: 5459.69188
+  dps: 7701.55147
+  tps: 5468.10154
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7457.23884
-  tps: 5294.63957
+  dps: 7467.74361
+  tps: 5302.09796
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7545.45936
-  tps: 5357.27614
+  dps: 7556.16482
+  tps: 5364.87702
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-49982"
  value: {
-  dps: 7721.10761
-  tps: 5481.9864
+  dps: 7732.86395
+  tps: 5490.3334
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-50641"
  value: {
-  dps: 7721.10761
-  tps: 5481.9864
+  dps: 7732.86395
+  tps: 5490.3334
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7605.03417
-  tps: 5399.57426
+  dps: 7614.37467
+  tps: 5406.20602
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7591.80662
-  tps: 5390.1827
+  dps: 7601.16482
+  tps: 5396.82702
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7579.98184
-  tps: 5381.7871
+  dps: 7591.61194
+  tps: 5390.04448
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7592.05174
+  tps: 5390.35674
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7621.12239
-  tps: 5410.9969
+  dps: 7632.14744
+  tps: 5418.82469
   hps: 11.11293
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7624.83142
-  tps: 5413.63031
+  dps: 7634.73193
+  tps: 5420.65967
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7615.32579
-  tps: 5406.88131
+  dps: 7625.70234
+  tps: 5414.24866
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7611.12191
-  tps: 5403.89656
+  dps: 7622.12209
+  tps: 5411.70668
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7618.18784
-  tps: 5408.91337
+  dps: 7629.19747
+  tps: 5416.7302
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7592.05174
+  tps: 5390.35674
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7592.05174
+  tps: 5390.35674
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7600.08894
-  tps: 5396.06315
+  dps: 7616.42601
+  tps: 5407.66246
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7624.2655
-  tps: 5413.22851
+  dps: 7641.15124
+  tps: 5425.21738
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7721.10761
-  tps: 5481.9864
+  dps: 7732.86395
+  tps: 5490.3334
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7592.05174
+  tps: 5390.35674
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7738.71872
-  tps: 5494.49029
+  dps: 7748.13768
+  tps: 5501.17775
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 5695.66359
-  tps: 4043.92115
+  dps: 5703.19939
+  tps: 4049.27157
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7540.31878
-  tps: 5353.62633
+  dps: 7550.31665
+  tps: 5360.72482
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 7490.19507
-  tps: 5318.0385
+  dps: 7502.30888
+  tps: 5326.6393
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7561.33235
-  tps: 5368.54597
+  dps: 7573.44392
+  tps: 5377.14519
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StormshroudArmor"
  value: {
-  dps: 6056.58177
-  tps: 4300.17305
+  dps: 6065.49357
+  tps: 4306.50044
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7618.18784
-  tps: 5408.91337
+  dps: 7629.19747
+  tps: 5416.7302
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7611.12191
-  tps: 5403.89656
+  dps: 7622.12209
+  tps: 5411.70668
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7598.75653
-  tps: 5395.11714
+  dps: 7609.74018
+  tps: 5402.91553
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 7372.30958
-  tps: 5234.3398
+  dps: 7381.6079
+  tps: 5240.94161
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheFistsofFury"
  value: {
-  dps: 4236.4554
-  tps: 3007.88333
+  dps: 4241.44782
+  tps: 3011.42795
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7652.89683
-  tps: 5433.55675
+  dps: 7664.12691
+  tps: 5441.53011
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7831.31203
-  tps: 5560.23154
+  dps: 7844.44191
+  tps: 5569.55375
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7892.82683
-  tps: 5603.90705
+  dps: 7906.24216
+  tps: 5613.43193
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7592.05174
+  tps: 5390.35674
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7592.05174
+  tps: 5390.35674
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7430.23555
-  tps: 5275.46724
+  dps: 7441.65634
+  tps: 5283.576
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7592.05174
+  tps: 5390.35674
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7581.0917
-  tps: 5382.57511
+  dps: 7592.05174
+  tps: 5390.35674
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6136.90509
-  tps: 4357.20261
+  dps: 6145.83677
+  tps: 4363.54411
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 7142.35816
-  tps: 5071.07429
+  dps: 7152.1567
+  tps: 5078.03125
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7409.87377
-  tps: 5261.01037
+  dps: 7421.3193
+  tps: 5269.13671
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 7739.15843
-  tps: 5494.80248
+  dps: 7750.68879
+  tps: 5502.98904
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28738.14015
-  tps: 20404.0795
+  dps: 28778.61466
+  tps: 20432.81641
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7721.10761
-  tps: 5481.9864
+  dps: 7732.86395
+  tps: 5490.3334
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8905.28677
-  tps: 6322.75361
+  dps: 8917.3396
+  tps: 6331.31112
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15542.59342
-  tps: 11035.24133
+  dps: 15564.44775
+  tps: 11050.7579
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3733.16965
-  tps: 2650.55045
+  dps: 3737.8211
+  tps: 2653.85298
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3836.06829
-  tps: 2723.60848
+  dps: 3839.77283
+  tps: 2726.23871
  }
 }
 dps_results: {
@@ -876,127 +876,127 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27470.72551
-  tps: 19504.21511
+  dps: 27506.12301
+  tps: 19529.34734
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7308.86451
-  tps: 5189.2938
+  dps: 7318.27839
+  tps: 5195.97766
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8379.5869
-  tps: 5949.5067
+  dps: 8390.25145
+  tps: 5957.07853
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14880.18295
-  tps: 10564.92989
+  dps: 14897.82475
+  tps: 10577.45557
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3532.48477
-  tps: 2508.06419
+  dps: 3536.67552
+  tps: 2511.03962
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3605.46112
-  tps: 2559.87739
+  dps: 3609.05962
+  tps: 2562.43233
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18174.15416
-  tps: 12903.64945
+  dps: 18213.19017
+  tps: 12931.36502
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3590.40285
-  tps: 2549.18602
+  dps: 3594.58701
+  tps: 2552.15677
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4155.01488
-  tps: 2950.06057
+  dps: 4162.15748
+  tps: 2955.13181
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9392.36407
-  tps: 6668.57849
+  dps: 9414.05702
+  tps: 6683.98048
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1611.75788
-  tps: 1144.34809
+  dps: 1614.25428
+  tps: 1146.12054
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1661.23906
-  tps: 1179.47973
+  dps: 1664.685
+  tps: 1181.92635
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28820.57085
-  tps: 20462.6053
+  dps: 28861.15663
+  tps: 20491.4212
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7757.547
-  tps: 5507.85837
+  dps: 7769.45231
+  tps: 5516.31114
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9007.69374
-  tps: 6395.46256
+  dps: 9019.92146
+  tps: 6404.14423
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15617.30776
-  tps: 11088.28851
+  dps: 15639.3021
+  tps: 11103.90449
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3752.11499
-  tps: 2664.00164
+  dps: 3756.79367
+  tps: 2667.3235
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-Assassination-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3873.67573
-  tps: 2750.30977
+  dps: 3877.42627
+  tps: 2752.97265
  }
 }
 dps_results: {
@@ -1044,91 +1044,91 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27577.62632
-  tps: 19580.11469
+  dps: 27612.6165
+  tps: 19604.95772
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7343.25643
-  tps: 5213.71207
+  dps: 7352.72164
+  tps: 5220.43237
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8478.20348
-  tps: 6019.52447
+  dps: 8489.04518
+  tps: 6027.22208
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15045.54649
-  tps: 10682.33801
+  dps: 15063.4387
+  tps: 10695.04148
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3550.83524
-  tps: 2521.09302
+  dps: 3555.07343
+  tps: 2524.10214
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3639.57133
-  tps: 2584.09564
+  dps: 3643.21911
+  tps: 2586.68557
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18277.78857
-  tps: 12977.22988
+  dps: 18317.07454
+  tps: 13005.12292
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3601.38272
-  tps: 2556.98173
+  dps: 3605.59186
+  tps: 2559.97022
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4193.49256
-  tps: 2977.37972
+  dps: 4200.7192
+  tps: 2982.51063
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9424.00019
-  tps: 6691.04013
+  dps: 9445.74928
+  tps: 6706.48199
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1617.44864
-  tps: 1148.38853
+  dps: 1619.95457
+  tps: 1150.16774
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-P1 Assassination-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1678.60214
-  tps: 1191.80752
+  dps: 1682.04808
+  tps: 1194.25414
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7271.13797
-  tps: 5162.50796
+  dps: 7281.36207
+  tps: 5169.76707
  }
 }

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -46,810 +46,810 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6403.11097
-  tps: 4546.20879
+  dps: 6368.75703
+  tps: 4521.81749
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6403.11097
-  tps: 4546.20879
+  dps: 6368.75703
+  tps: 4521.81749
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 6418.90803
-  tps: 4557.4247
+  dps: 6384.5541
+  tps: 4533.03341
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6542.88312
-  tps: 4645.44702
+  dps: 6510.06385
+  tps: 4622.14533
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6602.89425
-  tps: 4688.05492
+  dps: 6566.36422
+  tps: 4662.1186
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6400.78596
-  tps: 4544.55803
+  dps: 6366.40153
+  tps: 4520.14509
   hps: 88.67739
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6400.78596
-  tps: 4544.55803
+  dps: 6366.40153
+  tps: 4520.14509
   hps: 88.67739
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6570.30185
-  tps: 4664.91431
+  dps: 6538.39988
+  tps: 4642.26392
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50035"
  value: {
-  dps: 6913.46905
-  tps: 4908.56303
+  dps: 6888.72194
+  tps: 4890.99257
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50692"
  value: {
-  dps: 7018.77962
-  tps: 4983.33353
+  dps: 6994.0428
+  tps: 4965.77039
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5099.48424
-  tps: 3620.63381
+  dps: 5071.02609
+  tps: 3600.42853
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6060.49618
-  tps: 4302.95229
+  dps: 6029.43948
+  tps: 4280.90203
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6542.88312
-  tps: 4552.53808
+  dps: 6510.06385
+  tps: 4529.70243
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6692.84214
-  tps: 4751.91792
+  dps: 6657.71933
+  tps: 4726.98072
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6692.84214
-  tps: 4751.91792
+  dps: 6657.71933
+  tps: 4726.98072
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6688.24031
-  tps: 4748.65062
+  dps: 6654.18497
+  tps: 4724.47133
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6403.11097
-  tps: 4546.20879
+  dps: 6368.75703
+  tps: 4521.81749
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6403.11097
-  tps: 4546.20879
+  dps: 6368.75703
+  tps: 4521.81749
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6400.26843
-  tps: 4544.19058
+  dps: 6365.89542
+  tps: 4519.78575
   hps: 64
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6532.76275
-  tps: 4638.26155
+  dps: 6500.39127
+  tps: 4615.2778
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6565.80098
-  tps: 4661.7187
+  dps: 6530.46432
+  tps: 4636.62967
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6557.88994
-  tps: 4656.10185
+  dps: 6523.13244
+  tps: 4631.42403
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6891.01214
-  tps: 4892.61862
+  dps: 6854.88126
+  tps: 4866.96569
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6508.43734
-  tps: 4620.99051
+  dps: 6476.9559
+  tps: 4598.63869
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6833.06365
-  tps: 4851.47519
+  dps: 6796.70655
+  tps: 4825.66165
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6886.94957
-  tps: 4889.73419
+  dps: 6850.47774
+  tps: 4863.83919
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6400.26843
-  tps: 4544.19058
+  dps: 6365.89542
+  tps: 4519.78575
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6572.53366
-  tps: 4666.4989
+  dps: 6540.64092
+  tps: 4643.85505
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6639.9286
-  tps: 4714.3493
+  dps: 6603.91279
+  tps: 4688.77808
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6613.1387
-  tps: 4695.32848
+  dps: 6577.20332
+  tps: 4669.81436
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6542.88312
-  tps: 4645.44702
+  dps: 6510.06385
+  tps: 4622.14533
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6542.88312
-  tps: 4645.44702
+  dps: 6510.06385
+  tps: 4622.14533
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6570.30185
-  tps: 4664.91431
+  dps: 6538.39988
+  tps: 4642.26392
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6565.86556
-  tps: 4661.76454
+  dps: 6533.87759
+  tps: 4639.05309
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6539.59765
-  tps: 4643.11433
+  dps: 6504.34034
+  tps: 4618.08164
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6403.11097
-  tps: 4546.20879
+  dps: 6368.75703
+  tps: 4521.81749
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6542.88312
-  tps: 4645.44702
+  dps: 6510.06385
+  tps: 4622.14533
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6565.88779
-  tps: 4661.78033
+  dps: 6531.07265
+  tps: 4637.06158
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6517.24935
-  tps: 4627.24704
+  dps: 6483.03786
+  tps: 4602.95688
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6403.37583
-  tps: 4546.39684
+  dps: 6369.06004
+  tps: 4522.03263
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6403.11097
-  tps: 4546.20879
+  dps: 6368.75703
+  tps: 4521.81749
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6493.97613
-  tps: 4610.72305
+  dps: 6459.97456
+  tps: 4586.58194
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6542.88312
-  tps: 4645.44702
+  dps: 6510.06385
+  tps: 4622.14533
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6542.88312
-  tps: 4645.44702
+  dps: 6510.06385
+  tps: 4622.14533
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6646.42081
-  tps: 4718.95877
+  dps: 6610.84769
+  tps: 4693.70186
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6400.26843
-  tps: 4544.19058
+  dps: 6365.89542
+  tps: 4519.78575
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Gladiator'sVestments"
  value: {
-  dps: 6485.04458
-  tps: 4604.38165
+  dps: 6453.59305
+  tps: 4582.05107
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6400.26843
-  tps: 4544.19058
+  dps: 6365.89542
+  tps: 4519.78575
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6400.26843
-  tps: 4544.19058
+  dps: 6365.89542
+  tps: 4519.78575
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6539.27898
-  tps: 4642.88807
+  dps: 6504.55737
+  tps: 4618.23573
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-49982"
  value: {
-  dps: 6692.84214
-  tps: 4751.91792
+  dps: 6657.71933
+  tps: 4726.98072
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-50641"
  value: {
-  dps: 6692.84214
-  tps: 4751.91792
+  dps: 6657.71933
+  tps: 4726.98072
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6403.11097
-  tps: 4546.20879
+  dps: 6368.75703
+  tps: 4521.81749
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6570.30185
-  tps: 4664.91431
+  dps: 6538.39988
+  tps: 4642.26392
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6565.86556
-  tps: 4661.76454
+  dps: 6533.87759
+  tps: 4639.05309
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6582.50922
-  tps: 4673.58154
+  dps: 6547.57032
+  tps: 4648.77493
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6542.88312
-  tps: 4645.44702
+  dps: 6510.06385
+  tps: 4622.14533
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6574.44386
-  tps: 4667.85514
+  dps: 6541.47551
+  tps: 4644.44761
   hps: 11.11293
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LastWord-50179"
  value: {
-  dps: 6692.84214
-  tps: 4751.91792
+  dps: 6657.71933
+  tps: 4726.98072
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LastWord-50708"
  value: {
-  dps: 6692.84214
-  tps: 4751.91792
+  dps: 6657.71933
+  tps: 4726.98072
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6400.26843
-  tps: 4544.19058
+  dps: 6365.89542
+  tps: 4519.78575
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6403.11097
-  tps: 4546.20879
+  dps: 6368.75703
+  tps: 4521.81749
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6653.44666
-  tps: 4723.94713
+  dps: 6618.0024
+  tps: 4698.7817
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6593.88093
-  tps: 4681.65546
+  dps: 6560.47256
+  tps: 4657.93552
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Nibelung-49992"
  value: {
-  dps: 6692.84214
-  tps: 4751.91792
+  dps: 6657.71933
+  tps: 4726.98072
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Nibelung-50648"
  value: {
-  dps: 6692.84214
-  tps: 4751.91792
+  dps: 6657.71933
+  tps: 4726.98072
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6403.11097
-  tps: 4546.20879
+  dps: 6368.75703
+  tps: 4521.81749
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6568.89947
-  tps: 4663.91863
+  dps: 6535.95854
+  tps: 4640.53056
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6575.02097
-  tps: 4668.26489
+  dps: 6542.05141
+  tps: 4644.8565
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6403.11097
-  tps: 4546.20879
+  dps: 6368.75703
+  tps: 4521.81749
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6403.11097
-  tps: 4546.20879
+  dps: 6368.75703
+  tps: 4521.81749
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6403.11097
-  tps: 4546.20879
+  dps: 6368.75703
+  tps: 4521.81749
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6542.88312
-  tps: 4645.44702
+  dps: 6510.06385
+  tps: 4622.14533
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6542.88312
-  tps: 4645.44702
+  dps: 6510.06385
+  tps: 4622.14533
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6403.11097
-  tps: 4546.20879
+  dps: 6368.75703
+  tps: 4521.81749
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6552.15027
-  tps: 4652.02669
+  dps: 6503.13416
+  tps: 4617.22526
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6571.06365
-  tps: 4665.45519
+  dps: 6520.17544
+  tps: 4629.32456
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6692.84214
-  tps: 4751.91792
+  dps: 6657.71933
+  tps: 4726.98072
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6542.88312
-  tps: 4645.44702
+  dps: 6510.06385
+  tps: 4622.14533
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6400.26843
-  tps: 4544.19058
+  dps: 6365.89542
+  tps: 4519.78575
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6400.26843
-  tps: 4544.19058
+  dps: 6365.89542
+  tps: 4519.78575
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 6725.32223
-  tps: 4774.97879
+  dps: 6692.53268
+  tps: 4751.6982
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6692.84214
-  tps: 4751.91792
+  dps: 6657.71933
+  tps: 4726.98072
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6403.11097
-  tps: 4546.20879
+  dps: 6368.75703
+  tps: 4521.81749
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6400.26843
-  tps: 4544.19058
+  dps: 6365.89542
+  tps: 4519.78575
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Slayer'sArmor"
  value: {
-  dps: 5019.00418
-  tps: 3563.49297
+  dps: 4990.18477
+  tps: 3543.03119
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6400.26843
-  tps: 4544.19058
+  dps: 6365.89542
+  tps: 4519.78575
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6400.26843
-  tps: 4544.19058
+  dps: 6365.89542
+  tps: 4519.78575
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6403.11097
-  tps: 4546.20879
+  dps: 6368.75703
+  tps: 4521.81749
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6522.12201
-  tps: 4630.70662
+  dps: 6487.72615
+  tps: 4606.28556
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SparkofLife-37657"
  value: {
-  dps: 6491.43135
-  tps: 4608.91626
+  dps: 6455.95263
+  tps: 4583.72636
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6601.26087
-  tps: 4686.89522
+  dps: 6565.69482
+  tps: 4661.64332
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StormshroudArmor"
  value: {
-  dps: 5140.79435
-  tps: 3649.96399
+  dps: 5113.56599
+  tps: 3630.63185
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6575.02097
-  tps: 4668.26489
+  dps: 6542.05141
+  tps: 4644.8565
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6568.89947
-  tps: 4663.91863
+  dps: 6535.95854
+  tps: 4640.53056
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6558.18686
-  tps: 4656.31267
+  dps: 6525.29602
+  tps: 4632.96018
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6400.26843
-  tps: 4544.19058
+  dps: 6365.89542
+  tps: 4519.78575
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6403.11097
-  tps: 4546.20879
+  dps: 6368.75703
+  tps: 4521.81749
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6481.66115
-  tps: 4601.97942
+  dps: 6450.18759
+  tps: 4579.63319
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheFistsofFury"
  value: {
-  dps: 5895.06317
-  tps: 4185.49485
+  dps: 5870.87078
+  tps: 4168.31825
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6403.11097
-  tps: 4546.20879
+  dps: 6368.75703
+  tps: 4521.81749
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5992.81536
-  tps: 4254.89891
+  dps: 5968.98478
+  tps: 4237.97919
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6613.41884
-  tps: 4695.52738
+  dps: 6580.14878
+  tps: 4671.90563
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6720.16289
-  tps: 4771.31565
+  dps: 6683.05474
+  tps: 4744.96886
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6761.07131
-  tps: 4800.36063
+  dps: 6723.37142
+  tps: 4773.59371
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6542.88312
-  tps: 4645.44702
+  dps: 6510.06385
+  tps: 4622.14533
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6542.88312
-  tps: 4645.44702
+  dps: 6510.06385
+  tps: 4622.14533
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6482.39264
-  tps: 4602.49877
+  dps: 6447.18583
+  tps: 4577.50194
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6542.88312
-  tps: 4645.44702
+  dps: 6510.06385
+  tps: 4622.14533
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6542.88312
-  tps: 4645.44702
+  dps: 6510.06385
+  tps: 4622.14533
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5417.3318
-  tps: 3846.30558
+  dps: 5387.64725
+  tps: 3825.22955
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6302.26684
-  tps: 4474.60945
+  dps: 6274.23061
+  tps: 4454.70373
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6227.58837
-  tps: 4421.58775
+  dps: 6196.52876
+  tps: 4399.53542
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6400.26843
-  tps: 4544.19058
+  dps: 6365.89542
+  tps: 4519.78575
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 6676.17414
-  tps: 4740.08364
+  dps: 6640.54281
+  tps: 4714.7854
  }
 }
 dps_results: {
@@ -897,127 +897,127 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21485.49951
-  tps: 15254.70465
+  dps: 21367.2487
+  tps: 15170.74658
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6692.84214
-  tps: 4751.91792
+  dps: 6657.71933
+  tps: 4726.98072
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7870.05568
-  tps: 5587.73953
+  dps: 7827.87682
+  tps: 5557.79254
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12514.75938
-  tps: 8885.47916
+  dps: 12446.18263
+  tps: 8836.78967
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3319.65266
-  tps: 2356.95339
+  dps: 3300.38164
+  tps: 2343.27096
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3451.33199
-  tps: 2450.44571
+  dps: 3439.90191
+  tps: 2442.33035
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20574.80061
-  tps: 14608.10843
+  dps: 20479.35299
+  tps: 14540.34062
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6376.36903
-  tps: 4527.22201
+  dps: 6349.37885
+  tps: 4508.05899
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7464.9295
-  tps: 5300.09995
+  dps: 7428.15747
+  tps: 5273.9918
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11979.69119
-  tps: 8505.58075
+  dps: 11923.66322
+  tps: 8465.80089
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3159.33054
-  tps: 2243.12468
+  dps: 3143.47989
+  tps: 2231.87072
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3256.41229
-  tps: 2312.05273
+  dps: 3245.80115
+  tps: 2304.51882
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15757.71355
-  tps: 11187.97662
+  dps: 15622.35421
+  tps: 11091.87149
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5735.07614
-  tps: 4071.90406
+  dps: 5711.24682
+  tps: 4054.98524
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6903.27577
-  tps: 4901.3258
+  dps: 6869.78376
+  tps: 4877.54647
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8966.57012
-  tps: 6366.26479
+  dps: 8883.48849
+  tps: 6307.27683
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2684.62008
-  tps: 1906.08026
+  dps: 2670.72671
+  tps: 1896.21596
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2873.54896
-  tps: 2040.21976
+  dps: 2863.14847
+  tps: 2032.83542
  }
 }
 dps_results: {
@@ -1065,133 +1065,133 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21642.47237
-  tps: 15366.15538
+  dps: 21524.32799
+  tps: 15282.27287
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6734.77278
-  tps: 4781.68868
+  dps: 6699.37669
+  tps: 4756.55745
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7972.85523
-  tps: 5660.72721
+  dps: 7930.0991
+  tps: 5630.37036
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12619.69848
-  tps: 8959.98592
+  dps: 12550.74859
+  tps: 8911.0315
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3345.02144
-  tps: 2374.96522
+  dps: 3325.62914
+  tps: 2361.19669
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3505.27311
-  tps: 2488.74391
+  dps: 3493.65719
+  tps: 2480.49661
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20735.04939
-  tps: 14721.88506
+  dps: 20638.65771
+  tps: 14653.44697
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6416.56926
-  tps: 4555.76417
+  dps: 6389.40247
+  tps: 4536.47575
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7561.42784
-  tps: 5368.61376
+  dps: 7524.33962
+  tps: 5342.28113
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12079.83477
-  tps: 8576.68269
+  dps: 12023.51886
+  tps: 8536.69839
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3183.07493
-  tps: 2259.9832
+  dps: 3167.0942
+  tps: 2248.63688
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3306.38557
-  tps: 2347.53375
+  dps: 3295.6326
+  tps: 2339.89915
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15891.24718
-  tps: 11282.78549
+  dps: 15755.33113
+  tps: 11186.2851
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5769.89422
-  tps: 4096.6249
+  dps: 5745.89439
+  tps: 4079.58501
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6995.97045
-  tps: 4967.13902
+  dps: 6962.09213
+  tps: 4943.08541
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9049.1262
-  tps: 6424.8796
+  dps: 8965.51357
+  tps: 6365.51463
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2705.4602
-  tps: 1920.87674
+  dps: 2691.45151
+  tps: 1910.93057
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2919.33996
-  tps: 2072.73137
+  dps: 2908.80303
+  tps: 2065.25015
  }
 }
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6442.48162
-  tps: 4574.16195
+  dps: 6409.4689
+  tps: 4550.72292
  }
 }

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -46,810 +46,810 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6378.62343
+  tps: 4528.82264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6378.62343
+  tps: 4528.82264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 6384.5541
-  tps: 4533.03341
+  dps: 6394.4205
+  tps: 4540.03856
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6519.51362
+  tps: 4628.85467
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6566.36422
-  tps: 4662.1186
+  dps: 6576.63792
+  tps: 4669.41292
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6366.40153
-  tps: 4520.14509
+  dps: 6376.26245
+  tps: 4527.14634
   hps: 88.67739
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6366.40153
-  tps: 4520.14509
+  dps: 6376.26245
+  tps: 4527.14634
   hps: 88.67739
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6538.39988
-  tps: 4642.26392
+  dps: 6547.50364
+  tps: 4648.72758
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50035"
  value: {
-  dps: 6888.72194
-  tps: 4890.99257
+  dps: 6896.34961
+  tps: 4896.40822
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50692"
  value: {
-  dps: 6994.0428
-  tps: 4965.77039
+  dps: 7001.59861
+  tps: 4971.13501
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5071.02609
-  tps: 3600.42853
+  dps: 5079.7041
+  tps: 3606.58991
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6029.43948
-  tps: 4280.90203
+  dps: 6038.17677
+  tps: 4287.10551
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4529.70243
+  dps: 6519.51362
+  tps: 4536.27758
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6667.83187
+  tps: 4734.16063
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6667.83187
+  tps: 4734.16063
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6654.18497
-  tps: 4724.47133
+  dps: 6663.90323
+  tps: 4731.37129
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6378.62343
+  tps: 4528.82264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6378.62343
+  tps: 4528.82264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6375.75482
+  tps: 4526.78593
   hps: 64
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6500.39127
-  tps: 4615.2778
+  dps: 6510.47476
+  tps: 4622.43708
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6530.46432
-  tps: 4636.62967
+  dps: 6541.77775
+  tps: 4644.6622
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6523.13244
-  tps: 4631.42403
+  dps: 6533.09933
+  tps: 4638.50052
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6854.88126
-  tps: 4866.96569
+  dps: 6865.24851
+  tps: 4874.32644
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6476.9559
-  tps: 4598.63869
+  dps: 6486.62737
+  tps: 4605.50543
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6796.70655
-  tps: 4825.66165
+  dps: 6806.86912
+  tps: 4832.87708
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6850.47774
-  tps: 4863.83919
+  dps: 6861.03126
+  tps: 4871.33219
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6375.75482
+  tps: 4526.78593
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6540.64092
-  tps: 4643.85505
+  dps: 6550.55305
+  tps: 4650.89267
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6603.91279
-  tps: 4688.77808
+  dps: 6614.30025
+  tps: 4696.15318
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6577.20332
-  tps: 4669.81436
+  dps: 6587.729
+  tps: 4677.28759
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6519.51362
+  tps: 4628.85467
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6519.51362
+  tps: 4628.85467
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6538.39988
-  tps: 4642.26392
+  dps: 6547.50364
+  tps: 4648.72758
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6533.87759
-  tps: 4639.05309
+  dps: 6542.76349
+  tps: 4645.36208
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6504.34034
-  tps: 4618.08164
+  dps: 6514.56313
+  tps: 4625.33982
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6378.62343
+  tps: 4528.82264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6519.51362
+  tps: 4628.85467
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6531.07265
-  tps: 4637.06158
+  dps: 6541.79422
+  tps: 4644.6739
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6483.03786
-  tps: 4602.95688
+  dps: 6493.18503
+  tps: 4610.16137
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6369.06004
-  tps: 4522.03263
+  dps: 6378.93345
+  tps: 4529.04275
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6378.62343
+  tps: 4528.82264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6459.97456
-  tps: 4586.58194
+  dps: 6469.77201
+  tps: 4593.53813
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6519.51362
+  tps: 4628.85467
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6519.51362
+  tps: 4628.85467
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6610.84769
-  tps: 4693.70186
+  dps: 6621.05918
+  tps: 4700.95202
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6375.75482
+  tps: 4526.78593
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Gladiator'sVestments"
  value: {
-  dps: 6453.59305
-  tps: 4582.05107
+  dps: 6463.35355
+  tps: 4588.98102
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6375.75482
+  tps: 4526.78593
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6375.75482
+  tps: 4526.78593
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6504.55737
-  tps: 4618.23573
+  dps: 6515.68196
+  tps: 4626.13419
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-49982"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6667.83187
+  tps: 4734.16063
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-50641"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6667.83187
+  tps: 4734.16063
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6378.62343
+  tps: 4528.82264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6538.39988
-  tps: 4642.26392
+  dps: 6547.50364
+  tps: 4648.72758
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6533.87759
-  tps: 4639.05309
+  dps: 6542.76349
+  tps: 4645.36208
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6547.57032
-  tps: 4648.77493
+  dps: 6557.58933
+  tps: 4655.88842
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6519.51362
+  tps: 4628.85467
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6541.47551
-  tps: 4644.44761
+  dps: 6550.96771
+  tps: 4651.18707
   hps: 11.11293
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LastWord-50179"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6667.83187
+  tps: 4734.16063
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LastWord-50708"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6667.83187
+  tps: 4734.16063
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6375.75482
+  tps: 4526.78593
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6378.62343
+  tps: 4528.82264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6618.0024
-  tps: 4698.7817
+  dps: 6627.72658
+  tps: 4705.68587
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6560.47256
-  tps: 4657.93552
+  dps: 6569.64354
+  tps: 4664.44691
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Nibelung-49992"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6667.83187
+  tps: 4734.16063
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Nibelung-50648"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6667.83187
+  tps: 4734.16063
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6378.62343
+  tps: 4528.82264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6535.95854
-  tps: 4640.53056
+  dps: 6545.44266
+  tps: 4647.26429
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6542.05141
-  tps: 4644.8565
+  dps: 6551.54361
+  tps: 4651.59596
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6378.62343
+  tps: 4528.82264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6378.62343
+  tps: 4528.82264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6378.62343
+  tps: 4528.82264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6519.51362
+  tps: 4628.85467
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6519.51362
+  tps: 4628.85467
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6378.62343
+  tps: 4528.82264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6503.13416
-  tps: 4617.22526
+  dps: 6516.38271
+  tps: 4626.63172
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6520.17544
-  tps: 4629.32456
+  dps: 6533.99972
+  tps: 4639.1398
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6667.83187
+  tps: 4734.16063
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6519.51362
+  tps: 4628.85467
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6375.75482
+  tps: 4526.78593
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6375.75482
+  tps: 4526.78593
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 6692.53268
-  tps: 4751.6982
+  dps: 6700.99905
+  tps: 4757.70932
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6667.83187
+  tps: 4734.16063
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6378.62343
+  tps: 4528.82264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6375.75482
+  tps: 4526.78593
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Slayer'sArmor"
  value: {
-  dps: 4990.18477
-  tps: 3543.03119
+  dps: 4998.08767
+  tps: 3548.64224
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6375.75482
+  tps: 4526.78593
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6375.75482
+  tps: 4526.78593
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6378.62343
+  tps: 4528.82264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6487.72615
-  tps: 4606.28556
+  dps: 6498.32666
+  tps: 4613.81193
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SparkofLife-37657"
  value: {
-  dps: 6455.95263
-  tps: 4583.72636
+  dps: 6465.98002
+  tps: 4590.84581
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6565.69482
-  tps: 4661.64332
+  dps: 6575.91452
+  tps: 4668.89931
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StormshroudArmor"
  value: {
-  dps: 5113.56599
-  tps: 3630.63185
+  dps: 5121.68507
+  tps: 3636.3964
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6542.05141
-  tps: 4644.8565
+  dps: 6551.54361
+  tps: 4651.59596
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6535.95854
-  tps: 4640.53056
+  dps: 6545.44266
+  tps: 4647.26429
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6525.29602
-  tps: 4632.96018
+  dps: 6534.76599
+  tps: 4639.68386
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6375.75482
+  tps: 4526.78593
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6378.62343
+  tps: 4528.82264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6450.18759
-  tps: 4579.63319
+  dps: 6459.93616
+  tps: 4586.55467
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheFistsofFury"
  value: {
-  dps: 5870.87078
-  tps: 4168.31825
+  dps: 5878.19499
+  tps: 4173.51844
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6378.62343
+  tps: 4528.82264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5968.98478
-  tps: 4237.97919
+  dps: 5975.77088
+  tps: 4242.79733
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6580.14878
-  tps: 4671.90563
+  dps: 6589.73005
+  tps: 4678.70834
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6683.05474
-  tps: 4744.96886
+  dps: 6693.71723
+  tps: 4752.53923
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6723.37142
-  tps: 4773.59371
+  dps: 6733.97412
+  tps: 4781.12163
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6519.51362
+  tps: 4628.85467
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6519.51362
+  tps: 4628.85467
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6447.18583
-  tps: 4577.50194
+  dps: 6457.26984
+  tps: 4584.66159
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6519.51362
+  tps: 4628.85467
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6519.51362
+  tps: 4628.85467
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5387.64725
-  tps: 3825.22955
+  dps: 5396.6848
+  tps: 3831.64621
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6274.23061
-  tps: 4454.70373
+  dps: 6281.86771
+  tps: 4460.12607
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6196.52876
-  tps: 4399.53542
+  dps: 6205.47805
+  tps: 4405.88942
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6375.75482
+  tps: 4526.78593
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 6640.54281
-  tps: 4714.7854
+  dps: 6651.18177
+  tps: 4722.33906
  }
 }
 dps_results: {
@@ -897,127 +897,127 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21367.2487
-  tps: 15170.74658
+  dps: 21401.02134
+  tps: 15194.72515
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6667.83187
+  tps: 4734.16063
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7827.87682
-  tps: 5557.79254
+  dps: 7842.08238
+  tps: 5567.87849
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12446.18263
-  tps: 8836.78967
+  dps: 12466.96457
+  tps: 8851.54484
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3300.38164
-  tps: 2343.27096
+  dps: 3305.96503
+  tps: 2347.23517
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3439.90191
-  tps: 2442.33035
+  dps: 3444.89848
+  tps: 2445.87792
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20479.35299
-  tps: 14540.34062
+  dps: 20510.69545
+  tps: 14562.59377
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6349.37885
-  tps: 4508.05899
+  dps: 6356.61766
+  tps: 4513.19854
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7428.15747
-  tps: 5273.9918
+  dps: 7441.87327
+  tps: 5283.73002
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11923.66322
-  tps: 8465.80089
+  dps: 11941.13929
+  tps: 8478.2089
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3143.47989
-  tps: 2231.87072
+  dps: 3148.14294
+  tps: 2235.18149
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3245.80115
-  tps: 2304.51882
+  dps: 3250.6818
+  tps: 2307.98408
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15622.35421
-  tps: 11091.87149
+  dps: 15664.74617
+  tps: 11121.96978
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5711.24682
-  tps: 4054.98524
+  dps: 5717.49047
+  tps: 4059.41824
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6869.78376
-  tps: 4877.54647
+  dps: 6881.94132
+  tps: 4886.17834
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8883.48849
-  tps: 6307.27683
+  dps: 8909.27231
+  tps: 6325.58334
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2670.72671
-  tps: 1896.21596
+  dps: 2674.88752
+  tps: 1899.17014
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2863.14847
-  tps: 2032.83542
+  dps: 2868.08313
+  tps: 2036.33902
  }
 }
 dps_results: {
@@ -1065,133 +1065,133 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21524.32799
-  tps: 15282.27287
+  dps: 21558.42464
+  tps: 15306.48149
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6699.37669
-  tps: 4756.55745
+  dps: 6709.55461
+  tps: 4763.78377
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7930.0991
-  tps: 5630.37036
+  dps: 7944.48498
+  tps: 5640.58433
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12550.74859
-  tps: 8911.0315
+  dps: 12571.64447
+  tps: 8925.86757
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3325.62914
-  tps: 2361.19669
+  dps: 3331.2406
+  tps: 2365.18083
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3493.65719
-  tps: 2480.49661
+  dps: 3498.7281
+  tps: 2484.09695
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20638.65771
-  tps: 14653.44697
+  dps: 20670.3676
+  tps: 14675.961
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6389.40247
-  tps: 4536.47575
+  dps: 6396.67388
+  tps: 4541.63845
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7524.33962
-  tps: 5342.28113
+  dps: 7538.21821
+  tps: 5352.13493
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12023.51886
-  tps: 8536.69839
+  dps: 12041.10105
+  tps: 8549.18175
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3167.0942
-  tps: 2248.63688
+  dps: 3171.78121
+  tps: 2251.96466
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3295.6326
-  tps: 2339.89915
+  dps: 3300.58906
+  tps: 2343.41823
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15755.33113
-  tps: 11186.2851
+  dps: 15798.04053
+  tps: 11216.60877
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5745.89439
-  tps: 4079.58501
+  dps: 5752.16643
+  tps: 4084.03816
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6962.09213
-  tps: 4943.08541
+  dps: 6974.42938
+  tps: 4951.84486
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8965.51357
-  tps: 6365.51463
+  dps: 8991.47344
+  tps: 6383.94614
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2691.45151
-  tps: 1910.93057
+  dps: 2695.64019
+  tps: 1913.90454
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2908.80303
-  tps: 2065.25015
+  dps: 2913.80859
+  tps: 2068.8041
  }
 }
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6409.4689
-  tps: 4550.72292
+  dps: 6418.78721
+  tps: 4557.33892
  }
 }

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -46,810 +46,810 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6403.11097
+  tps: 4546.20879
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6403.11097
+  tps: 4546.20879
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 6384.5541
-  tps: 4533.03341
+  dps: 6418.90803
+  tps: 4557.4247
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6542.88312
+  tps: 4645.44702
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6566.36422
-  tps: 4662.1186
+  dps: 6602.89425
+  tps: 4688.05492
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6366.40153
-  tps: 4520.14509
+  dps: 6400.78596
+  tps: 4544.55803
   hps: 88.67739
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6366.40153
-  tps: 4520.14509
+  dps: 6400.78596
+  tps: 4544.55803
   hps: 88.67739
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6538.39988
-  tps: 4642.26392
+  dps: 6570.30185
+  tps: 4664.91431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50035"
  value: {
-  dps: 6888.72194
-  tps: 4890.99257
+  dps: 6913.46905
+  tps: 4908.56303
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50692"
  value: {
-  dps: 6994.0428
-  tps: 4965.77039
+  dps: 7018.77962
+  tps: 4983.33353
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5071.02609
-  tps: 3600.42853
+  dps: 5099.48424
+  tps: 3620.63381
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6029.43948
-  tps: 4280.90203
+  dps: 6060.49618
+  tps: 4302.95229
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4529.70243
+  dps: 6542.88312
+  tps: 4552.53808
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6692.84214
+  tps: 4751.91792
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6692.84214
+  tps: 4751.91792
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6654.18497
-  tps: 4724.47133
+  dps: 6688.24031
+  tps: 4748.65062
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6403.11097
+  tps: 4546.20879
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6403.11097
+  tps: 4546.20879
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6400.26843
+  tps: 4544.19058
   hps: 64
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6500.39127
-  tps: 4615.2778
+  dps: 6532.76275
+  tps: 4638.26155
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6530.46432
-  tps: 4636.62967
+  dps: 6565.80098
+  tps: 4661.7187
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6523.13244
-  tps: 4631.42403
+  dps: 6557.88994
+  tps: 4656.10185
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6854.88126
-  tps: 4866.96569
+  dps: 6891.01214
+  tps: 4892.61862
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6476.9559
-  tps: 4598.63869
+  dps: 6508.43734
+  tps: 4620.99051
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6796.70655
-  tps: 4825.66165
+  dps: 6833.06365
+  tps: 4851.47519
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6850.47774
-  tps: 4863.83919
+  dps: 6886.94957
+  tps: 4889.73419
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6400.26843
+  tps: 4544.19058
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6540.64092
-  tps: 4643.85505
+  dps: 6572.53366
+  tps: 4666.4989
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6603.91279
-  tps: 4688.77808
+  dps: 6639.9286
+  tps: 4714.3493
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6577.20332
-  tps: 4669.81436
+  dps: 6613.1387
+  tps: 4695.32848
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6542.88312
+  tps: 4645.44702
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6542.88312
+  tps: 4645.44702
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6538.39988
-  tps: 4642.26392
+  dps: 6570.30185
+  tps: 4664.91431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6533.87759
-  tps: 4639.05309
+  dps: 6565.86556
+  tps: 4661.76454
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6504.34034
-  tps: 4618.08164
+  dps: 6539.59765
+  tps: 4643.11433
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6403.11097
+  tps: 4546.20879
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6542.88312
+  tps: 4645.44702
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6531.07265
-  tps: 4637.06158
+  dps: 6565.88779
+  tps: 4661.78033
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6483.03786
-  tps: 4602.95688
+  dps: 6517.24935
+  tps: 4627.24704
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6369.06004
-  tps: 4522.03263
+  dps: 6403.37583
+  tps: 4546.39684
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6403.11097
+  tps: 4546.20879
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6459.97456
-  tps: 4586.58194
+  dps: 6493.97613
+  tps: 4610.72305
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6542.88312
+  tps: 4645.44702
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6542.88312
+  tps: 4645.44702
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6610.84769
-  tps: 4693.70186
+  dps: 6646.42081
+  tps: 4718.95877
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6400.26843
+  tps: 4544.19058
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Gladiator'sVestments"
  value: {
-  dps: 6453.59305
-  tps: 4582.05107
+  dps: 6485.04458
+  tps: 4604.38165
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6400.26843
+  tps: 4544.19058
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6400.26843
+  tps: 4544.19058
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6504.55737
-  tps: 4618.23573
+  dps: 6539.27898
+  tps: 4642.88807
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-49982"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6692.84214
+  tps: 4751.91792
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-50641"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6692.84214
+  tps: 4751.91792
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6403.11097
+  tps: 4546.20879
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6538.39988
-  tps: 4642.26392
+  dps: 6570.30185
+  tps: 4664.91431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6533.87759
-  tps: 4639.05309
+  dps: 6565.86556
+  tps: 4661.76454
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6547.57032
-  tps: 4648.77493
+  dps: 6582.50922
+  tps: 4673.58154
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6542.88312
+  tps: 4645.44702
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6541.47551
-  tps: 4644.44761
+  dps: 6574.44386
+  tps: 4667.85514
   hps: 11.11293
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LastWord-50179"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6692.84214
+  tps: 4751.91792
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LastWord-50708"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6692.84214
+  tps: 4751.91792
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6400.26843
+  tps: 4544.19058
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6403.11097
+  tps: 4546.20879
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6618.0024
-  tps: 4698.7817
+  dps: 6653.44666
+  tps: 4723.94713
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6560.47256
-  tps: 4657.93552
+  dps: 6593.88093
+  tps: 4681.65546
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Nibelung-49992"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6692.84214
+  tps: 4751.91792
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Nibelung-50648"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6692.84214
+  tps: 4751.91792
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6403.11097
+  tps: 4546.20879
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6535.95854
-  tps: 4640.53056
+  dps: 6568.89947
+  tps: 4663.91863
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6542.05141
-  tps: 4644.8565
+  dps: 6575.02097
+  tps: 4668.26489
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6403.11097
+  tps: 4546.20879
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6403.11097
+  tps: 4546.20879
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6403.11097
+  tps: 4546.20879
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6542.88312
+  tps: 4645.44702
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6542.88312
+  tps: 4645.44702
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6403.11097
+  tps: 4546.20879
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6503.13416
-  tps: 4617.22526
+  dps: 6552.15027
+  tps: 4652.02669
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6520.17544
-  tps: 4629.32456
+  dps: 6571.06365
+  tps: 4665.45519
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6692.84214
+  tps: 4751.91792
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6542.88312
+  tps: 4645.44702
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6400.26843
+  tps: 4544.19058
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6400.26843
+  tps: 4544.19058
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 6692.53268
-  tps: 4751.6982
+  dps: 6725.32223
+  tps: 4774.97879
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6692.84214
+  tps: 4751.91792
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6403.11097
+  tps: 4546.20879
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6400.26843
+  tps: 4544.19058
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Slayer'sArmor"
  value: {
-  dps: 4990.18477
-  tps: 3543.03119
+  dps: 5019.00418
+  tps: 3563.49297
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6400.26843
+  tps: 4544.19058
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6400.26843
+  tps: 4544.19058
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6403.11097
+  tps: 4546.20879
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6487.72615
-  tps: 4606.28556
+  dps: 6522.12201
+  tps: 4630.70662
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SparkofLife-37657"
  value: {
-  dps: 6455.95263
-  tps: 4583.72636
+  dps: 6491.43135
+  tps: 4608.91626
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6565.69482
-  tps: 4661.64332
+  dps: 6601.26087
+  tps: 4686.89522
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StormshroudArmor"
  value: {
-  dps: 5113.56599
-  tps: 3630.63185
+  dps: 5140.79435
+  tps: 3649.96399
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6542.05141
-  tps: 4644.8565
+  dps: 6575.02097
+  tps: 4668.26489
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6535.95854
-  tps: 4640.53056
+  dps: 6568.89947
+  tps: 4663.91863
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6525.29602
-  tps: 4632.96018
+  dps: 6558.18686
+  tps: 4656.31267
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6400.26843
+  tps: 4544.19058
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6403.11097
+  tps: 4546.20879
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6450.18759
-  tps: 4579.63319
+  dps: 6481.66115
+  tps: 4601.97942
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheFistsofFury"
  value: {
-  dps: 5870.87078
-  tps: 4168.31825
+  dps: 5895.06317
+  tps: 4185.49485
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6368.75703
-  tps: 4521.81749
+  dps: 6403.11097
+  tps: 4546.20879
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5968.98478
-  tps: 4237.97919
+  dps: 5992.81536
+  tps: 4254.89891
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6580.14878
-  tps: 4671.90563
+  dps: 6613.41884
+  tps: 4695.52738
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6683.05474
-  tps: 4744.96886
+  dps: 6720.16289
+  tps: 4771.31565
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6723.37142
-  tps: 4773.59371
+  dps: 6761.07131
+  tps: 4800.36063
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6542.88312
+  tps: 4645.44702
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6542.88312
+  tps: 4645.44702
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6447.18583
-  tps: 4577.50194
+  dps: 6482.39264
+  tps: 4602.49877
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6542.88312
+  tps: 4645.44702
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6510.06385
-  tps: 4622.14533
+  dps: 6542.88312
+  tps: 4645.44702
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5387.64725
-  tps: 3825.22955
+  dps: 5417.3318
+  tps: 3846.30558
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6274.23061
-  tps: 4454.70373
+  dps: 6302.26684
+  tps: 4474.60945
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6196.52876
-  tps: 4399.53542
+  dps: 6227.58837
+  tps: 4421.58775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6365.89542
-  tps: 4519.78575
+  dps: 6400.26843
+  tps: 4544.19058
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 6640.54281
-  tps: 4714.7854
+  dps: 6676.17414
+  tps: 4740.08364
  }
 }
 dps_results: {
@@ -897,22 +897,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21455.13196
-  tps: 15233.14369
+  dps: 21485.49951
+  tps: 15254.70465
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6657.71933
-  tps: 4726.98072
+  dps: 6692.84214
+  tps: 4751.91792
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7827.87682
-  tps: 5557.79254
+  dps: 7870.05568
+  tps: 5587.73953
  }
 }
 dps_results: {
@@ -939,22 +939,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20549.84158
-  tps: 14590.38752
+  dps: 20574.80061
+  tps: 14608.10843
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6349.37885
-  tps: 4508.05899
+  dps: 6376.36903
+  tps: 4527.22201
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7428.15747
-  tps: 5273.9918
+  dps: 7464.9295
+  tps: 5300.09995
  }
 }
 dps_results: {
@@ -981,22 +981,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15736.15375
-  tps: 11172.66916
+  dps: 15757.71355
+  tps: 11187.97662
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5711.24682
-  tps: 4054.98524
+  dps: 5735.07614
+  tps: 4071.90406
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6869.78376
-  tps: 4877.54647
+  dps: 6903.27577
+  tps: 4901.3258
  }
 }
 dps_results: {
@@ -1065,22 +1065,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21612.73625
-  tps: 15345.04273
+  dps: 21642.47237
+  tps: 15366.15538
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6699.37669
-  tps: 4756.55745
+  dps: 6734.77278
+  tps: 4781.68868
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Deadly OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7930.0991
-  tps: 5630.37036
+  dps: 7972.85523
+  tps: 5660.72721
  }
 }
 dps_results: {
@@ -1107,22 +1107,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20710.03848
-  tps: 14704.12732
+  dps: 20735.04939
+  tps: 14721.88506
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6389.40247
-  tps: 4536.47575
+  dps: 6416.56926
+  tps: 4555.76417
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7524.33962
-  tps: 5342.28113
+  dps: 7561.42784
+  tps: 5368.61376
  }
 }
 dps_results: {
@@ -1149,22 +1149,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15869.72997
-  tps: 11267.50828
+  dps: 15891.24718
+  tps: 11282.78549
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5745.89439
-  tps: 4079.58501
+  dps: 5769.89422
+  tps: 4096.6249
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Instant-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6962.09213
-  tps: 4943.08541
+  dps: 6995.97045
+  tps: 4967.13902
  }
 }
 dps_results: {
@@ -1191,7 +1191,7 @@ dps_results: {
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6409.4689
-  tps: 4550.72292
+  dps: 6442.48162
+  tps: 4574.16195
  }
 }

--- a/sim/rogue/TestSubtlety.results
+++ b/sim/rogue/TestSubtlety.results
@@ -46,837 +46,837 @@ character_stats_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7910.73633
-  tps: 5615.45289
+  dps: 7920.49509
+  tps: 5620.76379
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8160.111
+  tps: 5790.26176
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8096.21432
-  tps: 5747.10726
+  dps: 8139.19965
+  tps: 5774.36552
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7908.47096
-  tps: 5613.38084
-  hps: 87.95214
+  dps: 7895.34823
+  tps: 5604.0637
+  hps: 88.03911
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7908.47096
-  tps: 5613.38084
-  hps: 87.95214
+  dps: 7895.34823
+  tps: 5604.0637
+  hps: 88.03911
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8145.39114
-  tps: 5781.31636
+  dps: 8229.54937
+  tps: 5840.61892
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlackBruise-50035"
  value: {
-  dps: 8126.95377
-  tps: 5766.4657
+  dps: 8154.09554
+  tps: 5786.62827
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlackBruise-50692"
  value: {
-  dps: 8224.49934
-  tps: 5835.72993
+  dps: 8251.69598
+  tps: 5855.92978
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5855.06286
-  tps: 4155.54885
+  dps: 5844.09064
+  tps: 4148.49247
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6930.3859
-  tps: 4916.94301
+  dps: 6933.71939
+  tps: 4920.03935
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5654.76433
+  dps: 8160.111
+  tps: 5674.45653
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8292.7931
-  tps: 5885.92649
+  dps: 8379.74809
+  tps: 5947.20344
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
   hps: 64
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 8051.24268
-  tps: 5714.32467
+  dps: 8070.74536
+  tps: 5727.86822
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 8110.97002
-  tps: 5755.63292
+  dps: 8111.02091
+  tps: 5756.11412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 8115.51714
-  tps: 5760.85756
+  dps: 8108.49848
+  tps: 5755.83382
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8494.10615
-  tps: 6029.9847
+  dps: 8514.00234
+  tps: 6044.94166
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 8022.96114
-  tps: 5695.47067
+  dps: 8067.0093
+  tps: 5725.65384
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8355.81353
-  tps: 5929.72161
+  dps: 8381.40884
+  tps: 5944.53243
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8440.35579
-  tps: 5990.96755
+  dps: 8456.89617
+  tps: 6002.72072
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8146.09294
-  tps: 5781.81463
+  dps: 8227.43514
+  tps: 5839.11782
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 8121.14528
-  tps: 5764.81505
+  dps: 8142.22498
+  tps: 5779.8228
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 8119.28897
-  tps: 5764.69517
+  dps: 8124.1318
+  tps: 5766.19777
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8160.111
+  tps: 5790.26176
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8160.111
+  tps: 5790.26176
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8145.39114
-  tps: 5781.31636
+  dps: 8229.54937
+  tps: 5840.61892
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8138.32237
-  tps: 5776.46508
+  dps: 8211.31048
+  tps: 5827.66166
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 8008.71782
-  tps: 5684.19948
+  dps: 8061.54923
+  tps: 5722.09261
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8160.111
+  tps: 5790.26176
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 8055.96266
-  tps: 5715.71069
+  dps: 8094.7026
+  tps: 5743.70854
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 8011.22543
-  tps: 5686.73158
+  dps: 8045.32802
+  tps: 5708.61661
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7985.03341
-  tps: 5667.46192
+  dps: 8022.64239
+  tps: 5694.46659
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8160.111
+  tps: 5790.26176
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8160.111
+  tps: 5790.26176
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8165.74696
-  tps: 5796.00309
+  dps: 8152.57349
+  tps: 5786.64992
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7355.31271
-  tps: 5217.68854
+  dps: 7335.32718
+  tps: 5202.80306
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 8038.6991
-  tps: 5705.93055
+  dps: 8075.35809
+  tps: 5732.3037
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Heartpierce-49982"
  value: {
-  dps: 8322.96789
-  tps: 5905.97238
+  dps: 8327.08937
+  tps: 5911.04447
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Heartpierce-50641"
  value: {
-  dps: 8322.96789
-  tps: 5905.97238
+  dps: 8327.08937
+  tps: 5911.04447
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8145.39114
-  tps: 5781.31636
+  dps: 8229.54937
+  tps: 5840.61892
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8138.32237
-  tps: 5776.46508
+  dps: 8211.31048
+  tps: 5827.66166
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8105.23958
-  tps: 5753.06635
+  dps: 8092.43095
+  tps: 5743.97222
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8160.111
+  tps: 5790.26176
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8167.03074
-  tps: 5795.33545
+  dps: 8195.6864
+  tps: 5815.50798
   hps: 12.24393
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8131.35975
-  tps: 5771.64754
+  dps: 8136.2379
+  tps: 5775.06651
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 8056.81844
-  tps: 5717.98278
+  dps: 8054.31109
+  tps: 5717.35164
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8160.27572
-  tps: 5790.54159
+  dps: 8188.91013
+  tps: 5810.69917
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8167.03074
-  tps: 5795.33545
+  dps: 8195.6864
+  tps: 5815.50798
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8160.111
+  tps: 5790.26176
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8160.111
+  tps: 5790.26176
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 8039.78981
-  tps: 5703.81152
+  dps: 8044.37867
+  tps: 5707.91166
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 8058.3061
-  tps: 5716.95809
+  dps: 8062.9122
+  tps: 5721.07047
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8322.96789
-  tps: 5905.97238
+  dps: 8327.08937
+  tps: 5911.04447
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8160.111
+  tps: 5790.26176
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7753.33084
-  tps: 5504.39727
+  dps: 7770.29075
+  tps: 5513.02521
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Slayer'sArmor"
  value: {
-  dps: 5398.049
-  tps: 3830.02821
+  dps: 5401.06339
+  tps: 3833.62154
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SouloftheDead-40382"
  value: {
-  dps: 8049.16507
-  tps: 5712.91129
+  dps: 8062.99157
+  tps: 5720.80094
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SparkofLife-37657"
  value: {
-  dps: 7989.00261
-  tps: 5670.58243
+  dps: 7982.64087
+  tps: 5662.51989
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 8124.53042
-  tps: 5764.04397
+  dps: 8131.4197
+  tps: 5769.70522
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-StormshroudArmor"
  value: {
-  dps: 6026.29723
-  tps: 4277.06647
+  dps: 6042.63241
+  tps: 4288.88079
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8167.03074
-  tps: 5795.33545
+  dps: 8195.6864
+  tps: 5815.50798
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8160.27572
-  tps: 5790.54159
+  dps: 8188.91013
+  tps: 5810.69917
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8148.45443
-  tps: 5782.15233
+  dps: 8177.05167
+  tps: 5802.28377
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 7449.6961
-  tps: 5288.06439
+  dps: 7478.95969
+  tps: 5308.87686
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TheFistsofFury"
  value: {
-  dps: 7023.1747
-  tps: 4984.65516
+  dps: 7022.6121
+  tps: 4981.7534
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8206.74115
-  tps: 5821.66078
+  dps: 8215.56811
+  tps: 5827.61908
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 8338.74389
-  tps: 5919.27507
+  dps: 8364.12332
+  tps: 5936.56203
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8333.07865
-  tps: 5911.6267
+  dps: 8357.95919
+  tps: 5932.14117
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8160.111
+  tps: 5790.26176
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8160.111
+  tps: 5790.26176
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7957.01578
-  tps: 5645.0588
+  dps: 7945.60657
+  tps: 5638.13631
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8160.111
+  tps: 5790.26176
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8160.111
+  tps: 5790.26176
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6191.62619
-  tps: 4393.22618
+  dps: 6223.0158
+  tps: 4415.93701
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 7217.9529
-  tps: 5123.10827
+  dps: 7214.36952
+  tps: 5117.4369
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7894.94846
+  tps: 5603.77987
  }
 }
 dps_results: {
  key: "TestSubtlety-Average-Default"
  value: {
-  dps: 8347.98038
-  tps: 5924.38281
+  dps: 8364.03484
+  tps: 5935.83635
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30923.54437
-  tps: 21955.7165
+  dps: 30965.12027
+  tps: 21985.2354
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8322.96789
-  tps: 5905.97238
+  dps: 8327.08937
+  tps: 5911.04447
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9433.14934
-  tps: 6671.68798
+  dps: 9470.00074
+  tps: 6693.77629
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 19177.18925
-  tps: 13615.80437
+  dps: 19215.00221
+  tps: 13642.65157
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4083.7815
-  tps: 2897.30814
+  dps: 4126.48444
+  tps: 2928.35135
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4117.32376
-  tps: 2908.9149
+  dps: 4129.63209
+  tps: 2912.64778
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30634.66729
-  tps: 21750.61377
+  dps: 30680.17119
+  tps: 21782.92154
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8321.33769
-  tps: 5905.43211
+  dps: 8339.22713
+  tps: 5916.69307
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9443.50577
-  tps: 6678.10132
+  dps: 9434.95873
+  tps: 6665.19171
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 19046.90792
-  tps: 13523.30462
+  dps: 19078.54596
+  tps: 13545.76763
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4095.18482
-  tps: 2905.39825
+  dps: 4113.7071
+  tps: 2919.85129
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4154.83173
-  tps: 2939.24734
+  dps: 4162.37154
+  tps: 2944.60061
  }
 }
 dps_results: {
  key: "TestSubtlety-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7550.54233
-  tps: 5358.87694
+  dps: 7578.45125
+  tps: 5378.57626
  }
 }

--- a/sim/rogue/TestSubtlety.results
+++ b/sim/rogue/TestSubtlety.results
@@ -46,768 +46,768 @@ character_stats_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7910.73633
-  tps: 5615.45289
+  dps: 7935.79866
+  tps: 5631.27214
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8206.18775
+  tps: 5823.2188
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8096.21432
-  tps: 5747.10726
+  dps: 8194.75406
+  tps: 5816.2821
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7908.47096
-  tps: 5613.38084
-  hps: 87.95214
+  dps: 7910.02615
+  tps: 5614.19636
+  hps: 88.50074
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7908.47096
-  tps: 5613.38084
-  hps: 87.95214
+  dps: 7910.02615
+  tps: 5614.19636
+  hps: 88.50074
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8145.39114
-  tps: 5781.31636
+  dps: 8212.06964
+  tps: 5827.50625
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlackBruise-50035"
  value: {
-  dps: 8126.95377
-  tps: 5766.4657
+  dps: 8145.06853
+  tps: 5779.93301
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlackBruise-50692"
  value: {
-  dps: 8224.49934
-  tps: 5835.72993
+  dps: 8240.67674
+  tps: 5847.82055
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5855.06286
-  tps: 4155.54885
+  dps: 5890.92435
+  tps: 4178.68796
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6930.3859
-  tps: 4916.94301
+  dps: 6992.61556
+  tps: 4962.17743
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5654.76433
+  dps: 8206.18775
+  tps: 5706.75442
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8292.7931
-  tps: 5885.92649
+  dps: 8362.92723
+  tps: 5934.53425
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
   hps: 64
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 8051.24268
-  tps: 5714.32467
+  dps: 8135.32033
+  tps: 5772.9324
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 8110.97002
-  tps: 5755.63292
+  dps: 8130.34855
+  tps: 5770.96504
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 8115.51714
-  tps: 5760.85756
+  dps: 8134.30497
+  tps: 5769.83858
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8494.10615
-  tps: 6029.9847
+  dps: 8521.68888
+  tps: 6045.92969
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 8022.96114
-  tps: 5695.47067
+  dps: 8122.7086
+  tps: 5764.34115
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8355.81353
-  tps: 5929.72161
+  dps: 8414.63623
+  tps: 5971.07329
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8440.35579
-  tps: 5990.96755
+  dps: 8490.30359
+  tps: 6023.92971
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8146.09294
-  tps: 5781.81463
+  dps: 8211.33259
+  tps: 5827.34974
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 8121.14528
-  tps: 5764.81505
+  dps: 8180.88499
+  tps: 5804.80822
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 8119.28897
-  tps: 5764.69517
+  dps: 8136.95792
+  tps: 5775.2345
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8206.18775
+  tps: 5823.2188
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8206.18775
+  tps: 5823.2188
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8145.39114
-  tps: 5781.31636
+  dps: 8212.06964
+  tps: 5827.50625
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8138.32237
-  tps: 5776.46508
+  dps: 8230.30167
+  tps: 5840.85057
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 8008.71782
-  tps: 5684.19948
+  dps: 8073.32087
+  tps: 5730.9036
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8206.18775
+  tps: 5823.2188
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 8055.96266
-  tps: 5715.71069
+  dps: 8158.69788
+  tps: 5789.16014
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 8011.22543
-  tps: 5686.73158
+  dps: 8120.24562
+  tps: 5764.9898
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7985.03341
-  tps: 5667.46192
+  dps: 8079.77111
+  tps: 5735.88006
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8206.18775
+  tps: 5823.2188
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8206.18775
+  tps: 5823.2188
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8165.74696
-  tps: 5796.00309
+  dps: 8167.75001
+  tps: 5797.12517
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7355.31271
-  tps: 5217.68854
+  dps: 7394.20657
+  tps: 5248.19719
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 8038.6991
-  tps: 5705.93055
+  dps: 8101.8656
+  tps: 5751.56016
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Heartpierce-49982"
  value: {
-  dps: 8322.96789
-  tps: 5905.97238
+  dps: 8379.00685
+  tps: 5944.35065
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Heartpierce-50641"
  value: {
-  dps: 8322.96789
-  tps: 5905.97238
+  dps: 8379.00685
+  tps: 5944.35065
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8145.39114
-  tps: 5781.31636
+  dps: 8212.06964
+  tps: 5827.50625
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8138.32237
-  tps: 5776.46508
+  dps: 8230.30167
+  tps: 5840.85057
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8105.23958
-  tps: 5753.06635
+  dps: 8109.88559
+  tps: 5756.07106
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8206.18775
+  tps: 5823.2188
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8167.03074
-  tps: 5795.33545
+  dps: 8241.92448
+  tps: 5848.58029
   hps: 12.24393
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8131.35975
-  tps: 5771.64754
+  dps: 8168.69835
+  tps: 5796.99481
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 8056.81844
-  tps: 5717.98278
+  dps: 8072.88722
+  tps: 5729.74409
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8160.27572
-  tps: 5790.54159
+  dps: 8235.11749
+  tps: 5843.74953
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8167.03074
-  tps: 5795.33545
+  dps: 8241.92448
+  tps: 5848.58029
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8206.18775
+  tps: 5823.2188
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8206.18775
+  tps: 5823.2188
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 8039.78981
-  tps: 5703.81152
+  dps: 8125.01088
+  tps: 5766.79284
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 8058.3061
-  tps: 5716.95809
+  dps: 8145.2892
+  tps: 5781.19044
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8322.96789
-  tps: 5905.97238
+  dps: 8379.00685
+  tps: 5944.35065
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8206.18775
+  tps: 5823.2188
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7753.33084
-  tps: 5504.39727
+  dps: 7798.53399
+  tps: 5535.72325
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Slayer'sArmor"
  value: {
-  dps: 5398.049
-  tps: 3830.02821
+  dps: 5397.26192
+  tps: 3830.47056
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SouloftheDead-40382"
  value: {
-  dps: 8049.16507
-  tps: 5712.91129
+  dps: 8127.23602
+  tps: 5768.74668
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SparkofLife-37657"
  value: {
-  dps: 7989.00261
-  tps: 5670.58243
+  dps: 8031.54846
+  tps: 5699.60511
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 8124.53042
-  tps: 5764.04397
+  dps: 8177.83422
+  tps: 5805.0194
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-StormshroudArmor"
  value: {
-  dps: 6026.29723
-  tps: 4277.06647
+  dps: 6074.2182
+  tps: 4311.65208
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8167.03074
-  tps: 5795.33545
+  dps: 8241.92448
+  tps: 5848.58029
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8160.27572
-  tps: 5790.54159
+  dps: 8235.11749
+  tps: 5843.74953
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8148.45443
-  tps: 5782.15233
+  dps: 8223.20524
+  tps: 5835.2957
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 7449.6961
-  tps: 5288.06439
+  dps: 7517.27181
+  tps: 5336.13215
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TheFistsofFury"
  value: {
-  dps: 7023.1747
-  tps: 4984.65516
+  dps: 7037.95691
+  tps: 4994.09679
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8206.74115
-  tps: 5821.66078
+  dps: 8196.97765
+  tps: 5818.43276
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 8338.74389
-  tps: 5919.27507
+  dps: 8409.6066
+  tps: 5968.43256
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8333.07865
-  tps: 5911.6267
+  dps: 8392.40013
+  tps: 5957.82565
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8206.18775
+  tps: 5823.2188
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8206.18775
+  tps: 5823.2188
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7957.01578
-  tps: 5645.0588
+  dps: 8032.1451
+  tps: 5701.2593
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8206.18775
+  tps: 5823.2188
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8131.56687
-  tps: 5770.16768
+  dps: 8206.18775
+  tps: 5823.2188
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6191.62619
-  tps: 4393.22618
+  dps: 6251.58909
+  tps: 4436.87716
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 7217.9529
-  tps: 5123.10827
+  dps: 7244.26498
+  tps: 5140.15455
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7908.03319
-  tps: 5613.07003
+  dps: 7909.69905
+  tps: 5613.96412
  }
 }
 dps_results: {
  key: "TestSubtlety-Average-Default"
  value: {
-  dps: 8347.98038
-  tps: 5924.38281
+  dps: 8400.54622
+  tps: 5961.70958
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31047.20579
-  tps: 22043.51611
+  dps: 31076.26377
+  tps: 22064.14728
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8322.96789
-  tps: 5905.97238
+  dps: 8379.00685
+  tps: 5944.35065
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9433.14934
-  tps: 6671.68798
+  dps: 9517.32299
+  tps: 6728.40713
  }
 }
 dps_results: {
@@ -834,22 +834,22 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30756.11125
-  tps: 21836.83899
+  dps: 30784.52946
+  tps: 21857.01592
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8321.33769
-  tps: 5905.43211
+  dps: 8404.99962
+  tps: 5963.81568
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9443.50577
-  tps: 6678.10132
+  dps: 9490.3235
+  tps: 6713.53023
  }
 }
 dps_results: {
@@ -876,7 +876,7 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7550.54233
-  tps: 5358.87694
+  dps: 7622.09153
+  tps: 5408.05917
  }
 }

--- a/sim/rogue/TestSubtlety.results
+++ b/sim/rogue/TestSubtlety.results
@@ -46,837 +46,837 @@ character_stats_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7935.79866
-  tps: 5631.27214
+  dps: 7910.73633
+  tps: 5615.45289
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8206.18775
-  tps: 5823.2188
+  dps: 8131.56687
+  tps: 5770.16768
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8194.75406
-  tps: 5816.2821
+  dps: 8096.21432
+  tps: 5747.10726
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7910.02615
-  tps: 5614.19636
-  hps: 88.50074
+  dps: 7908.47096
+  tps: 5613.38084
+  hps: 87.95214
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7910.02615
-  tps: 5614.19636
-  hps: 88.50074
+  dps: 7908.47096
+  tps: 5613.38084
+  hps: 87.95214
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8212.06964
-  tps: 5827.50625
+  dps: 8145.39114
+  tps: 5781.31636
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlackBruise-50035"
  value: {
-  dps: 8145.06853
-  tps: 5779.93301
+  dps: 8126.95377
+  tps: 5766.4657
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlackBruise-50692"
  value: {
-  dps: 8240.67674
-  tps: 5847.82055
+  dps: 8224.49934
+  tps: 5835.72993
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5890.92435
-  tps: 4178.68796
+  dps: 5855.06286
+  tps: 4155.54885
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6992.61556
-  tps: 4962.17743
+  dps: 6930.3859
+  tps: 4916.94301
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8206.18775
-  tps: 5706.75442
+  dps: 8131.56687
+  tps: 5654.76433
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8362.92723
-  tps: 5934.53425
+  dps: 8292.7931
+  tps: 5885.92649
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
   hps: 64
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 8135.32033
-  tps: 5772.9324
+  dps: 8051.24268
+  tps: 5714.32467
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 8130.34855
-  tps: 5770.96504
+  dps: 8110.97002
+  tps: 5755.63292
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 8134.30497
-  tps: 5769.83858
+  dps: 8115.51714
+  tps: 5760.85756
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8521.68888
-  tps: 6045.92969
+  dps: 8494.10615
+  tps: 6029.9847
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 8122.7086
-  tps: 5764.34115
+  dps: 8022.96114
+  tps: 5695.47067
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8414.63623
-  tps: 5971.07329
+  dps: 8355.81353
+  tps: 5929.72161
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8490.30359
-  tps: 6023.92971
+  dps: 8440.35579
+  tps: 5990.96755
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8211.33259
-  tps: 5827.34974
+  dps: 8146.09294
+  tps: 5781.81463
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 8180.88499
-  tps: 5804.80822
+  dps: 8121.14528
+  tps: 5764.81505
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 8136.95792
-  tps: 5775.2345
+  dps: 8119.28897
+  tps: 5764.69517
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8206.18775
-  tps: 5823.2188
+  dps: 8131.56687
+  tps: 5770.16768
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8206.18775
-  tps: 5823.2188
+  dps: 8131.56687
+  tps: 5770.16768
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8212.06964
-  tps: 5827.50625
+  dps: 8145.39114
+  tps: 5781.31636
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8230.30167
-  tps: 5840.85057
+  dps: 8138.32237
+  tps: 5776.46508
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 8073.32087
-  tps: 5730.9036
+  dps: 8008.71782
+  tps: 5684.19948
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8206.18775
-  tps: 5823.2188
+  dps: 8131.56687
+  tps: 5770.16768
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 8158.69788
-  tps: 5789.16014
+  dps: 8055.96266
+  tps: 5715.71069
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 8120.24562
-  tps: 5764.9898
+  dps: 8011.22543
+  tps: 5686.73158
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForgeEmber-37660"
  value: {
-  dps: 8079.77111
-  tps: 5735.88006
+  dps: 7985.03341
+  tps: 5667.46192
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8206.18775
-  tps: 5823.2188
+  dps: 8131.56687
+  tps: 5770.16768
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8206.18775
-  tps: 5823.2188
+  dps: 8131.56687
+  tps: 5770.16768
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8167.75001
-  tps: 5797.12517
+  dps: 8165.74696
+  tps: 5796.00309
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7394.20657
-  tps: 5248.19719
+  dps: 7355.31271
+  tps: 5217.68854
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 8101.8656
-  tps: 5751.56016
+  dps: 8038.6991
+  tps: 5705.93055
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Heartpierce-49982"
  value: {
-  dps: 8379.00685
-  tps: 5944.35065
+  dps: 8322.96789
+  tps: 5905.97238
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Heartpierce-50641"
  value: {
-  dps: 8379.00685
-  tps: 5944.35065
+  dps: 8322.96789
+  tps: 5905.97238
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8212.06964
-  tps: 5827.50625
+  dps: 8145.39114
+  tps: 5781.31636
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8230.30167
-  tps: 5840.85057
+  dps: 8138.32237
+  tps: 5776.46508
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8109.88559
-  tps: 5756.07106
+  dps: 8105.23958
+  tps: 5753.06635
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8206.18775
-  tps: 5823.2188
+  dps: 8131.56687
+  tps: 5770.16768
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8241.92448
-  tps: 5848.58029
+  dps: 8167.03074
+  tps: 5795.33545
   hps: 12.24393
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8168.69835
-  tps: 5796.99481
+  dps: 8131.35975
+  tps: 5771.64754
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 8072.88722
-  tps: 5729.74409
+  dps: 8056.81844
+  tps: 5717.98278
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8235.11749
-  tps: 5843.74953
+  dps: 8160.27572
+  tps: 5790.54159
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8241.92448
-  tps: 5848.58029
+  dps: 8167.03074
+  tps: 5795.33545
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8206.18775
-  tps: 5823.2188
+  dps: 8131.56687
+  tps: 5770.16768
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8206.18775
-  tps: 5823.2188
+  dps: 8131.56687
+  tps: 5770.16768
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 8125.01088
-  tps: 5766.79284
+  dps: 8039.78981
+  tps: 5703.81152
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 8145.2892
-  tps: 5781.19044
+  dps: 8058.3061
+  tps: 5716.95809
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8379.00685
-  tps: 5944.35065
+  dps: 8322.96789
+  tps: 5905.97238
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8206.18775
-  tps: 5823.2188
+  dps: 8131.56687
+  tps: 5770.16768
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7798.53399
-  tps: 5535.72325
+  dps: 7753.33084
+  tps: 5504.39727
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Slayer'sArmor"
  value: {
-  dps: 5397.26192
-  tps: 3830.47056
+  dps: 5398.049
+  tps: 3830.02821
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SouloftheDead-40382"
  value: {
-  dps: 8127.23602
-  tps: 5768.74668
+  dps: 8049.16507
+  tps: 5712.91129
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SparkofLife-37657"
  value: {
-  dps: 8031.54846
-  tps: 5699.60511
+  dps: 7989.00261
+  tps: 5670.58243
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 8177.83422
-  tps: 5805.0194
+  dps: 8124.53042
+  tps: 5764.04397
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-StormshroudArmor"
  value: {
-  dps: 6074.2182
-  tps: 4311.65208
+  dps: 6026.29723
+  tps: 4277.06647
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8241.92448
-  tps: 5848.58029
+  dps: 8167.03074
+  tps: 5795.33545
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8235.11749
-  tps: 5843.74953
+  dps: 8160.27572
+  tps: 5790.54159
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8223.20524
-  tps: 5835.2957
+  dps: 8148.45443
+  tps: 5782.15233
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 7517.27181
-  tps: 5336.13215
+  dps: 7449.6961
+  tps: 5288.06439
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TheFistsofFury"
  value: {
-  dps: 7037.95691
-  tps: 4994.09679
+  dps: 7023.1747
+  tps: 4984.65516
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8196.97765
-  tps: 5818.43276
+  dps: 8206.74115
+  tps: 5821.66078
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 8409.6066
-  tps: 5968.43256
+  dps: 8338.74389
+  tps: 5919.27507
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8392.40013
-  tps: 5957.82565
+  dps: 8333.07865
+  tps: 5911.6267
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8206.18775
-  tps: 5823.2188
+  dps: 8131.56687
+  tps: 5770.16768
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8206.18775
-  tps: 5823.2188
+  dps: 8131.56687
+  tps: 5770.16768
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 8032.1451
-  tps: 5701.2593
+  dps: 7957.01578
+  tps: 5645.0588
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8206.18775
-  tps: 5823.2188
+  dps: 8131.56687
+  tps: 5770.16768
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8206.18775
-  tps: 5823.2188
+  dps: 8131.56687
+  tps: 5770.16768
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6251.58909
-  tps: 4436.87716
+  dps: 6191.62619
+  tps: 4393.22618
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 7244.26498
-  tps: 5140.15455
+  dps: 7217.9529
+  tps: 5123.10827
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7909.69905
-  tps: 5613.96412
+  dps: 7908.03319
+  tps: 5613.07003
  }
 }
 dps_results: {
  key: "TestSubtlety-Average-Default"
  value: {
-  dps: 8400.54622
-  tps: 5961.70958
+  dps: 8347.98038
+  tps: 5924.38281
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31076.26377
-  tps: 22064.14728
+  dps: 30923.54437
+  tps: 21955.7165
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8379.00685
-  tps: 5944.35065
+  dps: 8322.96789
+  tps: 5905.97238
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9517.32299
-  tps: 6728.40713
+  dps: 9433.14934
+  tps: 6671.68798
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 19300.57964
-  tps: 13703.41154
+  dps: 19177.18925
+  tps: 13615.80437
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4150.01988
-  tps: 2946.18566
+  dps: 4083.7815
+  tps: 2897.30814
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-P2 Subtlety-Subtlety-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4157.84222
-  tps: 2933.6399
+  dps: 4117.32376
+  tps: 2908.9149
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30784.52946
-  tps: 21857.01592
+  dps: 30634.66729
+  tps: 21750.61377
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8404.99962
-  tps: 5963.81568
+  dps: 8321.33769
+  tps: 5905.43211
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9490.3235
-  tps: 6713.53023
+  dps: 9443.50577
+  tps: 6678.10132
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 19143.19088
-  tps: 13591.66552
+  dps: 19046.90792
+  tps: 13523.30462
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4134.82153
-  tps: 2934.08787
+  dps: 4095.18482
+  tps: 2905.39825
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4210.26389
-  tps: 2979.89692
+  dps: 4154.83173
+  tps: 2939.24734
  }
 }
 dps_results: {
  key: "TestSubtlety-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7622.09153
-  tps: 5408.05917
+  dps: 7550.54233
+  tps: 5358.87694
  }
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -49,12 +49,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.47696
+  weights: 0.37294
   weights: 0
-  weights: 1.49618
+  weights: 1.50648
   weights: 0
   weights: 0
-  weights: 1.05358
+  weights: 1.0093
   weights: 0
   weights: 0
   weights: 0
@@ -91,1116 +91,1116 @@ stat_weights_results: {
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6530.21324
-  tps: 4139.14742
+  dps: 6561.39153
+  tps: 4158.58965
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6562.1774
-  tps: 4159.22127
+  dps: 6593.51074
+  tps: 4178.75995
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6478.81014
+  tps: 4086.52794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6274.05798
-  tps: 3978.4425
+  dps: 6303.77892
+  tps: 3996.97061
   hps: 91.87737
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6274.05798
-  tps: 3978.4425
+  dps: 6303.77892
+  tps: 3996.97061
   hps: 91.87737
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6455.02166
-  tps: 4069.79757
+  dps: 6485.36987
+  tps: 4089.3109
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6263.44909
-  tps: 3964.97262
+  dps: 6300.50836
+  tps: 3988.43333
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 6802.77035
-  tps: 4295.24649
+  dps: 6849.78888
+  tps: 4325.42122
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackBruise-50035"
  value: {
-  dps: 5711.23198
-  tps: 3612.74318
+  dps: 5741.29537
+  tps: 3631.12507
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackBruise-50692"
  value: {
-  dps: 5711.23198
-  tps: 3612.74318
+  dps: 5741.29537
+  tps: 3631.12507
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5087.973
-  tps: 3247.75897
+  dps: 5139.01017
+  tps: 3280.18377
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5311.89239
-  tps: 3391.25497
+  dps: 5380.96748
+  tps: 3433.68448
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6478.50304
-  tps: 4005.45717
+  dps: 6515.12214
+  tps: 4027.51946
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6677.88617
+  tps: 4213.26576
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6677.88617
+  tps: 4213.26576
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6677.88617
+  tps: 4213.26576
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
   hps: 64
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6356.59072
-  tps: 4025.30986
+  dps: 6391.89983
+  tps: 4045.3297
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6383.41637
-  tps: 4061.15949
+  dps: 6421.25429
+  tps: 4085.31356
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6286.40958
-  tps: 3991.41374
+  dps: 6327.44434
+  tps: 4016.12637
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 6573.51613
-  tps: 4150.64013
+  dps: 6606.59727
+  tps: 4172.30971
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6295.09327
-  tps: 3991.37165
+  dps: 6326.22983
+  tps: 4005.97594
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6327.44208
-  tps: 4013.52078
+  dps: 6361.3383
+  tps: 4034.07818
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6343.97436
-  tps: 4019.60416
+  dps: 6373.42712
+  tps: 4037.59126
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6465.17297
-  tps: 4077.34797
+  dps: 6491.75641
+  tps: 4094.87286
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6887.88308
-  tps: 4366.21394
+  dps: 6925.45793
+  tps: 4389.71711
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6811.84761
-  tps: 4321.12192
+  dps: 6847.49048
+  tps: 4342.91022
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 5072.88559
-  tps: 3216.39869
+  dps: 5101.59064
+  tps: 3233.71005
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EarthshatterGarb"
  value: {
-  dps: 5884.03718
-  tps: 3732.21453
+  dps: 5905.35901
+  tps: 3743.68819
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6478.81014
+  tps: 4086.52794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6478.2989
-  tps: 4084.71137
+  dps: 6514.9182
+  tps: 4107.93067
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6459.28268
-  tps: 4073.873
+  dps: 6490.20032
+  tps: 4094.123
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6455.71518
-  tps: 4071.78254
+  dps: 6488.49497
+  tps: 4093.27295
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6395.92678
-  tps: 4056.72781
+  dps: 6428.96286
+  tps: 4077.70688
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6478.81014
+  tps: 4086.52794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6364.14401
-  tps: 4033.9549
+  dps: 6397.54049
+  tps: 4055.52952
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6538.71875
-  tps: 4139.72947
+  dps: 6570.25322
+  tps: 4158.3157
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6310.78933
-  tps: 3998.18488
+  dps: 6334.54381
+  tps: 4012.64179
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6431.41494
-  tps: 4077.10096
+  dps: 6462.114
+  tps: 4096.24509
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6461.26315
-  tps: 4090.99901
+  dps: 6499.79532
+  tps: 4114.76472
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6478.50304
-  tps: 4086.69534
+  dps: 6515.12214
+  tps: 4109.20817
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6471.28166
-  tps: 4082.18435
+  dps: 6507.85974
+  tps: 4104.67212
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 5430.15833
-  tps: 3438.77826
+  dps: 5456.78191
+  tps: 3453.9235
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 6829.82099
-  tps: 4293.2697
+  dps: 6868.83265
+  tps: 4316.5737
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 6587.09019
-  tps: 4159.03685
+  dps: 6620.2408
+  tps: 4180.75028
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6360.22205
-  tps: 4032.39102
+  dps: 6390.57578
+  tps: 4051.32033
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 4980.4075
-  tps: 3167.10588
+  dps: 5006.2627
+  tps: 3183.93946
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Gladiator'sWartide"
  value: {
-  dps: 5852.2332
-  tps: 3723.71171
+  dps: 5890.87292
+  tps: 3747.08605
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6546.19532
-  tps: 4149.18435
+  dps: 6577.45114
+  tps: 4168.6748
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6582.51822
-  tps: 4171.99554
+  dps: 6613.95023
+  tps: 4191.5956
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6375.22557
-  tps: 4053.98854
+  dps: 6411.71687
+  tps: 4077.04482
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 6537.6901
-  tps: 4128.71224
+  dps: 6570.59798
+  tps: 4150.2737
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-49982"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6677.88617
+  tps: 4213.26576
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-50641"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6677.88617
+  tps: 4213.26576
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6459.28268
-  tps: 4073.873
+  dps: 6490.20032
+  tps: 4094.123
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6455.71518
-  tps: 4071.78254
+  dps: 6488.49497
+  tps: 4093.27295
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6454.75783
-  tps: 4072.77824
+  dps: 6486.03018
+  tps: 4090.93933
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6478.81014
+  tps: 4086.52794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LastWord-50179"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6677.88617
+  tps: 4213.26576
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LastWord-50708"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6677.88617
+  tps: 4213.26576
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6327.29654
-  tps: 4006.66849
+  dps: 6365.8763
+  tps: 4030.65444
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6476.51814
-  tps: 4104.48718
+  dps: 6509.70951
+  tps: 4121.3516
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Nibelung-49992"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6677.88617
+  tps: 4213.26576
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Nibelung-50648"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6677.88617
+  tps: 4213.26576
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6478.81014
+  tps: 4086.52794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6478.81014
+  tps: 4086.52794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6478.81014
+  tps: 4086.52794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6478.81014
+  tps: 4086.52794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6662.74813
-  tps: 4293.25217
+  dps: 6696.85895
+  tps: 4313.0634
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6712.3449
-  tps: 4333.14186
+  dps: 6747.09981
+  tps: 4353.53922
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6626.07943
-  tps: 4180.77526
+  dps: 6665.51737
+  tps: 4205.01661
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 6603.57298
-  tps: 4169.23286
+  dps: 6636.80795
+  tps: 4190.99955
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6440.60932
-  tps: 4061.28395
+  dps: 6475.98108
+  tps: 4082.93474
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 6532.52167
-  tps: 4125.47745
+  dps: 6565.40146
+  tps: 4147.02098
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6677.88617
+  tps: 4213.26576
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkycallTotem-33506"
  value: {
-  dps: 6553.0278
-  tps: 4135.67277
+  dps: 6588.01527
+  tps: 4158.3576
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterHarness"
  value: {
-  dps: 4224.24223
-  tps: 2696.26275
+  dps: 4257.95031
+  tps: 2715.20041
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterRegalia"
  value: {
-  dps: 5038.87594
-  tps: 3195.18602
+  dps: 5070.11934
+  tps: 3213.9831
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6517.43
-  tps: 4130.79026
+  dps: 6551.57738
+  tps: 4152.04319
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6546.55783
-  tps: 4149.73885
+  dps: 6580.86115
+  tps: 4171.08878
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6379.10996
-  tps: 4044.25284
+  dps: 6409.55531
+  tps: 4063.23914
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6373.76231
-  tps: 4042.70122
+  dps: 6403.40768
+  tps: 4059.9089
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SparkofLife-37657"
  value: {
-  dps: 6376.88272
-  tps: 4042.00011
+  dps: 6409.66452
+  tps: 4062.56764
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6383.32794
-  tps: 4024.12657
+  dps: 6414.90322
+  tps: 4044.31941
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 6505.64584
-  tps: 4108.65655
+  dps: 6538.37959
+  tps: 4130.10685
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StormshroudArmor"
  value: {
-  dps: 4883.25807
-  tps: 3122.74779
+  dps: 4912.14935
+  tps: 3137.89019
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6478.81014
+  tps: 4086.52794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6478.81014
+  tps: 4086.52794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6478.81014
+  tps: 4086.52794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6305.31388
-  tps: 3991.19128
+  dps: 6340.10848
+  tps: 4012.0601
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheFistsofFury"
  value: {
-  dps: 5875.21049
-  tps: 3717.08634
+  dps: 5936.21054
+  tps: 3755.036
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6300.05803
+  tps: 3994.47675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 5350.17175
-  tps: 3398.20797
+  dps: 5376.88142
+  tps: 3414.84166
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Thrall'sRegalia"
  value: {
-  dps: 6316.57313
-  tps: 4007.39571
+  dps: 6345.4662
+  tps: 4023.52759
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6478.81014
+  tps: 4086.52794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TidefuryRaiment"
  value: {
-  dps: 4786.70159
-  tps: 3061.83823
+  dps: 4830.34291
+  tps: 3088.72166
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6427.33136
-  tps: 4054.78435
+  dps: 6459.71065
+  tps: 4075.94163
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6427.33136
-  tps: 4054.78435
+  dps: 6459.71065
+  tps: 4075.94163
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6478.50304
-  tps: 4086.69534
+  dps: 6515.12214
+  tps: 4109.20817
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6471.28166
-  tps: 4082.18435
+  dps: 6507.85974
+  tps: 4104.67212
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6408.98675
-  tps: 4056.5474
+  dps: 6443.00312
+  tps: 4077.18534
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 6768.3504
-  tps: 4270.6899
+  dps: 6814.58056
+  tps: 4301.3039
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofQuakingEarth-47667"
  value: {
-  dps: 6505.64584
-  tps: 4108.65655
+  dps: 6538.37959
+  tps: 4130.10685
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 6505.64584
-  tps: 4108.65655
+  dps: 6538.37959
+  tps: 4130.10685
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemoftheElementalPlane-40708"
  value: {
-  dps: 6586.14034
-  tps: 4160.29484
+  dps: 6621.36497
+  tps: 4182.76413
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6471.28166
-  tps: 4082.18435
+  dps: 6507.85974
+  tps: 4104.67212
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6478.50304
-  tps: 4086.69534
+  dps: 6515.12214
+  tps: 4109.20817
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 4941.68228
-  tps: 3156.32715
+  dps: 4982.9779
+  tps: 3178.86402
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6888.53085
-  tps: 4344.81451
+  dps: 6932.70332
+  tps: 4370.37332
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6376.72654
-  tps: 4043.028
+  dps: 6406.98492
+  tps: 4061.8931
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 5284.42403
-  tps: 3350.92925
+  dps: 5307.2116
+  tps: 3364.25928
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WorldbreakerGarb"
  value: {
-  dps: 6362.33835
-  tps: 4086.99095
+  dps: 6403.63791
+  tps: 4114.2761
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 6621.02534
-  tps: 4180.02864
+  dps: 6654.34964
+  tps: 4201.85171
  }
 }
 dps_results: {
  key: "TestElemental-Average-Default"
  value: {
-  dps: 6702.5745
-  tps: 4233.6161
+  dps: 6746.477
+  tps: 4260.67589
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12252.46775
-  tps: 9057.3953
+  dps: 12334.342
+  tps: 9114.101
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6660.33499
-  tps: 4200.41231
+  dps: 6687.09509
+  tps: 4217.80511
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7536.50783
-  tps: 4760.37319
+  dps: 7570.48676
+  tps: 4782.44354
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4646.22746
-  tps: 3423.17282
+  dps: 4671.09546
+  tps: 3437.72815
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3557.08678
-  tps: 2288.09935
+  dps: 3583.32571
+  tps: 2306.91776
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5494.4411
-  tps: 3460.70727
+  dps: 5548.00641
+  tps: 3495.13081
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14635.58098
-  tps: 8836.09118
+  dps: 14721.35735
+  tps: 8888.63143
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7183.39436
-  tps: 4143.68369
+  dps: 7211.24578
+  tps: 4159.80144
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8814.95234
-  tps: 4679.24639
+  dps: 8850.44744
+  tps: 4698.13853
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6559.52372
-  tps: 3244.26355
+  dps: 6641.64245
+  tps: 3291.89853
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3921.75357
-  tps: 2206.51418
+  dps: 3958.61413
+  tps: 2228.54298
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6430.23434
-  tps: 3335.88485
+  dps: 6471.27664
+  tps: 3359.46196
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12095.80478
-  tps: 8938.79186
+  dps: 12211.94033
+  tps: 9015.45946
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6677.88617
+  tps: 4213.26576
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7421.91089
-  tps: 4684.85858
+  dps: 7454.69969
+  tps: 4705.72043
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4506.63021
-  tps: 3338.31114
+  dps: 4562.52218
+  tps: 3375.96078
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3506.38678
-  tps: 2256.20749
+  dps: 3565.18471
+  tps: 2296.13631
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5381.6728
-  tps: 3390.57507
+  dps: 5425.45389
+  tps: 3419.65288
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14453.36817
-  tps: 8850.1701
+  dps: 14543.00628
+  tps: 8905.46423
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7152.95136
-  tps: 4153.07735
+  dps: 7191.69609
+  tps: 4177.0809
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8620.55127
-  tps: 4619.44417
+  dps: 8654.28635
+  tps: 4637.13936
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6370.60994
-  tps: 3226.55466
+  dps: 6408.84265
+  tps: 3245.07318
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3896.98618
-  tps: 2212.27921
+  dps: 3936.09344
+  tps: 2238.16946
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6305.39732
-  tps: 3296.33849
+  dps: 6347.91705
+  tps: 3320.70821
  }
 }
 dps_results: {
  key: "TestElemental-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6677.88617
+  tps: 4213.26576
  }
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -49,12 +49,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.47326
+  weights: 0.47696
   weights: 0
-  weights: 1.5287
+  weights: 1.49618
   weights: 0
   weights: 0
-  weights: 1.0354
+  weights: 1.05358
   weights: 0
   weights: 0
   weights: 0
@@ -91,1116 +91,1116 @@ stat_weights_results: {
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6649.83583
-  tps: 4208.2544
+  dps: 6530.21324
+  tps: 4139.14742
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6682.39421
-  tps: 4228.67199
+  dps: 6562.1774
+  tps: 4159.22127
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6565.46797
-  tps: 4138.03645
+  dps: 6442.39613
+  tps: 4064.14039
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6388.77905
-  tps: 4044.68636
-  hps: 91.64631
+  dps: 6274.05798
+  tps: 3978.4425
+  hps: 91.87737
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6388.77905
-  tps: 4044.68636
-  hps: 91.64631
+  dps: 6274.05798
+  tps: 3978.4425
+  hps: 91.87737
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6581.15656
-  tps: 4144.80254
+  dps: 6455.02166
+  tps: 4069.79757
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6386.44566
-  tps: 4041.73949
+  dps: 6263.44909
+  tps: 3964.97262
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 6955.9939
-  tps: 4392.09832
+  dps: 6802.77035
+  tps: 4295.24649
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackBruise-50035"
  value: {
-  dps: 5818.32444
-  tps: 3676.8282
+  dps: 5711.23198
+  tps: 3612.74318
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackBruise-50692"
  value: {
-  dps: 5818.32444
-  tps: 3676.8282
+  dps: 5711.23198
+  tps: 3612.74318
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5277.90703
-  tps: 3366.92146
+  dps: 5087.973
+  tps: 3247.75897
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5517.11571
-  tps: 3518.97349
+  dps: 5311.89239
+  tps: 3391.25497
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6602.27391
-  tps: 4078.28045
+  dps: 6478.50304
+  tps: 4005.45717
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6778.4636
-  tps: 4273.41619
+  dps: 6644.35403
+  tps: 4191.30149
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6778.4636
-  tps: 4273.41619
+  dps: 6644.35403
+  tps: 4191.30149
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6778.4636
-  tps: 4273.41619
+  dps: 6644.35403
+  tps: 4191.30149
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
   hps: 64
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6489.22357
-  tps: 4103.82804
+  dps: 6356.59072
+  tps: 4025.30986
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6525.4179
-  tps: 4151.28599
+  dps: 6383.41637
+  tps: 4061.15949
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6430.79956
-  tps: 4078.40267
+  dps: 6286.40958
+  tps: 3991.41374
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 6705.72416
-  tps: 4231.6272
+  dps: 6573.51613
+  tps: 4150.64013
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6421.80971
-  tps: 4064.59273
+  dps: 6295.09327
+  tps: 3991.37165
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6442.03292
-  tps: 4077.88479
+  dps: 6327.44208
+  tps: 4013.52078
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6445.13819
-  tps: 4077.85966
+  dps: 6343.97436
+  tps: 4019.60416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6590.08423
-  tps: 4153.83294
+  dps: 6465.17297
+  tps: 4077.34797
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7023.87984
-  tps: 4448.80703
+  dps: 6887.88308
+  tps: 4366.21394
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6942.75555
-  tps: 4398.26497
+  dps: 6811.84761
+  tps: 4321.12192
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 5152.50193
-  tps: 3264.51566
+  dps: 5072.88559
+  tps: 3216.39869
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EarthshatterGarb"
  value: {
-  dps: 5993.7759
-  tps: 3799.68933
+  dps: 5884.03718
+  tps: 3732.21453
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6565.46797
-  tps: 4138.03645
+  dps: 6442.39613
+  tps: 4064.14039
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6604.01111
-  tps: 4159.63182
+  dps: 6478.2989
+  tps: 4084.71137
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6583.562
-  tps: 4149.94461
+  dps: 6459.28268
+  tps: 4073.873
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6579.92333
-  tps: 4147.65129
+  dps: 6455.71518
+  tps: 4071.78254
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6517.41446
-  tps: 4129.61696
+  dps: 6395.92678
+  tps: 4056.72781
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6565.46797
-  tps: 4138.03645
+  dps: 6442.39613
+  tps: 4064.14039
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6491.77793
-  tps: 4110.64037
+  dps: 6364.14401
+  tps: 4033.9549
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6673.91494
-  tps: 4219.42526
+  dps: 6538.71875
+  tps: 4139.72947
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6419.91643
-  tps: 4063.49379
+  dps: 6310.78933
+  tps: 3998.18488
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6549.20083
-  tps: 4145.14547
+  dps: 6431.41494
+  tps: 4077.10096
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6595.19053
-  tps: 4172.56048
+  dps: 6461.26315
+  tps: 4090.99901
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6602.27391
-  tps: 4161.01077
+  dps: 6478.50304
+  tps: 4086.69534
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6594.91272
-  tps: 4156.41591
+  dps: 6471.28166
+  tps: 4082.18435
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 5525.93535
-  tps: 3495.90051
+  dps: 5430.15833
+  tps: 3438.77826
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 6955.90738
-  tps: 4369.98647
+  dps: 6829.82099
+  tps: 4293.2697
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 6719.58805
-  tps: 4240.19894
+  dps: 6587.09019
+  tps: 4159.03685
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6476.68444
-  tps: 4099.66991
+  dps: 6360.22205
+  tps: 4032.39102
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 5071.51525
-  tps: 3226.2116
+  dps: 4980.4075
+  tps: 3167.10588
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Gladiator'sWartide"
  value: {
-  dps: 5984.17611
-  tps: 3803.15554
+  dps: 5852.2332
+  tps: 3723.71171
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6666.11502
-  tps: 4218.46319
+  dps: 6546.19532
+  tps: 4149.18435
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6703.11318
-  tps: 4241.66501
+  dps: 6582.51822
+  tps: 4171.99554
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6516.40273
-  tps: 4146.17539
+  dps: 6375.22557
+  tps: 4053.98854
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 6669.09753
-  tps: 4209.24885
+  dps: 6537.6901
+  tps: 4128.71224
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-49982"
  value: {
-  dps: 6778.4636
-  tps: 4273.41619
+  dps: 6644.35403
+  tps: 4191.30149
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-50641"
  value: {
-  dps: 6778.4636
-  tps: 4273.41619
+  dps: 6644.35403
+  tps: 4191.30149
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6583.562
-  tps: 4149.94461
+  dps: 6459.28268
+  tps: 4073.873
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6579.92333
-  tps: 4147.65129
+  dps: 6455.71518
+  tps: 4071.78254
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6568.65999
-  tps: 4140.66761
+  dps: 6454.75783
+  tps: 4072.77824
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6565.46797
-  tps: 4138.03645
+  dps: 6442.39613
+  tps: 4064.14039
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LastWord-50179"
  value: {
-  dps: 6778.4636
-  tps: 4273.41619
+  dps: 6644.35403
+  tps: 4191.30149
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LastWord-50708"
  value: {
-  dps: 6778.4636
-  tps: 4273.41619
+  dps: 6644.35403
+  tps: 4191.30149
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6458.73748
-  tps: 4086.75779
+  dps: 6327.29654
+  tps: 4006.66849
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6595.81649
-  tps: 4173.44997
+  dps: 6476.51814
+  tps: 4104.48718
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Nibelung-49992"
  value: {
-  dps: 6778.4636
-  tps: 4273.41619
+  dps: 6644.35403
+  tps: 4191.30149
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Nibelung-50648"
  value: {
-  dps: 6778.4636
-  tps: 4273.41619
+  dps: 6644.35403
+  tps: 4191.30149
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6565.46797
-  tps: 4138.03645
+  dps: 6442.39613
+  tps: 4064.14039
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6565.46797
-  tps: 4138.03645
+  dps: 6442.39613
+  tps: 4064.14039
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6565.46797
-  tps: 4138.03645
+  dps: 6442.39613
+  tps: 4064.14039
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6565.46797
-  tps: 4138.03645
+  dps: 6442.39613
+  tps: 4064.14039
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6803.20027
-  tps: 4384.99481
+  dps: 6662.74813
+  tps: 4293.25217
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6854.6667
-  tps: 4426.55671
+  dps: 6712.3449
+  tps: 4333.14186
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6758.8114
-  tps: 4260.47318
+  dps: 6626.07943
+  tps: 4180.77526
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 6736.42277
-  tps: 4250.60747
+  dps: 6603.57298
+  tps: 4169.23286
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6562.95354
-  tps: 4134.69287
+  dps: 6440.60932
+  tps: 4061.28395
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 6663.82449
-  tps: 4205.94557
+  dps: 6532.52167
+  tps: 4125.47745
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6778.4636
-  tps: 4273.41619
+  dps: 6644.35403
+  tps: 4191.30149
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkycallTotem-33506"
  value: {
-  dps: 6679.86951
-  tps: 4213.65967
+  dps: 6553.0278
+  tps: 4135.67277
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterHarness"
  value: {
-  dps: 4342.35836
-  tps: 2766.4694
+  dps: 4224.24223
+  tps: 2696.26275
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterRegalia"
  value: {
-  dps: 5146.10755
-  tps: 3261.21246
+  dps: 5038.87594
+  tps: 3195.18602
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6639.95012
-  tps: 4206.3681
+  dps: 6517.43
+  tps: 4130.79026
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6669.63246
-  tps: 4225.65888
+  dps: 6546.55783
+  tps: 4149.73885
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6495.92348
-  tps: 4111.73485
+  dps: 6379.10996
+  tps: 4044.25284
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6499.15017
-  tps: 4116.77326
+  dps: 6373.76231
+  tps: 4042.70122
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SparkofLife-37657"
  value: {
-  dps: 6496.72201
-  tps: 4117.43888
+  dps: 6376.88272
+  tps: 4042.00011
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6508.39252
-  tps: 4099.7682
+  dps: 6383.32794
+  tps: 4024.12657
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 6636.40472
-  tps: 4188.76853
+  dps: 6505.64584
+  tps: 4108.65655
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StormshroudArmor"
  value: {
-  dps: 5008.90985
-  tps: 3196.26282
+  dps: 4883.25807
+  tps: 3122.74779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6565.46797
-  tps: 4138.03645
+  dps: 6442.39613
+  tps: 4064.14039
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6565.46797
-  tps: 4138.03645
+  dps: 6442.39613
+  tps: 4064.14039
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6565.46797
-  tps: 4138.03645
+  dps: 6442.39613
+  tps: 4064.14039
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6425.56863
-  tps: 4063.01856
+  dps: 6305.31388
+  tps: 3991.19128
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheFistsofFury"
  value: {
-  dps: 6009.2333
-  tps: 3800.08858
+  dps: 5875.21049
+  tps: 3717.08634
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6384.929
-  tps: 4042.12942
+  dps: 6270.14125
+  tps: 3975.81925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 5439.10269
-  tps: 3453.02631
+  dps: 5350.17175
+  tps: 3398.20797
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Thrall'sRegalia"
  value: {
-  dps: 6428.84195
-  tps: 4072.96876
+  dps: 6316.57313
+  tps: 4007.39571
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6565.46797
-  tps: 4138.03645
+  dps: 6442.39613
+  tps: 4064.14039
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TidefuryRaiment"
  value: {
-  dps: 4911.31512
-  tps: 3138.24452
+  dps: 4786.70159
+  tps: 3061.83823
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6556.44614
-  tps: 4133.61375
+  dps: 6427.33136
+  tps: 4054.78435
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6556.44614
-  tps: 4133.61375
+  dps: 6427.33136
+  tps: 4054.78435
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6602.27391
-  tps: 4161.01077
+  dps: 6478.50304
+  tps: 4086.69534
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6594.91272
-  tps: 4156.41591
+  dps: 6471.28166
+  tps: 4082.18435
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6534.21585
-  tps: 4133.47315
+  dps: 6408.98675
+  tps: 4056.5474
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 6919.31089
-  tps: 4366.3071
+  dps: 6768.3504
+  tps: 4270.6899
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofQuakingEarth-47667"
  value: {
-  dps: 6636.40472
-  tps: 4188.76853
+  dps: 6505.64584
+  tps: 4108.65655
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 6636.40472
-  tps: 4188.76853
+  dps: 6505.64584
+  tps: 4108.65655
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemoftheElementalPlane-40708"
  value: {
-  dps: 6729.06913
-  tps: 4248.79073
+  dps: 6586.14034
+  tps: 4160.29484
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6594.91272
-  tps: 4156.41591
+  dps: 6471.28166
+  tps: 4082.18435
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6602.27391
-  tps: 4161.01077
+  dps: 6478.50304
+  tps: 4086.69534
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5062.52122
-  tps: 3230.96874
+  dps: 4941.68228
+  tps: 3156.32715
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7032.89828
-  tps: 4432.6694
+  dps: 6888.53085
+  tps: 4344.81451
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6493.44365
-  tps: 4110.44675
+  dps: 6376.72654
+  tps: 4043.028
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 5369.00046
-  tps: 3402.10854
+  dps: 5284.42403
+  tps: 3350.92925
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WorldbreakerGarb"
  value: {
-  dps: 6498.36223
-  tps: 4179.30909
+  dps: 6362.33835
+  tps: 4086.99095
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 6754.24777
-  tps: 4261.62828
+  dps: 6621.02534
+  tps: 4180.02864
  }
 }
 dps_results: {
  key: "TestElemental-Average-Default"
  value: {
-  dps: 6848.13915
-  tps: 4323.13457
+  dps: 6702.5745
+  tps: 4233.6161
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12595.12271
-  tps: 9286.93426
+  dps: 12252.46775
+  tps: 9057.3953
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6788.11419
-  tps: 4279.40476
+  dps: 6660.33499
+  tps: 4200.41231
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7672.76646
-  tps: 4846.47418
+  dps: 7536.50783
+  tps: 4760.37319
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4761.46285
-  tps: 3494.9087
+  dps: 4646.22746
+  tps: 3423.17282
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3657.41624
-  tps: 2349.34265
+  dps: 3557.08678
+  tps: 2288.09935
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5634.5564
-  tps: 3548.11119
+  dps: 5494.4411
+  tps: 3460.70727
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 15116.78352
-  tps: 9147.3006
+  dps: 14635.58098
+  tps: 8836.09118
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7349.15815
-  tps: 4240.59306
+  dps: 7183.39436
+  tps: 4143.68369
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8944.27013
-  tps: 4746.89602
+  dps: 8814.95234
+  tps: 4679.24639
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6777.18843
-  tps: 3369.00148
+  dps: 6559.52372
+  tps: 3244.26355
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4044.35586
-  tps: 2280.40157
+  dps: 3921.75357
+  tps: 2206.51418
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6555.03091
-  tps: 3402.26305
+  dps: 6430.23434
+  tps: 3335.88485
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12521.37042
-  tps: 9227.21866
+  dps: 12095.80478
+  tps: 8938.79186
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6778.4636
-  tps: 4273.41619
+  dps: 6644.35403
+  tps: 4191.30149
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7571.18286
-  tps: 4778.02603
+  dps: 7421.91089
+  tps: 4684.85858
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4654.22341
-  tps: 3434.34303
+  dps: 4506.63021
+  tps: 3338.31114
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3645.12497
-  tps: 2345.00529
+  dps: 3506.38678
+  tps: 2256.20749
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5514.86223
-  tps: 3472.67708
+  dps: 5381.6728
+  tps: 3390.57507
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14820.33409
-  tps: 9071.48383
+  dps: 14453.36817
+  tps: 8850.1701
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7292.79698
-  tps: 4234.86663
+  dps: 7152.95136
+  tps: 4153.07735
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8760.63466
-  tps: 4686.87954
+  dps: 8620.55127
+  tps: 4619.44417
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6587.28223
-  tps: 3349.98794
+  dps: 6370.60994
+  tps: 3226.55466
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4003.73776
-  tps: 2274.96725
+  dps: 3896.98618
+  tps: 2212.27921
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6427.20396
-  tps: 3364.46226
+  dps: 6305.39732
+  tps: 3296.33849
  }
 }
 dps_results: {
  key: "TestElemental-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6778.4636
-  tps: 4273.41619
+  dps: 6644.35403
+  tps: 4191.30149
  }
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -49,12 +49,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.47696
+  weights: 0.47326
   weights: 0
-  weights: 1.49618
+  weights: 1.5287
   weights: 0
   weights: 0
-  weights: 1.05358
+  weights: 1.0354
   weights: 0
   weights: 0
   weights: 0
@@ -91,963 +91,963 @@ stat_weights_results: {
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6530.21324
-  tps: 4139.14742
+  dps: 6649.83583
+  tps: 4208.2544
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6562.1774
-  tps: 4159.22127
+  dps: 6682.39421
+  tps: 4228.67199
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6565.46797
+  tps: 4138.03645
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6274.05798
-  tps: 3978.4425
-  hps: 91.87737
+  dps: 6388.77905
+  tps: 4044.68636
+  hps: 91.64631
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6274.05798
-  tps: 3978.4425
-  hps: 91.87737
+  dps: 6388.77905
+  tps: 4044.68636
+  hps: 91.64631
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6455.02166
-  tps: 4069.79757
+  dps: 6581.15656
+  tps: 4144.80254
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6263.44909
-  tps: 3964.97262
+  dps: 6386.44566
+  tps: 4041.73949
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 6802.77035
-  tps: 4295.24649
+  dps: 6955.9939
+  tps: 4392.09832
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackBruise-50035"
  value: {
-  dps: 5711.23198
-  tps: 3612.74318
+  dps: 5818.32444
+  tps: 3676.8282
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackBruise-50692"
  value: {
-  dps: 5711.23198
-  tps: 3612.74318
+  dps: 5818.32444
+  tps: 3676.8282
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5087.973
-  tps: 3247.75897
+  dps: 5277.90703
+  tps: 3366.92146
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5311.89239
-  tps: 3391.25497
+  dps: 5517.11571
+  tps: 3518.97349
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6478.50304
-  tps: 4005.45717
+  dps: 6602.27391
+  tps: 4078.28045
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6778.4636
+  tps: 4273.41619
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6778.4636
+  tps: 4273.41619
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6778.4636
+  tps: 4273.41619
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
   hps: 64
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6356.59072
-  tps: 4025.30986
+  dps: 6489.22357
+  tps: 4103.82804
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6383.41637
-  tps: 4061.15949
+  dps: 6525.4179
+  tps: 4151.28599
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6286.40958
-  tps: 3991.41374
+  dps: 6430.79956
+  tps: 4078.40267
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 6573.51613
-  tps: 4150.64013
+  dps: 6705.72416
+  tps: 4231.6272
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6295.09327
-  tps: 3991.37165
+  dps: 6421.80971
+  tps: 4064.59273
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6327.44208
-  tps: 4013.52078
+  dps: 6442.03292
+  tps: 4077.88479
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6343.97436
-  tps: 4019.60416
+  dps: 6445.13819
+  tps: 4077.85966
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6465.17297
-  tps: 4077.34797
+  dps: 6590.08423
+  tps: 4153.83294
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6887.88308
-  tps: 4366.21394
+  dps: 7023.87984
+  tps: 4448.80703
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6811.84761
-  tps: 4321.12192
+  dps: 6942.75555
+  tps: 4398.26497
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 5072.88559
-  tps: 3216.39869
+  dps: 5152.50193
+  tps: 3264.51566
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EarthshatterGarb"
  value: {
-  dps: 5884.03718
-  tps: 3732.21453
+  dps: 5993.7759
+  tps: 3799.68933
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6565.46797
+  tps: 4138.03645
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6478.2989
-  tps: 4084.71137
+  dps: 6604.01111
+  tps: 4159.63182
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6459.28268
-  tps: 4073.873
+  dps: 6583.562
+  tps: 4149.94461
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6455.71518
-  tps: 4071.78254
+  dps: 6579.92333
+  tps: 4147.65129
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6395.92678
-  tps: 4056.72781
+  dps: 6517.41446
+  tps: 4129.61696
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6565.46797
+  tps: 4138.03645
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6364.14401
-  tps: 4033.9549
+  dps: 6491.77793
+  tps: 4110.64037
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6538.71875
-  tps: 4139.72947
+  dps: 6673.91494
+  tps: 4219.42526
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6310.78933
-  tps: 3998.18488
+  dps: 6419.91643
+  tps: 4063.49379
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6431.41494
-  tps: 4077.10096
+  dps: 6549.20083
+  tps: 4145.14547
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6461.26315
-  tps: 4090.99901
+  dps: 6595.19053
+  tps: 4172.56048
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6478.50304
-  tps: 4086.69534
+  dps: 6602.27391
+  tps: 4161.01077
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6471.28166
-  tps: 4082.18435
+  dps: 6594.91272
+  tps: 4156.41591
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 5430.15833
-  tps: 3438.77826
+  dps: 5525.93535
+  tps: 3495.90051
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 6829.82099
-  tps: 4293.2697
+  dps: 6955.90738
+  tps: 4369.98647
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 6587.09019
-  tps: 4159.03685
+  dps: 6719.58805
+  tps: 4240.19894
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6360.22205
-  tps: 4032.39102
+  dps: 6476.68444
+  tps: 4099.66991
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 4980.4075
-  tps: 3167.10588
+  dps: 5071.51525
+  tps: 3226.2116
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Gladiator'sWartide"
  value: {
-  dps: 5852.2332
-  tps: 3723.71171
+  dps: 5984.17611
+  tps: 3803.15554
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6546.19532
-  tps: 4149.18435
+  dps: 6666.11502
+  tps: 4218.46319
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6582.51822
-  tps: 4171.99554
+  dps: 6703.11318
+  tps: 4241.66501
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6375.22557
-  tps: 4053.98854
+  dps: 6516.40273
+  tps: 4146.17539
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 6537.6901
-  tps: 4128.71224
+  dps: 6669.09753
+  tps: 4209.24885
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-49982"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6778.4636
+  tps: 4273.41619
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-50641"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6778.4636
+  tps: 4273.41619
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6459.28268
-  tps: 4073.873
+  dps: 6583.562
+  tps: 4149.94461
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6455.71518
-  tps: 4071.78254
+  dps: 6579.92333
+  tps: 4147.65129
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6454.75783
-  tps: 4072.77824
+  dps: 6568.65999
+  tps: 4140.66761
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6565.46797
+  tps: 4138.03645
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LastWord-50179"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6778.4636
+  tps: 4273.41619
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LastWord-50708"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6778.4636
+  tps: 4273.41619
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6327.29654
-  tps: 4006.66849
+  dps: 6458.73748
+  tps: 4086.75779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6476.51814
-  tps: 4104.48718
+  dps: 6595.81649
+  tps: 4173.44997
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Nibelung-49992"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6778.4636
+  tps: 4273.41619
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Nibelung-50648"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6778.4636
+  tps: 4273.41619
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6565.46797
+  tps: 4138.03645
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6565.46797
+  tps: 4138.03645
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6565.46797
+  tps: 4138.03645
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6565.46797
+  tps: 4138.03645
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6662.74813
-  tps: 4293.25217
+  dps: 6803.20027
+  tps: 4384.99481
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6712.3449
-  tps: 4333.14186
+  dps: 6854.6667
+  tps: 4426.55671
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6626.07943
-  tps: 4180.77526
+  dps: 6758.8114
+  tps: 4260.47318
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 6603.57298
-  tps: 4169.23286
+  dps: 6736.42277
+  tps: 4250.60747
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6440.60932
-  tps: 4061.28395
+  dps: 6562.95354
+  tps: 4134.69287
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 6532.52167
-  tps: 4125.47745
+  dps: 6663.82449
+  tps: 4205.94557
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6778.4636
+  tps: 4273.41619
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkycallTotem-33506"
  value: {
-  dps: 6553.0278
-  tps: 4135.67277
+  dps: 6679.86951
+  tps: 4213.65967
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterHarness"
  value: {
-  dps: 4224.24223
-  tps: 2696.26275
+  dps: 4342.35836
+  tps: 2766.4694
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterRegalia"
  value: {
-  dps: 5038.87594
-  tps: 3195.18602
+  dps: 5146.10755
+  tps: 3261.21246
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6517.43
-  tps: 4130.79026
+  dps: 6639.95012
+  tps: 4206.3681
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6546.55783
-  tps: 4149.73885
+  dps: 6669.63246
+  tps: 4225.65888
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6379.10996
-  tps: 4044.25284
+  dps: 6495.92348
+  tps: 4111.73485
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6373.76231
-  tps: 4042.70122
+  dps: 6499.15017
+  tps: 4116.77326
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SparkofLife-37657"
  value: {
-  dps: 6376.88272
-  tps: 4042.00011
+  dps: 6496.72201
+  tps: 4117.43888
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6383.32794
-  tps: 4024.12657
+  dps: 6508.39252
+  tps: 4099.7682
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 6505.64584
-  tps: 4108.65655
+  dps: 6636.40472
+  tps: 4188.76853
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StormshroudArmor"
  value: {
-  dps: 4883.25807
-  tps: 3122.74779
+  dps: 5008.90985
+  tps: 3196.26282
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6565.46797
+  tps: 4138.03645
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6565.46797
+  tps: 4138.03645
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6565.46797
+  tps: 4138.03645
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6305.31388
-  tps: 3991.19128
+  dps: 6425.56863
+  tps: 4063.01856
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheFistsofFury"
  value: {
-  dps: 5875.21049
-  tps: 3717.08634
+  dps: 6009.2333
+  tps: 3800.08858
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6270.14125
-  tps: 3975.81925
+  dps: 6384.929
+  tps: 4042.12942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 5350.17175
-  tps: 3398.20797
+  dps: 5439.10269
+  tps: 3453.02631
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Thrall'sRegalia"
  value: {
-  dps: 6316.57313
-  tps: 4007.39571
+  dps: 6428.84195
+  tps: 4072.96876
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6442.39613
-  tps: 4064.14039
+  dps: 6565.46797
+  tps: 4138.03645
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TidefuryRaiment"
  value: {
-  dps: 4786.70159
-  tps: 3061.83823
+  dps: 4911.31512
+  tps: 3138.24452
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6427.33136
-  tps: 4054.78435
+  dps: 6556.44614
+  tps: 4133.61375
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6427.33136
-  tps: 4054.78435
+  dps: 6556.44614
+  tps: 4133.61375
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6478.50304
-  tps: 4086.69534
+  dps: 6602.27391
+  tps: 4161.01077
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6471.28166
-  tps: 4082.18435
+  dps: 6594.91272
+  tps: 4156.41591
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6408.98675
-  tps: 4056.5474
+  dps: 6534.21585
+  tps: 4133.47315
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 6768.3504
-  tps: 4270.6899
+  dps: 6919.31089
+  tps: 4366.3071
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofQuakingEarth-47667"
  value: {
-  dps: 6505.64584
-  tps: 4108.65655
+  dps: 6636.40472
+  tps: 4188.76853
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 6505.64584
-  tps: 4108.65655
+  dps: 6636.40472
+  tps: 4188.76853
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemoftheElementalPlane-40708"
  value: {
-  dps: 6586.14034
-  tps: 4160.29484
+  dps: 6729.06913
+  tps: 4248.79073
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6471.28166
-  tps: 4082.18435
+  dps: 6594.91272
+  tps: 4156.41591
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6478.50304
-  tps: 4086.69534
+  dps: 6602.27391
+  tps: 4161.01077
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 4941.68228
-  tps: 3156.32715
+  dps: 5062.52122
+  tps: 3230.96874
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6888.53085
-  tps: 4344.81451
+  dps: 7032.89828
+  tps: 4432.6694
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6376.72654
-  tps: 4043.028
+  dps: 6493.44365
+  tps: 4110.44675
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 5284.42403
-  tps: 3350.92925
+  dps: 5369.00046
+  tps: 3402.10854
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WorldbreakerGarb"
  value: {
-  dps: 6362.33835
-  tps: 4086.99095
+  dps: 6498.36223
+  tps: 4179.30909
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 6621.02534
-  tps: 4180.02864
+  dps: 6754.24777
+  tps: 4261.62828
  }
 }
 dps_results: {
  key: "TestElemental-Average-Default"
  value: {
-  dps: 6702.5745
-  tps: 4233.6161
+  dps: 6848.13915
+  tps: 4323.13457
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12443.86939
-  tps: 9190.1004
+  dps: 12595.12271
+  tps: 9286.93426
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6660.33499
-  tps: 4200.41231
+  dps: 6788.11419
+  tps: 4279.40476
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7536.50783
-  tps: 4760.37319
+  dps: 7672.76646
+  tps: 4846.47418
  }
 }
 dps_results: {
@@ -1074,22 +1074,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14804.75945
-  tps: 8930.34538
+  dps: 15116.78352
+  tps: 9147.3006
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7183.39436
-  tps: 4143.68369
+  dps: 7349.15815
+  tps: 4240.59306
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8814.95234
-  tps: 4679.24639
+  dps: 8944.27013
+  tps: 4746.89602
  }
 }
 dps_results: {
@@ -1116,22 +1116,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12260.07973
-  tps: 9048.65429
+  dps: 12521.37042
+  tps: 9227.21866
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6778.4636
+  tps: 4273.41619
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7421.91089
-  tps: 4684.85858
+  dps: 7571.18286
+  tps: 4778.02603
  }
 }
 dps_results: {
@@ -1158,22 +1158,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14627.44987
-  tps: 8952.13718
+  dps: 14820.33409
+  tps: 9071.48383
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7152.95136
-  tps: 4153.07735
+  dps: 7292.79698
+  tps: 4234.86663
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8620.55127
-  tps: 4619.44417
+  dps: 8760.63466
+  tps: 4686.87954
  }
 }
 dps_results: {
@@ -1200,7 +1200,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6644.35403
-  tps: 4191.30149
+  dps: 6778.4636
+  tps: 4273.41619
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -46,1201 +46,1201 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7462.14887
-  tps: 4085.04763
+  dps: 7488.1111
+  tps: 4099.80575
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7481.98509
-  tps: 4096.4483
+  dps: 7508.05936
+  tps: 4111.2823
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7388.1271
-  tps: 4048.80343
+  dps: 7423.51619
+  tps: 4072.42624
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7511.16958
-  tps: 4115.5101
+  dps: 7545.63792
+  tps: 4135.54003
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7300.2786
-  tps: 3992.17656
-  hps: 94.38477
+  dps: 7325.37914
+  tps: 4006.33071
+  hps: 94.19099
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7300.2786
-  tps: 3992.17656
-  hps: 94.38477
+  dps: 7325.37914
+  tps: 4006.33071
+  hps: 94.19099
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7412.37797
-  tps: 4061.89239
+  dps: 7468.25188
+  tps: 4096.41876
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7143.55021
-  tps: 3901.85128
+  dps: 7195.54317
+  tps: 3929.51068
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 7784.67558
-  tps: 4287.36277
+  dps: 7826.79601
+  tps: 4310.82623
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50035"
  value: {
-  dps: 7401.17992
-  tps: 4051.05186
+  dps: 7437.77187
+  tps: 4071.27165
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50692"
  value: {
-  dps: 7457.54463
-  tps: 4081.80336
+  dps: 7491.75766
+  tps: 4099.73096
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6085.84034
-  tps: 3295.46021
+  dps: 6107.78923
+  tps: 3310.80904
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6002.56403
-  tps: 3259.30875
+  dps: 6036.49019
+  tps: 3281.968
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7410.93021
-  tps: 3949.71744
+  dps: 7446.47838
+  tps: 3972.73616
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7599.41138
+  tps: 4178.73186
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7599.41138
+  tps: 4178.73186
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7558.41238
-  tps: 4147.94038
+  dps: 7607.76534
+  tps: 4182.70933
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7325.80484
+  tps: 4006.42836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7325.80484
+  tps: 4006.42836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7325.78651
+  tps: 4006.42836
   hps: 64
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7447.43041
-  tps: 4076.56294
+  dps: 7473.99955
+  tps: 4092.62607
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7502.58492
-  tps: 4114.86779
+  dps: 7550.73621
+  tps: 4144.01852
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7531.88469
-  tps: 4112.41927
+  dps: 7567.10466
+  tps: 4133.06867
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 7569.57193
-  tps: 4150.0071
+  dps: 7620.80211
+  tps: 4183.41763
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7702.39925
-  tps: 4199.20601
+  dps: 7723.90444
+  tps: 4212.9881
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7424.93095
-  tps: 4057.68685
+  dps: 7452.37026
+  tps: 4079.36424
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7669.66556
-  tps: 4183.85545
+  dps: 7689.54181
+  tps: 4196.42406
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7701.18215
-  tps: 4195.94356
+  dps: 7743.25779
+  tps: 4221.65319
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7325.78946
+  tps: 4006.42836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7412.81173
-  tps: 4061.08079
+  dps: 7454.97497
+  tps: 4089.68379
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7783.73838
-  tps: 4277.98944
+  dps: 7834.81944
+  tps: 4308.68482
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7761.18353
-  tps: 4267.91365
+  dps: 7805.58034
+  tps: 4295.17933
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 6794.18115
-  tps: 3697.01455
+  dps: 6820.07613
+  tps: 3712.66515
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterGarb"
  value: {
-  dps: 6443.24652
-  tps: 3510.64704
+  dps: 6472.2612
+  tps: 3531.1991
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7388.1271
-  tps: 4048.80343
+  dps: 7423.51619
+  tps: 4072.42624
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7426.37534
-  tps: 4071.75825
+  dps: 7483.19718
+  tps: 4105.06911
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7405.97167
-  tps: 4055.51098
+  dps: 7451.90792
+  tps: 4087.86144
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7403.72191
-  tps: 4054.46691
+  dps: 7444.93011
+  tps: 4083.57346
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7480.13281
-  tps: 4100.37788
+  dps: 7529.4853
+  tps: 4132.15844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7325.80484
+  tps: 4006.42836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7388.1271
-  tps: 4048.80343
+  dps: 7423.51619
+  tps: 4072.42624
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7460.20524
-  tps: 4086.82405
+  dps: 7513.58735
+  tps: 4120.59294
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7537.76842
-  tps: 4129.41653
+  dps: 7566.22582
+  tps: 4142.69717
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7374.64896
-  tps: 4035.0597
+  dps: 7409.15089
+  tps: 4055.37529
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7400.83692
-  tps: 4049.80919
+  dps: 7426.45286
+  tps: 4064.33277
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7506.78458
-  tps: 4100.50397
+  dps: 7553.66744
+  tps: 4127.8658
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7410.93021
-  tps: 4061.97123
+  dps: 7446.47838
+  tps: 4085.70387
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7406.36959
-  tps: 4059.33767
+  dps: 7441.88594
+  tps: 4083.04834
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 7599.95946
-  tps: 4132.81755
+  dps: 7621.57609
+  tps: 4146.82475
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 7191.28761
-  tps: 3944.04178
+  dps: 7222.66862
+  tps: 3961.1461
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 7582.31413
-  tps: 4157.3339
+  dps: 7633.68522
+  tps: 4190.84064
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7515.54681
-  tps: 4106.85996
+  dps: 7534.1864
+  tps: 4116.53106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7356.65625
-  tps: 4024.41678
+  dps: 7382.02265
+  tps: 4038.77137
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 7043.10405
-  tps: 3790.10106
+  dps: 7060.98585
+  tps: 3803.07803
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sWartide"
  value: {
-  dps: 6139.75482
-  tps: 3306.78133
+  dps: 6164.32673
+  tps: 3319.6686
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7472.06698
-  tps: 4090.74796
+  dps: 7498.08523
+  tps: 4105.54402
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7494.60814
-  tps: 4103.70327
+  dps: 7520.75371
+  tps: 4118.58555
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7490.51517
-  tps: 4108.25946
+  dps: 7531.98352
+  tps: 4135.60835
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 7544.83336
-  tps: 4135.00201
+  dps: 7595.6296
+  tps: 4168.111
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-49982"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7599.41138
+  tps: 4178.73186
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-50641"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7599.41138
+  tps: 4178.73186
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7465.46564
-  tps: 4091.2463
+  dps: 7491.43253
+  tps: 4106.0173
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7405.97167
-  tps: 4055.51098
+  dps: 7451.90792
+  tps: 4087.86144
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7403.72191
-  tps: 4054.46691
+  dps: 7444.93011
+  tps: 4083.57346
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7438.42567
-  tps: 4065.7673
+  dps: 7455.51541
+  tps: 4073.95323
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7428.90379
-  tps: 4078.23974
+  dps: 7461.52054
+  tps: 4097.29
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7412.17375
-  tps: 4062.23723
-  hps: 10.94835
+  dps: 7447.43764
+  tps: 4084.86114
+  hps: 11.01615
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50179"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7599.41138
+  tps: 4178.73186
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50708"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7599.41138
+  tps: 4178.73186
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7300.75123
-  tps: 3992.28762
+  dps: 7325.78651
+  tps: 4006.42836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7325.80484
+  tps: 4006.42836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7489.05979
-  tps: 4091.21144
+  dps: 7532.9328
+  tps: 4119.0392
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Nibelung-49992"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7599.41138
+  tps: 4178.73186
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Nibelung-50648"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7599.41138
+  tps: 4178.73186
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7300.75123
-  tps: 3992.28762
+  dps: 7325.78651
+  tps: 4006.42836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7411.43243
-  tps: 4061.00771
+  dps: 7444.69103
+  tps: 4082.97566
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7412.17375
-  tps: 4062.23723
+  dps: 7447.43764
+  tps: 4084.86114
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7325.80484
+  tps: 4006.42836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7325.80484
+  tps: 4006.42836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7325.80484
+  tps: 4006.42836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7388.1271
-  tps: 4048.80343
+  dps: 7423.51619
+  tps: 4072.42624
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7388.1271
-  tps: 4048.80343
+  dps: 7423.51619
+  tps: 4072.42624
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7325.80484
+  tps: 4006.42836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7746.32521
-  tps: 4282.3992
+  dps: 7769.42672
+  tps: 4297.60264
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7795.96211
-  tps: 4315.11066
+  dps: 7819.59557
+  tps: 4330.67897
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7599.41138
+  tps: 4178.73186
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 7597.78679
-  tps: 4166.23072
+  dps: 7649.32899
+  tps: 4199.8543
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7382.74608
-  tps: 4046.01405
+  dps: 7435.99073
+  tps: 4078.56695
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7325.78946
+  tps: 4006.42836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 7538.5504
-  tps: 4131.51348
+  dps: 7589.30148
+  tps: 4164.59351
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7325.78946
+  tps: 4006.42836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7599.41138
+  tps: 4178.73186
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7325.80484
+  tps: 4006.42836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7300.74681
-  tps: 3992.28762
+  dps: 7325.78209
+  tps: 4006.42836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkycallTotem-33506"
  value: {
-  dps: 7509.22421
-  tps: 4114.80057
+  dps: 7568.52996
+  tps: 4152.76927
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterHarness"
  value: {
-  dps: 5412.4697
-  tps: 2916.30827
+  dps: 5419.01411
+  tps: 2919.09905
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterRegalia"
  value: {
-  dps: 5370.83455
-  tps: 2895.23293
+  dps: 5386.92277
+  tps: 2903.85164
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7474.45452
-  tps: 4090.02061
+  dps: 7502.79147
+  tps: 4105.04839
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7477.42399
-  tps: 4091.62867
+  dps: 7506.78813
+  tps: 4108.71487
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7368.37765
-  tps: 4031.15355
+  dps: 7393.81026
+  tps: 4045.55296
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7448.48361
-  tps: 4081.59115
+  dps: 7480.95231
+  tps: 4100.69159
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SparkofLife-37657"
  value: {
-  dps: 7444.84907
-  tps: 4077.55389
+  dps: 7480.12056
+  tps: 4095.94619
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7496.33405
-  tps: 4091.55234
+  dps: 7514.09178
+  tps: 4102.55734
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 7538.27545
-  tps: 4130.75028
+  dps: 7588.77562
+  tps: 4164.02757
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StormshroudArmor"
  value: {
-  dps: 5662.72482
-  tps: 3060.60555
+  dps: 5684.58217
+  tps: 3069.46111
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7412.17375
-  tps: 4062.23723
+  dps: 7447.43764
+  tps: 4084.86114
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7411.43243
-  tps: 4061.00771
+  dps: 7444.69103
+  tps: 4082.97566
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7402.33973
-  tps: 4056.18544
+  dps: 7435.51293
+  tps: 4078.15247
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7325.80484
+  tps: 4006.42836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7425.89361
-  tps: 4063.3092
+  dps: 7453.04703
+  tps: 4080.83899
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheFistsofFury"
  value: {
-  dps: 6506.59199
-  tps: 3525.03768
+  dps: 6518.87073
+  tps: 3533.65319
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7325.80484
+  tps: 4006.42836
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 7298.67114
-  tps: 4007.53183
+  dps: 7331.2289
+  tps: 4028.03859
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sRegalia"
  value: {
-  dps: 6933.08666
-  tps: 3814.59279
+  dps: 6969.38309
+  tps: 3836.24497
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7484.07506
-  tps: 4104.38113
+  dps: 7505.14093
+  tps: 4114.13359
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TidefuryRaiment"
  value: {
-  dps: 5358.43461
-  tps: 2871.34132
+  dps: 5395.48374
+  tps: 2898.50345
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7500.01941
-  tps: 4105.14248
+  dps: 7542.61808
+  tps: 4129.6815
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7577.27875
-  tps: 4160.48817
+  dps: 7588.17867
+  tps: 4161.33864
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7410.93021
-  tps: 4061.97123
+  dps: 7446.47838
+  tps: 4085.70387
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7406.36959
-  tps: 4059.33767
+  dps: 7441.88594
+  tps: 4083.04834
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7494.36772
-  tps: 4103.42171
+  dps: 7527.04601
+  tps: 4124.97842
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 7743.39549
-  tps: 4257.79431
+  dps: 7773.4131
+  tps: 4277.07669
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofQuakingEarth-47667"
  value: {
-  dps: 7649.17438
-  tps: 4188.77779
+  dps: 7691.3748
+  tps: 4217.79452
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 7794.03398
-  tps: 4265.56581
+  dps: 7843.38449
+  tps: 4299.0607
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheElementalPlane-40708"
  value: {
-  dps: 7552.46884
-  tps: 4148.13676
+  dps: 7578.38875
+  tps: 4165.12288
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7406.36959
-  tps: 4059.33767
+  dps: 7441.88594
+  tps: 4083.04834
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7410.93021
-  tps: 4061.97123
+  dps: 7446.47838
+  tps: 4085.70387
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6017.5766
-  tps: 3260.3942
+  dps: 6053.51034
+  tps: 3283.49309
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7774.02404
-  tps: 4258.08459
+  dps: 7806.73496
+  tps: 4277.87322
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7398.5406
-  tps: 4030.89699
+  dps: 7423.61621
+  tps: 4045.07376
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 7265.64136
-  tps: 3985.80988
+  dps: 7295.38289
+  tps: 4003.44058
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerGarb"
  value: {
-  dps: 6958.05368
-  tps: 3833.26382
+  dps: 6978.6044
+  tps: 3841.76654
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 7614.16961
-  tps: 4175.65088
+  dps: 7665.89299
+  tps: 4209.39818
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 7580.88956
-  tps: 4156.68444
+  dps: 7611.74491
+  tps: 4175.5283
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhItemSwap-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5914.50942
-  tps: 4602.44169
+  dps: 5937.45439
+  tps: 4615.71132
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhItemSwap-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5914.50942
-  tps: 3535.98126
+  dps: 5937.45439
+  tps: 3551.00975
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhItemSwap-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7263.47241
-  tps: 3923.68274
+  dps: 7270.95291
+  tps: 3928.63919
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhItemSwap-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3017.62841
-  tps: 3352.23131
+  dps: 3029.92474
+  tps: 3359.99656
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhItemSwap-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3017.62841
-  tps: 1885.25742
+  dps: 3029.92474
+  tps: 1893.59633
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhItemSwap-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3613.81475
-  tps: 2016.8859
+  dps: 3641.29399
+  tps: 2032.4313
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26280.0823
-  tps: 15800.12509
+  dps: 26447.63157
+  tps: 15879.62841
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7632.02128
-  tps: 4143.95964
+  dps: 7646.7218
+  tps: 4153.47787
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9442.93293
-  tps: 4519.47375
+  dps: 9477.89413
+  tps: 4540.33683
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12565.01507
-  tps: 7835.80918
+  dps: 12707.27305
+  tps: 7925.18348
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4046.17831
-  tps: 2128.67701
+  dps: 4056.6481
+  tps: 2134.25259
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5802.14486
-  tps: 2763.5393
+  dps: 5827.5252
+  tps: 2777.5894
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Wf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5240.34689
-  tps: 4084.42759
+  dps: 5263.07876
+  tps: 4095.04798
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Wf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5240.34689
-  tps: 3059.67362
+  dps: 5263.07876
+  tps: 3075.22842
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Wf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6507.97647
-  tps: 3382.31399
+  dps: 6524.10871
+  tps: 3392.88268
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Wf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2727.12579
-  tps: 3037.48723
+  dps: 2727.92772
+  tps: 3029.93856
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Wf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2727.12579
-  tps: 1674.11422
+  dps: 2727.92772
+  tps: 1674.92089
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Wf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3256.6925
-  tps: 1744.99468
+  dps: 3264.90659
+  tps: 1749.50042
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhItemSwap-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5936.53722
-  tps: 4632.3405
+  dps: 5955.01259
+  tps: 4644.11436
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhItemSwap-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5936.53722
-  tps: 3562.18291
+  dps: 5955.01259
+  tps: 3574.98519
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhItemSwap-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7311.46825
-  tps: 3984.26445
+  dps: 7321.53756
+  tps: 3991.26709
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhItemSwap-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2985.23642
-  tps: 3302.87427
+  dps: 2995.90672
+  tps: 3322.87699
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhItemSwap-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2985.23642
-  tps: 1868.98165
+  dps: 2995.90672
+  tps: 1876.83885
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhItemSwap-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3528.05086
-  tps: 1980.10901
+  dps: 3561.43895
+  tps: 2000.71033
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26001.7196
-  tps: 15826.97161
+  dps: 26173.11359
+  tps: 15928.74214
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7599.41138
+  tps: 4178.73186
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9379.65427
-  tps: 4577.15871
+  dps: 9407.576
+  tps: 4594.19241
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12695.11005
-  tps: 8088.67311
+  dps: 12777.30273
+  tps: 8135.43802
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4003.22646
-  tps: 2135.09199
+  dps: 4032.57609
+  tps: 2154.78905
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5726.92147
-  tps: 2782.07265
+  dps: 5752.09503
+  tps: 2797.27633
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Wf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5253.21575
-  tps: 4114.04403
+  dps: 5276.4605
+  tps: 4124.12972
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Wf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5253.21575
-  tps: 3078.07564
+  dps: 5276.4605
+  tps: 3093.19786
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Wf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6549.87949
-  tps: 3435.83935
+  dps: 6566.81221
+  tps: 3446.91184
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Wf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2693.44502
-  tps: 3023.54305
+  dps: 2699.32538
+  tps: 3004.54636
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Wf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2693.44502
-  tps: 1658.00334
+  dps: 2699.32538
+  tps: 1660.70541
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Wf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3201.91945
-  tps: 1730.66487
+  dps: 3212.59838
+  tps: 1736.5911
  }
 }
 dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7213.93376
-  tps: 3941.01356
+  dps: 7248.25443
+  tps: 3964.38236
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -46,964 +46,964 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7462.14887
-  tps: 4085.04763
+  dps: 7599.43763
+  tps: 4165.31745
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7481.98509
-  tps: 4096.4483
+  dps: 7619.79234
+  tps: 4177.05199
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7388.1271
-  tps: 4048.80343
+  dps: 7497.27676
+  tps: 4116.54284
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7511.16958
-  tps: 4115.5101
+  dps: 7618.92015
+  tps: 4182.33393
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7300.2786
-  tps: 3992.17656
-  hps: 94.38477
+  dps: 7432.80009
+  tps: 4069.3606
+  hps: 94.81599
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7300.2786
-  tps: 3992.17656
-  hps: 94.38477
+  dps: 7432.80009
+  tps: 4069.3606
+  hps: 94.81599
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7412.37797
-  tps: 4061.89239
+  dps: 7525.06647
+  tps: 4131.21344
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7143.55021
-  tps: 3901.85128
+  dps: 7305.04217
+  tps: 3992.19613
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 7784.67558
-  tps: 4287.36277
+  dps: 7898.59888
+  tps: 4356.68848
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50035"
  value: {
-  dps: 7401.17992
-  tps: 4051.05186
+  dps: 7485.5139
+  tps: 4099.91392
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50692"
  value: {
-  dps: 7457.54463
-  tps: 4081.80336
+  dps: 7546.19159
+  tps: 4133.63317
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6085.84034
-  tps: 3295.46021
+  dps: 6146.56001
+  tps: 3337.27192
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6002.56403
-  tps: 3259.30875
+  dps: 6111.44949
+  tps: 3330.62396
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7410.93021
-  tps: 3949.71744
+  dps: 7520.5369
+  tps: 4015.77431
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7672.52563
+  tps: 4221.33363
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7672.52563
+  tps: 4221.33363
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7558.41238
-  tps: 4147.94038
+  dps: 7698.53072
+  tps: 4235.65353
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7433.82436
+  tps: 4069.84101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7433.82436
+  tps: 4069.84101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7433.82436
+  tps: 4069.84101
   hps: 64
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7447.43041
-  tps: 4076.56294
+  dps: 7542.95169
+  tps: 4138.66033
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7502.58492
-  tps: 4114.86779
+  dps: 7617.31613
+  tps: 4188.8891
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7531.88469
-  tps: 4112.41927
+  dps: 7630.97415
+  tps: 4173.2754
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 7569.57193
-  tps: 4150.0071
+  dps: 7684.59928
+  tps: 4226.93142
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7702.39925
-  tps: 4199.20601
+  dps: 7821.58531
+  tps: 4272.35185
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7424.93095
-  tps: 4057.68685
+  dps: 7510.94619
+  tps: 4111.04299
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7669.66556
-  tps: 4183.85545
+  dps: 7766.10568
+  tps: 4243.77867
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7701.18215
-  tps: 4195.94356
+  dps: 7838.22209
+  tps: 4275.65734
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7433.82436
+  tps: 4069.84101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7412.81173
-  tps: 4061.08079
+  dps: 7536.13083
+  tps: 4136.38287
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7783.73838
-  tps: 4277.98944
+  dps: 7937.05238
+  tps: 4368.34768
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7761.18353
-  tps: 4267.91365
+  dps: 7865.69669
+  tps: 4332.01075
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 6794.18115
-  tps: 3697.01455
+  dps: 6871.23414
+  tps: 3741.80152
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterGarb"
  value: {
-  dps: 6443.24652
-  tps: 3510.64704
+  dps: 6531.4726
+  tps: 3563.5617
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7388.1271
-  tps: 4048.80343
+  dps: 7497.27676
+  tps: 4116.54284
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7426.37534
-  tps: 4071.75825
+  dps: 7560.32819
+  tps: 4154.86739
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7405.97167
-  tps: 4055.51098
+  dps: 7535.91127
+  tps: 4136.57516
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7403.72191
-  tps: 4054.46691
+  dps: 7533.96483
+  tps: 4135.5455
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7480.13281
-  tps: 4100.37788
+  dps: 7603.6195
+  tps: 4177.7323
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7433.82436
+  tps: 4069.84101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7388.1271
-  tps: 4048.80343
+  dps: 7497.27676
+  tps: 4116.54284
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7460.20524
-  tps: 4086.82405
+  dps: 7588.05783
+  tps: 4164.26702
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7537.76842
-  tps: 4129.41653
+  dps: 7630.46098
+  tps: 4185.37338
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7374.64896
-  tps: 4035.0597
+  dps: 7491.99399
+  tps: 4106.13192
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7400.83692
-  tps: 4049.80919
+  dps: 7536.5231
+  tps: 4129.04707
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7506.78458
-  tps: 4100.50397
+  dps: 7615.00137
+  tps: 4160.39196
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7410.93021
-  tps: 4061.97123
+  dps: 7520.5369
+  tps: 4130.01088
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7406.36959
-  tps: 4059.33767
+  dps: 7515.88487
+  tps: 4127.31727
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 7599.95946
-  tps: 4132.81755
+  dps: 7691.81494
+  tps: 4194.38705
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 7191.28761
-  tps: 3944.04178
+  dps: 7270.38046
+  tps: 3989.20468
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 7582.31413
-  tps: 4157.3339
+  dps: 7697.61777
+  tps: 4234.44356
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7515.54681
-  tps: 4106.85996
+  dps: 7638.97582
+  tps: 4180.16628
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7356.65625
-  tps: 4024.41678
+  dps: 7491.18762
+  tps: 4102.91106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 7043.10405
-  tps: 3790.10106
+  dps: 7114.84361
+  tps: 3834.2798
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sWartide"
  value: {
-  dps: 6139.75482
-  tps: 3306.78133
+  dps: 6249.71949
+  tps: 3377.67123
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7472.06698
-  tps: 4090.74796
+  dps: 7609.61499
+  tps: 4171.18472
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7494.60814
-  tps: 4103.70327
+  dps: 7632.74533
+  tps: 4184.51942
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7490.51517
-  tps: 4108.25946
+  dps: 7586.61418
+  tps: 4168.08943
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 7544.83336
-  tps: 4135.00201
+  dps: 7659.20636
+  tps: 4211.48644
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-49982"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7672.52563
+  tps: 4221.33363
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-50641"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7672.52563
+  tps: 4221.33363
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7465.46564
-  tps: 4091.2463
+  dps: 7603.07055
+  tps: 4171.75126
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7405.97167
-  tps: 4055.51098
+  dps: 7535.91127
+  tps: 4136.57516
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7403.72191
-  tps: 4054.46691
+  dps: 7533.96483
+  tps: 4135.5455
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7438.42567
-  tps: 4065.7673
+  dps: 7557.77391
+  tps: 4135.45465
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7428.90379
-  tps: 4078.23974
+  dps: 7536.16239
+  tps: 4134.45558
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7412.17375
-  tps: 4062.23723
-  hps: 10.94835
+  dps: 7526.43873
+  tps: 4131.62373
+  hps: 11.01615
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50179"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7672.52563
+  tps: 4221.33363
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50708"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7672.52563
+  tps: 4221.33363
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7300.75123
-  tps: 3992.28762
+  dps: 7433.82436
+  tps: 4069.84101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7433.82436
+  tps: 4069.84101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7489.05979
-  tps: 4091.21144
+  dps: 7606.6523
+  tps: 4168.83959
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Nibelung-49992"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7672.52563
+  tps: 4221.33363
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Nibelung-50648"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7672.52563
+  tps: 4221.33363
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7300.75123
-  tps: 3992.28762
+  dps: 7433.82436
+  tps: 4069.84101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7411.43243
-  tps: 4061.00771
+  dps: 7523.97235
+  tps: 4130.03347
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7412.17375
-  tps: 4062.23723
+  dps: 7526.43873
+  tps: 4131.62373
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7433.83052
+  tps: 4069.84101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7433.82436
+  tps: 4069.84101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7433.82436
+  tps: 4069.84101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7388.1271
-  tps: 4048.80343
+  dps: 7497.27676
+  tps: 4116.54284
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7388.1271
-  tps: 4048.80343
+  dps: 7497.27676
+  tps: 4116.54284
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7433.82436
+  tps: 4069.84101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7746.32521
-  tps: 4282.3992
+  dps: 7845.98347
+  tps: 4334.69184
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7795.96211
-  tps: 4315.11066
+  dps: 7897.35145
+  tps: 4368.56655
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7672.52563
+  tps: 4221.33363
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 7597.78679
-  tps: 4166.23072
+  dps: 7713.42595
+  tps: 4243.56544
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7382.74608
-  tps: 4046.01405
+  dps: 7521.98185
+  tps: 4128.95108
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7433.82436
+  tps: 4069.84101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 7538.5504
-  tps: 4131.51348
+  dps: 7652.8032
+  tps: 4207.91939
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7433.82436
+  tps: 4069.84101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7672.52563
+  tps: 4221.33363
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7433.82436
+  tps: 4069.84101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7300.74681
-  tps: 3992.28762
+  dps: 7433.82436
+  tps: 4069.84101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkycallTotem-33506"
  value: {
-  dps: 7509.22421
-  tps: 4114.80057
+  dps: 7624.78193
+  tps: 4180.16626
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterHarness"
  value: {
-  dps: 5412.4697
-  tps: 2916.30827
+  dps: 5490.16351
+  tps: 2958.99873
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterRegalia"
  value: {
-  dps: 5370.83455
-  tps: 2895.23293
+  dps: 5419.10587
+  tps: 2921.63627
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7474.45452
-  tps: 4090.02061
+  dps: 7593.19955
+  tps: 4168.2068
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7477.42399
-  tps: 4091.62867
+  dps: 7614.04535
+  tps: 4179.05119
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7368.37765
-  tps: 4031.15355
+  dps: 7503.2154
+  tps: 4109.8451
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7448.48361
-  tps: 4081.59115
+  dps: 7558.97799
+  tps: 4147.67463
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SparkofLife-37657"
  value: {
-  dps: 7444.84907
-  tps: 4077.55389
+  dps: 7545.04415
+  tps: 4136.2628
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7496.33405
-  tps: 4091.55234
+  dps: 7606.0628
+  tps: 4155.68351
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 7538.27545
-  tps: 4130.75028
+  dps: 7653.4768
+  tps: 4207.54069
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StormshroudArmor"
  value: {
-  dps: 5662.72482
-  tps: 3060.60555
+  dps: 5775.5539
+  tps: 3126.06697
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7412.17375
-  tps: 4062.23723
+  dps: 7526.43873
+  tps: 4131.62373
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7411.43243
-  tps: 4061.00771
+  dps: 7523.97235
+  tps: 4130.03347
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7402.33973
-  tps: 4056.18544
+  dps: 7509.70741
+  tps: 4122.71272
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7433.82436
+  tps: 4069.84101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7425.89361
-  tps: 4063.3092
+  dps: 7550.21585
+  tps: 4142.7351
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheFistsofFury"
  value: {
-  dps: 6506.59199
-  tps: 3525.03768
+  dps: 6607.84804
+  tps: 3586.41344
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7300.75417
-  tps: 3992.28762
+  dps: 7433.82436
+  tps: 4069.84101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 7298.67114
-  tps: 4007.53183
+  dps: 7413.67723
+  tps: 4074.71586
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sRegalia"
  value: {
-  dps: 6933.08666
-  tps: 3814.59279
+  dps: 7059.91375
+  tps: 3894.58839
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7484.07506
-  tps: 4104.38113
+  dps: 7557.24335
+  tps: 4151.51398
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TidefuryRaiment"
  value: {
-  dps: 5358.43461
-  tps: 2871.34132
+  dps: 5430.65197
+  tps: 2919.82826
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7500.01941
-  tps: 4105.14248
+  dps: 7634.77945
+  tps: 4187.38961
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7577.27875
-  tps: 4160.48817
+  dps: 7689.43622
+  tps: 4220.75554
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7410.93021
-  tps: 4061.97123
+  dps: 7520.5369
+  tps: 4130.01088
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7406.36959
-  tps: 4059.33767
+  dps: 7515.88487
+  tps: 4127.31727
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7494.36772
-  tps: 4103.42171
+  dps: 7601.74053
+  tps: 4168.03919
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 7743.39549
-  tps: 4257.79431
+  dps: 7836.78802
+  tps: 4319.61961
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofQuakingEarth-47667"
  value: {
-  dps: 7649.17438
-  tps: 4188.77779
+  dps: 7762.91516
+  tps: 4264.45874
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 7794.03398
-  tps: 4265.56581
+  dps: 7910.27338
+  tps: 4343.70913
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheElementalPlane-40708"
  value: {
-  dps: 7552.46884
-  tps: 4148.13676
+  dps: 7649.6034
+  tps: 4206.8637
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7406.36959
-  tps: 4059.33767
+  dps: 7515.88487
+  tps: 4127.31727
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7410.93021
-  tps: 4061.97123
+  dps: 7520.5369
+  tps: 4130.01088
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6017.5766
-  tps: 3260.3942
+  dps: 6086.80532
+  tps: 3300.83114
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7774.02404
-  tps: 4258.08459
+  dps: 7881.90515
+  tps: 4321.52187
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7398.5406
-  tps: 4030.89699
+  dps: 7533.16829
+  tps: 4109.33017
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 7265.64136
-  tps: 3985.80988
+  dps: 7389.27268
+  tps: 4060.17013
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerGarb"
  value: {
-  dps: 6958.05368
-  tps: 3833.26382
+  dps: 7055.53295
+  tps: 3886.84412
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 7614.16961
-  tps: 4175.65088
+  dps: 7730.16401
+  tps: 4253.22391
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 7580.88956
-  tps: 4156.68444
+  dps: 7682.97677
+  tps: 4218.7695
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhItemSwap-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5914.50942
-  tps: 4602.44169
+  dps: 5981.10819
+  tps: 4640.62132
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhItemSwap-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5914.50942
-  tps: 3535.98126
+  dps: 5981.10819
+  tps: 3580.61039
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhItemSwap-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7263.47241
-  tps: 3923.68274
+  dps: 7324.65623
+  tps: 3964.37819
  }
 }
 dps_results: {
@@ -1030,22 +1030,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26728.07993
-  tps: 16038.74452
+  dps: 26912.38052
+  tps: 16144.41127
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7632.02128
-  tps: 4143.95964
+  dps: 7747.87222
+  tps: 4215.92799
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9442.93293
-  tps: 4519.47375
+  dps: 9551.18819
+  tps: 4582.38167
  }
 }
 dps_results: {
@@ -1072,22 +1072,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Wf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5240.34689
-  tps: 4084.42759
+  dps: 5290.5369
+  tps: 4105.28184
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Wf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5240.34689
-  tps: 3059.67362
+  dps: 5290.5369
+  tps: 3093.78295
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Wf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6507.97647
-  tps: 3382.31399
+  dps: 6553.14712
+  tps: 3411.82039
  }
 }
 dps_results: {
@@ -1114,22 +1114,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhItemSwap-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5936.53722
-  tps: 4632.3405
+  dps: 6001.61383
+  tps: 4669.97815
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhItemSwap-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5936.53722
-  tps: 3562.18291
+  dps: 6001.61383
+  tps: 3606.66729
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhItemSwap-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7311.46825
-  tps: 3984.26445
+  dps: 7369.61326
+  tps: 4023.88743
  }
 }
 dps_results: {
@@ -1156,22 +1156,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26431.14213
-  tps: 16051.55452
+  dps: 26561.07405
+  tps: 16133.26105
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7556.6454
-  tps: 4149.10845
+  dps: 7672.52563
+  tps: 4221.33363
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9379.65427
-  tps: 4577.15871
+  dps: 9475.38482
+  tps: 4638.15273
  }
 }
 dps_results: {
@@ -1198,22 +1198,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Wf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5253.21575
-  tps: 4114.04403
+  dps: 5307.09409
+  tps: 4138.05853
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Wf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5253.21575
-  tps: 3078.07564
+  dps: 5307.09409
+  tps: 3113.64811
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Wf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6549.87949
-  tps: 3435.83935
+  dps: 6589.32805
+  tps: 3462.033
  }
 }
 dps_results: {
@@ -1240,7 +1240,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7213.93376
-  tps: 3941.01356
+  dps: 7330.97558
+  tps: 4013.85062
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -46,1201 +46,1201 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7599.43763
-  tps: 4165.31745
+  dps: 7462.14887
+  tps: 4085.04763
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7619.79234
-  tps: 4177.05199
+  dps: 7481.98509
+  tps: 4096.4483
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7497.27676
-  tps: 4116.54284
+  dps: 7388.1271
+  tps: 4048.80343
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7618.92015
-  tps: 4182.33393
+  dps: 7511.16958
+  tps: 4115.5101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7432.80009
-  tps: 4069.3606
-  hps: 94.81599
+  dps: 7300.2786
+  tps: 3992.17656
+  hps: 94.38477
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7432.80009
-  tps: 4069.3606
-  hps: 94.81599
+  dps: 7300.2786
+  tps: 3992.17656
+  hps: 94.38477
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7525.06647
-  tps: 4131.21344
+  dps: 7412.37797
+  tps: 4061.89239
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7305.04217
-  tps: 3992.19613
+  dps: 7143.55021
+  tps: 3901.85128
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 7898.59888
-  tps: 4356.68848
+  dps: 7784.67558
+  tps: 4287.36277
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50035"
  value: {
-  dps: 7485.5139
-  tps: 4099.91392
+  dps: 7401.17992
+  tps: 4051.05186
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50692"
  value: {
-  dps: 7546.19159
-  tps: 4133.63317
+  dps: 7457.54463
+  tps: 4081.80336
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6146.56001
-  tps: 3337.27192
+  dps: 6085.84034
+  tps: 3295.46021
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6111.44949
-  tps: 3330.62396
+  dps: 6002.56403
+  tps: 3259.30875
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7520.5369
-  tps: 4015.77431
+  dps: 7410.93021
+  tps: 3949.71744
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7672.52563
-  tps: 4221.33363
+  dps: 7556.6454
+  tps: 4149.10845
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7672.52563
-  tps: 4221.33363
+  dps: 7556.6454
+  tps: 4149.10845
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7698.53072
-  tps: 4235.65353
+  dps: 7558.41238
+  tps: 4147.94038
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7433.82436
-  tps: 4069.84101
+  dps: 7300.75417
+  tps: 3992.28762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7433.82436
-  tps: 4069.84101
+  dps: 7300.75417
+  tps: 3992.28762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7433.82436
-  tps: 4069.84101
+  dps: 7300.75417
+  tps: 3992.28762
   hps: 64
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7542.95169
-  tps: 4138.66033
+  dps: 7447.43041
+  tps: 4076.56294
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7617.31613
-  tps: 4188.8891
+  dps: 7502.58492
+  tps: 4114.86779
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7630.97415
-  tps: 4173.2754
+  dps: 7531.88469
+  tps: 4112.41927
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 7684.59928
-  tps: 4226.93142
+  dps: 7569.57193
+  tps: 4150.0071
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7821.58531
-  tps: 4272.35185
+  dps: 7702.39925
+  tps: 4199.20601
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7510.94619
-  tps: 4111.04299
+  dps: 7424.93095
+  tps: 4057.68685
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7766.10568
-  tps: 4243.77867
+  dps: 7669.66556
+  tps: 4183.85545
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7838.22209
-  tps: 4275.65734
+  dps: 7701.18215
+  tps: 4195.94356
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7433.82436
-  tps: 4069.84101
+  dps: 7300.75417
+  tps: 3992.28762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7536.13083
-  tps: 4136.38287
+  dps: 7412.81173
+  tps: 4061.08079
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7937.05238
-  tps: 4368.34768
+  dps: 7783.73838
+  tps: 4277.98944
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7865.69669
-  tps: 4332.01075
+  dps: 7761.18353
+  tps: 4267.91365
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 6871.23414
-  tps: 3741.80152
+  dps: 6794.18115
+  tps: 3697.01455
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterGarb"
  value: {
-  dps: 6531.4726
-  tps: 3563.5617
+  dps: 6443.24652
+  tps: 3510.64704
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7497.27676
-  tps: 4116.54284
+  dps: 7388.1271
+  tps: 4048.80343
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7560.32819
-  tps: 4154.86739
+  dps: 7426.37534
+  tps: 4071.75825
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7535.91127
-  tps: 4136.57516
+  dps: 7405.97167
+  tps: 4055.51098
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7533.96483
-  tps: 4135.5455
+  dps: 7403.72191
+  tps: 4054.46691
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7603.6195
-  tps: 4177.7323
+  dps: 7480.13281
+  tps: 4100.37788
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7433.82436
-  tps: 4069.84101
+  dps: 7300.75417
+  tps: 3992.28762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7497.27676
-  tps: 4116.54284
+  dps: 7388.1271
+  tps: 4048.80343
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7588.05783
-  tps: 4164.26702
+  dps: 7460.20524
+  tps: 4086.82405
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7630.46098
-  tps: 4185.37338
+  dps: 7537.76842
+  tps: 4129.41653
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7491.99399
-  tps: 4106.13192
+  dps: 7374.64896
+  tps: 4035.0597
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7536.5231
-  tps: 4129.04707
+  dps: 7400.83692
+  tps: 4049.80919
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7615.00137
-  tps: 4160.39196
+  dps: 7506.78458
+  tps: 4100.50397
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7520.5369
-  tps: 4130.01088
+  dps: 7410.93021
+  tps: 4061.97123
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7515.88487
-  tps: 4127.31727
+  dps: 7406.36959
+  tps: 4059.33767
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 7691.81494
-  tps: 4194.38705
+  dps: 7599.95946
+  tps: 4132.81755
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 7270.38046
-  tps: 3989.20468
+  dps: 7191.28761
+  tps: 3944.04178
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 7697.61777
-  tps: 4234.44356
+  dps: 7582.31413
+  tps: 4157.3339
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7638.97582
-  tps: 4180.16628
+  dps: 7515.54681
+  tps: 4106.85996
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7491.18762
-  tps: 4102.91106
+  dps: 7356.65625
+  tps: 4024.41678
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 7114.84361
-  tps: 3834.2798
+  dps: 7043.10405
+  tps: 3790.10106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sWartide"
  value: {
-  dps: 6249.71949
-  tps: 3377.67123
+  dps: 6139.75482
+  tps: 3306.78133
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7609.61499
-  tps: 4171.18472
+  dps: 7472.06698
+  tps: 4090.74796
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7632.74533
-  tps: 4184.51942
+  dps: 7494.60814
+  tps: 4103.70327
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7586.61418
-  tps: 4168.08943
+  dps: 7490.51517
+  tps: 4108.25946
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 7659.20636
-  tps: 4211.48644
+  dps: 7544.83336
+  tps: 4135.00201
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-49982"
  value: {
-  dps: 7672.52563
-  tps: 4221.33363
+  dps: 7556.6454
+  tps: 4149.10845
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-50641"
  value: {
-  dps: 7672.52563
-  tps: 4221.33363
+  dps: 7556.6454
+  tps: 4149.10845
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7603.07055
-  tps: 4171.75126
+  dps: 7465.46564
+  tps: 4091.2463
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7535.91127
-  tps: 4136.57516
+  dps: 7405.97167
+  tps: 4055.51098
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7533.96483
-  tps: 4135.5455
+  dps: 7403.72191
+  tps: 4054.46691
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7557.77391
-  tps: 4135.45465
+  dps: 7438.42567
+  tps: 4065.7673
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7536.16239
-  tps: 4134.45558
+  dps: 7428.90379
+  tps: 4078.23974
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7526.43873
-  tps: 4131.62373
-  hps: 11.01615
+  dps: 7412.17375
+  tps: 4062.23723
+  hps: 10.94835
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50179"
  value: {
-  dps: 7672.52563
-  tps: 4221.33363
+  dps: 7556.6454
+  tps: 4149.10845
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50708"
  value: {
-  dps: 7672.52563
-  tps: 4221.33363
+  dps: 7556.6454
+  tps: 4149.10845
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7433.82436
-  tps: 4069.84101
+  dps: 7300.75123
+  tps: 3992.28762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7433.82436
-  tps: 4069.84101
+  dps: 7300.75417
+  tps: 3992.28762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7606.6523
-  tps: 4168.83959
+  dps: 7489.05979
+  tps: 4091.21144
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Nibelung-49992"
  value: {
-  dps: 7672.52563
-  tps: 4221.33363
+  dps: 7556.6454
+  tps: 4149.10845
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Nibelung-50648"
  value: {
-  dps: 7672.52563
-  tps: 4221.33363
+  dps: 7556.6454
+  tps: 4149.10845
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7433.82436
-  tps: 4069.84101
+  dps: 7300.75123
+  tps: 3992.28762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7523.97235
-  tps: 4130.03347
+  dps: 7411.43243
+  tps: 4061.00771
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7526.43873
-  tps: 4131.62373
+  dps: 7412.17375
+  tps: 4062.23723
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7433.83052
-  tps: 4069.84101
+  dps: 7300.75417
+  tps: 3992.28762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7433.82436
-  tps: 4069.84101
+  dps: 7300.75417
+  tps: 3992.28762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7433.82436
-  tps: 4069.84101
+  dps: 7300.75417
+  tps: 3992.28762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7497.27676
-  tps: 4116.54284
+  dps: 7388.1271
+  tps: 4048.80343
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7497.27676
-  tps: 4116.54284
+  dps: 7388.1271
+  tps: 4048.80343
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7433.82436
-  tps: 4069.84101
+  dps: 7300.75417
+  tps: 3992.28762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7845.98347
-  tps: 4334.69184
+  dps: 7746.32521
+  tps: 4282.3992
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7897.35145
-  tps: 4368.56655
+  dps: 7795.96211
+  tps: 4315.11066
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7672.52563
-  tps: 4221.33363
+  dps: 7556.6454
+  tps: 4149.10845
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 7713.42595
-  tps: 4243.56544
+  dps: 7597.78679
+  tps: 4166.23072
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7521.98185
-  tps: 4128.95108
+  dps: 7382.74608
+  tps: 4046.01405
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7433.82436
-  tps: 4069.84101
+  dps: 7300.75417
+  tps: 3992.28762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 7652.8032
-  tps: 4207.91939
+  dps: 7538.5504
+  tps: 4131.51348
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7433.82436
-  tps: 4069.84101
+  dps: 7300.75417
+  tps: 3992.28762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7672.52563
-  tps: 4221.33363
+  dps: 7556.6454
+  tps: 4149.10845
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7433.82436
-  tps: 4069.84101
+  dps: 7300.75417
+  tps: 3992.28762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7433.82436
-  tps: 4069.84101
+  dps: 7300.74681
+  tps: 3992.28762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkycallTotem-33506"
  value: {
-  dps: 7624.78193
-  tps: 4180.16626
+  dps: 7509.22421
+  tps: 4114.80057
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterHarness"
  value: {
-  dps: 5490.16351
-  tps: 2958.99873
+  dps: 5412.4697
+  tps: 2916.30827
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterRegalia"
  value: {
-  dps: 5419.10587
-  tps: 2921.63627
+  dps: 5370.83455
+  tps: 2895.23293
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7593.19955
-  tps: 4168.2068
+  dps: 7474.45452
+  tps: 4090.02061
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7614.04535
-  tps: 4179.05119
+  dps: 7477.42399
+  tps: 4091.62867
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7503.2154
-  tps: 4109.8451
+  dps: 7368.37765
+  tps: 4031.15355
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7558.97799
-  tps: 4147.67463
+  dps: 7448.48361
+  tps: 4081.59115
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SparkofLife-37657"
  value: {
-  dps: 7545.04415
-  tps: 4136.2628
+  dps: 7444.84907
+  tps: 4077.55389
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7606.0628
-  tps: 4155.68351
+  dps: 7496.33405
+  tps: 4091.55234
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 7653.4768
-  tps: 4207.54069
+  dps: 7538.27545
+  tps: 4130.75028
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StormshroudArmor"
  value: {
-  dps: 5775.5539
-  tps: 3126.06697
+  dps: 5662.72482
+  tps: 3060.60555
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7526.43873
-  tps: 4131.62373
+  dps: 7412.17375
+  tps: 4062.23723
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7523.97235
-  tps: 4130.03347
+  dps: 7411.43243
+  tps: 4061.00771
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7509.70741
-  tps: 4122.71272
+  dps: 7402.33973
+  tps: 4056.18544
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7433.82436
-  tps: 4069.84101
+  dps: 7300.75417
+  tps: 3992.28762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7550.21585
-  tps: 4142.7351
+  dps: 7425.89361
+  tps: 4063.3092
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheFistsofFury"
  value: {
-  dps: 6607.84804
-  tps: 3586.41344
+  dps: 6506.59199
+  tps: 3525.03768
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7433.82436
-  tps: 4069.84101
+  dps: 7300.75417
+  tps: 3992.28762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 7413.67723
-  tps: 4074.71586
+  dps: 7298.67114
+  tps: 4007.53183
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sRegalia"
  value: {
-  dps: 7059.91375
-  tps: 3894.58839
+  dps: 6933.08666
+  tps: 3814.59279
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7557.24335
-  tps: 4151.51398
+  dps: 7484.07506
+  tps: 4104.38113
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TidefuryRaiment"
  value: {
-  dps: 5430.65197
-  tps: 2919.82826
+  dps: 5358.43461
+  tps: 2871.34132
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7634.77945
-  tps: 4187.38961
+  dps: 7500.01941
+  tps: 4105.14248
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7689.43622
-  tps: 4220.75554
+  dps: 7577.27875
+  tps: 4160.48817
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7520.5369
-  tps: 4130.01088
+  dps: 7410.93021
+  tps: 4061.97123
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7515.88487
-  tps: 4127.31727
+  dps: 7406.36959
+  tps: 4059.33767
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7601.74053
-  tps: 4168.03919
+  dps: 7494.36772
+  tps: 4103.42171
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 7836.78802
-  tps: 4319.61961
+  dps: 7743.39549
+  tps: 4257.79431
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofQuakingEarth-47667"
  value: {
-  dps: 7762.91516
-  tps: 4264.45874
+  dps: 7649.17438
+  tps: 4188.77779
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 7910.27338
-  tps: 4343.70913
+  dps: 7794.03398
+  tps: 4265.56581
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheElementalPlane-40708"
  value: {
-  dps: 7649.6034
-  tps: 4206.8637
+  dps: 7552.46884
+  tps: 4148.13676
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7515.88487
-  tps: 4127.31727
+  dps: 7406.36959
+  tps: 4059.33767
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7520.5369
-  tps: 4130.01088
+  dps: 7410.93021
+  tps: 4061.97123
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6086.80532
-  tps: 3300.83114
+  dps: 6017.5766
+  tps: 3260.3942
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7881.90515
-  tps: 4321.52187
+  dps: 7774.02404
+  tps: 4258.08459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7533.16829
-  tps: 4109.33017
+  dps: 7398.5406
+  tps: 4030.89699
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 7389.27268
-  tps: 4060.17013
+  dps: 7265.64136
+  tps: 3985.80988
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerGarb"
  value: {
-  dps: 7055.53295
-  tps: 3886.84412
+  dps: 6958.05368
+  tps: 3833.26382
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 7730.16401
-  tps: 4253.22391
+  dps: 7614.16961
+  tps: 4175.65088
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 7682.97677
-  tps: 4218.7695
+  dps: 7580.88956
+  tps: 4156.68444
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhItemSwap-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5981.10819
-  tps: 4640.62132
+  dps: 5914.50942
+  tps: 4602.44169
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhItemSwap-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5981.10819
-  tps: 3580.61039
+  dps: 5914.50942
+  tps: 3535.98126
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhItemSwap-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7324.65623
-  tps: 3964.37819
+  dps: 7263.47241
+  tps: 3923.68274
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhItemSwap-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3046.14277
-  tps: 3370.89821
+  dps: 3017.62841
+  tps: 3352.23131
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhItemSwap-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3046.14277
-  tps: 1904.45133
+  dps: 3017.62841
+  tps: 1885.25742
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-EnhItemSwap-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3663.34107
-  tps: 2044.44791
+  dps: 3613.81475
+  tps: 2016.8859
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26912.38052
-  tps: 16144.41127
+  dps: 26280.0823
+  tps: 15800.12509
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7747.87222
-  tps: 4215.92799
+  dps: 7632.02128
+  tps: 4143.95964
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9551.18819
-  tps: 4582.38167
+  dps: 9442.93293
+  tps: 4519.47375
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12944.42942
-  tps: 8082.70364
+  dps: 12565.01507
+  tps: 7835.80918
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4136.3294
-  tps: 2183.88249
+  dps: 4046.17831
+  tps: 2128.67701
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5883.15924
-  tps: 2808.35774
+  dps: 5802.14486
+  tps: 2763.5393
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Wf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5290.5369
-  tps: 4105.28184
+  dps: 5240.34689
+  tps: 4084.42759
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Wf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5290.5369
-  tps: 3093.78295
+  dps: 5240.34689
+  tps: 3059.67362
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Wf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6553.14712
-  tps: 3411.82039
+  dps: 6507.97647
+  tps: 3382.31399
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Wf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2759.93461
-  tps: 3000.72136
+  dps: 2727.12579
+  tps: 3037.48723
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Wf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2759.93461
-  tps: 1692.86763
+  dps: 2727.12579
+  tps: 1674.11422
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-Wf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3299.8264
-  tps: 1770.62534
+  dps: 3256.6925
+  tps: 1744.99468
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhItemSwap-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6001.61383
-  tps: 4669.97815
+  dps: 5936.53722
+  tps: 4632.3405
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhItemSwap-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6001.61383
-  tps: 3606.66729
+  dps: 5936.53722
+  tps: 3562.18291
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhItemSwap-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7369.61326
-  tps: 4023.88743
+  dps: 7311.46825
+  tps: 3984.26445
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhItemSwap-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3031.16773
-  tps: 3348.9367
+  dps: 2985.23642
+  tps: 3302.87427
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhItemSwap-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3031.16773
-  tps: 1900.39411
+  dps: 2985.23642
+  tps: 1868.98165
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-EnhItemSwap-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3599.05549
-  tps: 2025.6214
+  dps: 3528.05086
+  tps: 1980.10901
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26561.07405
-  tps: 16133.26105
+  dps: 26001.7196
+  tps: 15826.97161
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7672.52563
-  tps: 4221.33363
+  dps: 7556.6454
+  tps: 4149.10845
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9475.38482
-  tps: 4638.15273
+  dps: 9379.65427
+  tps: 4577.15871
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12925.2173
-  tps: 8188.5874
+  dps: 12695.11005
+  tps: 8088.67311
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4088.32964
-  tps: 2190.07335
+  dps: 4003.22646
+  tps: 2135.09199
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5807.90202
-  tps: 2836.06828
+  dps: 5726.92147
+  tps: 2782.07265
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Wf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5307.09409
-  tps: 4138.05853
+  dps: 5253.21575
+  tps: 4114.04403
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Wf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5307.09409
-  tps: 3113.64811
+  dps: 5253.21575
+  tps: 3078.07564
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Wf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6589.32805
-  tps: 3462.033
+  dps: 6549.87949
+  tps: 3435.83935
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Wf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2735.11266
-  tps: 2973.82857
+  dps: 2693.44502
+  tps: 3023.54305
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Wf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2735.11266
-  tps: 1681.26911
+  dps: 2693.44502
+  tps: 1658.00334
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-Wf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3241.93506
-  tps: 1752.21379
+  dps: 3201.91945
+  tps: 1730.66487
  }
 }
 dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7330.97558
-  tps: 4013.85062
+  dps: 7213.93376
+  tps: 3941.01356
  }
 }

--- a/sim/warlock/TestAffliction.results
+++ b/sim/warlock/TestAffliction.results
@@ -46,718 +46,718 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 11453.20511
-  tps: 10316.87586
+  dps: 11671.47589
+  tps: 10517.63145
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 11506.36152
-  tps: 10366.11307
+  dps: 11725.87844
+  tps: 10567.85443
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 11303.94042
-  tps: 10177.48599
+  dps: 11520.41761
+  tps: 10376.27933
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11577.83327
+  tps: 10430.88453
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 11116.40954
-  tps: 9998.6163
+  dps: 11331.00881
+  tps: 10196.53505
   hps: 95.83649
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 11116.40954
-  tps: 9998.6163
+  dps: 11331.00881
+  tps: 10196.53505
   hps: 95.83649
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 11403.56173
-  tps: 10266.42326
+  dps: 11595.06602
+  tps: 10438.59106
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8906.88559
-  tps: 8012.1463
+  dps: 9061.52238
+  tps: 8151.50534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 11432.62859
-  tps: 10096.40598
+  dps: 11633.22641
+  tps: 10275.08629
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11612.48751
-  tps: 10483.74146
+  dps: 11819.32135
+  tps: 10672.3726
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
   hps: 64
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 10665.11287
-  tps: 9644.89773
+  dps: 10845.72539
+  tps: 9805.12856
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 11249.68632
-  tps: 10136.31052
+  dps: 11448.52421
+  tps: 10317.69391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 11301.14727
-  tps: 10188.2437
+  dps: 11494.37005
+  tps: 10364.75645
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 11275.75053
-  tps: 10160.36942
+  dps: 11470.35436
+  tps: 10336.62098
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Death'sChoice-47464"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 11163.31963
-  tps: 10047.29692
+  dps: 11366.34622
+  tps: 10233.75404
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DeathbringerGarb"
  value: {
-  dps: 9870.35064
-  tps: 8886.5317
+  dps: 10043.33803
+  tps: 9042.54329
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Defender'sCode-40257"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 11414.15712
-  tps: 10285.41107
+  dps: 11602.82581
+  tps: 10455.87707
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11847.23646
-  tps: 10712.86612
+  dps: 12066.73182
+  tps: 10914.71549
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11821.53209
-  tps: 10693.49816
+  dps: 12041.71224
+  tps: 10897.40927
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11577.83327
+  tps: 10430.88453
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 11435.68771
-  tps: 10294.94154
+  dps: 11634.04868
+  tps: 10474.53683
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 11406.82967
-  tps: 10278.08362
+  dps: 11598.08846
+  tps: 10451.13971
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 11401.78405
-  tps: 10273.038
+  dps: 11594.63202
+  tps: 10447.68328
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 11341.64808
-  tps: 10229.56467
+  dps: 11549.75759
+  tps: 10418.89113
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11577.83327
+  tps: 10430.88453
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 11303.38305
-  tps: 10187.98839
+  dps: 11495.319
+  tps: 10361.71927
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 11480.44033
-  tps: 10349.43312
+  dps: 11682.78757
+  tps: 10533.80428
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 11143.66771
-  tps: 10028.73574
+  dps: 11351.16587
+  tps: 10219.35664
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 11315.69816
-  tps: 10187.18979
+  dps: 11531.512
+  tps: 10385.12482
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForgeEmber-37660"
  value: {
-  dps: 11335.95514
-  tps: 10212.0815
+  dps: 11535.23566
+  tps: 10393.242
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 11432.62859
-  tps: 10300.58003
+  dps: 11633.22641
+  tps: 10482.90688
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 11423.29713
-  tps: 10291.80184
+  dps: 11623.71694
+  tps: 10473.96004
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FuturesightRune-38763"
  value: {
-  dps: 11255.78763
-  tps: 10130.24632
+  dps: 11472.25151
+  tps: 10329.86566
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 9711.97188
-  tps: 8753.53096
+  dps: 9888.47537
+  tps: 8912.46182
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 11481.18641
-  tps: 10343.07557
+  dps: 11699.47162
+  tps: 10544.05075
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 11536.54624
-  tps: 10394.88765
+  dps: 11756.32247
+  tps: 10596.84126
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 11268.66198
-  tps: 10153.03267
+  dps: 11460.86217
+  tps: 10327.06154
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 10128.80045
-  tps: 9045.66207
+  dps: 10305.07391
+  tps: 9204.67291
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 11496.51237
-  tps: 10357.59508
+  dps: 11714.9479
+  tps: 10558.70383
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 11406.82967
-  tps: 10278.08362
+  dps: 11598.08846
+  tps: 10451.13971
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 11401.78405
-  tps: 10273.038
+  dps: 11594.63202
+  tps: 10447.68328
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IncisorFragment-37723"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 11391.83204
-  tps: 10259.55116
+  dps: 11591.1388
+  tps: 10440.40812
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11577.83327
+  tps: 10430.88453
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 11292.6058
-  tps: 10164.98179
+  dps: 11507.72339
+  tps: 10362.58458
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MaleficRaiment"
  value: {
-  dps: 7548.45616
-  tps: 6683.44873
+  dps: 7696.90078
+  tps: 6819.04279
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 11221.09797
-  tps: 10105.07526
+  dps: 11416.79378
+  tps: 10284.2016
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 11812.97223
-  tps: 10685.80079
+  dps: 12018.94403
+  tps: 10874.62419
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11577.83327
+  tps: 10430.88453
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11577.83327
+  tps: 10430.88453
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PlagueheartGarb"
  value: {
-  dps: 9312.84097
-  tps: 8351.20764
+  dps: 9470.2733
+  tps: 8490.13009
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11577.83327
+  tps: 10430.88453
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11577.83327
+  tps: 10430.88453
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 11547.15701
-  tps: 10427.0515
+  dps: 11771.14568
+  tps: 10630.79701
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 11589.19745
-  tps: 10467.44748
+  dps: 11817.04505
+  tps: 10674.53271
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11582.24204
-  tps: 10453.49599
+  dps: 11797.24319
+  tps: 10650.29445
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 11367.30044
-  tps: 10234.41299
+  dps: 11567.74096
+  tps: 10416.29158
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 11450.38733
-  tps: 10319.38297
+  dps: 11667.48931
+  tps: 10518.54694
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 11500.16414
-  tps: 10365.56199
+  dps: 11717.56363
+  tps: 10565.48688
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulPreserver-37111"
  value: {
-  dps: 11242.42306
-  tps: 10117.31028
+  dps: 11457.52655
+  tps: 10315.57969
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SouloftheDead-40382"
  value: {
-  dps: 11247.35941
-  tps: 10134.40282
+  dps: 11434.18319
+  tps: 10304.44145
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SparkofLife-37657"
  value: {
-  dps: 11317.66018
-  tps: 10205.22056
+  dps: 11527.2461
+  tps: 10398.23138
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 11112.62806
-  tps: 9993.7236
+  dps: 11327.57096
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11577.83327
+  tps: 10430.88453
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11577.83327
+  tps: 10430.88453
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11577.83327
+  tps: 10430.88453
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 11183.19413
-  tps: 10061.49164
+  dps: 11396.97204
+  tps: 10258.53658
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 11178.611
-  tps: 10059.49803
+  dps: 11378.30284
+  tps: 10243.01782
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11324.68921
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11577.83327
+  tps: 10430.88453
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 11114.38043
-  tps: 9993.7236
+  dps: 11329.32333
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 11114.38043
-  tps: 9993.7236
+  dps: 11329.32333
+  tps: 10192.09702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 11432.62859
-  tps: 10300.58003
+  dps: 11633.22641
+  tps: 10482.90688
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 11423.29713
-  tps: 10291.80184
+  dps: 11623.71694
+  tps: 10473.96004
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 11435.15379
-  tps: 10318.37861
+  dps: 11650.67833
+  tps: 10517.65257
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 11423.29713
-  tps: 10291.80184
+  dps: 11623.71694
+  tps: 10473.96004
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 11432.62859
-  tps: 10300.58003
+  dps: 11633.22641
+  tps: 10482.90688
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WingedTalisman-37844"
  value: {
-  dps: 11260.42747
-  tps: 10135.73378
+  dps: 11477.95287
+  tps: 10336.59074
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 11741.72991
-  tps: 10610.66988
+  dps: 11941.60077
+  tps: 10792.2099
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-AffItemSwap-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30975.4155
-  tps: 36020.61664
+  dps: 31006.40413
+  tps: 36040.22631
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-AffItemSwap-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11678.01792
-  tps: 10551.43599
+  dps: 11897.51885
+  tps: 10754.55652
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-AffItemSwap-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12667.22063
-  tps: 11505.99205
+  dps: 12906.41302
+  tps: 11724.96029
  }
 }
 dps_results: {
@@ -784,22 +784,22 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-Affliction Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 33646.6365
-  tps: 38759.13239
+  dps: 33680.99513
+  tps: 38781.09777
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-Affliction Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11612.48751
-  tps: 10483.74146
+  dps: 11819.32135
+  tps: 10672.3726
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-Affliction Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12779.88468
-  tps: 11625.23817
+  dps: 13021.09171
+  tps: 11850.62662
  }
 }
 dps_results: {
@@ -826,7 +826,7 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 11571.23022
-  tps: 10483.74146
+  dps: 11778.06406
+  tps: 10672.3726
  }
 }

--- a/sim/warlock/TestAffliction.results
+++ b/sim/warlock/TestAffliction.results
@@ -46,787 +46,787 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 11671.47589
-  tps: 10517.63145
+  dps: 11453.20511
+  tps: 10316.87586
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 11725.87844
-  tps: 10567.85443
+  dps: 11506.36152
+  tps: 10366.11307
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 11520.41761
-  tps: 10376.27933
+  dps: 11303.94042
+  tps: 10177.48599
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 11577.83327
-  tps: 10430.88453
+  dps: 11379.08153
+  tps: 10250.33548
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 11331.00881
-  tps: 10196.53505
+  dps: 11116.40954
+  tps: 9998.6163
   hps: 95.83649
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 11331.00881
-  tps: 10196.53505
+  dps: 11116.40954
+  tps: 9998.6163
   hps: 95.83649
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 11595.06602
-  tps: 10438.59106
+  dps: 11403.56173
+  tps: 10266.42326
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 9061.52238
-  tps: 8151.50534
+  dps: 8906.88559
+  tps: 8012.1463
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 11633.22641
-  tps: 10275.08629
+  dps: 11432.62859
+  tps: 10096.40598
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11819.32135
-  tps: 10672.3726
+  dps: 11612.48751
+  tps: 10483.74146
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
   hps: 64
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 10845.72539
-  tps: 9805.12856
+  dps: 10665.11287
+  tps: 9644.89773
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 11448.52421
-  tps: 10317.69391
+  dps: 11249.68632
+  tps: 10136.31052
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 11494.37005
-  tps: 10364.75645
+  dps: 11301.14727
+  tps: 10188.2437
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 11470.35436
-  tps: 10336.62098
+  dps: 11275.75053
+  tps: 10160.36942
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Death'sChoice-47464"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 11366.34622
-  tps: 10233.75404
+  dps: 11163.31963
+  tps: 10047.29692
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DeathbringerGarb"
  value: {
-  dps: 10043.33803
-  tps: 9042.54329
+  dps: 9870.35064
+  tps: 8886.5317
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Defender'sCode-40257"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 11602.82581
-  tps: 10455.87707
+  dps: 11414.15712
+  tps: 10285.41107
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 12066.73182
-  tps: 10914.71549
+  dps: 11847.23646
+  tps: 10712.86612
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 12041.71224
-  tps: 10897.40927
+  dps: 11821.53209
+  tps: 10693.49816
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 11577.83327
-  tps: 10430.88453
+  dps: 11379.08153
+  tps: 10250.33548
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 11634.04868
-  tps: 10474.53683
+  dps: 11435.68771
+  tps: 10294.94154
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 11598.08846
-  tps: 10451.13971
+  dps: 11406.82967
+  tps: 10278.08362
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 11594.63202
-  tps: 10447.68328
+  dps: 11401.78405
+  tps: 10273.038
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 11549.75759
-  tps: 10418.89113
+  dps: 11341.64808
+  tps: 10229.56467
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 11577.83327
-  tps: 10430.88453
+  dps: 11379.08153
+  tps: 10250.33548
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 11495.319
-  tps: 10361.71927
+  dps: 11303.38305
+  tps: 10187.98839
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 11682.78757
-  tps: 10533.80428
+  dps: 11480.44033
+  tps: 10349.43312
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 11351.16587
-  tps: 10219.35664
+  dps: 11143.66771
+  tps: 10028.73574
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 11531.512
-  tps: 10385.12482
+  dps: 11315.69816
+  tps: 10187.18979
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForgeEmber-37660"
  value: {
-  dps: 11535.23566
-  tps: 10393.242
+  dps: 11335.95514
+  tps: 10212.0815
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 11633.22641
-  tps: 10482.90688
+  dps: 11432.62859
+  tps: 10300.58003
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 11623.71694
-  tps: 10473.96004
+  dps: 11423.29713
+  tps: 10291.80184
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FuturesightRune-38763"
  value: {
-  dps: 11472.25151
-  tps: 10329.86566
+  dps: 11255.78763
+  tps: 10130.24632
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 9888.47537
-  tps: 8912.46182
+  dps: 9711.97188
+  tps: 8753.53096
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 11699.47162
-  tps: 10544.05075
+  dps: 11481.18641
+  tps: 10343.07557
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 11756.32247
-  tps: 10596.84126
+  dps: 11536.54624
+  tps: 10394.88765
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 11460.86217
-  tps: 10327.06154
+  dps: 11268.66198
+  tps: 10153.03267
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 10305.07391
-  tps: 9204.67291
+  dps: 10128.80045
+  tps: 9045.66207
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 11714.9479
-  tps: 10558.70383
+  dps: 11496.51237
+  tps: 10357.59508
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 11598.08846
-  tps: 10451.13971
+  dps: 11406.82967
+  tps: 10278.08362
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 11594.63202
-  tps: 10447.68328
+  dps: 11401.78405
+  tps: 10273.038
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IncisorFragment-37723"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 11591.1388
-  tps: 10440.40812
+  dps: 11391.83204
+  tps: 10259.55116
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 11577.83327
-  tps: 10430.88453
+  dps: 11379.08153
+  tps: 10250.33548
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 11507.72339
-  tps: 10362.58458
+  dps: 11292.6058
+  tps: 10164.98179
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MaleficRaiment"
  value: {
-  dps: 7696.90078
-  tps: 6819.04279
+  dps: 7548.45616
+  tps: 6683.44873
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 11416.79378
-  tps: 10284.2016
+  dps: 11221.09797
+  tps: 10105.07526
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 12018.94403
-  tps: 10874.62419
+  dps: 11812.97223
+  tps: 10685.80079
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 11577.83327
-  tps: 10430.88453
+  dps: 11379.08153
+  tps: 10250.33548
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 11577.83327
-  tps: 10430.88453
+  dps: 11379.08153
+  tps: 10250.33548
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PlagueheartGarb"
  value: {
-  dps: 9470.2733
-  tps: 8490.13009
+  dps: 9312.84097
+  tps: 8351.20764
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 11577.83327
-  tps: 10430.88453
+  dps: 11379.08153
+  tps: 10250.33548
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 11577.83327
-  tps: 10430.88453
+  dps: 11379.08153
+  tps: 10250.33548
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 11771.14568
-  tps: 10630.79701
+  dps: 11547.15701
+  tps: 10427.0515
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 11817.04505
-  tps: 10674.53271
+  dps: 11589.19745
+  tps: 10467.44748
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11797.24319
-  tps: 10650.29445
+  dps: 11582.24204
+  tps: 10453.49599
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 11567.74096
-  tps: 10416.29158
+  dps: 11367.30044
+  tps: 10234.41299
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 11667.48931
-  tps: 10518.54694
+  dps: 11450.38733
+  tps: 10319.38297
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 11717.56363
-  tps: 10565.48688
+  dps: 11500.16414
+  tps: 10365.56199
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulPreserver-37111"
  value: {
-  dps: 11457.52655
-  tps: 10315.57969
+  dps: 11242.42306
+  tps: 10117.31028
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SouloftheDead-40382"
  value: {
-  dps: 11434.18319
-  tps: 10304.44145
+  dps: 11247.35941
+  tps: 10134.40282
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SparkofLife-37657"
  value: {
-  dps: 11527.2461
-  tps: 10398.23138
+  dps: 11317.66018
+  tps: 10205.22056
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 11327.57096
-  tps: 10192.09702
+  dps: 11112.62806
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 11577.83327
-  tps: 10430.88453
+  dps: 11379.08153
+  tps: 10250.33548
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 11577.83327
-  tps: 10430.88453
+  dps: 11379.08153
+  tps: 10250.33548
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 11577.83327
-  tps: 10430.88453
+  dps: 11379.08153
+  tps: 10250.33548
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 11396.97204
-  tps: 10258.53658
+  dps: 11183.19413
+  tps: 10061.49164
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 11378.30284
-  tps: 10243.01782
+  dps: 11178.611
+  tps: 10059.49803
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 11324.68921
-  tps: 10192.09702
+  dps: 11109.74631
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 11577.83327
-  tps: 10430.88453
+  dps: 11379.08153
+  tps: 10250.33548
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 11329.32333
-  tps: 10192.09702
+  dps: 11114.38043
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 11329.32333
-  tps: 10192.09702
+  dps: 11114.38043
+  tps: 9993.7236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 11633.22641
-  tps: 10482.90688
+  dps: 11432.62859
+  tps: 10300.58003
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 11623.71694
-  tps: 10473.96004
+  dps: 11423.29713
+  tps: 10291.80184
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 11650.67833
-  tps: 10517.65257
+  dps: 11435.15379
+  tps: 10318.37861
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 11623.71694
-  tps: 10473.96004
+  dps: 11423.29713
+  tps: 10291.80184
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 11633.22641
-  tps: 10482.90688
+  dps: 11432.62859
+  tps: 10300.58003
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WingedTalisman-37844"
  value: {
-  dps: 11477.95287
-  tps: 10336.59074
+  dps: 11260.42747
+  tps: 10135.73378
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 11941.60077
-  tps: 10792.2099
+  dps: 11741.72991
+  tps: 10610.66988
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-AffItemSwap-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31006.40413
-  tps: 36040.22631
+  dps: 30577.37099
+  tps: 35622.57213
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-AffItemSwap-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11897.51885
-  tps: 10754.55652
+  dps: 11678.01792
+  tps: 10551.43599
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-AffItemSwap-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12906.41302
-  tps: 11724.96029
+  dps: 12667.22063
+  tps: 11505.99205
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-AffItemSwap-NoBuffs-LongMultiTarget"
  value: {
-  dps: 18696.91539
-  tps: 24054.02815
+  dps: 18435.79012
+  tps: 23799.04672
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-AffItemSwap-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6935.65437
-  tps: 6522.92244
+  dps: 6792.07588
+  tps: 6389.74223
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-AffItemSwap-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6872.74986
-  tps: 6373.79672
+  dps: 6779.9194
+  tps: 6291.59289
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-Affliction Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 33680.99513
-  tps: 38781.09777
+  dps: 33228.98596
+  tps: 38341.48185
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-Affliction Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11819.32135
-  tps: 10672.3726
+  dps: 11612.48751
+  tps: 10483.74146
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-Affliction Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13021.09171
-  tps: 11850.62662
+  dps: 12779.88468
+  tps: 11625.23817
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-Affliction Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 20481.64778
-  tps: 25913.33266
+  dps: 20193.60406
+  tps: 25631.0173
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-Affliction Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6913.29467
-  tps: 6498.7916
+  dps: 6786.88724
+  tps: 6382.36032
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-Affliction Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6857.04872
-  tps: 6354.9422
+  dps: 6755.06057
+  tps: 6262.74335
  }
 }
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 11778.06406
-  tps: 10672.3726
+  dps: 11571.23022
+  tps: 10483.74146
  }
 }

--- a/sim/warlock/TestAffliction.results
+++ b/sim/warlock/TestAffliction.results
@@ -46,787 +46,787 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 11453.20511
-  tps: 10316.87586
+  dps: 11527.27105
+  tps: 10386.15903
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 11506.36152
-  tps: 10366.11307
+  dps: 11581.12421
+  tps: 10436.08211
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 11303.94042
-  tps: 10177.48599
+  dps: 11377.17224
+  tps: 10245.96686
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11439.16775
+  tps: 10304.72439
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 11116.40954
-  tps: 9998.6163
+  dps: 11189.66435
+  tps: 10067.34021
   hps: 95.83649
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 11116.40954
-  tps: 9998.6163
+  dps: 11189.66435
+  tps: 10067.34021
   hps: 95.83649
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 11403.56173
-  tps: 10266.42326
+  dps: 11466.09856
+  tps: 10322.5283
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8906.88559
-  tps: 8012.1463
+  dps: 8959.87489
+  tps: 8060.83385
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 11432.62859
-  tps: 10096.40598
+  dps: 11493.91449
+  tps: 10150.84788
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11612.48751
-  tps: 10483.74146
+  dps: 11677.68974
+  tps: 10543.24637
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
   hps: 64
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 10665.11287
-  tps: 9644.89773
+  dps: 10726.65544
+  tps: 9701.1837
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 11249.68632
-  tps: 10136.31052
+  dps: 11306.26498
+  tps: 10186.92593
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 11301.14727
-  tps: 10188.2437
+  dps: 11362.84778
+  tps: 10245.03181
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 11275.75053
-  tps: 10160.36942
+  dps: 11338.25543
+  tps: 10218.39201
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Death'sChoice-47464"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 11163.31963
-  tps: 10047.29692
+  dps: 11222.26677
+  tps: 10101.75108
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DeathbringerGarb"
  value: {
-  dps: 9870.35064
-  tps: 8886.5317
+  dps: 9925.47843
+  tps: 8937.35711
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Defender'sCode-40257"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 11414.15712
-  tps: 10285.41107
+  dps: 11468.30783
+  tps: 10333.86447
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11847.23646
-  tps: 10712.86612
+  dps: 11923.9785
+  tps: 10784.47711
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11821.53209
-  tps: 10693.49816
+  dps: 11895.89732
+  tps: 10763.8253
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11439.16775
+  tps: 10304.72439
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 11435.68771
-  tps: 10294.94154
+  dps: 11500.59943
+  tps: 10353.60277
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 11406.82967
-  tps: 10278.08362
+  dps: 11467.11865
+  tps: 10332.67528
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 11401.78405
-  tps: 10273.038
+  dps: 11461.92593
+  tps: 10327.48256
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 11341.64808
-  tps: 10229.56467
+  dps: 11408.50842
+  tps: 10290.62658
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11439.16775
+  tps: 10304.72439
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 11303.38305
-  tps: 10187.98839
+  dps: 11362.1226
+  tps: 10240.64823
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 11480.44033
-  tps: 10349.43312
+  dps: 11539.87362
+  tps: 10403.86176
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 11143.66771
-  tps: 10028.73574
+  dps: 11210.43102
+  tps: 10090.33168
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 11315.69816
-  tps: 10187.18979
+  dps: 11390.49887
+  tps: 10257.20279
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForgeEmber-37660"
  value: {
-  dps: 11335.95514
-  tps: 10212.0815
+  dps: 11399.10897
+  tps: 10270.32188
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 11432.62859
-  tps: 10300.58003
+  dps: 11493.91449
+  tps: 10356.133
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 11423.29713
-  tps: 10291.80184
+  dps: 11484.52926
+  tps: 10347.30401
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FuturesightRune-38763"
  value: {
-  dps: 11255.78763
-  tps: 10130.24632
+  dps: 11329.31121
+  tps: 10199.22467
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 9711.97188
-  tps: 8753.53096
+  dps: 9766.15059
+  tps: 8802.03365
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 11481.18641
-  tps: 10343.07557
+  dps: 11555.18813
+  tps: 10412.28908
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 11536.54624
-  tps: 10394.88765
+  dps: 11611.46368
+  tps: 10464.98288
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 11268.66198
-  tps: 10153.03267
+  dps: 11328.42672
+  tps: 10206.30357
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 10128.80045
-  tps: 9045.66207
+  dps: 10182.41835
+  tps: 9094.57897
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 11496.51237
-  tps: 10357.59508
+  dps: 11570.61606
+  tps: 10426.90562
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 11406.82967
-  tps: 10278.08362
+  dps: 11467.11865
+  tps: 10332.67528
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 11401.78405
-  tps: 10273.038
+  dps: 11461.92593
+  tps: 10327.48256
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IncisorFragment-37723"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 11391.83204
-  tps: 10259.55116
+  dps: 11453.93345
+  tps: 10315.59244
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11439.16775
+  tps: 10304.72439
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 11292.6058
-  tps: 10164.98179
+  dps: 11366.77177
+  tps: 10234.35606
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MaleficRaiment"
  value: {
-  dps: 7548.45616
-  tps: 6683.44873
+  dps: 7591.32865
+  tps: 6722.4017
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 11221.09797
-  tps: 10105.07526
+  dps: 11281.97276
+  tps: 10161.45707
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 11812.97223
-  tps: 10685.80079
+  dps: 11887.38285
+  tps: 10756.24007
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11439.16775
+  tps: 10304.72439
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11439.16775
+  tps: 10304.72439
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PlagueheartGarb"
  value: {
-  dps: 9312.84097
-  tps: 8351.20764
+  dps: 9359.64839
+  tps: 8392.78029
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11439.16775
+  tps: 10304.72439
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11439.16775
+  tps: 10304.72439
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 11547.15701
-  tps: 10427.0515
+  dps: 11625.98404
+  tps: 10501.82098
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 11589.19745
-  tps: 10467.44748
+  dps: 11670.63715
+  tps: 10545.17763
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11582.24204
-  tps: 10453.49599
+  dps: 11647.22326
+  tps: 10512.7799
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 11367.30044
-  tps: 10234.41299
+  dps: 11430.58604
+  tps: 10291.54158
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 11450.38733
-  tps: 10319.38297
+  dps: 11523.19295
+  tps: 10387.52749
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 11500.16414
-  tps: 10365.56199
+  dps: 11573.54467
+  tps: 10434.24914
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulPreserver-37111"
  value: {
-  dps: 11242.42306
-  tps: 10117.31028
+  dps: 11315.48372
+  tps: 10185.82818
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SouloftheDead-40382"
  value: {
-  dps: 11247.35941
-  tps: 10134.40282
+  dps: 11307.66059
+  tps: 10191.04595
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SparkofLife-37657"
  value: {
-  dps: 11317.66018
-  tps: 10205.22056
+  dps: 11388.65961
+  tps: 10272.08241
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 11112.62806
-  tps: 9993.7236
+  dps: 11185.95054
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11439.16775
+  tps: 10304.72439
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11439.16775
+  tps: 10304.72439
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11439.16775
+  tps: 10304.72439
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 11183.19413
-  tps: 10061.49164
+  dps: 11255.3957
+  tps: 10129.16691
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 11178.611
-  tps: 10059.49803
+  dps: 11240.0614
+  tps: 10116.39773
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 11109.74631
-  tps: 9993.7236
+  dps: 11183.06879
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 11379.08153
-  tps: 10250.33548
+  dps: 11439.16775
+  tps: 10304.72439
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 11114.38043
-  tps: 9993.7236
+  dps: 11187.70292
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 11114.38043
-  tps: 9993.7236
+  dps: 11187.70292
+  tps: 10062.5531
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 11432.62859
-  tps: 10300.58003
+  dps: 11493.91449
+  tps: 10356.133
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 11423.29713
-  tps: 10291.80184
+  dps: 11484.52926
+  tps: 10347.30401
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 11435.15379
-  tps: 10318.37861
+  dps: 11506.66285
+  tps: 10385.6861
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 11423.29713
-  tps: 10291.80184
+  dps: 11484.52926
+  tps: 10347.30401
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 11432.62859
-  tps: 10300.58003
+  dps: 11493.91449
+  tps: 10356.133
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WingedTalisman-37844"
  value: {
-  dps: 11260.42747
-  tps: 10135.73378
+  dps: 11334.42372
+  tps: 10205.2069
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 11741.72991
-  tps: 10610.66988
+  dps: 11802.48852
+  tps: 10665.88472
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-AffItemSwap-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30577.37099
-  tps: 35622.57213
+  dps: 30702.64081
+  tps: 35745.75223
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-AffItemSwap-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11678.01792
-  tps: 10551.43599
+  dps: 11748.80892
+  tps: 10617.02564
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-AffItemSwap-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12667.22063
-  tps: 11505.99205
+  dps: 12745.64043
+  tps: 11577.89304
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-AffItemSwap-NoBuffs-LongMultiTarget"
  value: {
-  dps: 18435.79012
-  tps: 23799.04672
+  dps: 18516.05245
+  tps: 23877.60621
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-AffItemSwap-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6792.07588
-  tps: 6389.74223
+  dps: 6829.15587
+  tps: 6423.7778
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-AffItemSwap-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6779.9194
-  tps: 6291.59289
+  dps: 6811.71339
+  tps: 6318.22566
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-Affliction Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 33228.98596
-  tps: 38341.48185
+  dps: 33373.39434
+  tps: 38482.88131
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-Affliction Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11612.48751
-  tps: 10483.74146
+  dps: 11677.68974
+  tps: 10543.24637
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-Affliction Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12779.88468
-  tps: 11625.23817
+  dps: 12850.02367
+  tps: 11691.84173
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-Affliction Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 20193.60406
-  tps: 25631.0173
+  dps: 20278.25295
+  tps: 25714.2092
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-Affliction Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6786.88724
-  tps: 6382.36032
+  dps: 6818.67874
+  tps: 6411.1851
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-P3-Affliction Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6755.06057
-  tps: 6262.74335
+  dps: 6788.22378
+  tps: 6292.68525
  }
 }
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 11571.23022
-  tps: 10483.74146
+  dps: 11636.43245
+  tps: 10543.24637
  }
 }

--- a/sim/warlock/TestDemonology.results
+++ b/sim/warlock/TestDemonology.results
@@ -46,745 +46,745 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 10818.17267
-  tps: 9097.89267
+  dps: 10657.30945
+  tps: 8937.02944
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 10847.94372
-  tps: 9123.87613
+  dps: 10686.64701
+  tps: 8962.57942
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 10683.75148
-  tps: 8980.71863
+  dps: 10522.28201
+  tps: 8819.24917
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 10809.53337
-  tps: 9060.6935
+  dps: 10654.79674
+  tps: 8905.95686
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10488.47305
-  tps: 8808.66519
+  dps: 10336.07995
+  tps: 8656.27209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10483.89956
-  tps: 8804.18516
+  dps: 10333.60242
+  tps: 8653.88801
   hps: 97.91731
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10483.89956
-  tps: 8804.18516
+  dps: 10333.60242
+  tps: 8653.88801
   hps: 97.91731
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 10826.60521
-  tps: 9075.60232
+  dps: 10695.08856
+  tps: 8944.08566
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8543.70051
-  tps: 7151.52372
+  dps: 8429.05458
+  tps: 7036.87779
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 10852.451
-  tps: 8919.15252
+  dps: 10695.1043
+  tps: 8764.95276
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11028.43587
-  tps: 9280.41618
+  dps: 10872.02947
+  tps: 9124.00978
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10488.47305
-  tps: 8808.66519
+  dps: 10336.07995
+  tps: 8656.27209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10488.47305
-  tps: 8808.66519
+  dps: 10336.07995
+  tps: 8656.27209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10560.07634
-  tps: 8872.77762
+  dps: 10401.37782
+  tps: 8714.0791
   hps: 64
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 10266.90574
-  tps: 8731.83177
+  dps: 10105.20752
+  tps: 8570.13356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 10580.27388
-  tps: 8900.46602
+  dps: 10448.908
+  tps: 8769.10014
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 10649.66223
-  tps: 8968.24854
+  dps: 10511.88132
+  tps: 8830.46763
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 10600.68766
-  tps: 8911.40632
+  dps: 10466.51195
+  tps: 8777.23061
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Death'sChoice-47464"
  value: {
-  dps: 10488.46171
-  tps: 8808.65385
+  dps: 10336.06861
+  tps: 8656.26075
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10522.55583
-  tps: 8842.74797
+  dps: 10366.22127
+  tps: 8686.41341
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10488.47305
-  tps: 8808.66519
+  dps: 10336.07995
+  tps: 8656.27209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 10488.47305
-  tps: 8808.66519
+  dps: 10336.07995
+  tps: 8656.27209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DeathbringerGarb"
  value: {
-  dps: 9459.12697
-  tps: 7984.80129
+  dps: 9354.59914
+  tps: 7880.27347
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10488.47305
-  tps: 8808.66519
+  dps: 10336.07995
+  tps: 8656.27209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 10818.33213
-  tps: 9070.31244
+  dps: 10675.53691
+  tps: 8927.51722
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11244.13909
-  tps: 9512.89392
+  dps: 11094.78391
+  tps: 9363.53873
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11151.05668
-  tps: 9424.64956
+  dps: 10994.37478
+  tps: 9267.96766
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 10809.53337
-  tps: 9060.6935
+  dps: 10654.79674
+  tps: 8905.95686
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 10855.78996
-  tps: 9099.5421
+  dps: 10722.00707
+  tps: 8965.75921
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 10814.96858
-  tps: 9066.94889
+  dps: 10671.47648
+  tps: 8923.45678
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 10814.58377
-  tps: 9066.56408
+  dps: 10665.33364
+  tps: 8917.31395
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10690.69931
-  tps: 9008.17171
+  dps: 10538.17646
+  tps: 8855.64886
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10527.39522
-  tps: 8843.65599
+  dps: 10371.71591
+  tps: 8687.97668
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 10802.00038
-  tps: 9053.98069
+  dps: 10647.36714
+  tps: 8899.34745
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 10611.0578
-  tps: 8930.17566
+  dps: 10465.04832
+  tps: 8784.16618
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 10828.438
-  tps: 9119.18526
+  dps: 10684.23096
+  tps: 8974.97822
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10530.60891
-  tps: 8842.76656
+  dps: 10369.51826
+  tps: 8681.67591
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10699.1301
-  tps: 8993.06146
+  dps: 10539.82154
+  tps: 8833.7529
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForgeEmber-37660"
  value: {
-  dps: 10817.93979
-  tps: 9111.56099
+  dps: 10659.73542
+  tps: 8953.35663
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 10852.451
-  tps: 9099.03691
+  dps: 10695.1043
+  tps: 8941.69021
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 10839.35512
-  tps: 9087.95068
+  dps: 10682.4329
+  tps: 8931.02846
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 10488.47305
-  tps: 8808.66519
+  dps: 10336.07995
+  tps: 8656.27209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10675.28716
-  tps: 8974.19933
+  dps: 10515.59893
+  tps: 8814.51109
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 9391.0582
-  tps: 7878.80944
+  dps: 9278.4821
+  tps: 7766.23334
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 10834.95292
-  tps: 9112.58831
+  dps: 10674.99428
+  tps: 8952.62967
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 10866.78354
-  tps: 9139.64363
+  dps: 10707.167
+  tps: 8980.02708
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 10634.58151
-  tps: 8953.06671
+  dps: 10499.48942
+  tps: 8817.97463
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 9781.67897
-  tps: 8144.31525
+  dps: 9648.91637
+  tps: 8011.55264
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 10836.31547
-  tps: 9113.23286
+  dps: 10675.10248
+  tps: 8952.01987
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 10814.96858
-  tps: 9066.94889
+  dps: 10671.47648
+  tps: 8923.45678
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 10814.58377
-  tps: 9066.56408
+  dps: 10665.33364
+  tps: 8917.31395
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IncisorFragment-37723"
  value: {
-  dps: 10488.47305
-  tps: 8808.66519
+  dps: 10336.07995
+  tps: 8656.27209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 10828.15177
-  tps: 9081.32209
+  dps: 10686.89586
+  tps: 8940.06618
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 10802.00038
-  tps: 9053.98069
+  dps: 10647.36714
+  tps: 8899.34745
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10488.47305
-  tps: 8808.66519
+  dps: 10336.07995
+  tps: 8656.27209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10710.27418
-  tps: 9003.64868
+  dps: 10548.30556
+  tps: 8841.68006
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MaleficRaiment"
  value: {
-  dps: 7395.3468
-  tps: 6117.46707
+  dps: 7295.03361
+  tps: 6017.15387
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 10568.54716
-  tps: 8888.7393
+  dps: 10414.65668
+  tps: 8734.84882
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 10791.28688
-  tps: 9085.21824
+  dps: 10630.03777
+  tps: 8923.96913
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10488.47305
-  tps: 8808.66519
+  dps: 10336.07995
+  tps: 8656.27209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 10802.00038
-  tps: 9053.98069
+  dps: 10647.36714
+  tps: 8899.34745
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 10802.00038
-  tps: 9053.98069
+  dps: 10647.36714
+  tps: 8899.34745
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10488.47305
-  tps: 8808.66519
+  dps: 10336.07995
+  tps: 8656.27209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10488.47305
-  tps: 8808.66519
+  dps: 10336.07995
+  tps: 8656.27209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10488.47305
-  tps: 8808.66519
+  dps: 10336.07995
+  tps: 8656.27209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PlagueheartGarb"
  value: {
-  dps: 9083.34176
-  tps: 7642.12938
+  dps: 8961.54393
+  tps: 7520.33155
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 10808.27904
-  tps: 9059.59248
+  dps: 10653.56158
+  tps: 8904.87502
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 10809.53337
-  tps: 9060.6935
+  dps: 10654.79674
+  tps: 8905.95686
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10488.47305
-  tps: 8808.66519
+  dps: 10336.07995
+  tps: 8656.27209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 10912.11747
-  tps: 9197.57276
+  dps: 10759.25546
+  tps: 9043.66902
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 10968.66613
-  tps: 9249.67118
+  dps: 10799.22718
+  tps: 9078.12002
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11014.30052
-  tps: 9266.28083
+  dps: 10845.75029
+  tps: 9097.7306
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 10813.13529
-  tps: 9062.50902
+  dps: 10654.98034
+  tps: 8904.35407
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10488.47305
-  tps: 8808.66519
+  dps: 10336.07995
+  tps: 8656.27209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10488.47305
-  tps: 8808.66519
+  dps: 10336.07995
+  tps: 8656.27209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10488.47305
-  tps: 8808.66519
+  dps: 10336.07995
+  tps: 8656.27209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10560.07634
-  tps: 8872.77762
+  dps: 10401.37782
+  tps: 8714.0791
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 10799.65512
-  tps: 9083.88471
+  dps: 10643.77135
+  tps: 8928.00094
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 10828.65432
-  tps: 9109.76254
+  dps: 10673.37231
+  tps: 8954.48054
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10634.10621
-  tps: 8937.28459
+  dps: 10475.22043
+  tps: 8778.39881
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SouloftheDead-40382"
  value: {
-  dps: 10631.46761
-  tps: 8948.6835
+  dps: 10499.42428
+  tps: 8816.6466
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SparkofLife-37657"
  value: {
-  dps: 10679.72581
-  tps: 8991.46094
+  dps: 10523.92904
+  tps: 8835.66417
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 10650.70807
-  tps: 8953.19358
+  dps: 10510.38347
+  tps: 8812.86898
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 10802.00038
-  tps: 9053.98069
+  dps: 10647.36714
+  tps: 8899.34745
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 10802.00038
-  tps: 9053.98069
+  dps: 10647.36714
+  tps: 8899.34745
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 10802.00038
-  tps: 9053.98069
+  dps: 10647.36714
+  tps: 8899.34745
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10592.02561
-  tps: 8901.66052
+  dps: 10433.44636
+  tps: 8743.08127
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10548.05824
-  tps: 8858.26253
+  dps: 10399.71996
+  tps: 8709.92426
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10488.47305
-  tps: 8808.66519
+  dps: 10336.07995
+  tps: 8656.27209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 10802.00038
-  tps: 9053.98069
+  dps: 10647.36714
+  tps: 8899.34745
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 10671.99504
-  tps: 8968.05878
+  dps: 10520.63134
+  tps: 8816.69509
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 10671.99504
-  tps: 8968.05878
+  dps: 10520.63134
+  tps: 8816.69509
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 10852.451
-  tps: 9099.03691
+  dps: 10695.1043
+  tps: 8941.69021
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 10839.35512
-  tps: 9087.95068
+  dps: 10682.4329
+  tps: 8931.02846
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 10742.68707
-  tps: 9046.79817
+  dps: 10589.249
+  tps: 8893.36011
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 10839.35512
-  tps: 9087.95068
+  dps: 10682.4329
+  tps: 8931.02846
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 10852.451
-  tps: 9099.03691
+  dps: 10695.1043
+  tps: 8941.69021
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10690.27152
-  tps: 8988.4162
+  dps: 10529.24609
+  tps: 8827.39077
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 11152.61837
-  tps: 9398.69874
+  dps: 10990.42151
+  tps: 9236.50189
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36487.73236
-  tps: 40760.9842
+  dps: 36061.55113
+  tps: 40334.80297
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11028.43587
-  tps: 9280.41618
+  dps: 10872.02947
+  tps: 9124.00978
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12542.18456
-  tps: 10566.58221
+  dps: 12399.03182
+  tps: 10423.42948
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 22450.6182
-  tps: 27732.27995
+  dps: 22167.7774
+  tps: 27449.43916
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6409.62669
-  tps: 5803.04161
+  dps: 6303.3054
+  tps: 5696.72032
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6708.60048
-  tps: 5978.76668
+  dps: 6562.89111
+  tps: 5833.05731
  }
 }
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 10890.05072
-  tps: 9279.34716
+  dps: 10729.90184
+  tps: 9119.19827
  }
 }

--- a/sim/warlock/TestDemonology.results
+++ b/sim/warlock/TestDemonology.results
@@ -46,718 +46,718 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 10657.30945
-  tps: 8937.02944
+  dps: 10818.17267
+  tps: 9097.89267
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 10686.64701
-  tps: 8962.57942
+  dps: 10847.94372
+  tps: 9123.87613
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 10522.28201
-  tps: 8819.24917
+  dps: 10683.75148
+  tps: 8980.71863
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 10654.79674
-  tps: 8905.95686
+  dps: 10809.53337
+  tps: 9060.6935
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10488.47305
+  tps: 8808.66519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10333.60242
-  tps: 8653.88801
+  dps: 10483.89956
+  tps: 8804.18516
   hps: 97.91731
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10333.60242
-  tps: 8653.88801
+  dps: 10483.89956
+  tps: 8804.18516
   hps: 97.91731
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 10695.08856
-  tps: 8944.08566
+  dps: 10826.60521
+  tps: 9075.60232
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8429.05458
-  tps: 7036.87779
+  dps: 8543.70051
+  tps: 7151.52372
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 10695.1043
-  tps: 8764.95276
+  dps: 10852.451
+  tps: 8919.15252
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 10872.02947
-  tps: 9124.00978
+  dps: 11028.43587
+  tps: 9280.41618
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10488.47305
+  tps: 8808.66519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10488.47305
+  tps: 8808.66519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10401.37782
-  tps: 8714.0791
+  dps: 10560.07634
+  tps: 8872.77762
   hps: 64
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 10105.20752
-  tps: 8570.13356
+  dps: 10266.90574
+  tps: 8731.83177
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 10448.908
-  tps: 8769.10014
+  dps: 10580.27388
+  tps: 8900.46602
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 10511.88132
-  tps: 8830.46763
+  dps: 10649.66223
+  tps: 8968.24854
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 10466.51195
-  tps: 8777.23061
+  dps: 10600.68766
+  tps: 8911.40632
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Death'sChoice-47464"
  value: {
-  dps: 10336.06861
-  tps: 8656.26075
+  dps: 10488.46171
+  tps: 8808.65385
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10366.22127
-  tps: 8686.41341
+  dps: 10522.55583
+  tps: 8842.74797
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10488.47305
+  tps: 8808.66519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10488.47305
+  tps: 8808.66519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DeathbringerGarb"
  value: {
-  dps: 9354.59914
-  tps: 7880.27347
+  dps: 9459.12697
+  tps: 7984.80129
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10488.47305
+  tps: 8808.66519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 10675.53691
-  tps: 8927.51722
+  dps: 10818.33213
+  tps: 9070.31244
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11094.78391
-  tps: 9363.53873
+  dps: 11244.13909
+  tps: 9512.89392
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 10994.37478
-  tps: 9267.96766
+  dps: 11151.05668
+  tps: 9424.64956
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 10654.79674
-  tps: 8905.95686
+  dps: 10809.53337
+  tps: 9060.6935
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 10722.00707
-  tps: 8965.75921
+  dps: 10855.78996
+  tps: 9099.5421
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 10671.47648
-  tps: 8923.45678
+  dps: 10814.96858
+  tps: 9066.94889
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 10665.33364
-  tps: 8917.31395
+  dps: 10814.58377
+  tps: 9066.56408
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10538.17646
-  tps: 8855.64886
+  dps: 10690.69931
+  tps: 9008.17171
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10371.71591
-  tps: 8687.97668
+  dps: 10527.39522
+  tps: 8843.65599
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 10647.36714
-  tps: 8899.34745
+  dps: 10802.00038
+  tps: 9053.98069
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 10465.04832
-  tps: 8784.16618
+  dps: 10611.0578
+  tps: 8930.17566
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 10684.23096
-  tps: 8974.97822
+  dps: 10828.438
+  tps: 9119.18526
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10369.51826
-  tps: 8681.67591
+  dps: 10530.60891
+  tps: 8842.76656
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10539.82154
-  tps: 8833.7529
+  dps: 10699.1301
+  tps: 8993.06146
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForgeEmber-37660"
  value: {
-  dps: 10659.73542
-  tps: 8953.35663
+  dps: 10817.93979
+  tps: 9111.56099
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 10695.1043
-  tps: 8941.69021
+  dps: 10852.451
+  tps: 9099.03691
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 10682.4329
-  tps: 8931.02846
+  dps: 10839.35512
+  tps: 9087.95068
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10488.47305
+  tps: 8808.66519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10515.59893
-  tps: 8814.51109
+  dps: 10675.28716
+  tps: 8974.19933
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 9278.4821
-  tps: 7766.23334
+  dps: 9391.0582
+  tps: 7878.80944
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 10674.99428
-  tps: 8952.62967
+  dps: 10834.95292
+  tps: 9112.58831
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 10707.167
-  tps: 8980.02708
+  dps: 10866.78354
+  tps: 9139.64363
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 10499.48942
-  tps: 8817.97463
+  dps: 10634.58151
+  tps: 8953.06671
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 9648.91637
-  tps: 8011.55264
+  dps: 9781.67897
+  tps: 8144.31525
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 10675.10248
-  tps: 8952.01987
+  dps: 10836.31547
+  tps: 9113.23286
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 10671.47648
-  tps: 8923.45678
+  dps: 10814.96858
+  tps: 9066.94889
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 10665.33364
-  tps: 8917.31395
+  dps: 10814.58377
+  tps: 9066.56408
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IncisorFragment-37723"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10488.47305
+  tps: 8808.66519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 10686.89586
-  tps: 8940.06618
+  dps: 10828.15177
+  tps: 9081.32209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 10647.36714
-  tps: 8899.34745
+  dps: 10802.00038
+  tps: 9053.98069
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10488.47305
+  tps: 8808.66519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10548.30556
-  tps: 8841.68006
+  dps: 10710.27418
+  tps: 9003.64868
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MaleficRaiment"
  value: {
-  dps: 7295.03361
-  tps: 6017.15387
+  dps: 7395.3468
+  tps: 6117.46707
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 10414.65668
-  tps: 8734.84882
+  dps: 10568.54716
+  tps: 8888.7393
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 10630.03777
-  tps: 8923.96913
+  dps: 10791.28688
+  tps: 9085.21824
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10488.47305
+  tps: 8808.66519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 10647.36714
-  tps: 8899.34745
+  dps: 10802.00038
+  tps: 9053.98069
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 10647.36714
-  tps: 8899.34745
+  dps: 10802.00038
+  tps: 9053.98069
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10488.47305
+  tps: 8808.66519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10488.47305
+  tps: 8808.66519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10488.47305
+  tps: 8808.66519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PlagueheartGarb"
  value: {
-  dps: 8961.54393
-  tps: 7520.33155
+  dps: 9083.34176
+  tps: 7642.12938
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 10653.56158
-  tps: 8904.87502
+  dps: 10808.27904
+  tps: 9059.59248
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 10654.79674
-  tps: 8905.95686
+  dps: 10809.53337
+  tps: 9060.6935
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10488.47305
+  tps: 8808.66519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 10759.25546
-  tps: 9043.66902
+  dps: 10912.11747
+  tps: 9197.57276
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 10799.22718
-  tps: 9078.12002
+  dps: 10968.66613
+  tps: 9249.67118
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 10845.75029
-  tps: 9097.7306
+  dps: 11014.30052
+  tps: 9266.28083
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 10654.98034
-  tps: 8904.35407
+  dps: 10813.13529
+  tps: 9062.50902
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10488.47305
+  tps: 8808.66519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10488.47305
+  tps: 8808.66519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10488.47305
+  tps: 8808.66519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10401.37782
-  tps: 8714.0791
+  dps: 10560.07634
+  tps: 8872.77762
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 10643.77135
-  tps: 8928.00094
+  dps: 10799.65512
+  tps: 9083.88471
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 10673.37231
-  tps: 8954.48054
+  dps: 10828.65432
+  tps: 9109.76254
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10475.22043
-  tps: 8778.39881
+  dps: 10634.10621
+  tps: 8937.28459
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SouloftheDead-40382"
  value: {
-  dps: 10499.42428
-  tps: 8816.6466
+  dps: 10631.46761
+  tps: 8948.6835
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SparkofLife-37657"
  value: {
-  dps: 10523.92904
-  tps: 8835.66417
+  dps: 10679.72581
+  tps: 8991.46094
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 10510.38347
-  tps: 8812.86898
+  dps: 10650.70807
+  tps: 8953.19358
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 10647.36714
-  tps: 8899.34745
+  dps: 10802.00038
+  tps: 9053.98069
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 10647.36714
-  tps: 8899.34745
+  dps: 10802.00038
+  tps: 9053.98069
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 10647.36714
-  tps: 8899.34745
+  dps: 10802.00038
+  tps: 9053.98069
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10433.44636
-  tps: 8743.08127
+  dps: 10592.02561
+  tps: 8901.66052
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10399.71996
-  tps: 8709.92426
+  dps: 10548.05824
+  tps: 8858.26253
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10488.47305
+  tps: 8808.66519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 10647.36714
-  tps: 8899.34745
+  dps: 10802.00038
+  tps: 9053.98069
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 10520.63134
-  tps: 8816.69509
+  dps: 10671.99504
+  tps: 8968.05878
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 10520.63134
-  tps: 8816.69509
+  dps: 10671.99504
+  tps: 8968.05878
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 10695.1043
-  tps: 8941.69021
+  dps: 10852.451
+  tps: 9099.03691
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 10682.4329
-  tps: 8931.02846
+  dps: 10839.35512
+  tps: 9087.95068
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 10589.249
-  tps: 8893.36011
+  dps: 10742.68707
+  tps: 9046.79817
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 10682.4329
-  tps: 8931.02846
+  dps: 10839.35512
+  tps: 9087.95068
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 10695.1043
-  tps: 8941.69021
+  dps: 10852.451
+  tps: 9099.03691
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10529.24609
-  tps: 8827.39077
+  dps: 10690.27152
+  tps: 8988.4162
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 10990.42151
-  tps: 9236.50189
+  dps: 11152.61837
+  tps: 9398.69874
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36465.79623
-  tps: 40739.04807
+  dps: 36487.73236
+  tps: 40760.9842
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10872.02947
-  tps: 9124.00978
+  dps: 11028.43587
+  tps: 9280.41618
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12399.03182
-  tps: 10423.42948
+  dps: 12542.18456
+  tps: 10566.58221
  }
 }
 dps_results: {
@@ -784,7 +784,7 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 10729.90184
-  tps: 9119.19827
+  dps: 10890.05072
+  tps: 9279.34716
  }
 }

--- a/sim/warlock/TestDemonology.results
+++ b/sim/warlock/TestDemonology.results
@@ -46,745 +46,745 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 10657.30945
-  tps: 8937.02944
+  dps: 10697.52061
+  tps: 8977.2406
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 10686.64701
-  tps: 8962.57942
+  dps: 10727.00529
+  tps: 9002.9377
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 10522.28201
-  tps: 8819.24917
+  dps: 10561.88085
+  tps: 8858.848
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 10654.79674
-  tps: 8905.95686
+  dps: 10697.3991
+  tps: 8948.55923
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10377.23619
+  tps: 8697.42833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10333.60242
-  tps: 8653.88801
+  dps: 10374.70312
+  tps: 8694.98872
   hps: 97.91731
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10333.60242
-  tps: 8653.88801
+  dps: 10374.70312
+  tps: 8694.98872
   hps: 97.91731
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 10695.08856
-  tps: 8944.08566
+  dps: 10733.59773
+  tps: 8982.59483
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8429.05458
-  tps: 7036.87779
+  dps: 8462.03879
+  tps: 7069.862
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 10695.1043
-  tps: 8764.95276
+  dps: 10742.37656
+  tps: 8811.27957
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 10872.02947
-  tps: 9124.00978
+  dps: 10918.26664
+  tps: 9170.24695
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10377.23619
+  tps: 8697.42833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10377.23619
+  tps: 8697.42833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10401.37782
-  tps: 8714.0791
+  dps: 10443.15711
+  tps: 8755.8584
   hps: 64
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 10105.20752
-  tps: 8570.13356
+  dps: 10167.12313
+  tps: 8632.04917
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 10448.908
-  tps: 8769.10014
+  dps: 10501.09085
+  tps: 8821.28299
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 10511.88132
-  tps: 8830.46763
+  dps: 10550.36499
+  tps: 8868.9513
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 10466.51195
-  tps: 8777.23061
+  dps: 10507.00377
+  tps: 8817.72243
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Death'sChoice-47464"
  value: {
-  dps: 10336.06861
-  tps: 8656.26075
+  dps: 10377.22485
+  tps: 8697.41699
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10366.22127
-  tps: 8686.41341
+  dps: 10412.43981
+  tps: 8732.63195
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10377.23619
+  tps: 8697.42833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10377.23619
+  tps: 8697.42833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DeathbringerGarb"
  value: {
-  dps: 9354.59914
-  tps: 7880.27347
+  dps: 9387.57776
+  tps: 7913.25208
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10377.23619
+  tps: 8697.42833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 10675.53691
-  tps: 8927.51722
+  dps: 10716.32865
+  tps: 8968.30896
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11094.78391
-  tps: 9363.53873
+  dps: 11141.27121
+  tps: 9410.02604
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 10994.37478
-  tps: 9267.96766
+  dps: 11045.84246
+  tps: 9319.43534
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 10654.79674
-  tps: 8905.95686
+  dps: 10697.3991
+  tps: 8948.55923
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 10722.00707
-  tps: 8965.75921
+  dps: 10761.18797
+  tps: 9004.94011
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 10671.47648
-  tps: 8923.45678
+  dps: 10713.8959
+  tps: 8965.8762
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 10665.33364
-  tps: 8917.31395
+  dps: 10709.58908
+  tps: 8961.56938
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10538.17646
-  tps: 8855.64886
+  dps: 10582.46496
+  tps: 8899.93736
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10371.71591
-  tps: 8687.97668
+  dps: 10413.38341
+  tps: 8729.64418
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 10647.36714
-  tps: 8899.34745
+  dps: 10689.94105
+  tps: 8941.92136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 10465.04832
-  tps: 8784.16618
+  dps: 10503.13788
+  tps: 8822.25574
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 10684.23096
-  tps: 8974.97822
+  dps: 10737.418
+  tps: 9028.16526
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10369.51826
-  tps: 8681.67591
+  dps: 10420.40162
+  tps: 8732.55927
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10539.82154
-  tps: 8833.7529
+  dps: 10579.60604
+  tps: 8873.5374
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForgeEmber-37660"
  value: {
-  dps: 10659.73542
-  tps: 8953.35663
+  dps: 10715.93369
+  tps: 9009.55489
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 10695.1043
-  tps: 8941.69021
+  dps: 10742.37656
+  tps: 8988.96246
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 10682.4329
-  tps: 8931.02846
+  dps: 10729.16276
+  tps: 8977.75832
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10377.23619
+  tps: 8697.42833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10515.59893
-  tps: 8814.51109
+  dps: 10557.34865
+  tps: 8856.26081
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 9278.4821
-  tps: 7766.23334
+  dps: 9310.85203
+  tps: 7798.60327
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 10674.99428
-  tps: 8952.62967
+  dps: 10715.31862
+  tps: 8992.95401
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 10707.167
-  tps: 8980.02708
+  dps: 10747.68935
+  tps: 9020.54944
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 10499.48942
-  tps: 8817.97463
+  dps: 10537.60281
+  tps: 8856.08802
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 9648.91637
-  tps: 8011.55264
+  dps: 9686.55964
+  tps: 8049.19591
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 10675.10248
-  tps: 8952.01987
+  dps: 10715.44657
+  tps: 8992.36396
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 10671.47648
-  tps: 8923.45678
+  dps: 10713.8959
+  tps: 8965.8762
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 10665.33364
-  tps: 8917.31395
+  dps: 10709.58908
+  tps: 8961.56938
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IncisorFragment-37723"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10377.23619
+  tps: 8697.42833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 10686.89586
-  tps: 8940.06618
+  dps: 10730.878
+  tps: 8984.04833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 10647.36714
-  tps: 8899.34745
+  dps: 10689.94105
+  tps: 8941.92136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10377.23619
+  tps: 8697.42833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10548.30556
-  tps: 8841.68006
+  dps: 10588.16441
+  tps: 8881.53891
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MaleficRaiment"
  value: {
-  dps: 7295.03361
-  tps: 6017.15387
+  dps: 7327.34761
+  tps: 6049.46788
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 10414.65668
-  tps: 8734.84882
+  dps: 10465.98497
+  tps: 8786.17711
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 10630.03777
-  tps: 8923.96913
+  dps: 10671.06511
+  tps: 8964.99646
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10377.23619
+  tps: 8697.42833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 10647.36714
-  tps: 8899.34745
+  dps: 10689.94105
+  tps: 8941.92136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 10647.36714
-  tps: 8899.34745
+  dps: 10689.94105
+  tps: 8941.92136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10377.23619
+  tps: 8697.42833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10377.23619
+  tps: 8697.42833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10377.23619
+  tps: 8697.42833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PlagueheartGarb"
  value: {
-  dps: 8961.54393
-  tps: 7520.33155
+  dps: 8999.91625
+  tps: 7558.70387
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 10653.56158
-  tps: 8904.87502
+  dps: 10696.15865
+  tps: 8947.47209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 10654.79674
-  tps: 8905.95686
+  dps: 10697.3991
+  tps: 8948.55923
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10377.23619
+  tps: 8697.42833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 10759.25546
-  tps: 9043.66902
+  dps: 10793.95382
+  tps: 9078.3481
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 10799.22718
-  tps: 9078.12002
+  dps: 10855.45365
+  tps: 9134.27566
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 10845.75029
-  tps: 9097.7306
+  dps: 10892.15586
+  tps: 9144.13617
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 10654.98034
-  tps: 8904.35407
+  dps: 10697.30303
+  tps: 8946.67676
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10377.23619
+  tps: 8697.42833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10377.23619
+  tps: 8697.42833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10377.23619
+  tps: 8697.42833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10401.37782
-  tps: 8714.0791
+  dps: 10443.15711
+  tps: 8755.8584
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 10643.77135
-  tps: 8928.00094
+  dps: 10685.92103
+  tps: 8970.15061
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 10673.37231
-  tps: 8954.48054
+  dps: 10715.40018
+  tps: 8996.50841
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10475.22043
-  tps: 8778.39881
+  dps: 10516.81463
+  tps: 8819.99302
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SouloftheDead-40382"
  value: {
-  dps: 10499.42428
-  tps: 8816.6466
+  dps: 10543.02198
+  tps: 8860.2443
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SparkofLife-37657"
  value: {
-  dps: 10523.92904
-  tps: 8835.66417
+  dps: 10567.51914
+  tps: 8879.25426
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 10510.38347
-  tps: 8812.86898
+  dps: 10553.12214
+  tps: 8855.60764
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 10647.36714
-  tps: 8899.34745
+  dps: 10689.94105
+  tps: 8941.92136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 10647.36714
-  tps: 8899.34745
+  dps: 10689.94105
+  tps: 8941.92136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 10647.36714
-  tps: 8899.34745
+  dps: 10689.94105
+  tps: 8941.92136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10433.44636
-  tps: 8743.08127
+  dps: 10474.91997
+  tps: 8784.55488
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10399.71996
-  tps: 8709.92426
+  dps: 10452.19069
+  tps: 8762.39498
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10336.07995
-  tps: 8656.27209
+  dps: 10377.23619
+  tps: 8697.42833
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 10647.36714
-  tps: 8899.34745
+  dps: 10689.94105
+  tps: 8941.92136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 10520.63134
-  tps: 8816.69509
+  dps: 10569.89371
+  tps: 8865.95745
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 10520.63134
-  tps: 8816.69509
+  dps: 10569.89371
+  tps: 8865.95745
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 10695.1043
-  tps: 8941.69021
+  dps: 10742.37656
+  tps: 8988.96246
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 10682.4329
-  tps: 8931.02846
+  dps: 10729.16276
+  tps: 8977.75832
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 10589.249
-  tps: 8893.36011
+  dps: 10630.22769
+  tps: 8934.33879
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 10682.4329
-  tps: 8931.02846
+  dps: 10729.16276
+  tps: 8977.75832
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 10695.1043
-  tps: 8941.69021
+  dps: 10742.37656
+  tps: 8988.96246
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10529.24609
-  tps: 8827.39077
+  dps: 10571.53581
+  tps: 8869.68049
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 10990.42151
-  tps: 9236.50189
+  dps: 11037.59179
+  tps: 9283.67216
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36061.55113
-  tps: 40334.80297
+  dps: 36186.78488
+  tps: 40460.03672
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10872.02947
-  tps: 9124.00978
+  dps: 10918.26664
+  tps: 9170.24695
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12399.03182
-  tps: 10423.42948
+  dps: 12436.88976
+  tps: 10461.28742
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 22167.7774
-  tps: 27449.43916
+  dps: 22250.79301
+  tps: 27532.45476
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6303.3054
-  tps: 5696.72032
+  dps: 6332.04864
+  tps: 5725.46355
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6562.89111
-  tps: 5833.05731
+  dps: 6605.18233
+  tps: 5875.34853
  }
 }
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 10729.90184
-  tps: 9119.19827
+  dps: 10783.18993
+  tps: 9172.48637
  }
 }

--- a/sim/warlock/TestDestruction.results
+++ b/sim/warlock/TestDestruction.results
@@ -46,738 +46,738 @@ character_stats_results: {
 dps_results: {
  key: "TestDestruction-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 11208.46015
-  tps: 9129.47321
+  dps: 10961.53036
+  tps: 8933.07276
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 11248.03927
-  tps: 9162.97969
+  dps: 11000.2265
+  tps: 8965.83745
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 11106.67972
-  tps: 9066.89445
+  dps: 10875.21911
+  tps: 8889.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10886.01755
-  tps: 8856.83434
+  dps: 10646.06461
+  tps: 8666.2805
   hps: 97.7892
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10886.01755
-  tps: 8856.83434
+  dps: 10646.06461
+  tps: 8666.2805
   hps: 97.7892
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 11133.52321
-  tps: 9090.22212
+  dps: 10916.47512
+  tps: 8921.93325
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8656.43739
-  tps: 7026.11459
+  dps: 8435.30532
+  tps: 6852.67208
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 11150.27972
-  tps: 8924.07327
+  dps: 10917.94029
+  tps: 8749.30556
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11462.71624
-  tps: 9386.4201
+  dps: 11230.20203
+  tps: 9204.18378
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
   hps: 64
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 10316.48545
-  tps: 8450.80104
+  dps: 10065.09851
+  tps: 8248.94897
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 11021.27556
-  tps: 8978.28775
+  dps: 10756.54698
+  tps: 8765.43972
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 11103.6655
-  tps: 9060.06521
+  dps: 10864.31248
+  tps: 8865.79539
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 10972.6699
-  tps: 8937.55044
+  dps: 10721.90895
+  tps: 8735.85832
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Death'sChoice-47464"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10929.97568
-  tps: 8896.07179
+  dps: 10678.3713
+  tps: 8695.05534
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DeathbringerGarb"
  value: {
-  dps: 9710.59945
-  tps: 7941.15203
+  dps: 9475.71346
+  tps: 7751.26136
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 11134.30649
-  tps: 9090.46112
+  dps: 10911.09555
+  tps: 8919.32827
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11586.04113
-  tps: 9460.22326
+  dps: 11331.74349
+  tps: 9258.80155
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11529.99565
-  tps: 9411.11552
+  dps: 11279.27372
+  tps: 9213.97901
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 11106.67972
-  tps: 9066.89445
+  dps: 10875.21911
+  tps: 8889.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 11159.13458
-  tps: 9111.10421
+  dps: 10941.91812
+  tps: 8942.73784
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 11133.52321
-  tps: 9089.75617
+  dps: 10916.47512
+  tps: 8921.4703
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 11122.70393
-  tps: 9080.49081
+  dps: 10912.69502
+  tps: 8918.0682
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 11033.83092
-  tps: 8993.07019
+  dps: 10785.72512
+  tps: 8795.65223
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 11106.67972
-  tps: 9066.89445
+  dps: 10875.21911
+  tps: 8889.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 11114.36015
-  tps: 9066.18807
+  dps: 10840.94182
+  tps: 8842.3067
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 11247.9087
-  tps: 9169.72627
+  dps: 10976.74725
+  tps: 8951.40119
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10897.29866
-  tps: 8866.84365
+  dps: 10658.99382
+  tps: 8677.77742
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 11086.12468
-  tps: 9025.91865
+  dps: 10841.92408
+  tps: 8831.81098
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForgeEmber-37660"
  value: {
-  dps: 11151.75912
-  tps: 9086.46708
+  dps: 10881.95967
+  tps: 8869.35176
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 11150.27972
-  tps: 9103.73965
+  dps: 10917.94029
+  tps: 8925.40566
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 11141.55972
-  tps: 9096.37061
+  dps: 10909.39605
+  tps: 8918.17989
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FuturesightRune-38763"
  value: {
-  dps: 11043.8867
-  tps: 8990.29656
+  dps: 10800.77637
+  tps: 8797.13171
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 9405.34988
-  tps: 7663.80341
+  dps: 9197.67923
+  tps: 7503.91576
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 11228.24971
-  tps: 9146.22645
+  dps: 10980.87843
+  tps: 8949.4551
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 11273.22598
-  tps: 9184.30249
+  dps: 11024.85132
+  tps: 8986.68821
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 11039.06835
-  tps: 9005.83891
+  dps: 10788.03561
+  tps: 8800.63225
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 10018.2846
-  tps: 8118.36095
+  dps: 9765.68851
+  tps: 7918.77367
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 11238.40912
-  tps: 9154.50863
+  dps: 10990.77028
+  tps: 8957.51893
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 11133.52321
-  tps: 9089.75617
+  dps: 10916.47512
+  tps: 8921.4703
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 11122.70393
-  tps: 9080.49081
+  dps: 10912.69502
+  tps: 8918.0682
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IncisorFragment-37723"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 11112.02846
-  tps: 9074.75581
+  dps: 10897.05943
+  tps: 8908.11649
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 11106.67972
-  tps: 9066.89445
+  dps: 10875.21911
+  tps: 8889.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 11092.02102
-  tps: 9030.69313
+  dps: 10847.66498
+  tps: 8836.45863
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MaleficRaiment"
  value: {
-  dps: 7551.99983
-  tps: 6070.46014
+  dps: 7343.28827
+  tps: 5891.60211
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 10988.60282
-  tps: 8948.86311
+  dps: 10725.5694
+  tps: 8737.5599
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 11130.4614
-  tps: 9065.86213
+  dps: 10884.3957
+  tps: 8870.11017
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 11106.67972
-  tps: 9066.89445
+  dps: 10875.21911
+  tps: 8889.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 11106.67972
-  tps: 9066.89445
+  dps: 10875.21911
+  tps: 8889.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PlagueheartGarb"
  value: {
-  dps: 9036.59838
-  tps: 7346.53972
+  dps: 8803.0182
+  tps: 7151.71201
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 11106.67972
-  tps: 9066.89445
+  dps: 10875.21911
+  tps: 8889.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 11106.67972
-  tps: 9066.89445
+  dps: 10875.21911
+  tps: 8889.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 11402.32721
-  tps: 9331.00856
+  dps: 11171.33978
+  tps: 9150.18605
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11433.72226
-  tps: 9361.62802
+  dps: 11186.21744
+  tps: 9169.54302
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 11106.67972
-  tps: 9066.5502
+  dps: 10875.21911
+  tps: 8888.93259
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 11170.68008
-  tps: 9101.47443
+  dps: 10924.59312
+  tps: 8905.78204
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 11206.66109
-  tps: 9132.25
+  dps: 10959.77144
+  tps: 8935.88326
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulPreserver-37111"
  value: {
-  dps: 11021.35885
-  tps: 8971.09633
+  dps: 10778.60311
+  tps: 8778.20249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SouloftheDead-40382"
  value: {
-  dps: 11018.90307
-  tps: 8980.81909
+  dps: 10754.66034
+  tps: 8768.40642
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SparkofLife-37657"
  value: {
-  dps: 10952.41004
-  tps: 8922.48591
+  dps: 10715.62196
+  tps: 8732.21055
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 10881.55735
-  tps: 8853.36071
+  dps: 10639.38304
+  tps: 8660.2948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 11106.67972
-  tps: 9066.89445
+  dps: 10875.21911
+  tps: 8889.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 11106.67972
-  tps: 9066.89445
+  dps: 10875.21911
+  tps: 8889.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 11106.67972
-  tps: 9066.89445
+  dps: 10875.21911
+  tps: 8889.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10971.66367
-  tps: 8929.01846
+  dps: 10730.01658
+  tps: 8737.05599
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10923.36592
-  tps: 8889.64662
+  dps: 10677.25215
+  tps: 8693.31927
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10886.43003
-  tps: 8856.88071
+  dps: 10646.68443
+  tps: 8666.51567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 11106.67972
-  tps: 9066.89445
+  dps: 10875.21911
+  tps: 8889.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 10881.55735
-  tps: 8853.36071
+  dps: 10639.38304
+  tps: 8660.2948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 10881.55735
-  tps: 8853.36071
+  dps: 10639.38304
+  tps: 8660.2948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 11150.27972
-  tps: 9103.73965
+  dps: 10917.94029
+  tps: 8925.40566
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 11141.55972
-  tps: 9096.37061
+  dps: 10909.39605
+  tps: 8918.17989
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 11113.00109
-  tps: 9062.19594
+  dps: 10878.33202
+  tps: 8874.60281
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 11141.55972
-  tps: 9096.37061
+  dps: 10909.39605
+  tps: 8918.17989
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 11150.27972
-  tps: 9103.73965
+  dps: 10917.94029
+  tps: 8925.40566
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WingedTalisman-37844"
  value: {
-  dps: 11019.46719
-  tps: 8969.87293
+  dps: 10777.18242
+  tps: 8777.45266
  }
 }
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 11618.02375
-  tps: 9513.53995
+  dps: 11347.11833
+  tps: 9294.33863
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P2-Destruction Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25400.01436
-  tps: 29973.35511
+  dps: 25045.51101
+  tps: 29646.38192
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P2-Destruction Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11462.71624
-  tps: 9386.4201
+  dps: 11230.20203
+  tps: 9204.18378
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P2-Destruction Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13023.40831
-  tps: 10661.00442
+  dps: 12672.34004
+  tps: 10389.78638
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P2-Destruction Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14979.46532
-  tps: 20117.12009
+  dps: 14747.64316
+  tps: 19897.73433
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P2-Destruction Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6438.58318
-  tps: 5449.1427
+  dps: 6252.00838
+  tps: 5293.3348
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P2-Destruction Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6521.27281
-  tps: 5493.45637
+  dps: 6335.39879
+  tps: 5336.68885
  }
 }
 dps_results: {
  key: "TestDestruction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 11462.71624
-  tps: 9386.4201
+  dps: 11230.20203
+  tps: 9204.18378
  }
 }

--- a/sim/warlock/TestDestruction.results
+++ b/sim/warlock/TestDestruction.results
@@ -46,711 +46,711 @@ character_stats_results: {
 dps_results: {
  key: "TestDestruction-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 10961.53036
-  tps: 8933.07276
+  dps: 11208.46015
+  tps: 9129.47321
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 11000.2265
-  tps: 8965.83745
+  dps: 11248.03927
+  tps: 9162.97969
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 11106.67972
+  tps: 9066.89445
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10646.06461
-  tps: 8666.2805
+  dps: 10886.01755
+  tps: 8856.83434
   hps: 97.7892
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10646.06461
-  tps: 8666.2805
+  dps: 10886.01755
+  tps: 8856.83434
   hps: 97.7892
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 10916.47512
-  tps: 8921.93325
+  dps: 11133.52321
+  tps: 9090.22212
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8435.30532
-  tps: 6852.67208
+  dps: 8656.43739
+  tps: 7026.11459
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 10917.94029
-  tps: 8749.30556
+  dps: 11150.27972
+  tps: 8924.07327
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11230.20203
-  tps: 9204.18378
+  dps: 11462.71624
+  tps: 9386.4201
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
   hps: 64
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 10065.09851
-  tps: 8248.94897
+  dps: 10316.48545
+  tps: 8450.80104
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 10756.54698
-  tps: 8765.43972
+  dps: 11021.27556
+  tps: 8978.28775
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 10864.31248
-  tps: 8865.79539
+  dps: 11103.6655
+  tps: 9060.06521
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 10721.90895
-  tps: 8735.85832
+  dps: 10972.6699
+  tps: 8937.55044
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Death'sChoice-47464"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10678.3713
-  tps: 8695.05534
+  dps: 10929.97568
+  tps: 8896.07179
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DeathbringerGarb"
  value: {
-  dps: 9475.71346
-  tps: 7751.26136
+  dps: 9710.59945
+  tps: 7941.15203
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 10911.09555
-  tps: 8919.32827
+  dps: 11134.30649
+  tps: 9090.46112
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11331.74349
-  tps: 9258.80155
+  dps: 11586.04113
+  tps: 9460.22326
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11279.27372
-  tps: 9213.97901
+  dps: 11529.99565
+  tps: 9411.11552
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 11106.67972
+  tps: 9066.89445
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 10941.91812
-  tps: 8942.73784
+  dps: 11159.13458
+  tps: 9111.10421
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 10916.47512
-  tps: 8921.4703
+  dps: 11133.52321
+  tps: 9089.75617
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 10912.69502
-  tps: 8918.0682
+  dps: 11122.70393
+  tps: 9080.49081
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10785.72512
-  tps: 8795.65223
+  dps: 11033.83092
+  tps: 8993.07019
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 11106.67972
+  tps: 9066.89445
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 10840.94182
-  tps: 8842.3067
+  dps: 11114.36015
+  tps: 9066.18807
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 10976.74725
-  tps: 8951.40119
+  dps: 11247.9087
+  tps: 9169.72627
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10658.99382
-  tps: 8677.77742
+  dps: 10897.29866
+  tps: 8866.84365
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10841.92408
-  tps: 8831.81098
+  dps: 11086.12468
+  tps: 9025.91865
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForgeEmber-37660"
  value: {
-  dps: 10881.95967
-  tps: 8869.35176
+  dps: 11151.75912
+  tps: 9086.46708
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 10917.94029
-  tps: 8925.40566
+  dps: 11150.27972
+  tps: 9103.73965
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 10909.39605
-  tps: 8918.17989
+  dps: 11141.55972
+  tps: 9096.37061
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10800.77637
-  tps: 8797.13171
+  dps: 11043.8867
+  tps: 8990.29656
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 9197.67923
-  tps: 7503.91576
+  dps: 9405.34988
+  tps: 7663.80341
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 10980.87843
-  tps: 8949.4551
+  dps: 11228.24971
+  tps: 9146.22645
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 11024.85132
-  tps: 8986.68821
+  dps: 11273.22598
+  tps: 9184.30249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 10788.03561
-  tps: 8800.63225
+  dps: 11039.06835
+  tps: 9005.83891
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 9765.68851
-  tps: 7918.77367
+  dps: 10018.2846
+  tps: 8118.36095
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 10990.77028
-  tps: 8957.51893
+  dps: 11238.40912
+  tps: 9154.50863
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 10916.47512
-  tps: 8921.4703
+  dps: 11133.52321
+  tps: 9089.75617
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 10912.69502
-  tps: 8918.0682
+  dps: 11122.70393
+  tps: 9080.49081
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IncisorFragment-37723"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 10897.05943
-  tps: 8908.11649
+  dps: 11112.02846
+  tps: 9074.75581
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 11106.67972
+  tps: 9066.89445
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10847.66498
-  tps: 8836.45863
+  dps: 11092.02102
+  tps: 9030.69313
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MaleficRaiment"
  value: {
-  dps: 7343.28827
-  tps: 5891.60211
+  dps: 7551.99983
+  tps: 6070.46014
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 10725.5694
-  tps: 8737.5599
+  dps: 10988.60282
+  tps: 8948.86311
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 10884.3957
-  tps: 8870.11017
+  dps: 11130.4614
+  tps: 9065.86213
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 11106.67972
+  tps: 9066.89445
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 11106.67972
+  tps: 9066.89445
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PlagueheartGarb"
  value: {
-  dps: 8803.0182
-  tps: 7151.71201
+  dps: 9036.59838
+  tps: 7346.53972
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 11106.67972
+  tps: 9066.89445
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 11106.67972
+  tps: 9066.89445
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 11171.33978
-  tps: 9150.18605
+  dps: 11402.32721
+  tps: 9331.00856
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11186.21744
-  tps: 9169.54302
+  dps: 11433.72226
+  tps: 9361.62802
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8888.93259
+  dps: 11106.67972
+  tps: 9066.5502
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 10924.59312
-  tps: 8905.78204
+  dps: 11170.68008
+  tps: 9101.47443
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 10959.77144
-  tps: 8935.88326
+  dps: 11206.66109
+  tps: 9132.25
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10778.60311
-  tps: 8778.20249
+  dps: 11021.35885
+  tps: 8971.09633
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SouloftheDead-40382"
  value: {
-  dps: 10754.66034
-  tps: 8768.40642
+  dps: 11018.90307
+  tps: 8980.81909
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SparkofLife-37657"
  value: {
-  dps: 10715.62196
-  tps: 8732.21055
+  dps: 10952.41004
+  tps: 8922.48591
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 10639.38304
-  tps: 8660.2948
+  dps: 10881.55735
+  tps: 8853.36071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 11106.67972
+  tps: 9066.89445
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 11106.67972
+  tps: 9066.89445
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 11106.67972
+  tps: 9066.89445
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10730.01658
-  tps: 8737.05599
+  dps: 10971.66367
+  tps: 8929.01846
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10677.25215
-  tps: 8693.31927
+  dps: 10923.36592
+  tps: 8889.64662
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10886.43003
+  tps: 8856.88071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 11106.67972
+  tps: 9066.89445
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 10639.38304
-  tps: 8660.2948
+  dps: 10881.55735
+  tps: 8853.36071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 10639.38304
-  tps: 8660.2948
+  dps: 10881.55735
+  tps: 8853.36071
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 10917.94029
-  tps: 8925.40566
+  dps: 11150.27972
+  tps: 9103.73965
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 10909.39605
-  tps: 8918.17989
+  dps: 11141.55972
+  tps: 9096.37061
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 10878.33202
-  tps: 8874.60281
+  dps: 11113.00109
+  tps: 9062.19594
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 10909.39605
-  tps: 8918.17989
+  dps: 11141.55972
+  tps: 9096.37061
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 10917.94029
-  tps: 8925.40566
+  dps: 11150.27972
+  tps: 9103.73965
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10777.18242
-  tps: 8777.45266
+  dps: 11019.46719
+  tps: 8969.87293
  }
 }
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 11347.11833
-  tps: 9294.33863
+  dps: 11618.02375
+  tps: 9513.53995
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P2-Destruction Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25350.34702
-  tps: 29951.21793
+  dps: 25400.01436
+  tps: 29973.35511
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P2-Destruction Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11230.20203
-  tps: 9204.18378
+  dps: 11462.71624
+  tps: 9386.4201
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P2-Destruction Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12672.34004
-  tps: 10389.78638
+  dps: 13023.40831
+  tps: 10661.00442
  }
 }
 dps_results: {
@@ -777,7 +777,7 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 11230.20203
-  tps: 9204.18378
+  dps: 11462.71624
+  tps: 9386.4201
  }
 }

--- a/sim/warlock/TestDestruction.results
+++ b/sim/warlock/TestDestruction.results
@@ -46,738 +46,738 @@ character_stats_results: {
 dps_results: {
  key: "TestDestruction-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 10961.53036
-  tps: 8933.07276
+  dps: 11030.07603
+  tps: 8985.82459
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 11000.2265
-  tps: 8965.83745
+  dps: 11069.01906
+  tps: 9018.7932
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 10948.87298
+  tps: 8946.22922
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10646.06461
-  tps: 8666.2805
+  dps: 10712.76449
+  tps: 8717.51714
   hps: 97.7892
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10646.06461
-  tps: 8666.2805
+  dps: 10712.76449
+  tps: 8717.51714
   hps: 97.7892
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 10916.47512
-  tps: 8921.93325
+  dps: 10964.3034
+  tps: 8960.68094
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8435.30532
-  tps: 6852.67208
+  dps: 8508.66524
+  tps: 6916.08595
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 10917.94029
-  tps: 8749.30556
+  dps: 10991.87002
+  tps: 8805.33923
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11230.20203
-  tps: 9204.18378
+  dps: 11281.43323
+  tps: 9246.00851
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
   hps: 64
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 10065.09851
-  tps: 8248.94897
+  dps: 10134.23021
+  tps: 8306.50491
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 10756.54698
-  tps: 8765.43972
+  dps: 10823.07168
+  tps: 8816.51494
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 10864.31248
-  tps: 8865.79539
+  dps: 10936.33705
+  tps: 8923.53966
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 10721.90895
-  tps: 8735.85832
+  dps: 10801.4903
+  tps: 8799.88286
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Death'sChoice-47464"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10678.3713
-  tps: 8695.05534
+  dps: 10750.02366
+  tps: 8750.75669
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DeathbringerGarb"
  value: {
-  dps: 9475.71346
-  tps: 7751.26136
+  dps: 9579.03406
+  tps: 7839.35796
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 10911.09555
-  tps: 8919.32827
+  dps: 10983.79357
+  tps: 8974.04598
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11331.74349
-  tps: 9258.80155
+  dps: 11398.72125
+  tps: 9312.27933
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11279.27372
-  tps: 9213.97901
+  dps: 11346.47571
+  tps: 9267.21569
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 10948.87298
+  tps: 8946.22922
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 10941.91812
-  tps: 8942.73784
+  dps: 11016.41353
+  tps: 9000.40668
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 10916.47512
-  tps: 8921.4703
+  dps: 10964.3034
+  tps: 8960.21799
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 10912.69502
-  tps: 8918.0682
+  dps: 10961.72077
+  tps: 8957.89362
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10785.72512
-  tps: 8795.65223
+  dps: 10861.56439
+  tps: 8857.04489
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 10948.87298
+  tps: 8946.22922
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 10840.94182
-  tps: 8842.3067
+  dps: 10903.27004
+  tps: 8894.48254
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 10976.74725
-  tps: 8951.40119
+  dps: 11044.65337
+  tps: 9003.61162
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10658.99382
-  tps: 8677.77742
+  dps: 10733.9226
+  tps: 8736.00246
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10841.92408
-  tps: 8831.81098
+  dps: 10909.70668
+  tps: 8883.93253
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForgeEmber-37660"
  value: {
-  dps: 10881.95967
-  tps: 8869.35176
+  dps: 10955.5869
+  tps: 8926.67379
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 10917.94029
-  tps: 8925.40566
+  dps: 10991.87002
+  tps: 8982.58247
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 10909.39605
-  tps: 8918.17989
+  dps: 10983.27061
+  tps: 8975.31182
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10800.77637
-  tps: 8797.13171
+  dps: 10868.31757
+  tps: 8849.0406
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 9197.67923
-  tps: 7503.91576
+  dps: 9256.7659
+  tps: 7549.83148
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 10980.87843
-  tps: 8949.4551
+  dps: 11049.54755
+  tps: 9002.30889
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 11024.85132
-  tps: 8986.68821
+  dps: 11093.80099
+  tps: 9039.77372
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 10788.03561
-  tps: 8800.63225
+  dps: 10851.1186
+  tps: 8852.79577
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 9765.68851
-  tps: 7918.77367
+  dps: 9832.44677
+  tps: 7969.82771
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 10990.77028
-  tps: 8957.51893
+  dps: 11059.5131
+  tps: 9010.43075
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 10916.47512
-  tps: 8921.4703
+  dps: 10964.3034
+  tps: 8960.21799
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 10912.69502
-  tps: 8918.0682
+  dps: 10961.72077
+  tps: 8957.89362
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IncisorFragment-37723"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 10897.05943
-  tps: 8908.11649
+  dps: 10971.50229
+  tps: 8965.93206
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 10948.87298
+  tps: 8946.22922
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10847.66498
-  tps: 8836.45863
+  dps: 10915.49038
+  tps: 8888.61388
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MaleficRaiment"
  value: {
-  dps: 7343.28827
-  tps: 5891.60211
+  dps: 7376.61255
+  tps: 5919.49319
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 10725.5694
-  tps: 8737.5599
+  dps: 10795.38305
+  tps: 8791.58014
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 10884.3957
-  tps: 8870.11017
+  dps: 10949.72677
+  tps: 8920.02536
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 10948.87298
+  tps: 8946.22922
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 10948.87298
+  tps: 8946.22922
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PlagueheartGarb"
  value: {
-  dps: 8803.0182
-  tps: 7151.71201
+  dps: 8852.53254
+  tps: 7192.55138
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 10948.87298
+  tps: 8946.22922
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 10948.87298
+  tps: 8946.22922
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 11171.33978
-  tps: 9150.18605
+  dps: 11222.1622
+  tps: 9191.62408
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11186.21744
-  tps: 9169.54302
+  dps: 11264.71023
+  tps: 9230.85088
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8888.93259
+  dps: 10948.87298
+  tps: 8945.88497
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 10924.59312
-  tps: 8905.78204
+  dps: 10992.90314
+  tps: 8958.33923
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 10959.77144
-  tps: 8935.88326
+  dps: 11028.3059
+  tps: 8988.62582
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10778.60311
-  tps: 8778.20249
+  dps: 10845.98172
+  tps: 8829.99037
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SouloftheDead-40382"
  value: {
-  dps: 10754.66034
-  tps: 8768.40642
+  dps: 10819.7547
+  tps: 8818.18624
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SparkofLife-37657"
  value: {
-  dps: 10715.62196
-  tps: 8732.21055
+  dps: 10781.30821
+  tps: 8785.60923
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 10639.38304
-  tps: 8660.2948
+  dps: 10703.32083
+  tps: 8709.63427
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 10948.87298
+  tps: 8946.22922
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 10948.87298
+  tps: 8946.22922
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 10948.87298
+  tps: 8946.22922
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10730.01658
-  tps: 8737.05599
+  dps: 10797.08521
+  tps: 8788.58784
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10677.25215
-  tps: 8693.31927
+  dps: 10750.52148
+  tps: 8751.09912
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10646.68443
-  tps: 8666.51567
+  dps: 10713.2214
+  tps: 8717.60839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 10875.21911
-  tps: 8889.27684
+  dps: 10948.87298
+  tps: 8946.22922
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 10639.38304
-  tps: 8660.2948
+  dps: 10703.32083
+  tps: 8709.63427
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 10639.38304
-  tps: 8660.2948
+  dps: 10703.32083
+  tps: 8709.63427
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 10917.94029
-  tps: 8925.40566
+  dps: 10991.87002
+  tps: 8982.58247
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 10909.39605
-  tps: 8918.17989
+  dps: 10983.27061
+  tps: 8975.31182
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 10878.33202
-  tps: 8874.60281
+  dps: 10942.04748
+  tps: 8925.36299
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 10909.39605
-  tps: 8918.17989
+  dps: 10983.27061
+  tps: 8975.31182
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 10917.94029
-  tps: 8925.40566
+  dps: 10991.87002
+  tps: 8982.58247
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10777.18242
-  tps: 8777.45266
+  dps: 10844.61319
+  tps: 8829.24513
  }
 }
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 11347.11833
-  tps: 9294.33863
+  dps: 11428.72268
+  tps: 9360.87835
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P2-Destruction Warlock-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25045.51101
-  tps: 29646.38192
+  dps: 25148.41254
+  tps: 29741.12806
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P2-Destruction Warlock-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11230.20203
-  tps: 9204.18378
+  dps: 11281.43323
+  tps: 9246.00851
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P2-Destruction Warlock-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12672.34004
-  tps: 10389.78638
+  dps: 12760.86525
+  tps: 10462.45223
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P2-Destruction Warlock-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14747.64316
-  tps: 19897.73433
+  dps: 14813.02056
+  tps: 19960.30367
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P2-Destruction Warlock-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6252.00838
-  tps: 5293.3348
+  dps: 6304.95062
+  tps: 5337.64562
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-P2-Destruction Warlock-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6335.39879
-  tps: 5336.68885
+  dps: 6368.62973
+  tps: 5364.44408
  }
 }
 dps_results: {
  key: "TestDestruction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 11230.20203
-  tps: 9204.18378
+  dps: 11281.43323
+  tps: 9246.00851
  }
 }

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -67,8 +67,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7954.65643
-  tps: 6529.98852
+  dps: 7953.74227
+  tps: 6529.25719
  }
 }
 dps_results: {
@@ -196,8 +196,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7912.10221
-  tps: 6501.43503
+  dps: 7911.1488
+  tps: 6500.6723
  }
 }
 dps_results: {
@@ -329,8 +329,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7912.31948
-  tps: 6502.05211
+  dps: 7911.65664
+  tps: 6501.52184
  }
 }
 dps_results: {
@@ -413,8 +413,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7890.67838
-  tps: 6484.24404
+  dps: 7890.00442
+  tps: 6483.70487
  }
 }
 dps_results: {
@@ -715,8 +715,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-StormshroudArmor"
  value: {
-  dps: 6283.86224
-  tps: 5164.02999
+  dps: 6283.84748
+  tps: 5164.01818
  }
 }
 dps_results: {
@@ -757,8 +757,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-TheFistsofFury"
  value: {
-  dps: 4698.98789
-  tps: 3950.71423
+  dps: 4698.67439
+  tps: 3950.46343
  }
 }
 dps_results: {

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -67,8 +67,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7953.74227
-  tps: 6529.25719
+  dps: 7954.65643
+  tps: 6529.98852
  }
 }
 dps_results: {
@@ -196,8 +196,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7911.1488
-  tps: 6500.6723
+  dps: 7912.10221
+  tps: 6501.43503
  }
 }
 dps_results: {
@@ -329,8 +329,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7911.65664
-  tps: 6501.52184
+  dps: 7912.31948
+  tps: 6502.05211
  }
 }
 dps_results: {
@@ -413,8 +413,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7890.00442
-  tps: 6483.70487
+  dps: 7890.67838
+  tps: 6484.24404
  }
 }
 dps_results: {
@@ -715,8 +715,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-StormshroudArmor"
  value: {
-  dps: 6283.84748
-  tps: 5164.01818
+  dps: 6283.86224
+  tps: 5164.02999
  }
 }
 dps_results: {
@@ -757,8 +757,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-TheFistsofFury"
  value: {
-  dps: 4698.67439
-  tps: 3950.46343
+  dps: 4698.98789
+  tps: 3950.71423
  }
 }
 dps_results: {

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -67,8 +67,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7953.74227
-  tps: 6529.25719
+  dps: 7953.93663
+  tps: 6529.41268
  }
 }
 dps_results: {
@@ -196,8 +196,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7911.1488
-  tps: 6500.6723
+  dps: 7911.69793
+  tps: 6501.11161
  }
 }
 dps_results: {
@@ -329,8 +329,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7911.65664
-  tps: 6501.52184
+  dps: 7912.04401
+  tps: 6501.83174
  }
 }
 dps_results: {
@@ -413,8 +413,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7890.00442
-  tps: 6483.70487
+  dps: 7890.33517
+  tps: 6483.96947
  }
 }
 dps_results: {
@@ -715,8 +715,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-StormshroudArmor"
  value: {
-  dps: 6283.84748
-  tps: 5164.01818
+  dps: 6283.8491
+  tps: 5164.01948
  }
 }
 dps_results: {
@@ -757,8 +757,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-TheFistsofFury"
  value: {
-  dps: 4698.67439
-  tps: 3950.46343
+  dps: 4698.76059
+  tps: 3950.53239
  }
 }
 dps_results: {

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -67,8 +67,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6729.11788
-  tps: 4972.78975
+  dps: 6728.20373
+  tps: 4972.13082
  }
 }
 dps_results: {
@@ -196,8 +196,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6703.80991
-  tps: 4955.35226
+  dps: 6702.85649
+  tps: 4954.68487
  }
 }
 dps_results: {
@@ -329,8 +329,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6704.43093
-  tps: 4956.08138
+  dps: 6703.76809
+  tps: 4955.6
  }
 }
 dps_results: {
@@ -413,8 +413,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6680.37342
-  tps: 4938.59026
+  dps: 6679.69946
+  tps: 4938.10094
  }
 }
 dps_results: {
@@ -715,8 +715,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-StormshroudArmor"
  value: {
-  dps: 5026.99008
-  tps: 3728.69266
+  dps: 5026.97531
+  tps: 3728.68217
  }
 }
 dps_results: {
@@ -757,8 +757,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 5014.29135
-  tps: 3714.91236
+  dps: 5013.95542
+  tps: 3714.67361
  }
 }
 dps_results: {

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -67,8 +67,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6728.20373
-  tps: 4972.13082
+  dps: 6729.11788
+  tps: 4972.78975
  }
 }
 dps_results: {
@@ -196,8 +196,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6702.85649
-  tps: 4954.68487
+  dps: 6703.80991
+  tps: 4955.35226
  }
 }
 dps_results: {
@@ -329,8 +329,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6703.76809
-  tps: 4955.6
+  dps: 6704.43093
+  tps: 4956.08138
  }
 }
 dps_results: {
@@ -413,8 +413,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6679.69946
-  tps: 4938.10094
+  dps: 6680.37342
+  tps: 4938.59026
  }
 }
 dps_results: {
@@ -715,8 +715,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-StormshroudArmor"
  value: {
-  dps: 5026.97531
-  tps: 3728.68217
+  dps: 5026.99008
+  tps: 3728.69266
  }
 }
 dps_results: {
@@ -757,8 +757,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 5013.95542
-  tps: 3714.67361
+  dps: 5014.29135
+  tps: 3714.91236
  }
 }
 dps_results: {

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -67,8 +67,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6728.20373
-  tps: 4972.13082
+  dps: 6728.39808
+  tps: 4972.26687
  }
 }
 dps_results: {
@@ -196,8 +196,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6702.85649
-  tps: 4954.68487
+  dps: 6703.40562
+  tps: 4955.06926
  }
 }
 dps_results: {
@@ -329,8 +329,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6703.76809
-  tps: 4955.6
+  dps: 6704.15547
+  tps: 4955.88079
  }
 }
 dps_results: {
@@ -413,8 +413,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6679.69946
-  tps: 4938.10094
+  dps: 6680.03022
+  tps: 4938.33247
  }
 }
 dps_results: {
@@ -715,8 +715,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-StormshroudArmor"
  value: {
-  dps: 5026.97531
-  tps: 3728.68217
+  dps: 5026.97693
+  tps: 3728.68346
  }
 }
 dps_results: {
@@ -757,8 +757,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 5013.95542
-  tps: 3714.67361
+  dps: 5014.05187
+  tps: 3714.74112
  }
 }
 dps_results: {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -112,8 +112,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1668.17341
-  tps: 4295.8649
+  dps: 1668.84405
+  tps: 4297.25547
  }
 }
 dps_results: {
@@ -241,8 +241,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1686.46615
-  tps: 4339.71103
+  dps: 1686.65934
+  tps: 4340.11162
  }
 }
 dps_results: {
@@ -367,8 +367,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1667.87542
-  tps: 4299.65824
+  dps: 1668.16351
+  tps: 4300.25559
  }
 }
 dps_results: {
@@ -753,8 +753,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormshroudArmor"
  value: {
-  dps: 1252.46024
-  tps: 3268.34029
+  dps: 1252.46799
+  tps: 3268.35635
  }
 }
 dps_results: {
@@ -795,8 +795,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 1140.112
-  tps: 2623.09015
+  dps: 1140.21151
+  tps: 2623.29648
  }
 }
 dps_results: {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -112,8 +112,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1668.84405
-  tps: 4297.25547
+  dps: 1668.17341
+  tps: 4295.8649
  }
 }
 dps_results: {
@@ -241,8 +241,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1686.65934
-  tps: 4340.11162
+  dps: 1686.46615
+  tps: 4339.71103
  }
 }
 dps_results: {
@@ -367,8 +367,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1668.16351
-  tps: 4300.25559
+  dps: 1667.87542
+  tps: 4299.65824
  }
 }
 dps_results: {
@@ -753,8 +753,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormshroudArmor"
  value: {
-  dps: 1252.46799
-  tps: 3268.35635
+  dps: 1252.46024
+  tps: 3268.34029
  }
 }
 dps_results: {
@@ -795,8 +795,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 1140.21151
-  tps: 2623.29648
+  dps: 1140.112
+  tps: 2623.09015
  }
 }
 dps_results: {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -112,8 +112,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1668.17341
-  tps: 4295.8649
+  dps: 1668.32233
+  tps: 4296.17369
  }
 }
 dps_results: {
@@ -753,8 +753,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormshroudArmor"
  value: {
-  dps: 1252.46024
-  tps: 3268.34029
+  dps: 1252.46659
+  tps: 3268.35344
  }
 }
 dps_results: {
@@ -795,8 +795,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 1140.112
-  tps: 2623.09015
+  dps: 1140.15775
+  tps: 2623.185
  }
 }
 dps_results: {

--- a/ui/core/components/character_stats.tsx
+++ b/ui/core/components/character_stats.tsx
@@ -216,12 +216,11 @@ export class CharacterStats extends Component {
 			debuffStats = debuffStats.addStat(Stat.StatSpellHit, 3 * Mechanics.SPELL_HIT_RATING_PER_HIT_CHANCE);
 		}
 		if (debuffs.totemOfWrath || debuffs.heartOfTheCrusader || debuffs.masterPoisoner) {
+			debuffStats = debuffStats.addStat(Stat.StatSpellCrit, 3 * Mechanics.SPELL_CRIT_RATING_PER_CRIT_CHANCE);
 			debuffStats = debuffStats.addStat(Stat.StatMeleeCrit, 3 * Mechanics.MELEE_CRIT_RATING_PER_CRIT_CHANCE);
 		}
 		if (debuffs.improvedScorch || debuffs.wintersChill || debuffs.shadowMastery) {
 			debuffStats = debuffStats.addStat(Stat.StatSpellCrit, 5 * Mechanics.SPELL_CRIT_RATING_PER_CRIT_CHANCE);
-		} else if (debuffs.totemOfWrath || debuffs.heartOfTheCrusader || debuffs.masterPoisoner) {
-			debuffStats = debuffStats.addStat(Stat.StatSpellCrit, 3 * Mechanics.SPELL_CRIT_RATING_PER_CRIT_CHANCE);
 		}
 
 		return debuffStats;


### PR DESCRIPTION
Follow up to: https://github.com/wowsims/wotlk/pull/3736

Blizzard confirmed the debuffs do stack: 
![image](https://github.com/wowsims/wotlk/assets/9436142/df88c633-9273-4f19-b587-8764c7294db9)

Further tests confirmed that spell crit suppression is:
- 2.1% against 83
- 0.3% against 82
- Unsure against 81 (doesn't matter too much honestly)