### PR TITLE
Fix: Possible docker permissions issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM golang:1.21
 
 WORKDIR /wotlk
 COPY . .
+COPY gitconfig /etc/gitconfig
 
 RUN apt-get update
 RUN apt-get install -y protobuf-compiler

--- a/gitconfig
+++ b/gitconfig
@@ -1,0 +1,2 @@
+[safe]
+  directory = *


### PR DESCRIPTION
Running Ubuntu 20.04 on WSL2 Windows 11.

I encountered this issue after getting the latest changes which included the update to go:1.21:

```
$(echo $WOTLK_CMD) make release
make: Circular ui/core/index.ts <- ui/core/index.ts dependency dropped.
Starting server compile now...
go: downloading github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
go: downloading github.com/google/uuid v1.3.1
go: downloading golang.org/x/exp v0.0.0-20221028150844-83b7d23a625f
Build Completed Successfully
cp ./assets/favicon_io/icon-windows_amd64.syso ./sim/web/icon-windows_amd64.syso
cd ./sim/web/ && GOOS=windows GOARCH=amd64 GOAMD64=v2 go build -o wowsimwotlk-windows.exe -ldflags="-X 'main.Version=' -s -w"
go: downloading golang.org/x/sys v0.1.0
error obtaining VCS status: exit status 128
        Use -buildvcs=false to disable VCS stamping.
make: *** [makefile:180: wowsimwotlk-windows.exe] Error 1
```

It seems in some user scenarios the files that are copied in the Docker container aren't owned by the same user and when go is being executed it fails due to this.

Description: https://github.com/golang/go/issues/51253#issuecomment-1372564591
Fix: https://github.com/golang/go/issues/51253#issuecomment-1684798833
