### PR TITLE
Update Elemental T10 4pc

### DIFF
--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -434,8 +434,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 8209.20382
-  tps: 4559.89103
+  dps: 8215.41125
+  tps: 4564.44786
  }
 }
 dps_results: {

--- a/sim/shaman/items_wotlk.go
+++ b/sim/shaman/items_wotlk.go
@@ -64,22 +64,10 @@ var ItemSetFrostWitchRegalia = core.NewItemSet(core.ItemSet{
 						// Find the number of ticks whose duration is closest to 6s.
 						// "our testing confirms that the 4pc t10 setbonus adds to FS the closest number of ticks to 6 seconds always"
 						// https://web.archive.org/web/20100808192139/http://elitistjerks.com/f79/t76510-elemental_patch_3_3_now_more_fire_nova/p25/
-						numTicks := 2
-						period := fsDot.TickPeriod()
-						sixSeconds := time.Second * 6
-
-						for i := 3; i <= 10; i++ {
-							finishesAtCur := time.Duration(numTicks) * period
-							finishesAtNew := time.Duration(i) * period
-
-							if math.Abs(float64(sixSeconds-finishesAtNew)) <= math.Abs(float64(sixSeconds-finishesAtCur)) {
-								numTicks = i
-							} else {
-								break
-							}
-						}
-						fsDot.Duration = fsDot.RemainingDuration(sim) + time.Duration(numTicks)*period
-						fsDot.Refresh(sim)
+						fsDot.RecomputeAuraDuration()
+						tickPeriod := fsDot.TickPeriod()
+						numTicks := int32(math.Round(float64(time.Second) * 6 / float64(tickPeriod)))
+						fsDot.RescheduleNextTickAndExtend(sim, numTicks)
 					}
 				},
 			})

--- a/sim/shaman/shocks.go
+++ b/sim/shaman/shocks.go
@@ -65,10 +65,12 @@ func (shaman *Shaman) registerFlameShockSpell(shockTimer *core.Timer) {
 	config.CritMultiplier = shaman.ElementalCritMultiplier(core.TernaryFloat64(shaman.HasMajorGlyph(proto.ShamanMajorGlyph_GlyphOfFlameShock), 0.6, 0))
 	config.DamageMultiplier += 0.1 * float64(shaman.Talents.BoomingEchoes)
 
+	flameShockBaseNumberOfTicks := 6 + core.TernaryInt32(shaman.HasSetBonus(ItemSetThrallsRegalia, 2), 3, 0)
 	config.ApplyEffects = func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 		baseDamage := 500 + 0.214*spell.SpellPower()
 		result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
 		if result.Landed() {
+			spell.Dot(target).NumberOfTicks = flameShockBaseNumberOfTicks
 			spell.Dot(target).Apply(sim)
 		}
 		spell.DealDamage(sim, result)
@@ -89,7 +91,7 @@ func (shaman *Shaman) registerFlameShockSpell(shockTimer *core.Timer) {
 				shaman.LavaBurst.BonusCritRating -= 100 * core.CritRatingPerCritChance
 			},
 		},
-		NumberOfTicks:       6 + core.TernaryInt32(shaman.HasSetBonus(ItemSetThrallsRegalia, 2), 3, 0),
+		NumberOfTicks:       flameShockBaseNumberOfTicks,
 		TickLength:          time.Second * 3,
 		AffectedByCastSpeed: true,
 


### PR DESCRIPTION
Based on logs, Flame Shock with [Elemental Shaman's T10 4-set bonus](https://www.wowhead.com/wotlk/spell=70817/item-shaman-t10-elemental-4p-bonus) behaves differently than other refreshed/rolled over DoTs.

Logs: https://classic.warcraftlogs.com/reports/a:9KMHBQnN8tAZfwJr#fight=37&type=summary&source=36&view=events

Spreadsheet showing the relevant timeline of events: https://docs.google.com/spreadsheets/d/1ToSXfky85q8fzkPTFGiT9xnldzipEc5vb4p7h7IsZSU/edit#gid=2029445151

Our conclusion is that Flame Shock dynamically updates its haste when Lava Burst finishes casting (not when it hits). Check the Lava Burst casts at 71 seconds (after gaining Hyperspeed Acceleration) and at 220 seconds (after losing Heroism), and note that Flame Shock updates its tick interval for the current tick immediately, before the Lava Burst hits the target.

I tried making use of the existing Rollover function, but ultimately concluded the behavior was too different, thus `RescheduleNextTickAndExtend`. I also took queues from feral/rogue sims for the NumberOfTicks overwrite.