### PR TITLE
Fix lust

### DIFF
--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -559,6 +559,7 @@ func registerExternalConsecutiveCDApproximation(agent Agent, config externalCons
 
 var BloodlustActionID = ActionID{SpellID: 2825}
 
+const SatedAuraLabel = "Sated"
 const BloodlustAuraTag = "Bloodlust"
 const BloodlustDuration = time.Second * 40
 const BloodlustCD = time.Minute * 10
@@ -578,8 +579,10 @@ func registerBloodlustCD(agent Agent) {
 			},
 		},
 
-		ApplyEffects: func(sim *Simulation, _ *Unit, _ *Spell) {
-			bloodlustAura.Activate(sim)
+		ApplyEffects: func(sim *Simulation, target *Unit, _ *Spell) {
+			if !target.HasActiveAura(SatedAuraLabel) {
+				bloodlustAura.Activate(sim)
+			}
 		},
 	})
 
@@ -589,7 +592,7 @@ func registerBloodlustCD(agent Agent) {
 		Type:     CooldownTypeDPS,
 		ShouldActivate: func(sim *Simulation, character *Character) bool {
 			// Haste portion doesn't stack with Power Infusion, so prefer to wait.
-			return !character.HasActiveAuraWithTag(PowerInfusionAuraTag)
+			return !character.HasActiveAuraWithTag(PowerInfusionAuraTag) && !character.HasActiveAura(SatedAuraLabel)
 		},
 	})
 }
@@ -598,8 +601,7 @@ func BloodlustAura(character *Character, actionTag int32) *Aura {
 	actionID := BloodlustActionID.WithTag(actionTag)
 
 	sated := character.GetOrRegisterAura(Aura{
-		Label:    "Sated-" + actionID.String(),
-		Tag:      BloodlustAuraTag, // tag as bloodlust so lust wont apply again.
+		Label:    SatedAuraLabel,
 		ActionID: ActionID{SpellID: 57724},
 		Duration: time.Minute * 10,
 	})
@@ -611,11 +613,15 @@ func BloodlustAura(character *Character, actionTag int32) *Aura {
 		Duration: BloodlustDuration,
 		OnGain: func(aura *Aura, sim *Simulation) {
 			character.MultiplyAttackSpeed(sim, 1.3)
-
 			for _, pet := range character.Pets {
 				if pet.IsEnabled() && !pet.IsGuardian() {
 					BloodlustAura(&pet.Character, actionTag).Activate(sim)
 				}
+			}
+
+			if character.HasActiveAura(SatedAuraLabel) {
+				aura.Deactivate(sim) // immediately remove it person already has sated.
+				return
 			}
 		},
 		OnExpire: func(aura *Aura, sim *Simulation) {

--- a/sim/core/raid.go
+++ b/sim/core/raid.go
@@ -152,55 +152,6 @@ func NewRaid(raidConfig *proto.Raid) *Raid {
 		nextPetIndex: int32(numParties) * 5,
 	}
 
-	// If there is at least 1 Shaman in the raid, disable Bloodlust on all other
-	// Shaman and on the RaidBuffs.
-	allShaman := RaidPlayersWithClass(raidConfig, proto.Class_ClassShaman)
-
-	var luster *proto.Player
-	for _, sham := range allShaman {
-		if ele, ok := sham.Spec.(*proto.Player_ElementalShaman); ok {
-			if ele.ElementalShaman == nil || ele.ElementalShaman.Options == nil {
-				continue
-			}
-			if luster == nil {
-				if ele.ElementalShaman.Options.Bloodlust {
-					luster = sham
-				}
-			} else {
-				ele.ElementalShaman.Options.Bloodlust = false
-			}
-		}
-		if enh, ok := sham.Spec.(*proto.Player_EnhancementShaman); ok {
-			if enh.EnhancementShaman == nil || enh.EnhancementShaman.Options == nil {
-				continue
-			}
-			if luster == nil {
-				if enh.EnhancementShaman.Options.Bloodlust {
-					luster = sham
-				}
-			} else {
-				enh.EnhancementShaman.Options.Bloodlust = false
-			}
-		}
-		if resto, ok := sham.Spec.(*proto.Player_RestorationShaman); ok {
-			if resto.RestorationShaman == nil || resto.RestorationShaman.Options == nil {
-				continue
-			}
-			if luster == nil {
-				if resto.RestorationShaman.Options.Bloodlust {
-					luster = sham
-				}
-			} else {
-				resto.RestorationShaman.Options.Bloodlust = false
-			}
-		}
-	}
-	if luster != nil {
-		if raidConfig.Buffs != nil {
-			raidConfig.Buffs.Bloodlust = false
-		}
-	}
-
 	for partyIndex, partyConfig := range raidConfig.Parties {
 		if partyConfig != nil && partyIndex < numParties {
 			raid.Parties = append(raid.Parties, NewParty(raid, partyIndex, partyConfig))

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -13,7 +13,7 @@ character_stats_results: {
   final_stats: 221
   final_stats: 0
   final_stats: 5504.84
-  final_stats: 469.94995
+  final_stats: 469.94994
   final_stats: 2072.9756
   final_stats: 221
   final_stats: 94

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -13,7 +13,7 @@ character_stats_results: {
   final_stats: 221
   final_stats: 0
   final_stats: 5725.0336
-  final_stats: 469.94995
+  final_stats: 469.94994
   final_stats: 2164.78757
   final_stats: 221
   final_stats: 94

--- a/sim/shaman/bloodlust.go
+++ b/sim/shaman/bloodlust.go
@@ -44,15 +44,21 @@ func (shaman *Shaman) registerBloodlustCD() {
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
 			// Need to check if any raid member has lust, not just self, because of
 			// major CD ordering issues with the shared bloodlust.
+
+			// If all players in all parties already have sated, don't cast.
+			allSated := true
 			for _, party := range shaman.Env.Raid.Parties {
 				for _, partyMember := range party.Players {
 					// If anyone currently has bloodlust, don't cast this.
 					if partyMember.GetCharacter().HasActiveAuraWithTag(core.BloodlustAuraTag) {
 						return false
 					}
+					if !partyMember.GetCharacter().HasActiveAura(core.SatedAuraLabel) {
+						allSated = false
+					}
 				}
 			}
-			return true
+			return true && !allSated
 		},
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, _ *core.Spell) {

--- a/sim/shaman/bloodlust.go
+++ b/sim/shaman/bloodlust.go
@@ -46,7 +46,8 @@ func (shaman *Shaman) registerBloodlustCD() {
 			// major CD ordering issues with the shared bloodlust.
 			for _, party := range shaman.Env.Raid.Parties {
 				for _, partyMember := range party.Players {
-					if partyMember.GetCharacter().HasActiveAura("Bloodlust-" + core.BloodlustActionID.WithTag(-1).String()) {
+					// If anyone currently has bloodlust, don't cast this.
+					if partyMember.GetCharacter().HasActiveAuraWithTag(core.BloodlustAuraTag) {
 						return false
 					}
 				}
@@ -56,7 +57,12 @@ func (shaman *Shaman) registerBloodlustCD() {
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, _ *core.Spell) {
 			for _, blAura := range blAuras {
-				blAura.Activate(sim)
+				target := blAura.Unit
+				// Only activate bloodlust on units without bloodlust and without sated.
+				if !target.HasActiveAura(core.SatedAuraLabel) && !target.HasActiveAuraWithTag(core.BloodlustAuraTag) {
+					blAura.Activate(sim)
+				}
+
 			}
 		},
 	})

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -49,12 +49,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.35511
+  weights: 0.34984
   weights: 0
-  weights: 1.67793
+  weights: 1.68089
   weights: 0
   weights: 0
-  weights: 1.03944
+  weights: 1.01093
   weights: 0
   weights: 0
   weights: 0
@@ -91,963 +91,963 @@ stat_weights_results: {
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7222.83456
-  tps: 4087.29431
+  dps: 7216.60799
+  tps: 4061.69912
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7258.25953
-  tps: 4107.10665
+  dps: 7252.00273
+  tps: 4081.38912
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7181.87621
-  tps: 4023.07385
+  dps: 7245.80469
+  tps: 4070.58626
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6930.28525
-  tps: 3914.52834
-  hps: 92.28755
+  dps: 6952.08193
+  tps: 3928.98077
+  hps: 92.48336
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6930.28525
-  tps: 3914.52834
-  hps: 92.28755
+  dps: 6952.08193
+  tps: 3928.98077
+  hps: 92.48336
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7195.64996
-  tps: 4030.58855
+  dps: 7257.0007
+  tps: 4076.81545
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6990.81007
-  tps: 3933.01055
+  dps: 7042.9928
+  tps: 3975.10955
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 7587.45378
-  tps: 4286.7679
+  dps: 7632.92263
+  tps: 4324.97942
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackBruise-50035"
  value: {
-  dps: 6348.54429
-  tps: 3573.18711
+  dps: 6414.66673
+  tps: 3614.56085
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackBruise-50692"
  value: {
-  dps: 6348.54429
-  tps: 3573.18711
+  dps: 6414.66673
+  tps: 3614.56085
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5408.32334
-  tps: 3030.69882
+  dps: 5432.07046
+  tps: 3044.22902
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5653.17027
-  tps: 3158.28452
+  dps: 5759.03018
+  tps: 3234.29797
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7222.1743
-  tps: 3964.99661
+  dps: 7286.47359
+  tps: 4011.82908
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7383.90937
-  tps: 4146.2629
+  dps: 7449.28149
+  tps: 4195.60134
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7383.90937
-  tps: 4146.2629
+  dps: 7449.28149
+  tps: 4195.60134
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7383.90937
-  tps: 4146.2629
+  dps: 7449.28149
+  tps: 4195.60134
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
   hps: 64
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7035.92216
-  tps: 3982.30894
+  dps: 7036.6579
+  tps: 3965.71482
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7093.16769
-  tps: 4028.95199
+  dps: 7090.59415
+  tps: 4022.88423
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7003.02264
-  tps: 3964.24563
+  dps: 6994.50116
+  tps: 3938.95694
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 7324.32564
-  tps: 4105.42718
+  dps: 7388.10276
+  tps: 4153.65601
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6965.39518
-  tps: 3942.42059
+  dps: 6956.1527
+  tps: 3917.38136
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6971.54053
-  tps: 3936.55182
+  dps: 7005.7992
+  tps: 3947.90809
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7004.56764
-  tps: 3963.30551
+  dps: 7036.74824
+  tps: 3974.99945
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7198.63396
-  tps: 4032.33244
+  dps: 7261.35541
+  tps: 4079.16115
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7529.31634
-  tps: 4278.59503
+  dps: 7576.79747
+  tps: 4295.02298
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7460.59951
-  tps: 4225.66587
+  dps: 7509.96645
+  tps: 4266.48849
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 5701.80556
-  tps: 3190.31283
+  dps: 5698.68228
+  tps: 3192.77732
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EarthshatterGarb"
  value: {
-  dps: 6579.01211
-  tps: 3695.94381
+  dps: 6637.12217
+  tps: 3726.51995
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7181.87621
-  tps: 4023.07385
+  dps: 7245.80469
+  tps: 4070.58626
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7227.1302
-  tps: 4047.99179
+  dps: 7291.81829
+  tps: 4096.23904
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7195.64996
-  tps: 4030.42213
+  dps: 7257.0007
+  tps: 4076.70046
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7192.70568
-  tps: 4028.36114
+  dps: 7254.51461
+  tps: 4075.22548
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7093.7644
-  tps: 4022.75543
+  dps: 7076.02437
+  tps: 4002.80954
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7181.87621
-  tps: 4023.07385
+  dps: 7245.80469
+  tps: 4070.58626
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7080.52846
-  tps: 4008.70025
+  dps: 7135.92696
+  tps: 4048.05275
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7234.1008
-  tps: 4096.20366
+  dps: 7226.71979
+  tps: 4074.51019
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6941.85418
-  tps: 3931.86367
+  dps: 6938.27333
+  tps: 3907.83393
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7113.33919
-  tps: 4026.05615
+  dps: 7107.20606
+  tps: 4000.83914
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7156.30772
-  tps: 4048.56456
+  dps: 7152.9694
+  tps: 4028.54789
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7222.1743
-  tps: 4045.38613
+  dps: 7286.47359
+  tps: 4093.17748
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7214.11468
-  tps: 4040.92368
+  dps: 7278.33981
+  tps: 4088.65923
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 6042.83671
-  tps: 3391.82412
+  dps: 6042.42831
+  tps: 3391.41259
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 7443.16639
-  tps: 4168.59601
+  dps: 7432.83605
+  tps: 4157.62065
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 7339.74652
-  tps: 4113.56724
+  dps: 7403.69808
+  tps: 4161.90591
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7034.43812
-  tps: 3981.92866
+  dps: 7028.37231
+  tps: 3956.98415
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 5575.98295
-  tps: 3141.49783
+  dps: 5613.6985
+  tps: 3164.55535
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Gladiator'sWartide"
  value: {
-  dps: 6579.92689
-  tps: 3682.8821
+  dps: 6635.98755
+  tps: 3726.67434
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7240.54704
-  tps: 4097.20048
+  dps: 7234.30536
+  tps: 4071.54412
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7280.80269
-  tps: 4119.7145
+  dps: 7274.52666
+  tps: 4093.91911
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7048.85326
-  tps: 3999.26303
+  dps: 7074.99348
+  tps: 4014.33841
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 7286.30822
-  tps: 4083.77984
+  dps: 7349.87436
+  tps: 4131.77644
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-49982"
  value: {
-  dps: 7383.90937
-  tps: 4146.2629
+  dps: 7449.28149
+  tps: 4195.60134
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-50641"
  value: {
-  dps: 7383.90937
-  tps: 4146.2629
+  dps: 7449.28149
+  tps: 4195.60134
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7195.64996
-  tps: 4030.42213
+  dps: 7257.0007
+  tps: 4076.70046
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7192.70568
-  tps: 4028.36114
+  dps: 7254.51461
+  tps: 4075.22548
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7186.80374
-  tps: 4031.68111
+  dps: 7251.11902
+  tps: 4079.04645
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7181.87621
-  tps: 4023.07385
+  dps: 7245.80469
+  tps: 4070.58626
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LastWord-50179"
  value: {
-  dps: 7383.90937
-  tps: 4146.2629
+  dps: 7449.28149
+  tps: 4195.60134
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LastWord-50708"
  value: {
-  dps: 7383.90937
-  tps: 4146.2629
+  dps: 7449.28149
+  tps: 4195.60134
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7014.30025
-  tps: 3970.03283
+  dps: 7004.81101
+  tps: 3946.91676
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7153.97016
-  tps: 4049.90828
+  dps: 7146.53841
+  tps: 4024.41021
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Nibelung-49992"
  value: {
-  dps: 7383.90937
-  tps: 4146.2629
+  dps: 7449.28149
+  tps: 4195.60134
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Nibelung-50648"
  value: {
-  dps: 7383.90937
-  tps: 4146.2629
+  dps: 7449.28149
+  tps: 4195.60134
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7181.87621
-  tps: 4023.07385
+  dps: 7245.80469
+  tps: 4070.58626
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7181.87621
-  tps: 4023.07385
+  dps: 7245.80469
+  tps: 4070.58626
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7181.87621
-  tps: 4023.07385
+  dps: 7245.80469
+  tps: 4070.58626
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7181.87621
-  tps: 4023.07385
+  dps: 7245.80469
+  tps: 4070.58626
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7351.22254
-  tps: 4230.37063
+  dps: 7427.03004
+  tps: 4275.75938
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7403.4626
-  tps: 4269.80677
+  dps: 7480.22656
+  tps: 4316.03492
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7368.9685
-  tps: 4138.30033
+  dps: 7437.11071
+  tps: 4188.95694
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 7358.47187
-  tps: 4123.45161
+  dps: 7422.63525
+  tps: 4171.92365
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7181.87621
-  tps: 4023.05851
+  dps: 7245.80469
+  tps: 4070.52481
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 7280.00387
-  tps: 4080.70678
+  dps: 7343.46337
+  tps: 4128.65225
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7383.90937
-  tps: 4146.2629
+  dps: 7449.28149
+  tps: 4195.60134
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkycallTotem-33506"
  value: {
-  dps: 7264.73389
-  tps: 4074.16014
+  dps: 7335.3942
+  tps: 4132.12405
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterHarness"
  value: {
-  dps: 4610.86817
-  tps: 2568.09776
+  dps: 4780.13067
+  tps: 2682.16334
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterRegalia"
  value: {
-  dps: 5608.36043
-  tps: 3129.87269
+  dps: 5634.1235
+  tps: 3155.34125
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7189.01981
-  tps: 4075.3999
+  dps: 7182.8221
+  tps: 4049.28215
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7221.22433
-  tps: 4094.09446
+  dps: 7214.99914
+  tps: 4067.86548
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7055.37106
-  tps: 3993.63596
+  dps: 7049.28739
+  tps: 3968.61914
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7030.80867
-  tps: 3987.84237
+  dps: 7026.29463
+  tps: 3966.72442
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SparkofLife-37657"
  value: {
-  dps: 7060.20639
-  tps: 3998.76366
+  dps: 7045.99621
+  tps: 3974.31222
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7113.4843
-  tps: 3998.9751
+  dps: 7160.26903
+  tps: 4035.90335
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 7247.22126
-  tps: 4064.72683
+  dps: 7310.12618
+  tps: 4112.40648
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StormshroudArmor"
  value: {
-  dps: 5161.0871
-  tps: 2880.36141
+  dps: 5226.94083
+  tps: 2918.11378
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7181.87621
-  tps: 4023.07385
+  dps: 7245.80469
+  tps: 4070.58626
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7181.87621
-  tps: 4023.07385
+  dps: 7245.80469
+  tps: 4070.58626
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7181.87621
-  tps: 4023.07385
+  dps: 7245.80469
+  tps: 4070.58626
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6964.19665
-  tps: 3941.92546
+  dps: 6953.25119
+  tps: 3914.87036
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheFistsofFury"
  value: {
-  dps: 6526.12034
-  tps: 3665.43034
+  dps: 6589.78349
+  tps: 3702.69462
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6934.60411
-  tps: 3926.09388
+  dps: 6928.62349
+  tps: 3901.49416
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 5971.41705
-  tps: 3361.27181
+  dps: 5995.77007
+  tps: 3378.64913
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Thrall'sRegalia"
  value: {
-  dps: 7089.80307
-  tps: 4011.28445
+  dps: 7105.0829
+  tps: 4022.80613
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7181.87621
-  tps: 4023.07385
+  dps: 7245.80469
+  tps: 4070.58626
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TidefuryRaiment"
  value: {
-  dps: 5202.375
-  tps: 2902.60446
+  dps: 5290.80177
+  tps: 2957.01164
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7134.25112
-  tps: 4009.97963
+  dps: 7199.6117
+  tps: 4058.93164
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7134.25112
-  tps: 4009.97963
+  dps: 7199.6117
+  tps: 4058.93164
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7222.1743
-  tps: 4045.38613
+  dps: 7286.47359
+  tps: 4093.17748
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7214.11468
-  tps: 4040.92368
+  dps: 7278.33981
+  tps: 4088.65923
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7096.24713
-  tps: 4003.48646
+  dps: 7135.53047
+  tps: 4030.85077
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 7558.51042
-  tps: 4266.82863
+  dps: 7611.19683
+  tps: 4302.94948
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofQuakingEarth-47667"
  value: {
-  dps: 7247.22126
-  tps: 4064.72683
+  dps: 7310.12618
+  tps: 4112.40648
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 7247.22126
-  tps: 4064.72683
+  dps: 7310.12618
+  tps: 4112.40648
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemoftheElementalPlane-40708"
  value: {
-  dps: 7297.41918
-  tps: 4097.1737
+  dps: 7349.8638
+  tps: 4134.72973
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7214.11468
-  tps: 4040.92368
+  dps: 7278.33981
+  tps: 4088.65923
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7222.1743
-  tps: 4045.38613
+  dps: 7286.47359
+  tps: 4093.17748
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5048.65852
-  tps: 2803.12782
+  dps: 5090.45096
+  tps: 2832.52161
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7637.0945
-  tps: 4287.56536
+  dps: 7697.63845
+  tps: 4332.84466
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7073.17838
-  tps: 3986.14764
+  dps: 7069.83291
+  tps: 3962.94915
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 5875.83993
-  tps: 3299.77855
+  dps: 5906.42726
+  tps: 3316.79654
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WorldbreakerGarb"
  value: {
-  dps: 7119.35411
-  tps: 4073.55774
+  dps: 7131.2982
+  tps: 4074.63615
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 7378.29871
-  tps: 4133.91741
+  dps: 7442.68637
+  tps: 4182.53068
  }
 }
 dps_results: {
  key: "TestElemental-Average-Default"
  value: {
-  dps: 7486.73284
-  tps: 4211.31342
+  dps: 7514.63805
+  tps: 4227.027
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8973.5832
-  tps: 4462.55688
+  dps: 9156.12696
+  tps: 4568.98546
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7444.78568
-  tps: 4153.11459
+  dps: 7456.53168
+  tps: 4169.28297
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9042.20125
-  tps: 4797.08247
+  dps: 9184.09164
+  tps: 4869.56538
  }
 }
 dps_results: {
@@ -1074,22 +1074,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8973.5832
-  tps: 4462.55688
+  dps: 9156.12696
+  tps: 4568.98546
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7444.78568
-  tps: 4153.11459
+  dps: 7456.53168
+  tps: 4169.28297
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9042.20125
-  tps: 4797.08247
+  dps: 9184.09164
+  tps: 4869.56538
  }
 }
 dps_results: {
@@ -1116,22 +1116,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8819.52604
-  tps: 4484.22969
+  dps: 8986.85494
+  tps: 4580.35971
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7383.90937
-  tps: 4146.2629
+  dps: 7449.28149
+  tps: 4195.60134
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8778.12039
-  tps: 4686.22892
+  dps: 8938.59616
+  tps: 4803.53435
  }
 }
 dps_results: {
@@ -1158,22 +1158,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8819.52604
-  tps: 4484.22969
+  dps: 8986.85494
+  tps: 4580.35971
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7383.90937
-  tps: 4146.2629
+  dps: 7449.28149
+  tps: 4195.60134
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8778.12039
-  tps: 4686.22892
+  dps: 8938.59616
+  tps: 4803.53435
  }
 }
 dps_results: {
@@ -1200,7 +1200,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7363.33688
-  tps: 4146.2629
+  dps: 7428.86408
+  tps: 4195.60134
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -46,964 +46,964 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7261.73163
-  tps: 4021.38271
+  dps: 7480.55573
+  tps: 4127.42005
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7281.38086
-  tps: 4032.66549
+  dps: 7500.64131
+  tps: 4138.99402
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7175.99432
-  tps: 3971.65885
+  dps: 7386.33896
+  tps: 4076.06014
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7262.37182
-  tps: 4021.10531
+  dps: 7497.51354
+  tps: 4138.70973
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7101.61886
-  tps: 3929.48233
-  hps: 94.81929
+  dps: 7316.87063
+  tps: 4032.97256
+  hps: 95.39133
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7101.61886
-  tps: 3929.48233
-  hps: 94.81929
+  dps: 7316.87063
+  tps: 4032.97256
+  hps: 95.39133
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7192.55707
-  tps: 3984.79605
+  dps: 7424.80227
+  tps: 4096.93947
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6987.90945
-  tps: 3852.21803
+  dps: 7160.10328
+  tps: 3933.6339
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 7611.7191
-  tps: 4243.47916
+  dps: 7829.11715
+  tps: 4345.45916
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50035"
  value: {
-  dps: 7149.73688
-  tps: 3948.91713
+  dps: 7363.53375
+  tps: 4047.82556
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50692"
  value: {
-  dps: 7200.27945
-  tps: 3974.71415
+  dps: 7425.16996
+  tps: 4082.73785
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5902.23184
-  tps: 3240.23494
+  dps: 6105.10405
+  tps: 3343.63497
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5802.20146
-  tps: 3188.88491
+  dps: 6018.1042
+  tps: 3301.2355
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7198.51633
-  tps: 3874.59817
+  dps: 7409.27851
+  tps: 3976.37623
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7333.96031
-  tps: 4067.37191
+  dps: 7557.2516
+  tps: 4179.34252
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7333.96031
-  tps: 4067.37191
+  dps: 7557.2516
+  tps: 4179.34252
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7343.37445
-  tps: 4073.18446
+  dps: 7564.56645
+  tps: 4186.12282
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7101.85829
-  tps: 3929.58191
+  dps: 7317.13213
+  tps: 4033.25006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7101.85829
-  tps: 3929.58191
+  dps: 7317.13213
+  tps: 4033.25006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7101.86065
-  tps: 3929.58191
+  dps: 7317.13213
+  tps: 4033.25006
   hps: 64
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7217.2008
-  tps: 3988.28667
+  dps: 7449.88021
+  tps: 4110.31021
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7292.9994
-  tps: 4047.65007
+  dps: 7511.84615
+  tps: 4143.33666
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7294.53413
-  tps: 4025.27237
+  dps: 7537.9893
+  tps: 4140.85406
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 7344.74724
-  tps: 4070.81238
+  dps: 7557.06893
+  tps: 4172.2235
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7478.12742
-  tps: 4124.41198
+  dps: 7701.93753
+  tps: 4231.84682
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7196.34734
-  tps: 3982.74405
+  dps: 7416.81273
+  tps: 4087.03735
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7407.56714
-  tps: 4083.69252
+  dps: 7632.28879
+  tps: 4187.18086
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7472.97522
-  tps: 4121.15277
+  dps: 7709.50139
+  tps: 4230.09232
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7101.85829
-  tps: 3929.58191
+  dps: 7317.13213
+  tps: 4033.25006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7194.4864
-  tps: 3982.73779
+  dps: 7411.76139
+  tps: 4092.30964
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7532.57066
-  tps: 4199.92936
+  dps: 7746.74781
+  tps: 4298.26716
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7486.97529
-  tps: 4172.59091
+  dps: 7701.87391
+  tps: 4269.02382
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 6564.23006
-  tps: 3602.17896
+  dps: 6802.42773
+  tps: 3725.37694
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterGarb"
  value: {
-  dps: 6242.74716
-  tps: 3440.33563
+  dps: 6451.73657
+  tps: 3545.34607
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7175.99432
-  tps: 3971.65885
+  dps: 7386.33896
+  tps: 4076.06014
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7203.25013
-  tps: 3988.39546
+  dps: 7427.06809
+  tps: 4096.55442
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7192.17973
-  tps: 3981.3687
+  dps: 7409.04081
+  tps: 4091.11567
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7185.51376
-  tps: 3977.60757
+  dps: 7404.27821
+  tps: 4087.81395
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7236.3489
-  tps: 4007.30081
+  dps: 7476.18987
+  tps: 4128.21039
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7101.85829
-  tps: 3929.58191
+  dps: 7317.13213
+  tps: 4033.25006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7175.99432
-  tps: 3971.65885
+  dps: 7386.33896
+  tps: 4076.06014
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7231.61855
-  tps: 4004.04502
+  dps: 7491.93941
+  tps: 4140.12054
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7322.86203
-  tps: 4055.6967
+  dps: 7555.15003
+  tps: 4171.48104
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7150.90191
-  tps: 3958.23782
+  dps: 7394.75045
+  tps: 4077.92588
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7200.99762
-  tps: 3986.50866
+  dps: 7418.47302
+  tps: 4091.64598
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7250.82244
-  tps: 4020.09372
+  dps: 7478.36964
+  tps: 4132.05804
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7198.51633
-  tps: 3984.60053
+  dps: 7409.27851
+  tps: 4089.30414
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7194.01193
-  tps: 3982.0122
+  dps: 7404.6906
+  tps: 4086.65534
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 7347.04455
-  tps: 4051.15174
+  dps: 7565.50093
+  tps: 4156.67031
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 6962.69438
-  tps: 3853.9496
+  dps: 7182.63546
+  tps: 3972.23715
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 7355.80275
-  tps: 4078.06727
+  dps: 7568.3341
+  tps: 4179.62617
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7284.62094
-  tps: 4028.45062
+  dps: 7502.39154
+  tps: 4132.9124
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7157.23341
-  tps: 3961.37883
+  dps: 7373.73695
+  tps: 4065.8676
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 6848.67878
-  tps: 3736.20575
+  dps: 7048.68368
+  tps: 3826.99778
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sWartide"
  value: {
-  dps: 5965.77642
-  tps: 3253.36737
+  dps: 6170.36747
+  tps: 3355.34928
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7271.55624
-  tps: 4027.0241
+  dps: 7490.59852
+  tps: 4133.20703
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7293.88492
-  tps: 4039.84544
+  dps: 7513.42304
+  tps: 4146.35927
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7253.18975
-  tps: 4018.86143
+  dps: 7492.04271
+  tps: 4138.95336
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 7322.76342
-  tps: 4056.09437
+  dps: 7534.56993
+  tps: 4157.16435
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-49982"
  value: {
-  dps: 7333.96031
-  tps: 4067.37191
+  dps: 7557.2516
+  tps: 4179.34252
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-50641"
  value: {
-  dps: 7333.96031
-  tps: 4067.37191
+  dps: 7557.2516
+  tps: 4179.34252
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7251.72581
-  tps: 4027.81708
+  dps: 7470.30462
+  tps: 4133.79166
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7192.17973
-  tps: 3981.3687
+  dps: 7409.04081
+  tps: 4091.11567
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7185.51376
-  tps: 3977.60757
+  dps: 7404.27821
+  tps: 4087.81395
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7226.81453
-  tps: 3994.56053
+  dps: 7448.63429
+  tps: 4101.71192
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7200.7573
-  tps: 3985.31387
+  dps: 7435.92461
+  tps: 4096.49307
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7198.94897
-  tps: 3983.33747
-  hps: 10.94835
+  dps: 7411.08401
+  tps: 4090.27547
+  hps: 11.01615
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50179"
  value: {
-  dps: 7333.96031
-  tps: 4067.37191
+  dps: 7557.2516
+  tps: 4179.34252
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50708"
  value: {
-  dps: 7333.96031
-  tps: 4067.37191
+  dps: 7557.2516
+  tps: 4179.34252
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7101.85829
-  tps: 3929.58191
+  dps: 7317.13213
+  tps: 4033.25006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7101.85829
-  tps: 3929.58191
+  dps: 7317.13213
+  tps: 4033.25006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7295.58508
-  tps: 4040.76045
+  dps: 7503.64293
+  tps: 4138.56917
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Nibelung-49992"
  value: {
-  dps: 7333.96031
-  tps: 4067.37191
+  dps: 7557.2516
+  tps: 4179.34252
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Nibelung-50648"
  value: {
-  dps: 7333.96031
-  tps: 4067.37191
+  dps: 7557.2516
+  tps: 4179.34252
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7101.86089
-  tps: 3929.58191
+  dps: 7317.13213
+  tps: 4033.25006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7192.39395
-  tps: 3980.00684
+  dps: 7407.00223
+  tps: 4088.28394
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7198.94897
-  tps: 3983.33747
+  dps: 7411.08401
+  tps: 4090.27547
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7101.85829
-  tps: 3929.58191
+  dps: 7317.13213
+  tps: 4033.25006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7101.85829
-  tps: 3929.58191
+  dps: 7317.13213
+  tps: 4033.25006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7101.85829
-  tps: 3929.58191
+  dps: 7317.13213
+  tps: 4033.25006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7175.99432
-  tps: 3971.65885
+  dps: 7386.33896
+  tps: 4076.06014
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7175.99432
-  tps: 3971.65885
+  dps: 7386.33896
+  tps: 4076.06014
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7101.85829
-  tps: 3929.58191
+  dps: 7317.13213
+  tps: 4033.25006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7511.52197
-  tps: 4194.00216
+  dps: 7753.96747
+  tps: 4323.37708
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7560.9339
-  tps: 4226.54674
+  dps: 7804.5183
+  tps: 4356.73088
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7333.96031
-  tps: 4067.37191
+  dps: 7557.2516
+  tps: 4179.34252
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 7369.22729
-  tps: 4086.87678
+  dps: 7582.01324
+  tps: 4188.61514
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7158.71736
-  tps: 3960.40218
+  dps: 7386.78856
+  tps: 4074.49755
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7101.85829
-  tps: 3929.58191
+  dps: 7317.13213
+  tps: 4033.25006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 7317.39347
-  tps: 4052.61753
+  dps: 7529.11355
+  tps: 4153.62335
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7101.85829
-  tps: 3929.58191
+  dps: 7317.13213
+  tps: 4033.25006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7333.96031
-  tps: 4067.37191
+  dps: 7557.2516
+  tps: 4179.34252
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7101.85829
-  tps: 3929.58191
+  dps: 7317.13213
+  tps: 4033.25006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7101.85535
-  tps: 3929.58191
+  dps: 7317.13213
+  tps: 4033.25006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkycallTotem-33506"
  value: {
-  dps: 7271.59094
-  tps: 4031.36254
+  dps: 7503.13518
+  tps: 4138.62373
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterHarness"
  value: {
-  dps: 5254.60032
-  tps: 2865.56746
+  dps: 5415.34665
+  tps: 2943.95101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterRegalia"
  value: {
-  dps: 5159.36084
-  tps: 2820.53535
+  dps: 5320.15975
+  tps: 2900.20711
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7268.9912
-  tps: 4028.30998
+  dps: 7487.49452
+  tps: 4133.01231
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7273.60598
-  tps: 4033.83308
+  dps: 7515.93136
+  tps: 4146.65228
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7168.84433
-  tps: 3968.04593
+  dps: 7385.6057
+  tps: 4072.70676
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7220.52318
-  tps: 3998.11031
+  dps: 7429.09158
+  tps: 4089.05797
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SparkofLife-37657"
  value: {
-  dps: 7205.61751
-  tps: 3990.74576
+  dps: 7452.9667
+  tps: 4112.33435
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7223.06667
-  tps: 3992.7301
+  dps: 7452.00547
+  tps: 4108.68715
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 7319.0358
-  tps: 4052.21294
+  dps: 7528.51121
+  tps: 4150.78428
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StormshroudArmor"
  value: {
-  dps: 5492.74643
-  tps: 3001.0998
+  dps: 5664.37287
+  tps: 3088.27653
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7198.94897
-  tps: 3983.33747
+  dps: 7411.08401
+  tps: 4090.27547
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7192.39395
-  tps: 3980.00684
+  dps: 7407.00223
+  tps: 4088.28394
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7183.17087
-  tps: 3975.58454
+  dps: 7399.08014
+  tps: 4082.74053
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7101.85829
-  tps: 3929.58191
+  dps: 7317.13213
+  tps: 4033.25006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7196.95645
-  tps: 3976.43934
+  dps: 7430.18687
+  tps: 4097.40158
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheFistsofFury"
  value: {
-  dps: 6306.6477
-  tps: 3449.64549
+  dps: 6494.7317
+  tps: 3545.86564
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7101.85829
-  tps: 3929.58191
+  dps: 7317.13213
+  tps: 4033.25006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 7085.54609
-  tps: 3925.50117
+  dps: 7275.33065
+  tps: 4015.11157
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sRegalia"
  value: {
-  dps: 6777.65985
-  tps: 3766.91662
+  dps: 6956.23851
+  tps: 3852.92824
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7232.72954
-  tps: 3999.92351
+  dps: 7478.17445
+  tps: 4129.024
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TidefuryRaiment"
  value: {
-  dps: 5194.11174
-  tps: 2830.5604
+  dps: 5355.11105
+  tps: 2904.21431
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7313.12631
-  tps: 4046.01728
+  dps: 7558.05279
+  tps: 4173.34011
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7327.06213
-  tps: 4059.42895
+  dps: 7535.00581
+  tps: 4160.28393
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7198.51633
-  tps: 3984.60053
+  dps: 7409.27851
+  tps: 4089.30414
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7194.01193
-  tps: 3982.0122
+  dps: 7404.6906
+  tps: 4086.65534
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7238.47012
-  tps: 4001.05264
+  dps: 7466.5239
+  tps: 4119.88231
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 7504.53035
-  tps: 4164.03211
+  dps: 7783.58747
+  tps: 4314.1923
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofQuakingEarth-47667"
  value: {
-  dps: 7420.14878
-  tps: 4107.40437
+  dps: 7636.26227
+  tps: 4212.36375
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 7576.02432
-  tps: 4189.72074
+  dps: 7792.87514
+  tps: 4292.23179
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheElementalPlane-40708"
  value: {
-  dps: 7273.96714
-  tps: 4026.36999
+  dps: 7538.61709
+  tps: 4160.92952
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7194.01193
-  tps: 3982.0122
+  dps: 7404.6906
+  tps: 4086.65534
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7198.51633
-  tps: 3984.60053
+  dps: 7409.27851
+  tps: 4089.30414
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5823.40986
-  tps: 3193.08214
+  dps: 6051.16308
+  tps: 3312.45893
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7541.80677
-  tps: 4170.22971
+  dps: 7778.81973
+  tps: 4293.06631
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7158.39988
-  tps: 3966.48619
+  dps: 7378.7003
+  tps: 4073.73244
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 7071.52327
-  tps: 3922.56598
+  dps: 7284.68366
+  tps: 4027.60898
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerGarb"
  value: {
-  dps: 6790.10223
-  tps: 3776.17158
+  dps: 6949.35217
+  tps: 3844.80381
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 7383.44152
-  tps: 4096.20449
+  dps: 7596.49704
+  tps: 4198.13286
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 7350.31744
-  tps: 4073.16668
+  dps: 7576.36428
+  tps: 4184.97499
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-FT-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25444.50459
-  tps: 15395.95991
+  dps: 25965.21383
+  tps: 15728.86752
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-FT-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7370.23048
-  tps: 4060.37589
+  dps: 7599.96071
+  tps: 4170.90052
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-FT-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8525.78968
-  tps: 4070.2622
+  dps: 9537.99941
+  tps: 4535.40617
  }
 }
 dps_results: {
@@ -1030,22 +1030,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-WF-FullBuffs-LongMultiTarget"
  value: {
-  dps: 24786.12981
-  tps: 14943.75589
+  dps: 25091.30746
+  tps: 15124.2391
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-WF-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7451.40339
-  tps: 4121.02268
+  dps: 7701.60351
+  tps: 4247.90027
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-FT-WF-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8567.66941
-  tps: 4104.11414
+  dps: 9652.925
+  tps: 4628.50426
  }
 }
 dps_results: {
@@ -1072,22 +1072,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-WF-FT-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21383.48311
-  tps: 13139.44238
+  dps: 21794.31376
+  tps: 13271.32898
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-WF-FT-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6333.10442
-  tps: 3402.7965
+  dps: 6555.98154
+  tps: 3510.95709
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-WF-FT-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7527.71106
-  tps: 3480.03171
+  dps: 8494.50677
+  tps: 3914.41667
  }
 }
 dps_results: {
@@ -1114,22 +1114,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-WF-WF-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20548.40102
-  tps: 12505.53106
+  dps: 20978.57494
+  tps: 12736.70809
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-WF-WF-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6421.32953
-  tps: 3468.38048
+  dps: 6636.281
+  tps: 3567.04956
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-P1-WF-WF-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7569.11703
-  tps: 3514.26531
+  dps: 8622.15266
+  tps: 4005.03127
  }
 }
 dps_results: {
@@ -1156,22 +1156,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-FT-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25346.32663
-  tps: 15417.77376
+  dps: 25778.94947
+  tps: 15756.01325
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-FT-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7333.96031
-  tps: 4067.37191
+  dps: 7557.2516
+  tps: 4179.34252
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-FT-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8461.47325
-  tps: 4104.9541
+  dps: 9599.57092
+  tps: 4666.58399
  }
 }
 dps_results: {
@@ -1198,22 +1198,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-WF-FullBuffs-LongMultiTarget"
  value: {
-  dps: 24558.40732
-  tps: 14895.78289
+  dps: 25337.11058
+  tps: 15490.73618
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-WF-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7431.52413
-  tps: 4131.06481
+  dps: 7687.43515
+  tps: 4262.64534
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-FT-WF-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8592.1438
-  tps: 4184.28983
+  dps: 9715.23117
+  tps: 4740.03731
  }
 }
 dps_results: {
@@ -1240,22 +1240,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-WF-FT-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21028.54377
-  tps: 12838.60779
+  dps: 21508.02472
+  tps: 13149.16065
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-WF-FT-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6290.13696
-  tps: 3401.52484
+  dps: 6494.63817
+  tps: 3493.04504
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-WF-FT-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7450.3584
-  tps: 3487.2364
+  dps: 8398.27091
+  tps: 3916.3862
  }
 }
 dps_results: {
@@ -1282,22 +1282,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-WF-WF-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20457.97124
-  tps: 12554.95085
+  dps: 21034.79165
+  tps: 12869.74086
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-WF-WF-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6398.912
-  tps: 3469.53007
+  dps: 6563.73913
+  tps: 3548.71796
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-P1-WF-WF-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7493.26969
-  tps: 3528.13398
+  dps: 8476.86271
+  tps: 3979.84841
  }
 }
 dps_results: {
@@ -1324,7 +1324,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6985.64136
-  tps: 3852.78762
+  dps: 7236.61581
+  tps: 3979.87431
  }
 }

--- a/ui/elemental_shaman/presets.ts
+++ b/ui/elemental_shaman/presets.ts
@@ -269,6 +269,7 @@ export const ROTATION_PRESET_ADVANCED = {
     specRotationOptionsJson: ElementalShamanRotation.toJsonString(DefaultRotation),
     rotation: APLRotation.fromJsonString(`{
       "enabled": true,
+      "type": "TypeAPL",
       "prepullActions": [
         {"action":{"castSpell":{"spellId":{"spellId":59159}}},"doAtValue":{"const":{"val":"-3.75s"}}},
         {"action":{"castSpell":{"spellId":{"spellId":49238}}},"doAtValue":{"const":{"val":"-2.50s"}}},


### PR DESCRIPTION
Now correctly applies and uses the sated value. This removes the need for special code in raid to enable/disable casting lust.