### PR TITLE
fix shadowfiend scaling

### DIFF
--- a/sim/priest/healing/TestHoly.results
+++ b/sim/priest/healing/TestHoly.results
@@ -46,889 +46,778 @@ character_stats_results: {
 dps_results: {
  key: "TestHoly-AllItems-AbsolutionRegalia"
  value: {
-  dps: 87.12967
-  tps: 48.5365
-  hps: 3633.41402
+  tps: 28.7349
+  hps: 3258.01419
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 103.98612
-  tps: 56.14018
-  hps: 5391.0722
+  tps: 33.80448
+  hps: 4965.2314
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 104.61933
-  tps: 56.14018
-  hps: 5436.21953
+  tps: 33.80448
+  hps: 5008.44419
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5199.71539
+  tps: 33.62536
+  hps: 4671.06042
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 98.83407
-  tps: 55.95466
-  hps: 5105.78996
+  tps: 33.78925
+  hps: 4696.75666
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 98.83407
-  tps: 55.95466
-  hps: 5105.78996
+  tps: 33.78925
+  hps: 4696.75666
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.80257
-  hps: 5243.10114
+  tps: 33.9271
+  hps: 4712.19715
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 89.23853
-  tps: 49.06008
-  hps: 4009.75185
+  tps: 34.37075
+  hps: 3781.37157
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 99.55363
-  tps: 61.30402
-  hps: 5228.98951
+  tps: 33.62536
+  hps: 4697.65416
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5202.98543
+  tps: 33.62536
+  hps: 4674.78994
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 5055.2512
+  tps: 33.50009
+  hps: 4680.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 108.73046
-  tps: 63.73045
-  hps: 5846.40602
+  tps: 35.02424
+  hps: 5444.02096
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 113.35971
-  tps: 66.28564
-  hps: 5486.62923
+  tps: 35.4319
+  hps: 4826.93873
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 5016.44368
+  tps: 33.50009
+  hps: 4639.86885
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 98.83407
-  tps: 52.20173
-  hps: 5171.48014
+  tps: 36.25385
+  hps: 4991.42137
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-Death'sChoice-47464"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 5000.79593
+  tps: 33.50009
+  hps: 4625.82265
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-Defender'sCode-40257"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5204.49678
+  tps: 33.62536
+  hps: 4675.40401
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 98.83407
-  tps: 55.02095
-  hps: 4994.432
+  tps: 33.59289
+  hps: 4609.39037
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 98.83407
-  tps: 54.73392
-  hps: 4989.41132
+  tps: 33.50009
+  hps: 4611.51097
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5199.71539
+  tps: 33.62536
+  hps: 4671.06042
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 99.55363
-  tps: 61.68547
-  hps: 5271.311
+  tps: 33.88124
+  hps: 4739.64808
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5202.98543
+  tps: 33.62536
+  hps: 4674.78994
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5202.18171
+  tps: 33.62536
+  hps: 4673.98622
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 98.83407
-  tps: 58.13109
-  hps: 5060.58655
+  tps: 38.39152
+  hps: 4710.51234
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5199.71539
+  tps: 33.62536
+  hps: 4671.06042
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 5023.54843
+  tps: 33.50009
+  hps: 4646.46312
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 102.57578
-  tps: 54.76384
-  hps: 5167.35725
+  tps: 33.50009
+  hps: 4780.33637
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 102.02892
-  tps: 54.76384
-  hps: 5197.18054
+  tps: 33.50009
+  hps: 4812.70969
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-ForgeEmber-37660"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 5011.74617
+  tps: 33.50009
+  hps: 4634.88742
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 99.55363
-  tps: 61.30402
-  hps: 5228.98951
+  tps: 33.62536
+  hps: 4697.65416
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 99.40972
-  tps: 61.30402
-  hps: 5223.13469
+  tps: 33.62536
+  hps: 4692.33541
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-FuturesightRune-38763"
  value: {
-  dps: 101.35749
-  tps: 58.35541
-  hps: 5339.08305
+  tps: 33.93196
+  hps: 4898.95282
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-GarbofFaith"
  value: {
-  dps: 97.80047
-  tps: 43.09071
-  hps: 4261.66942
+  tps: 32.20118
+  hps: 4086.6638
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 110.04387
-  tps: 59.5397
-  hps: 5405.77815
+  tps: 33.07388
+  hps: 4892.22954
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 106.32058
-  tps: 44.29892
-  hps: 4736.73909
+  tps: 32.62469
+  hps: 4514.28784
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 104.30272
-  tps: 54.76384
-  hps: 5619.27517
+  tps: 33.50009
+  hps: 5272.69127
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 105.02228
-  tps: 54.76384
-  hps: 5700.93152
+  tps: 33.50009
+  hps: 5357.93736
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 5015.34235
+  tps: 33.50009
+  hps: 4638.61052
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-Heartpierce-49982"
  value: {
-  dps: 98.83407
-  tps: 66.39932
-  hps: 5319.57826
+  tps: 38.10606
+  hps: 4783.9391
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-Heartpierce-50641"
  value: {
-  dps: 98.83407
-  tps: 66.39932
-  hps: 5319.57826
+  tps: 38.10606
+  hps: 4783.9391
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 104.59055
-  tps: 54.76384
-  hps: 5208.85202
+  tps: 33.50009
+  hps: 4819.02561
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5202.98543
+  tps: 33.62536
+  hps: 4674.78994
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5202.18171
+  tps: 33.62536
+  hps: 4673.98622
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-IncisorFragment-37723"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 98.83407
-  tps: 66.39932
-  hps: 5319.57826
+  tps: 38.10606
+  hps: 4783.9391
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5199.71539
+  tps: 33.62536
+  hps: 4671.06042
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-LastWord-50179"
  value: {
-  dps: 98.83407
-  tps: 66.39932
-  hps: 5319.57826
+  tps: 38.10606
+  hps: 4783.9391
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-LastWord-50708"
  value: {
-  dps: 98.83407
-  tps: 66.39932
-  hps: 5319.57826
+  tps: 38.10606
+  hps: 4783.9391
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 100.33004
-  tps: 57.01663
-  hps: 5365.94294
+  tps: 34.12799
+  hps: 5050.69095
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 5011.74617
+  tps: 33.50009
+  hps: 4634.88742
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 102.02892
-  tps: 54.76384
-  hps: 5162.77603
+  tps: 33.50009
+  hps: 4778.42686
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-Nibelung-49992"
  value: {
-  dps: 98.83407
-  tps: 66.39932
-  hps: 5319.57826
+  tps: 38.10606
+  hps: 4783.9391
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-Nibelung-50648"
  value: {
-  dps: 98.83407
-  tps: 66.39932
-  hps: 5319.57826
+  tps: 38.10606
+  hps: 4783.9391
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5199.71539
+  tps: 33.62536
+  hps: 4671.06042
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5199.71539
+  tps: 33.62536
+  hps: 4671.06042
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5199.71539
+  tps: 33.62536
+  hps: 4671.06042
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5199.71539
+  tps: 33.62536
+  hps: 4671.06042
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-RegaliaofFaith"
  value: {
-  dps: 94.72711
-  tps: 58.19439
-  hps: 4851.16581
+  tps: 32.22689
+  hps: 4348.40323
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 103.15143
-  tps: 54.76384
-  hps: 5160.52328
+  tps: 33.50009
+  hps: 4774.49607
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 103.66951
-  tps: 54.76384
-  hps: 5180.83593
+  tps: 33.50009
+  hps: 4793.44101
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5199.71539
+  tps: 33.62536
+  hps: 4671.06042
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.21451
-  hps: 5260.18978
+  tps: 33.65436
+  hps: 4730.96315
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-SanctificationGarb"
  value: {
-  dps: 100.00238
-  tps: 50.48018
-  hps: 4572.05945
+  tps: 32.44078
+  hps: 4235.82951
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-SanctificationRegalia"
  value: {
-  dps: 98.82558
-  tps: 60.23322
-  hps: 4953.67119
+  tps: 33.05961
+  hps: 4426.89037
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 103.38169
-  tps: 59.51685
-  hps: 5266.86034
+  tps: 39.10083
+  hps: 4891.84009
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 103.95733
-  tps: 60.1604
-  hps: 5294.27326
+  tps: 39.77043
+  hps: 4921.16155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-SouloftheDead-40382"
  value: {
-  dps: 98.83407
-  tps: 65.99294
-  hps: 5248.27938
+  tps: 41.17652
+  hps: 4790.50815
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-SparkofLife-37657"
  value: {
-  dps: 98.83407
-  tps: 58.52129
-  hps: 5255.05794
+  tps: 33.85034
+  hps: 4829.90116
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 100.54464
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5199.71539
+  tps: 33.62536
+  hps: 4671.06042
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5199.71539
+  tps: 33.62536
+  hps: 4671.06042
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5199.71539
+  tps: 33.62536
+  hps: 4671.06042
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 99.44077
-  tps: 55.09365
-  hps: 5070.0468
+  tps: 33.5646
+  hps: 4689.38502
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 98.83407
-  tps: 68.20113
-  hps: 5334.92312
+  tps: 39.76762
+  hps: 4833.76775
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 98.83407
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 98.83407
-  tps: 61.30402
-  hps: 5199.71539
+  tps: 33.62536
+  hps: 4671.06042
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 102.13263
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 102.13263
-  tps: 54.76384
-  hps: 4991.2512
+  tps: 33.50009
+  hps: 4616.62155
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 99.55363
-  tps: 61.30402
-  hps: 5228.98951
+  tps: 33.62536
+  hps: 4697.65416
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 99.40972
-  tps: 61.30402
-  hps: 5223.13469
+  tps: 33.62536
+  hps: 4692.33541
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 100.79127
-  tps: 55.42497
-  hps: 5088.49071
+  tps: 33.47327
+  hps: 4682.80516
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 99.40972
-  tps: 61.30402
-  hps: 5223.13469
+  tps: 33.62536
+  hps: 4692.33541
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 99.55363
-  tps: 61.30402
-  hps: 5228.98951
+  tps: 33.62536
+  hps: 4697.65416
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 102.23039
-  tps: 66.87192
-  hps: 5703.99304
+  tps: 38.31735
+  hps: 5127.10194
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-VestmentsofAbsolution"
  value: {
-  dps: 85.82192
-  tps: 47.79809
-  hps: 3715.88876
+  tps: 28.5452
+  hps: 3348.52412
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-WingedTalisman-37844"
  value: {
-  dps: 102.5408
-  tps: 54.76384
-  hps: 5072.76575
+  tps: 33.50009
+  hps: 4691.69885
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-Zabra'sRaiment"
  value: {
-  dps: 97.70631
-  tps: 60.61888
-  hps: 5150.02286
+  tps: 33.26162
+  hps: 4642.3662
  }
 }
 dps_results: {
  key: "TestHoly-AllItems-Zabra'sRegalia"
  value: {
-  dps: 104.14004
-  tps: 60.82634
-  hps: 4815.65072
+  tps: 33.16601
+  hps: 4285.75184
  }
 }
 dps_results: {
  key: "TestHoly-Average-Default"
  value: {
-  dps: 96.34965
-  tps: 67.14115
-  hps: 5330.50791
+  tps: 38.90914
+  hps: 4813.78909
  }
 }
 dps_results: {
  key: "TestHoly-Settings-Undead-p1_holy-Holy-holy-FullBuffs-LongMultiTarget"
  value: {
-  dps: 98.83407
-  tps: 1327.98649
-  hps: 5319.57826
+  tps: 762.12118
+  hps: 4783.9391
  }
 }
 dps_results: {
  key: "TestHoly-Settings-Undead-p1_holy-Holy-holy-FullBuffs-LongSingleTarget"
  value: {
-  dps: 98.83407
-  tps: 66.39932
-  hps: 5319.57826
+  tps: 38.10606
+  hps: 4783.9391
  }
 }
 dps_results: {
@@ -941,32 +830,28 @@ dps_results: {
 dps_results: {
  key: "TestHoly-Settings-Undead-p1_holy-Holy-holy-NoBuffs-LongMultiTarget"
  value: {
-  dps: 46.75554
-  tps: 728.99189
-  hps: 3001.49045
+  tps: 306.6239
+  hps: 2639.74256
  }
 }
 dps_results: {
  key: "TestHoly-Settings-Undead-p1_holy-Holy-holy-NoBuffs-LongSingleTarget"
  value: {
-  dps: 46.75554
-  tps: 36.44959
-  hps: 3001.49045
+  tps: 15.3312
+  hps: 2639.74256
  }
 }
 dps_results: {
  key: "TestHoly-Settings-Undead-p1_holy-Holy-holy-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 176.37332
-  tps: 121.46866
+  tps: 24.76732
   hps: 4127.55625
  }
 }
 dps_results: {
  key: "TestHoly-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 81.58725
-  tps: 66.39932
-  hps: 5319.57826
+  tps: 38.10606
+  hps: 4783.9391
  }
 }

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -46,42 +46,42 @@ character_stats_results: {
 dps_results: {
  key: "TestShadow-AllItems-AbsolutionRegalia"
  value: {
-  dps: 5215.37937
+  dps: 5164.57384
   tps: 5001.99945
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7246.87874
+  dps: 7180.5237
   tps: 6980.76798
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7283.96624
+  dps: 7217.25729
   tps: 7016.33205
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7103.93859
+  dps: 7038.0313
   tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6946.63392
+  dps: 6883.08268
   tps: 6692.63687
   hps: 88.41863
  }
@@ -89,7 +89,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6946.63392
+  dps: 6883.08268
   tps: 6692.63687
   hps: 88.41863
  }
@@ -97,49 +97,49 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7131.74259
+  dps: 7065.82184
   tps: 6867.1703
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5977.94276
+  dps: 5922.0786
   tps: 5745.8846
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7145.13061
+  dps: 7078.82116
   tps: 6742.10569
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7269.54495
+  dps: 7203.62421
   tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
   hps: 64
  }
@@ -147,1057 +147,1057 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 7497.44916
+  dps: 7425.33366
   tps: 7201.99347
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 8688.61684
+  dps: 8622.96838
   tps: 8423.11803
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7065.58021
+  dps: 7002.1095
   tps: 6811.80656
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7128.07281
+  dps: 7065.04988
   tps: 6874.87104
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7041.02444
+  dps: 6977.84112
   tps: 6796.7544
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6980.52358
+  dps: 6917.10749
   tps: 6726.83508
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7136.16005
+  dps: 7070.23931
   tps: 6871.78215
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7681.84674
+  dps: 7615.09152
   tps: 7415.96876
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7598.93668
+  dps: 7532.74407
   tps: 7335.82996
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7103.93859
+  dps: 7038.0313
   tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7150.3731
+  dps: 7084.06365
   tps: 6883.90215
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7131.74259
+  dps: 7065.82184
   tps: 6867.36469
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7127.29857
+  dps: 7061.38498
   tps: 6862.89107
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7109.6941
+  dps: 7046.29406
   tps: 6858.12022
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7103.93859
+  dps: 7038.0313
   tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7130.40545
+  dps: 7067.76575
   tps: 6878.16124
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7278.66346
+  dps: 7213.19453
   tps: 7016.31243
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6961.74278
+  dps: 6898.26889
   tps: 6707.41501
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7132.24465
+  dps: 7066.9835
   tps: 6870.84269
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7039.12802
+  dps: 6975.66551
   tps: 6785.31486
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7145.13061
+  dps: 7078.82116
   tps: 6878.94894
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7136.89221
+  dps: 7070.66319
   tps: 6871.05677
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7066.87504
+  dps: 7000.85318
   tps: 6805.11495
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GarbofFaith"
  value: {
-  dps: 6355.36192
+  dps: 6293.81843
   tps: 6106.54656
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 6790.77625
+  dps: 6720.22721
   tps: 6497.13055
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 6929.48265
+  dps: 6867.47913
   tps: 6659.95406
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7265.42249
+  dps: 7198.89049
   tps: 6998.55001
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7307.56738
+  dps: 7240.63321
   tps: 7038.96372
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7092.0406
+  dps: 7029.51581
   tps: 6839.2775
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-49982"
  value: {
-  dps: 7269.54495
+  dps: 7203.62421
   tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-50641"
  value: {
-  dps: 7269.54495
+  dps: 7203.62421
   tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7131.74259
+  dps: 7065.82184
   tps: 6867.36469
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7127.29857
+  dps: 7061.38498
   tps: 6862.89107
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7113.79542
+  dps: 7047.71723
   tps: 6853.45039
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7103.93859
+  dps: 7038.0313
   tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50179"
  value: {
-  dps: 7269.54495
+  dps: 7203.62421
   tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50708"
  value: {
-  dps: 7269.54495
+  dps: 7203.62421
   tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7016.12023
+  dps: 6949.86464
   tps: 6755.81861
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7040.95691
+  dps: 6977.49439
   tps: 6787.14375
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7232.52516
+  dps: 7167.05739
   tps: 6970.51278
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Nibelung-49992"
  value: {
-  dps: 7269.54495
+  dps: 7203.62421
   tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Nibelung-50648"
  value: {
-  dps: 7269.54495
+  dps: 7203.62421
   tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7103.93859
+  dps: 7038.0313
   tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7103.93859
+  dps: 7038.0313
   tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7103.93859
+  dps: 7038.0313
   tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7103.93859
+  dps: 7038.0313
   tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RegaliaofFaith"
  value: {
-  dps: 6152.3564
+  dps: 6091.90776
   tps: 5899.57281
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7363.33817
+  dps: 7298.17918
   tps: 7101.02785
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7414.01554
+  dps: 7348.5701
   tps: 7150.46811
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7239.2827
+  dps: 7173.37542
   tps: 6974.83221
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7103.93859
+  dps: 7038.0313
   tps: 6838.92515
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationGarb"
  value: {
-  dps: 6915.15711
+  dps: 6851.80673
   tps: 6658.12643
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationRegalia"
  value: {
-  dps: 6596.68756
+  dps: 6533.35693
   tps: 6335.93423
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7211.47704
+  dps: 7145.45981
   tps: 6949.63641
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7245.19295
+  dps: 7178.85399
   tps: 6982.38348
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7071.55602
+  dps: 7006.87398
   tps: 6812.64694
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7063.23123
+  dps: 6999.73824
   tps: 6809.39044
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SparkofLife-37657"
  value: {
-  dps: 7082.05267
+  dps: 7018.70576
   tps: 6825.07284
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6955.79321
+  dps: 6892.60138
   tps: 6702.52482
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7103.93859
+  dps: 7038.0313
   tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7103.93859
+  dps: 7038.0313
   tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7103.93859
+  dps: 7038.0313
   tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7009.4044
+  dps: 6944.43241
   tps: 6751.69818
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6973.48936
+  dps: 6910.05566
   tps: 6718.57509
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6945.12136
+  dps: 6881.64582
   tps: 6691.40581
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7103.93859
+  dps: 7038.0313
   tps: 6839.48809
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6955.79321
+  dps: 6892.60138
   tps: 6702.52482
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6955.79321
+  dps: 6892.60138
   tps: 6702.52482
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7145.13061
+  dps: 7078.82116
   tps: 6878.94894
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7136.89221
+  dps: 7070.66319
   tps: 6871.05677
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7166.07706
+  dps: 7101.43415
   tps: 6909.61154
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7136.89221
+  dps: 7070.66319
   tps: 6871.05677
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7145.13061
+  dps: 7078.82116
   tps: 6878.94894
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7563.60834
+  dps: 7496.43917
   tps: 7294.05439
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VestmentsofAbsolution"
  value: {
-  dps: 5086.13636
+  dps: 5036.17043
   tps: 4871.32012
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7081.61876
+  dps: 7015.12737
   tps: 6815.19166
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRaiment"
  value: {
-  dps: 6504.64961
+  dps: 6442.35951
   tps: 6246.86201
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRegalia"
  value: {
-  dps: 6858.40695
+  dps: 6795.14727
   tps: 6597.21322
  }
 }
 dps_results: {
  key: "TestShadow-Average-Default"
  value: {
-  dps: 7338.33372
+  dps: 7270.16218
   tps: 7070.73441
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7278.33213
+  dps: 7212.76721
   tps: 7709.45276
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7278.33213
+  dps: 7212.76721
   tps: 7014.56678
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8647.16609
+  dps: 8447.65335
   tps: 7834.17551
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3798.86536
+  dps: 3763.12834
   tps: 4556.08738
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3798.86536
+  dps: 3763.12834
   tps: 3710.26527
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3971.64182
+  dps: 3871.62847
   tps: 3656.06736
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Clipping-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7278.33213
+  dps: 7212.76721
   tps: 7709.45276
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Clipping-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7278.33213
+  dps: 7212.76721
   tps: 7014.56678
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Clipping-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8647.16609
+  dps: 8447.65335
   tps: 7834.17551
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Clipping-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3798.86536
+  dps: 3763.12834
   tps: 4556.08738
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Clipping-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3798.86536
+  dps: 3763.12834
   tps: 3710.26527
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Clipping-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3971.64182
+  dps: 3871.62847
   tps: 3656.06736
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Ideal-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7278.33213
+  dps: 7212.76721
   tps: 7709.45276
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Ideal-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7278.33213
+  dps: 7212.76721
   tps: 7014.56678
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Ideal-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8647.16609
+  dps: 8447.65335
   tps: 7834.17551
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Ideal-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3798.86536
+  dps: 3763.12834
   tps: 4556.08738
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Ideal-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3798.86536
+  dps: 3763.12834
   tps: 3710.26527
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Ideal-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3971.64182
+  dps: 3871.62847
   tps: 3656.06736
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7265.38882
+  dps: 7199.57058
   tps: 7703.19008
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7265.38882
+  dps: 7199.57058
   tps: 7001.25511
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8641.80372
+  dps: 8442.40384
   tps: 7829.0883
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3785.301
+  dps: 3749.42634
   tps: 4542.50185
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3785.301
+  dps: 3749.42634
   tps: 3696.35081
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3965.9512
+  dps: 3865.99425
   tps: 3650.45945
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Clipping-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7265.38882
+  dps: 7199.57058
   tps: 7703.19008
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Clipping-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7265.38882
+  dps: 7199.57058
   tps: 7001.25511
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Clipping-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8641.80372
+  dps: 8442.40384
   tps: 7829.0883
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Clipping-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3785.301
+  dps: 3749.42634
   tps: 4542.50185
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Clipping-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3785.301
+  dps: 3749.42634
   tps: 3696.35081
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Clipping-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3965.9512
+  dps: 3865.99425
   tps: 3650.45945
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Ideal-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7265.38882
+  dps: 7199.57058
   tps: 7703.19008
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Ideal-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7265.38882
+  dps: 7199.57058
   tps: 7001.25511
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Ideal-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8641.80372
+  dps: 8442.40384
   tps: 7829.0883
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Ideal-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3785.301
+  dps: 3749.42634
   tps: 4542.50185
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Ideal-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3785.301
+  dps: 3749.42634
   tps: 3696.35081
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Ideal-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3965.9512
+  dps: 3865.99425
   tps: 3650.45945
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Basic-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7269.54495
+  dps: 7203.62421
   tps: 7705.74594
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Basic-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7269.54495
+  dps: 7203.62421
   tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Basic-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8646.83433
+  dps: 8447.15232
   tps: 7833.61075
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Basic-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3794.58518
+  dps: 3758.56835
   tps: 4550.17994
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Basic-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3794.58518
+  dps: 3758.56835
   tps: 3705.28086
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Basic-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3968.19958
+  dps: 3868.11911
   tps: 3652.52035
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Clipping-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7269.54495
+  dps: 7203.62421
   tps: 7705.74594
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Clipping-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7269.54495
+  dps: 7203.62421
   tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Clipping-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8646.83433
+  dps: 8447.15232
   tps: 7833.61075
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Clipping-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3794.58518
+  dps: 3758.56835
   tps: 4550.17994
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Clipping-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3794.58518
+  dps: 3758.56835
   tps: 3705.28086
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Clipping-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3968.19958
+  dps: 3868.11911
   tps: 3652.52035
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Ideal-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7269.54495
+  dps: 7203.62421
   tps: 7705.74594
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Ideal-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7269.54495
+  dps: 7203.62421
   tps: 7005.16705
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Ideal-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8646.83433
+  dps: 8447.15232
   tps: 7833.61075
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Ideal-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3794.58518
+  dps: 3758.56835
   tps: 4550.17994
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Ideal-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3794.58518
+  dps: 3758.56835
   tps: 3705.28086
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Ideal-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3968.19958
+  dps: 3868.11911
   tps: 3652.52035
  }
 }
 dps_results: {
  key: "TestShadow-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7226.34532
+  dps: 7206.42932
   tps: 7005.16705
  }
 }

--- a/sim/priest/shadowfiend.go
+++ b/sim/priest/shadowfiend.go
@@ -42,12 +42,11 @@ func (priest *Priest) registerShadowfiendSpell() {
 		},
 	})
 
-	priest.AddMajorCooldown(core.MajorCooldown{
-		Spell:    priest.Shadowfiend,
-		Priority: 1,
-		Type:     core.CooldownTypeMana,
-		ShouldActivate: func(sim *core.Simulation, character *core.Character) bool {
-			return character.CurrentManaPercent() <= 0.5
-		},
-	})
+	if !priest.IsUsingAPL {
+		priest.AddMajorCooldown(core.MajorCooldown{
+			Spell:    priest.Shadowfiend,
+			Priority: 1,
+			Type:     core.CooldownTypeMana,
+		})
+	}
 }

--- a/sim/priest/smite/TestSmite.results
+++ b/sim/priest/smite/TestSmite.results
@@ -46,822 +46,822 @@ character_stats_results: {
 dps_results: {
  key: "TestSmite-AllItems-AbsolutionRegalia"
  value: {
-  dps: 2439.72155
-  tps: 1999.93002
+  dps: 1995.65978
+  tps: 1685.19061
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 3556.55337
-  tps: 2915.44059
+  dps: 2894.04696
+  tps: 2431.07532
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 3573.51644
-  tps: 2928.99069
+  dps: 2907.685
+  tps: 2442.39619
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 3515.04676
-  tps: 2879.82409
+  dps: 2844.67304
+  tps: 2388.45874
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 3424.79122
-  tps: 2811.10192
-  hps: 89.19554
+  dps: 2784.21341
+  tps: 2340.78415
+  hps: 90.33849
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 3424.79122
-  tps: 2811.10192
-  hps: 89.19554
+  dps: 2784.21341
+  tps: 2340.78415
+  hps: 90.33849
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 3557.12446
-  tps: 2916.06363
+  dps: 2896.6066
+  tps: 2430.4724
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 2719.66531
-  tps: 2227.23205
+  dps: 2214.0364
+  tps: 1868.07834
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 3534.13248
-  tps: 2838.30646
+  dps: 2859.94481
+  tps: 2353.70915
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 3550.74408
-  tps: 2907.79899
+  dps: 2874.02992
+  tps: 2411.10571
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
   hps: 64
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 4044.12149
-  tps: 3322.15915
+  dps: 3656.43315
+  tps: 3094.38378
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 4089.41418
-  tps: 3356.13556
+  dps: 3403.97761
+  tps: 2858.95096
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 3465.75677
-  tps: 2843.63745
+  dps: 2809.61022
+  tps: 2358.63454
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 3494.1806
-  tps: 2878.12428
+  dps: 2856.17338
+  tps: 2406.6212
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 3494.02523
-  tps: 2865.07831
+  dps: 2988.88506
+  tps: 2512.16435
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Death'sChoice-47464"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 3430.97844
-  tps: 2814.68799
+  dps: 2792.70508
+  tps: 2346.01678
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Defender'sCode-40257"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 3519.42164
-  tps: 2882.9391
+  dps: 2848.80173
+  tps: 2390.98808
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 3588.34351
-  tps: 2939.33739
+  dps: 2892.00829
+  tps: 2422.7308
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 3566.84623
-  tps: 2925.67831
+  dps: 2878.27734
+  tps: 2413.69279
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 3515.04676
-  tps: 2879.82409
+  dps: 2844.67304
+  tps: 2388.45874
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 3567.28222
-  tps: 2923.4926
+  dps: 2901.60191
+  tps: 2436.99942
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 3517.91455
-  tps: 2881.53537
+  dps: 2846.44341
+  tps: 2389.0365
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 3516.23677
-  tps: 2880.78429
+  dps: 2846.03224
+  tps: 2389.54878
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 3439.83625
-  tps: 2820.40862
+  dps: 2775.36116
+  tps: 2330.40091
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 3515.04676
-  tps: 2879.82409
+  dps: 2844.67304
+  tps: 2388.45874
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 3517.15524
-  tps: 2893.77741
+  dps: 2847.15813
+  tps: 2398.41544
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 3560.48484
-  tps: 2917.233
+  dps: 2886.63813
+  tps: 2423.12085
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 3512.48539
-  tps: 2884.34163
+  dps: 2927.69669
+  tps: 2463.26545
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 3504.12206
-  tps: 2873.55847
+  dps: 2851.89303
+  tps: 2396.08356
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ForgeEmber-37660"
  value: {
-  dps: 3503.46119
-  tps: 2873.46369
+  dps: 2851.36407
+  tps: 2394.13159
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 3534.13248
-  tps: 2895.06231
+  dps: 2859.94481
+  tps: 2401.12839
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 3530.31533
-  tps: 2892.01467
+  dps: 2856.89045
+  tps: 2398.59446
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-FuturesightRune-38763"
  value: {
-  dps: 3513.79187
-  tps: 2883.95344
+  dps: 2865.78098
+  tps: 2408.01177
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-GarbofFaith"
  value: {
-  dps: 3195.27336
-  tps: 2629.64243
+  dps: 2622.90525
+  tps: 2209.44725
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 3674.16429
-  tps: 3020.28957
+  dps: 3097.07074
+  tps: 2621.61262
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 3424.33159
-  tps: 2812.71505
+  dps: 2778.12313
+  tps: 2340.70258
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 3565.03491
-  tps: 2922.21564
+  dps: 2900.86598
+  tps: 2436.73575
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 3584.31112
-  tps: 2937.61348
+  dps: 2916.36375
+  tps: 2449.60037
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 3486.02121
-  tps: 2866.63403
+  dps: 2850.05052
+  tps: 2398.02263
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Heartpierce-49982"
  value: {
-  dps: 3567.28222
-  tps: 2923.4926
+  dps: 2901.60191
+  tps: 2436.99942
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Heartpierce-50641"
  value: {
-  dps: 3567.28222
-  tps: 2923.4926
+  dps: 2901.60191
+  tps: 2436.99942
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 3517.91455
-  tps: 2881.53537
+  dps: 2846.44341
+  tps: 2389.0365
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 3516.23677
-  tps: 2880.78429
+  dps: 2846.03224
+  tps: 2389.54878
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-IncisorFragment-37723"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 3655.53806
-  tps: 3005.99579
+  dps: 2985.93267
+  tps: 2511.63616
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 3515.04676
-  tps: 2879.82409
+  dps: 2844.67304
+  tps: 2388.45874
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-LastWord-50179"
  value: {
-  dps: 3567.28222
-  tps: 2923.4926
+  dps: 2901.60191
+  tps: 2436.99942
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-LastWord-50708"
  value: {
-  dps: 3567.28222
-  tps: 2923.4926
+  dps: 2901.60191
+  tps: 2436.99942
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 3589.38904
-  tps: 2949.50656
+  dps: 2955.91562
+  tps: 2482.50483
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 3440.3824
-  tps: 2821.44998
+  dps: 2799.28132
+  tps: 2351.15048
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 3519.20886
-  tps: 2885.74614
+  dps: 2863.61187
+  tps: 2405.67062
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Nibelung-49992"
  value: {
-  dps: 3567.28222
-  tps: 2923.4926
+  dps: 2901.60191
+  tps: 2436.99942
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Nibelung-50648"
  value: {
-  dps: 3567.28222
-  tps: 2923.4926
+  dps: 2901.60191
+  tps: 2436.99942
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 3515.04676
-  tps: 2879.82409
+  dps: 2844.67304
+  tps: 2388.45874
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 3515.04676
-  tps: 2879.82409
+  dps: 2844.67304
+  tps: 2388.45874
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 3515.04676
-  tps: 2879.82409
+  dps: 2844.67304
+  tps: 2388.45874
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 3515.04676
-  tps: 2879.82409
+  dps: 2844.67304
+  tps: 2388.45874
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RegaliaofFaith"
  value: {
-  dps: 3171.70798
-  tps: 2614.34326
+  dps: 2639.07517
+  tps: 2233.62531
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 3636.78793
-  tps: 3002.77267
+  dps: 2965.6255
+  tps: 2506.39096
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 3664.12974
-  tps: 3027.33494
+  dps: 2988.30259
+  tps: 2527.17565
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 3547.63247
-  tps: 2905.89266
+  dps: 2872.02031
+  tps: 2410.33656
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 3533.41433
-  tps: 2896.81646
+  dps: 2869.30107
+  tps: 2408.39573
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SanctificationGarb"
  value: {
-  dps: 3381.69858
-  tps: 2785.47441
+  dps: 2766.23464
+  tps: 2331.88086
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SanctificationRegalia"
  value: {
-  dps: 3379.04248
-  tps: 2779.34229
+  dps: 2799.71504
+  tps: 2362.65649
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 3655.32002
-  tps: 3010.35987
+  dps: 3004.25046
+  tps: 2532.71111
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 3696.66999
-  tps: 3045.47916
+  dps: 3024.45542
+  tps: 2551.52189
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SoulPreserver-37111"
  value: {
-  dps: 3476.3643
-  tps: 2851.38558
+  dps: 2829.57624
+  tps: 2377.55851
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SouloftheDead-40382"
  value: {
-  dps: 3568.38796
-  tps: 2941.41224
+  dps: 2942.10685
+  tps: 2478.39753
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SparkofLife-37657"
  value: {
-  dps: 3509.33269
-  tps: 2879.94573
+  dps: 2879.02312
+  tps: 2419.68116
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 3449.56279
-  tps: 2830.83871
+  dps: 2809.43043
+  tps: 2361.09267
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 3515.04676
-  tps: 2879.82409
+  dps: 2844.67304
+  tps: 2388.45874
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 3515.04676
-  tps: 2879.82409
+  dps: 2844.67304
+  tps: 2388.45874
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 3515.04676
-  tps: 2879.82409
+  dps: 2844.67304
+  tps: 2388.45874
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 3492.64077
-  tps: 2867.46623
+  dps: 2857.32763
+  tps: 2399.73234
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 3565.45289
-  tps: 2929.69927
+  dps: 2918.1954
+  tps: 2453.9325
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 3418.53565
-  tps: 2805.19206
+  dps: 2783.08293
+  tps: 2338.96466
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 3515.04676
-  tps: 2879.82409
+  dps: 2844.67304
+  tps: 2388.45874
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 3449.56279
-  tps: 2830.83871
+  dps: 2809.43043
+  tps: 2361.09267
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 3449.56279
-  tps: 2830.83871
+  dps: 2809.43043
+  tps: 2361.09267
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 3534.13248
-  tps: 2895.06231
+  dps: 2859.94481
+  tps: 2401.12839
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 3530.31533
-  tps: 2892.01467
+  dps: 2856.89045
+  tps: 2398.59446
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 3499.57866
-  tps: 2869.39443
+  dps: 2822.59725
+  tps: 2369.91019
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 3530.31533
-  tps: 2892.01467
+  dps: 2856.89045
+  tps: 2398.59446
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 3534.13248
-  tps: 2895.06231
+  dps: 2859.94481
+  tps: 2401.12839
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 3670.3816
-  tps: 3003.42647
+  dps: 2971.98183
+  tps: 2487.99516
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-VestmentsofAbsolution"
  value: {
-  dps: 2359.60453
-  tps: 1934.03968
+  dps: 1927.27166
+  tps: 1630.71415
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-WingedTalisman-37844"
  value: {
-  dps: 3474.00422
-  tps: 2851.44258
+  dps: 2835.27316
+  tps: 2382.3622
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Zabra'sRaiment"
  value: {
-  dps: 3372.11
-  tps: 2777.18447
+  dps: 2815.72712
+  tps: 2378.09865
  }
 }
 dps_results: {
  key: "TestSmite-AllItems-Zabra'sRegalia"
  value: {
-  dps: 3538.85721
-  tps: 2908.07518
+  dps: 2931.27671
+  tps: 2466.27309
  }
 }
 dps_results: {
  key: "TestSmite-Average-Default"
  value: {
-  dps: 3572.59181
-  tps: 2929.61876
+  dps: 2892.01638
+  tps: 2428.52981
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-p1-Basic-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3567.28222
-  tps: 4024.17641
+  dps: 2901.60191
+  tps: 3015.73285
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-p1-Basic-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3567.28222
-  tps: 2923.4926
+  dps: 2901.60191
+  tps: 2436.99942
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-p1-Basic-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4892.96346
-  tps: 4109.83599
+  dps: 4836.07031
+  tps: 4107.85388
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-p1-Basic-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1195.49321
-  tps: 1418.57429
+  dps: 896.13946
+  tps: 839.16729
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-p1-Basic-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1195.49321
-  tps: 966.68622
+  dps: 896.13946
+  tps: 745.40377
  }
 }
 dps_results: {
  key: "TestSmite-Settings-Undead-p1-Basic-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2827.933
-  tps: 2204.06829
+  dps: 2520.9093
+  tps: 2134.74022
  }
 }
 dps_results: {
  key: "TestSmite-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3551.04865
-  tps: 2923.4926
+  dps: 2901.60191
+  tps: 2436.99942
  }
 }

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -13,7 +13,7 @@ character_stats_results: {
   final_stats: 221
   final_stats: 0
   final_stats: 5504.84
-  final_stats: 469.94994
+  final_stats: 469.94995
   final_stats: 2072.9756
   final_stats: 221
   final_stats: 94

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -13,7 +13,7 @@ character_stats_results: {
   final_stats: 264
   final_stats: 0
   final_stats: 5996.3904
-  final_stats: 418.94994
+  final_stats: 418.94995
   final_stats: 2218.9399
   final_stats: 264
   final_stats: 94

--- a/ui/core/proto_utils/utils.ts
+++ b/ui/core/proto_utils/utils.ts
@@ -1156,12 +1156,12 @@ const paladinRaces = [
 	Race.RaceHuman,
 ];
 const priestRaces = [
+	Race.RaceTroll,
 	Race.RaceBloodElf,
 	Race.RaceDraenei,
 	Race.RaceDwarf,
 	Race.RaceHuman,
 	Race.RaceNightElf,
-	Race.RaceTroll,
 	Race.RaceUndead,
 ];
 const rogueRaces = [

--- a/ui/shadow_priest/presets.ts
+++ b/ui/shadow_priest/presets.ts
@@ -6,12 +6,14 @@ import {
 	Glyphs,
 	IndividualBuffs,
 	Potions,
+	Profession,
 	RaidBuffs,
 	TristateEffect,
 } from '../core/proto/common.js';
 import { SavedTalents } from '../core/proto/ui.js';
 
 import {
+	ShadowPriest_Options_Armor as Armor,
 	ShadowPriest_Rotation as Rotation,
 	ShadowPriest_Options as Options,
 	ShadowPriest_Rotation_RotationType,
@@ -64,7 +66,7 @@ export const DefaultOptions = Options.create({
 	useShadowfiend: true,
 	useMindBlast: true,
 	useShadowWordDeath: true,
-	latency: 100,
+	armor: Armor.InnerFire,
 });
 
 export const DefaultConsumes = Consumes.create({
@@ -105,8 +107,11 @@ export const DefaultDebuffs = Debuffs.create({
 	ebonPlaguebringer: true,
 	heartOfTheCrusader: true,
 	judgementOfWisdom: true,
+	shadowMastery: true,
 });
 
 export const OtherDefaults = {
 	channelClipDelay: 100,
+	profession1: Profession.Engineering,
+	profession2: Profession.Tailoring,
 };


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1ctQRsrlzE_AVyNA9nbrTOUbLwe28zYTk_T461_DJ3YM/edit#gid=0

Bunch of shadowfiend scaling fixes after investigation:
- Shadowfiend doesn't miss (no misses, dodges, parries, etc.)
- Shadowfiend base damage was too high
- Shadowfiend SP scaling was too high
- Shadowfiend strength scaling was incorrect
- Crit % in logs is much higher, around 9-12% but I didn't test this explicitly, so it's around 11% now

Also fix shadow priest presets