### PR TITLE
Simple-perf-measures

### DIFF
--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -345,18 +345,6 @@ func (character *Character) AddPet(pet PetAgent) {
 	character.Pets = append(character.Pets, pet.GetPet())
 }
 
-func (character *Character) MultiplyMeleeSpeed(sim *Simulation, amount float64) {
-	character.Unit.MultiplyMeleeSpeed(sim, amount)
-}
-
-func (character *Character) MultiplyRangedSpeed(sim *Simulation, amount float64) {
-	character.Unit.MultiplyRangedSpeed(sim, amount)
-}
-
-func (character *Character) MultiplyAttackSpeed(sim *Simulation, amount float64) {
-	character.Unit.MultiplyAttackSpeed(sim, amount)
-}
-
 func (character *Character) GetBaseStats() stats.Stats {
 	return character.baseStats
 }
@@ -523,7 +511,7 @@ func (character *Character) advance(sim *Simulation) {
 
 	for _, pet := range character.Pets {
 		if pet.enabled {
-			pet.advance(sim)
+			pet.Unit.advance(sim)
 		}
 	}
 }

--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -326,7 +326,7 @@ func (sim *Simulation) reset() {
 		sim.Duration += time.Duration(sim.RandomFloat("sim duration")*float64(variation)) - sim.DurationVariation
 	}
 
-	sim.pendingActions = make([]*PendingAction, 0, 64)
+	sim.pendingActions = sim.pendingActions[:0]
 
 	sim.executePhase = 0
 	sim.nextExecutePhase()


### PR DESCRIPTION
[core] don't needlessly reset auraTracker.minExpires fully after Refresh() or Deactivate() anymore

[character] advance() assumes that pets don't have pets anymore

I'm planning to make some more changes building on the latter assumption - does that sound viable? 