### PR TITLE
warrior: add spell debuffs for bryntroll

### DIFF
--- a/ui/warrior/sim.ts
+++ b/ui/warrior/sim.ts
@@ -15,6 +15,7 @@ import { GemColor } from '../core/proto/common.js';
 import { Profession } from '../core/proto/common.js';
 
 
+import * as IconInputs from '../core/components/icon_inputs.js';
 import * as OtherInputs from '../core/components/other_inputs.js';
 import * as Mechanics from '../core/constants/mechanics.js';
 
@@ -126,6 +127,7 @@ export class WarriorSimUI extends IndividualSimUI<Spec.SpecWarrior> {
 					sunderArmor: true,
 					curseOfWeakness: TristateEffect.TristateEffectRegular,
 					faerieFire: TristateEffect.TristateEffectImproved,
+					ebonPlaguebringer: true,
 				}),
 			},
 
@@ -139,6 +141,9 @@ export class WarriorSimUI extends IndividualSimUI<Spec.SpecWarrior> {
 			rotationInputs: WarriorInputs.WarriorRotationConfig,
 			// Buff and Debuff inputs to include/exclude, overriding the EP-based defaults.
 			includeBuffDebuffInputs: [
+				// just for Bryntroll
+				IconInputs.SpellDamageDebuff,
+				IconInputs.SpellHitDebuff,
 			],
 			excludeBuffDebuffInputs: [
 			],


### PR DESCRIPTION
Bryntroll uses spell attack table so should receive spell hit and spell dmg debuffs