### PR TITLE
Implement 2 warlock-specific APL values to help with snapshotting

### DIFF
--- a/proto/apl.proto
+++ b/proto/apl.proto
@@ -76,7 +76,7 @@ message APLAction {
     }
 }
 
-// NextIndex: 59
+// NextIndex: 61
 message APLValue {
     oneof value {
         // Operators
@@ -160,6 +160,8 @@ message APLValue {
         // Class or Spec-specific values
         APLValueTotemRemainingTime totem_remaining_time = 49;
         APLValueCatExcessEnergy cat_excess_energy = 52;
+        APLValueWarlockShouldRecastDrainSoul warlock_should_recast_drain_soul = 59;
+        APLValueWarlockShouldRefreshCorruption warlock_should_refresh_corruption = 60;
     }
 }
 
@@ -466,4 +468,9 @@ message APLValueTotemRemainingTime {
     ShamanTotems.TotemType totem_type = 1;
 }
 message APLValueCatExcessEnergy {
+}
+message APLValueWarlockShouldRecastDrainSoul {
+}
+message APLValueWarlockShouldRefreshCorruption {
+    UnitReference target_unit = 1;
 }

--- a/sim/core/apl_values_spell.go
+++ b/sim/core/apl_values_spell.go
@@ -145,7 +145,7 @@ func (value *APLValueSpellTravelTime) Type() proto.APLValueType {
 	return proto.APLValueType_ValueTypeDuration
 }
 func (value *APLValueSpellTravelTime) GetDuration(sim *Simulation) time.Duration {
-	return time.Duration(float64(time.Second) * value.spell.Unit.DistanceFromTarget / value.spell.MissileSpeed)
+	return value.spell.TravelTime()
 }
 func (value *APLValueSpellTravelTime) String() string {
 	return fmt.Sprintf("Travel Time(%s)", value.spell.ActionID)

--- a/sim/core/spell.go
+++ b/sim/core/spell.go
@@ -576,6 +576,14 @@ func (spell *Spell) CastTime() time.Duration {
 	return spell.Unit.ApplyCastSpeedForSpell(spell.DefaultCast.CastTime, spell)
 }
 
+func (spell *Spell) TravelTime() time.Duration {
+	if spell.MissileSpeed == 0 {
+		return 0
+	} else {
+		return time.Duration(float64(time.Second) * spell.Unit.DistanceFromTarget / spell.MissileSpeed)
+	}
+}
+
 // Handles computing the cost of spells and checking whether the Unit
 // meets them.
 type SpellCost interface {

--- a/sim/core/spell_result.go
+++ b/sim/core/spell_result.go
@@ -3,7 +3,6 @@ package core
 import (
 	"fmt"
 	"math"
-	"time"
 
 	"github.com/wowsims/wotlk/sim/core/stats"
 )
@@ -367,9 +366,8 @@ func (dot *Dot) CalcAndDealPeriodicSnapshotHealing(sim *Simulation, target *Unit
 }
 
 func (spell *Spell) WaitTravelTime(sim *Simulation, callback func(*Simulation)) {
-	travelTime := time.Duration(float64(time.Second) * spell.Unit.DistanceFromTarget / spell.MissileSpeed)
 	StartDelayedAction(sim, DelayedActionOptions{
-		DoAt:     sim.CurrentTime + travelTime,
+		DoAt:     sim.CurrentTime + spell.TravelTime(),
 		OnAction: callback,
 	})
 }

--- a/sim/warlock/apl_values.go
+++ b/sim/warlock/apl_values.go
@@ -1,0 +1,138 @@
+package warlock
+
+import (
+	"github.com/wowsims/wotlk/sim/core"
+	"github.com/wowsims/wotlk/sim/core/proto"
+)
+
+func (warlock *Warlock) NewAPLValue(rot *core.APLRotation, config *proto.APLValue) core.APLValue {
+	switch config.Value.(type) {
+	case *proto.APLValue_WarlockShouldRecastDrainSoul:
+		return warlock.newValueWarlockShouldRecastDrainSoul(rot, config.GetWarlockShouldRecastDrainSoul())
+	case *proto.APLValue_WarlockShouldRefreshCorruption:
+		return warlock.newValueWarlockShouldRefreshCorruption(rot, config.GetWarlockShouldRefreshCorruption())
+	default:
+		return nil
+	}
+}
+
+type APLValueWarlockShouldRecastDrainSoul struct {
+	core.DefaultAPLValueImpl
+	warlock *Warlock
+}
+
+func (warlock *Warlock) newValueWarlockShouldRecastDrainSoul(rot *core.APLRotation, config *proto.APLValueWarlockShouldRecastDrainSoul) core.APLValue {
+	return &APLValueWarlockShouldRecastDrainSoul{
+		warlock: warlock,
+	}
+}
+func (value *APLValueWarlockShouldRecastDrainSoul) Type() proto.APLValueType {
+	return proto.APLValueType_ValueTypeBool
+}
+func (value *APLValueWarlockShouldRecastDrainSoul) GetBool(sim *core.Simulation) bool {
+	warlock := value.warlock
+
+	// Assert that we're currently channeling Drain Soul.
+	if warlock.ChanneledDot == nil || warlock.ChanneledDot.Spell != warlock.DrainSoul {
+		return false
+	}
+
+	uaRefresh := warlock.UnstableAffliction.CurDot().RemainingDuration(sim) -
+		warlock.UnstableAffliction.CastTime()
+
+	curseRefresh := max(
+		warlock.CurseOfAgony.CurDot().RemainingDuration(sim),
+		warlock.CurseOfDoom.CurDot().RemainingDuration(sim),
+		warlock.CurseOfElements.CurDot().RemainingDuration(sim),
+		warlock.CurseOfTongues.CurDot().RemainingDuration(sim),
+		warlock.CurseOfWeakness.CurDot().RemainingDuration(sim),
+	) - warlock.CurseOfAgony.CastTime()
+
+	hauntRefresh := warlock.HauntDebuffAuras.Get(warlock.CurrentTarget).RemainingDuration(sim) -
+		warlock.Haunt.CastTime() -
+		warlock.Haunt.TravelTime()
+
+	timeUntilRefresh := min(uaRefresh, curseRefresh)
+
+	// the amount of ticks we have left, assuming we continue channeling
+	dsDot := warlock.ChanneledDot
+	ticksLeft := int(timeUntilRefresh/dsDot.TickPeriod()) + 1
+	ticksLeft = min(ticksLeft, int(hauntRefresh/dsDot.TickPeriod()))
+	ticksLeft = min(ticksLeft, dsDot.NumTicksRemaining(sim))
+
+	// amount of ticks we'd get assuming we recast drain soul
+	recastTicks := int(timeUntilRefresh/warlock.ApplyCastSpeed(dsDot.TickLength)) + 1
+	recastTicks = min(recastTicks, int(hauntRefresh/warlock.ApplyCastSpeed(dsDot.TickLength)))
+	recastTicks = min(recastTicks, int(dsDot.NumberOfTicks))
+
+	if ticksLeft <= 0 || recastTicks <= 0 {
+		return false
+	}
+
+	snapshotDmg := warlock.DrainSoul.ExpectedTickDamageFromCurrentSnapshot(sim, warlock.CurrentTarget) * float64(ticksLeft)
+	recastDmg := warlock.DrainSoul.ExpectedTickDamage(sim, warlock.CurrentTarget) * float64(recastTicks)
+	snapshotDPS := snapshotDmg / (float64(ticksLeft) * dsDot.TickPeriod().Seconds())
+	recastDps := recastDmg / (float64(recastTicks)*warlock.ApplyCastSpeed(dsDot.TickLength).Seconds() +
+		humanReactionTime.Seconds())
+
+	//if sim.Log != nil {
+	//	warlock.Log(sim, "Should Recast Drain Soul Calc: %.2f (%d) > %.2f (%d)", recastDps, recastTicks, snapshotDPS, ticksLeft)
+	//}
+	return recastDps > snapshotDPS
+}
+func (value *APLValueWarlockShouldRecastDrainSoul) String() string {
+	return "Warlock Should Recast Drain Soul()"
+}
+
+type APLValueWarlockShouldRefreshCorruption struct {
+	core.DefaultAPLValueImpl
+	warlock *Warlock
+	target  core.UnitReference
+}
+
+func (warlock *Warlock) newValueWarlockShouldRefreshCorruption(rot *core.APLRotation, config *proto.APLValueWarlockShouldRefreshCorruption) core.APLValue {
+	target := rot.GetTargetUnit(config.TargetUnit)
+	if target.Get() == nil {
+		return nil
+	}
+
+	return &APLValueWarlockShouldRefreshCorruption{
+		warlock: warlock,
+	}
+}
+func (value *APLValueWarlockShouldRefreshCorruption) Type() proto.APLValueType {
+	return proto.APLValueType_ValueTypeBool
+}
+func (value *APLValueWarlockShouldRefreshCorruption) GetBool(sim *core.Simulation) bool {
+	warlock := value.warlock
+	target := value.target.Get()
+
+	dot := warlock.Corruption.Dot(target)
+	if !dot.IsActive() {
+		return true
+	}
+
+	// check if reapplying corruption is worthwhile
+	snapshotCrit := dot.SnapshotCritChance
+	snapshotMult := dot.SnapshotAttackerMultiplier * (snapshotCrit*(warlock.Corruption.CritMultiplier-1) + 1)
+
+	attackTable := warlock.AttackTables[target.UnitIndex]
+	curCrit := warlock.Corruption.SpellCritChance(target)
+	curDmg := dot.Spell.AttackerDamageMultiplier(attackTable) * (curCrit*(warlock.Corruption.CritMultiplier-1) + 1)
+
+	relDmgInc := curDmg / snapshotMult
+
+	snapshotDmg := warlock.Corruption.ExpectedTickDamageFromCurrentSnapshot(sim, target)
+	snapshotDmg *= float64(sim.GetRemainingDuration()) / float64(warlock.Corruption.Dot(target).TickPeriod())
+	snapshotDmg *= (relDmgInc - 1)
+	snapshotDmg -= warlock.Corruption.ExpectedTickDamageFromCurrentSnapshot(sim, target)
+
+	//if sim.Log != nil {
+	//	warlock.Log(sim, "Relative Corruption Inc: [%.2f], expected dmg gain: [%.2f]", relDmgInc, snapshotDmg)
+	//}
+
+	return relDmgInc > 1.15 || snapshotDmg > 10000
+}
+func (value *APLValueWarlockShouldRefreshCorruption) String() string {
+	return "Warlock Should Refresh Corruption()"
+}

--- a/sim/warlock/apl_values.go
+++ b/sim/warlock/apl_values.go
@@ -123,7 +123,7 @@ func (value *APLValueWarlockShouldRefreshCorruption) GetBool(sim *core.Simulatio
 	relDmgInc := curDmg / snapshotMult
 
 	snapshotDmg := warlock.Corruption.ExpectedTickDamageFromCurrentSnapshot(sim, target)
-	snapshotDmg *= float64(sim.GetRemainingDuration()) / float64(warlock.Corruption.Dot(target).TickPeriod())
+	snapshotDmg *= float64(sim.GetRemainingDuration()) / float64(dot.TickPeriod())
 	snapshotDmg *= (relDmgInc - 1)
 	snapshotDmg -= warlock.Corruption.ExpectedTickDamageFromCurrentSnapshot(sim, target)
 

--- a/sim/warlock/rotation.go
+++ b/sim/warlock/rotation.go
@@ -136,7 +136,7 @@ func (warlock *Warlock) defineRotation() {
 	mainTarget := warlock.CurrentTarget // assumed to be the first element in the target list
 	var hauntTravel time.Duration
 	if warlock.Talents.Haunt {
-		hauntTravel = time.Duration(float64(time.Second) * warlock.DistanceFromTarget / warlock.Haunt.MissileSpeed)
+		hauntTravel = warlock.Haunt.TravelTime()
 	}
 	critDebuffCat := warlock.GetEnemyExclusiveCategories(core.SpellCritEffectCategory).Get(mainTarget)
 
@@ -253,7 +253,7 @@ func (warlock *Warlock) defineRotation() {
 
 	// refresh corruption with shadow bolt if it's running out
 	if warlock.Talents.EverlastingAffliction == 5 && len(allUnits) > 1 {
-		travel := time.Duration(float64(time.Second) * warlock.DistanceFromTarget / warlock.ShadowBolt.MissileSpeed)
+		travel := warlock.ShadowBolt.TravelTime()
 		curIndex := len(acl)
 
 		acl = aclAppendSimple(acl, warlock.ShadowBolt, func(sim *core.Simulation) (bool, *core.Unit) {

--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -37,6 +37,9 @@ import {
 	APLValueCurrentRuneDeath,
 	APLValueCurrentRuneActive,
 	APLValueCurrentNonDeathRuneCount,
+	APLValueRuneSlotCooldown,
+	APLValueRuneGrace,
+	APLValueRuneSlotGrace,
 	APLValueGCDIsReady,
 	APLValueGCDTimeToReady,
 	APLValueAutoTimeToNext,
@@ -67,9 +70,8 @@ import {
 	APLValueNumberTargets,
 	APLValueTotemRemainingTime,
 	APLValueCatExcessEnergy,
-	APLValueRuneSlotCooldown,
-	APLValueRuneGrace,
-	APLValueRuneSlotGrace,
+	APLValueWarlockShouldRecastDrainSoul,
+	APLValueWarlockShouldRefreshCorruption,
 } from '../../proto/apl.js';
 
 import { EventID } from '../../typed_event.js';
@@ -972,6 +974,25 @@ const valueKindFactories: {[f in NonNullable<APLValueKind>]: ValueKindConfig<APL
 		newValue: APLValueCatExcessEnergy.create,
 		includeIf: (player: Player<any>, isPrepull: boolean) => player.spec == Spec.SpecFeralDruid,
 		fields: [
+		],
+	}),
+	'warlockShouldRecastDrainSoul': inputBuilder({
+		label: 'Should Recast Drain Soul',
+		submenu: ['Warlock'],
+		shortDescription: 'Returns <b>True</b> if the current Drain Soul channel should be immediately recast, to get a better snapshot.',
+		newValue: APLValueWarlockShouldRecastDrainSoul.create,
+		includeIf: (player: Player<any>, isPrepull: boolean) => player.getClass() == Class.ClassWarlock,
+		fields: [
+		],
+	}),
+	'warlockShouldRefreshCorruption': inputBuilder({
+		label: 'Should Refresh Corruption',
+		submenu: ['Warlock'],
+		shortDescription: 'Returns <b>True</b> if the current Corruption has expired, or should be refreshed to get a better snapshot.',
+		newValue: APLValueWarlockShouldRecastDrainSoul.create,
+		includeIf: (player: Player<any>, isPrepull: boolean) => player.getClass() == Class.ClassWarlock,
+		fields: [
+			AplHelpers.unitFieldConfig('targetUnit', 'targets'),
 		],
 	}),
 };


### PR DESCRIPTION
Also moves the spell travel-time calculations into a helper function, so it is easily re-used.