### PR TITLE
Add option to disable auto-gemming expertise

### DIFF
--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -220,6 +220,7 @@ export class Player<SpecType extends Spec> {
 	private distanceFromTarget: number = 0;
 	private healingModel: HealingModel = HealingModel.create();
 	private healingEnabled: boolean = false;
+	private disableExpertiseGemming: boolean = false;
 
 	private autoRotationGenerator: AutoRotationGenerator<SpecType> | null = null;
 	private simpleRotationGenerator: SimpleRotationGenerator<SpecType> | null = null;
@@ -253,6 +254,7 @@ export class Player<SpecType extends Spec> {
 	readonly inFrontOfTargetChangeEmitter = new TypedEvent<void>('PlayerInFrontOfTarget');
 	readonly distanceFromTargetChangeEmitter = new TypedEvent<void>('PlayerDistanceFromTarget');
 	readonly healingModelChangeEmitter = new TypedEvent<void>('PlayerHealingModel');
+	readonly disableExpertiseGemmingChangeEmitter = new TypedEvent<void>('DisableExpertiseGemming');
 	readonly epWeightsChangeEmitter = new TypedEvent<void>('PlayerEpWeights');
 	readonly miscOptionsChangeEmitter = new TypedEvent<void>('PlayerMiscOptions');
 
@@ -295,6 +297,7 @@ export class Player<SpecType extends Spec> {
 			this.inFrontOfTargetChangeEmitter,
 			this.distanceFromTargetChangeEmitter,
 			this.healingModelChangeEmitter,
+			this.disableExpertiseGemmingChangeEmitter,
 			this.epWeightsChangeEmitter,
 			this.epRatiosChangeEmitter,
 			this.epRefStatChangeEmitter,
@@ -903,6 +906,18 @@ export class Player<SpecType extends Spec> {
 			this.setDefaultHealingParams(this.healingModel)
 		}
 		this.healingModelChangeEmitter.emit(eventID);
+	}
+
+	getDisableExpertiseGemming(): boolean {
+		return this.disableExpertiseGemming;
+	}
+
+	setDisableExpertiseGemming(eventID: EventID, newDisableExpertiseGemming: boolean) {
+		if (newDisableExpertiseGemming == this.disableExpertiseGemming)
+			return;
+
+		this.disableExpertiseGemming = newDisableExpertiseGemming;
+		this.disableExpertiseGemmingChangeEmitter.emit(eventID);
 	}
 
 	computeStatsEP(stats?: Stats): number {

--- a/ui/warrior/inputs.ts
+++ b/ui/warrior/inputs.ts
@@ -38,6 +38,19 @@ export const StartingRage = InputHelpers.makeSpecOptionsNumberInput<Spec.SpecWar
 	labelTooltip: 'Initial rage at the start of each iteration.',
 });
 
+// Allows for auto gemming whilst ignoring expertise cap
+// (Useful for Arms)
+export const DisableExpertiseGemming = {
+	type: 'boolean' as const,
+	label: 'Disable expertise gemming',
+	labelTooltip: 'Disables auto gemming for expertise',
+	changedEvent: (player: Player<any>) => player.disableExpertiseGemmingChangeEmitter,
+	getValue: (player: Player<any>) => player.getDisableExpertiseGemming(),
+	setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
+		player.setDisableExpertiseGemming(eventID, newValue);
+	},
+};
+
 export const StanceSnapshot = InputHelpers.makeSpecOptionsBooleanInput<Spec.SpecWarrior>({
 	fieldName: 'stanceSnapshot',
 	label: 'Stance Snapshot',

--- a/ui/warrior/sim.ts
+++ b/ui/warrior/sim.ts
@@ -147,6 +147,7 @@ export class WarriorSimUI extends IndividualSimUI<Spec.SpecWarrior> {
 				inputs: [
 					WarriorInputs.StartingRage,
 					WarriorInputs.StanceSnapshot,
+					WarriorInputs.DisableExpertiseGemming,
 					OtherInputs.TankAssignment,
 					OtherInputs.InFrontOfTarget,
 				],
@@ -210,8 +211,12 @@ export class WarriorSimUI extends IndividualSimUI<Spec.SpecWarrior> {
 		// Rank order red gems to use with their associated stat caps
 		const redGemCaps = new Array<[number, Stats]>();
 		redGemCaps.push([40117, this.calcArpCap(optimizedGear)]);
+		// Should we gem expertise?
+		const enableExpertiseGemming = !this.player.getDisableExpertiseGemming()
 		const expCap = this.calcExpCap();
-		redGemCaps.push([40118, expCap]);
+		if(enableExpertiseGemming){
+			redGemCaps.push([40118, expCap]);
+		}
 		const critCap = this.calcCritCap(optimizedGear);
 		redGemCaps.push([40111, new Stats()]);
 
@@ -231,7 +236,9 @@ export class WarriorSimUI extends IndividualSimUI<Spec.SpecWarrior> {
 		const yellowGemCaps = new Array<[number, Stats]>();
 		const hitCap = new Stats().withStat(Stat.StatMeleeHit, 8. * 32.79 + 4);
 		yellowGemCaps.push([40125, hitCap]);
-		yellowGemCaps.push([40162, hitCap.add(expCap)]);
+		if(enableExpertiseGemming){
+			yellowGemCaps.push([40162, hitCap.add(expCap)]);
+		}
 		yellowGemCaps.push([40143, hitCap]);
 		yellowGemCaps.push([40142, critCap]);
 		await this.fillGemsToCaps(optimizedGear, yellowSockets, yellowGemCaps, 0, 0);


### PR DESCRIPTION
As an Arms Warrior you don't really need expertise. Auto gemming currently will always try to gem for the cap. This PR adds an option to disable this.

As this is purely a UI feature I haven't extended the Warrior Spec for this. I hope that's ok, otherwise please let me know what your preferred solution is.

I couldn't get the logic to work for the checkboxes that have `showWhen` or `enableWhen` so for now this always shows.