### PR TITLE
ghoul-updates

### DIFF
--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -46,1040 +46,1040 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 10754.83741
-  tps: 5401.20167
+  dps: 10752.86181
+  tps: 5402.67641
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10494.11529
-  tps: 5314.22588
+  dps: 10496.44956
+  tps: 5317.22874
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10286.59456
-  tps: 5201.33594
+  dps: 10285.53354
+  tps: 5202.76878
   hps: 94.38579
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10286.59456
-  tps: 5201.33594
+  dps: 10285.53354
+  tps: 5202.76878
   hps: 94.38579
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 10777.77853
-  tps: 5413.64002
+  dps: 10776.58316
+  tps: 5415.10219
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 10224.75033
-  tps: 5137.44777
+  dps: 10165.65093
+  tps: 5103.60096
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 8064.37105
-  tps: 4066.44351
+  dps: 8037.83779
+  tps: 4055.66066
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 7983.01641
-  tps: 4028.95888
+  dps: 7985.28671
+  tps: 4017.90032
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 7708.80943
-  tps: 3895.86593
+  dps: 7704.95578
+  tps: 3860.54236
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 10748.51732
-  tps: 5289.94263
+  dps: 10746.54246
+  tps: 5291.38705
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 12536.68391
-  tps: 6395.68301
+  dps: 12531.41877
+  tps: 6396.34433
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 12642.97714
-  tps: 6456.99042
+  dps: 12628.38472
+  tps: 6451.53574
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 10974.55471
-  tps: 5519.82079
+  dps: 10973.31612
+  tps: 5521.35213
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
   hps: 64
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 10444.38155
-  tps: 5289.11569
+  dps: 10444.55487
+  tps: 5291.04646
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 10498.59297
-  tps: 5322.8224
+  dps: 10497.9371
+  tps: 5323.94582
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 10563.63196
-  tps: 5319.58268
+  dps: 10562.63008
+  tps: 5321.17256
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 8971.55191
-  tps: 4522.13701
+  dps: 8998.85492
+  tps: 4528.94525
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 7923.58393
-  tps: 3986.34677
+  dps: 7949.76431
+  tps: 3984.79993
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10392.16698
-  tps: 5260.49561
+  dps: 10390.50339
+  tps: 5261.34425
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10920.8639
-  tps: 5556.86151
+  dps: 10935.76131
+  tps: 5568.42775
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11000.765
-  tps: 5604.25014
+  dps: 11005.14104
+  tps: 5606.86705
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10304.88702
-  tps: 5210.89732
+  dps: 10303.82518
+  tps: 5212.33265
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 10783.80284
-  tps: 5417.25461
+  dps: 10782.60747
+  tps: 5418.71677
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 10510.12726
-  tps: 5304.48641
+  dps: 10505.03348
+  tps: 5301.61866
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 10462.44736
-  tps: 5293.06414
+  dps: 10459.02629
+  tps: 5290.53815
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 10748.51732
-  tps: 5397.90064
+  dps: 10746.54246
+  tps: 5399.37454
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 10748.51732
-  tps: 5397.90064
+  dps: 10746.54246
+  tps: 5399.37454
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 10777.77853
-  tps: 5413.64002
+  dps: 10776.58316
+  tps: 5415.10219
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 10771.74883
-  tps: 5410.1607
+  dps: 10770.18547
+  tps: 5411.62287
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10439.68704
-  tps: 5258.59836
+  dps: 10443.33395
+  tps: 5261.95347
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 10748.51732
-  tps: 5397.90064
+  dps: 10746.54246
+  tps: 5399.37454
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 10497.58646
-  tps: 5318.43418
+  dps: 10496.23394
+  tps: 5318.76785
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 10430.31833
-  tps: 5281.25906
+  dps: 10429.04601
+  tps: 5282.32245
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForgeEmber-37660"
  value: {
-  dps: 10406.55428
-  tps: 5269.03391
+  dps: 10402.37214
+  tps: 5268.36731
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 10748.51732
-  tps: 5397.90064
+  dps: 10746.54246
+  tps: 5399.37454
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 10748.51732
-  tps: 5397.90064
+  dps: 10746.54246
+  tps: 5399.37454
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 10519.08369
-  tps: 5325.28465
+  dps: 10518.01477
+  tps: 5326.74751
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 10465.07659
-  tps: 5300.73012
+  dps: 10463.33763
+  tps: 5302.10561
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 10777.77853
-  tps: 5413.64002
+  dps: 10776.58316
+  tps: 5415.10219
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 10771.74883
-  tps: 5410.1607
+  dps: 10770.18547
+  tps: 5411.62287
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IncisorFragment-37723"
  value: {
-  dps: 10524.77378
-  tps: 5335.37956
+  dps: 10523.91911
+  tps: 5336.9549
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 10748.51732
-  tps: 5397.90064
+  dps: 10746.54246
+  tps: 5399.37454
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 10780.4067
-  tps: 5414.5567
+  dps: 10778.42808
+  tps: 5416.03484
   hps: 16.33197
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50179"
  value: {
-  dps: 12219.1304
-  tps: 6212.62959
+  dps: 12189.38754
+  tps: 6199.13092
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50708"
  value: {
-  dps: 12288.94826
-  tps: 6251.43979
+  dps: 12259.25591
+  tps: 6238.00098
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 10537.06691
-  tps: 5331.18522
+  dps: 10526.5663
+  tps: 5327.27388
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 10630.13863
-  tps: 5363.65131
+  dps: 10635.69587
+  tps: 5367.87524
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10298.42661
-  tps: 5207.52016
+  dps: 10297.36505
+  tps: 5208.95461
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 10774.33253
-  tps: 5411.38412
+  dps: 10772.35463
+  tps: 5412.86145
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 10780.4067
-  tps: 5414.5567
+  dps: 10778.42808
+  tps: 5416.03484
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10335.72473
-  tps: 5227.0176
+  dps: 10334.66149
+  tps: 5228.45712
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10342.05594
-  tps: 5230.32721
+  dps: 10340.99241
+  tps: 5231.76759
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 10748.51732
-  tps: 5397.90064
+  dps: 10746.54246
+  tps: 5399.37454
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 10748.51732
-  tps: 5397.90064
+  dps: 10746.54246
+  tps: 5399.37454
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 10344.76619
-  tps: 5237.58139
+  dps: 10341.92367
+  tps: 5237.94539
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 10353.27625
-  tps: 5242.68743
+  dps: 10350.43373
+  tps: 5243.05143
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 10964.43193
-  tps: 5513.87128
+  dps: 10962.80318
+  tps: 5515.40276
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 10748.51732
-  tps: 5397.90064
+  dps: 10746.54246
+  tps: 5399.37454
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 8598.72981
-  tps: 4298.67912
+  dps: 8585.15019
+  tps: 4311.90741
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 7926.61748
-  tps: 3986.20418
+  dps: 7934.97982
+  tps: 3983.02747
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 9833.54413
-  tps: 5019.12006
+  dps: 9863.42561
+  tps: 5020.60276
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 8283.79281
-  tps: 4166.64725
+  dps: 8278.63909
+  tps: 4143.50636
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10304.27901
-  tps: 5210.28873
+  dps: 10303.23764
+  tps: 5211.73779
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 13808.56331
-  tps: 7100.50507
+  dps: 13812.93471
+  tps: 7102.54664
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SouloftheDead-40382"
  value: {
-  dps: 10433.97649
-  tps: 5283.45396
+  dps: 10432.70417
+  tps: 5284.51734
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofLife-37657"
  value: {
-  dps: 10377.60572
-  tps: 5250.58305
+  dps: 10379.35826
+  tps: 5251.97334
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 10402.17605
-  tps: 5250.56842
+  dps: 10402.51258
+  tps: 5252.882
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 7639.88369
-  tps: 3853.54147
+  dps: 7676.70878
+  tps: 3875.55129
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 10780.4067
-  tps: 5414.5567
+  dps: 10778.42808
+  tps: 5416.03484
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 10774.33253
-  tps: 5411.38412
+  dps: 10772.35463
+  tps: 5412.86145
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 10763.70274
-  tps: 5405.8321
+  dps: 10761.72609
+  tps: 5407.30802
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 9190.61767
-  tps: 4642.02628
+  dps: 9173.07455
+  tps: 4634.91236
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 8148.52516
-  tps: 4102.48775
+  dps: 8128.46139
+  tps: 4065.93113
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 8787.22488
-  tps: 4336.9956
+  dps: 8799.60356
+  tps: 4350.36159
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 10782.77825
-  tps: 5413.36636
+  dps: 10771.63065
+  tps: 5408.67424
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 10526.01489
-  tps: 5343.74696
+  dps: 10523.66311
+  tps: 5344.12261
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 10521.5377
-  tps: 5337.87843
+  dps: 10514.66511
+  tps: 5332.79327
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 10748.51732
-  tps: 5397.90064
+  dps: 10746.54246
+  tps: 5399.37454
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 10748.51732
-  tps: 5397.90064
+  dps: 10746.54246
+  tps: 5399.37454
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 10323.3432
-  tps: 5189.9161
+  dps: 10312.50272
+  tps: 5186.50501
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 10748.51732
-  tps: 5397.90064
+  dps: 10746.54246
+  tps: 5399.37454
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 10748.51732
-  tps: 5397.90064
+  dps: 10746.54246
+  tps: 5399.37454
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 7946.5183
-  tps: 4018.58564
+  dps: 8012.10279
+  tps: 4036.72483
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7758.45516
-  tps: 3736.30682
+  dps: 7766.3101
+  tps: 3741.34326
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10286.58252
-  tps: 5201.32871
+  dps: 10285.5215
+  tps: 5202.76156
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 11006.29667
-  tps: 5538.17409
+  dps: 11005.90156
+  tps: 5538.26912
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P3 -Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 32425.42303
-  tps: 16656.61868
+  dps: 32421.74446
+  tps: 16656.08321
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P3 -Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 10852.15867
-  tps: 5501.71363
+  dps: 10851.11699
+  tps: 5503.21034
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P3 -Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13925.67238
-  tps: 6323.88887
+  dps: 13936.91984
+  tps: 6335.51473
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P3 -Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 17424.94757
-  tps: 8939.84816
+  dps: 17420.6997
+  tps: 8937.25269
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P3 -Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6229.21755
-  tps: 3165.56487
+  dps: 6225.90184
+  tps: 3164.4222
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P3 -Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7320.99306
-  tps: 3287.18623
+  dps: 7306.89178
+  tps: 3278.89099
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P3 -Basic-blood_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29195.40357
-  tps: 15861.54377
+  dps: 29213.10075
+  tps: 15870.80875
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P3 -Basic-blood_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10273.1784
-  tps: 5429.26092
+  dps: 10258.63951
+  tps: 5420.39076
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P3 -Basic-blood_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13994.94209
-  tps: 6380.16193
+  dps: 13963.19168
+  tps: 6368.52587
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P3 -Basic-blood_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15771.96802
-  tps: 8585.72539
+  dps: 15762.16943
+  tps: 8577.90162
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P3 -Basic-blood_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5892.98116
-  tps: 3137.39582
+  dps: 5904.42278
+  tps: 3142.36376
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P3 -Basic-blood_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7388.56047
-  tps: 3347.43804
+  dps: 7401.11559
+  tps: 3356.10984
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P3 -Basic-blood_pesti_dd-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27130.40312
-  tps: 15428.40206
+  dps: 27122.28681
+  tps: 15423.78827
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P3 -Basic-blood_pesti_dd-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10277.47466
-  tps: 5431.12909
+  dps: 10276.86836
+  tps: 5428.06193
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P3 -Basic-blood_pesti_dd-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13892.54341
-  tps: 6302.17621
+  dps: 13869.01326
+  tps: 6274.48344
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P3 -Basic-blood_pesti_dd-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14629.55664
-  tps: 8287.54854
+  dps: 14628.23707
+  tps: 8286.52265
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P3 -Basic-blood_pesti_dd-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5857.38104
-  tps: 3103.70429
+  dps: 5854.07494
+  tps: 3101.45469
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-Blood P3 -Basic-blood_pesti_dd-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7255.99389
-  tps: 3252.29881
+  dps: 7265.05412
+  tps: 3257.14244
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P3 -Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 32844.91465
-  tps: 16734.77262
+  dps: 32841.02145
+  tps: 16734.2366
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P3 -Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 10974.55471
-  tps: 5519.82079
+  dps: 10973.31612
+  tps: 5521.35213
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P3 -Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14185.55866
-  tps: 6375.93319
+  dps: 14196.69031
+  tps: 6387.82816
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P3 -Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 17661.29459
-  tps: 8984.34245
+  dps: 17656.94508
+  tps: 8981.68316
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P3 -Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6300.30738
-  tps: 3177.16631
+  dps: 6296.83513
+  tps: 3175.99209
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P3 -Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7459.94244
-  tps: 3315.85124
+  dps: 7445.4697
+  tps: 3307.33313
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P3 -Basic-blood_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29460.36768
-  tps: 15906.58952
+  dps: 29479.23537
+  tps: 15916.50948
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P3 -Basic-blood_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10384.664
-  tps: 5455.5901
+  dps: 10369.59414
+  tps: 5446.51733
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P3 -Basic-blood_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14239.48996
-  tps: 6426.52359
+  dps: 14206.30775
+  tps: 6414.57022
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P3 -Basic-blood_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15915.58469
-  tps: 8609.2386
+  dps: 15905.6751
+  tps: 8601.20484
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P3 -Basic-blood_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5931.07206
-  tps: 3138.25278
+  dps: 5940.58783
+  tps: 3141.89232
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P3 -Basic-blood_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7516.92444
-  tps: 3372.75695
+  dps: 7529.68148
+  tps: 3381.61311
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P3 -Basic-blood_pesti_dd-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27237.38498
-  tps: 15444.46282
+  dps: 27229.0312
+  tps: 15439.73625
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P3 -Basic-blood_pesti_dd-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10368.3705
-  tps: 5444.91121
+  dps: 10367.95684
+  tps: 5441.77244
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P3 -Basic-blood_pesti_dd-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14137.47419
-  tps: 6347.57974
+  dps: 14114.35284
+  tps: 6319.18525
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P3 -Basic-blood_pesti_dd-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14680.6283
-  tps: 8289.3738
+  dps: 14679.44716
+  tps: 8288.41496
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P3 -Basic-blood_pesti_dd-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5912.18124
-  tps: 3113.94457
+  dps: 5908.75804
+  tps: 3111.58029
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-Blood P3 -Basic-blood_pesti_dd-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7389.70294
-  tps: 3279.60854
+  dps: 7398.90689
+  tps: 3284.478
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 10467.12156
-  tps: 5295.96892
+  dps: 10471.28868
+  tps: 5290.35485
  }
 }

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -46,1383 +46,1383 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 11082.06883
-  tps: 6490.77374
+  dps: 11029.75885
+  tps: 6458.25746
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 11038.13477
-  tps: 6462.06369
+  dps: 10986.11377
+  tps: 6432.27033
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10852.3219
-  tps: 6352.92559
+  dps: 10803.76755
+  tps: 6322.66268
   hps: 64.65047
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10852.3219
-  tps: 6352.92559
+  dps: 10803.76755
+  tps: 6322.66268
   hps: 64.65047
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 11102.3787
-  tps: 6502.95967
+  dps: 11052.15364
+  tps: 6471.69433
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 10612.7623
-  tps: 6218.78683
+  dps: 10650.23611
+  tps: 6242.34254
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 8721.19094
-  tps: 5107.83834
+  dps: 8709.20754
+  tps: 5098.06603
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 8614.83081
-  tps: 5046.15923
+  dps: 8657.61591
+  tps: 5072.21003
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8346.45652
-  tps: 4886.51115
+  dps: 8333.09632
+  tps: 4877.28847
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 11074.81115
-  tps: 6356.69075
+  dps: 11022.5283
+  tps: 6324.84074
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 11372.09767
-  tps: 6664.79105
+  dps: 11320.97171
+  tps: 6632.98517
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 11372.09767
-  tps: 6664.79105
+  dps: 11320.97171
+  tps: 6632.98517
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11380.01042
-  tps: 6669.5387
+  dps: 11327.99058
+  tps: 6637.19649
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 10991.85659
-  tps: 6436.6464
+  dps: 10941.84356
+  tps: 6405.50828
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 11020.36132
-  tps: 6453.45764
+  dps: 10971.60378
+  tps: 6424.09138
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 11091.5468
-  tps: 6486.28338
+  dps: 11042.12472
+  tps: 6455.57518
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 9570.45442
-  tps: 5602.68015
+  dps: 9493.38956
+  tps: 5557.02054
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 8519.21054
-  tps: 4981.27641
+  dps: 8515.00216
+  tps: 4978.30278
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 10793.26034
-  tps: 6317.48865
+  dps: 10747.37309
+  tps: 6288.826
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10969.56949
-  tps: 6423.27414
+  dps: 10925.98158
+  tps: 6395.99109
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 11432.07497
-  tps: 6693.86398
+  dps: 11370.23553
+  tps: 6657.5083
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11507.98672
-  tps: 6740.93298
+  dps: 11454.52509
+  tps: 6710.6177
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10872.55688
-  tps: 6365.06658
+  dps: 10823.98527
+  tps: 6334.79331
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 11104.13437
-  tps: 6504.01307
+  dps: 11054.37425
+  tps: 6473.02669
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11032.7186
-  tps: 6456.40024
+  dps: 11022.66321
+  tps: 6448.70397
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 10982.65136
-  tps: 6424.86824
+  dps: 10968.95311
+  tps: 6415.41761
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 11074.81115
-  tps: 6486.41913
+  dps: 11022.5283
+  tps: 6453.91912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 11074.81115
-  tps: 6486.41913
+  dps: 11022.5283
+  tps: 6453.91912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 11102.3787
-  tps: 6502.95967
+  dps: 11052.15364
+  tps: 6471.69433
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 11095.68148
-  tps: 6498.94134
+  dps: 11046.27204
+  tps: 6468.16537
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10938.1542
-  tps: 6391.20775
+  dps: 10945.25624
+  tps: 6396.91892
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 11074.81115
-  tps: 6486.41913
+  dps: 11022.5283
+  tps: 6453.91912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 10998.78479
-  tps: 6438.75424
+  dps: 10944.10262
+  tps: 6406.44656
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 10978.76726
-  tps: 6428.7928
+  dps: 10929.48883
+  tps: 6398.09544
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 10957.85488
-  tps: 6416.24537
+  dps: 10907.19371
+  tps: 6384.71837
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 11074.81115
-  tps: 6486.41913
+  dps: 11022.5283
+  tps: 6453.91912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 11074.81115
-  tps: 6486.41913
+  dps: 11022.5283
+  tps: 6453.91912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 10794.15125
-  tps: 6318.0232
+  dps: 10748.31018
+  tps: 6289.38825
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 11099.56643
-  tps: 6501.27231
+  dps: 11050.05749
+  tps: 6470.43664
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 10945.33084
-  tps: 6409.27864
+  dps: 10944.2126
+  tps: 6409.24047
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 10791.28192
-  tps: 6316.3016
+  dps: 10745.28771
+  tps: 6287.57477
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 11102.3787
-  tps: 6502.95967
+  dps: 11052.15364
+  tps: 6471.69433
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 11095.68148
-  tps: 6498.94134
+  dps: 11046.27204
+  tps: 6468.16537
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 11091.51767
-  tps: 6496.44305
+  dps: 11042.2229
+  tps: 6465.73589
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 11074.81115
-  tps: 6486.41913
+  dps: 11022.5283
+  tps: 6453.91912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 11108.34559
-  tps: 6506.5398
+  dps: 11055.91963
+  tps: 6473.95392
   hps: 16.93247
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50179"
  value: {
-  dps: 11372.09767
-  tps: 6664.79105
+  dps: 11320.97171
+  tps: 6632.98517
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50708"
  value: {
-  dps: 11372.09767
-  tps: 6664.79105
+  dps: 11320.97171
+  tps: 6632.98517
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 11038.81672
-  tps: 6458.39132
+  dps: 11028.38501
+  tps: 6450.89622
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 11014.10938
-  tps: 6449.99808
+  dps: 10962.02936
+  tps: 6417.61976
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10865.44328
-  tps: 6360.79841
+  dps: 10816.89663
+  tps: 6330.54012
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 11101.95807
-  tps: 6502.70729
+  dps: 11049.55938
+  tps: 6470.13777
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 11108.34559
-  tps: 6506.5398
+  dps: 11055.91963
+  tps: 6473.95392
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10906.51252
-  tps: 6385.43996
+  dps: 10857.82173
+  tps: 6355.09518
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10913.48385
-  tps: 6389.62276
+  dps: 10864.76861
+  tps: 6359.26331
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 11074.81115
-  tps: 6486.41913
+  dps: 11022.5283
+  tps: 6453.91912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 11074.81115
-  tps: 6486.41913
+  dps: 11022.5283
+  tps: 6453.91912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 10833.80346
-  tps: 6342.34899
+  dps: 10800.64308
+  tps: 6322.37171
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 10835.58967
-  tps: 6343.42072
+  dps: 10802.44456
+  tps: 6323.45259
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11372.09767
-  tps: 6664.79105
+  dps: 11320.97171
+  tps: 6632.98517
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 10795.19066
-  tps: 6318.64684
+  dps: 10749.40346
+  tps: 6290.04422
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 11074.81115
-  tps: 6486.41913
+  dps: 11022.5283
+  tps: 6453.91912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 10791.0016
-  tps: 6316.13341
+  dps: 10744.99336
+  tps: 6287.39816
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 9345.60039
-  tps: 5473.81199
+  dps: 9343.55343
+  tps: 5472.24056
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 8416.50559
-  tps: 4923.40601
+  dps: 8446.53074
+  tps: 4938.47015
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 10501.56053
-  tps: 6161.79112
+  dps: 10482.66681
+  tps: 6149.15344
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 8847.89838
-  tps: 5173.29023
+  dps: 8866.55693
+  tps: 5183.43009
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10865.98448
-  tps: 6361.12314
+  dps: 10817.6101
+  tps: 6330.9682
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shadowmourne-49623"
  value: {
-  dps: 11372.09767
-  tps: 6664.79105
+  dps: 11320.97171
+  tps: 6632.98517
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 10788.80575
-  tps: 6314.8159
+  dps: 10742.68761
+  tps: 6286.01471
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 10801.92998
-  tps: 6322.69044
+  dps: 10761.44484
+  tps: 6297.26905
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 10788.80575
-  tps: 6314.8159
+  dps: 10742.68761
+  tps: 6286.01471
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 11235.08221
-  tps: 6575.52601
+  dps: 11187.60765
+  tps: 6545.83704
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 10788.80575
-  tps: 6314.8159
+  dps: 10742.68761
+  tps: 6286.01471
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 11275.84434
-  tps: 6599.31299
+  dps: 11227.5962
+  tps: 6569.15285
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 10788.80575
-  tps: 6314.8159
+  dps: 10742.68761
+  tps: 6286.01471
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 10982.82604
-  tps: 6431.22807
+  dps: 10932.93169
+  tps: 6400.16116
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 10953.33621
-  tps: 6410.14536
+  dps: 10921.63629
+  tps: 6391.17866
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 10986.41653
-  tps: 6431.36764
+  dps: 10957.31466
+  tps: 6414.58603
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StormshroudArmor"
  value: {
-  dps: 8230.05781
-  tps: 4818.41382
+  dps: 8240.36976
+  tps: 4824.75541
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 11108.34559
-  tps: 6506.5398
+  dps: 11055.91963
+  tps: 6473.95392
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 11101.95807
-  tps: 6502.70729
+  dps: 11049.55938
+  tps: 6470.13777
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 11090.77993
-  tps: 6496.0004
+  dps: 11038.42893
+  tps: 6463.4595
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 9607.37222
-  tps: 5627.64452
+  dps: 9605.67916
+  tps: 5626.66594
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 8473.49769
-  tps: 4956.08872
+  dps: 8505.38142
+  tps: 4976.38116
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 9301.30431
-  tps: 5431.90091
+  dps: 9315.50921
+  tps: 5440.26563
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 11102.07382
-  tps: 6498.78015
+  dps: 11110.49266
+  tps: 6502.89006
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 11122.86734
-  tps: 6513.99034
+  dps: 11103.20349
+  tps: 6502.22581
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 11125.55097
-  tps: 6516.99338
+  dps: 11140.93303
+  tps: 6524.89234
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 11074.81115
-  tps: 6486.41913
+  dps: 11022.5283
+  tps: 6453.91912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 11074.81115
-  tps: 6486.41913
+  dps: 11022.5283
+  tps: 6453.91912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 10845.68599
-  tps: 6346.72272
+  dps: 10901.75141
+  tps: 6378.73417
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 11074.81115
-  tps: 6486.41913
+  dps: 11022.5283
+  tps: 6453.91912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 11074.81115
-  tps: 6486.41913
+  dps: 11022.5283
+  tps: 6453.91912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 8617.71783
-  tps: 5048.46892
+  dps: 8657.63803
+  tps: 5071.57977
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 10248.51298
-  tps: 5988.15544
+  dps: 10265.40805
+  tps: 6000.94816
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10852.40166
-  tps: 6352.97344
+  dps: 10803.90078
+  tps: 6322.74261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 10796.37855
-  tps: 6319.35958
+  dps: 10750.65291
+  tps: 6290.79389
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 11299.03365
-  tps: 6621.67078
+  dps: 11297.52192
+  tps: 6620.65465
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 37746.32071
-  tps: 22501.16355
+  dps: 37835.77503
+  tps: 22557.09099
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11328.86941
-  tps: 6646.57683
+  dps: 11314.12124
+  tps: 6635.91991
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13061.91024
-  tps: 7479.79583
+  dps: 13089.24808
+  tps: 7494.54173
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 19223.50961
-  tps: 11440.37548
+  dps: 19239.14495
+  tps: 11449.91388
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6773.58767
-  tps: 3968.81739
+  dps: 6770.86014
+  tps: 3967.39634
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7305.01835
-  tps: 4185.81786
+  dps: 7301.28553
+  tps: 4183.49163
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Basic-frost_bl_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26224.26021
-  tps: 15477.91906
+  dps: 26247.92126
+  tps: 15491.77838
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Basic-frost_bl_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11306.80073
-  tps: 6528.31117
+  dps: 11297.58272
+  tps: 6522.32328
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Basic-frost_bl_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13425.18395
-  tps: 7190.4658
+  dps: 13436.79681
+  tps: 7196.48982
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Basic-frost_bl_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13761.42828
-  tps: 8083.8193
+  dps: 13762.89221
+  tps: 8084.71381
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Basic-frost_bl_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6874.6967
-  tps: 3951.40832
+  dps: 6858.47832
+  tps: 3941.78626
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Basic-frost_bl_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7856.74295
-  tps: 4143.75318
+  dps: 7838.73035
+  tps: 4133.25519
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Basic-frost_uh_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29863.62675
-  tps: 17660.43657
+  dps: 29874.22042
+  tps: 17666.35967
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Basic-frost_uh_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11252.46043
-  tps: 6494.08499
+  dps: 11235.23555
+  tps: 6483.37883
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Basic-frost_uh_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13308.65752
-  tps: 7120.97594
+  dps: 13289.2203
+  tps: 7107.20748
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Basic-frost_uh_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15663.22549
-  tps: 9223.0971
+  dps: 15651.53729
+  tps: 9215.92857
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Basic-frost_uh_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6819.86774
-  tps: 3917.20075
+  dps: 6823.57997
+  tps: 3919.36125
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Basic-frost_uh_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7750.56361
-  tps: 4077.05239
+  dps: 7745.34323
+  tps: 4073.80114
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Desync--FullBuffs-LongMultiTarget"
  value: {
-  dps: 36538.51786
-  tps: 21780.14541
+  dps: 36334.15904
+  tps: 21657.38558
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Desync--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11311.99737
-  tps: 6643.07283
+  dps: 11317.71576
+  tps: 6646.34756
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Desync--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12892.54923
-  tps: 7373.00522
+  dps: 12893.37168
+  tps: 7372.09373
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Desync--NoBuffs-LongMultiTarget"
  value: {
-  dps: 19505.3895
-  tps: 11613.09894
+  dps: 19347.75677
+  tps: 11518.36187
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Desync--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6826.08821
-  tps: 4004.70027
+  dps: 6823.04363
+  tps: 4002.74809
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Desync--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7214.35823
-  tps: 4129.096
+  dps: 7195.54124
+  tps: 4117.41822
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Desync-frost_bl_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26224.26021
-  tps: 15477.91906
+  dps: 26247.92126
+  tps: 15491.77838
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Desync-frost_bl_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11306.80073
-  tps: 6528.31117
+  dps: 11297.58272
+  tps: 6522.32328
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Desync-frost_bl_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13425.18395
-  tps: 7190.4658
+  dps: 13436.79681
+  tps: 7196.48982
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Desync-frost_bl_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13761.42828
-  tps: 8083.8193
+  dps: 13762.89221
+  tps: 8084.71381
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Desync-frost_bl_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6874.6967
-  tps: 3951.40832
+  dps: 6858.47832
+  tps: 3941.78626
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Desync-frost_bl_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7856.74295
-  tps: 4143.75318
+  dps: 7838.73035
+  tps: 4133.25519
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Desync-frost_uh_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29863.62675
-  tps: 17660.43657
+  dps: 29874.22042
+  tps: 17666.35967
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Desync-frost_uh_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11252.46043
-  tps: 6494.08499
+  dps: 11235.23555
+  tps: 6483.37883
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Desync-frost_uh_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13308.65752
-  tps: 7120.97594
+  dps: 13289.2203
+  tps: 7107.20748
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Desync-frost_uh_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15663.22549
-  tps: 9223.0971
+  dps: 15651.53729
+  tps: 9215.92857
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Desync-frost_uh_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6819.86774
-  tps: 3917.20075
+  dps: 6823.57997
+  tps: 3919.36125
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-Frost P3-Desync-frost_uh_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7750.56361
-  tps: 4077.05239
+  dps: 7745.34323
+  tps: 4073.80114
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 37080.37833
-  tps: 22092.5078
+  dps: 37662.42597
+  tps: 22441.27621
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11372.09767
-  tps: 6664.79105
+  dps: 11320.97171
+  tps: 6632.98517
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13129.24014
-  tps: 7503.0169
+  dps: 13123.57673
+  tps: 7497.53796
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 19187.85994
-  tps: 11413.6731
+  dps: 19353.89799
+  tps: 11512.90978
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6813.66049
-  tps: 3988.46658
+  dps: 6809.56639
+  tps: 3986.15931
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7352.9856
-  tps: 4204.88245
+  dps: 7337.49665
+  tps: 4195.72657
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Basic-frost_bl_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26490.97772
-  tps: 15629.02719
+  dps: 26558.18843
+  tps: 15669.65009
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Basic-frost_bl_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11347.20365
-  tps: 6545.23588
+  dps: 11329.72016
+  tps: 6534.12475
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Basic-frost_bl_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13521.72246
-  tps: 7229.75982
+  dps: 13546.51677
+  tps: 7243.71622
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Basic-frost_bl_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13809.69922
-  tps: 8107.72558
+  dps: 13850.19658
+  tps: 8132.18668
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Basic-frost_bl_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6904.25778
-  tps: 3964.03769
+  dps: 6899.86182
+  tps: 3961.52521
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Basic-frost_bl_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7891.18235
-  tps: 4154.32097
+  dps: 7873.87678
+  tps: 4144.46021
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Basic-frost_uh_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30006.82843
-  tps: 17737.92628
+  dps: 30004.11703
+  tps: 17735.96273
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Basic-frost_uh_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11314.11533
-  tps: 6522.16153
+  dps: 11315.70214
+  tps: 6523.02195
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Basic-frost_uh_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13324.87114
-  tps: 7112.10065
+  dps: 13332.49345
+  tps: 7114.43817
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Basic-frost_uh_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15806.91535
-  tps: 9304.98435
+  dps: 15750.11064
+  tps: 9270.80658
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Basic-frost_uh_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6862.0224
-  tps: 3937.65392
+  dps: 6834.27784
+  tps: 3920.7197
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Basic-frost_uh_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7815.53637
-  tps: 4106.87387
+  dps: 7785.29023
+  tps: 4088.701
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Desync--FullBuffs-LongMultiTarget"
  value: {
-  dps: 36450.97829
-  tps: 21719.92866
+  dps: 36984.45133
+  tps: 22039.40955
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Desync--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11346.32896
-  tps: 6655.57112
+  dps: 11357.72862
+  tps: 6663.4342
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Desync--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12928.14238
-  tps: 7377.58783
+  dps: 12968.01864
+  tps: 7400.9381
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Desync--NoBuffs-LongMultiTarget"
  value: {
-  dps: 19454.78095
-  tps: 11578.6041
+  dps: 19388.34358
+  tps: 11539.15891
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Desync--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6859.35239
-  tps: 4019.44566
+  dps: 6856.16474
+  tps: 4017.51554
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Desync--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7251.92292
-  tps: 4142.3065
+  dps: 7239.13086
+  tps: 4134.45363
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Desync-frost_bl_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26490.97772
-  tps: 15629.02719
+  dps: 26558.18843
+  tps: 15669.65009
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Desync-frost_bl_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11347.20365
-  tps: 6545.23588
+  dps: 11329.72016
+  tps: 6534.12475
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Desync-frost_bl_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13521.72246
-  tps: 7229.75982
+  dps: 13546.51677
+  tps: 7243.71622
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Desync-frost_bl_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13809.69922
-  tps: 8107.72558
+  dps: 13850.19658
+  tps: 8132.18668
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Desync-frost_bl_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6904.25778
-  tps: 3964.03769
+  dps: 6899.86182
+  tps: 3961.52521
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Desync-frost_bl_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7891.18235
-  tps: 4154.32097
+  dps: 7873.87678
+  tps: 4144.46021
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Desync-frost_uh_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30006.82843
-  tps: 17737.92628
+  dps: 30004.11703
+  tps: 17735.96273
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Desync-frost_uh_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11314.11533
-  tps: 6522.16153
+  dps: 11315.70214
+  tps: 6523.02195
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Desync-frost_uh_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13324.87114
-  tps: 7112.10065
+  dps: 13332.49345
+  tps: 7114.43817
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Desync-frost_uh_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15806.91535
-  tps: 9304.98435
+  dps: 15750.11064
+  tps: 9270.80658
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Desync-frost_uh_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6862.0224
-  tps: 3937.65392
+  dps: 6834.27784
+  tps: 3920.7197
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-Frost P3-Desync-frost_uh_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7815.53637
-  tps: 4106.87387
+  dps: 7785.29023
+  tps: 4088.701
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 11027.93101
-  tps: 6471.82959
+  dps: 11088.30538
+  tps: 6504.2719
  }
 }

--- a/sim/deathknight/dps/TestFrostUH.results
+++ b/sim/deathknight/dps/TestFrostUH.results
@@ -46,1047 +46,1047 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 11251.54421
-  tps: 8018.04448
+  dps: 11223.30473
+  tps: 8001.09258
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 11171.28344
-  tps: 7960.80312
+  dps: 11142.55196
+  tps: 7942.11658
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10938.45052
-  tps: 7787.60753
+  dps: 10927.50741
+  tps: 7783.38576
   hps: 60.89457
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10938.45052
-  tps: 7787.60753
+  dps: 10927.50741
+  tps: 7783.38576
   hps: 60.89457
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 11284.08002
-  tps: 8041.99084
+  dps: 11256.05058
+  tps: 8025.19353
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 10636.64956
-  tps: 7585.15797
+  dps: 10597.20989
+  tps: 7560.97234
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 8644.80776
-  tps: 6158.61236
+  dps: 8709.19598
+  tps: 6203.13351
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 8572.94608
-  tps: 6116.0937
+  dps: 8608.25638
+  tps: 6138.33907
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8317.48936
-  tps: 5925.96532
+  dps: 8324.11773
+  tps: 5930.33519
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 11251.54421
-  tps: 7857.68359
+  dps: 11223.30473
+  tps: 7841.07073
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 11526.14188
-  tps: 8220.14837
+  dps: 11494.97142
+  tps: 8201.03926
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 11526.14188
-  tps: 8220.14837
+  dps: 11494.97142
+  tps: 8201.03926
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11533.97826
-  tps: 8225.91595
+  dps: 11503.73772
+  tps: 8207.49126
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 11122.24898
-  tps: 7922.88319
+  dps: 11089.01681
+  tps: 7902.25667
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 11174.05936
-  tps: 7962.84105
+  dps: 11120.76193
+  tps: 7926.12455
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 11204.29879
-  tps: 7962.82312
+  dps: 11191.27795
+  tps: 7957.41137
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 9762.11409
-  tps: 6956.38367
+  dps: 9696.97092
+  tps: 6909.51341
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkrunedPlate"
  value: {
-  dps: 8547.02718
-  tps: 6077.98008
+  dps: 8557.50672
+  tps: 6085.80686
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 10925.71045
-  tps: 7778.23084
+  dps: 10892.45854
+  tps: 7757.58979
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 11089.08278
-  tps: 7898.47287
+  dps: 11071.52147
+  tps: 7889.3801
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 11610.23825
-  tps: 8268.87565
+  dps: 11567.2193
+  tps: 8239.98216
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11630.61002
-  tps: 8289.76084
+  dps: 11655.08184
+  tps: 8308.14889
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 11292.13108
-  tps: 8047.91642
+  dps: 11264.38949
+  tps: 8031.33097
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11160.77388
-  tps: 7938.63885
+  dps: 11180.84218
+  tps: 7952.12297
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11142.00905
-  tps: 7926.61552
+  dps: 11124.66601
+  tps: 7915.58497
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 11251.54421
-  tps: 8018.04448
+  dps: 11223.30473
+  tps: 8001.09258
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 11251.54421
-  tps: 8018.04448
+  dps: 11223.30473
+  tps: 8001.09258
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 11284.08002
-  tps: 8041.99084
+  dps: 11256.05058
+  tps: 8025.19353
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 11278.25086
-  tps: 8037.70057
+  dps: 11249.29413
+  tps: 8020.22078
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 11008.84688
-  tps: 7825.63226
+  dps: 10992.07928
+  tps: 7816.20047
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 11251.54421
-  tps: 8018.04448
+  dps: 11223.30473
+  tps: 8001.09258
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 11178.50956
-  tps: 7965.93136
+  dps: 11026.07962
+  tps: 7856.72398
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 11104.88592
-  tps: 7910.10398
+  dps: 11073.92245
+  tps: 7891.14722
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForgeEmber-37660"
  value: {
-  dps: 11069.57051
-  tps: 7884.11184
+  dps: 11040.91037
+  tps: 7866.85033
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 11251.54421
-  tps: 8018.04448
+  dps: 11223.30473
+  tps: 8001.09258
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 11251.54421
-  tps: 8018.04448
+  dps: 11223.30473
+  tps: 8001.09258
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 10926.95511
-  tps: 7779.1469
+  dps: 10893.59515
+  tps: 7758.42633
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 11194.66719
-  tps: 7976.18299
+  dps: 11183.94639
+  tps: 7972.12484
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 11093.07695
-  tps: 7902.53231
+  dps: 11052.6163
+  tps: 7876.86733
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 10923.03777
-  tps: 7776.26374
+  dps: 10889.98093
+  tps: 7755.76627
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 11284.08002
-  tps: 8041.99084
+  dps: 11256.05058
+  tps: 8025.19353
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 11278.25086
-  tps: 8037.70057
+  dps: 11249.29413
+  tps: 8020.22078
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-IncisorFragment-37723"
  value: {
-  dps: 11172.15699
-  tps: 7959.61549
+  dps: 11158.72634
+  tps: 7953.56289
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 11251.54421
-  tps: 8018.04448
+  dps: 11223.30473
+  tps: 8001.09258
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 11286.59546
-  tps: 8043.8422
+  dps: 11258.32367
+  tps: 8026.86652
   hps: 16.40824
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-LastWord-50179"
  value: {
-  dps: 11526.14188
-  tps: 8220.14837
+  dps: 11494.97142
+  tps: 8201.03926
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-LastWord-50708"
  value: {
-  dps: 11526.14188
-  tps: 8220.14837
+  dps: 11494.97142
+  tps: 8201.03926
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 11247.18119
-  tps: 8007.31419
+  dps: 11239.68428
+  tps: 8000.59069
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 11124.58698
-  tps: 7924.60396
+  dps: 11114.75263
+  tps: 7921.19824
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 11279.91903
-  tps: 8038.92835
+  dps: 11251.65339
+  tps: 8021.9572
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 11286.59546
-  tps: 8043.8422
+  dps: 11258.32367
+  tps: 8026.86652
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 11251.54421
-  tps: 8018.04448
+  dps: 11223.30473
+  tps: 8001.09258
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 11251.54421
-  tps: 8018.04448
+  dps: 11223.30473
+  tps: 8001.09258
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 10987.12685
-  tps: 7823.58412
+  dps: 10932.73429
+  tps: 7787.40143
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 10989.24224
-  tps: 7825.14105
+  dps: 10934.59768
+  tps: 7788.77288
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11526.14188
-  tps: 8220.14837
+  dps: 11494.97142
+  tps: 8201.03926
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 10928.40721
-  tps: 7780.21565
+  dps: 10894.92118
+  tps: 7759.40229
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 11251.54421
-  tps: 8018.04448
+  dps: 11223.30473
+  tps: 8001.09258
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 10922.63581
-  tps: 7775.9679
+  dps: 10889.61806
+  tps: 7755.49919
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 9425.54593
-  tps: 6723.48002
+  dps: 9324.69436
+  tps: 6649.84516
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ScourgebornePlate"
  value: {
-  dps: 8504.15571
-  tps: 6045.68916
+  dps: 8486.02968
+  tps: 6033.28361
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 10613.96969
-  tps: 7579.91803
+  dps: 10652.6584
+  tps: 7610.00404
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 8884.65191
-  tps: 6315.01929
+  dps: 8941.08722
+  tps: 6358.24812
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Shadowmourne-49623"
  value: {
-  dps: 11526.14188
-  tps: 8220.14837
+  dps: 11494.97142
+  tps: 8201.03926
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 10919.48716
-  tps: 7773.65049
+  dps: 10886.77554
+  tps: 7753.40709
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 10934.3049
-  tps: 7784.55635
+  dps: 10902.59178
+  tps: 7765.04785
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 10919.48716
-  tps: 7773.65049
+  dps: 10886.77554
+  tps: 7753.40709
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 11403.71892
-  tps: 8116.41258
+  dps: 11369.86997
+  tps: 8095.55826
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 10919.48716
-  tps: 7773.65049
+  dps: 10886.77554
+  tps: 7753.40709
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 11446.71446
-  tps: 8146.76221
+  dps: 11412.16288
+  tps: 8125.41224
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 10919.48716
-  tps: 7773.65049
+  dps: 10886.77554
+  tps: 7753.40709
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SouloftheDead-40382"
  value: {
-  dps: 11107.49706
-  tps: 7912.02578
+  dps: 11076.72569
+  tps: 7893.21041
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SparkofLife-37657"
  value: {
-  dps: 11038.9129
-  tps: 7856.32342
+  dps: 11035.42025
+  tps: 7855.1168
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 11211.40367
-  tps: 7989.13801
+  dps: 11157.0658
+  tps: 7950.83026
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-StormshroudArmor"
  value: {
-  dps: 8163.52543
-  tps: 5817.85199
+  dps: 8245.37495
+  tps: 5876.30234
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 11286.59546
-  tps: 8043.8422
+  dps: 11258.32367
+  tps: 8026.86652
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 11279.91903
-  tps: 8038.92835
+  dps: 11251.65339
+  tps: 8021.9572
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 11268.23528
-  tps: 8030.32911
+  dps: 11239.98041
+  tps: 8013.36588
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 9761.81699
-  tps: 6959.75829
+  dps: 9763.63204
+  tps: 6960.89255
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Thassarian'sPlate"
  value: {
-  dps: 8589.26388
-  tps: 6105.116
+  dps: 8558.84126
+  tps: 6083.89263
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 9501.80604
-  tps: 6745.04481
+  dps: 9501.21531
+  tps: 6746.31539
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 11344.18626
-  tps: 8077.14692
+  dps: 11313.72939
+  tps: 8056.69973
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 11281.81341
-  tps: 8040.02878
+  dps: 11282.3879
+  tps: 8041.00808
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 11327.31766
-  tps: 8071.82236
+  dps: 11344.11007
+  tps: 8086.75747
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 11251.54421
-  tps: 8018.04448
+  dps: 11223.30473
+  tps: 8001.09258
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 11251.54421
-  tps: 8018.04448
+  dps: 11223.30473
+  tps: 8001.09258
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 10933.04413
-  tps: 7773.76503
+  dps: 10930.09733
+  tps: 7769.14914
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 11251.54421
-  tps: 8018.04448
+  dps: 11223.30473
+  tps: 8001.09258
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 11251.54421
-  tps: 8018.04448
+  dps: 11223.30473
+  tps: 8001.09258
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 8618.76109
-  tps: 6148.7341
+  dps: 8652.56711
+  tps: 6172.5295
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 10408.22106
-  tps: 7399.84096
+  dps: 10437.92309
+  tps: 7418.54158
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10938.51004
-  tps: 7787.65134
+  dps: 10927.6512
+  tps: 7783.49159
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 10930.06676
-  tps: 7781.43708
+  dps: 10896.43665
+  tps: 7760.51768
  }
 }
 dps_results: {
  key: "TestFrostUH-Average-Default"
  value: {
-  dps: 11458.80401
-  tps: 8174.12737
+  dps: 11461.3981
+  tps: 8176.07261
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 29413.57644
-  tps: 21403.7089
+  dps: 29416.22802
+  tps: 21405.87415
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11435.76771
-  tps: 8168.25176
+  dps: 11447.42906
+  tps: 8177.30187
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13455.89041
-  tps: 9289.49688
+  dps: 13450.0091
+  tps: 9289.18189
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 15461.05969
-  tps: 11227.96856
+  dps: 15440.1963
+  tps: 11212.66809
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6710.09669
-  tps: 4778.96894
+  dps: 6720.72451
+  tps: 4786.35579
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7513.53269
-  tps: 5197.99432
+  dps: 7519.48078
+  tps: 5201.17082
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-frost_uh_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29010.93257
-  tps: 20961.22623
+  dps: 28966.01784
+  tps: 20928.42523
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-frost_uh_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11420.48913
-  tps: 8014.68002
+  dps: 11404.19923
+  tps: 8001.70202
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-frost_uh_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14117.24198
-  tps: 9160.38746
+  dps: 14126.2476
+  tps: 9164.89999
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-frost_uh_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15335.05422
-  tps: 11026.12553
+  dps: 15318.06982
+  tps: 11014.08438
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-frost_uh_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6876.28096
-  tps: 4798.32051
+  dps: 6873.39093
+  tps: 4796.24732
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-Frost P1-Basic-frost_uh_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8171.53701
-  tps: 5220.69838
+  dps: 8176.07264
+  tps: 5224.57131
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 29381.11924
-  tps: 21368.61531
+  dps: 29326.49842
+  tps: 21328.605
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11526.14188
-  tps: 8220.14837
+  dps: 11494.97142
+  tps: 8201.03926
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13579.29903
-  tps: 9349.76382
+  dps: 13525.99688
+  tps: 9315.88611
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 15128.42944
-  tps: 10975.67352
+  dps: 15023.76504
+  tps: 10898.43746
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6676.9877
-  tps: 4747.59169
+  dps: 6690.22347
+  tps: 4756.32034
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7552.43194
-  tps: 5209.38453
+  dps: 7545.19127
+  tps: 5201.91874
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-frost_uh_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29113.78926
-  tps: 21023.02172
+  dps: 29007.45315
+  tps: 20944.64382
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-frost_uh_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11442.57048
-  tps: 8017.68947
+  dps: 11491.39758
+  tps: 8054.26255
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-frost_uh_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14171.03858
-  tps: 9168.1814
+  dps: 14215.8894
+  tps: 9198.33964
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-frost_uh_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15477.80377
-  tps: 11122.4023
+  dps: 15450.48494
+  tps: 11103.28189
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-frost_uh_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6897.10012
-  tps: 4805.94199
+  dps: 6907.24362
+  tps: 4814.18266
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-Frost P1-Basic-frost_uh_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8163.88119
-  tps: 5198.36509
+  dps: 8183.14767
+  tps: 5212.57631
  }
 }
 dps_results: {
  key: "TestFrostUH-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 10648.16317
-  tps: 7599.72515
+  dps: 10488.62817
+  tps: 7483.94348
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -46,1376 +46,1376 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 11386.58941
-  tps: 7526.51032
-  hps: 425.1668
+  dps: 11438.25314
+  tps: 7562.4611
+  hps: 418.74234
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 11386.58941
-  tps: 7526.51032
-  hps: 438.86369
+  dps: 11438.25314
+  tps: 7562.4611
+  hps: 432.31455
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 11968.24569
-  tps: 7814.70753
-  hps: 324.63789
+  dps: 11987.09424
+  tps: 7815.20256
+  hps: 321.64781
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 11638.42355
-  tps: 7738.99656
-  hps: 320.58623
+  dps: 11668.32122
+  tps: 7760.15215
+  hps: 315.10972
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 11386.68528
-  tps: 7526.58441
-  hps: 413.96081
+  dps: 11438.31898
+  tps: 7562.51169
+  hps: 408.31737
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 11386.68528
-  tps: 7526.58441
-  hps: 413.96081
+  dps: 11438.31898
+  tps: 7562.51169
+  hps: 408.31737
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 11992.64273
-  tps: 7836.30525
-  hps: 320.16496
+  dps: 12012.54281
+  tps: 7836.47344
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 11335.79773
-  tps: 7311.89928
-  hps: 302.04873
+  dps: 11341.54125
+  tps: 7314.8544
+  hps: 302.45308
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 8927.6074
-  tps: 5764.46636
-  hps: 256.16032
+  dps: 8938.21256
+  tps: 5760.79173
+  hps: 260.97407
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 8766.27207
-  tps: 5692.23961
-  hps: 247.9175
+  dps: 8750.58474
+  tps: 5678.98468
+  hps: 249.56588
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8511.55245
-  tps: 5489.60877
-  hps: 247.75593
+  dps: 8505.73123
+  tps: 5472.94501
+  hps: 245.79221
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 11968.24569
-  tps: 7658.41338
-  hps: 320.16496
+  dps: 11987.09424
+  tps: 7658.89851
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 12112.73176
-  tps: 7948.73421
-  hps: 320.16496
+  dps: 12134.70888
+  tps: 7950.21977
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 12112.73176
-  tps: 7948.73421
-  hps: 320.16496
+  dps: 12134.70888
+  tps: 7950.21977
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 12125.88471
-  tps: 7961.54708
-  hps: 320.16496
+  dps: 12146.75712
+  tps: 7962.25623
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.28255
+  tps: 7562.46093
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.28255
+  tps: 7562.46093
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 416.96102
+  dps: 11438.30511
+  tps: 7562.49521
+  hps: 410.93938
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 11535.91902
-  tps: 7665.49218
-  hps: 321.0075
+  dps: 11595.79229
+  tps: 7706.43318
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 11603.62037
-  tps: 7718.7299
-  hps: 321.0075
+  dps: 11644.07752
+  tps: 7748.49705
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 11759.2049
-  tps: 7731.37271
-  hps: 320.58623
+  dps: 11803.64124
+  tps: 7758.96595
+  hps: 314.68845
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 9921.10986
-  tps: 6420.7675
-  hps: 292.59093
+  dps: 9925.07429
+  tps: 6430.21007
+  hps: 289.86734
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 8817.13622
-  tps: 5669.75836
-  hps: 305.35065
+  dps: 8825.9019
+  tps: 5654.31339
+  hps: 309.85918
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 12037.48624
-  tps: 8000.92327
-  hps: 354.2878
+  dps: 12009.26436
+  tps: 7977.98332
+  hps: 351.33891
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 11495.73922
-  tps: 7628.85609
-  hps: 321.0075
+  dps: 11558.57467
+  tps: 7672.68474
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 11888.29743
-  tps: 7959.3083
-  hps: 326.484
+  dps: 11891.73383
+  tps: 7983.44774
+  hps: 326.90527
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11958.2821
-  tps: 8054.48519
-  hps: 325.64146
+  dps: 11970.74711
+  tps: 8073.76767
+  hps: 322.69257
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.26683
+  tps: 7562.43702
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 11997.79367
-  tps: 7840.8274
-  hps: 320.16496
+  dps: 12016.07853
+  tps: 7839.14967
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11848.4543
-  tps: 7783.00499
-  hps: 318.47988
+  dps: 11851.17556
+  tps: 7776.9113
+  hps: 319.32242
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11780.58937
-  tps: 7717.35199
-  hps: 317.21607
+  dps: 11782.96904
+  tps: 7726.26769
+  hps: 318.05861
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 11968.24569
-  tps: 7814.70753
-  hps: 324.63789
+  dps: 11987.09424
+  tps: 7815.20256
+  hps: 321.64781
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 11968.24569
-  tps: 7814.70753
-  hps: 320.16496
+  dps: 11987.09424
+  tps: 7815.20256
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 11992.64273
-  tps: 7836.30525
-  hps: 320.16496
+  dps: 12012.54281
+  tps: 7836.47344
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 11986.19357
-  tps: 7831.29177
-  hps: 320.16496
+  dps: 12006.68937
+  tps: 7831.42456
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 11771.55903
-  tps: 7692.92151
-  hps: 319.32242
+  dps: 11759.79723
+  tps: 7674.83362
+  hps: 318.47988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 336.56382
+  dps: 11438.28255
+  tps: 7562.46093
+  hps: 330.82192
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 11968.24569
-  tps: 7814.70753
-  hps: 320.16496
+  dps: 11987.09424
+  tps: 7815.20256
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 11629.641
-  tps: 7742.60561
-  hps: 321.0075
+  dps: 11687.70288
+  tps: 7784.80745
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 11519.21216
-  tps: 7646.8729
-  hps: 321.0075
+  dps: 11573.71686
+  tps: 7684.61132
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.28255
+  tps: 7562.46093
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.28255
+  tps: 7562.46093
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 11489.8788
-  tps: 7620.66842
-  hps: 321.0075
+  dps: 11549.58926
+  tps: 7660.78271
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 11968.24569
-  tps: 7814.70753
-  hps: 320.16496
+  dps: 11987.09424
+  tps: 7815.20256
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 11968.24569
-  tps: 7814.70753
-  hps: 320.16496
+  dps: 11987.09424
+  tps: 7815.20256
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 12055.92635
-  tps: 8015.67986
-  hps: 354.2878
+  dps: 12027.97199
+  tps: 7992.92081
+  hps: 351.33891
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 11656.35303
-  tps: 7748.75002
-  hps: 321.0075
+  dps: 11709.32394
+  tps: 7785.65046
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.26683
+  tps: 7562.43702
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.28938
+  tps: 7562.4713
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.28938
+  tps: 7562.4713
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 11564.39899
-  tps: 7688.281
-  hps: 320.58623
+  dps: 11601.88591
+  tps: 7717.07558
+  hps: 315.10972
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 11999.1202
-  tps: 7969.29506
-  hps: 354.2878
+  dps: 11969.78734
+  tps: 7944.86079
+  hps: 351.33891
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.28255
+  tps: 7562.46093
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 11992.64273
-  tps: 7836.30525
-  hps: 320.16496
+  dps: 12012.54281
+  tps: 7836.47344
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 11986.19357
-  tps: 7831.29177
-  hps: 320.16496
+  dps: 12006.68937
+  tps: 7831.42456
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 11583.58836
-  tps: 7690.60391
-  hps: 321.0075
+  dps: 11635.30172
+  tps: 7726.46439
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 11968.24569
-  tps: 7814.70753
-  hps: 320.16496
+  dps: 11987.09424
+  tps: 7815.20256
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 12005.68586
-  tps: 7844.6712
-  hps: 336.64865
+  dps: 12024.58925
+  tps: 7845.18547
+  hps: 333.69976
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50179"
  value: {
-  dps: 12112.73176
-  tps: 7948.73421
-  hps: 320.16496
+  dps: 12134.70888
+  tps: 7950.21977
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50708"
  value: {
-  dps: 12112.73176
-  tps: 7948.73421
-  hps: 320.16496
+  dps: 12134.70888
+  tps: 7950.21977
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.26683
+  tps: 7562.43702
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.28255
+  tps: 7562.46093
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 11756.47038
-  tps: 7737.72528
-  hps: 316.7948
+  dps: 11796.12822
+  tps: 7767.16733
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 11516.51107
-  tps: 7658.40213
-  hps: 321.0075
+  dps: 11572.37398
+  tps: 7700.83712
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.26683
+  tps: 7562.43702
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 11998.5544
-  tps: 7838.96383
-  hps: 320.16496
+  dps: 12017.44734
+  tps: 7839.47444
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 12005.68586
-  tps: 7844.6712
-  hps: 320.16496
+  dps: 12024.58925
+  tps: 7845.18547
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.28255
+  tps: 7562.46093
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.28255
+  tps: 7562.46093
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.28255
+  tps: 7562.46093
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 11968.24569
-  tps: 7814.70753
-  hps: 323.79922
+  dps: 11987.09424
+  tps: 7815.20256
+  hps: 320.81685
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 11968.24569
-  tps: 7814.70753
-  hps: 324.63789
+  dps: 11987.09424
+  tps: 7815.20256
+  hps: 321.64781
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.28255
+  tps: 7562.46093
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 11495.50266
-  tps: 7623.15264
-  hps: 321.0075
+  dps: 11525.53508
+  tps: 7642.37822
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 11506.0339
-  tps: 7631.97303
-  hps: 321.0075
+  dps: 11535.80251
+  tps: 7651.01179
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 12112.73176
-  tps: 7948.73421
-  hps: 320.16496
+  dps: 12134.70888
+  tps: 7950.21977
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 12077.43981
-  tps: 8032.89589
-  hps: 354.2878
+  dps: 12049.79757
+  tps: 8010.34788
+  hps: 351.33891
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 11968.24569
-  tps: 7814.70753
-  hps: 320.16496
+  dps: 11987.09424
+  tps: 7815.20256
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.26683
+  tps: 7562.43702
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 11993.02693
-  tps: 7964.52466
-  hps: 354.2878
+  dps: 11963.66721
+  tps: 7940.15533
+  hps: 351.33891
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 9525.28507
-  tps: 6149.3073
-  hps: 273.96949
+  dps: 9524.8041
+  tps: 6154.81315
+  hps: 276.15832
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 8729.90657
-  tps: 5583.73744
-  hps: 284.5687
+  dps: 8755.58403
+  tps: 5594.29074
+  hps: 285.71002
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 10329.39157
-  tps: 6874.50681
-  hps: 306.02996
+  dps: 10316.25751
+  tps: 6866.1521
+  hps: 301.93865
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 9392.50463
-  tps: 6184.76544
-  hps: 324.83312
+  dps: 9408.45404
+  tps: 6193.21741
+  hps: 323.53896
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.26683
+  tps: 7562.43702
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 12112.73176
-  tps: 7948.73421
-  hps: 320.16496
+  dps: 12134.70888
+  tps: 7950.21977
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.28255
+  tps: 7562.46093
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 11945.28569
-  tps: 7927.14031
-  hps: 354.2878
+  dps: 11915.72619
+  tps: 7903.29589
+  hps: 351.33891
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 11961.85428
-  tps: 7943.7019
-  hps: 354.2878
+  dps: 11936.69249
+  tps: 7924.22455
+  hps: 351.33891
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 11945.28569
-  tps: 7927.14031
-  hps: 354.2878
+  dps: 11915.72619
+  tps: 7903.29589
+  hps: 351.33891
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 11945.28569
-  tps: 7927.14031
-  hps: 354.2878
+  dps: 11915.72619
+  tps: 7903.29589
+  hps: 351.33891
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 11945.28569
-  tps: 7927.14031
-  hps: 354.2878
+  dps: 11915.72619
+  tps: 7903.29589
+  hps: 351.33891
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 11945.28569
-  tps: 7927.14031
-  hps: 354.2878
+  dps: 11915.72619
+  tps: 7903.29589
+  hps: 351.33891
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 352.96102
+  dps: 11438.30511
+  tps: 7562.49521
+  hps: 346.93938
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.28255
+  tps: 7562.46093
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.28255
+  tps: 7562.46093
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SoulPreserver-37111"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.28255
+  tps: 7562.46093
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SouloftheDead-40382"
  value: {
-  dps: 11524.96312
-  tps: 7653.10611
-  hps: 321.0075
+  dps: 11581.88029
+  tps: 7692.16351
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 11587.29884
-  tps: 7621.79593
+  dps: 11618.09561
+  tps: 7647.35321
   hps: 315.10972
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 11634.70386
-  tps: 7681.43189
-  hps: 321.85004
+  dps: 11685.36065
+  tps: 7716.9763
+  hps: 321.42877
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StormshroudArmor"
  value: {
-  dps: 8381.14072
-  tps: 5450.54168
-  hps: 226.05362
+  dps: 8363.8414
+  tps: 5421.47864
+  hps: 225.74565
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 12005.68586
-  tps: 7844.6712
-  hps: 320.16496
+  dps: 12024.58925
+  tps: 7845.18547
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 11998.5544
-  tps: 7838.96383
-  hps: 320.16496
+  dps: 12017.44734
+  tps: 7839.47444
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 11986.07434
-  tps: 7828.97594
-  hps: 320.16496
+  dps: 12004.94901
+  tps: 7829.48014
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.26683
+  tps: 7562.43702
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.28255
+  tps: 7562.46093
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 10132.10034
-  tps: 6625.10476
-  hps: 290.54436
+  dps: 10110.59709
+  tps: 6583.32206
+  hps: 286.28871
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 8863.96906
-  tps: 5668.38989
-  hps: 301.49008
+  dps: 8862.28937
+  tps: 5650.37019
+  hps: 301.08702
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.28255
+  tps: 7562.46093
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 10591.53851
-  tps: 6873.44705
-  hps: 304.38433
+  dps: 10596.60128
+  tps: 6872.43752
+  hps: 304.79181
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 12098.22146
-  tps: 7891.53916
-  hps: 320.58623
+  dps: 12061.68587
+  tps: 7855.67751
+  hps: 318.47988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 11720.57679
-  tps: 7791.88575
-  hps: 321.85004
+  dps: 11715.09457
+  tps: 7780.74882
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 11730.62277
-  tps: 7805.13668
-  hps: 314.68845
+  dps: 11733.55333
+  tps: 7803.46948
+  hps: 316.37353
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 11968.24569
-  tps: 7814.70753
-  hps: 320.16496
+  dps: 11987.09424
+  tps: 7815.20256
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 11968.24569
-  tps: 7814.70753
-  hps: 320.16496
+  dps: 11987.09424
+  tps: 7815.20256
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 11559.75027
-  tps: 7586.19243
-  hps: 315.53099
+  dps: 11553.09227
+  tps: 7569.07153
+  hps: 316.37353
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 11968.24569
-  tps: 7814.70753
-  hps: 320.16496
+  dps: 11987.09424
+  tps: 7815.20256
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 11968.24569
-  tps: 7814.70753
-  hps: 320.16496
+  dps: 11987.09424
+  tps: 7815.20256
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 8765.34774
-  tps: 5684.52231
-  hps: 250.27985
+  dps: 8811.94313
+  tps: 5716.42694
+  hps: 251.2904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 11393.27428
-  tps: 7398.50065
-  hps: 322.61266
+  dps: 11395.03509
+  tps: 7402.17848
+  hps: 322.54958
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 11386.53943
-  tps: 7526.45852
-  hps: 321.0075
+  dps: 11438.26683
+  tps: 7562.43702
+  hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 12102.02662
-  tps: 8052.57135
-  hps: 354.2878
+  dps: 12074.74108
+  tps: 8030.26452
+  hps: 351.33891
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 12083.63019
-  tps: 7959.79518
-  hps: 318.97184
+  dps: 12080.22153
+  tps: 7959.84181
+  hps: 319.17663
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 58105.82701
-  tps: 60796.79416
-  hps: 318.76192
+  dps: 58290.35239
+  tps: 61053.6133
+  hps: 320.02518
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11898.31908
-  tps: 7928.48366
-  hps: 317.91975
+  dps: 11917.40726
+  tps: 7935.7238
+  hps: 320.44626
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16848.79039
-  tps: 8795.40056
+  dps: 16864.94618
+  tps: 8820.5795
   hps: 216.85917
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 35204.04887
-  tps: 37758.02393
+  dps: 35191.14924
+  tps: 37745.91048
   hps: 207.00864
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6085.94017
-  tps: 4441.00825
-  hps: 207.00864
+  dps: 6073.59102
+  tps: 4427.01416
+  hps: 206.73152
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7612.51401
-  tps: 4527.00365
-  hps: 149.6448
+  dps: 7579.80252
+  tps: 4496.67664
+  hps: 159.344
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-uh_2h_ss-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14162.47017
-  tps: 9309.15453
+  dps: 14165.35662
+  tps: 9310.25956
   hps: 42.10858
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-uh_2h_ss-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10195.05616
-  tps: 5983.65206
+  dps: 10195.14094
+  tps: 5983.39426
   hps: 42.10858
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-uh_2h_ss-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 15152.29189
-  tps: 7149.1882
+  dps: 15149.8816
+  tps: 7146.71782
   hps: 210.54288
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-uh_2h_ss-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6743.93816
-  tps: 4598.24299
+  dps: 6743.02312
+  tps: 4596.18416
   hps: 27.712
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-uh_2h_ss-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5051.26254
-  tps: 3184.17764
+  dps: 5050.90646
+  tps: 3182.17362
   hps: 27.712
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-uh_2h_ss-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6556.62368
-  tps: 3463.71404
+  dps: 6556.50427
+  tps: 3455.66307
   hps: 138.56
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-uh_dnd_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 58938.04669
-  tps: 61024.06571
+  dps: 58907.41878
+  tps: 60994.4634
   hps: 235.80803
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-uh_dnd_aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11160.96856
-  tps: 7450.27485
+  dps: 11166.24446
+  tps: 7453.31537
   hps: 235.80803
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-uh_dnd_aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16118.92387
-  tps: 8655.00378
+  dps: 16132.6799
+  tps: 8664.46552
   hps: 336.86861
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-uh_dnd_aoe-NoBuffs-LongMultiTarget"
  value: {
-  dps: 35066.62671
-  tps: 37445.68202
+  dps: 35068.57742
+  tps: 37450.11087
   hps: 155.74144
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-uh_dnd_aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5693.91545
-  tps: 4174.17306
+  dps: 5696.76392
+  tps: 4178.63055
   hps: 155.1872
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-uh_dnd_aoe-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7141.87591
-  tps: 4450.32827
+  dps: 7145.99955
+  tps: 4446.35054
   hps: 221.696
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-unholy_dw_ss-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36076.66664
-  tps: 43074.02535
+  dps: 36085.77545
+  tps: 43097.77682
   hps: 235.80803
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-unholy_dw_ss-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11360.34886
-  tps: 7623.56434
+  dps: 11359.86279
+  tps: 7620.00658
   hps: 235.80803
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-unholy_dw_ss-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16203.53878
-  tps: 8807.56953
+  dps: 16214.52165
+  tps: 8813.67894
   hps: 336.86861
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-unholy_dw_ss-NoBuffs-LongMultiTarget"
  value: {
-  dps: 18614.99006
-  tps: 22823.77288
+  dps: 18604.32001
+  tps: 22813.86753
   hps: 155.74144
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-unholy_dw_ss-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5829.87154
-  tps: 4285.00282
+  dps: 5829.27205
+  tps: 4283.75246
   hps: 155.1872
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-unholy_dw_ss-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7217.21711
-  tps: 4501.57345
+  dps: 7203.1042
+  tps: 4483.49763
   hps: 221.696
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 58738.90776
-  tps: 61349.01007
-  hps: 322.27131
+  dps: 58794.76494
+  tps: 61398.71191
+  hps: 321.42877
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 12112.73176
-  tps: 7948.73421
-  hps: 320.16496
+  dps: 12134.70888
+  tps: 7950.21977
+  hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 17254.6897
-  tps: 8835.04558
+  dps: 17289.52823
+  tps: 8874.00041
   hps: 216.95389
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 35571.33886
-  tps: 38148.06637
+  dps: 35562.22903
+  tps: 38143.42638
   hps: 206.56764
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6185.87601
-  tps: 4451.17036
-  hps: 208.78582
+  dps: 6176.61072
+  tps: 4439.85742
+  hps: 209.06309
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7822.66151
-  tps: 4553.96745
-  hps: 153.88596
+  dps: 7797.10312
+  tps: 4536.25664
+  hps: 159.4314
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-uh_2h_ss-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14279.05441
-  tps: 9300.01857
+  dps: 14361.12682
+  tps: 9346.40063
   hps: 42.12697
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-uh_2h_ss-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10296.72537
-  tps: 5969.30762
+  dps: 10313.37416
+  tps: 5964.57287
   hps: 42.12697
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-uh_2h_ss-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 15435.03419
-  tps: 7137.9645
+  dps: 15425.59404
+  tps: 7139.14152
   hps: 210.63484
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-uh_2h_ss-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6769.67013
-  tps: 4575.20315
+  dps: 6761.94219
+  tps: 4569.5131
   hps: 27.7272
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-uh_2h_ss-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5081.69311
-  tps: 3167.07248
+  dps: 5081.39742
+  tps: 3166.06186
   hps: 27.7272
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-uh_2h_ss-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6701.94323
-  tps: 3493.82943
+  dps: 6680.90713
+  tps: 3470.07521
   hps: 138.636
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-uh_dnd_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 59358.52039
-  tps: 61324.18765
+  dps: 59343.37616
+  tps: 61308.5245
   hps: 235.91102
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-uh_dnd_aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11307.88621
-  tps: 7450.84128
+  dps: 11313.5294
+  tps: 7454.40638
   hps: 235.91102
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-uh_dnd_aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16449.84874
-  tps: 8693.0837
+  dps: 16475.45277
+  tps: 8713.61689
   hps: 337.01574
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-uh_dnd_aoe-NoBuffs-LongMultiTarget"
  value: {
-  dps: 35186.81459
-  tps: 37536.48079
-  hps: 155.54959
+  dps: 35109.43466
+  tps: 37444.05902
+  hps: 155.27232
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-uh_dnd_aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5755.08349
-  tps: 4186.31129
+  dps: 5748.09908
+  tps: 4179.27955
   hps: 155.27232
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-uh_dnd_aoe-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7281.92943
-  tps: 4475.49171
+  dps: 7264.64219
+  tps: 4458.29405
   hps: 221.8176
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-unholy_dw_ss-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36317.66084
-  tps: 43273.70413
+  dps: 36291.06866
+  tps: 43249.80547
   hps: 235.91102
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-unholy_dw_ss-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11497.76882
-  tps: 7626.07328
+  dps: 11457.30561
+  tps: 7593.73156
   hps: 235.91102
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-unholy_dw_ss-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16545.2745
-  tps: 8850.9478
+  dps: 16563.8433
+  tps: 8862.06053
   hps: 337.01574
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-unholy_dw_ss-NoBuffs-LongMultiTarget"
  value: {
-  dps: 18706.21982
-  tps: 22906.43598
+  dps: 18703.05825
+  tps: 22903.87171
   hps: 155.82686
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-unholy_dw_ss-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5875.76306
-  tps: 4283.25783
+  dps: 5878.77619
+  tps: 4284.65854
   hps: 155.27232
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-unholy_dw_ss-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7361.01775
-  tps: 4536.88219
+  dps: 7338.4941
+  tps: 4512.22992
   hps: 221.8176
  }
 }
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 11620.29838
-  tps: 7666.00758
-  hps: 315.53099
+  dps: 11559.47339
+  tps: 7600.23481
+  hps: 313.84591
  }
 }

--- a/sim/deathknight/ghoul_pet_abilities.go
+++ b/sim/deathknight/ghoul_pet_abilities.go
@@ -2,6 +2,7 @@ package deathknight
 
 import (
 	"github.com/wowsims/wotlk/sim/core"
+	"time"
 )
 
 type PetAbilityType int
@@ -61,8 +62,9 @@ func (ghoulPet *GhoulPet) newClaw() PetAbility {
 
 			Cast: core.CastConfig{
 				DefaultCast: core.Cast{
-					GCD: core.GCDDefault,
+					GCD: time.Second,
 				},
+				IgnoreHaste: true,
 			},
 
 			DamageMultiplier: 1.5,
@@ -74,7 +76,10 @@ func (ghoulPet *GhoulPet) newClaw() PetAbility {
 					spell.Unit.MHWeaponDamage(sim, spell.MeleeAttackPower()) +
 					spell.BonusWeaponDamage()
 
-				spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialHitAndCrit)
+				result := spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialHitAndCrit)
+				if !result.Landed() {
+					ghoulPet.AddFocus(sim, 32, spell.ActionID)
+				}
 			},
 		}),
 	}

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -46,965 +46,965 @@ character_stats_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2180.75725
-  tps: 6645.94777
+  dps: 2178.89685
+  tps: 6604.42217
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 2103.90596
-  tps: 6476.18337
-  hps: 82.01664
+  dps: 2098.58708
+  tps: 6387.47199
+  hps: 82.05874
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 2103.90596
-  tps: 6476.18337
-  hps: 82.01664
+  dps: 2098.58708
+  tps: 6387.47199
+  hps: 82.05874
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 2106.82524
-  tps: 6485.72386
+  dps: 2101.68687
+  tps: 6394.76033
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 2068.06994
-  tps: 6381.479
+  dps: 2069.57733
+  tps: 6315.35028
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1942.12999
-  tps: 5981.83769
+  dps: 1951.04876
+  tps: 5999.67312
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1873.53336
-  tps: 5692.88873
+  dps: 1902.10341
+  tps: 5723.9637
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1788.44446
-  tps: 5470.61891
+  dps: 1797.30344
+  tps: 5482.03124
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2100.60102
-  tps: 6335.80186
+  dps: 2095.30481
+  tps: 6248.90352
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 2536.58837
-  tps: 7419.04346
+  dps: 2536.97604
+  tps: 7472.48013
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 2590.7832
-  tps: 7651.21815
+  dps: 2596.82022
+  tps: 7555.12826
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2123.22555
-  tps: 6539.10579
+  dps: 2117.77626
+  tps: 6448.03134
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
   hps: 64
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2139.58579
-  tps: 6602.70435
+  dps: 2128.42518
+  tps: 6490.7227
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2179.17984
-  tps: 6623.65852
+  dps: 2177.48684
+  tps: 6648.95967
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 2173.69505
-  tps: 6686.03103
+  dps: 2167.54753
+  tps: 6598.01328
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 2397.59468
-  tps: 7428.23311
+  dps: 2404.55578
+  tps: 7303.75641
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedPlate"
  value: {
-  dps: 2109.98928
-  tps: 6508.46083
+  dps: 2100.31485
+  tps: 6374.96392
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Death'sChoice-47464"
  value: {
-  dps: 2293.94759
-  tps: 7093.2463
+  dps: 2285.75604
+  tps: 6984.90267
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 2125.49627
-  tps: 6551.26682
+  dps: 2116.11995
+  tps: 6445.09213
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 2222.81326
-  tps: 6714.57449
+  dps: 2233.19831
+  tps: 6701.88119
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 2245.10588
-  tps: 6817.40833
+  dps: 2244.53019
+  tps: 6840.53594
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 2109.95104
-  tps: 6497.28203
+  dps: 2104.5681
+  tps: 6408.16355
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2108.15348
-  tps: 6488.47796
+  dps: 2103.0797
+  tps: 6397.64834
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 2167.45627
-  tps: 6589.92063
+  dps: 2178.90902
+  tps: 6579.88783
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 2153.58281
-  tps: 6575.72721
+  dps: 2169.78775
+  tps: 6554.3478
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 2100.60102
-  tps: 6465.10394
+  dps: 2095.30481
+  tps: 6376.43216
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2100.60102
-  tps: 6465.10394
+  dps: 2095.30481
+  tps: 6376.43216
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 2106.82524
-  tps: 6485.72386
+  dps: 2101.68687
+  tps: 6394.76033
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2105.46004
-  tps: 6482.89312
+  dps: 2099.75889
+  tps: 6388.2258
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 2151.1035
-  tps: 6571.74939
+  dps: 2148.14386
+  tps: 6539.60579
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 2100.60102
-  tps: 6465.10394
+  dps: 2095.30481
+  tps: 6376.43216
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2165.82642
-  tps: 6594.97876
+  dps: 2161.7446
+  tps: 6561.18356
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2133.49566
-  tps: 6585.4789
+  dps: 2123.38828
+  tps: 6475.10175
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2127.29721
-  tps: 6567.52958
+  dps: 2119.73362
+  tps: 6464.94988
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2100.60102
-  tps: 6465.10394
+  dps: 2095.30481
+  tps: 6376.43216
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2100.60102
-  tps: 6465.10394
+  dps: 2095.30481
+  tps: 6376.43216
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2179.47635
-  tps: 6745.11794
+  dps: 2173.22369
+  tps: 6652.07226
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 2150.5769
-  tps: 6620.56201
+  dps: 2150.6699
+  tps: 6537.76858
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 2106.82524
-  tps: 6485.72386
+  dps: 2101.68687
+  tps: 6394.76033
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2105.46004
-  tps: 6482.89312
+  dps: 2099.75889
+  tps: 6388.2258
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2161.05477
-  tps: 6646.62044
+  dps: 2154.88468
+  tps: 6554.96486
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 2100.60102
-  tps: 6465.10394
+  dps: 2095.30481
+  tps: 6376.43216
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2111.30684
-  tps: 6501.94801
-  hps: 15.08033
+  dps: 2105.91132
+  tps: 6412.76475
+  hps: 14.94508
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-LastWord-50179"
  value: {
-  dps: 2368.96693
-  tps: 7152.14774
+  dps: 2348.29668
+  tps: 7071.40748
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-LastWord-50708"
  value: {
-  dps: 2391.93819
-  tps: 7212.02643
+  dps: 2371.17177
+  tps: 7130.8883
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2157.58229
-  tps: 6563.59054
+  dps: 2165.43973
+  tps: 6664.36471
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 2150.53719
-  tps: 6617.3188
+  dps: 2139.53067
+  tps: 6537.34344
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2107.82687
-  tps: 6489.9717
+  dps: 2102.46363
+  tps: 6400.9547
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 2109.26764
-  tps: 6494.93009
+  dps: 2103.89103
+  tps: 6405.84426
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2111.30684
-  tps: 6501.94801
+  dps: 2105.91132
+  tps: 6412.76475
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 2120.09042
-  tps: 6532.17668
+  dps: 2114.61342
+  tps: 6442.57378
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 2122.17211
-  tps: 6539.3408
+  dps: 2116.6758
+  tps: 6449.63845
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 2100.60102
-  tps: 6465.10394
+  dps: 2095.30481
+  tps: 6376.43216
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 2100.60102
-  tps: 6465.10394
+  dps: 2095.30481
+  tps: 6376.43216
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 2121.92969
-  tps: 6534.23364
+  dps: 2128.98454
+  tps: 6470.03246
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 2124.70185
-  tps: 6539.98172
+  dps: 2131.62725
+  tps: 6475.51212
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2120.93659
-  tps: 6526.63368
+  dps: 2114.99925
+  tps: 6437.31423
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2100.60102
-  tps: 6465.10394
+  dps: 2095.30481
+  tps: 6376.43216
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 2290.08438
-  tps: 7026.59286
+  dps: 2288.6008
+  tps: 7060.26603
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgebornePlate"
  value: {
-  dps: 2076.26335
-  tps: 6420.23025
+  dps: 2080.26982
+  tps: 6358.57273
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 2555.42299
-  tps: 7970.16347
+  dps: 2556.55703
+  tps: 7915.65274
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 2227.46539
-  tps: 6935.23154
+  dps: 2226.70592
+  tps: 6799.66515
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2109.05084
-  tps: 6494.13225
+  dps: 2103.75453
+  tps: 6404.99822
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Shadowmourne-49623"
  value: {
-  dps: 2850.16489
-  tps: 8373.87811
+  dps: 2868.91708
+  tps: 8430.73217
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SoulPreserver-37111"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SouloftheDead-40382"
  value: {
-  dps: 2135.23096
-  tps: 6591.22553
+  dps: 2124.66057
+  tps: 6477.73985
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 2125.37253
-  tps: 6521.736
+  dps: 2136.21964
+  tps: 6561.01848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 2172.3812
-  tps: 6632.22383
+  dps: 2175.62263
+  tps: 6737.30946
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-StormshroudArmor"
  value: {
-  dps: 1768.31752
-  tps: 5418.6909
+  dps: 1767.34392
+  tps: 5354.00895
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2111.30684
-  tps: 6501.94801
+  dps: 2105.91132
+  tps: 6412.76475
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 2109.26764
-  tps: 6494.93009
+  dps: 2103.89103
+  tps: 6405.84426
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2105.69903
-  tps: 6482.64874
+  dps: 2100.35553
+  tps: 6393.7334
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 2442.16832
-  tps: 7513.25203
+  dps: 2429.67306
+  tps: 7360.3197
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sPlate"
  value: {
-  dps: 2111.81535
-  tps: 6515.27869
+  dps: 2116.99661
+  tps: 6443.25686
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 2042.13785
-  tps: 6361.81688
+  dps: 2045.35014
+  tps: 6417.53645
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 2116.45779
-  tps: 6495.44207
+  dps: 2110.15629
+  tps: 6457.1646
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2186.19538
-  tps: 6627.70507
+  dps: 2181.77031
+  tps: 6625.91077
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2186.98619
-  tps: 6643.91982
+  dps: 2189.66675
+  tps: 6637.19102
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2100.60102
-  tps: 6465.10394
+  dps: 2095.30481
+  tps: 6376.43216
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2100.60102
-  tps: 6465.10394
+  dps: 2095.30481
+  tps: 6376.43216
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 2119.68568
-  tps: 6411.56878
+  dps: 2124.09225
+  tps: 6488.79524
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2100.60102
-  tps: 6465.10394
+  dps: 2095.30481
+  tps: 6376.43216
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2100.60102
-  tps: 6465.10394
+  dps: 2095.30481
+  tps: 6376.43216
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1881.86077
-  tps: 5738.15318
+  dps: 1893.61136
+  tps: 5733.45162
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 1816.00511
-  tps: 5823.96126
+  dps: 1827.70072
+  tps: 5801.03842
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-WingedTalisman-37844"
  value: {
-  dps: 2103.93256
-  tps: 6476.56943
+  dps: 2098.60544
+  tps: 6387.73848
  }
 }
 dps_results: {
  key: "TestBloodTank-Average-Default"
  value: {
-  dps: 2470.36963
-  tps: 8338.10195
-  dtps: 292.15925
+  dps: 2483.36769
+  tps: 8342.53895
+  dtps: 293.41808
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-blood_aggro-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2017.54527
-  tps: 4434.85079
+  dps: 2026.58808
+  tps: 4459.72501
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-blood_aggro-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2017.54527
-  tps: 4434.85079
+  dps: 2026.58808
+  tps: 4459.72501
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-blood_aggro-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2940.49796
-  tps: 4799.42354
+  dps: 2982.04152
+  tps: 4890.76359
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-blood_aggro-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1219.58101
-  tps: 2654.88028
+  dps: 1223.75004
+  tps: 2657.11163
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-blood_aggro-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1219.58101
-  tps: 2654.88028
+  dps: 1223.75004
+  tps: 2657.11163
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-blood_aggro-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1772.51539
-  tps: 2696.93294
+  dps: 1797.0372
+  tps: 2720.03527
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-blood_icy_touch-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7783.10531
-  tps: 18202.80464
+  dps: 7786.10604
+  tps: 18205.88346
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-blood_icy_touch-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2159.41991
-  tps: 6527.45547
+  dps: 2168.40233
+  tps: 6587.74453
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-blood_icy_touch-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3055.37663
-  tps: 6992.02998
+  dps: 3096.22661
+  tps: 7054.15439
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-blood_icy_touch-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4168.33725
-  tps: 9884.74763
+  dps: 4159.81193
+  tps: 9786.38821
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-blood_icy_touch-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1296.45233
-  tps: 3906.23604
+  dps: 1304.28358
+  tps: 3917.98149
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-Blood Tank P1-Basic-blood_icy_touch-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1836.37292
-  tps: 3999.00231
+  dps: 1876.24585
+  tps: 4036.24839
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-blood_aggro-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2036.47911
-  tps: 4469.52564
+  dps: 2044.94485
+  tps: 4492.60888
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-blood_aggro-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2036.47911
-  tps: 4469.52564
+  dps: 2044.94485
+  tps: 4492.60888
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-blood_aggro-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2978.40272
-  tps: 4858.70412
+  dps: 3014.92325
+  tps: 4938.19347
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-blood_aggro-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1232.92827
-  tps: 2679.69739
+  dps: 1237.61281
+  tps: 2682.79934
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-blood_aggro-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1232.92827
-  tps: 2679.69739
+  dps: 1237.61281
+  tps: 2682.79934
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-blood_aggro-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1799.5427
-  tps: 2742.7054
+  dps: 1824.78521
+  tps: 2767.06191
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-blood_icy_touch-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7866.49144
-  tps: 18378.54059
+  dps: 7871.52585
+  tps: 18386.6769
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-blood_icy_touch-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2179.17614
-  tps: 6573.01153
+  dps: 2188.29896
+  tps: 6632.90335
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-blood_icy_touch-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3094.83463
-  tps: 7057.88326
+  dps: 3134.87742
+  tps: 7117.86947
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-blood_icy_touch-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4225.79341
-  tps: 10007.38607
+  dps: 4215.32035
+  tps: 9904.96538
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-blood_icy_touch-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1310.88733
-  tps: 3940.50247
+  dps: 1318.56824
+  tps: 3951.73057
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-Blood Tank P1-Basic-blood_icy_touch-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1862.89402
-  tps: 4046.22435
+  dps: 1902.94412
+  tps: 4083.30208
  }
 }
 dps_results: {
  key: "TestBloodTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2504.76153
-  tps: 8256.02734
-  dtps: 270.46514
+  dps: 2498.93922
+  tps: 8252.62868
+  dtps: 269.98489
  }
 }


### PR DESCRIPTION
[dk] ghoul's Claw ability now has a 1s GCD, isn't affected by haste anymore, and has a refund, as tested in-game (it's essentially a Sinister Strike)

I can't test at the moment, but it looks like non-permanent ghouls use the pre-WotLK energy ticks (~20e / 2s), while the permanent ghoul gains energy every ~100ms. None of that is very consequential, of course ;)