### PR TITLE
vigo/more-dk-refactoring

### DIFF
--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -108,12 +108,6 @@ func (spell *Spell) makeCastFunc(config CastConfig) CastSuccessFunc {
 		if config.CD.Timer != nil {
 			// By panicking if spell is on CD, we force each sim to properly check for their own CDs.
 			if !spell.CD.IsReady(sim) {
-				if spell.Unit.PseudoStats.GracefulCastCDFailures {
-					if sim.Log != nil {
-						sim.Log("Failed cast because of CD")
-					}
-					return false
-				}
 				panic(fmt.Sprintf("Trying to cast %s but is still on cooldown for %s, curTime = %s", spell.ActionID, spell.CD.TimeToReady(sim), sim.CurrentTime))
 			}
 			spell.CD.Set(sim.CurrentTime + spell.CurCast.CastTime + spell.CD.Duration)
@@ -122,12 +116,6 @@ func (spell *Spell) makeCastFunc(config CastConfig) CastSuccessFunc {
 		if config.SharedCD.Timer != nil {
 			// By panicking if spell is on CD, we force each sim to properly check for their own CDs.
 			if !spell.SharedCD.IsReady(sim) {
-				if spell.Unit.PseudoStats.GracefulCastCDFailures {
-					if sim.Log != nil {
-						sim.Log("Failed cast because of SharedCD")
-					}
-					return false
-				}
 				panic(fmt.Sprintf("Trying to cast %s but is still on shared cooldown for %s, curTime = %s", spell.ActionID, spell.SharedCD.TimeToReady(sim), sim.CurrentTime))
 			}
 			spell.SharedCD.Set(sim.CurrentTime + spell.CurCast.CastTime + spell.SharedCD.Duration)
@@ -221,12 +209,6 @@ func (spell *Spell) makeCastFuncSimple() CastSuccessFunc {
 		if spell.CD.Timer != nil {
 			// By panicking if spell is on CD, we force each sim to properly check for their own CDs.
 			if !spell.CD.IsReady(sim) {
-				if spell.Unit.PseudoStats.GracefulCastCDFailures {
-					if sim.Log != nil {
-						sim.Log("Failed cast because of CD")
-					}
-					return false
-				}
 				panic(fmt.Sprintf("Trying to cast %s but is still on cooldown for %s, curTime = %s", spell.ActionID, spell.CD.TimeToReady(sim), sim.CurrentTime))
 			}
 
@@ -236,12 +218,6 @@ func (spell *Spell) makeCastFuncSimple() CastSuccessFunc {
 		if spell.SharedCD.Timer != nil {
 			// By panicking if spell is on CD, we force each sim to properly check for their own CDs.
 			if !spell.SharedCD.IsReady(sim) {
-				if spell.Unit.PseudoStats.GracefulCastCDFailures {
-					if sim.Log != nil {
-						sim.Log("Failed cast because of SharedCD")
-					}
-					return false
-				}
 				panic(fmt.Sprintf("Trying to cast %s but is still on shared cooldown for %s, curTime = %s", spell.ActionID, spell.SharedCD.TimeToReady(sim), sim.CurrentTime))
 			}
 

--- a/sim/core/rage.go
+++ b/sim/core/rage.go
@@ -46,26 +46,17 @@ func (unit *Unit) EnableRageBar(options RageBarOptions, onRageGain OnRageGain) {
 			if result.Outcome.Matches(OutcomeMiss) {
 				return
 			}
-			if !spell.ProcMask.Matches(ProcMaskMelee) {
-				return
-			}
-			if !spell.ProcMask.Matches(ProcMaskWhiteHit) {
-				return
-			}
-
-			// Need separate check to exclude auto replacers (e.g. Heroic Strike and Cleave).
-			if spell.ProcMask.Matches(ProcMaskMeleeMHSpecial) {
-				return
-			}
 
 			var hitFactor float64
 			var speed float64
-			if spell.IsMH() {
+			if spell.ProcMask == ProcMaskMeleeMHAuto {
 				hitFactor = 3.5
 				speed = options.MHSwingSpeed
-			} else {
+			} else if spell.ProcMask == ProcMaskMeleeOHAuto {
 				hitFactor = 1.75
 				speed = options.OHSwingSpeed
+			} else {
+				return
 			}
 
 			if result.Outcome.Matches(OutcomeCrit) {
@@ -162,7 +153,7 @@ func (rb *rageBar) SpendRage(sim *Simulation, amount float64, metrics *ResourceM
 	rb.currentRage = newRage
 }
 
-func (rb *rageBar) reset(sim *Simulation) {
+func (rb *rageBar) reset(_ *Simulation) {
 	if rb.unit == nil {
 		return
 	}

--- a/sim/core/stats/stats.go
+++ b/sim/core/stats/stats.go
@@ -296,8 +296,6 @@ type PseudoStats struct {
 	CostMultiplier float64 // Multiplies spell cost.
 	CostReduction  float64 // Reduces spell cost.
 
-	GracefulCastCDFailures bool
-
 	CastSpeedMultiplier   float64
 	MeleeSpeedMultiplier  float64
 	RangedSpeedMultiplier float64

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -104,7 +104,7 @@ type Unit struct {
 	rageBar
 	energyBar
 	focusBar
-	RunicPowerBar
+	runicPowerBar
 
 	// All spells that can be cast by this unit.
 	Spellbook                 []*Spell
@@ -469,7 +469,7 @@ func (unit *Unit) reset(sim *Simulation, _ Agent) {
 
 	unit.energyBar.reset(sim)
 	unit.rageBar.reset(sim)
-	unit.RunicPowerBar.reset(sim)
+	unit.runicPowerBar.reset(sim)
 
 	unit.AutoAttacks.reset(sim)
 

--- a/sim/deathknight/blood_tap.go
+++ b/sim/deathknight/blood_tap.go
@@ -17,7 +17,7 @@ func (dk *Deathknight) registerBloodTapSpell() {
 		ActionID: actionID,
 		Duration: time.Second * 20,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			dk.CorrectBloodTapConversion(sim)
+			dk.BloodTapConversion(sim)
 
 			// Gain at the end, to take into account previous effects for callback
 			amountOfRunicPower := 10.0

--- a/sim/deathknight/deathknight.go
+++ b/sim/deathknight/deathknight.go
@@ -70,8 +70,8 @@ type Deathknight struct {
 
 	bonusCoeffs DeathknightCoeffs
 
-	onRuneSpendT10          core.OnRune
-	onRuneSpendBladeBarrier core.OnRune
+	onRuneSpendT10          core.OnRuneChange
+	onRuneSpendBladeBarrier core.OnRuneChange
 
 	Inputs DeathknightInputs
 
@@ -423,24 +423,15 @@ func NewDeathknight(character core.Character, inputs DeathknightInputs, talents 
 		currentRunicPower,
 		maxRunicPower,
 		10*time.Second,
-		func(sim *core.Simulation) {
+		func(sim *core.Simulation, changeType core.RuneChangeType) {
 			if dk.onRuneSpendT10 != nil {
-				dk.onRuneSpendT10(sim)
+				dk.onRuneSpendT10(sim, changeType)
 			}
 			if dk.onRuneSpendBladeBarrier != nil {
-				dk.onRuneSpendBladeBarrier(sim)
+				dk.onRuneSpendBladeBarrier(sim, changeType)
 			}
 		},
-		func(sim *core.Simulation) {
-		},
-		func(sim *core.Simulation) {
-		},
-		func(sim *core.Simulation) {
-		},
-		func(sim *core.Simulation) {
-		},
-		func(sim *core.Simulation) {
-		},
+		nil,
 	)
 
 	dk.AddStatDependency(stats.Agility, stats.MeleeCrit, core.CritPerAgiMaxLevel[character.Class]*core.CritRatingPerCritChance)
@@ -450,7 +441,6 @@ func NewDeathknight(character core.Character, inputs DeathknightInputs, talents 
 	dk.AddStatDependency(stats.BonusArmor, stats.Armor, 1)
 
 	dk.PseudoStats.CanParry = true
-	dk.PseudoStats.GracefulCastCDFailures = true
 
 	// Base dodge unaffected by Diminishing Returns
 	dk.PseudoStats.BaseDodge += 0.03664

--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -596,8 +596,8 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7680.78842
-  tps: 3867.18911
+  dps: 7684.98105
+  tps: 3869.55379
  }
 }
 dps_results: {

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -631,8 +631,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8431.71541
-  tps: 4942.4876
+  dps: 8434.6511
+  tps: 4944.24901
  }
 }
 dps_results: {

--- a/sim/deathknight/dps/TestFrostUH.results
+++ b/sim/deathknight/dps/TestFrostUH.results
@@ -631,8 +631,8 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 8496.26328
-  tps: 6063.04911
+  dps: 8496.30758
+  tps: 6063.08171
  }
 }
 dps_results: {

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -694,8 +694,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 7950.8625
-  tps: 5295.51975
+  dps: 7951.04048
+  tps: 5295.69983
   hps: 297.77471
  }
 }

--- a/sim/deathknight/dps/rotation_blood_helper.go
+++ b/sim/deathknight/dps/rotation_blood_helper.go
@@ -75,10 +75,10 @@ func (dk *DpsDeathknight) blDiseaseCheck(sim *core.Simulation, target *core.Unit
 			return false
 		}
 
-		crpb := dk.CopyRunicPowerBar()
-		spellCost := crpb.OptimalRuneCost(core.RuneCost(spell.DefaultCast.Cost))
+		spellCost := dk.OptimalRuneCost(core.RuneCost(spell.DefaultCast.Cost))
 
-		crpb.SpendRuneCost(sim, spell, spellCost)
+		crpb := dk.Predictor()
+		crpb.SpendRuneCost(sim, spellCost)
 
 		if dk.sr.hasGod {
 			currentBloodRunes := crpb.CurrentBloodRunes()

--- a/sim/deathknight/dps/rotation_frost.go
+++ b/sim/deathknight/dps/rotation_frost.go
@@ -40,7 +40,7 @@ func (fr *FrostRotation) Initialize(dk *DpsDeathknight) {
 	}
 }
 
-func (fr *FrostRotation) Reset(sim *core.Simulation) {
+func (fr *FrostRotation) Reset(_ *core.Simulation) {
 	fr.oblitCount = 0
 
 	fr.hyperSpeedMCD = nil
@@ -151,7 +151,7 @@ func (dk *DpsDeathknight) castAllMajorCooldowns(sim *core.Simulation) {
 
 func (dk *DpsDeathknight) RotationActionCallback_UA_Frost(sim *core.Simulation, target *core.Unit, s *deathknight.Sequence) time.Duration {
 	if dk.UnbreakableArmor != nil {
-		if !dk.LeftBloodRuneReady() {
+		if !dk.LeftBloodRuneReady() && dk.BloodTap.CanCast(sim, nil) {
 			dk.BloodTap.Cast(sim, nil)
 		}
 		casted := dk.UnbreakableArmor.Cast(sim, target)

--- a/sim/deathknight/dps/rotation_shared_helper.go
+++ b/sim/deathknight/dps/rotation_shared_helper.go
@@ -17,7 +17,7 @@ type SharedRotation struct {
 	hasGod  bool
 }
 
-func (sr *SharedRotation) Reset(sim *core.Simulation) {
+func (sr *SharedRotation) Reset(_ *core.Simulation) {
 	sr.recastedFF = false
 	sr.recastedBP = false
 }
@@ -47,10 +47,10 @@ func (dk *DpsDeathknight) shDiseaseCheck(sim *core.Simulation, target *core.Unit
 		ffExpiresAt := ffRemaining + sim.CurrentTime
 		bpExpiresAt := bpRemaining + sim.CurrentTime
 
-		crpb := dk.CopyRunicPowerBar()
-		spellCost := crpb.OptimalRuneCost(core.RuneCost(spell.DefaultCast.Cost))
+		spellCost := dk.OptimalRuneCost(core.RuneCost(spell.DefaultCast.Cost))
 
-		crpb.SpendRuneCost(sim, spell, spellCost)
+		crpb := dk.Predictor()
+		crpb.SpendRuneCost(sim, spellCost)
 
 		afterCastTime := sim.CurrentTime + castGcd
 		currentFrostRunes := crpb.CurrentFrostRunes()
@@ -86,7 +86,7 @@ func (dk *DpsDeathknight) shRecastAvailableCheck(expiresAt time.Duration, afterC
 	return false
 }
 
-func (dk *DpsDeathknight) shShouldSpreadDisease(sim *core.Simulation) bool {
+func (dk *DpsDeathknight) shShouldSpreadDisease(_ *core.Simulation) bool {
 	prioritizeSpread := dk.Env.GetNumTargets() > 1
 
 	// on 2 or 3 targets, we don't want to spread if we have diseases up on all targets already (to maximize Desolation uptime)
@@ -104,7 +104,7 @@ func (dk *DpsDeathknight) shShouldSpreadDisease(sim *core.Simulation) bool {
 	return dk.sr.recastedFF && dk.sr.recastedBP && prioritizeSpread
 }
 
-func (dk *DpsDeathknight) RotationAction_CancelBT(sim *core.Simulation, target *core.Unit, s *deathknight.Sequence) time.Duration {
+func (dk *DpsDeathknight) RotationAction_CancelBT(sim *core.Simulation, _ *core.Unit, s *deathknight.Sequence) time.Duration {
 	dk.BloodTapAura.Deactivate(sim)
 	s.Advance()
 	return sim.CurrentTime

--- a/sim/deathknight/dps/rotation_unholy.go
+++ b/sim/deathknight/dps/rotation_unholy.go
@@ -153,7 +153,9 @@ func (dk *DpsDeathknight) RotationActionCallback_UnholyDndRotation(sim *core.Sim
 				dk.uhAfterGargoyleSequence(sim)
 				return sim.CurrentTime
 			}
-			cast = dk.DeathAndDecay.Cast(sim, target)
+			if cast = dk.DeathAndDecay.CanCast(sim, target); cast {
+				dk.DeathAndDecay.Cast(sim, target)
+			}
 		}
 	} else {
 		if dk.uhGargoyleCheck(sim, target, dk.SpellGCD()+core.GCDDefault+50*time.Millisecond) {
@@ -388,14 +390,14 @@ func (dk *DpsDeathknight) uhAfterGargoyleSequence(sim *core.Simulation) {
 	}
 }
 
-func (dk *DpsDeathknight) RotationActionCallback_Haste_Snapshot(sim *core.Simulation, target *core.Unit, s *deathknight.Sequence) time.Duration {
+func (dk *DpsDeathknight) RotationActionCallback_Haste_Snapshot(sim *core.Simulation, _ *core.Unit, s *deathknight.Sequence) time.Duration {
 	dk.ur.gargoyleSnapshot.ActivateMajorCooldowns(sim)
 	dk.UpdateMajorCooldowns()
 	s.Advance()
 	return sim.CurrentTime
 }
 
-func (dk *DpsDeathknight) uhGhoulFrenzySequence(sim *core.Simulation, bloodTap bool) {
+func (dk *DpsDeathknight) uhGhoulFrenzySequence(_ *core.Simulation, bloodTap bool) {
 	if bloodTap {
 		dk.RotationSequence.Clear().
 			NewAction(dk.RotationActionCallback_BT).
@@ -422,7 +424,7 @@ func (dk *DpsDeathknight) uhGhoulFrenzySequence(sim *core.Simulation, bloodTap b
 	}
 }
 
-func (dk *DpsDeathknight) uhRecastDiseasesSequence(sim *core.Simulation) {
+func (dk *DpsDeathknight) uhRecastDiseasesSequence(_ *core.Simulation) {
 	dk.RotationSequence.Clear()
 
 	// If we have glyph of Disease and both dots active try to refresh with pesti
@@ -577,13 +579,13 @@ func (dk *DpsDeathknight) RotationActionCallback_Pesti_Custom(sim *core.Simulati
 	}
 }
 
-func (dk *DpsDeathknight) RotationActionUH_ResetToSsMain(sim *core.Simulation, target *core.Unit, s *deathknight.Sequence) time.Duration {
+func (dk *DpsDeathknight) RotationActionUH_ResetToSsMain(sim *core.Simulation, _ *core.Unit, _ *deathknight.Sequence) time.Duration {
 	dk.RotationSequence.Clear().
 		NewAction(dk.RotationActionCallback_UnholySsRotation)
 	return sim.CurrentTime
 }
 
-func (dk *DpsDeathknight) RotationActionUH_ResetToDndMain(sim *core.Simulation, target *core.Unit, s *deathknight.Sequence) time.Duration {
+func (dk *DpsDeathknight) RotationActionUH_ResetToDndMain(sim *core.Simulation, _ *core.Unit, _ *deathknight.Sequence) time.Duration {
 	dk.RotationSequence.Clear().
 		NewAction(dk.RotationActionCallback_UnholyDndRotation)
 	return sim.CurrentTime

--- a/sim/deathknight/items.go
+++ b/sim/deathknight/items.go
@@ -220,8 +220,8 @@ func (dk *Deathknight) registerScourgelordsBattlegearProc() {
 		},
 	})
 
-	dk.onRuneSpendT10 = func(sim *core.Simulation) {
-		if dk.AllRunesSpent() {
+	dk.onRuneSpendT10 = func(sim *core.Simulation, changeType core.RuneChangeType) {
+		if changeType.Matches(core.SpendRune) && dk.AllRunesSpent() {
 			damageAura.Activate(sim)
 		}
 	}

--- a/sim/deathknight/talents_blood.go
+++ b/sim/deathknight/talents_blood.go
@@ -232,8 +232,8 @@ func (dk *Deathknight) applyBladeBarrier() {
 		},
 	})
 
-	dk.onRuneSpendBladeBarrier = func(sim *core.Simulation) {
-		if dk.CurrentBloodRunes() == 0 {
+	dk.onRuneSpendBladeBarrier = func(sim *core.Simulation, changeType core.RuneChangeType) {
+		if changeType.Matches(core.SpendRune) && dk.CurrentBloodRunes() == 0 {
 			dk.BladeBarrierAura.Activate(sim)
 		}
 	}

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -596,8 +596,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 2545.69883
-  tps: 7934.83741
+  dps: 2550.61832
+  tps: 7948.25554
  }
 }
 dps_results: {


### PR DESCRIPTION
[core] drive-by: make RageBar's OnSpellHit() slightly more efficient

[core] GracefulCastCDFailures pseudostat removed... 
[dk] ... rotations changed to check CDs before casting 

[dk/core] replace CopyRunicPowerBar() with a light-weight Predictor class, so there's no more gating on "isACopy" in RunicPowerBar 
[dk/core] remove RuneMeta.lastSpendTime
[dk/core] more RunicPowerBar cleanup
[dk/core] replace OnRuneSpend and the various OnXXXRuneGain callbacks by OnRuneChange 
[dk/core] fix: spending death rune wasn't counting towards OnRuneSpend effects 
[dk/core] add RuneChangeType flags to OnRuneChange event, and have the Cast & Refund type methods call OnRuneChange only once

The dk/core refactoring part will allow to properly hook APL's DoNextAction() to Rune or Runic Power changes.