### PR TITLE
fix arcane missiles and arcane concentration CC

### DIFF
--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -46,718 +46,718 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 12808.45967
-  tps: 7818.76795
+  dps: 12864.27933
+  tps: 7851.99528
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 12853.11166
-  tps: 7845.26252
+  dps: 12909.11684
+  tps: 7878.60296
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 12717.20321
-  tps: 7767.46835
+  dps: 12821.62212
+  tps: 7829.6487
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 12450.23098
-  tps: 7607.77524
-  hps: 103.16878
+  dps: 12493.89854
+  tps: 7633.6518
+  hps: 104.40923
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 12450.23098
-  tps: 7607.77524
-  hps: 103.16878
+  dps: 12493.89854
+  tps: 7633.6518
+  hps: 104.40923
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 12821.978
-  tps: 7828.25874
+  dps: 12896.00915
+  tps: 7872.80597
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8513.57873
-  tps: 5212.21929
+  dps: 8559.88278
+  tps: 5241.09333
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 11041.36959
-  tps: 6760.62376
+  dps: 11008.00654
+  tps: 6739.52609
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 12766.99993
-  tps: 7643.06009
+  dps: 12871.81114
+  tps: 7704.21122
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 13132.44885
-  tps: 8018.98262
+  dps: 13247.12774
+  tps: 8088.5358
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
   hps: 64
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 12580.7347
-  tps: 7684.91474
+  dps: 12630.08312
+  tps: 7717.02353
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 12600.27499
-  tps: 7723.25529
+  dps: 12675.87185
+  tps: 7772.50672
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 12736.77579
-  tps: 7780.47552
+  dps: 12827.2793
+  tps: 7826.39647
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Death'sChoice-47464"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 12487.7628
-  tps: 7629.03227
+  dps: 12541.19437
+  tps: 7661.02629
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Defender'sCode-40257"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 12761.44123
-  tps: 7793.93262
+  dps: 12871.53219
+  tps: 7860.71541
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 13079.04195
-  tps: 7989.83102
+  dps: 13132.16684
+  tps: 8021.66397
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 12717.20321
-  tps: 7767.46835
+  dps: 12821.62212
+  tps: 7829.6487
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 12858.08554
-  tps: 7850.17305
+  dps: 12947.93313
+  tps: 7902.69401
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 12756.51589
-  tps: 7790.88024
+  dps: 12865.14901
+  tps: 7856.82803
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 12732.71357
-  tps: 7777.24891
+  dps: 12853.68652
+  tps: 7849.19837
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 12676.43816
-  tps: 7751.23777
+  dps: 12803.05574
+  tps: 7826.13336
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 12717.20321
-  tps: 7767.46835
+  dps: 12821.62212
+  tps: 7829.6487
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 12586.62737
-  tps: 7689.15526
+  dps: 12624.79175
+  tps: 7713.42662
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 12843.21157
-  tps: 7842.24312
+  dps: 12880.80667
+  tps: 7866.01283
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 12556.81736
-  tps: 7671.55838
+  dps: 12648.07098
+  tps: 7716.13185
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 12670.44441
-  tps: 7736.87565
+  dps: 12725.69066
+  tps: 7769.75334
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForgeEmber-37660"
  value: {
-  dps: 12731.11613
-  tps: 7774.75619
+  dps: 12795.77387
+  tps: 7814.80618
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 12766.99993
-  tps: 7797.00939
+  dps: 12871.81114
+  tps: 7859.42925
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 12757.04059
-  tps: 7791.10118
+  dps: 12861.77334
+  tps: 7853.47314
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FrostfireGarb"
  value: {
-  dps: 8961.25628
-  tps: 5474.53088
+  dps: 9058.40983
+  tps: 5543.04139
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuturesightRune-38763"
  value: {
-  dps: 12673.45207
-  tps: 7740.32503
+  dps: 12689.39843
+  tps: 7745.73513
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 9353.86368
-  tps: 5713.6332
+  dps: 9321.46838
+  tps: 5692.60287
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 12830.78567
-  tps: 7832.01524
+  dps: 12886.69808
+  tps: 7865.29912
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 12881.52657
-  tps: 7862.1227
+  dps: 12937.6498
+  tps: 7895.53513
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 12602.01898
-  tps: 7716.26469
+  dps: 12654.87807
+  tps: 7752.25937
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Heartpierce-49982"
  value: {
-  dps: 13132.44885
-  tps: 8018.98262
+  dps: 13247.12774
+  tps: 8088.5358
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Heartpierce-50641"
  value: {
-  dps: 13132.44885
-  tps: 8018.98262
+  dps: 13247.12774
+  tps: 8088.5358
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 12836.38529
-  tps: 7836.60477
+  dps: 12896.4001
+  tps: 7872.3437
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 12756.51589
-  tps: 7790.88024
+  dps: 12865.14901
+  tps: 7856.82803
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 12732.71357
-  tps: 7777.24891
+  dps: 12853.68652
+  tps: 7849.19837
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IncisorFragment-37723"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 12835.74668
-  tps: 7837.97414
+  dps: 12966.50678
+  tps: 7911.18667
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 12717.20321
-  tps: 7767.46835
+  dps: 12821.62212
+  tps: 7829.6487
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 9717.58465
-  tps: 5941.19216
+  dps: 9774.91778
+  tps: 5977.53055
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KirinTorGarb"
  value: {
-  dps: 9484.27978
-  tps: 5789.31499
+  dps: 9537.94626
+  tps: 5824.43454
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 12725.60112
-  tps: 7770.47792
+  dps: 12801.99598
+  tps: 7806.95692
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 12553.69309
-  tps: 7668.99528
+  dps: 12595.86635
+  tps: 7695.53783
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 12731.92553
-  tps: 7775.25579
+  dps: 12790.64297
+  tps: 7811.06588
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Nibelung-49992"
  value: {
-  dps: 13132.44885
-  tps: 8018.98262
+  dps: 13247.12774
+  tps: 8088.5358
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Nibelung-50648"
  value: {
-  dps: 13132.44885
-  tps: 8018.98262
+  dps: 13247.12774
+  tps: 8088.5358
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 12717.20321
-  tps: 7767.46835
+  dps: 12821.62212
+  tps: 7829.6487
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 12717.20321
-  tps: 7767.46835
+  dps: 12821.62212
+  tps: 7829.6487
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 12717.20321
-  tps: 7767.46835
+  dps: 12821.62212
+  tps: 7829.6487
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 12717.20321
-  tps: 7767.46835
+  dps: 12821.62212
+  tps: 7829.6487
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 13048.3978
-  tps: 8078.65948
+  dps: 13095.97219
+  tps: 8105.46523
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 13120.44663
-  tps: 8135.8376
+  dps: 13167.78246
+  tps: 8162.3441
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 13089.54849
-  tps: 7993.43996
+  dps: 13199.08863
+  tps: 8058.64155
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 12769.41064
-  tps: 7796.41369
+  dps: 12809.21562
+  tps: 7821.20046
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 12822.39747
-  tps: 7830.77722
+  dps: 12907.25562
+  tps: 7872.64258
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 12868.85944
-  tps: 7859.46159
+  dps: 12962.38255
+  tps: 7906.43934
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SoulPreserver-37111"
  value: {
-  dps: 12597.37751
-  tps: 7693.5209
+  dps: 12652.32019
+  tps: 7726.21349
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SouloftheDead-40382"
  value: {
-  dps: 12671.91578
-  tps: 7743.77321
+  dps: 12732.07943
+  tps: 7773.93995
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SparkofLife-37657"
  value: {
-  dps: 12608.18937
-  tps: 7695.67037
+  dps: 12695.50522
+  tps: 7747.62431
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 12451.92705
-  tps: 7608.43508
+  dps: 12546.05734
+  tps: 7667.73727
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 12717.20321
-  tps: 7767.46835
+  dps: 12821.62212
+  tps: 7829.6487
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 12717.20321
-  tps: 7767.46835
+  dps: 12821.62212
+  tps: 7829.6487
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 12717.20321
-  tps: 7767.46835
+  dps: 12821.62212
+  tps: 7829.6487
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 12565.38898
-  tps: 7673.77157
+  dps: 12619.5102
+  tps: 7704.43095
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 12594.03149
-  tps: 7693.90309
+  dps: 12686.22352
+  tps: 7740.04744
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TempestRegalia"
  value: {
-  dps: 6973.12514
-  tps: 4286.78086
+  dps: 6988.48685
+  tps: 4300.795
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 12445.1548
-  tps: 7603.19851
+  dps: 12499.46504
+  tps: 7635.50546
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 10273.41213
-  tps: 6309.25782
+  dps: 10432.91656
+  tps: 6404.66783
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 12717.20321
-  tps: 7767.46835
+  dps: 12821.62212
+  tps: 7829.6487
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 12446.00152
-  tps: 7605.20203
+  dps: 12559.18163
+  tps: 7676.92503
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 12446.00152
-  tps: 7605.20203
+  dps: 12559.18163
+  tps: 7676.92503
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 12766.99993
-  tps: 7797.00939
+  dps: 12871.81114
+  tps: 7859.42925
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 12757.04059
-  tps: 7791.10118
+  dps: 12861.77334
+  tps: 7853.47314
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 12823.15837
-  tps: 7840.21672
+  dps: 12912.31848
+  tps: 7885.66799
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 12757.04059
-  tps: 7791.10118
+  dps: 12861.77334
+  tps: 7853.47314
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 12766.99993
-  tps: 7797.00939
+  dps: 12871.81114
+  tps: 7859.42925
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WingedTalisman-37844"
  value: {
-  dps: 12595.77777
-  tps: 7693.5723
+  dps: 12655.7794
+  tps: 7729.29408
  }
 }
 dps_results: {
  key: "TestArcane-Average-Default"
  value: {
-  dps: 13230.87782
-  tps: 8080.55814
+  dps: 13262.8124
+  tps: 8100.50301
  }
 }
 dps_results: {
@@ -805,49 +805,49 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Settings-Troll-P3Arcane-Arcane-Arcane-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13132.44885
-  tps: 9910.00084
+  dps: 13247.12774
+  tps: 9960.45845
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P3Arcane-Arcane-Arcane-FullBuffs-LongSingleTarget"
  value: {
-  dps: 13132.44885
-  tps: 8018.98262
+  dps: 13247.12774
+  tps: 8088.5358
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P3Arcane-Arcane-Arcane-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 17068.15278
-  tps: 10276.21701
+  dps: 16955.33206
+  tps: 10210.39553
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P3Arcane-Arcane-Arcane-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6810.59333
-  tps: 5707.06685
+  dps: 6783.06695
+  tps: 5690.62687
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P3Arcane-Arcane-Arcane-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6810.59333
-  tps: 4175.34366
+  dps: 6783.06695
+  tps: 4157.90548
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P3Arcane-Arcane-Arcane-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8622.66811
-  tps: 5128.49405
+  dps: 8606.33757
+  tps: 5115.66057
  }
 }
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 13132.44885
-  tps: 8018.98262
+  dps: 13247.12774
+  tps: 8088.5358
  }
 }

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -46,808 +46,808 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 12968.90816
-  tps: 10426.29246
+  dps: 13009.73246
+  tps: 10459.13959
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 13019.91363
-  tps: 10466.71961
+  dps: 13060.92184
+  tps: 10499.71648
  }
 }
 dps_results: {
  key: "TestFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 13126.21798
-  tps: 10554.41791
+  dps: 13122.48378
+  tps: 10549.03702
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 12571.84808
-  tps: 10112.54646
-  hps: 102.2099
+  dps: 12653.24553
+  tps: 10177.90318
+  hps: 101.8257
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 12571.84808
-  tps: 10112.54646
-  hps: 102.2099
+  dps: 12653.24553
+  tps: 10177.90318
+  hps: 101.8257
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 13099.89188
-  tps: 10532.22682
+  dps: 13120.6107
+  tps: 10551.222
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8293.744
-  tps: 6671.10756
+  dps: 8376.74771
+  tps: 6737.17047
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 10860.28011
-  tps: 8736.63922
+  dps: 10963.9819
+  tps: 8818.71782
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 13184.48058
-  tps: 10390.70519
+  dps: 13180.75461
+  tps: 10385.42742
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 13549.88601
-  tps: 10894.37222
+  dps: 13519.43021
+  tps: 10867.28582
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
   hps: 64
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 12825.09726
-  tps: 10318.27892
+  dps: 12844.66173
+  tps: 10333.46112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 12904.66659
-  tps: 10389.15892
+  dps: 12916.82644
+  tps: 10398.42727
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 12767.11919
-  tps: 10275.98684
+  dps: 12767.28909
+  tps: 10274.31783
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Death'sChoice-47464"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 12691.66853
-  tps: 10207.8889
+  dps: 12671.84412
+  tps: 10192.04844
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 13135.60368
-  tps: 10562.29932
+  dps: 13115.35479
+  tps: 10543.24497
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 13511.55151
-  tps: 10863.08416
+  dps: 13477.76119
+  tps: 10836.26716
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 13126.21798
-  tps: 10554.41791
+  dps: 13122.48378
+  tps: 10549.03702
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 13146.32195
-  tps: 10569.76239
+  dps: 13163.30327
+  tps: 10585.5611
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 13138.33076
-  tps: 10564.17237
+  dps: 13108.6436
+  tps: 10537.7239
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 13129.65834
-  tps: 10557.74776
+  dps: 13063.68609
+  tps: 10501.55465
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 12755.80567
-  tps: 10259.41618
+  dps: 12743.86845
+  tps: 10249.68141
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 13126.21798
-  tps: 10554.41791
+  dps: 13122.48378
+  tps: 10549.03702
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 12979.53604
-  tps: 10450.06665
+  dps: 12919.82202
+  tps: 10401.16455
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 13079.48471
-  tps: 10521.41419
+  dps: 13146.52339
+  tps: 10574.94741
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 12707.89517
-  tps: 10226.48194
+  dps: 12663.45091
+  tps: 10190.52371
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 12811.25491
-  tps: 10301.3358
+  dps: 12851.51075
+  tps: 10333.72011
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 12921.06772
-  tps: 10392.98514
+  dps: 12992.89334
+  tps: 10449.8256
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 13184.48058
-  tps: 10600.59807
+  dps: 13180.75461
+  tps: 10595.22082
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 13172.82806
-  tps: 10591.36204
+  dps: 13169.10044
+  tps: 10585.98406
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FrostfireGarb"
  value: {
-  dps: 9100.05275
-  tps: 7333.25815
+  dps: 9106.53393
+  tps: 7338.18356
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 12875.88464
-  tps: 10355.77466
+  dps: 12836.40884
+  tps: 10322.7898
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 9546.0262
-  tps: 7679.13302
+  dps: 9521.61548
+  tps: 7659.30909
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 12994.4109
-  tps: 10446.50603
+  dps: 13035.32715
+  tps: 10479.42804
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 13052.37165
-  tps: 10492.44598
+  dps: 13093.49689
+  tps: 10525.53814
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 12935.06911
-  tps: 10411.98548
+  dps: 12899.36965
+  tps: 10384.66521
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-49982"
  value: {
-  dps: 13549.88601
-  tps: 10894.37222
+  dps: 13519.43021
+  tps: 10867.28582
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 13549.88601
-  tps: 10894.37222
+  dps: 13519.43021
+  tps: 10867.28582
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 12999.50018
-  tps: 10452.09591
+  dps: 13040.50003
+  tps: 10485.08597
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 13138.33076
-  tps: 10564.17237
+  dps: 13108.6436
+  tps: 10537.7239
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 13129.65834
-  tps: 10557.74776
+  dps: 13063.68609
+  tps: 10501.55465
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 13090.42529
-  tps: 10534.53365
+  dps: 13182.14408
+  tps: 10608.57418
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 13126.21798
-  tps: 10554.41791
+  dps: 13122.48378
+  tps: 10549.03702
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 9999.56914
-  tps: 8058.60127
+  dps: 10025.50245
+  tps: 8080.74667
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KirinTorGarb"
  value: {
-  dps: 10173.40246
-  tps: 8185.30307
+  dps: 10227.11852
+  tps: 8229.29745
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 12968.52873
-  tps: 10431.41906
+  dps: 12947.07014
+  tps: 10414.65918
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 12703.52976
-  tps: 10220.05679
+  dps: 12774.40385
+  tps: 10276.11025
  }
 }
 dps_results: {
  key: "TestFire-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 12933.66316
-  tps: 10401.89034
+  dps: 12979.74604
+  tps: 10438.52779
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Nibelung-49992"
  value: {
-  dps: 13549.88601
-  tps: 10894.37222
+  dps: 13519.43021
+  tps: 10867.28582
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Nibelung-50648"
  value: {
-  dps: 13549.88601
-  tps: 10894.37222
+  dps: 13519.43021
+  tps: 10867.28582
  }
 }
 dps_results: {
  key: "TestFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 13126.21798
-  tps: 10554.41791
+  dps: 13122.48378
+  tps: 10549.03702
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 13126.21798
-  tps: 10554.41791
+  dps: 13122.48378
+  tps: 10549.03702
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 13126.21798
-  tps: 10554.41791
+  dps: 13122.48378
+  tps: 10549.03702
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 13126.21798
-  tps: 10554.41791
+  dps: 13122.48378
+  tps: 10549.03702
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 13111.34125
-  tps: 10585.37437
+  dps: 13173.48746
+  tps: 10637.00144
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 13180.32742
-  tps: 10645.71613
+  dps: 13243.01567
+  tps: 10697.84982
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 13536.35916
-  tps: 10883.47463
+  dps: 13533.11397
+  tps: 10878.42679
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 13057.39887
-  tps: 10498.8142
+  dps: 13068.95017
+  tps: 10507.88141
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 13001.34879
-  tps: 10459.64783
+  dps: 12998.59317
+  tps: 10456.22661
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 13031.90266
-  tps: 10483.53963
+  dps: 12986.69493
+  tps: 10447.58126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SoulPreserver-37111"
  value: {
-  dps: 12727.79142
-  tps: 10235.18227
+  dps: 12767.74632
+  tps: 10267.32157
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SouloftheDead-40382"
  value: {
-  dps: 12902.96869
-  tps: 10389.30078
+  dps: 12893.59421
+  tps: 10381.32094
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 12714.26315
-  tps: 10228.36074
+  dps: 12742.45058
+  tps: 10251.94786
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 13029.16693
-  tps: 10480.77793
+  dps: 13021.57212
+  tps: 10473.82207
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 13126.21798
-  tps: 10554.41791
+  dps: 13122.48378
+  tps: 10549.03702
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 13126.21798
-  tps: 10554.41791
+  dps: 13122.48378
+  tps: 10549.03702
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 13126.21798
-  tps: 10554.41791
+  dps: 13122.48378
+  tps: 10549.03702
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 12701.64512
-  tps: 10217.39335
+  dps: 12757.82678
+  tps: 10262.04594
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 12698.90782
-  tps: 10216.65276
+  dps: 12715.43529
+  tps: 10230.5827
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TempestRegalia"
  value: {
-  dps: 6646.2808
-  tps: 5355.0122
+  dps: 6742.83264
+  tps: 5432.56053
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 12553.90915
-  tps: 10097.36243
+  dps: 12593.23709
+  tps: 10128.99126
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 10187.08505
-  tps: 8211.63862
+  dps: 10311.1849
+  tps: 8313.26244
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 13126.21798
-  tps: 10554.41791
+  dps: 13122.48378
+  tps: 10549.03702
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 13196.26532
-  tps: 10613.82261
+  dps: 13210.95227
+  tps: 10624.73369
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 13196.26532
-  tps: 10613.82261
+  dps: 13210.95227
+  tps: 10624.73369
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 13184.48058
-  tps: 10600.59807
+  dps: 13180.75461
+  tps: 10595.22082
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 13172.82806
-  tps: 10591.36204
+  dps: 13169.10044
+  tps: 10585.98406
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 12906.75232
-  tps: 10378.55715
+  dps: 12902.27585
+  tps: 10374.25295
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 13172.82806
-  tps: 10591.36204
+  dps: 13169.10044
+  tps: 10585.98406
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 13184.48058
-  tps: 10600.59807
+  dps: 13180.75461
+  tps: 10595.22082
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WingedTalisman-37844"
  value: {
-  dps: 12746.49407
-  tps: 10251.43037
+  dps: 12787.79649
+  tps: 10284.63878
  }
 }
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
-  dps: 13545.96253
-  tps: 10889.398
+  dps: 13539.21556
+  tps: 10883.66645
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-AOE-FullBuffs-LongMultiTarget"
  value: {
-  dps: 73285.22884
-  tps: 66029.12692
+  dps: 73286.23353
+  tps: 61995.78783
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-AOE-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4661.0459
-  tps: 3678.00317
+  dps: 4889.85275
+  tps: 3864.36789
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-AOE-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6432.96599
-  tps: 4923.69871
+  dps: 6433.16827
+  tps: 4921.9397
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-AOE-NoBuffs-LongMultiTarget"
  value: {
-  dps: 44917.50953
-  tps: 42534.45533
+  dps: 45253.19102
+  tps: 39113.7221
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-AOE-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2042.24742
-  tps: 1616.70524
+  dps: 2120.65992
+  tps: 1679.6451
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-AOE-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3986.80858
-  tps: 2999.60592
+  dps: 4012.30181
+  tps: 3016.54411
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-Fire-FullBuffs-LongMultiTarget"
  value: {
-  dps: 43248.47987
-  tps: 38737.54663
+  dps: 46366.54494
+  tps: 39572.13845
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-Fire-FullBuffs-LongSingleTarget"
  value: {
-  dps: 13549.88601
-  tps: 10894.37222
+  dps: 13519.43021
+  tps: 10867.28582
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-Fire-FullBuffs-ShortSingleTarget"
  value: {
   dps: 16175.94397
-  tps: 12886.05115
+  tps: 12885.94902
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-Fire-NoBuffs-LongMultiTarget"
  value: {
-  dps: 20768.18032
-  tps: 19896.01249
+  dps: 31299.82426
+  tps: 28314.1489
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-Fire-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5335.41404
-  tps: 4281.82285
+  dps: 5434.89757
+  tps: 4362.36175
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-Fire-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8612.75738
-  tps: 6804.06673
+  dps: 8613.44367
+  tps: 6804.38206
  }
 }
 dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 13549.88601
-  tps: 10894.37222
+  dps: 13519.43021
+  tps: 10867.28582
  }
 }

--- a/sim/mage/TestFrostFire.results
+++ b/sim/mage/TestFrostFire.results
@@ -46,766 +46,766 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostFire-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 12173.49441
-  tps: 9764.65867
+  dps: 12186.98379
+  tps: 9772.23107
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 12221.61302
-  tps: 9802.76335
+  dps: 12235.15751
+  tps: 9810.37983
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 12105.37845
-  tps: 9720.56018
+  dps: 12146.44136
+  tps: 9745.76435
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 11792.2552
-  tps: 9461.36953
+  dps: 11797.13635
+  tps: 9463.45912
   hps: 101.94314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 11792.2552
-  tps: 9461.36953
+  dps: 11797.13635
+  tps: 9463.45912
   hps: 101.94314
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 12227.74501
-  tps: 9814.39616
+  dps: 12255.22767
+  tps: 9830.1331
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8001.42739
-  tps: 6448.08687
+  dps: 8005.17251
+  tps: 6450.47184
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 10258.10962
-  tps: 8262.92113
+  dps: 10297.59532
+  tps: 8289.11807
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 12159.45631
-  tps: 9569.77581
+  dps: 12200.70879
+  tps: 9594.46617
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 12577.80639
-  tps: 10103.96603
+  dps: 12627.00615
+  tps: 10132.75745
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
   hps: 64
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 12037.3857
-  tps: 9659.79654
+  dps: 12054.852
+  tps: 9670.31502
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 12069.97921
-  tps: 9704.45263
+  dps: 12089.10909
+  tps: 9716.53844
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Greatness-44255"
  value: {
   dps: 11943.65424
-  tps: 9584.02712
+  tps: 9583.63736
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Death'sChoice-47464"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
   dps: 11851.0747
-  tps: 9506.13841
+  tps: 9505.8688
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 12188.77
-  tps: 9790.18419
+  dps: 12234.9141
+  tps: 9817.83221
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 12517.0408
-  tps: 10053.59068
+  dps: 12602.71877
+  tps: 10110.14032
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 12105.37845
-  tps: 9720.56018
+  dps: 12146.44136
+  tps: 9745.76435
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 12266.47162
-  tps: 9844.79682
+  dps: 12291.62095
+  tps: 9858.63775
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 12185.10291
-  tps: 9788.69868
+  dps: 12232.68878
+  tps: 9816.19232
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 12165.07261
-  tps: 9774.33511
+  dps: 12226.12227
+  tps: 9810.74464
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 12020.58344
-  tps: 9646.63102
+  dps: 12038.01559
+  tps: 9657.34751
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 12105.37845
-  tps: 9720.56018
+  dps: 12146.44136
+  tps: 9745.76435
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 12126.78869
-  tps: 9747.37488
+  dps: 12134.60998
+  tps: 9751.90644
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 12288.4852
-  tps: 9860.8692
+  dps: 12305.21571
+  tps: 9871.04414
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 11762.90916
-  tps: 9439.04332
+  dps: 11762.68938
+  tps: 9438.2012
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 12024.76414
-  tps: 9646.88058
+  dps: 12038.08321
+  tps: 9654.31672
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 12182.94491
-  tps: 9772.88284
+  dps: 12182.96005
+  tps: 9772.65707
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 12159.45631
-  tps: 9763.39624
+  dps: 12200.70879
+  tps: 9788.75206
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 12148.64074
-  tps: 9754.82903
+  dps: 12189.8553
+  tps: 9780.15452
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FrostfireGarb"
  value: {
-  dps: 8662.14951
-  tps: 6959.85476
+  dps: 8662.17581
+  tps: 6959.59995
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 11987.06361
-  tps: 9615.80736
+  dps: 11987.23034
+  tps: 9615.65554
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 8976.93044
-  tps: 7202.98805
+  dps: 8982.01434
+  tps: 7204.45975
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 12197.55371
-  tps: 9783.71101
+  dps: 12211.07065
+  tps: 9791.30545
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 12252.23396
-  tps: 9827.01178
+  dps: 12265.81351
+  tps: 9834.65632
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 12114.14008
-  tps: 9734.85927
+  dps: 12138.93613
+  tps: 9749.86312
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Heartpierce-49982"
  value: {
-  dps: 12577.80639
-  tps: 10103.96603
+  dps: 12627.00615
+  tps: 10132.75745
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 12577.80639
-  tps: 10103.96603
+  dps: 12627.00615
+  tps: 10132.75745
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 12203.53998
-  tps: 9790.10586
+  dps: 12217.08196
+  tps: 9797.72034
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 12185.10291
-  tps: 9788.69868
+  dps: 12232.68878
+  tps: 9816.19232
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 12165.07261
-  tps: 9774.33511
+  dps: 12226.12227
+  tps: 9810.74464
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 12206.81705
-  tps: 9798.81257
+  dps: 12206.81922
+  tps: 9798.47182
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 12105.37845
-  tps: 9720.56018
+  dps: 12146.44136
+  tps: 9745.76435
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 9315.20199
-  tps: 7482.90698
+  dps: 9315.357
+  tps: 7482.88746
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-KirinTorGarb"
  value: {
-  dps: 9505.31643
-  tps: 7627.11741
+  dps: 9505.32159
+  tps: 7626.8912
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 12072.164
-  tps: 9685.87447
+  dps: 12072.16793
+  tps: 9685.53018
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 11975.66229
-  tps: 9607.47924
+  dps: 11975.67743
+  tps: 9607.25347
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 12150.04875
-  tps: 9749.14339
+  dps: 12180.51332
+  tps: 9770.32853
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Nibelung-49992"
  value: {
-  dps: 12577.80639
-  tps: 10103.96603
+  dps: 12627.00615
+  tps: 10132.75745
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Nibelung-50648"
  value: {
-  dps: 12577.80639
-  tps: 10103.96603
+  dps: 12627.00615
+  tps: 10132.75745
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 12105.37845
-  tps: 9720.56018
+  dps: 12146.44136
+  tps: 9745.76435
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 12105.37845
-  tps: 9720.56018
+  dps: 12146.44136
+  tps: 9745.76435
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 12105.37845
-  tps: 9720.56018
+  dps: 12146.44136
+  tps: 9745.76435
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 12105.37845
-  tps: 9720.56018
+  dps: 12146.44136
+  tps: 9745.76435
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 12365.39189
-  tps: 9972.31533
+  dps: 12380.70403
+  tps: 9982.70358
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 12437.95834
-  tps: 10036.69434
+  dps: 12453.22257
+  tps: 10047.02466
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 12493.36304
-  tps: 10032.08087
+  dps: 12535.8987
+  tps: 10058.46285
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 12125.71371
-  tps: 9732.40772
+  dps: 12159.58557
+  tps: 9753.37274
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 12141.11833
-  tps: 9742.09959
+  dps: 12140.95028
+  tps: 9741.72463
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 12184.91262
-  tps: 9777.46361
+  dps: 12184.74457
+  tps: 9777.08865
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SoulPreserver-37111"
  value: {
-  dps: 11946.02459
-  tps: 9584.52747
+  dps: 11959.25349
+  tps: 9591.89148
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SouloftheDead-40382"
  value: {
-  dps: 12017.3722
-  tps: 9651.10227
+  dps: 12017.40137
+  tps: 9650.73734
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 11985.59689
-  tps: 9616.64705
+  dps: 11985.4194
+  tps: 9616.30739
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 12227.43614
-  tps: 9815.02715
+  dps: 12229.92714
+  tps: 9816.70395
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 12105.37845
-  tps: 9720.56018
+  dps: 12146.44136
+  tps: 9745.76435
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 12105.37845
-  tps: 9720.56018
+  dps: 12146.44136
+  tps: 9745.76435
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 12105.37845
-  tps: 9720.56018
+  dps: 12146.44136
+  tps: 9745.76435
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 11874.6166
-  tps: 9525.72952
+  dps: 11874.6174
+  tps: 9525.47767
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 11827.60709
-  tps: 9488.51229
+  dps: 11827.58773
+  tps: 9488.2023
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TempestRegalia"
  value: {
-  dps: 6250.02774
-  tps: 5041.98447
+  dps: 6228.95348
+  tps: 5025.19501
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 11781.98386
-  tps: 9454.62515
+  dps: 11795.02491
+  tps: 9461.83889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 9573.21907
-  tps: 7725.71346
+  dps: 9615.59269
+  tps: 7758.26239
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 12105.37845
-  tps: 9720.56018
+  dps: 12146.44136
+  tps: 9745.76435
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 12310.46371
-  tps: 9879.39127
+  dps: 12307.6654
+  tps: 9876.66599
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 12310.46371
-  tps: 9879.39127
+  dps: 12307.6654
+  tps: 9876.66599
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 12159.45631
-  tps: 9763.39624
+  dps: 12200.70879
+  tps: 9788.75206
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 12148.64074
-  tps: 9754.82903
+  dps: 12189.8553
+  tps: 9780.15452
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 12079.23672
-  tps: 9693.14483
+  dps: 12096.70116
+  tps: 9703.82847
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 12148.64074
-  tps: 9754.82903
+  dps: 12189.8553
+  tps: 9780.15452
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 12159.45631
-  tps: 9763.39624
+  dps: 12200.70879
+  tps: 9788.75206
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-WingedTalisman-37844"
  value: {
-  dps: 11955.91447
-  tps: 9593.76964
+  dps: 11968.95069
+  tps: 9600.97951
  }
 }
 dps_results: {
  key: "TestFrostFire-Average-Default"
  value: {
-  dps: 12564.73305
-  tps: 10092.35278
+  dps: 12630.14632
+  tps: 10133.77869
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P3FrostFire-Fire-Frostfire-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16762.17562
-  tps: 15724.2487
+  dps: 16762.59809
+  tps: 15648.23676
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P3FrostFire-Fire-Frostfire-FullBuffs-LongSingleTarget"
  value: {
-  dps: 12577.80639
-  tps: 10103.96603
+  dps: 12627.00615
+  tps: 10132.75745
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P3FrostFire-Fire-Frostfire-FullBuffs-ShortSingleTarget"
  value: {
   dps: 14690.26847
-  tps: 11681.37121
+  tps: 11679.18109
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P3FrostFire-Fire-Frostfire-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10079.70218
-  tps: 10266.3159
+  dps: 9972.2522
+  tps: 10151.3672
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P3FrostFire-Fire-Frostfire-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5962.82885
-  tps: 4793.75985
+  dps: 6150.50165
+  tps: 4946.8326
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P3FrostFire-Fire-Frostfire-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7604.3315
-  tps: 5985.51808
+  dps: 7604.10976
+  tps: 5985.2982
  }
 }
 dps_results: {
  key: "TestFrostFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 12577.80639
-  tps: 10103.96603
+  dps: 12627.00615
+  tps: 10132.75745
  }
 }

--- a/sim/mage/mage.go
+++ b/sim/mage/mage.go
@@ -54,26 +54,27 @@ type Mage struct {
 	// Cached values for a few mechanics.
 	bonusCritDamage float64
 
-	ArcaneBarrage    *core.Spell
-	ArcaneBlast      *core.Spell
-	ArcaneExplosion  *core.Spell
-	ArcaneMissiles   *core.Spell
-	Blizzard         *core.Spell
-	DeepFreeze       *core.Spell
-	Ignite           *core.Spell
-	LivingBomb       *core.Spell
-	Fireball         *core.Spell
-	FireBlast        *core.Spell
-	Flamestrike      *core.Spell
-	FlamestrikeRank8 *core.Spell
-	Frostbolt        *core.Spell
-	FrostfireBolt    *core.Spell
-	IceLance         *core.Spell
-	Pyroblast        *core.Spell
-	Scorch           *core.Spell
-	MirrorImage      *core.Spell
-	BlastWave        *core.Spell
-	DragonsBreath    *core.Spell
+	ArcaneBarrage           *core.Spell
+	ArcaneBlast             *core.Spell
+	ArcaneExplosion         *core.Spell
+	ArcaneMissiles          *core.Spell
+	ArcaneMissilesTickSpell *core.Spell
+	Blizzard                *core.Spell
+	DeepFreeze              *core.Spell
+	Ignite                  *core.Spell
+	LivingBomb              *core.Spell
+	Fireball                *core.Spell
+	FireBlast               *core.Spell
+	Flamestrike             *core.Spell
+	FlamestrikeRank8        *core.Spell
+	Frostbolt               *core.Spell
+	FrostfireBolt           *core.Spell
+	IceLance                *core.Spell
+	Pyroblast               *core.Spell
+	Scorch                  *core.Spell
+	MirrorImage             *core.Spell
+	BlastWave               *core.Spell
+	DragonsBreath           *core.Spell
 
 	IcyVeins             *core.Spell
 	SummonWaterElemental *core.Spell

--- a/sim/mage/talents.go
+++ b/sim/mage/talents.go
@@ -139,7 +139,6 @@ func (mage *Mage) applyArcaneConcentration() {
 		return
 	}
 
-	procChance := 0.02 * float64(mage.Talents.ArcaneConcentration)
 	bonusCrit := float64(mage.Talents.ArcanePotency) * 15 * core.CritRatingPerCritChance
 
 	// The result that caused the proc. Used to check we don't deactivate from the same proc.
@@ -184,6 +183,9 @@ func (mage *Mage) applyArcaneConcentration() {
 			if !spell.Flags.Matches(SpellFlagMage) {
 				return
 			}
+			if spell.DefaultCast.Cost == 0 {
+				return
+			}
 			if spell == mage.ArcaneMissiles && mage.MissileBarrageAura.IsActive() {
 				return
 			}
@@ -208,6 +210,13 @@ func (mage *Mage) applyArcaneConcentration() {
 
 			if !result.Landed() {
 				return
+			}
+
+			procChance := 0.02 * float64(mage.Talents.ArcaneConcentration)
+
+			// Arcane Missile ticks can proc CC, just at a low rate of about 1.5% with 5/5 Arcane Concentration
+			if spell == mage.ArcaneMissilesTickSpell {
+				procChance *= 0.15
 			}
 
 			if sim.RandomFloat("Arcane Concentration") > procChance {


### PR DESCRIPTION
Arcane missiles can proc JoW, and essentially all trinkets.
Fix clearcasting so it doesn't get consumed on free spells such as living bomb explosion, ignite application, AM ticks, blizzard ticks, etc.

Logs for AM clearcasting proc-rate: https://classic.warcraftlogs.com/reports/6ByPGJmHKvn17g9w#boss=0&difficulty=0

95% CI is about ~1%-2% so it could be either one of those, but this is fine.