### PR TITLE
Vigo/faster advance

### DIFF
--- a/sim/core/aura.go
+++ b/sim/core/aura.go
@@ -488,17 +488,14 @@ func (at *auraTracker) advance(sim *Simulation) time.Duration {
 	}
 
 restart:
-	minExpires := NeverExpires
+	at.minExpires = NeverExpires
 	for _, aura := range at.activeAuras {
 		if aura.expires <= sim.CurrentTime && aura.expires != 0 {
 			aura.Deactivate(sim)
 			goto restart // activeAuras have changed
 		}
-		if aura.expires < minExpires {
-			minExpires = aura.expires
-		}
+		at.minExpires = min(at.minExpires, aura.expires)
 	}
-	at.minExpires = minExpires
 	return at.minExpires
 }
 

--- a/sim/core/aura.go
+++ b/sim/core/aura.go
@@ -164,6 +164,7 @@ func (aura *Aura) Refresh(sim *Simulation) {
 		aura.expires = sim.CurrentTime + aura.Duration
 		if aura.expires < aura.Unit.minExpires {
 			aura.Unit.minExpires = aura.expires
+			sim.rescheduleTracker(aura.expires)
 		}
 	}
 }
@@ -474,14 +475,16 @@ func (at *auraTracker) reset(sim *Simulation) {
 		resetEffect(sim)
 	}
 
+	at.minExpires = NeverExpires
+
 	for _, aura := range at.auras {
 		aura.reset(sim)
 	}
 }
 
-func (at *auraTracker) advance(sim *Simulation) {
+func (at *auraTracker) advance(sim *Simulation) time.Duration {
 	if at.minExpires > sim.CurrentTime {
-		return
+		return at.minExpires
 	}
 
 restart:
@@ -496,6 +499,7 @@ restart:
 		}
 	}
 	at.minExpires = minExpires
+	return at.minExpires
 }
 
 func (at *auraTracker) doneIteration(sim *Simulation) {

--- a/sim/core/aura_helpers.go
+++ b/sim/core/aura_helpers.go
@@ -222,7 +222,7 @@ func (character *Character) NewTemporaryStatsAuraWrapped(auraLabel string, actio
 			if sim.Log != nil {
 				character.Log(sim, "Lost %s from fading %s.", buffs.FlatString(), actionID)
 			}
-			character.AddStatsDynamic(sim, buffs.Multiply(-1))
+			character.AddStatsDynamic(sim, buffs.Invert())
 		},
 	}
 

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -513,14 +513,16 @@ func (character *Character) reset(sim *Simulation, agent Agent) {
 }
 
 // Advance moves time forward counting down auras, CDs, mana regen, etc
-func (character *Character) advance(sim *Simulation) {
-	character.Unit.advance(sim)
+func (character *Character) advance(sim *Simulation) time.Duration {
+	minExpires := character.Unit.advance(sim)
 
 	for _, pet := range character.Pets {
 		if pet.enabled {
-			pet.Unit.advance(sim)
+			minExpires = min(minExpires, pet.Unit.advance(sim))
 		}
 	}
+
+	return minExpires
 }
 
 func (character *Character) HasProfession(prof proto.Profession) bool {

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -495,10 +495,6 @@ func (character *Character) FillPlayerStats(playerStats *proto.PlayerStats) {
 	}
 }
 
-func (character *Character) init(sim *Simulation) {
-	character.Unit.init(sim)
-}
-
 func (character *Character) reset(sim *Simulation, agent Agent) {
 	character.Unit.reset(sim, agent)
 	character.majorCooldownManager.reset(sim)
@@ -510,19 +506,6 @@ func (character *Character) reset(sim *Simulation, agent Agent) {
 	for _, petAgent := range character.PetAgents {
 		petAgent.GetPet().reset(sim, petAgent)
 	}
-}
-
-// Advance moves time forward counting down auras, CDs, mana regen, etc
-func (character *Character) advance(sim *Simulation) time.Duration {
-	minExpires := character.Unit.advance(sim)
-
-	for _, pet := range character.Pets {
-		if pet.enabled {
-			minExpires = min(minExpires, pet.Unit.advance(sim))
-		}
-	}
-
-	return minExpires
 }
 
 func (character *Character) HasProfession(prof proto.Profession) bool {

--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -776,7 +776,7 @@ func apReductionEffect(aura *Aura, apReduction float64) *ExclusiveEffect {
 			ee.Aura.Unit.AddStatsDynamic(sim, statReduction)
 		},
 		OnExpire: func(ee *ExclusiveEffect, sim *Simulation) {
-			ee.Aura.Unit.AddStatsDynamic(sim, statReduction.Multiply(-1))
+			ee.Aura.Unit.AddStatsDynamic(sim, statReduction.Invert())
 		},
 	})
 }

--- a/sim/core/pet.go
+++ b/sim/core/pet.go
@@ -251,10 +251,7 @@ func (pet *Pet) Disable(sim *Simulation) {
 
 	if sim.Log != nil {
 		pet.Log(sim, "Pet dismissed")
-
-		if sim.Log != nil {
-			pet.Log(sim, pet.GetStats().String())
-		}
+		pet.Log(sim, pet.GetStats().String())
 	}
 }
 

--- a/sim/core/pet.go
+++ b/sim/core/pet.go
@@ -211,7 +211,7 @@ func (pet *Pet) Disable(sim *Simulation) {
 
 	// Remove inherited stats on dismiss if not permanent
 	if pet.isGuardian || pet.timeoutAction != nil {
-		pet.AddStatsDynamic(sim, pet.inheritedStats.Multiply(-1))
+		pet.AddStatsDynamic(sim, pet.inheritedStats.Invert())
 		pet.inheritedStats = stats.Stats{}
 	}
 

--- a/sim/core/pet.go
+++ b/sim/core/pet.go
@@ -110,10 +110,6 @@ func (pet *Pet) reset(sim *Simulation, agent PetAgent) {
 		pet.Enable(sim, agent)
 	}
 }
-func (pet *Pet) advance(sim *Simulation) {
-	pet.Character.advance(sim)
-}
-
 func (pet *Pet) doneIteration(sim *Simulation) {
 	pet.Character.doneIteration(sim)
 	pet.isReset = false
@@ -172,6 +168,8 @@ func (pet *Pet) Enable(sim *Simulation, petAgent PetAgent) {
 		pet.Log(sim, "Pet inherited stats: %s", pet.ApplyStatDependencies(pet.inheritedStats))
 		pet.Log(sim, "Pet summoned")
 	}
+
+	sim.addTracker(&pet.auraTracker)
 }
 
 // Helper for enabling a pet that will expire after a certain duration.
@@ -248,6 +246,8 @@ func (pet *Pet) Disable(sim *Simulation) {
 	if pet.OnPetDisable != nil {
 		pet.OnPetDisable(sim)
 	}
+
+	sim.removeTracker(&pet.auraTracker)
 
 	if sim.Log != nil {
 		pet.Log(sim, "Pet dismissed")

--- a/sim/core/stats/stats.go
+++ b/sim/core/stats/stats.go
@@ -183,21 +183,20 @@ func (s Stat) StatName() string {
 }
 
 func FromFloatArray(values []float64) Stats {
-	stats := Stats{}
+	var stats Stats
 	copy(stats[:], values)
 	return stats
 }
 
 // Adds two Stats together, returning the new Stats.
 func (stats Stats) Add(other Stats) Stats {
-	var newStats Stats
-	for k, v := range stats {
-		newStats[k] = v + other[k]
+	for k := range stats {
+		stats[k] += other[k]
 	}
-	return newStats
+	return stats
 }
 
-// Adds another to Stats to this, in-place.
+// Adds another to Stats to this, in-place. For performance, only.
 func (stats *Stats) AddInplace(other *Stats) {
 	for k := range stats {
 		stats[k] += other[k]
@@ -206,38 +205,37 @@ func (stats *Stats) AddInplace(other *Stats) {
 
 // Subtracts another Stats from this one, returning the new Stats.
 func (stats Stats) Subtract(other Stats) Stats {
-	var newStats Stats
-	for k, v := range stats {
-		newStats[k] = v - other[k]
+	for k := range stats {
+		stats[k] -= other[k]
 	}
-	return newStats
+	return stats
+}
+
+func (stats Stats) Invert() Stats {
+	for k, v := range stats {
+		stats[k] = -v
+	}
+	return stats
 }
 
 func (stats Stats) Multiply(multiplier float64) Stats {
-	var newStats Stats
-	for k, v := range stats {
-		newStats[k] = v * multiplier
+	for k := range stats {
+		stats[k] *= multiplier
 	}
-	return newStats
+	return stats
 }
 
 // Multiplies two Stats together by multiplying the values of corresponding
 // stats, like a dot product operation.
 func (stats Stats) DotProduct(other Stats) Stats {
-	var newStats Stats
-	for k, v := range stats {
-		newStats[k] = v * other[k]
+	for k := range stats {
+		stats[k] *= other[k]
 	}
-	return newStats
+	return stats
 }
 
 func (stats Stats) Equals(other Stats) bool {
-	for k, v := range stats {
-		if v != other[k] {
-			return false
-		}
-	}
-	return true
+	return stats == other
 }
 
 func (stats Stats) EqualsWithTolerance(other Stats, tolerance float64) bool {

--- a/sim/core/target.go
+++ b/sim/core/target.go
@@ -160,28 +160,12 @@ func NewTarget(options *proto.Target, targetIndex int32) *Target {
 	return target
 }
 
-func (target *Target) finalize() {
-	target.Unit.finalize()
-}
-
-func (target *Target) init(sim *Simulation) {
-	target.Unit.init(sim)
-}
-
 func (target *Target) Reset(sim *Simulation) {
 	target.Unit.reset(sim, nil)
 	target.SetGCDTimer(sim, 0)
 	if target.AI != nil {
 		target.AI.Reset(sim)
 	}
-}
-
-func (target *Target) Advance(sim *Simulation) {
-	target.Unit.advance(sim)
-}
-
-func (target *Target) doneIteration(sim *Simulation) {
-	target.Unit.doneIteration(sim)
 }
 
 func (target *Target) NextTarget() *Target {

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -477,6 +477,10 @@ func (unit *Unit) reset(sim *Simulation, _ Agent) {
 
 	unit.DynamicStatsPets = unit.DynamicStatsPets[:0]
 	unit.DynamicMeleeSpeedPets = unit.DynamicMeleeSpeedPets[:0]
+
+	if unit.Type != PetUnit {
+		sim.addTracker(&unit.auraTracker)
+	}
 }
 
 func (unit *Unit) startPull(sim *Simulation) {
@@ -488,10 +492,6 @@ func (unit *Unit) startPull(sim *Simulation) {
 }
 
 // Advance moves time forward counting down auras, and nothing else, currently.
-func (unit *Unit) advance(sim *Simulation) {
-	unit.auraTracker.advance(sim)
-}
-
 func (unit *Unit) doneIteration(sim *Simulation) {
 	unit.Hardcast = Hardcast{}
 	unit.doneIterationGCD(sim)

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -46,184 +46,184 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 11438.25314
-  tps: 7562.4611
+  dps: 11438.45749
+  tps: 7562.27641
   hps: 418.74234
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 11438.25314
-  tps: 7562.4611
+  dps: 11438.45749
+  tps: 7562.27641
   hps: 432.31455
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 11987.09424
-  tps: 7815.20256
+  dps: 11987.5544
+  tps: 7815.17056
   hps: 321.64781
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 11668.32122
-  tps: 7760.15215
+  dps: 11668.51326
+  tps: 7759.87924
   hps: 315.10972
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 11438.31898
-  tps: 7562.51169
+  dps: 11438.52333
+  tps: 7562.327
   hps: 408.31737
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 11438.31898
-  tps: 7562.51169
+  dps: 11438.52333
+  tps: 7562.327
   hps: 408.31737
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 12012.54281
-  tps: 7836.47344
+  dps: 12013.00298
+  tps: 7836.44144
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 11341.54125
-  tps: 7314.8544
+  dps: 11341.63964
+  tps: 7315.02681
   hps: 302.45308
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 8938.21256
-  tps: 5760.79173
+  dps: 8938.17521
+  tps: 5760.72148
   hps: 260.97407
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 8750.58474
-  tps: 5678.98468
+  dps: 8750.65427
+  tps: 5679.0567
   hps: 249.56588
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8505.73123
-  tps: 5472.94501
+  dps: 8505.75319
+  tps: 5472.82635
   hps: 245.79221
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 11987.09424
-  tps: 7658.89851
+  dps: 11987.5544
+  tps: 7658.86715
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 12134.70888
-  tps: 7950.21977
+  dps: 12135.19759
+  tps: 7950.18776
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 12134.70888
-  tps: 7950.21977
+  dps: 12135.19759
+  tps: 7950.18776
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 12146.75712
-  tps: 7962.25623
+  dps: 12147.24584
+  tps: 7962.22422
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 11438.28255
-  tps: 7562.46093
+  dps: 11438.48691
+  tps: 7562.27623
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 11438.28255
-  tps: 7562.46093
+  dps: 11438.48691
+  tps: 7562.27623
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 11438.30511
-  tps: 7562.49521
+  dps: 11438.50946
+  tps: 7562.31052
   hps: 410.93938
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 11595.79229
-  tps: 7706.43318
+  dps: 11595.74534
+  tps: 7706.0194
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 11644.07752
-  tps: 7748.49705
+  dps: 11644.36771
+  tps: 7748.50954
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 11803.64124
-  tps: 7758.96595
+  dps: 11803.78136
+  tps: 7758.76767
   hps: 314.68845
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 9925.07429
-  tps: 6430.21007
+  dps: 9925.0801
+  tps: 6430.26092
   hps: 289.86734
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 8825.9019
-  tps: 5654.31339
+  dps: 8825.9268
+  tps: 5654.26236
   hps: 309.85918
  }
 }
@@ -238,168 +238,168 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 11558.57467
-  tps: 7672.68474
+  dps: 11558.5734
+  tps: 7672.46319
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 11891.73383
-  tps: 7983.44774
+  dps: 11891.79701
+  tps: 7982.98203
   hps: 326.90527
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11970.74711
-  tps: 8073.76767
+  dps: 11971.93921
+  tps: 8074.33889
   hps: 322.69257
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 11438.26683
-  tps: 7562.43702
+  dps: 11438.47118
+  tps: 7562.25233
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 12016.07853
-  tps: 7839.14967
+  dps: 12016.61782
+  tps: 7839.14676
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11851.17556
-  tps: 7776.9113
+  dps: 11851.85681
+  tps: 7777.11138
   hps: 319.32242
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11782.96904
-  tps: 7726.26769
+  dps: 11783.31523
+  tps: 7726.23935
   hps: 318.05861
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 11987.09424
-  tps: 7815.20256
+  dps: 11987.5544
+  tps: 7815.17056
   hps: 321.64781
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 11987.09424
-  tps: 7815.20256
+  dps: 11987.5544
+  tps: 7815.17056
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 12012.54281
-  tps: 7836.47344
+  dps: 12013.00298
+  tps: 7836.44144
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 12006.68937
-  tps: 7831.42456
+  dps: 12007.14954
+  tps: 7831.39255
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 11759.79723
-  tps: 7674.83362
+  dps: 11759.81948
+  tps: 7674.70939
   hps: 318.47988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 11438.28255
-  tps: 7562.46093
+  dps: 11438.48691
+  tps: 7562.27623
   hps: 330.82192
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 11987.09424
-  tps: 7815.20256
+  dps: 11987.5544
+  tps: 7815.17056
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 11687.70288
-  tps: 7784.80745
+  dps: 11687.67692
+  tps: 7784.64024
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 11573.71686
-  tps: 7684.61132
+  dps: 11573.63791
+  tps: 7684.18489
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 11438.28255
-  tps: 7562.46093
+  dps: 11438.48691
+  tps: 7562.27623
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 11438.28255
-  tps: 7562.46093
+  dps: 11438.48691
+  tps: 7562.27623
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 11549.58926
-  tps: 7660.78271
+  dps: 11549.51414
+  tps: 7660.34405
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 11987.09424
-  tps: 7815.20256
+  dps: 11987.5544
+  tps: 7815.17056
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 11987.09424
-  tps: 7815.20256
+  dps: 11987.5544
+  tps: 7815.17056
   hps: 317.21607
  }
 }
@@ -414,40 +414,40 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 11709.32394
-  tps: 7785.65046
+  dps: 11709.53505
+  tps: 7785.45971
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 11438.26683
-  tps: 7562.43702
+  dps: 11438.47118
+  tps: 7562.25233
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 11438.28938
-  tps: 7562.4713
+  dps: 11438.49374
+  tps: 7562.28661
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 11438.28938
-  tps: 7562.4713
+  dps: 11438.49374
+  tps: 7562.28661
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 11601.88591
-  tps: 7717.07558
+  dps: 11602.16505
+  tps: 7717.12338
   hps: 315.10972
  }
 }
@@ -462,192 +462,192 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 11438.28255
-  tps: 7562.46093
+  dps: 11438.48691
+  tps: 7562.27623
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 12012.54281
-  tps: 7836.47344
+  dps: 12013.00298
+  tps: 7836.44144
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 12006.68937
-  tps: 7831.42456
+  dps: 12007.14954
+  tps: 7831.39255
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 11635.30172
-  tps: 7726.46439
+  dps: 11635.50909
+  tps: 7726.27678
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 11987.09424
-  tps: 7815.20256
+  dps: 11987.5544
+  tps: 7815.17056
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 12024.58925
-  tps: 7845.18547
+  dps: 12025.05112
+  tps: 7845.1532
   hps: 333.69976
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50179"
  value: {
-  dps: 12134.70888
-  tps: 7950.21977
+  dps: 12135.19759
+  tps: 7950.18776
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50708"
  value: {
-  dps: 12134.70888
-  tps: 7950.21977
+  dps: 12135.19759
+  tps: 7950.18776
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 11438.26683
-  tps: 7562.43702
+  dps: 11438.47118
+  tps: 7562.25233
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 11438.28255
-  tps: 7562.46093
+  dps: 11438.48691
+  tps: 7562.27623
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 11796.12822
-  tps: 7767.16733
+  dps: 11796.50596
+  tps: 7767.3875
   hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 11572.37398
-  tps: 7700.83712
+  dps: 11572.08246
+  tps: 7700.14357
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 11438.26683
-  tps: 7562.43702
+  dps: 11438.47118
+  tps: 7562.25233
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 12017.44734
-  tps: 7839.47444
+  dps: 12017.90889
+  tps: 7839.44222
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 12024.58925
-  tps: 7845.18547
+  dps: 12025.05112
+  tps: 7845.1532
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 11438.28255
-  tps: 7562.46093
+  dps: 11438.48691
+  tps: 7562.27623
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 11438.28255
-  tps: 7562.46093
+  dps: 11438.48691
+  tps: 7562.27623
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 11438.28255
-  tps: 7562.46093
+  dps: 11438.48691
+  tps: 7562.27623
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 11987.09424
-  tps: 7815.20256
+  dps: 11987.5544
+  tps: 7815.17056
   hps: 320.81685
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 11987.09424
-  tps: 7815.20256
+  dps: 11987.5544
+  tps: 7815.17056
   hps: 321.64781
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 11438.28255
-  tps: 7562.46093
+  dps: 11438.48691
+  tps: 7562.27623
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 11525.53508
-  tps: 7642.37822
+  dps: 11525.49873
+  tps: 7641.9538
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 11535.80251
-  tps: 7651.01179
+  dps: 11535.76616
+  tps: 7650.58738
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 12134.70888
-  tps: 7950.21977
+  dps: 12135.19759
+  tps: 7950.18776
   hps: 317.21607
  }
 }
@@ -662,16 +662,16 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 11987.09424
-  tps: 7815.20256
+  dps: 11987.5544
+  tps: 7815.17056
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 11438.26683
-  tps: 7562.43702
+  dps: 11438.47118
+  tps: 7562.25233
   hps: 315.53099
  }
 }
@@ -686,56 +686,56 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 9524.8041
-  tps: 6154.81315
+  dps: 9524.88146
+  tps: 6154.85345
   hps: 276.15832
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 8755.58403
-  tps: 5594.29074
+  dps: 8755.47565
+  tps: 5594.01923
   hps: 285.71002
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 11176.76821
-  tps: 7488.5116
+  dps: 11176.77083
+  tps: 7488.65535
   hps: 337.25075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 9848.12263
-  tps: 6488.55742
+  dps: 9847.94922
+  tps: 6488.27998
   hps: 361.94891
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 11438.26683
-  tps: 7562.43702
+  dps: 11438.47118
+  tps: 7562.25233
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 12134.70888
-  tps: 7950.21977
+  dps: 12135.19759
+  tps: 7950.18776
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 11438.28255
-  tps: 7562.46093
+  dps: 11438.48691
+  tps: 7562.27623
   hps: 315.53099
  }
 }
@@ -790,224 +790,224 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 11438.30511
-  tps: 7562.49521
+  dps: 11438.50946
+  tps: 7562.31052
   hps: 346.93938
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 11438.28255
-  tps: 7562.46093
+  dps: 11438.48691
+  tps: 7562.27623
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 11438.28255
-  tps: 7562.46093
+  dps: 11438.48691
+  tps: 7562.27623
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SoulPreserver-37111"
  value: {
-  dps: 11438.28255
-  tps: 7562.46093
+  dps: 11438.48691
+  tps: 7562.27623
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SouloftheDead-40382"
  value: {
-  dps: 11581.88029
-  tps: 7692.16351
+  dps: 11581.80134
+  tps: 7691.73707
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 11618.09561
-  tps: 7647.35321
+  dps: 11617.90322
+  tps: 7646.97001
   hps: 315.10972
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 11685.36065
-  tps: 7716.9763
+  dps: 11685.70493
+  tps: 7717.06189
   hps: 321.42877
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StormshroudArmor"
  value: {
-  dps: 8363.8414
-  tps: 5421.47864
+  dps: 8363.919
+  tps: 5421.57083
   hps: 225.74565
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 12024.58925
-  tps: 7845.18547
+  dps: 12025.05112
+  tps: 7845.1532
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 12017.44734
-  tps: 7839.47444
+  dps: 12017.90889
+  tps: 7839.44222
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 12004.94901
-  tps: 7829.48014
+  dps: 12005.40998
+  tps: 7829.44801
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 11438.26683
-  tps: 7562.43702
+  dps: 11438.47118
+  tps: 7562.25233
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 11438.28255
-  tps: 7562.46093
+  dps: 11438.48691
+  tps: 7562.27623
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 10110.59709
-  tps: 6583.32206
+  dps: 10110.43124
+  tps: 6583.43523
   hps: 286.28871
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 8862.28937
-  tps: 5650.37019
+  dps: 8862.34756
+  tps: 5650.2624
   hps: 301.08702
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 11438.28255
-  tps: 7562.46093
+  dps: 11438.48691
+  tps: 7562.27623
   hps: 315.53099
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 10596.77085
-  tps: 6872.60709
+  dps: 10596.77508
+  tps: 6872.29966
   hps: 304.79181
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 12061.68587
-  tps: 7855.67751
+  dps: 12061.62753
+  tps: 7855.52655
   hps: 318.47988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 11715.09457
-  tps: 7780.74882
+  dps: 11715.56241
+  tps: 7780.88002
   hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 11733.55333
-  tps: 7803.46948
+  dps: 11733.7699
+  tps: 7803.58013
   hps: 316.37353
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 11987.09424
-  tps: 7815.20256
+  dps: 11987.5544
+  tps: 7815.17056
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 11987.09424
-  tps: 7815.20256
+  dps: 11987.5544
+  tps: 7815.17056
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 11553.09227
-  tps: 7569.07153
+  dps: 11553.2202
+  tps: 7568.84609
   hps: 316.37353
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 11987.09424
-  tps: 7815.20256
+  dps: 11987.5544
+  tps: 7815.17056
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 11987.09424
-  tps: 7815.20256
+  dps: 11987.5544
+  tps: 7815.17056
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 8811.94313
-  tps: 5716.42694
+  dps: 8811.89514
+  tps: 5716.31537
   hps: 251.2904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 11395.03509
-  tps: 7402.17848
+  dps: 11394.89688
+  tps: 7402.08667
   hps: 322.54958
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 11438.26683
-  tps: 7562.43702
+  dps: 11438.47118
+  tps: 7562.25233
   hps: 315.53099
  }
 }
@@ -1022,56 +1022,56 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 12080.22153
-  tps: 7959.84181
+  dps: 12080.15755
+  tps: 7959.80277
   hps: 319.17663
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 58290.35239
-  tps: 61053.6133
+  dps: 58289.40143
+  tps: 61052.68007
   hps: 320.02518
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11917.40726
-  tps: 7935.7238
+  dps: 11917.8928
+  tps: 7935.64076
   hps: 320.44626
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16864.94618
-  tps: 8820.5795
+  dps: 16867.44038
+  tps: 8820.07393
   hps: 216.85917
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 35191.14924
-  tps: 37745.91048
+  dps: 35192.7445
+  tps: 37747.41149
   hps: 207.00864
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6073.59102
-  tps: 4427.01416
+  dps: 6073.28917
+  tps: 4426.31004
   hps: 206.73152
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7579.80252
-  tps: 4496.67664
+  dps: 7578.67773
+  tps: 4493.17081
   hps: 159.344
  }
 }
@@ -1126,8 +1126,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-Unholy P3 -Basic-uh_dnd_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 58907.41878
-  tps: 60994.4634
+  dps: 58908.71496
+  tps: 60996.09128
   hps: 235.80803
  }
 }
@@ -1222,48 +1222,48 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 58794.76494
-  tps: 61398.71191
+  dps: 58795.89675
+  tps: 61400.18708
   hps: 321.42877
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 12134.70888
-  tps: 7950.21977
+  dps: 12135.19759
+  tps: 7950.18776
   hps: 317.21607
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 17289.52823
-  tps: 8874.00041
+  dps: 17291.49508
+  tps: 8873.44022
   hps: 216.95389
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 35562.22903
-  tps: 38143.42638
+  dps: 35563.85
+  tps: 38144.57064
   hps: 206.56764
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6176.61072
-  tps: 4439.85742
+  dps: 6176.27952
+  tps: 4439.18077
   hps: 209.06309
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7797.10312
-  tps: 4536.25664
+  dps: 7795.80165
+  tps: 4532.50068
   hps: 159.4314
  }
 }
@@ -1318,8 +1318,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-Unholy P3 -Basic-uh_dnd_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 59343.37616
-  tps: 61308.5245
+  dps: 59350.47187
+  tps: 61313.3856
   hps: 235.91102
  }
 }
@@ -1414,8 +1414,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 11559.47339
-  tps: 7600.23481
+  dps: 11560.14955
+  tps: 7600.46486
   hps: 313.84591
  }
 }

--- a/sim/deathknight/horn_of_winter.go
+++ b/sim/deathknight/horn_of_winter.go
@@ -14,7 +14,7 @@ func (dk *Deathknight) registerHornOfWinterSpell() {
 	rpMetrics := dk.NewRunicPowerMetrics(actionID)
 
 	bonusStats := stats.Stats{stats.Strength: 155.0, stats.Agility: 155.0}
-	negativeStats := bonusStats.Multiply(-1)
+	negativeStats := bonusStats.Invert()
 
 	dk.HornOfWinterAura = dk.RegisterAura(core.Aura{
 		Label:    "Horn of Winter",

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -46,925 +46,925 @@ character_stats_results: {
 dps_results: {
  key: "TestBalance-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7955.53882
-  tps: 7725.71884
+  dps: 7956.34981
+  tps: 7726.52983
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7994.14906
-  tps: 7763.27761
+  dps: 7994.96005
+  tps: 7764.0886
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 7739.69529
-  tps: 7517.76901
+  dps: 7740.50628
+  tps: 7518.58
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7740.43617
-  tps: 7516.44117
+  dps: 7741.43044
+  tps: 7517.43544
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7760.08636
-  tps: 7537.41233
+  dps: 7760.88595
+  tps: 7538.21193
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5539.42356
-  tps: 5296.83462
+  dps: 5540.19154
+  tps: 5297.6026
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7782.97207
-  tps: 7409.03281
+  dps: 7783.96634
+  tps: 7410.00719
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 7875.29688
-  tps: 7648.19491
+  dps: 7876.10787
+  tps: 7649.0059
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7980.53458
-  tps: 7753.43261
+  dps: 7981.34557
+  tps: 7754.2436
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7837.74451
-  tps: 7619.48812
+  dps: 7838.52444
+  tps: 7620.26806
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7813.15261
-  tps: 7597.22242
+  dps: 7813.78548
+  tps: 7597.85528
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7822.27985
-  tps: 7609.83256
+  dps: 7823.0901
+  tps: 7610.64281
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 7875.29688
-  tps: 7648.19491
+  dps: 7876.10787
+  tps: 7649.0059
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7705.68441
-  tps: 7485.45432
+  dps: 7706.42878
+  tps: 7486.19868
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7770.03316
-  tps: 7546.62427
+  dps: 7770.84334
+  tps: 7547.43445
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 8289.76557
-  tps: 8065.39737
+  dps: 8290.48587
+  tps: 8066.11768
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 8239.31187
-  tps: 8020.68115
+  dps: 8240.14645
+  tps: 8021.51573
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 3816.51455
-  tps: 3573.14003
+  dps: 3816.9924
+  tps: 3573.61788
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DreamwalkerGarb"
  value: {
-  dps: 6908.17207
-  tps: 6693.73315
+  dps: 6908.7872
+  tps: 6694.34827
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7740.43617
-  tps: 7516.44117
+  dps: 7741.43044
+  tps: 7517.43544
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7794.48797
-  tps: 7570.1756
+  dps: 7795.34155
+  tps: 7571.02918
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7760.08636
-  tps: 7536.67358
+  dps: 7760.88595
+  tps: 7537.47318
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7751.86791
-  tps: 7528.24447
+  dps: 7752.72149
+  tps: 7529.09805
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7740.43617
-  tps: 7516.44117
+  dps: 7741.43044
+  tps: 7517.43544
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7827.86663
-  tps: 7611.5782
+  dps: 7828.57572
+  tps: 7612.28729
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 8049.11786
-  tps: 7825.29016
+  dps: 8049.8978
+  tps: 7826.07009
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7669.31221
-  tps: 7448.90275
+  dps: 7670.13395
+  tps: 7449.72449
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7836.19808
-  tps: 7609.62809
+  dps: 7837.00907
+  tps: 7610.43908
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7955.52617
-  tps: 7731.39319
+  dps: 7956.50539
+  tps: 7732.3724
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7782.97207
-  tps: 7557.79499
+  dps: 7783.96634
+  tps: 7558.78926
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7774.46489
-  tps: 7549.52422
+  dps: 7775.45916
+  tps: 7550.51849
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 7875.29688
-  tps: 7648.19491
+  dps: 7876.10787
+  tps: 7649.0059
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7750.20254
-  tps: 7525.97446
+  dps: 7751.01353
+  tps: 7526.78545
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 4138.55704
-  tps: 3898.40361
+  dps: 4139.2161
+  tps: 3899.06267
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 7382.3541
-  tps: 7149.61058
+  dps: 7383.15344
+  tps: 7150.40991
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7974.84394
-  tps: 7744.49823
+  dps: 7975.65493
+  tps: 7745.30922
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 8018.71921
-  tps: 7787.17865
+  dps: 8019.5302
+  tps: 7787.98964
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7808.74698
-  tps: 7590.10005
+  dps: 7809.59235
+  tps: 7590.94542
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 7875.29688
-  tps: 7648.19491
+  dps: 7876.10787
+  tps: 7649.0059
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Heartpierce-49982"
  value: {
-  dps: 7980.53458
-  tps: 7753.43261
+  dps: 7981.34557
+  tps: 7754.2436
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Heartpierce-50641"
  value: {
-  dps: 7980.53458
-  tps: 7753.43261
+  dps: 7981.34557
+  tps: 7754.2436
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdolofLunarFury-47670"
  value: {
-  dps: 8195.40593
-  tps: 7973.7449
+  dps: 8196.02866
+  tps: 7974.36763
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 7875.29688
-  tps: 7648.19491
+  dps: 7876.10787
+  tps: 7649.0059
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 7875.29688
-  tps: 7648.19491
+  dps: 7876.10787
+  tps: 7649.0059
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 7875.29688
-  tps: 7648.19491
+  dps: 7876.10787
+  tps: 7649.0059
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 8228.08355
-  tps: 8005.96565
+  dps: 8228.70628
+  tps: 8006.58839
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 7984.07868
-  tps: 7758.7186
+  dps: 7984.97007
+  tps: 7759.60999
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 7921.89015
-  tps: 7692.47954
+  dps: 7922.70114
+  tps: 7693.29053
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 7875.29688
-  tps: 7648.19491
+  dps: 7876.10787
+  tps: 7649.0059
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7760.08636
-  tps: 7536.67358
+  dps: 7760.88595
+  tps: 7537.47318
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7751.86791
-  tps: 7528.24447
+  dps: 7752.72149
+  tps: 7529.09805
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7751.92777
-  tps: 7533.36046
+  dps: 7752.78135
+  tps: 7534.21404
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7740.43617
-  tps: 7516.44117
+  dps: 7741.43044
+  tps: 7517.43544
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 3961.64237
-  tps: 3720.13171
+  dps: 3962.02377
+  tps: 3720.51311
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LasherweaveRegalia"
  value: {
-  dps: 9052.58771
-  tps: 8835.21532
+  dps: 9053.85772
+  tps: 8836.48533
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LastWord-50179"
  value: {
-  dps: 7980.53458
-  tps: 7753.43261
+  dps: 7981.34557
+  tps: 7754.2436
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LastWord-50708"
  value: {
-  dps: 7980.53458
-  tps: 7753.43261
+  dps: 7981.34557
+  tps: 7754.2436
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7746.15096
-  tps: 7522.79549
+  dps: 7746.96195
+  tps: 7523.60648
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 4295.29741
-  tps: 4058.93787
+  dps: 4295.83203
+  tps: 4059.4725
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 7433.2016
-  tps: 7213.56614
+  dps: 7433.7972
+  tps: 7214.16174
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7798.88438
-  tps: 7579.89869
+  dps: 7799.72975
+  tps: 7580.74406
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7836.19808
-  tps: 7609.62809
+  dps: 7837.00907
+  tps: 7610.43908
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Nibelung-49992"
  value: {
-  dps: 7980.53458
-  tps: 7753.43261
+  dps: 7981.34557
+  tps: 7754.2436
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Nibelung-50648"
  value: {
-  dps: 7980.53458
-  tps: 7753.43261
+  dps: 7981.34557
+  tps: 7754.2436
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NightsongBattlegear"
  value: {
-  dps: 4102.50892
-  tps: 3863.51587
+  dps: 4103.11699
+  tps: 3864.12395
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NightsongGarb"
  value: {
-  dps: 7161.08701
-  tps: 6939.51067
+  dps: 7161.69171
+  tps: 6940.11538
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7740.43617
-  tps: 7516.44117
+  dps: 7741.43044
+  tps: 7517.43544
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7740.43617
-  tps: 7516.44117
+  dps: 7741.43044
+  tps: 7517.43544
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7740.43617
-  tps: 7516.44117
+  dps: 7741.43044
+  tps: 7517.43544
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7740.43617
-  tps: 7516.44117
+  dps: 7741.43044
+  tps: 7517.43544
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 8109.74606
-  tps: 7883.72891
+  dps: 8110.42182
+  tps: 7884.40467
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 8170.79131
-  tps: 7943.91386
+  dps: 8171.46707
+  tps: 7944.58962
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7959.25404
-  tps: 7731.56984
+  dps: 7960.27089
+  tps: 7732.58669
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 7875.29688
-  tps: 7648.19491
+  dps: 7876.10787
+  tps: 7649.0059
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7740.43617
-  tps: 7515.97233
+  dps: 7741.43044
+  tps: 7516.9666
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 7875.29688
-  tps: 7648.19491
+  dps: 7876.10787
+  tps: 7649.0059
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7918.68359
-  tps: 7689.86729
+  dps: 7919.49458
+  tps: 7690.67828
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7953.78381
-  tps: 7724.01162
+  dps: 7954.5948
+  tps: 7724.82261
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7773.01769
-  tps: 7548.16828
+  dps: 7773.82868
+  tps: 7548.97927
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7820.21509
-  tps: 7604.97754
+  dps: 7820.99502
+  tps: 7605.75747
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SparkofLife-37657"
  value: {
-  dps: 7800.77563
-  tps: 7579.98704
+  dps: 7801.70652
+  tps: 7580.91792
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-StormshroudArmor"
  value: {
-  dps: 4650.31838
-  tps: 4403.16021
+  dps: 4650.8598
+  tps: 4403.70163
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7740.43617
-  tps: 7516.44117
+  dps: 7741.43044
+  tps: 7517.43544
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7740.43617
-  tps: 7516.44117
+  dps: 7741.43044
+  tps: 7517.43544
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7740.43617
-  tps: 7516.44117
+  dps: 7741.43044
+  tps: 7517.43544
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7684.51564
-  tps: 7462.06326
+  dps: 7685.32663
+  tps: 7462.87425
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7726.71458
-  tps: 7507.49741
+  dps: 7727.45895
+  tps: 7508.24177
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartHarness"
  value: {
-  dps: 3143.97598
-  tps: 2910.93504
+  dps: 3144.6063
+  tps: 2911.56537
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartRegalia"
  value: {
-  dps: 4999.57756
-  tps: 4767.69926
+  dps: 5000.52417
+  tps: 4768.64588
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7740.43617
-  tps: 7516.44117
+  dps: 7741.43044
+  tps: 7517.43544
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7782.97207
-  tps: 7557.79499
+  dps: 7783.96634
+  tps: 7558.78926
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7774.46489
-  tps: 7549.52422
+  dps: 7775.45916
+  tps: 7550.51849
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7760.73261
-  tps: 7536.21776
+  dps: 7761.5436
+  tps: 7537.02875
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7774.46489
-  tps: 7549.52422
+  dps: 7775.45916
+  tps: 7550.51849
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7782.97207
-  tps: 7557.79499
+  dps: 7783.96634
+  tps: 7558.78926
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 4543.92675
-  tps: 4295.53131
+  dps: 4544.50589
+  tps: 4296.11046
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 8330.44775
-  tps: 8101.20328
+  dps: 8331.29312
+  tps: 8102.04865
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 7875.29688
-  tps: 7648.19491
+  dps: 7876.10787
+  tps: 7649.0059
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7641.39187
-  tps: 7420.12701
+  dps: 7642.20286
+  tps: 7420.938
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 7875.29688
-  tps: 7648.19491
+  dps: 7876.10787
+  tps: 7649.0059
  }
 }
 dps_results: {
  key: "TestBalance-Average-Default"
  value: {
-  dps: 8100.32878
-  tps: 7879.31144
+  dps: 8100.86396
+  tps: 7879.84661
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-basic_p3-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11523.2493
-  tps: 13652.05958
+  dps: 11523.55701
+  tps: 13652.36729
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-basic_p3-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7980.53458
-  tps: 7753.43261
+  dps: 7981.34557
+  tps: 7754.2436
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-basic_p3-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9068.31699
-  tps: 8199.52435
+  dps: 9069.5693
+  tps: 8200.77666
  }
 }
 dps_results: {
@@ -977,29 +977,29 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-basic_p3-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2126.32387
-  tps: 2017.6588
+  dps: 2126.6499
+  tps: 2017.98483
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P1-Default-basic_p3-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5466.11374
-  tps: 5191.20889
+  dps: 5467.05639
+  tps: 5192.15153
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-Default-basic_p3-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13656.03972
-  tps: 15890.1954
+  dps: 13657.04799
+  tps: 15891.20368
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-Default-basic_p3-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9462.41826
-  tps: 9217.54431
+  dps: 9462.67232
+  tps: 9217.79837
  }
 }
 dps_results: {
@@ -1019,8 +1019,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-4P-Default-basic_p3-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3196.44523
-  tps: 3083.01435
+  dps: 3196.84155
+  tps: 3083.41067
  }
 }
 dps_results: {
@@ -1040,8 +1040,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Default-basic_p3-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9672.57764
-  tps: 9425.74229
+  dps: 9673.08679
+  tps: 9426.25145
  }
 }
 dps_results: {
@@ -1061,8 +1061,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P2-Default-basic_p3-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3551.44197
-  tps: 3443.17036
+  dps: 3551.99031
+  tps: 3443.71869
  }
 }
 dps_results: {
@@ -1082,8 +1082,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-Default-basic_p3-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11509.34883
-  tps: 11256.11433
+  dps: 11509.93964
+  tps: 11256.70513
  }
 }
 dps_results: {
@@ -1103,8 +1103,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-P3-Default-basic_p3-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5144.64513
-  tps: 5048.18973
+  dps: 5145.05495
+  tps: 5048.59956
  }
 }
 dps_results: {
@@ -1117,7 +1117,7 @@ dps_results: {
 dps_results: {
  key: "TestBalance-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7941.37823
-  tps: 7753.43261
+  dps: 7942.18922
+  tps: 7754.2436
  }
 }

--- a/sim/druid/balance/TestBalancePhase3.results
+++ b/sim/druid/balance/TestBalancePhase3.results
@@ -46,904 +46,904 @@ character_stats_results: {
 dps_results: {
  key: "TestBalancePhase3-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 11324.93953
-  tps: 11027.74803
+  dps: 11325.35833
+  tps: 11028.16682
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 11370.68839
-  tps: 11072.28764
+  dps: 11371.10719
+  tps: 11072.70643
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 11066.84259
-  tps: 10778.55408
+  dps: 11067.26139
+  tps: 10778.97287
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 11149.96424
-  tps: 10852.80653
+  dps: 11150.5319
+  tps: 10853.37419
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 11189.67496
-  tps: 10893.40169
+  dps: 11190.24262
+  tps: 10893.96935
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8576.52153
-  tps: 8297.00123
+  dps: 8577.13335
+  tps: 8297.61305
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 11199.74684
-  tps: 10686.23825
+  dps: 11200.3145
+  tps: 10686.79456
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 11199.74544
-  tps: 10895.68607
+  dps: 11200.29661
+  tps: 10896.23724
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11569.2566
-  tps: 11267.35306
+  dps: 11569.8474
+  tps: 11267.94387
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 11186.05136
-  tps: 10900.09718
+  dps: 11186.42322
+  tps: 10900.46903
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 11234.03996
-  tps: 10946.29845
+  dps: 11234.1572
+  tps: 10946.41569
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 11160.37083
-  tps: 10880.4051
+  dps: 11161.00646
+  tps: 10881.04073
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 11199.74544
-  tps: 10895.68607
+  dps: 11200.29661
+  tps: 10896.23724
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Death'sChoice-47464"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 11032.15715
-  tps: 10746.01606
+  dps: 11032.4587
+  tps: 10746.31761
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 11200.02655
-  tps: 10903.25406
+  dps: 11200.59421
+  tps: 10903.82172
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11648.63144
-  tps: 11355.73059
+  dps: 11649.01255
+  tps: 11356.11171
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11502.17785
-  tps: 11208.88664
+  dps: 11502.84416
+  tps: 11209.55296
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 6292.61571
-  tps: 6001.38905
+  dps: 6293.1839
+  tps: 6001.95724
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DreamwalkerGarb"
  value: {
-  dps: 8892.21479
-  tps: 8617.54642
+  dps: 8892.75989
+  tps: 8618.09153
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 11149.96424
-  tps: 10852.80653
+  dps: 11150.5319
+  tps: 10853.37419
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 11217.91162
-  tps: 10919.63709
+  dps: 11218.47928
+  tps: 10920.20475
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 11189.67496
-  tps: 10892.61323
+  dps: 11190.24262
+  tps: 10893.18089
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 11165.67852
-  tps: 10868.35071
+  dps: 11166.24618
+  tps: 10868.91837
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 11149.96424
-  tps: 10852.80653
+  dps: 11150.5319
+  tps: 10853.37419
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 11120.10482
-  tps: 10832.42446
+  dps: 11120.74977
+  tps: 10833.06941
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 11433.93289
-  tps: 11141.91099
+  dps: 11434.30475
+  tps: 11142.28284
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10999.62423
-  tps: 10713.73483
+  dps: 10999.92578
+  tps: 10714.03638
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 11183.53397
-  tps: 10890.08014
+  dps: 11183.95276
+  tps: 10890.49893
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForgeEmber-37660"
  value: {
-  dps: 11282.76588
-  tps: 10991.67413
+  dps: 11283.33431
+  tps: 10992.24256
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 11199.74684
-  tps: 10901.22967
+  dps: 11200.3145
+  tps: 10901.79733
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 11189.79032
-  tps: 10891.54504
+  dps: 11190.35798
+  tps: 10892.1127
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 11199.74544
-  tps: 10895.68607
+  dps: 11200.29661
+  tps: 10896.23724
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-FuturesightRune-38763"
  value: {
-  dps: 11081.63878
-  tps: 10790.87828
+  dps: 11082.05757
+  tps: 10791.29708
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 6842.77268
-  tps: 6565.58285
+  dps: 6843.60756
+  tps: 6566.41773
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 9483.62474
-  tps: 9184.56226
+  dps: 9484.29822
+  tps: 9185.23574
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 11347.81396
-  tps: 11050.01783
+  dps: 11348.23276
+  tps: 11050.43662
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 11399.80131
-  tps: 11100.63102
+  dps: 11400.2201
+  tps: 11101.04982
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 11116.83473
-  tps: 10829.97201
+  dps: 11117.20658
+  tps: 10830.34387
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 11199.74544
-  tps: 10895.68607
+  dps: 11200.29661
+  tps: 10896.23724
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Heartpierce-49982"
  value: {
-  dps: 11569.2566
-  tps: 11267.35306
+  dps: 11569.8474
+  tps: 11267.94387
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Heartpierce-50641"
  value: {
-  dps: 11569.2566
-  tps: 11267.35306
+  dps: 11569.8474
+  tps: 11267.94387
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 11199.74544
-  tps: 10895.68607
+  dps: 11200.29661
+  tps: 10896.23724
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 11199.74544
-  tps: 10895.68607
+  dps: 11200.29661
+  tps: 10896.23724
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 11199.74544
-  tps: 10895.68607
+  dps: 11200.29661
+  tps: 10896.23724
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 11655.56374
-  tps: 11355.4271
+  dps: 11656.25948
+  tps: 11356.12284
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 11246.07271
-  tps: 10941.3144
+  dps: 11246.76627
+  tps: 10942.00796
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 11250.94838
-  tps: 10944.2231
+  dps: 11251.49955
+  tps: 10944.77427
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 11199.74544
-  tps: 10895.68607
+  dps: 11200.29661
+  tps: 10896.23724
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 11354.08241
-  tps: 11059.98478
+  dps: 11354.5012
+  tps: 11060.40357
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 11189.67496
-  tps: 10892.61323
+  dps: 11190.24262
+  tps: 10893.18089
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 11165.67852
-  tps: 10868.35071
+  dps: 11166.24618
+  tps: 10868.91837
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IncisorFragment-37723"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 11165.65857
-  tps: 10873.18602
+  dps: 11166.22623
+  tps: 10873.75368
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 11149.96424
-  tps: 10852.80653
+  dps: 11150.5319
+  tps: 10853.37419
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 6558.24029
-  tps: 6276.56564
+  dps: 6559.02164
+  tps: 6277.34699
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LasherweaveRegalia"
  value: {
-  dps: 10923.42073
-  tps: 10639.22141
+  dps: 10924.11512
+  tps: 10639.91581
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LastWord-50179"
  value: {
-  dps: 11569.2566
-  tps: 11267.35306
+  dps: 11569.8474
+  tps: 11267.94387
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LastWord-50708"
  value: {
-  dps: 11569.2566
-  tps: 11267.35306
+  dps: 11569.8474
+  tps: 11267.94387
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 11076.53282
-  tps: 10786.85976
+  dps: 11076.95161
+  tps: 10787.27856
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 7050.4856
-  tps: 6772.80063
+  dps: 7051.23127
+  tps: 6773.54629
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 9584.78156
-  tps: 9303.17302
+  dps: 9585.45709
+  tps: 9303.84855
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 11095.2425
-  tps: 10808.84521
+  dps: 11095.53848
+  tps: 10809.14119
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 11183.53397
-  tps: 10890.08014
+  dps: 11183.95276
+  tps: 10890.49893
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Nibelung-49992"
  value: {
-  dps: 11569.2566
-  tps: 11267.35306
+  dps: 11569.8474
+  tps: 11267.94387
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Nibelung-50648"
  value: {
-  dps: 11569.2566
-  tps: 11267.35306
+  dps: 11569.8474
+  tps: 11267.94387
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-NightsongBattlegear"
  value: {
-  dps: 6740.80929
-  tps: 6458.98236
+  dps: 6741.0199
+  tps: 6459.19297
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-NightsongGarb"
  value: {
-  dps: 9232.56142
-  tps: 8950.9766
+  dps: 9233.013
+  tps: 8951.42819
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 11149.96424
-  tps: 10852.80653
+  dps: 11150.5319
+  tps: 10853.37419
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 11149.96424
-  tps: 10852.80653
+  dps: 11150.5319
+  tps: 10853.37419
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 11149.96424
-  tps: 10852.80653
+  dps: 11150.5319
+  tps: 10853.37419
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 11149.96424
-  tps: 10852.80653
+  dps: 11150.5319
+  tps: 10853.37419
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 11495.88327
-  tps: 11194.96912
+  dps: 11496.47407
+  tps: 11195.55992
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 11569.2566
-  tps: 11267.35306
+  dps: 11569.8474
+  tps: 11267.94387
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11526.77531
-  tps: 11224.77915
+  dps: 11527.36612
+  tps: 11225.36995
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 11199.74544
-  tps: 10895.68607
+  dps: 11200.29661
+  tps: 10896.23724
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 11149.96424
-  tps: 10852.29229
+  dps: 11150.5319
+  tps: 10852.85995
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 11199.74544
-  tps: 10895.68607
+  dps: 11200.29661
+  tps: 10896.23724
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 11281.27017
-  tps: 10985.23294
+  dps: 11281.68896
+  tps: 10985.65174
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 11322.86004
-  tps: 11025.7235
+  dps: 11323.27883
+  tps: 11026.14229
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SoulPreserver-37111"
  value: {
-  dps: 11108.6722
-  tps: 10817.19714
+  dps: 11109.09099
+  tps: 10817.61594
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SouloftheDead-40382"
  value: {
-  dps: 11159.36656
-  tps: 10875.79974
+  dps: 11159.73842
+  tps: 10876.1716
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SparkofLife-37657"
  value: {
-  dps: 10981.65364
-  tps: 10688.3534
+  dps: 10981.86425
+  tps: 10688.56401
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 11102.58103
-  tps: 10816.2409
+  dps: 11103.18551
+  tps: 10816.84538
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-StormshroudArmor"
  value: {
-  dps: 7996.23794
-  tps: 7713.16149
+  dps: 7997.1445
+  tps: 7714.06805
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 11149.96424
-  tps: 10852.80653
+  dps: 11150.5319
+  tps: 10853.37419
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 11149.96424
-  tps: 10852.80653
+  dps: 11150.5319
+  tps: 10853.37419
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 11149.96424
-  tps: 10852.80653
+  dps: 11150.5319
+  tps: 10853.37419
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 11003.80708
-  tps: 10715.10386
+  dps: 11004.22587
+  tps: 10715.52265
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 11042.52792
-  tps: 10757.17809
+  dps: 11042.82947
+  tps: 10757.47964
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ThunderheartHarness"
  value: {
-  dps: 4179.57927
-  tps: 3894.24418
+  dps: 4179.93303
+  tps: 3894.59794
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ThunderheartRegalia"
  value: {
-  dps: 6486.3586
-  tps: 6208.30018
+  dps: 6487.10693
+  tps: 6209.04852
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 11149.96424
-  tps: 10852.80653
+  dps: 11150.5319
+  tps: 10853.37419
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 11102.58103
-  tps: 10816.2409
+  dps: 11103.18551
+  tps: 10816.84538
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 11102.58103
-  tps: 10816.2409
+  dps: 11103.18551
+  tps: 10816.84538
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 11199.74684
-  tps: 10901.22967
+  dps: 11200.3145
+  tps: 10901.79733
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 11189.79032
-  tps: 10891.54504
+  dps: 11190.35798
+  tps: 10892.1127
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 11094.11574
-  tps: 10803.02545
+  dps: 11094.53453
+  tps: 10803.44424
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 11189.79032
-  tps: 10891.54504
+  dps: 11190.35798
+  tps: 10892.1127
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 11199.74684
-  tps: 10901.22967
+  dps: 11200.3145
+  tps: 10901.79733
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 8024.16722
-  tps: 7741.46867
+  dps: 8024.80768
+  tps: 7742.10913
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 11434.44654
-  tps: 11135.17677
+  dps: 11434.9222
+  tps: 11135.65243
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 11199.74544
-  tps: 10895.68607
+  dps: 11200.29661
+  tps: 10896.23724
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10952.71017
-  tps: 10665.35757
+  dps: 10953.12897
+  tps: 10665.77636
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 11199.74544
-  tps: 10895.68607
+  dps: 11200.29661
+  tps: 10896.23724
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Average-Default"
  value: {
-  dps: 11684.26392
-  tps: 11385.07957
+  dps: 11684.92628
+  tps: 11385.74193
  }
 }
 dps_results: {
@@ -956,8 +956,8 @@ dps_results: {
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-P3-Default-basic_p3-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11569.2566
-  tps: 11267.35306
+  dps: 11569.8474
+  tps: 11267.94387
  }
 }
 dps_results: {
@@ -977,8 +977,8 @@ dps_results: {
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-P3-Default-basic_p3-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4306.26802
-  tps: 4176.7608
+  dps: 4306.67784
+  tps: 4177.17062
  }
 }
 dps_results: {
@@ -991,7 +991,7 @@ dps_results: {
 dps_results: {
  key: "TestBalancePhase3-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 11518.43885
-  tps: 11267.35306
+  dps: 11519.02966
+  tps: 11267.94387
  }
 }

--- a/sim/druid/force_of_nature.go
+++ b/sim/druid/force_of_nature.go
@@ -99,7 +99,7 @@ func (treant *TreantPet) enable(sim *core.Simulation) {
 }
 
 func (treant *TreantPet) disable(sim *core.Simulation) {
-	treant.AddStatsDynamic(sim, treant.snapshotStat.Multiply(-1))
+	treant.AddStatsDynamic(sim, treant.snapshotStat.Invert())
 }
 
 func (treant *TreantPet) Initialize() {

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -175,8 +175,8 @@ func (druid *Druid) registerCatFormSpell() {
 			druid.PseudoStats.SpiritRegenMultiplier /= AnimalSpiritRegenSuppression
 			druid.PseudoStats.BaseDodge -= 0.02 * float64(druid.Talents.FeralSwiftness)
 
-			druid.AddStatsDynamic(sim, predBonus.Multiply(-1))
-			druid.AddStatsDynamic(sim, statBonus.Multiply(-1))
+			druid.AddStatsDynamic(sim, predBonus.Invert())
+			druid.AddStatsDynamic(sim, statBonus.Invert())
 			druid.DisableDynamicStatDep(sim, agiApDep)
 			if hotwDep != nil {
 				druid.DisableDynamicStatDep(sim, hotwDep)
@@ -313,8 +313,8 @@ func (druid *Druid) registerBearFormSpell() {
 			druid.PseudoStats.SpiritRegenMultiplier /= AnimalSpiritRegenSuppression
 			druid.PseudoStats.BaseDodge -= 0.02 * float64(druid.Talents.FeralSwiftness+druid.Talents.NaturalReaction)
 
-			druid.AddStatsDynamic(sim, predBonus.Multiply(-1))
-			druid.AddStatsDynamic(sim, statBonus.Multiply(-1))
+			druid.AddStatsDynamic(sim, predBonus.Invert())
+			druid.AddStatsDynamic(sim, statBonus.Invert())
 			druid.RemoveDynamicEquipScaling(sim, stats.Armor, druid.BearArmorMultiplier())
 			if potpDep != nil {
 				druid.DisableDynamicStatDep(sim, potpDep)

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -139,8 +139,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6190.47799
-  tps: 5332.40349
+  dps: 6190.49223
+  tps: 5332.41384
  }
 }
 dps_results: {
@@ -645,7 +645,7 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 7332.71535
+  dps: 7332.76102
   tps: 6334.02364
  }
 }
@@ -722,8 +722,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-StormshroudArmor"
  value: {
-  dps: 5749.1606
-  tps: 4917.55842
+  dps: 5749.16653
+  tps: 4917.56435
  }
 }
 dps_results: {
@@ -785,7 +785,7 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7462.62688
+  dps: 7462.64882
   tps: 6411.87337
  }
 }
@@ -883,8 +883,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-Average-Default"
  value: {
-  dps: 7613.42893
-  tps: 6565.95875
+  dps: 7613.429
+  tps: 6565.95867
  }
 }
 dps_results: {
@@ -960,7 +960,7 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Dwarf-P1-Basic-sv-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3827.28433
+  dps: 3827.28691
   tps: 3506.67975
  }
 }
@@ -1086,7 +1086,7 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Orc-P1-Basic-sv-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3842.06248
+  dps: 3842.06655
   tps: 3499.66519
  }
 }

--- a/sim/hunter/wotlk_items.go
+++ b/sim/hunter/wotlk_items.go
@@ -183,7 +183,7 @@ var ItemSetAhnKaharBloodHuntersBattlegear = core.NewItemSet(core.ItemSet{
 					aura.Unit.AddStatsDynamic(sim, curBonus)
 				},
 				OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-					aura.Unit.AddStatsDynamic(sim, curBonus.Multiply(-1))
+					aura.Unit.AddStatsDynamic(sim, curBonus.Invert())
 				},
 			})
 

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -46,760 +46,760 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 13953.50484
-  tps: 8529.6224
+  dps: 13954.08561
+  tps: 8529.97086
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 14002.20855
-  tps: 8558.56613
+  dps: 14002.79056
+  tps: 8558.91533
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 14098.48853
-  tps: 8616.99407
+  dps: 14102.62985
+  tps: 8619.47886
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 13570.48054
-  tps: 8301.21176
+  dps: 13570.70047
+  tps: 8301.34371
   hps: 102.59478
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 13570.48054
-  tps: 8301.21176
+  dps: 13570.70047
+  tps: 8301.34371
   hps: 102.59478
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 14164.59783
-  tps: 8660.81984
+  dps: 14169.39961
+  tps: 8663.70091
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 9400.34807
-  tps: 5761.20564
+  dps: 9401.29017
+  tps: 5761.7709
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 13016.9934
-  tps: 7969.18021
+  dps: 13020.68851
+  tps: 7971.39727
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 14153.75036
-  tps: 8479.07871
+  dps: 14157.9037
+  tps: 8481.52087
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 14534.84777
-  tps: 8881.62757
+  dps: 14539.40704
+  tps: 8884.36314
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
   hps: 64
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 13739.18549
-  tps: 8409.55363
+  dps: 13739.71587
+  tps: 8409.87186
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 13742.04306
-  tps: 8433.14912
+  dps: 13742.50303
+  tps: 8433.4251
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 13922.71186
-  tps: 8518.79698
+  dps: 13923.05438
+  tps: 8519.0025
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Death'sChoice-47464"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 13604.02027
-  tps: 8325.17006
+  dps: 13604.634
+  tps: 8325.5383
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Defender'sCode-40257"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 14119.30327
-  tps: 8629.77264
+  dps: 14123.70706
+  tps: 8632.41491
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 14432.72609
-  tps: 8822.44187
+  dps: 14436.52856
+  tps: 8824.72335
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 14098.48853
-  tps: 8616.99407
+  dps: 14102.62985
+  tps: 8619.47886
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 14200.11845
-  tps: 8681.11733
+  dps: 14204.92982
+  tps: 8684.00416
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 14113.25521
-  tps: 8626.11305
+  dps: 14117.659
+  tps: 8628.75533
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 14082.22395
-  tps: 8607.42875
+  dps: 14086.36527
+  tps: 8609.91354
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 13768.64832
-  tps: 8424.57855
+  dps: 13769.07437
+  tps: 8424.83418
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 14098.48853
-  tps: 8616.99407
+  dps: 14102.62985
+  tps: 8619.47886
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 13716.86032
-  tps: 8395.9978
+  dps: 13717.39071
+  tps: 8396.31603
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 13997.09067
-  tps: 8563.48154
+  dps: 13997.6284
+  tps: 8563.80417
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 13698.66408
-  tps: 8383.227
+  dps: 13698.98308
+  tps: 8383.4184
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 13802.9661
-  tps: 8440.15998
+  dps: 13803.54303
+  tps: 8440.50614
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForgeEmber-37660"
  value: {
-  dps: 13886.95321
-  tps: 8495.81295
+  dps: 13887.71562
+  tps: 8496.2704
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 14153.75036
-  tps: 8649.83987
+  dps: 14157.9037
+  tps: 8652.33187
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 14142.698
-  tps: 8643.27071
+  dps: 14146.84893
+  tps: 8645.76126
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FrostfireGarb"
  value: {
-  dps: 9963.048
-  tps: 6110.94165
+  dps: 9965.398
+  tps: 6112.35165
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuturesightRune-38763"
  value: {
-  dps: 13850.68321
-  tps: 8471.28476
+  dps: 13850.8144
+  tps: 8471.36347
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 10158.5805
-  tps: 6217.50974
+  dps: 10160.32265
+  tps: 6218.55503
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 13977.8567
-  tps: 8544.09426
+  dps: 13978.43809
+  tps: 8544.4431
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 14033.20182
-  tps: 8576.98486
+  dps: 14033.78463
+  tps: 8577.33454
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 13720.2455
-  tps: 8414.63798
+  dps: 13720.8825
+  tps: 8415.02017
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Heartpierce-49982"
  value: {
-  dps: 14534.84777
-  tps: 8881.62757
+  dps: 14539.40704
+  tps: 8884.36314
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Heartpierce-50641"
  value: {
-  dps: 14534.84777
-  tps: 8881.62757
+  dps: 14539.40704
+  tps: 8884.36314
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 13988.9944
-  tps: 8551.90548
+  dps: 13989.57636
+  tps: 8552.25465
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 14113.25521
-  tps: 8626.11305
+  dps: 14117.659
+  tps: 8628.75533
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 14082.22395
-  tps: 8607.42875
+  dps: 14086.36527
+  tps: 8609.91354
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IncisorFragment-37723"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 14198.55729
-  tps: 8687.73362
+  dps: 14203.69054
+  tps: 8690.81357
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 14098.48853
-  tps: 8616.99407
+  dps: 14102.62985
+  tps: 8619.47886
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 10787.29441
-  tps: 6610.11976
+  dps: 10790.39246
+  tps: 6611.97858
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KirinTorGarb"
  value: {
-  dps: 10456.41828
-  tps: 6401.40122
+  dps: 10460.56782
+  tps: 6403.89095
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 13926.72895
-  tps: 8519.26083
+  dps: 13926.9496
+  tps: 8519.39322
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 13658.90086
-  tps: 8359.9395
+  dps: 13659.43124
+  tps: 8360.25773
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 13866.24673
-  tps: 8480.65664
+  dps: 13866.82366
+  tps: 8481.00279
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Nibelung-49992"
  value: {
-  dps: 14534.84777
-  tps: 8881.62757
+  dps: 14539.40704
+  tps: 8884.36314
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Nibelung-50648"
  value: {
-  dps: 14534.84777
-  tps: 8881.62757
+  dps: 14539.40704
+  tps: 8884.36314
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 14098.48853
-  tps: 8616.99407
+  dps: 14102.62985
+  tps: 8619.47886
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 14098.48853
-  tps: 8616.99407
+  dps: 14102.62985
+  tps: 8619.47886
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 14098.48853
-  tps: 8616.99407
+  dps: 14102.62985
+  tps: 8619.47886
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 14098.48853
-  tps: 8616.99407
+  dps: 14102.62985
+  tps: 8619.47886
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 14226.0168
-  tps: 8807.33359
+  dps: 14226.49107
+  tps: 8807.61816
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 14301.08061
-  tps: 8866.1722
+  dps: 14301.5559
+  tps: 8866.45738
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 14515.82433
-  tps: 8869.98168
+  dps: 14520.11011
+  tps: 8872.55315
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 14047.90992
-  tps: 8587.2763
+  dps: 14052.54106
+  tps: 8590.05498
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 14047.26019
-  tps: 8590.58367
+  dps: 14047.47989
+  tps: 8590.71549
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 14098.83827
-  tps: 8621.27065
+  dps: 14099.37712
+  tps: 8621.59396
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SoulPreserver-37111"
  value: {
-  dps: 13723.26912
-  tps: 8392.79753
+  dps: 13723.84401
+  tps: 8393.14246
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SouloftheDead-40382"
  value: {
-  dps: 13869.05211
-  tps: 8490.95433
+  dps: 13869.83216
+  tps: 8491.42236
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SparkofLife-37657"
  value: {
-  dps: 13804.6704
-  tps: 8444.63389
+  dps: 13807.82023
+  tps: 8446.52379
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 13597.95393
-  tps: 8320.92886
+  dps: 13598.52459
+  tps: 8321.27125
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 14098.48853
-  tps: 8616.99407
+  dps: 14102.62985
+  tps: 8619.47886
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 14098.48853
-  tps: 8616.99407
+  dps: 14102.62985
+  tps: 8619.47886
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 14098.48853
-  tps: 8616.99407
+  dps: 14102.62985
+  tps: 8619.47886
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 13696.72653
-  tps: 8380.17162
+  dps: 13697.05602
+  tps: 8380.36931
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 13786.68365
-  tps: 8436.81625
+  dps: 13786.97892
+  tps: 8436.99341
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TempestRegalia"
  value: {
-  dps: 7623.91478
-  tps: 4688.11067
+  dps: 7626.35061
+  tps: 4689.57217
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 13557.23375
-  tps: 8294.12574
+  dps: 13557.8044
+  tps: 8294.46814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 11280.26162
-  tps: 6928.20553
+  dps: 11281.2493
+  tps: 6928.79814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 14098.48853
-  tps: 8616.99407
+  dps: 14102.62985
+  tps: 8619.47886
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 13621.04938
-  tps: 8335.7771
+  dps: 13621.62004
+  tps: 8336.11949
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 13621.04938
-  tps: 8335.7771
+  dps: 13621.62004
+  tps: 8336.11949
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 14153.75036
-  tps: 8649.83987
+  dps: 14157.9037
+  tps: 8652.33187
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 14142.698
-  tps: 8643.27071
+  dps: 14146.84893
+  tps: 8645.76126
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 13853.30726
-  tps: 8471.24104
+  dps: 13854.10173
+  tps: 8471.71772
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 14142.698
-  tps: 8643.27071
+  dps: 14146.84893
+  tps: 8645.76126
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 14153.75036
-  tps: 8649.83987
+  dps: 14157.9037
+  tps: 8652.33187
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WingedTalisman-37844"
  value: {
-  dps: 13725.03031
-  tps: 8394.80368
+  dps: 13725.95428
+  tps: 8395.35806
  }
 }
 dps_results: {
  key: "TestArcane-Average-Default"
  value: {
-  dps: 14613.44573
-  tps: 8933.25504
+  dps: 14617.25532
+  tps: 8935.54079
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P3Arcane-Arcane-arcane-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14534.84777
-  tps: 11003.89336
+  dps: 14539.40704
+  tps: 11006.62893
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P3Arcane-Arcane-arcane-FullBuffs-LongSingleTarget"
  value: {
-  dps: 14534.84777
-  tps: 8881.62757
+  dps: 14539.40704
+  tps: 8884.36314
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P3Arcane-Arcane-arcane-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 19285.28841
-  tps: 11641.10345
+  dps: 19303.35945
+  tps: 11651.94607
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P3Arcane-Arcane-arcane-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7170.3065
-  tps: 5960.45363
+  dps: 7172.11756
+  tps: 5961.54028
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P3Arcane-Arcane-arcane-NoBuffs-LongSingleTarget"
  value: {
-  dps: 7170.3065
-  tps: 4397.25115
+  dps: 7172.11756
+  tps: 4398.33779
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-P3Arcane-Arcane-arcane-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 10296.60049
-  tps: 6168.05942
+  dps: 10298.11319
+  tps: 6168.96704
  }
 }
 dps_results: {
@@ -847,7 +847,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 14534.84777
-  tps: 8881.62757
+  dps: 14539.40704
+  tps: 8884.36314
  }
 }

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -46,795 +46,795 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 13075.03625
-  tps: 10515.55147
+  dps: 13075.21495
+  tps: 10515.69443
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 13126.48143
-  tps: 10556.34651
+  dps: 13126.66013
+  tps: 10556.48947
  }
 }
 dps_results: {
  key: "TestFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 13176.85152
-  tps: 10597.06816
+  dps: 13177.03725
+  tps: 10597.21675
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 12598.13771
-  tps: 10137.22481
+  dps: 12598.20104
+  tps: 10137.27547
   hps: 102.21554
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 12598.13771
-  tps: 10137.22481
+  dps: 12598.20104
+  tps: 10137.27547
   hps: 102.21554
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 13310.85763
-  tps: 10705.67825
+  dps: 13311.97613
+  tps: 10706.57304
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8451.8556
-  tps: 6801.54493
+  dps: 8452.06795
+  tps: 6801.71481
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 12595.81869
-  tps: 10135.67699
+  dps: 12596.82644
+  tps: 10136.48319
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 13234.90129
-  tps: 10432.34377
+  dps: 13235.08703
+  tps: 10432.48939
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 13657.93312
-  tps: 10983.19564
+  dps: 13658.42121
+  tps: 10983.58612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
   hps: 64
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 12899.35385
-  tps: 10380.15509
+  dps: 12899.60667
+  tps: 10380.35734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 13078.07261
-  tps: 10539.11444
+  dps: 13078.2516
+  tps: 10539.25763
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 12836.72263
-  tps: 10333.23543
+  dps: 12836.96403
+  tps: 10333.42855
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Death'sChoice-47464"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 12690.72952
-  tps: 10211.69602
+  dps: 12690.93219
+  tps: 10211.85815
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 13253.34457
-  tps: 10658.32889
+  dps: 13254.07095
+  tps: 10658.91
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 13571.83455
-  tps: 10918.16165
+  dps: 13571.86882
+  tps: 10918.18907
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 13176.85152
-  tps: 10597.06816
+  dps: 13177.03725
+  tps: 10597.21675
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 13331.57614
-  tps: 10721.63383
+  dps: 13332.71265
+  tps: 10722.54304
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 13242.49631
-  tps: 10649.82927
+  dps: 13242.97138
+  tps: 10650.20932
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 13215.34007
-  tps: 10628.04896
+  dps: 13215.78086
+  tps: 10628.4016
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 12816.58014
-  tps: 10310.28045
+  dps: 12816.79395
+  tps: 10310.4515
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 13176.85152
-  tps: 10597.06816
+  dps: 13177.03725
+  tps: 10597.21675
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 12899.72826
-  tps: 10392.92727
+  dps: 12899.80085
+  tps: 10392.98534
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 13167.86167
-  tps: 10593.92181
+  dps: 13168.08834
+  tps: 10594.10315
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 12650.02541
-  tps: 10183.45558
+  dps: 12650.18412
+  tps: 10183.58255
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 12916.02389
-  tps: 10389.4577
+  dps: 12916.20259
+  tps: 10389.60066
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 13035.40233
-  tps: 10488.00821
+  dps: 13035.71369
+  tps: 10488.2573
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 13234.90129
-  tps: 10643.0947
+  dps: 13235.08703
+  tps: 10643.24329
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 13223.29134
-  tps: 10633.88939
+  dps: 13223.47707
+  tps: 10634.03798
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FrostfireGarb"
  value: {
-  dps: 9224.0398
-  tps: 7437.20382
+  dps: 9225.77844
+  tps: 7438.59474
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 12801.26903
-  tps: 10298.18996
+  dps: 12801.37332
+  tps: 10298.2734
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 9618.54899
-  tps: 7742.14544
+  dps: 9619.33412
+  tps: 7742.77355
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 13100.75884
-  tps: 10535.94899
+  dps: 13100.93754
+  tps: 10536.09195
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 13159.21927
-  tps: 10582.307
+  dps: 13159.39797
+  tps: 10582.44996
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 12877.30895
-  tps: 10370.42216
+  dps: 12877.4845
+  tps: 10370.5626
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-49982"
  value: {
-  dps: 13657.93312
-  tps: 10983.19564
+  dps: 13658.42121
+  tps: 10983.58612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 13657.93312
-  tps: 10983.19564
+  dps: 13658.42121
+  tps: 10983.58612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 13105.84362
-  tps: 10541.47793
+  dps: 13106.02232
+  tps: 10541.62088
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 13242.49631
-  tps: 10649.82927
+  dps: 13242.97138
+  tps: 10650.20932
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 13215.34007
-  tps: 10628.04896
+  dps: 13215.78086
+  tps: 10628.4016
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 13254.88749
-  tps: 10667.60285
+  dps: 13255.47169
+  tps: 10668.0702
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 13176.85152
-  tps: 10597.06816
+  dps: 13177.03725
+  tps: 10597.21675
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 10150.37926
-  tps: 8184.11142
+  dps: 10151.51582
+  tps: 8185.02066
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KirinTorGarb"
  value: {
-  dps: 10174.93615
-  tps: 8190.11927
+  dps: 10176.89962
+  tps: 8191.69005
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 12977.21179
-  tps: 10441.6082
+  dps: 12977.33621
+  tps: 10441.70774
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 12820.22407
-  tps: 10316.28258
+  dps: 12820.48502
+  tps: 10316.49134
  }
 }
 dps_results: {
  key: "TestFire-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 12940.25235
-  tps: 10411.81756
+  dps: 12940.44217
+  tps: 10411.96942
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Nibelung-49992"
  value: {
-  dps: 13657.93312
-  tps: 10983.19564
+  dps: 13658.42121
+  tps: 10983.58612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Nibelung-50648"
  value: {
-  dps: 13657.93312
-  tps: 10983.19564
+  dps: 13658.42121
+  tps: 10983.58612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 13176.85152
-  tps: 10597.06816
+  dps: 13177.03725
+  tps: 10597.21675
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 13176.85152
-  tps: 10597.06816
+  dps: 13177.03725
+  tps: 10597.21675
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 13176.85152
-  tps: 10597.06816
+  dps: 13177.03725
+  tps: 10597.21675
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 13176.85152
-  tps: 10597.06816
+  dps: 13177.03725
+  tps: 10597.21675
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 13288.87916
-  tps: 10733.49554
+  dps: 13289.11136
+  tps: 10733.68129
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 13359.17632
-  tps: 10795.04797
+  dps: 13359.40851
+  tps: 10795.23373
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 13588.83319
-  tps: 10927.66784
+  dps: 13589.01892
+  tps: 10927.81642
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 13230.74079
-  tps: 10641.68773
+  dps: 13231.30837
+  tps: 10642.14179
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 12992.91324
-  tps: 10456.08275
+  dps: 12993.05718
+  tps: 10456.1979
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 13029.42182
-  tps: 10486.16844
+  dps: 13029.56576
+  tps: 10486.28359
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SoulPreserver-37111"
  value: {
-  dps: 12831.84087
-  tps: 10322.70218
+  dps: 12832.01957
+  tps: 10322.84513
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SouloftheDead-40382"
  value: {
-  dps: 12910.56856
-  tps: 10396.29111
+  dps: 12910.69299
+  tps: 10396.39065
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 12864.49549
-  tps: 10350.91427
+  dps: 12864.65671
+  tps: 10351.04324
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 12977.19977
-  tps: 10440.75716
+  dps: 12977.49151
+  tps: 10440.99055
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 13176.85152
-  tps: 10597.06816
+  dps: 13177.03725
+  tps: 10597.21675
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 13176.85152
-  tps: 10597.06816
+  dps: 13177.03725
+  tps: 10597.21675
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 13176.85152
-  tps: 10597.06816
+  dps: 13177.03725
+  tps: 10597.21675
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 12770.02586
-  tps: 10275.03662
+  dps: 12770.20533
+  tps: 10275.1802
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 12674.72312
-  tps: 10200.60493
+  dps: 12674.95465
+  tps: 10200.79016
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TempestRegalia"
  value: {
-  dps: 6810.61935
-  tps: 5490.3607
+  dps: 6811.28385
+  tps: 5490.8923
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 12656.45958
-  tps: 10183.62816
+  dps: 12656.63828
+  tps: 10183.77112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 10389.00715
-  tps: 8375.64509
+  dps: 10390.80493
+  tps: 8377.08332
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 13176.85152
-  tps: 10597.06816
+  dps: 13177.03725
+  tps: 10597.21675
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 13065.3804
-  tps: 10510.68962
+  dps: 13065.42708
+  tps: 10510.72697
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 13065.3804
-  tps: 10510.68962
+  dps: 13065.42708
+  tps: 10510.72697
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 13234.90129
-  tps: 10643.0947
+  dps: 13235.08703
+  tps: 10643.24329
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 13223.29134
-  tps: 10633.88939
+  dps: 13223.47707
+  tps: 10634.03798
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 12976.08372
-  tps: 10439.49735
+  dps: 12976.31466
+  tps: 10439.6821
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 13223.29134
-  tps: 10633.88939
+  dps: 13223.47707
+  tps: 10634.03798
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 13234.90129
-  tps: 10643.0947
+  dps: 13235.08703
+  tps: 10643.24329
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WingedTalisman-37844"
  value: {
-  dps: 12854.72858
-  tps: 10342.24336
+  dps: 12854.99272
+  tps: 10342.45468
  }
 }
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
-  dps: 13647.56998
-  tps: 10976.345
+  dps: 13648.39173
+  tps: 10977.00239
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-fire-FullBuffs-LongMultiTarget"
  value: {
-  dps: 47198.34684
-  tps: 40246.95092
+  dps: 47357.96542
+  tps: 40374.67309
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-fire-FullBuffs-LongSingleTarget"
  value: {
-  dps: 13657.93312
-  tps: 10983.19564
+  dps: 13658.42121
+  tps: 10983.58612
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-fire-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16639.01795
-  tps: 13278.24586
+  dps: 16639.64556
+  tps: 13278.74795
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-fire-NoBuffs-LongMultiTarget"
  value: {
-  dps: 31667.26219
-  tps: 28597.87741
+  dps: 31805.50425
+  tps: 28708.54798
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-fire-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5480.74776
-  tps: 4403.83872
+  dps: 5481.38165
+  tps: 4404.34584
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-fire-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8595.35537
-  tps: 6799.11734
+  dps: 8595.78676
+  tps: 6799.46245
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-fire_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 73870.95939
-  tps: 62521.49884
+  dps: 73962.74686
+  tps: 62594.93046
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-fire_aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4910.05987
-  tps: 3882.92875
+  dps: 4910.61336
+  tps: 3883.37155
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-fire_aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6475.00347
-  tps: 4970.60434
+  dps: 6475.15129
+  tps: 4970.72261
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-fire_aoe-NoBuffs-LongMultiTarget"
  value: {
-  dps: 45827.36387
-  tps: 39597.00741
+  dps: 45856.78096
+  tps: 39620.54109
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-P3Fire-Fire-fire_aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2106.10842
-  tps: 1669.76756
+  dps: 2106.12625
+  tps: 1669.78182
  }
 }
 dps_results: {
@@ -847,7 +847,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 13657.93312
-  tps: 10983.19564
+  dps: 13658.42121
+  tps: 10983.58612
  }
 }

--- a/sim/mage/TestFrostFire.results
+++ b/sim/mage/TestFrostFire.results
@@ -46,130 +46,130 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostFire-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 12250.80263
-  tps: 9832.64582
+  dps: 12250.87587
+  tps: 9832.70442
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 12299.2177
-  tps: 9871.02094
+  dps: 12299.29095
+  tps: 9871.07954
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 12193.30158
-  tps: 9783.90311
+  dps: 12193.69631
+  tps: 9784.21889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 11858.02206
-  tps: 9521.48277
+  dps: 11858.05634
+  tps: 9521.51019
   hps: 102.0626
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 11858.02206
-  tps: 9521.48277
+  dps: 11858.05634
+  tps: 9521.51019
   hps: 102.0626
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 12256.85044
-  tps: 9835.00158
+  dps: 12257.24517
+  tps: 9835.31736
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8233.61542
-  tps: 6633.94504
+  dps: 8234.23452
+  tps: 6634.44032
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Bloodmage'sRegalia"
  value: {
-  dps: 11590.71004
-  tps: 9323.36924
+  dps: 11591.49399
+  tps: 9323.9964
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 12247.38861
-  tps: 9631.68542
+  dps: 12247.78334
+  tps: 9631.99488
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 12644.04433
-  tps: 10147.19423
+  dps: 12644.44887
+  tps: 10147.51786
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
   hps: 64
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 12081.46084
-  tps: 9702.08999
+  dps: 12081.52577
+  tps: 9702.14193
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 12094.04668
-  tps: 9726.21825
+  dps: 12094.29474
+  tps: 9726.41669
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 12029.11409
-  tps: 9659.81008
+  dps: 12029.26164
+  tps: 9659.92812
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Death'sChoice-47464"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
@@ -182,99 +182,99 @@ dps_results: {
 dps_results: {
  key: "TestFrostFire-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Defender'sCode-40257"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 12282.73812
-  tps: 9855.72076
+  dps: 12283.13285
+  tps: 9856.03654
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 12546.1289
-  tps: 10070.56433
+  dps: 12547.19411
+  tps: 10071.4165
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 12193.30158
-  tps: 9783.90311
+  dps: 12193.69631
+  tps: 9784.21889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 12285.41851
-  tps: 9856.20487
+  dps: 12285.92046
+  tps: 9856.60644
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 12250.16186
-  tps: 9830.97287
+  dps: 12250.55659
+  tps: 9831.28865
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 12232.1321
-  tps: 9815.93251
+  dps: 12232.52683
+  tps: 9816.24829
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 12119.55854
-  tps: 9733.5997
+  dps: 12119.81938
+  tps: 9733.80836
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 12193.30158
-  tps: 9783.90311
+  dps: 12193.69631
+  tps: 9784.21889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 12086.08288
-  tps: 9716.42566
+  dps: 12086.22026
+  tps: 9716.53556
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 12380.08714
-  tps: 9940.73221
+  dps: 12380.15207
+  tps: 9940.78415
  }
 }
 dps_results: {
@@ -287,29 +287,29 @@ dps_results: {
 dps_results: {
  key: "TestFrostFire-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 12101.15603
-  tps: 9714.03181
+  dps: 12101.22928
+  tps: 9714.09041
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForgeEmber-37660"
  value: {
-  dps: 12215.90883
-  tps: 9808.01816
+  dps: 12216.11668
+  tps: 9808.18444
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 12247.38861
-  tps: 9826.76295
+  dps: 12247.78334
+  tps: 9827.07873
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 12236.5712
-  tps: 9818.19098
+  dps: 12236.96593
+  tps: 9818.50676
  }
 }
 dps_results: {
@@ -322,134 +322,134 @@ dps_results: {
 dps_results: {
  key: "TestFrostFire-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-FuturesightRune-38763"
  value: {
-  dps: 12040.32568
-  tps: 9665.82756
+  dps: 12040.53678
+  tps: 9665.99644
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 9036.24773
-  tps: 7249.90252
+  dps: 9036.77652
+  tps: 7250.32554
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 12275.01016
-  tps: 9851.83338
+  dps: 12275.08341
+  tps: 9851.89198
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 12330.02729
-  tps: 9895.44147
+  dps: 12330.10054
+  tps: 9895.50007
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 11992.4567
-  tps: 9639.25358
+  dps: 11992.78935
+  tps: 9639.51971
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Heartpierce-49982"
  value: {
-  dps: 12644.04433
-  tps: 10147.19423
+  dps: 12644.44887
+  tps: 10147.51786
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 12644.04433
-  tps: 10147.19423
+  dps: 12644.44887
+  tps: 10147.51786
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 12281.00926
-  tps: 9858.09924
+  dps: 12281.08251
+  tps: 9858.15784
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 12250.16186
-  tps: 9830.97287
+  dps: 12250.55659
+  tps: 9831.28865
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 12232.1321
-  tps: 9815.93251
+  dps: 12232.52683
+  tps: 9816.24829
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-IncisorFragment-37723"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 12225.40535
-  tps: 9815.22083
+  dps: 12225.90731
+  tps: 9815.62239
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 12193.30158
-  tps: 9783.90311
+  dps: 12193.69631
+  tps: 9784.21889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Khadgar'sRegalia"
  value: {
-  dps: 9469.71223
-  tps: 7612.0208
+  dps: 9470.09131
+  tps: 7612.32407
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-KirinTorGarb"
  value: {
-  dps: 9533.71422
-  tps: 7654.44416
+  dps: 9533.91609
+  tps: 7654.60565
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 12138.52336
-  tps: 9748.35955
+  dps: 12138.58829
+  tps: 9748.41149
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 12006.04523
-  tps: 9640.3037
+  dps: 12006.11016
+  tps: 9640.35564
  }
 }
 dps_results: {
@@ -462,197 +462,197 @@ dps_results: {
 dps_results: {
  key: "TestFrostFire-AllItems-Nibelung-49992"
  value: {
-  dps: 12644.04433
-  tps: 10147.19423
+  dps: 12644.44887
+  tps: 10147.51786
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Nibelung-50648"
  value: {
-  dps: 12644.04433
-  tps: 10147.19423
+  dps: 12644.44887
+  tps: 10147.51786
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 12193.30158
-  tps: 9783.90311
+  dps: 12193.69631
+  tps: 9784.21889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 12193.30158
-  tps: 9783.90311
+  dps: 12193.69631
+  tps: 9784.21889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 12193.30158
-  tps: 9783.90311
+  dps: 12193.69631
+  tps: 9784.21889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 12193.30158
-  tps: 9783.90311
+  dps: 12193.69631
+  tps: 9784.21889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 12441.08615
-  tps: 10042.14668
+  dps: 12441.36877
+  tps: 10042.37278
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 12514.3894
-  tps: 10107.24315
+  dps: 12514.67202
+  tps: 10107.46925
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 12583.98998
-  tps: 10097.56924
+  dps: 12584.39452
+  tps: 10097.89287
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 12198.0536
-  tps: 9786.18708
+  dps: 12198.44833
+  tps: 9786.50286
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 12204.48769
-  tps: 9801.49641
+  dps: 12204.56094
+  tps: 9801.55501
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 12248.50139
-  tps: 9837.06622
+  dps: 12248.57464
+  tps: 9837.12482
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SoulPreserver-37111"
  value: {
-  dps: 12021.93136
-  tps: 9651.23616
+  dps: 12022.00461
+  tps: 9651.29475
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SouloftheDead-40382"
  value: {
-  dps: 12096.47546
-  tps: 9723.86379
+  dps: 12096.54039
+  tps: 9723.91573
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SparkofLife-37657"
  value: {
-  dps: 12130.84097
-  tps: 9741.41624
+  dps: 12131.1227
+  tps: 9741.64161
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 12184.99797
-  tps: 9782.40857
+  dps: 12185.14495
+  tps: 9782.52615
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 12193.30158
-  tps: 9783.90311
+  dps: 12193.69631
+  tps: 9784.21889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 12193.30158
-  tps: 9783.90311
+  dps: 12193.69631
+  tps: 9784.21889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 12193.30158
-  tps: 9783.90311
+  dps: 12193.69631
+  tps: 9784.21889
  }
 }
 dps_results: {
@@ -665,99 +665,99 @@ dps_results: {
 dps_results: {
  key: "TestFrostFire-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 11917.92499
-  tps: 9569.79328
+  dps: 11918.00761
+  tps: 9569.85938
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TempestRegalia"
  value: {
-  dps: 6330.52951
-  tps: 5108.85579
+  dps: 6330.94076
+  tps: 5109.18479
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 11856.87997
-  tps: 9520.41188
+  dps: 11856.95322
+  tps: 9520.47048
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 9661.80788
-  tps: 7791.5961
+  dps: 9661.85908
+  tps: 7791.63706
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 12193.30158
-  tps: 9783.90311
+  dps: 12193.69631
+  tps: 9784.21889
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 12363.98769
-  tps: 9926.662
+  dps: 12364.30693
+  tps: 9926.91739
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 12363.98769
-  tps: 9926.662
+  dps: 12364.30693
+  tps: 9926.91739
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 12247.38861
-  tps: 9826.76295
+  dps: 12247.78334
+  tps: 9827.07873
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 12236.5712
-  tps: 9818.19098
+  dps: 12236.96593
+  tps: 9818.50676
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 12160.47753
-  tps: 9760.55698
+  dps: 12160.61328
+  tps: 9760.66557
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 12236.5712
-  tps: 9818.19098
+  dps: 12236.96593
+  tps: 9818.50676
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 12247.38861
-  tps: 9826.76295
+  dps: 12247.78334
+  tps: 9827.07873
  }
 }
 dps_results: {
  key: "TestFrostFire-AllItems-WingedTalisman-37844"
  value: {
-  dps: 12031.0769
-  tps: 9659.76942
+  dps: 12031.15015
+  tps: 9659.82802
  }
 }
 dps_results: {
  key: "TestFrostFire-Average-Default"
  value: {
-  dps: 12732.86222
-  tps: 10221.59846
+  dps: 12733.71708
+  tps: 10222.28234
  }
 }
 dps_results: {
@@ -770,29 +770,29 @@ dps_results: {
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P3FrostFire-Fire-frostfire-FullBuffs-LongSingleTarget"
  value: {
-  dps: 12644.04433
-  tps: 10147.19423
+  dps: 12644.44887
+  tps: 10147.51786
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P3FrostFire-Fire-frostfire-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14776.25966
-  tps: 11770.73364
+  dps: 14776.82451
+  tps: 11771.18552
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P3FrostFire-Fire-frostfire-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10061.51081
-  tps: 10248.12299
+  dps: 10065.05137
+  tps: 10250.95543
  }
 }
 dps_results: {
  key: "TestFrostFire-Settings-Troll-P3FrostFire-Fire-frostfire-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6264.75924
-  tps: 5042.4346
+  dps: 6265.245
+  tps: 5042.8232
  }
 }
 dps_results: {
@@ -805,7 +805,7 @@ dps_results: {
 dps_results: {
  key: "TestFrostFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 12644.04433
-  tps: 10147.19423
+  dps: 12644.44887
+  tps: 10147.51786
  }
 }

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -46,1158 +46,1158 @@ character_stats_results: {
 dps_results: {
  key: "TestShadow-AllItems-AbsolutionRegalia"
  value: {
-  dps: 5214.22231
-  tps: 5000.84239
+  dps: 5215.37937
+  tps: 5001.99945
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7245.72432
-  tps: 6979.61355
+  dps: 7246.87874
+  tps: 6980.76798
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7282.81182
-  tps: 7015.17762
+  dps: 7283.96624
+  tps: 7016.33205
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7102.8118
-  tps: 6838.3613
+  dps: 7103.93859
+  tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6945.41779
-  tps: 6691.42073
+  dps: 6946.63392
+  tps: 6692.63687
   hps: 88.41863
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6945.41779
-  tps: 6691.42073
+  dps: 6946.63392
+  tps: 6692.63687
   hps: 88.41863
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7130.60598
-  tps: 6866.03369
+  dps: 7131.74259
+  tps: 6867.1703
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5976.85773
-  tps: 5744.79957
+  dps: 5977.94276
+  tps: 5745.8846
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7144.00382
-  tps: 6741.00144
+  dps: 7145.13061
+  tps: 6742.10569
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7268.39053
-  tps: 7004.01263
+  dps: 7269.54495
+  tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
   hps: 64
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 7496.02559
-  tps: 7200.5699
+  dps: 7497.44916
+  tps: 7201.99347
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 8685.72202
-  tps: 8420.22322
+  dps: 8688.61684
+  tps: 8423.11803
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7064.47695
-  tps: 6810.7033
+  dps: 7065.58021
+  tps: 6811.80656
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7126.92446
-  tps: 6873.72269
+  dps: 7128.07281
+  tps: 6874.87104
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7039.66558
-  tps: 6795.39554
+  dps: 7041.02444
+  tps: 6796.7544
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6979.38314
-  tps: 6725.69464
+  dps: 6980.52358
+  tps: 6726.83508
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7135.02344
-  tps: 6870.64554
+  dps: 7136.16005
+  tps: 6871.78215
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7678.60076
-  tps: 7412.72278
+  dps: 7681.84674
+  tps: 7415.96876
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7596.88495
-  tps: 7333.77822
+  dps: 7598.93668
+  tps: 7335.82996
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7102.8118
-  tps: 6838.3613
+  dps: 7103.93859
+  tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7149.24928
-  tps: 6882.77832
+  dps: 7150.3731
+  tps: 6883.90215
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7130.60598
-  tps: 6866.22808
+  dps: 7131.74259
+  tps: 6867.36469
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7126.15853
-  tps: 6861.75103
+  dps: 7127.29857
+  tps: 6862.89107
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7108.09214
-  tps: 6856.51827
+  dps: 7109.6941
+  tps: 6858.12022
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7102.8118
-  tps: 6838.3613
+  dps: 7103.93859
+  tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7129.24883
-  tps: 6877.00461
+  dps: 7130.40545
+  tps: 6878.16124
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7277.56176
-  tps: 7015.21074
+  dps: 7278.66346
+  tps: 7016.31243
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6960.59537
-  tps: 6706.2676
+  dps: 6961.74278
+  tps: 6707.41501
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7131.09023
-  tps: 6869.68826
+  dps: 7132.24465
+  tps: 6870.84269
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7038.02442
-  tps: 6784.21127
+  dps: 7039.12802
+  tps: 6785.31486
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7144.00382
-  tps: 6877.82215
+  dps: 7145.13061
+  tps: 6878.94894
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7135.76542
-  tps: 6869.92998
+  dps: 7136.89221
+  tps: 6871.05677
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7065.63235
-  tps: 6803.97528
+  dps: 7066.87504
+  tps: 6805.11495
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GarbofFaith"
  value: {
-  dps: 6353.67271
-  tps: 6104.85735
+  dps: 6355.36192
+  tps: 6106.54656
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 6789.4264
-  tps: 6495.78071
+  dps: 6790.77625
+  tps: 6497.13055
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 6928.09177
-  tps: 6658.56317
+  dps: 6929.48265
+  tps: 6659.95406
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7264.26807
-  tps: 6997.39559
+  dps: 7265.42249
+  tps: 6998.55001
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7306.41295
-  tps: 7037.8093
+  dps: 7307.56738
+  tps: 7038.96372
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7090.9263
-  tps: 6838.1632
+  dps: 7092.0406
+  tps: 6839.2775
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-49982"
  value: {
-  dps: 7268.39053
-  tps: 7004.01263
+  dps: 7269.54495
+  tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-50641"
  value: {
-  dps: 7268.39053
-  tps: 7004.01263
+  dps: 7269.54495
+  tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7130.60598
-  tps: 6866.22808
+  dps: 7131.74259
+  tps: 6867.36469
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7126.15853
-  tps: 6861.75103
+  dps: 7127.29857
+  tps: 6862.89107
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7112.70706
-  tps: 6852.36203
+  dps: 7113.79542
+  tps: 6853.45039
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7102.8118
-  tps: 6838.3613
+  dps: 7103.93859
+  tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50179"
  value: {
-  dps: 7268.39053
-  tps: 7004.01263
+  dps: 7269.54495
+  tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50708"
  value: {
-  dps: 7268.39053
-  tps: 7004.01263
+  dps: 7269.54495
+  tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7014.82633
-  tps: 6754.52471
+  dps: 7016.12023
+  tps: 6755.81861
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7039.85331
-  tps: 6786.04015
+  dps: 7040.95691
+  tps: 6787.14375
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7231.36284
-  tps: 6969.35046
+  dps: 7232.52516
+  tps: 6970.51278
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Nibelung-49992"
  value: {
-  dps: 7268.39053
-  tps: 7004.01263
+  dps: 7269.54495
+  tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Nibelung-50648"
  value: {
-  dps: 7268.39053
-  tps: 7004.01263
+  dps: 7269.54495
+  tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7102.8118
-  tps: 6838.3613
+  dps: 7103.93859
+  tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7102.8118
-  tps: 6838.3613
+  dps: 7103.93859
+  tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7102.8118
-  tps: 6838.3613
+  dps: 7103.93859
+  tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7102.8118
-  tps: 6838.3613
+  dps: 7103.93859
+  tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RegaliaofFaith"
  value: {
-  dps: 6151.18793
-  tps: 5898.40433
+  dps: 6152.3564
+  tps: 5899.57281
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7362.41442
-  tps: 7100.10409
+  dps: 7363.33817
+  tps: 7101.02785
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7413.09179
-  tps: 7149.54435
+  dps: 7414.01554
+  tps: 7150.46811
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7238.13844
-  tps: 6973.68794
+  dps: 7239.2827
+  tps: 6974.83221
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7102.8118
-  tps: 6837.79836
+  dps: 7103.93859
+  tps: 6838.92515
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationGarb"
  value: {
-  dps: 6914.0245
-  tps: 6656.99382
+  dps: 6915.15711
+  tps: 6658.12643
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationRegalia"
  value: {
-  dps: 6595.74326
-  tps: 6334.98993
+  dps: 6596.68756
+  tps: 6335.93423
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7210.32261
-  tps: 6948.48199
+  dps: 7211.47704
+  tps: 6949.63641
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7244.03852
-  tps: 6981.22905
+  dps: 7245.19295
+  tps: 6982.38348
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7070.40159
-  tps: 6811.49252
+  dps: 7071.55602
+  tps: 6812.64694
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7062.12793
-  tps: 6808.28714
+  dps: 7063.23123
+  tps: 6809.39044
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SparkofLife-37657"
  value: {
-  dps: 7080.549
-  tps: 6823.59085
+  dps: 7082.05267
+  tps: 6825.07284
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6954.68776
-  tps: 6701.41937
+  dps: 6955.79321
+  tps: 6702.52482
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7102.8118
-  tps: 6838.3613
+  dps: 7103.93859
+  tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7102.8118
-  tps: 6838.3613
+  dps: 7103.93859
+  tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7102.8118
-  tps: 6838.3613
+  dps: 7103.93859
+  tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7008.22684
-  tps: 6750.52062
+  dps: 7009.4044
+  tps: 6751.69818
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6972.34941
-  tps: 6717.43514
+  dps: 6973.48936
+  tps: 6718.57509
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6943.96693
-  tps: 6690.25138
+  dps: 6945.12136
+  tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7102.8118
-  tps: 6838.3613
+  dps: 7103.93859
+  tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6954.68776
-  tps: 6701.41937
+  dps: 6955.79321
+  tps: 6702.52482
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6954.68776
-  tps: 6701.41937
+  dps: 6955.79321
+  tps: 6702.52482
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7144.00382
-  tps: 6877.82215
+  dps: 7145.13061
+  tps: 6878.94894
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7135.76542
-  tps: 6869.92998
+  dps: 7136.89221
+  tps: 6871.05677
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7164.33044
-  tps: 6907.86493
+  dps: 7166.07706
+  tps: 6909.61154
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7135.76542
-  tps: 6869.92998
+  dps: 7136.89221
+  tps: 6871.05677
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7144.00382
-  tps: 6877.82215
+  dps: 7145.13061
+  tps: 6878.94894
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7562.63766
-  tps: 7293.08371
+  dps: 7563.60834
+  tps: 7294.05439
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VestmentsofAbsolution"
  value: {
-  dps: 5085.19221
-  tps: 4870.37597
+  dps: 5086.13636
+  tps: 4871.32012
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7079.74765
-  tps: 6813.32055
+  dps: 7081.61876
+  tps: 6815.19166
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRaiment"
  value: {
-  dps: 6503.15317
-  tps: 6245.36556
+  dps: 6504.64961
+  tps: 6246.86201
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRegalia"
  value: {
-  dps: 6855.75179
-  tps: 6594.55807
+  dps: 6858.40695
+  tps: 6597.21322
  }
 }
 dps_results: {
  key: "TestShadow-Average-Default"
  value: {
-  dps: 7337.35628
-  tps: 7069.75697
+  dps: 7338.33372
+  tps: 7070.73441
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7277.22779
-  tps: 7708.34842
+  dps: 7278.33213
+  tps: 7709.45276
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7277.22779
-  tps: 7013.46243
+  dps: 7278.33213
+  tps: 7014.56678
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8646.76774
-  tps: 7833.77716
+  dps: 8647.16609
+  tps: 7834.17551
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3798.00573
-  tps: 4555.22776
+  dps: 3798.86536
+  tps: 4556.08738
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3798.00573
-  tps: 3709.40564
+  dps: 3798.86536
+  tps: 3710.26527
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Basic-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3970.78593
-  tps: 3655.21147
+  dps: 3971.64182
+  tps: 3656.06736
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7277.22779
-  tps: 7708.34842
+  dps: 7278.33213
+  tps: 7709.45276
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7277.22779
-  tps: 7013.46243
+  dps: 7278.33213
+  tps: 7014.56678
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8646.76774
-  tps: 7833.77716
+  dps: 8647.16609
+  tps: 7834.17551
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3798.00573
-  tps: 4555.22776
+  dps: 3798.86536
+  tps: 4556.08738
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3798.00573
-  tps: 3709.40564
+  dps: 3798.86536
+  tps: 3710.26527
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Clipping-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3970.78593
-  tps: 3655.21147
+  dps: 3971.64182
+  tps: 3656.06736
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7277.22779
-  tps: 7708.34842
+  dps: 7278.33213
+  tps: 7709.45276
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7277.22779
-  tps: 7013.46243
+  dps: 7278.33213
+  tps: 7014.56678
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8646.76774
-  tps: 7833.77716
+  dps: 8647.16609
+  tps: 7834.17551
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3798.00573
-  tps: 4555.22776
+  dps: 3798.86536
+  tps: 4556.08738
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3798.00573
-  tps: 3709.40564
+  dps: 3798.86536
+  tps: 3710.26527
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-P1-Ideal-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3970.78593
-  tps: 3655.21147
+  dps: 3971.64182
+  tps: 3656.06736
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7264.23598
-  tps: 7702.03724
+  dps: 7265.38882
+  tps: 7703.19008
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7264.23598
-  tps: 7000.10227
+  dps: 7265.38882
+  tps: 7001.25511
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8641.41316
-  tps: 7828.69774
+  dps: 8641.80372
+  tps: 7829.0883
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3784.39276
-  tps: 4541.59361
+  dps: 3785.301
+  tps: 4542.50185
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3784.39276
-  tps: 3695.44257
+  dps: 3785.301
+  tps: 3696.35081
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Basic-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3965.09584
-  tps: 3649.60409
+  dps: 3965.9512
+  tps: 3650.45945
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7264.23598
-  tps: 7702.03724
+  dps: 7265.38882
+  tps: 7703.19008
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7264.23598
-  tps: 7000.10227
+  dps: 7265.38882
+  tps: 7001.25511
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8641.41316
-  tps: 7828.69774
+  dps: 8641.80372
+  tps: 7829.0883
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3784.39276
-  tps: 4541.59361
+  dps: 3785.301
+  tps: 4542.50185
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3784.39276
-  tps: 3695.44257
+  dps: 3785.301
+  tps: 3696.35081
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Clipping-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3965.09584
-  tps: 3649.60409
+  dps: 3965.9512
+  tps: 3650.45945
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7264.23598
-  tps: 7702.03724
+  dps: 7265.38882
+  tps: 7703.19008
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7264.23598
-  tps: 7000.10227
+  dps: 7265.38882
+  tps: 7001.25511
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8641.41316
-  tps: 7828.69774
+  dps: 8641.80372
+  tps: 7829.0883
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3784.39276
-  tps: 4541.59361
+  dps: 3785.301
+  tps: 4542.50185
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3784.39276
-  tps: 3695.44257
+  dps: 3785.301
+  tps: 3696.35081
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-P1-Ideal-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3965.09584
-  tps: 3649.60409
+  dps: 3965.9512
+  tps: 3650.45945
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7268.39053
-  tps: 7704.59151
+  dps: 7269.54495
+  tps: 7705.74594
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7268.39053
-  tps: 7004.01263
+  dps: 7269.54495
+  tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8646.44371
-  tps: 7833.22013
+  dps: 8646.83433
+  tps: 7833.61075
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3793.51939
-  tps: 4549.11415
+  dps: 3794.58518
+  tps: 4550.17994
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3793.51939
-  tps: 3704.21507
+  dps: 3794.58518
+  tps: 3705.28086
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Basic-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3967.34289
-  tps: 3651.66367
+  dps: 3968.19958
+  tps: 3652.52035
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7268.39053
-  tps: 7704.59151
+  dps: 7269.54495
+  tps: 7705.74594
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7268.39053
-  tps: 7004.01263
+  dps: 7269.54495
+  tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8646.44371
-  tps: 7833.22013
+  dps: 8646.83433
+  tps: 7833.61075
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3793.51939
-  tps: 4549.11415
+  dps: 3794.58518
+  tps: 4550.17994
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3793.51939
-  tps: 3704.21507
+  dps: 3794.58518
+  tps: 3705.28086
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Clipping-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3967.34289
-  tps: 3651.66367
+  dps: 3968.19958
+  tps: 3652.52035
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7268.39053
-  tps: 7704.59151
+  dps: 7269.54495
+  tps: 7705.74594
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7268.39053
-  tps: 7004.01263
+  dps: 7269.54495
+  tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8646.44371
-  tps: 7833.22013
+  dps: 8646.83433
+  tps: 7833.61075
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3793.51939
-  tps: 4549.11415
+  dps: 3794.58518
+  tps: 4550.17994
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3793.51939
-  tps: 3704.21507
+  dps: 3794.58518
+  tps: 3705.28086
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-P1-Ideal-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3967.34289
-  tps: 3651.66367
+  dps: 3968.19958
+  tps: 3652.52035
  }
 }
 dps_results: {
  key: "TestShadow-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7225.1909
-  tps: 7004.01263
+  dps: 7226.34532
+  tps: 7005.16705
  }
 }

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -13,7 +13,7 @@ character_stats_results: {
   final_stats: 221
   final_stats: 0
   final_stats: 5504.84
-  final_stats: 469.94994
+  final_stats: 469.94995
   final_stats: 2072.9756
   final_stats: 221
   final_stats: 94

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -13,7 +13,7 @@ character_stats_results: {
   final_stats: 221
   final_stats: 0
   final_stats: 5725.0336
-  final_stats: 469.94994
+  final_stats: 469.94995
   final_stats: 2164.78757
   final_stats: 221
   final_stats: 94

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -848,8 +848,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 6249.0902
-  tps: 4436.85404
+  dps: 6249.08938
+  tps: 4436.85346
  }
 }
 dps_results: {
@@ -1191,8 +1191,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-combat_cleave_snd-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19073.06074
-  tps: 13541.87312
+  dps: 19073.0606
+  tps: 13541.87303
  }
 }
 dps_results: {
@@ -1317,8 +1317,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-P1-MH Instant OH Deadly-fan_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21279.96437
-  tps: 15108.77471
+  dps: 21279.95781
+  tps: 15108.77004
  }
 }
 dps_results: {
@@ -1863,8 +1863,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-combat_cleave_snd-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19208.77456
-  tps: 13638.22994
+  dps: 19208.77464
+  tps: 13638.23
  }
 }
 dps_results: {
@@ -1989,8 +1989,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-P1-MH Instant OH Deadly-fan_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21444.63805
-  tps: 15225.69301
+  dps: 21444.63148
+  tps: 15225.68835
  }
 }
 dps_results: {

--- a/sim/rogue/TestSubtlety.results
+++ b/sim/rogue/TestSubtlety.results
@@ -855,8 +855,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-Settings-Orc-P2 Subtlety-Subtlety--NoBuffs-LongMultiTarget"
  value: {
-  dps: 19003.30323
-  tps: 13492.34529
+  dps: 19003.33314
+  tps: 13492.36653
  }
 }
 dps_results: {

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -105,7 +105,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6863.2786
+  dps: 6863.3299
   tps: 3823.37452
  }
 }
@@ -133,7 +133,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6995.72931
+  dps: 6995.78061
   tps: 3905.14802
  }
 }
@@ -182,28 +182,28 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6901.79178
+  dps: 6901.84308
   tps: 3767.96597
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7051.44519
+  dps: 7051.4988
   tps: 3939.43553
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7051.44519
+  dps: 7051.4988
   tps: 3939.43553
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7051.44519
+  dps: 7051.4988
   tps: 3939.43553
  }
 }
@@ -252,7 +252,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 6996.27855
+  dps: 6996.33216
   tps: 3900.96796
  }
 }
@@ -294,14 +294,14 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6882.94517
+  dps: 6882.99647
   tps: 3835.16975
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6904.04454
+  dps: 6904.19776
   tps: 3874.20329
  }
 }
@@ -329,28 +329,28 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6863.2786
+  dps: 6863.3299
   tps: 3823.37452
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7018.69366
+  dps: 7018.74496
   tps: 3917.24537
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6871.18675
+  dps: 6871.23805
   tps: 3827.93672
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6872.26306
+  dps: 6872.31435
   tps: 3828.27886
  }
 }
@@ -371,7 +371,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6863.2786
+  dps: 6863.3299
   tps: 3823.37452
  }
 }
@@ -413,14 +413,14 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6901.79178
+  dps: 6901.84308
   tps: 3844.66467
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6894.08914
+  dps: 6894.14044
   tps: 3840.40664
  }
 }
@@ -441,7 +441,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 7011.07785
+  dps: 7011.13146
   tps: 3908.74365
  }
 }
@@ -462,14 +462,14 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 5599.49222
+  dps: 5599.54922
   tps: 3139.93184
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Gladiator'sWartide"
  value: {
-  dps: 6418.68763
+  dps: 6418.74463
   tps: 3577.66691
  }
 }
@@ -497,35 +497,35 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 6960.25357
+  dps: 6960.30718
   tps: 3880.41695
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-49982"
  value: {
-  dps: 7051.44519
+  dps: 7051.4988
   tps: 3939.43553
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-50641"
  value: {
-  dps: 7051.44519
+  dps: 7051.4988
   tps: 3939.43553
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6871.18675
+  dps: 6871.23805
   tps: 3827.93672
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6872.26306
+  dps: 6872.31435
   tps: 3828.27886
  }
 }
@@ -539,28 +539,28 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7250.86496
+  dps: 7250.91626
   tps: 4065.52967
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6863.2786
+  dps: 6863.3299
   tps: 3823.37452
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LastWord-50179"
  value: {
-  dps: 7051.44519
+  dps: 7051.4988
   tps: 3939.43553
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LastWord-50708"
  value: {
-  dps: 7051.44519
+  dps: 7051.4988
   tps: 3939.43553
  }
 }
@@ -595,14 +595,14 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Nibelung-49992"
  value: {
-  dps: 7051.44519
+  dps: 7051.4988
   tps: 3939.43553
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Nibelung-50648"
  value: {
-  dps: 7051.44519
+  dps: 7051.4988
   tps: 3939.43553
  }
 }
@@ -616,14 +616,14 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6863.2786
+  dps: 6863.3299
   tps: 3823.37452
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6863.2786
+  dps: 6863.3299
   tps: 3823.37452
  }
 }
@@ -651,14 +651,14 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6863.2786
+  dps: 6863.3299
   tps: 3823.37452
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6863.2786
+  dps: 6863.3299
   tps: 3823.37452
  }
 }
@@ -686,21 +686,21 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7042.80824
+  dps: 7042.86185
   tps: 3934.4335
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 7029.04843
+  dps: 7029.10204
   tps: 3918.18556
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6967.17719
+  dps: 6967.22849
   tps: 3885.82183
  }
 }
@@ -714,7 +714,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 6954.12913
+  dps: 6954.18274
   tps: 3877.46091
  }
 }
@@ -728,7 +728,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7051.44519
+  dps: 7051.4988
   tps: 3939.43553
  }
 }
@@ -812,7 +812,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 6922.28204
+  dps: 6922.33565
   tps: 3862.08949
  }
 }
@@ -826,21 +826,21 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6863.2786
+  dps: 6863.3299
   tps: 3823.37452
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6863.2786
+  dps: 6863.3299
   tps: 3823.37452
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6863.2786
+  dps: 6863.3299
   tps: 3823.37452
  }
 }
@@ -861,7 +861,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-TheFistsofFury"
  value: {
-  dps: 5903.08891
+  dps: 5903.11713
   tps: 3270.18423
  }
 }
@@ -875,7 +875,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 5764.26175
+  dps: 5764.32445
   tps: 3223.73654
  }
 }
@@ -889,14 +889,14 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6863.2786
+  dps: 6863.3299
   tps: 3823.37452
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TidefuryRaiment"
  value: {
-  dps: 4683.16927
+  dps: 4683.20062
   tps: 2571.13876
  }
 }
@@ -917,14 +917,14 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6901.79178
+  dps: 6901.84308
   tps: 3844.66467
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6894.08914
+  dps: 6894.14044
   tps: 3840.40664
  }
 }
@@ -945,14 +945,14 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-TotemofQuakingEarth-47667"
  value: {
-  dps: 6922.28204
+  dps: 6922.33565
   tps: 3862.08949
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 6922.28204
+  dps: 6922.33565
   tps: 3862.08949
  }
 }
@@ -966,14 +966,14 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6894.08914
+  dps: 6894.14044
   tps: 3840.40664
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6901.79178
+  dps: 6901.84308
   tps: 3844.66467
  }
 }
@@ -1015,14 +1015,14 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 7048.0761
+  dps: 7048.12971
   tps: 3928.18288
  }
 }
 dps_results: {
  key: "TestElemental-Average-Default"
  value: {
-  dps: 7238.66237
+  dps: 7238.67361
   tps: 4043.58814
  }
 }
@@ -1057,7 +1057,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2999.98425
+  dps: 3000.03597
   tps: 1528.55443
  }
 }
@@ -1078,7 +1078,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7176.03346
+  dps: 7176.08989
   tps: 3986.58618
  }
 }
@@ -1092,14 +1092,14 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4646.5071
+  dps: 4646.54934
   tps: 1634.61929
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-Adaptive-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3242.65672
+  dps: 3242.70738
   tps: 1666.24672
  }
 }
@@ -1141,7 +1141,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2999.98425
+  dps: 3000.03597
   tps: 1528.55443
  }
 }
@@ -1162,7 +1162,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7176.03346
+  dps: 7176.08989
   tps: 3986.58618
  }
 }
@@ -1176,14 +1176,14 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4646.5071
+  dps: 4646.54934
   tps: 1634.61929
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-P1-EleFireElemental-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3242.65672
+  dps: 3242.70738
   tps: 1666.24672
  }
 }
@@ -1225,7 +1225,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2934.74475
+  dps: 2934.77196
   tps: 1513.76853
  }
 }
@@ -1246,7 +1246,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-Adaptive-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7051.44519
+  dps: 7051.4988
   tps: 3939.43553
  }
 }
@@ -1309,7 +1309,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2934.74475
+  dps: 2934.77196
   tps: 1513.76853
  }
 }
@@ -1330,7 +1330,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-P1-EleFireElemental-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7051.44519
+  dps: 7051.4988
   tps: 3939.43553
  }
 }
@@ -1365,7 +1365,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7031.02778
+  dps: 7031.08139
   tps: 3939.43553
  }
 }

--- a/sim/warlock/TestDemonology.results
+++ b/sim/warlock/TestDemonology.results
@@ -812,8 +812,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Settings-Orc-P2-Demonology Warlock-demo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6317.53516
-  tps: 5713.07986
+  dps: 6317.52711
+  tps: 5713.07182
  }
 }
 dps_results: {

--- a/sim/warlock/warlock.go
+++ b/sim/warlock/warlock.go
@@ -180,7 +180,7 @@ func (warlock *Warlock) Initialize() {
 			})
 		}
 		if warlock.ItemSwap.IsEnabled() {
-			warlock.AddStats(correction.Multiply(-1))
+			warlock.AddStats(correction.Invert())
 			warlock.MultiplyCastSpeed(1.0)
 		}
 	})

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -883,8 +883,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 8268.01597
-  tps: 6799.55785
+  dps: 8268.01631
+  tps: 6799.55814
  }
 }
 dps_results: {


### PR DESCRIPTION
[core] Simulation.advance() now iterates over enabled units' auraTrackers, and caches their combined "minExpires" to skip iterating when there's nothing to do
[core] removed some needless method shadowing for Target, Character, and Pet
[core] added Stats.Invert() as a shortcut for Stats.Multiply(-1), and simplified most others

Test changes only happen because the order of `advance()` calls isn't the same as before. DPS changes are typically in the noise.