### PR TITLE
Vigo/perf fix

### DIFF
--- a/sim/core/apl_values_spell.go
+++ b/sim/core/apl_values_spell.go
@@ -96,8 +96,8 @@ func (rot *APLRotation) newValueSpellCastTime(config *proto.APLValueSpellCastTim
 func (value *APLValueSpellCastTime) Type() proto.APLValueType {
 	return proto.APLValueType_ValueTypeDuration
 }
-func (value *APLValueSpellCastTime) GetDuration(sim *Simulation) time.Duration {
-	return value.spell.Unit.ApplyCastSpeedForSpell(value.spell.DefaultCast.CastTime, value.spell)
+func (value *APLValueSpellCastTime) GetDuration(_ *Simulation) time.Duration {
+	return value.spell.CastTime()
 }
 func (value *APLValueSpellCastTime) String() string {
 	return fmt.Sprintf("Cast Time(%s)", value.spell.ActionID)
@@ -120,7 +120,7 @@ func (rot *APLRotation) newValueSpellChannelTime(config *proto.APLValueSpellChan
 func (value *APLValueSpellChannelTime) Type() proto.APLValueType {
 	return proto.APLValueType_ValueTypeDuration
 }
-func (value *APLValueSpellChannelTime) GetDuration(sim *Simulation) time.Duration {
+func (value *APLValueSpellChannelTime) GetDuration(_ *Simulation) time.Duration {
 	return value.spell.Unit.ApplyCastSpeedForSpell(value.spell.DefaultCast.ChannelTime, value.spell)
 }
 func (value *APLValueSpellChannelTime) String() string {
@@ -144,7 +144,7 @@ func (rot *APLRotation) newValueSpellTravelTime(config *proto.APLValueSpellTrave
 func (value *APLValueSpellTravelTime) Type() proto.APLValueType {
 	return proto.APLValueType_ValueTypeDuration
 }
-func (value *APLValueSpellTravelTime) GetDuration(sim *Simulation) time.Duration {
+func (value *APLValueSpellTravelTime) GetDuration(_ *Simulation) time.Duration {
 	return value.spell.TravelTime()
 }
 func (value *APLValueSpellTravelTime) String() string {
@@ -192,7 +192,7 @@ func (rot *APLRotation) newValueSpellIsChanneling(config *proto.APLValueSpellIsC
 func (value *APLValueSpellIsChanneling) Type() proto.APLValueType {
 	return proto.APLValueType_ValueTypeBool
 }
-func (value *APLValueSpellIsChanneling) GetBool(sim *Simulation) bool {
+func (value *APLValueSpellIsChanneling) GetBool(_ *Simulation) bool {
 	return value.spell.Unit.ChanneledDot != nil && value.spell.Unit.ChanneledDot.Spell == value.spell
 }
 func (value *APLValueSpellIsChanneling) String() string {
@@ -216,7 +216,7 @@ func (rot *APLRotation) newValueSpellChanneledTicks(config *proto.APLValueSpellC
 func (value *APLValueSpellChanneledTicks) Type() proto.APLValueType {
 	return proto.APLValueType_ValueTypeInt
 }
-func (value *APLValueSpellChanneledTicks) GetInt(sim *Simulation) int32 {
+func (value *APLValueSpellChanneledTicks) GetInt(_ *Simulation) int32 {
 	channeledDot := value.spell.Unit.ChanneledDot
 	if channeledDot == nil {
 		return 0

--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -34,7 +34,7 @@ type CastConfig struct {
 	CD       Cooldown
 	SharedCD Cooldown
 
-	GetCastTime func(spell *Spell) time.Duration
+	CastTime func(spell *Spell) time.Duration
 }
 
 type Cast struct {
@@ -108,10 +108,6 @@ func (spell *Spell) makeCastFunc(config CastConfig) CastSuccessFunc {
 			spell.CurCast.GCD = spell.Unit.ApplyCastSpeed(spell.CurCast.GCD)
 			spell.CurCast.CastTime = spell.Unit.ApplyCastSpeedForSpell(spell.CurCast.CastTime, spell)
 			spell.CurCast.ChannelTime = spell.Unit.ApplyCastSpeedForSpell(spell.CurCast.ChannelTime, spell)
-		}
-
-		if spell.GetCastTime != nil {
-			spell.CurCast.CastTime = spell.GetCastTime(spell)
 		}
 
 		if config.CD.Timer != nil {

--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -65,19 +65,17 @@ func (cast *Cast) EffectiveTime() time.Duration {
 type CastFunc func(*Simulation, *Unit)
 type CastSuccessFunc func(*Simulation, *Unit) bool
 
-func (spell *Spell) castFailureHelper(sim *Simulation, gracefulFailure bool, message string, vals ...interface{}) bool {
-	reason := fmt.Sprintf(spell.ActionID.String()+" failed to cast: "+message, vals...)
+func (spell *Spell) castFailureHelper(sim *Simulation, gracefulFailure bool, message string, vals ...any) bool {
 	if sim.CurrentTime < 0 && spell.Unit.IsUsingAPL {
-		spell.Unit.Rotation.ValidationWarning(reason)
-		return false
+		spell.Unit.Rotation.ValidationWarning(fmt.Sprintf(spell.ActionID.String()+" failed to cast: "+message, vals...))
 	} else if gracefulFailure {
 		if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
-			spell.Unit.Log(sim, reason)
+			spell.Unit.Log(sim, fmt.Sprintf(spell.ActionID.String()+" failed to cast: "+message, vals...))
 		}
-		return false
 	} else {
-		panic(reason)
+		panic(fmt.Sprintf(spell.ActionID.String()+" failed to cast: "+message, vals...))
 	}
+	return false
 }
 
 func (spell *Spell) makeCastFunc(config CastConfig) CastSuccessFunc {

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -335,9 +335,6 @@ func (unit *Unit) ApplyCastSpeed(dur time.Duration) time.Duration {
 	return time.Duration(float64(dur) * unit.CastSpeed)
 }
 func (unit *Unit) ApplyCastSpeedForSpell(dur time.Duration, spell *Spell) time.Duration {
-	if spell.GetCastTime != nil {
-		return spell.GetCastTime(spell)
-	}
 	return time.Duration(float64(dur) * unit.CastSpeed * spell.CastTimeMultiplier)
 }
 

--- a/sim/hunter/multi_shot.go
+++ b/sim/hunter/multi_shot.go
@@ -23,15 +23,18 @@ func (hunter *Hunter) registerMultiShotSpell(timer *core.Timer) {
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
 				GCD:      core.GCDDefault,
-				CastTime: 1, // Dummy value so core doesn't optimize the cast away
+				CastTime: time.Millisecond * 500,
 			},
-			ModifyCast: func(_ *core.Simulation, _ *core.Spell, cast *core.Cast) {
-				cast.CastTime = hunter.MultiShotCastTime()
+			ModifyCast: func(_ *core.Simulation, spell *core.Spell, cast *core.Cast) {
+				cast.CastTime = spell.CastTime()
 			},
 			IgnoreHaste: true, // Hunter GCD is locked at 1.5s
 			CD: core.Cooldown{
 				Timer:    timer,
 				Duration: time.Second*10 - core.TernaryDuration(hunter.HasMajorGlyph(proto.HunterMajorGlyph_GlyphOfMultiShot), time.Second*1, 0),
+			},
+			CastTime: func(spell *core.Spell) time.Duration {
+				return time.Duration(float64(spell.DefaultCast.CastTime) / hunter.RangedSwingSpeed())
 			},
 		},
 
@@ -59,8 +62,4 @@ func (hunter *Hunter) registerMultiShotSpell(timer *core.Timer) {
 			}
 		},
 	})
-}
-
-func (hunter *Hunter) MultiShotCastTime() time.Duration {
-	return time.Duration(float64(time.Millisecond*500) / hunter.RangedSwingSpeed())
 }

--- a/sim/hunter/steady_shot.go
+++ b/sim/hunter/steady_shot.go
@@ -60,10 +60,14 @@ func (hunter *Hunter) registerSteadyShotSpell() {
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
 				GCD:      core.GCDDefault,
-				CastTime: time.Millisecond * 2000,
+				CastTime: time.Second * 2,
 			},
 			IgnoreHaste: true, // Hunter GCD is locked at 1.5s
-			GetCastTime: func(spell *core.Spell) time.Duration {
+			ModifyCast: func(_ *core.Simulation, spell *core.Spell, cast *core.Cast) {
+				cast.CastTime = spell.CastTime()
+			},
+
+			CastTime: func(spell *core.Spell) time.Duration {
 				return time.Duration(float64(spell.DefaultCast.CastTime) / hunter.RangedSwingSpeed())
 			},
 		},


### PR DESCRIPTION
[core] castFailureHelper() doesn't needlessly format warning strings anymore

this was a >10% regression for my regular test set of legacy rotations.

[core] APL now queries Spell.CastTime() instead of ApplyCastSpeedForSpell(), so dynamic overrides don't affect the core spell cast anymore

[hunter] use this facility for Steady Shot instead, and also add it to Multi Shot

only a minor regression, but also a very minor use case.