### PR TITLE
Fix Shield Wall damage reduction (&update tests)

### DIFF
--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -46,7 +46,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 1.01803
+  weights: 0.84402
   weights: 0
   weights: 0
   weights: 0
@@ -57,7 +57,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.19691
+  weights: 0.26128
   weights: 0
   weights: 0
   weights: 0
@@ -66,12 +66,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.02012
+  weights: 0.01763
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.42911
-  weights: 0.07235
+  weights: 0.4296
+  weights: 0.02365
   weights: 0
   weights: 0
   weights: 0
@@ -921,9 +921,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 2772.35319
-  tps: 6734.95331
-  dtps: 127.69906
+  dps: 2771.43209
+  tps: 6732.50018
+  dtps: 127.46896
  }
 }
 dps_results: {

--- a/sim/warrior/shield_wall.go
+++ b/sim/warrior/shield_wall.go
@@ -15,7 +15,7 @@ func (warrior *Warrior) RegisterShieldWallCD() {
 	duration := time.Second*12 + core.TernaryDuration(warrior.HasSetBonus(ItemSetDreadnaughtPlate, 4), time.Second*3, 0)
 	hasGlyph := warrior.HasMajorGlyph(proto.WarriorMajorGlyph_GlyphOfShieldWall)
 	//This is the inverse of the tooltip since it is a damage TAKEN coefficient
-	damageTaken := core.TernaryFloat64(hasGlyph, 0.4, 0.6)
+	damageTaken := core.TernaryFloat64(hasGlyph, 0.6, 0.4)
 
 	actionID := core.ActionID{SpellID: 871}
 	swAura := warrior.RegisterAura(core.Aura{


### PR DESCRIPTION
From the looks of things seems that Shield Wall damage reduction % is broken currently.

Shield Wall should reduce damage by 60% without glyph (0.4 damage taken coeff) and by 40% with glyph (0.6 damage taken coeff). 

This part of the code is invalid in my opinion currently (despite the comment!):
`//This is the inverse of the tooltip since it is a damage TAKEN coefficient`
`damageTaken := core.TernaryFloat64(hasGlyph, 0.4, 0.6)`
Currently it works like this: If Glyph is enabled, take 0.4 damange coeff, so 60% damage reduction. Otherwise (no Glyph) take 0.6 damage taken coeff. This patch changes it to be other way around (correct).

Incorrect behaviour can be observed for example with this profile:
https://wowsims.github.io/wotlk/protection_warrior/#eJztVm9sU1UU7zmv7V6v+3N7Ke71ZZulicsYNLw/lKwk5haNCQnELBKNmn3AkKFTxLH6QRpjFgnCBoloihuLDlhM2IxxghFnIjA3omIkNqsxMGMgBMY0bo51xboPzNs+Xkf8CwG/efLuyzm/c3+/c/JO7+sjtTJSVFDD9dCMrQAfAJ4B2ImQRRgHmALMAiYRWxHuL6cQwCi8CDsBegEOIJzPpWElUmBYB2rC8wq46zc9ubWxRXZRjzoGpIwmd0nKT5VB9zvDOPQJEg+d3SUFpY+FW0w790jK7io7OpZGZW+FFZXRhMhlBU+QckAJ/VAItVcFnSJyiPBNkU/YIaPbdkvK6xVBj9i+f3/uEhIdYsukkLhsSZTRz4TEAX8B8NDjdi8eOmK7TvppmyTuveJeTI8I3e5Ci30i6pdtymxCUESpoJfKikuT6qXHpPWu/PPpwQySQXT8b7dlTLtVRpzJoGAAOgEGwDUI8CXgu+AmDlX8dNuhxgxrhibMMENmSAubZlg3jHAO0I2woWumpuumaegXQJEPppBeuoRKTwoD21NYsyOF2o/J4nFwTkFRF3i8XftydooP4XlUpOBdbB4iXuJWnQQVb7CIuIgU0mOMqTReSiQjEmNFqsDk/kYbCxewy262SL0nXkmKxL6ldZE8jZTKb60IzNkGrEqtiKtEioRjbIHqJWXy0W14Y36ZGoovIT5Diy1dLtYKserE0jXNJnT1SDcSytWF8QXzNWXVbR0Edrfqi7P5hNXknI/51fL4QkJ0UcAQKdNObfflmiO0tlR2M2xx5IQIGpoqE7c8Oi1Gw5wqrnQwouaLyK1pLPjnhqWCn52cx9vTOAAwCtWe/JDX/hD1mnlL8cXW3Ke433YCri50nL1+9qqjwfclizXYEPVaoC/qt+cUsZAkX7Qxb99x4xo2Z97GOFvbtOHpwJqmzU8FalY3tjzftGFxYJ0i1/7Hp7qmLXonZFpPnfwXnXX/lJ8509G56k708VeWf+byBVi1D95ouPbA7MQwv14ry8V/0MP5V+cL3c1fl8x+z62xXOUNsS/uPdgxx2+3ePqlmV+PD5zgVz8qefybHT/zBxO+i8tfO8fbv+0MLSse4c/0H535Knmab35v7yN7Lo7/bT2pcuTViTVDhXzfobH6Kw9l+Gh10JU5McE7n9viibSc5lf0+17etDHN66f7uh1bfrnl/ifbDv/26PQY9y/JHHs2MnjTfKZ9vjpzsnfrxE0znvjTy9Y6JGf/oDBViMVHA/wOmU9YDg==
This is P4 Prot Warrior BIS. Fight lasts 115 seconds, so with or without Glyph Shield Wall can be used only once. Still unequipping SW glyph increases DTPS and p(death). It should be other way around, because without glyph equippedm shield wall should be 60% dmg reduction not 40%, therefore DTPS should be lower.