### PR TITLE
vigo/aura-stuff

### DIFF
--- a/sim/core/environment.go
+++ b/sim/core/environment.go
@@ -36,8 +36,6 @@ type Environment struct {
 	Encounter Encounter
 	AllUnits  []*Unit
 
-	characters []*Character // "cached" in init(), for advance()
-
 	BaseDuration      time.Duration // base duration
 	DurationVariation time.Duration // variation per duration
 
@@ -194,7 +192,6 @@ func (env *Environment) finalize(raidProto *proto.Raid, _ *proto.Encounter, raid
 		sim := newSimWithEnv(env, &proto.SimOptions{
 			Iterations: 1,
 		})
-		sim.Init()
 		sim.reset()
 		sim.PrePull()
 		sim.Cleanup()

--- a/sim/core/pet.go
+++ b/sim/core/pet.go
@@ -251,6 +251,8 @@ func (pet *Pet) Disable(sim *Simulation) {
 		pet.OnPetDisable(sim)
 	}
 
+	pet.auraTracker.expireAll(sim)
+
 	sim.removeTracker(&pet.auraTracker)
 
 	if sim.Log != nil {

--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -257,25 +257,6 @@ func (sim *Simulation) Reseed(seed int64) {
 	sim.reseedRands(seed)
 }
 
-func (sim *Simulation) Init() {
-	for _, target := range sim.Encounter.Targets {
-		target.init(sim)
-	}
-
-	for _, party := range sim.Raid.Parties {
-		for _, player := range party.Players {
-			character := player.GetCharacter()
-			character.init(sim)
-
-			for _, pet := range character.Pets {
-				pet.init(sim)
-			}
-
-			sim.characters = append(sim.characters, character)
-		}
-	}
-}
-
 // Run runs the simulation for the configured number of iterations, and
 // collects all the metrics together.
 func (sim *Simulation) run() *proto.RaidSimResult {
@@ -293,8 +274,6 @@ func (sim *Simulation) run() *proto.RaidSimResult {
 	// sim.Log = func(message string, vals ...interface{}) {
 	// 	fmt.Printf(fmt.Sprintf("[%0.1f] "+message+"\n", append([]interface{}{sim.CurrentTime.Seconds()}, vals...)...))
 	// }
-
-	sim.Init()
 
 	sim.runOnce()
 	firstIterationDuration := sim.Duration

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -449,10 +449,6 @@ func (unit *Unit) finalize() {
 	}
 }
 
-func (unit *Unit) init(sim *Simulation) {
-	unit.auraTracker.init(sim)
-}
-
 func (unit *Unit) reset(sim *Simulation, _ Agent) {
 	unit.enabled = true
 	unit.resetCDs(sim)

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -110,8 +110,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 8922.12473
-  tps: 5752.63543
+  dps: 8922.1323
+  tps: 5752.64694
   hps: 259.25488
  }
 }
@@ -454,8 +454,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 11999.96041
-  tps: 7973.39438
+  dps: 11999.9702
+  tps: 7973.40926
   hps: 354.70907
  }
 }
@@ -678,8 +678,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 11993.79722
-  tps: 7968.59879
+  dps: 11993.807
+  tps: 7968.61366
   hps: 354.70907
  }
 }
@@ -694,8 +694,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 8762.55163
-  tps: 5593.55439
+  dps: 8762.55823
+  tps: 5593.56442
   hps: 284.94914
  }
 }
@@ -894,8 +894,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 10116.60471
-  tps: 6593.78774
+  dps: 10116.61902
+  tps: 6593.8095
   hps: 285.90184
  }
 }
@@ -1022,8 +1022,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 12079.79774
-  tps: 7959.30783
+  dps: 12079.79755
+  tps: 7959.30754
   hps: 319.10091
  }
 }
@@ -1038,8 +1038,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11918.71627
-  tps: 7937.39165
+  dps: 11918.70505
+  tps: 7937.3746
   hps: 320.44626
  }
 }
@@ -1222,8 +1222,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 58800.10394
-  tps: 61393.11759
+  dps: 58799.838
+  tps: 61392.71336
   hps: 321.42877
  }
 }

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -427,8 +427,8 @@ dps_results: {
 dps_results: {
  key: "TestBM-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5010.01957
-  tps: 3329.43898
+  dps: 5009.99192
+  tps: 3329.41133
  }
 }
 dps_results: {
@@ -883,8 +883,8 @@ dps_results: {
 dps_results: {
  key: "TestBM-Average-Default"
  value: {
-  dps: 6433.20289
-  tps: 4349.46161
+  dps: 6433.20261
+  tps: 4349.46133
  }
 }
 dps_results: {

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -118,8 +118,8 @@ dps_results: {
 dps_results: {
  key: "TestMM-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 6686.52738
-  tps: 5771.94376
+  dps: 6686.53191
+  tps: 5771.94829
  }
 }
 dps_results: {
@@ -883,8 +883,8 @@ dps_results: {
 dps_results: {
  key: "TestMM-Average-Default"
  value: {
-  dps: 7344.09626
-  tps: 6425.47971
+  dps: 7344.09621
+  tps: 6425.47967
  }
 }
 dps_results: {

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -118,8 +118,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 7194.5108
-  tps: 6155.87799
+  dps: 7194.51316
+  tps: 6155.88035
  }
 }
 dps_results: {
@@ -210,15 +210,15 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7425.02994
-  tps: 6385.17627
+  dps: 7425.03998
+  tps: 6385.18631
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7469.95689
-  tps: 6430.25502
+  dps: 7469.96694
+  tps: 6430.26506
  }
 }
 dps_results: {
@@ -231,15 +231,15 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7784.13327
-  tps: 6715.61133
+  dps: 7784.14332
+  tps: 6715.62137
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7396.17936
-  tps: 6357.10266
+  dps: 7396.1894
+  tps: 6357.1127
  }
 }
 dps_results: {
@@ -273,8 +273,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7385.71833
-  tps: 6359.45593
+  dps: 7385.72837
+  tps: 6359.46597
  }
 }
 dps_results: {
@@ -336,15 +336,15 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7480.9062
-  tps: 6441.19766
+  dps: 7480.91424
+  tps: 6441.20569
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7416.28413
-  tps: 6376.32826
+  dps: 7416.29418
+  tps: 6376.3383
  }
 }
 dps_results: {
@@ -364,8 +364,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7392.79724
-  tps: 6353.46465
+  dps: 7392.80728
+  tps: 6353.47469
  }
 }
 dps_results: {
@@ -399,8 +399,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 7432.98729
-  tps: 6441.48965
+  dps: 7432.96221
+  tps: 6441.46457
  }
 }
 dps_results: {
@@ -420,8 +420,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7445.33117
-  tps: 6405.78072
+  dps: 7445.3402
+  tps: 6405.78976
  }
 }
 dps_results: {
@@ -483,8 +483,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7485.77625
-  tps: 6430.34335
+  dps: 7485.7863
+  tps: 6430.3534
   hps: 12.062
  }
 }
@@ -547,8 +547,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.78407
+  tps: 6282.62319
  }
 }
 dps_results: {
@@ -701,15 +701,15 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7418.26087
-  tps: 6380.04354
+  dps: 7418.27092
+  tps: 6380.05358
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SparkofLife-37657"
  value: {
-  dps: 7346.83555
-  tps: 6307.83386
+  dps: 7346.8252
+  tps: 6307.82351
  }
 }
 dps_results: {
@@ -722,8 +722,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-StormshroudArmor"
  value: {
-  dps: 5749.16653
-  tps: 4917.56435
+  dps: 5749.1606
+  tps: 4917.55842
  }
 }
 dps_results: {
@@ -764,8 +764,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-TheFistsofFury"
  value: {
-  dps: 7286.56585
-  tps: 6255.03199
+  dps: 7286.57619
+  tps: 6255.04233
  }
 }
 dps_results: {
@@ -778,15 +778,15 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7427.14457
-  tps: 6394.70422
+  dps: 7427.15491
+  tps: 6394.71457
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7462.64882
-  tps: 6411.87337
+  dps: 7462.64808
+  tps: 6411.87264
  }
 }
 dps_results: {
@@ -869,22 +869,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7907.75642
-  tps: 6856.68995
+  dps: 7907.74607
+  tps: 6856.67961
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 8038.02534
-  tps: 6996.15478
+  dps: 8038.02702
+  tps: 6996.15646
  }
 }
 dps_results: {
  key: "TestSV-Average-Default"
  value: {
-  dps: 7613.429
-  tps: 6565.95867
+  dps: 7613.42876
+  tps: 6565.95842
  }
 }
 dps_results: {
@@ -918,8 +918,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1458.77564
-  tps: 1151.94758
+  dps: 1458.77488
+  tps: 1151.94682
  }
 }
 dps_results: {
@@ -995,8 +995,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11127.56021
-  tps: 12244.96943
+  dps: 11127.64581
+  tps: 12245.05503
  }
 }
 dps_results: {
@@ -1016,15 +1016,15 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31043.87526
-  tps: 30943.98744
+  dps: 31043.96692
+  tps: 30944.07909
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3673.65532
-  tps: 2631.13163
+  dps: 3673.6404
+  tps: 2631.11671
  }
 }
 dps_results: {
@@ -1044,8 +1044,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1479.79057
-  tps: 1153.06491
+  dps: 1479.7841
+  tps: 1153.05843
  }
 }
 dps_results: {
@@ -1142,7 +1142,7 @@ dps_results: {
 dps_results: {
  key: "TestSV-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7549.75619
-  tps: 6580.76751
+  dps: 7549.76383
+  tps: 6580.77515
  }
 }

--- a/sim/lib/library.go
+++ b/sim/lib/library.go
@@ -154,7 +154,6 @@ func new(json *C.char) {
 	}
 	sim.RegisterAll()
 	_active_sim = core.NewSim(input)
-	_active_sim.Init()
 	_active_sim.Reseed(_active_seed)
 	_active_seed += 1
 	_active_sim.Reset()

--- a/sim/priest/healing/TestHoly.results
+++ b/sim/priest/healing/TestHoly.results
@@ -768,7 +768,7 @@ dps_results: {
  key: "TestHoly-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
   tps: 38.31735
-  hps: 5127.10194
+  hps: 5126.68095
  }
 }
 dps_results: {

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -46,788 +46,788 @@ character_stats_results: {
 dps_results: {
  key: "TestShadow-AllItems-AbsolutionRegalia"
  value: {
-  dps: 5164.57384
-  tps: 5001.99945
+  dps: 5163.87973
+  tps: 5002.24826
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7180.5237
-  tps: 6980.76798
+  dps: 7179.43613
+  tps: 6979.65399
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7217.25729
-  tps: 7016.33205
+  dps: 7216.16324
+  tps: 7015.21411
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7038.0313
-  tps: 6839.48809
+  dps: 7036.95443
+  tps: 6838.39051
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6883.08268
-  tps: 6692.63687
+  dps: 6882.12464
+  tps: 6691.55493
   hps: 88.41863
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6883.08268
-  tps: 6692.63687
+  dps: 6882.12464
+  tps: 6691.55493
   hps: 88.41863
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7065.82184
-  tps: 6867.1703
+  dps: 7064.74369
+  tps: 6866.06658
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5922.0786
-  tps: 5745.8846
+  dps: 5921.0744
+  tps: 5744.91657
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7078.82116
-  tps: 6742.10569
+  dps: 7077.73702
+  tps: 6741.01949
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7203.62421
-  tps: 7005.16705
+  dps: 7202.53046
+  tps: 7004.0493
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
   hps: 64
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 7425.33366
-  tps: 7201.99347
+  dps: 7424.45702
+  tps: 7202.50548
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 8622.96838
-  tps: 8423.11803
+  dps: 8622.86792
+  tps: 8423.89568
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7002.1095
-  tps: 6811.80656
+  dps: 7001.07427
+  tps: 6810.72757
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7065.04988
-  tps: 6874.87104
+  dps: 7064.26298
+  tps: 6874.21792
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6977.84112
-  tps: 6796.7544
+  dps: 6977.29498
+  tps: 6797.12513
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6917.10749
-  tps: 6726.83508
+  dps: 6916.07291
+  tps: 6725.75345
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7070.23931
-  tps: 6871.78215
+  dps: 7069.16115
+  tps: 6870.68
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7615.09152
-  tps: 7415.96876
+  dps: 7614.00777
+  tps: 7415.41407
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7532.74407
-  tps: 7335.82996
+  dps: 7532.38461
+  tps: 7336.29475
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7038.0313
-  tps: 6839.48809
+  dps: 7036.95443
+  tps: 6838.39051
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7084.06365
-  tps: 6883.90215
+  dps: 7082.97951
+  tps: 6882.79778
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7065.82184
-  tps: 6867.36469
+  dps: 7064.74369
+  tps: 6866.26253
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7061.38498
-  tps: 6862.89107
+  dps: 7060.30682
+  tps: 6861.78891
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7046.29406
-  tps: 6858.12022
+  dps: 7045.34981
+  tps: 6858.95973
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7038.0313
-  tps: 6839.48809
+  dps: 7036.95443
+  tps: 6838.39051
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7067.76575
-  tps: 6878.16124
+  dps: 7066.72423
+  tps: 6877.4637
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7213.19453
-  tps: 7016.31243
+  dps: 7212.12119
+  tps: 7015.21031
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6898.26889
-  tps: 6707.41501
+  dps: 6897.23386
+  tps: 6706.32863
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7066.9835
-  tps: 6870.84269
+  dps: 7065.91594
+  tps: 6869.74087
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6975.66551
-  tps: 6785.31486
+  dps: 6974.63026
+  tps: 6784.23586
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7078.82116
-  tps: 6878.94894
+  dps: 7077.73702
+  tps: 6877.84697
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7070.66319
-  tps: 6871.05677
+  dps: 7069.5805
+  tps: 6869.95568
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7000.85318
-  tps: 6805.11495
+  dps: 6999.98726
+  tps: 6804.34294
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GarbofFaith"
  value: {
-  dps: 6293.81843
-  tps: 6106.54656
+  dps: 6292.78795
+  tps: 6106.38747
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 6720.22721
-  tps: 6497.13055
+  dps: 6719.4502
+  tps: 6496.79829
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 6867.47913
-  tps: 6659.95406
+  dps: 6866.74038
+  tps: 6659.90568
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7198.89049
-  tps: 6998.55001
+  dps: 7197.79968
+  tps: 6997.43405
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7240.63321
-  tps: 7038.96372
+  dps: 7239.53505
+  tps: 7037.84328
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7029.51581
-  tps: 6839.2775
+  dps: 7028.74706
+  tps: 6839.03678
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-49982"
  value: {
-  dps: 7203.62421
-  tps: 7005.16705
+  dps: 7202.53046
+  tps: 7004.0493
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-50641"
  value: {
-  dps: 7203.62421
-  tps: 7005.16705
+  dps: 7202.53046
+  tps: 7004.0493
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7065.82184
-  tps: 6867.36469
+  dps: 7064.74369
+  tps: 6866.26253
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7061.38498
-  tps: 6862.89107
+  dps: 7060.30682
+  tps: 6861.78891
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7047.71723
-  tps: 6853.45039
+  dps: 7046.56329
+  tps: 6853.47226
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7038.0313
-  tps: 6839.48809
+  dps: 7036.95443
+  tps: 6838.39051
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50179"
  value: {
-  dps: 7203.62421
-  tps: 7005.16705
+  dps: 7202.53046
+  tps: 7004.0493
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50708"
  value: {
-  dps: 7203.62421
-  tps: 7005.16705
+  dps: 7202.53046
+  tps: 7004.0493
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6949.86464
-  tps: 6755.81861
+  dps: 6948.8873
+  tps: 6754.80477
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6977.49439
-  tps: 6787.14375
+  dps: 6976.45915
+  tps: 6786.06475
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7167.05739
-  tps: 6970.51278
+  dps: 7165.89658
+  tps: 6969.333
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Nibelung-49992"
  value: {
-  dps: 7203.62421
-  tps: 7005.16705
+  dps: 7202.53046
+  tps: 7004.0493
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Nibelung-50648"
  value: {
-  dps: 7203.62421
-  tps: 7005.16705
+  dps: 7202.53046
+  tps: 7004.0493
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7038.0313
-  tps: 6839.48809
+  dps: 7036.95443
+  tps: 6838.39051
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7038.0313
-  tps: 6839.48809
+  dps: 7036.95443
+  tps: 6838.39051
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7038.0313
-  tps: 6839.48809
+  dps: 7036.95443
+  tps: 6838.39051
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7038.0313
-  tps: 6839.48809
+  dps: 7036.95443
+  tps: 6838.39051
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RegaliaofFaith"
  value: {
-  dps: 6091.90776
-  tps: 5899.57281
+  dps: 6091.27365
+  tps: 5899.77057
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7298.17918
-  tps: 7101.02785
+  dps: 7297.53401
+  tps: 7101.04609
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7348.5701
-  tps: 7150.46811
+  dps: 7347.93941
+  tps: 7150.50624
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7173.37542
-  tps: 6974.83221
+  dps: 7172.28296
+  tps: 6973.71904
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7038.0313
-  tps: 6838.92515
+  dps: 7036.95443
+  tps: 6837.82317
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationGarb"
  value: {
-  dps: 6851.80673
-  tps: 6658.12643
+  dps: 6850.88709
+  tps: 6658.43755
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationRegalia"
  value: {
-  dps: 6533.35693
-  tps: 6335.93423
+  dps: 6532.67593
+  tps: 6336.15789
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7145.45981
-  tps: 6949.63641
+  dps: 7144.37842
+  tps: 6948.41856
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7178.85399
-  tps: 6982.38348
+  dps: 7177.76671
+  tps: 6981.08849
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7006.87398
-  tps: 6812.64694
+  dps: 7005.81702
+  tps: 6811.55157
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6999.73824
-  tps: 6809.39044
+  dps: 6998.70317
+  tps: 6808.31161
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SparkofLife-37657"
  value: {
-  dps: 7018.70576
-  tps: 6825.07284
+  dps: 7017.95376
+  tps: 6824.96376
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6892.60138
-  tps: 6702.52482
+  dps: 6891.63494
+  tps: 6701.23244
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7038.0313
-  tps: 6839.48809
+  dps: 7036.95443
+  tps: 6838.39051
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7038.0313
-  tps: 6839.48809
+  dps: 7036.95443
+  tps: 6838.39051
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7038.0313
-  tps: 6839.48809
+  dps: 7036.95443
+  tps: 6838.39051
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6944.43241
-  tps: 6751.69818
+  dps: 6943.3878
+  tps: 6750.59917
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6910.05566
-  tps: 6718.57509
+  dps: 6909.02126
+  tps: 6717.48509
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6881.64582
-  tps: 6691.40581
+  dps: 6880.61094
+  tps: 6690.32387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7038.0313
-  tps: 6839.48809
+  dps: 7036.95443
+  tps: 6838.39051
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6892.60138
-  tps: 6702.52482
+  dps: 6891.63494
+  tps: 6701.23244
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6892.60138
-  tps: 6702.52482
+  dps: 6891.63494
+  tps: 6701.23244
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7078.82116
-  tps: 6878.94894
+  dps: 7077.73702
+  tps: 6877.84697
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7070.66319
-  tps: 6871.05677
+  dps: 7069.5805
+  tps: 6869.95568
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7101.43415
-  tps: 6909.61154
+  dps: 7100.68007
+  tps: 6908.78989
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7070.66319
-  tps: 6871.05677
+  dps: 7069.5805
+  tps: 6869.95568
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7078.82116
-  tps: 6878.94894
+  dps: 7077.73702
+  tps: 6877.84697
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7496.43917
-  tps: 7294.05439
+  dps: 7495.56473
+  tps: 7294.01004
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VestmentsofAbsolution"
  value: {
-  dps: 5036.17043
-  tps: 4871.32012
+  dps: 5035.69921
+  tps: 4871.59745
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7015.12737
-  tps: 6815.19166
+  dps: 7014.09249
+  tps: 6814.10972
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRaiment"
  value: {
-  dps: 6442.35951
-  tps: 6246.86201
+  dps: 6441.55089
+  tps: 6246.55679
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRegalia"
  value: {
-  dps: 6795.14727
-  tps: 6597.21322
+  dps: 6794.45473
+  tps: 6597.3886
  }
 }
 dps_results: {
  key: "TestShadow-Average-Default"
  value: {
-  dps: 7270.16218
-  tps: 7070.73441
+  dps: 7269.39951
+  tps: 7070.42507
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7212.76721
-  tps: 7709.45276
+  dps: 7211.74262
+  tps: 7700.54163
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7212.76721
-  tps: 7014.56678
+  dps: 7211.74262
+  tps: 7013.23156
  }
 }
 dps_results: {
@@ -840,14 +840,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3763.12834
+  dps: 3762.60202
   tps: 4556.08738
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3763.12834
+  dps: 3762.60202
   tps: 3710.26527
  }
 }
@@ -861,15 +861,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Clipping-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7212.76721
-  tps: 7709.45276
+  dps: 7211.74262
+  tps: 7700.54163
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Clipping-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7212.76721
-  tps: 7014.56678
+  dps: 7211.74262
+  tps: 7013.23156
  }
 }
 dps_results: {
@@ -882,14 +882,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Clipping-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3763.12834
+  dps: 3762.60202
   tps: 4556.08738
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Clipping-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3763.12834
+  dps: 3762.60202
   tps: 3710.26527
  }
 }
@@ -903,15 +903,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Ideal-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7212.76721
-  tps: 7709.45276
+  dps: 7211.74262
+  tps: 7700.54163
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Ideal-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7212.76721
-  tps: 7014.56678
+  dps: 7211.74262
+  tps: 7013.23156
  }
 }
 dps_results: {
@@ -924,14 +924,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Ideal-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3763.12834
+  dps: 3762.60202
   tps: 4556.08738
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Ideal-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3763.12834
+  dps: 3762.60202
   tps: 3710.26527
  }
 }
@@ -945,15 +945,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7199.57058
-  tps: 7703.19008
+  dps: 7198.47749
+  tps: 7696.05653
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7199.57058
-  tps: 7001.25511
+  dps: 7198.47749
+  tps: 7000.13832
  }
 }
 dps_results: {
@@ -966,14 +966,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3749.42634
+  dps: 3748.89721
   tps: 4542.50185
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3749.42634
+  dps: 3748.89721
   tps: 3696.35081
  }
 }
@@ -987,15 +987,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Clipping-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7199.57058
-  tps: 7703.19008
+  dps: 7198.47749
+  tps: 7696.05653
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Clipping-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7199.57058
-  tps: 7001.25511
+  dps: 7198.47749
+  tps: 7000.13832
  }
 }
 dps_results: {
@@ -1008,14 +1008,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Clipping-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3749.42634
+  dps: 3748.89721
   tps: 4542.50185
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Clipping-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3749.42634
+  dps: 3748.89721
   tps: 3696.35081
  }
 }
@@ -1029,15 +1029,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Ideal-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7199.57058
-  tps: 7703.19008
+  dps: 7198.47749
+  tps: 7696.05653
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Ideal-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7199.57058
-  tps: 7001.25511
+  dps: 7198.47749
+  tps: 7000.13832
  }
 }
 dps_results: {
@@ -1050,14 +1050,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Ideal-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3749.42634
+  dps: 3748.89721
   tps: 4542.50185
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Ideal-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3749.42634
+  dps: 3748.89721
   tps: 3696.35081
  }
 }
@@ -1071,15 +1071,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Basic-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7203.62421
-  tps: 7705.74594
+  dps: 7202.53046
+  tps: 7698.60318
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Basic-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7203.62421
-  tps: 7005.16705
+  dps: 7202.53046
+  tps: 7004.0493
  }
 }
 dps_results: {
@@ -1092,14 +1092,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Basic-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3758.56835
+  dps: 3758.03903
   tps: 4550.17994
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Basic-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3758.56835
+  dps: 3758.03903
   tps: 3705.28086
  }
 }
@@ -1113,15 +1113,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Clipping-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7203.62421
-  tps: 7705.74594
+  dps: 7202.53046
+  tps: 7698.60318
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Clipping-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7203.62421
-  tps: 7005.16705
+  dps: 7202.53046
+  tps: 7004.0493
  }
 }
 dps_results: {
@@ -1134,14 +1134,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Clipping-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3758.56835
+  dps: 3758.03903
   tps: 4550.17994
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Clipping-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3758.56835
+  dps: 3758.03903
   tps: 3705.28086
  }
 }
@@ -1155,15 +1155,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Ideal-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7203.62421
-  tps: 7705.74594
+  dps: 7202.53046
+  tps: 7698.60318
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Ideal-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7203.62421
-  tps: 7005.16705
+  dps: 7202.53046
+  tps: 7004.0493
  }
 }
 dps_results: {
@@ -1176,14 +1176,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Ideal-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3758.56835
+  dps: 3758.03903
   tps: 4550.17994
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Ideal-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3758.56835
+  dps: 3758.03903
   tps: 3705.28086
  }
 }
@@ -1197,7 +1197,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7206.42932
-  tps: 7005.16705
+  dps: 7205.05382
+  tps: 7004.0493
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -104,7 +104,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 7859.68944
+  dps: 7859.6865
   tps: 4335.4831
  }
 }
@@ -434,14 +434,14 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7565.76429
+  dps: 7565.77165
   tps: 4151.9691
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7588.63065
+  dps: 7588.63801
   tps: 4165.15337
  }
 }
@@ -848,7 +848,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7507.02339
+  dps: 7507.02633
   tps: 4125.15935
  }
 }
@@ -869,7 +869,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7603.46703
+  dps: 7603.47318
   tps: 4178.03518
  }
 }
@@ -981,7 +981,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 7623.51766
+  dps: 7623.51762
   tps: 4189.17589
  }
 }


### PR DESCRIPTION
[core] remove the effectively unused sim.init() hierarchy
[core] expire aura for disabled pets (so they don't start with buffs lasting until the next advance()) 
[core] don't call into "user land" before the internal aura tracker state is consistent (for aura.Deactivate())