### PR TITLE
Fix warrior suggest gem option with weapon mastery talent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ ui/*/index.html
 # IDE folders
 .vscode
 .idea
+.history
 
 # binaries
 dist

--- a/ui/warrior/sim.ts
+++ b/ui/warrior/sim.ts
@@ -8,18 +8,15 @@ import { TristateEffect } from '../core/proto/common.js'
 import { Stats } from '../core/proto_utils/stats.js';
 import { Player } from '../core/player.js';
 import { IndividualSimUI } from '../core/individual_sim_ui.js';
-import { EventID, TypedEvent } from '../core/typed_event.js';
+import { TypedEvent } from '../core/typed_event.js';
 import { Gear } from '../core/proto_utils/gear.js';
 import { ItemSlot } from '../core/proto/common.js';
 import { GemColor } from '../core/proto/common.js';
 import { Profession } from '../core/proto/common.js';
 
-import { Warrior, Warrior_Rotation as WarriorRotation, WarriorTalents as WarriorTalents, Warrior_Options as WarriorOptions } from '../core/proto/warrior.js';
 
-import * as IconInputs from '../core/components/icon_inputs.js';
 import * as OtherInputs from '../core/components/other_inputs.js';
 import * as Mechanics from '../core/constants/mechanics.js';
-import * as Tooltips from '../core/constants/tooltips.js';
 
 import * as WarriorInputs from './inputs.js';
 import * as Presets from './presets.js';
@@ -214,7 +211,7 @@ export class WarriorSimUI extends IndividualSimUI<Spec.SpecWarrior> {
 		const redGemCaps = new Array<[number, Stats]>();
 		redGemCaps.push([40117, this.calcArpCap(optimizedGear)]);
 		const expCap = this.calcExpCap();
-    redGemCaps.push([40118, expCap]);
+		redGemCaps.push([40118, expCap]);
 		const critCap = this.calcCritCap(optimizedGear);
 		redGemCaps.push([40111, new Stats()]);
 
@@ -241,17 +238,17 @@ export class WarriorSimUI extends IndividualSimUI<Spec.SpecWarrior> {
 	}
 
 	calcExpCap(): Stats {
-    let expCap = 6.5 * 32.79 + 4;
-    const weaponMastery = this.player.getTalents().weaponMastery;
-    const hasWeaponMasteryTalent = !!weaponMastery;
-    
+		let expCap = 6.5 * 32.79 + 4;
+		const weaponMastery = this.player.getTalents().weaponMastery;
+		const hasWeaponMasteryTalent = !!weaponMastery;
+		
 		if (hasWeaponMasteryTalent) {
-      expCap -=
-        weaponMastery * 4 * Mechanics.EXPERTISE_PER_QUARTER_PERCENT_REDUCTION;
-    }
+			expCap -=
+				weaponMastery * 4 * Mechanics.EXPERTISE_PER_QUARTER_PERCENT_REDUCTION;
+		}
 
-    return new Stats().withStat(Stat.StatExpertise, expCap);
-  }
+		return new Stats().withStat(Stat.StatExpertise, expCap);
+	}
 
 	calcArpCap(gear: Gear): Stats {
 		let arpCap = 1404;

--- a/ui/warrior/sim.ts
+++ b/ui/warrior/sim.ts
@@ -213,8 +213,8 @@ export class WarriorSimUI extends IndividualSimUI<Spec.SpecWarrior> {
 		// Rank order red gems to use with their associated stat caps
 		const redGemCaps = new Array<[number, Stats]>();
 		redGemCaps.push([40117, this.calcArpCap(optimizedGear)]);
-		const expCap = new Stats().withStat(Stat.StatExpertise, 6.5 * 32.79 + 4);
-		redGemCaps.push([40118, expCap]);
+		const expCap = this.calcExpCap();
+    redGemCaps.push([40118, expCap]);
 		const critCap = this.calcCritCap(optimizedGear);
 		redGemCaps.push([40111, new Stats()]);
 
@@ -239,6 +239,19 @@ export class WarriorSimUI extends IndividualSimUI<Spec.SpecWarrior> {
 		yellowGemCaps.push([40142, critCap]);
 		await this.fillGemsToCaps(optimizedGear, yellowSockets, yellowGemCaps, 0, 0);
 	}
+
+	calcExpCap(): Stats {
+    let expCap = 6.5 * 32.79 + 4;
+    const weaponMastery = this.player.getTalents().weaponMastery;
+    const hasWeaponMasteryTalent = !!weaponMastery;
+    
+		if (hasWeaponMasteryTalent) {
+      expCap -=
+        weaponMastery * 4 * Mechanics.EXPERTISE_PER_QUARTER_PERCENT_REDUCTION;
+    }
+
+    return new Stats().withStat(Stat.StatExpertise, expCap);
+  }
 
 	calcArpCap(gear: Gear): Stats {
 		let arpCap = 1404;


### PR DESCRIPTION
I was working on a BIS set for Arms and found out that the suggest gem option would always over cap expertise by ~70. 
This indicated to me that the Weapon Mastery talent wasn't accounted for.

This PR fixes this issue.


**Issue**
As you can see in the first 2 screenshots the calculated expertise is the same however weapon mastery is active.

2/2 Strength of Arms + 2/2 Weapon mastery:
![image](https://github.com/wowsims/wotlk/assets/1216787/48157bb7-1544-46bb-b1da-634a61e45102)

2/2 Strength of Arms + 0/2 Weapon mastery: 
![image](https://github.com/wowsims/wotlk/assets/1216787/827f9260-eb4b-40dd-9959-09c8753d6ed4)

0/2 Strength of Arms + 2/2 Weapon master:
![image](https://github.com/wowsims/wotlk/assets/1216787/18f55e70-e35e-46d2-ba44-a5e45b07245e)

