### PR TITLE
fix PI for locks

### DIFF
--- a/sim/core/aura.go
+++ b/sim/core/aura.go
@@ -645,9 +645,9 @@ func (aura *Aura) Deactivate(sim *Simulation) {
 
 	if !aura.ActionID.IsEmptyAction() {
 		if sim.CurrentTime > aura.expires {
-			aura.metrics.Uptime += aura.expires - aura.startTime
+			aura.metrics.Uptime += aura.expires - MaxDuration(aura.startTime, 0)
 		} else {
-			aura.metrics.Uptime += sim.CurrentTime - aura.startTime
+			aura.metrics.Uptime += sim.CurrentTime - MaxDuration(aura.startTime, 0)
 		}
 	}
 

--- a/sim/warlock/TestDemonology.results
+++ b/sim/warlock/TestDemonology.results
@@ -756,7 +756,7 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12436.88976
+  dps: 12437.18825
   tps: 10461.28742
  }
 }

--- a/ui/warlock/presets.ts
+++ b/ui/warlock/presets.ts
@@ -11,7 +11,7 @@ import {
 	Debuffs,
 	TristateEffect,
 	Faction,
-	Spec,
+	Spec, Profession,
 } from '../core/proto/common.js';
 import { SavedRotation, SavedTalents } from '../core/proto/ui.js';
 import { Player } from '../core/player.js';
@@ -188,6 +188,8 @@ export const DestroDebuffs = Debuffs.create({
 
 export const OtherDefaults = {
 	distanceFromTarget: 25,
+	profession1: Profession.Engineering,
+	profession2: Profession.Tailoring,
 };
 
 export const SWP_BIS = {


### PR DESCRIPTION
Closes https://github.com/wowsims/wotlk/issues/3796

- Also sets default professions to engi + tailoring which matches all the lock presets
- Also fixes a small bug with aura metrics which were counting pre-pull auras into uptime percentage