### PR TITLE
Add melee crit cap display

### DIFF
--- a/ui/core/components/character_stats.tsx
+++ b/ui/core/components/character_stats.tsx
@@ -1,4 +1,4 @@
-import { Stat, Class, PseudoStat } from '..//proto/common.js';
+import { Stat, Class, PseudoStat, Spec } from '..//proto/common.js';
 import { TristateEffect } from '..//proto/common.js'
 import { getClassStatName, statOrder } from '..//proto_utils/names.js';
 import { Stats } from '..//proto_utils/stats.js';
@@ -19,6 +19,7 @@ export type StatMods = { talents: Stats };
 export class CharacterStats extends Component {
 	readonly stats: Array<Stat>;
 	readonly valueElems: Array<HTMLTableCellElement>;
+	readonly meleeCritCapValueElem: HTMLTableCellElement | undefined;
 
 	private readonly player: Player<any>;
 	private readonly modifyDisplayStats?: (player: Player<any>) => StatMods;
@@ -45,7 +46,7 @@ export class CharacterStats extends Component {
 			const row = (
 			<tr
 				className='character-stats-table-row'
-			>	
+			>
 				<td className="character-stats-table-label">{statName}</td>
 				<td className="character-stats-table-value">
 					{this.bonusStatsLink(stat)}
@@ -58,8 +59,23 @@ export class CharacterStats extends Component {
 			this.valueElems.push(valueElem);
 		});
 
+		if(this.shouldShowMeleeCritCap(player)) {
+			const row = (
+			<tr
+				className='character-stats-table-row'
+			>
+				<td className="character-stats-table-label">Melee Crit Cap</td>
+				<td className="character-stats-table-value"></td>
+			</tr>);
+
+			table.appendChild(row);
+			this.meleeCritCapValueElem = row.getElementsByClassName('character-stats-table-value')[0] as HTMLTableCellElement;
+		} else {
+			this.meleeCritCapValueElem = undefined;
+		}
+
 		this.updateStats(player);
-		TypedEvent.onAny([player.currentStatsEmitter, player.sim.changeEmitter]).on(() => {
+		TypedEvent.onAny([player.currentStatsEmitter, player.sim.changeEmitter, player.talentsChangeEmitter]).on(() => {
 			this.updateStats(player);
 		});
 	}
@@ -90,7 +106,7 @@ export class CharacterStats extends Component {
 		this.stats.forEach((stat, idx) => {
 			let valueElem = (
 				<a
-					href="javascript:void(0)" 
+					href="javascript:void(0)"
 					className="stat-value-link"
 					attributes={{role:"button"}}>
 					{`${this.statDisplayString(finalStats, finalStats, stat)} `}
@@ -110,7 +126,7 @@ export class CharacterStats extends Component {
 				valueElem.classList.add('text-danger');
 			}
 
-			let tooltipContent = 
+			let tooltipContent =
 			<div>
 				<div className="character-stats-tooltip-row">
 					<span>Base:</span>
@@ -154,6 +170,76 @@ export class CharacterStats extends Component {
 				html: true,
 			});
 		});
+
+		if(this.meleeCritCapValueElem) {
+			const meleeCritCapInfo = player.getMeleeCritCapInfo();
+
+			const valueElem = (
+				<a
+					href="javascript:void(0)"
+					className="stat-value-link"
+					attributes={{role:"button"}}>
+					{`${this.meleeCritCapDisplayString(player, finalStats)} `}
+				</a>
+			)
+
+			const capDelta = meleeCritCapInfo.playerCritCapDelta;
+			if (capDelta == 0) {
+				valueElem.classList.add('text-white');
+			} else if (capDelta > 0) {
+				valueElem.classList.add('text-danger');
+			} else if (capDelta < 0) {
+				valueElem.classList.add('text-success');
+			}
+
+			this.meleeCritCapValueElem.querySelector('.stat-value-link')?.remove();
+			this.meleeCritCapValueElem.prepend(valueElem);
+
+			const tooltipContent = (
+			<div>
+				<div className="character-stats-tooltip-row">
+					<span>Glancing:</span>
+					<span>{`${meleeCritCapInfo.glancing.toFixed(2)}%`}</span>
+				</div>
+				<div className="character-stats-tooltip-row">
+					<span>Suppression:</span>
+					<span>{`${meleeCritCapInfo.suppression.toFixed(2)}%`}</span>
+				</div>
+				<div className="character-stats-tooltip-row">
+					<span>To Hit Cap:</span>
+					<span>{`${meleeCritCapInfo.remainingMeleeHitCap.toFixed(2)}%`}</span>
+				</div>
+				<div className="character-stats-tooltip-row">
+					<span>To Exp Cap:</span>
+					<span>{`${meleeCritCapInfo.remainingExpertiseCap.toFixed(2)}%`}</span>
+				</div>
+				<div className="character-stats-tooltip-row">
+					<span>Debuffs:</span>
+					<span>{`${meleeCritCapInfo.debuffCrit.toFixed(2)}%`}</span>
+				</div>
+				{meleeCritCapInfo.specSpecificOffset != 0 &&
+				<div className="character-stats-tooltip-row">
+					<span>Spec Offsets:</span>
+					<span>{`${meleeCritCapInfo.specSpecificOffset.toFixed(2)}%`}</span>
+				</div>
+				}
+				<div className="character-stats-tooltip-row">
+					<span>Final Crit Cap:</span>
+					<span>{`${meleeCritCapInfo.baseCritCap.toFixed(2)}%`}</span>
+				</div>
+				<hr/>
+				<div className="character-stats-tooltip-row">
+					<span>Can Raise By:</span>
+					<span>{`${(meleeCritCapInfo.remainingExpertiseCap + meleeCritCapInfo.remainingMeleeHitCap).toFixed(2)}%`}</span>
+				</div>
+			</div>
+			);
+
+			Tooltip.getOrCreateInstance(valueElem, {
+				title: tooltipContent,
+				html: true,
+			});
+		}
 	}
 
 	private statDisplayString(stats: Stats, deltaStats: Stats, stat: Stat): string {
@@ -261,5 +347,27 @@ export class CharacterStats extends Component {
 		});
 
 		return link as HTMLElement;
+	}
+
+	private shouldShowMeleeCritCap(player: Player<any>): boolean {
+		return [
+			Spec.SpecDeathknight,
+			Spec.SpecEnhancementShaman,
+			Spec.SpecFeralDruid,
+			Spec.SpecRetributionPaladin,
+			Spec.SpecRogue,
+			Spec.SpecWarrior
+		].includes(player.spec);
+	}
+
+	private meleeCritCapDisplayString(player: Player<any>, finalStats: Stats): string {
+		const playerCritCapDelta = player.getMeleeCritCap();
+
+		if(playerCritCapDelta === 0.0) {
+			return 'Exact';
+		}
+
+		const prefix = playerCritCapDelta > 0 ? 'Over by ' : 'Under by ';
+		return `${prefix} ${Math.abs(playerCritCapDelta).toFixed(2)}%`;
 	}
 }

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -82,7 +82,7 @@ import {
 	ShamanSpecs,
 } from './proto_utils/utils.js';
 
-
+import * as Mechanics from './constants/mechanics.js';
 import { getLanguageCode } from './constants/lang.js';
 import { EventID, TypedEvent } from './typed_event.js';
 import { Party, MAX_PARTY_SIZE } from './party.js';
@@ -187,6 +187,23 @@ export class UnitMetadataList {
 	asList(): Array<UnitMetadata> {
 		return this.metadatas.slice();
 	}
+}
+
+export interface MeleeCritCapInfo {
+	meleeCrit: number,
+	meleeHit: number,
+	expertise: number,
+	suppression: number,
+	glancing: number,
+	debuffCrit: number,
+	hasOffhandWeapon: boolean,
+	meleeHitCap: number,
+	expertiseCap: number,
+	remainingMeleeHitCap: number,
+	remainingExpertiseCap: number,
+	baseCritCap: number,
+	specSpecificOffset: number,
+	playerCritCapDelta: number
 }
 
 export type AutoRotationGenerator<SpecType extends Spec> = (player: Player<SpecType>) => APLRotation;
@@ -655,6 +672,61 @@ export class Player<SpecType extends Spec> {
 
 		this.bonusStats = newBonusStats;
 		this.bonusStatsChangeEmitter.emit(eventID);
+	}
+
+	getMeleeCritCapInfo(): MeleeCritCapInfo {
+		const meleeCrit = (this.currentStats.finalStats?.stats[Stat.StatMeleeCrit] || 0.0) / Mechanics.MELEE_CRIT_RATING_PER_CRIT_CHANCE;
+		const meleeHit = (this.currentStats.finalStats?.stats[Stat.StatMeleeHit] || 0.0) / Mechanics.MELEE_HIT_RATING_PER_HIT_CHANCE;
+		const expertise = (this.currentStats.finalStats?.stats[Stat.StatExpertise] || 0.0) / Mechanics.EXPERTISE_PER_QUARTER_PERCENT_REDUCTION / 4;
+		const agility = (this.currentStats.finalStats?.stats[Stat.StatAgility] || 0.0) / this.getClass();
+		const suppression = 4.8;
+		const glancing = 24.0;
+
+		const hasOffhandWeapon = this.getGear().getEquippedItem(ItemSlot.ItemSlotOffHand)?.item.weaponSpeed !== undefined;
+		const meleeHitCap = hasOffhandWeapon ? 27.0 : 8.0;
+		const expertiseCap = this.getInFrontOfTarget() ? 20.5 : 6.5;
+
+		const remainingMeleeHitCap = Math.max(meleeHitCap - meleeHit, 0.0);
+		const remainingExpertiseCap = Math.max(expertiseCap - expertise, 0.0)
+
+		let specSpecificOffset = 0.0;
+
+		if(this.spec === Spec.SpecEnhancementShaman) {
+			// Elemental Devastation uptime is near 100%
+			const ranks = (this as Player<Spec.SpecEnhancementShaman>).getTalents().elementalDevastation;
+			specSpecificOffset = 3.0 * ranks;
+		}
+
+		let debuffCrit = 0.0;
+
+		const debuffs = this.sim.raid.getDebuffs();
+		if (debuffs.totemOfWrath || debuffs.heartOfTheCrusader || debuffs.masterPoisoner) {
+			debuffCrit = 3.0;
+		}
+
+		const baseCritCap = 100.0 - glancing + suppression - remainingMeleeHitCap - remainingExpertiseCap - specSpecificOffset;
+		const playerCritCapDelta = meleeCrit - baseCritCap + debuffCrit;
+
+		return {
+			meleeCrit,
+			meleeHit,
+			expertise,
+			suppression,
+			glancing,
+			debuffCrit,
+			hasOffhandWeapon,
+			meleeHitCap,
+			expertiseCap,
+			remainingMeleeHitCap,
+			remainingExpertiseCap,
+			baseCritCap,
+			specSpecificOffset,
+			playerCritCapDelta
+		};
+	}
+
+	getMeleeCritCap() {
+		return this.getMeleeCritCapInfo().playerCritCapDelta
 	}
 
 	getRotation(): SpecRotation<SpecType> {
@@ -1366,7 +1438,7 @@ export class Player<SpecType extends Spec> {
 					this.setRotation(eventID, rot as SpecRotation<SpecType>);
 				}
 				const opt = this.getSpecOptions() as SpecOptions<ShamanSpecs>;
-				
+
 				// Update Bloodlust to be part of rotation instead of options to support APL casting bloodlust.
 				if (opt.bloodlust) {
 					opt.bloodlust = false;


### PR DESCRIPTION
Added in the form of a new spec-gated row in the character stats pane

Text is green if below crit cap, red if above, white if equal.  

Tooltip includes several details about said crit cap, including mechanics modifiers, cap final value, and how much the cap can be raised.

A special modifier for Enhancement is included, based on the number of talent points in Elemental Devastation.  The stats display now updates on talent change to accommodate this change.  

Screenshots:

![image](https://github.com/wowsims/wotlk/assets/56484534/96de8925-6c94-444b-a266-36bf5aeafeb3)

![image](https://github.com/wowsims/wotlk/assets/56484534/85c253d8-0523-4a9f-a516-173b1a0916b9)

![image](https://github.com/wowsims/wotlk/assets/56484534/b361b766-07b8-4a98-9c35-59c9e5f08820)

Resolves #2774