### PR TITLE
Vigo/auto attacks

### DIFF
--- a/sim/common/tbc/melee_trinkets.go
+++ b/sim/common/tbc/melee_trinkets.go
@@ -25,7 +25,7 @@ func init() {
 
 	core.NewItemEffect(11815, func(agent core.Agent) {
 		character := agent.GetCharacter()
-		if !character.AutoAttacks.AutoSwingMelee() {
+		if !character.AutoAttacks.AutoSwingMelee {
 			return
 		}
 
@@ -40,7 +40,7 @@ func init() {
 			Label:    "Hand of Justice",
 			Duration: core.NeverExpires,
 			OnInit: func(aura *core.Aura, sim *core.Simulation) {
-				config := character.AutoAttacks.MHConfig
+				config := *character.AutoAttacks.MHConfig()
 				config.ActionID = core.ActionID{ItemID: 11815}
 				handOfJusticeSpell = character.GetOrRegisterSpell(config)
 			},

--- a/sim/common/wotlk/capacitors.go
+++ b/sim/common/wotlk/capacitors.go
@@ -172,7 +172,7 @@ func init() {
 
 		core.NewItemEffect(itemID, func(agent core.Agent) {
 			character := agent.GetCharacter()
-			if !character.AutoAttacks.AutoSwingMelee() {
+			if !character.AutoAttacks.AutoSwingMelee {
 				return
 			}
 
@@ -184,24 +184,24 @@ func init() {
 					SpellSchool:      core.SpellSchoolPhysical,
 					ProcMask:         core.ProcMaskMeleeMHSpecial,
 					Flags:            core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | core.SpellFlagNoOnCastComplete,
-					DamageMultiplier: character.AutoAttacks.MHConfig.DamageMultiplier * 0.5,
-					CritMultiplier:   character.AutoAttacks.MHConfig.CritMultiplier,
-					ThreatMultiplier: character.AutoAttacks.MHConfig.ThreatMultiplier,
+					DamageMultiplier: character.AutoAttacks.MHConfig().DamageMultiplier * 0.5,
+					CritMultiplier:   character.AutoAttacks.MHConfig().CritMultiplier,
+					ThreatMultiplier: character.AutoAttacks.MHConfig().ThreatMultiplier,
 					ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 						baseDamage := character.MHWeaponDamage(sim, spell.MeleeAttackPower())
 						spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
 					},
 				})
 
-				if character.AutoAttacks.IsDualWielding() {
+				if character.AutoAttacks.IsDualWielding {
 					ohSpell = character.GetOrRegisterSpell(core.SpellConfig{
 						ActionID:         core.ActionID{SpellID: 71434}, // "Manifest Anger"
 						SpellSchool:      core.SpellSchoolPhysical,
 						ProcMask:         core.ProcMaskMeleeOHSpecial,
 						Flags:            core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | core.SpellFlagNoOnCastComplete,
-						DamageMultiplier: character.AutoAttacks.OHConfig.DamageMultiplier * 0.5,
-						CritMultiplier:   character.AutoAttacks.OHConfig.CritMultiplier,
-						ThreatMultiplier: character.AutoAttacks.OHConfig.ThreatMultiplier,
+						DamageMultiplier: character.AutoAttacks.OHConfig().DamageMultiplier * 0.5,
+						CritMultiplier:   character.AutoAttacks.OHConfig().CritMultiplier,
+						ThreatMultiplier: character.AutoAttacks.OHConfig().ThreatMultiplier,
 						ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 							baseDamage := character.OHWeaponDamage(sim, spell.MeleeAttackPower())
 							spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)

--- a/sim/core/aura.go
+++ b/sim/core/aura.go
@@ -478,11 +478,15 @@ func (at *auraTracker) reset(sim *Simulation) {
 	}
 }
 
-func (at *auraTracker) advance(sim *Simulation) time.Duration {
+// inlineable stub for advance
+func (at *auraTracker) tryAdvance(sim *Simulation) time.Duration {
 	if sim.CurrentTime < at.minExpires {
 		return at.minExpires
 	}
+	return at.advance(sim)
+}
 
+func (at *auraTracker) advance(sim *Simulation) time.Duration {
 restart:
 	at.minExpires = NeverExpires
 	for _, aura := range at.activeAuras {

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -624,16 +624,15 @@ func (character *Character) doneIteration(sim *Simulation) {
 }
 
 func (character *Character) GetPseudoStatsProto() []float64 {
-	vals := make([]float64, stats.PseudoStatsLen)
-	vals[proto.PseudoStat_PseudoStatMainHandDps] = character.AutoAttacks.MH().DPS()
-	vals[proto.PseudoStat_PseudoStatOffHandDps] = character.AutoAttacks.OH().DPS()
-	vals[proto.PseudoStat_PseudoStatRangedDps] = character.AutoAttacks.Ranged().DPS()
-	vals[proto.PseudoStat_PseudoStatBlockValueMultiplier] = character.PseudoStats.BlockValueMultiplier
-	// Base values are modified by Enemy attackTables, but we display for LVL 80 enemy as paperdoll default
-	vals[proto.PseudoStat_PseudoStatDodge] = character.PseudoStats.BaseDodge + character.GetDiminishedDodgeChance()
-	vals[proto.PseudoStat_PseudoStatParry] = character.PseudoStats.BaseParry + character.GetDiminishedParryChance()
-	//vals[proto.PseudoStat_PseudoStatMiss] = 0.05 + character.GetDiminishedMissChance() + character.PseudoStats.ReducedPhysicalHitTakenChance
-	return vals
+	return []float64{
+		proto.PseudoStat_PseudoStatMainHandDps:          character.AutoAttacks.MH().DPS(),
+		proto.PseudoStat_PseudoStatOffHandDps:           character.AutoAttacks.OH().DPS(),
+		proto.PseudoStat_PseudoStatRangedDps:            character.AutoAttacks.Ranged().DPS(),
+		proto.PseudoStat_PseudoStatBlockValueMultiplier: character.PseudoStats.BlockValueMultiplier,
+		// Base values are modified by Enemy attackTables, but we display for LVL 80 enemy as paperdoll default
+		proto.PseudoStat_PseudoStatDodge: character.PseudoStats.BaseDodge + character.GetDiminishedDodgeChance(),
+		proto.PseudoStat_PseudoStatParry: character.PseudoStats.BaseParry + character.GetDiminishedParryChance(),
+	}
 }
 
 func (character *Character) GetMetricsProto() *proto.UnitMetrics {

--- a/sim/core/item_swaps.go
+++ b/sim/core/item_swaps.go
@@ -142,9 +142,8 @@ func (swap *ItemSwap) SwapItems(sim *Simulation, slots []proto.ItemSlot, useGCD 
 		onSwap(sim)
 	}
 
-	if character.AutoAttacks.AutoSwingMelee() && meleeWeaponSwapped && sim.CurrentTime > 0 {
-		character.AutoAttacks.CancelAutoSwing(sim)
-		character.AutoAttacks.restartMelee(sim, false)
+	if character.AutoAttacks.AutoSwingMelee && meleeWeaponSwapped && sim.CurrentTime > 0 {
+		character.AutoAttacks.StopMeleeUntil(sim, sim.CurrentTime, false)
 	}
 
 	if useGCD {
@@ -194,17 +193,17 @@ func (swap *ItemSwap) swapWeapon(slot proto.ItemSlot) {
 
 	switch slot {
 	case proto.ItemSlot_ItemSlotMainHand:
-		if character.AutoAttacks.AutoSwingMelee() {
+		if character.AutoAttacks.AutoSwingMelee {
 			character.AutoAttacks.SetMH(character.WeaponFromMainHand(swap.mhCritMultiplier))
 		}
 	case proto.ItemSlot_ItemSlotOffHand:
-		if character.AutoAttacks.AutoSwingMelee() {
+		if character.AutoAttacks.AutoSwingMelee {
 			character.AutoAttacks.SetOH(character.WeaponFromOffHand(swap.ohCritMultiplier))
 			//Special case for when the OHAuto Spell was set up with a non weapon and does not have a crit multiplier.
 			character.PseudoStats.CanBlock = character.OffHand().WeaponType == proto.WeaponType_WeaponTypeShield
 		}
 	case proto.ItemSlot_ItemSlotRanged:
-		if character.AutoAttacks.AutoSwingRanged() {
+		if character.AutoAttacks.AutoSwingRanged {
 			character.AutoAttacks.SetRanged(character.WeaponFromRanged(swap.rangedCritMultiplier))
 		}
 	}

--- a/sim/core/item_swaps.go
+++ b/sim/core/item_swaps.go
@@ -208,8 +208,6 @@ func (swap *ItemSwap) swapWeapon(slot proto.ItemSlot) {
 			character.AutoAttacks.SetRanged(character.WeaponFromRanged(swap.rangedCritMultiplier))
 		}
 	}
-
-	character.AutoAttacks.isDualWielding = character.MainHand().SwingSpeed != 0 && character.OffHand().SwingSpeed != 0
 }
 
 func (swap *ItemSwap) finalize() {

--- a/sim/core/spell_outcome.go
+++ b/sim/core/spell_outcome.go
@@ -378,7 +378,7 @@ func (spell *Spell) fixedCritCheck(sim *Simulation, critChance float64) bool {
 
 func (result *SpellResult) applyAttackTableMiss(spell *Spell, attackTable *AttackTable, roll float64, chance *float64) bool {
 	missChance := attackTable.BaseMissChance - spell.PhysicalHitChance(attackTable)
-	if spell.Unit.AutoAttacks.IsDualWielding() && !spell.Unit.PseudoStats.DisableDWMissPenalty {
+	if spell.Unit.AutoAttacks.IsDualWielding && !spell.Unit.PseudoStats.DisableDWMissPenalty {
 		missChance += 0.19
 	}
 	*chance = max(0, missChance)
@@ -505,7 +505,7 @@ func (result *SpellResult) applyAttackTableHit(spell *Spell) {
 
 func (result *SpellResult) applyEnemyAttackTableMiss(spell *Spell, attackTable *AttackTable, roll float64, chance *float64) bool {
 	missChance := attackTable.BaseMissChance + spell.Unit.PseudoStats.IncreasedMissChance + result.Target.GetDiminishedMissChance() + result.Target.PseudoStats.ReducedPhysicalHitTakenChance
-	if spell.Unit.AutoAttacks.IsDualWielding() && !spell.Unit.PseudoStats.DisableDWMissPenalty {
+	if spell.Unit.AutoAttacks.IsDualWielding && !spell.Unit.PseudoStats.DisableDWMissPenalty {
 		missChance += 0.19
 	}
 	*chance = max(0, missChance)

--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -46,1040 +46,1040 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 10739.58168
-  tps: 5400.1528
+  dps: 10741.61533
+  tps: 5401.84848
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10453.28965
-  tps: 5290.29797
+  dps: 10454.16679
+  tps: 5290.93479
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10273.55258
-  tps: 5200.42225
+  dps: 10275.51572
+  tps: 5202.03768
   hps: 94.38579
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10273.55258
-  tps: 5200.42225
+  dps: 10275.51572
+  tps: 5202.03768
   hps: 94.38579
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 10767.53164
-  tps: 5415.09831
+  dps: 10769.56377
+  tps: 5416.79288
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 10217.72821
-  tps: 5135.69749
+  dps: 10261.35442
+  tps: 5162.91183
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 8054.46811
-  tps: 4068.23945
+  dps: 8073.28492
+  tps: 4073.72772
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 7964.45643
-  tps: 4014.61106
+  dps: 8011.22871
+  tps: 4042.43378
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 7656.78528
-  tps: 3858.70972
+  dps: 7747.14648
+  tps: 3912.20006
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 10733.26981
-  tps: 5288.91677
+  dps: 10735.30194
+  tps: 5290.57746
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 12587.4826
-  tps: 6434.98695
+  dps: 12569.16603
+  tps: 6421.19142
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 12650.0376
-  tps: 6470.27191
+  dps: 12629.44234
+  tps: 6455.39297
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 10963.90338
-  tps: 5521.25581
+  dps: 10966.07289
+  tps: 5523.0453
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
   hps: 64
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 10417.96388
-  tps: 5276.00948
+  dps: 10419.13257
+  tps: 5277.14824
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 10461.50974
-  tps: 5298.64486
+  dps: 10460.89475
+  tps: 5298.39348
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 10551.10607
-  tps: 5319.25445
+  dps: 10553.15508
+  tps: 5320.94849
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 8991.05824
-  tps: 4533.35621
+  dps: 8976.86927
+  tps: 4531.5221
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 7956.51999
-  tps: 4002.8062
+  dps: 7941.6571
+  tps: 3995.09352
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10370.09946
-  tps: 5251.52815
+  dps: 10372.0626
+  tps: 5253.14357
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10950.44078
-  tps: 5578.76152
+  dps: 10941.6685
+  tps: 5573.73978
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11000.29493
-  tps: 5607.27662
+  dps: 10999.90578
+  tps: 5607.57155
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10291.82545
-  tps: 5209.97944
+  dps: 10293.79312
+  tps: 5211.59817
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 10771.64747
-  tps: 5417.5678
+  dps: 10773.6796
+  tps: 5419.26237
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 10530.4602
-  tps: 5325.52699
+  dps: 10527.68231
+  tps: 5323.37289
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 10474.95147
-  tps: 5310.30154
+  dps: 10486.13733
+  tps: 5317.61759
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 10733.26981
-  tps: 5396.85385
+  dps: 10735.30194
+  tps: 5398.54843
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 10733.26981
-  tps: 5396.85385
+  dps: 10735.30194
+  tps: 5398.54843
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 10767.53164
-  tps: 5415.09831
+  dps: 10769.56377
+  tps: 5416.79288
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 10761.71324
-  tps: 5412.37463
+  dps: 10763.74537
+  tps: 5414.06921
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10401.00289
-  tps: 5241.10427
+  dps: 10382.19848
+  tps: 5228.98597
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 10733.26981
-  tps: 5396.85385
+  dps: 10735.30194
+  tps: 5398.54843
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 10448.5033
-  tps: 5291.2511
+  dps: 10447.75279
+  tps: 5290.86367
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 10408.22212
-  tps: 5271.64204
+  dps: 10409.38561
+  tps: 5272.77767
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForgeEmber-37660"
  value: {
-  dps: 10376.16664
-  tps: 5254.38513
+  dps: 10377.33012
+  tps: 5255.52076
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 10733.26981
-  tps: 5396.85385
+  dps: 10735.30194
+  tps: 5398.54843
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 10733.26981
-  tps: 5396.85385
+  dps: 10735.30194
+  tps: 5398.54843
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 10505.86987
-  tps: 5324.34851
+  dps: 10507.89513
+  tps: 5326.00884
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 10421.65706
-  tps: 5273.56265
+  dps: 10422.5075
+  tps: 5275.85001
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 10767.53164
-  tps: 5415.09831
+  dps: 10769.56377
+  tps: 5416.79288
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 10761.71324
-  tps: 5412.37463
+  dps: 10763.74537
+  tps: 5414.06921
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IncisorFragment-37723"
  value: {
-  dps: 10510.14937
-  tps: 5333.56383
+  dps: 10512.13718
+  tps: 5335.19778
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 10733.26981
-  tps: 5396.85385
+  dps: 10735.30194
+  tps: 5398.54843
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 10765.11773
-  tps: 5413.49941
+  dps: 10767.1575
+  tps: 5415.19959
   hps: 16.44049
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50179"
  value: {
-  dps: 12210.67921
-  tps: 6205.42881
+  dps: 12253.59563
+  tps: 6236.81887
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50708"
  value: {
-  dps: 12280.41202
-  tps: 6244.22166
+  dps: 12323.98075
+  tps: 6276.00856
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 10513.95177
-  tps: 5326.11573
+  dps: 10505.72187
+  tps: 5320.37895
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 10621.62611
-  tps: 5361.3445
+  dps: 10623.58924
+  tps: 5362.95992
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10285.37195
-  tps: 5206.60376
+  dps: 10287.33802
+  tps: 5208.22133
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 10759.05146
-  tps: 5410.32883
+  dps: 10761.08977
+  tps: 5412.02794
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 10765.11773
-  tps: 5413.49941
+  dps: 10767.1575
+  tps: 5415.19959
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10322.63015
-  tps: 5226.09266
+  dps: 10324.60544
+  tps: 5227.71697
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10328.95457
-  tps: 5229.40082
+  dps: 10330.93144
+  tps: 5231.02628
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 10733.26981
-  tps: 5396.85385
+  dps: 10735.30194
+  tps: 5398.54843
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 10733.26981
-  tps: 5396.85385
+  dps: 10735.30194
+  tps: 5398.54843
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 10331.40223
-  tps: 5236.55523
+  dps: 10333.40258
+  tps: 5238.19335
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 10339.91229
-  tps: 5241.66126
+  dps: 10341.91264
+  tps: 5243.29939
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 10954.00355
-  tps: 5516.10713
+  dps: 10956.1733
+  tps: 5517.8968
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 10733.26981
-  tps: 5396.85385
+  dps: 10735.30194
+  tps: 5398.54843
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 8597.50429
-  tps: 4321.96848
+  dps: 8575.39408
+  tps: 4306.42421
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 7918.42228
-  tps: 3972.01755
+  dps: 7896.08653
+  tps: 3961.6275
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 10625.9448
-  tps: 5436.88283
+  dps: 10615.69833
+  tps: 5434.24155
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 8614.70939
-  tps: 4325.60733
+  dps: 8636.84154
+  tps: 4339.33195
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10291.07675
-  tps: 5209.29787
+  dps: 10293.03966
+  tps: 5210.91316
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 13699.8788
-  tps: 7035.58301
+  dps: 13816.21798
+  tps: 7097.45263
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SouloftheDead-40382"
  value: {
-  dps: 10411.63291
-  tps: 5273.03344
+  dps: 10412.8016
+  tps: 5274.1722
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofLife-37657"
  value: {
-  dps: 10337.92958
-  tps: 5230.89431
+  dps: 10339.53189
+  tps: 5231.67721
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 10384.0868
-  tps: 5242.94494
+  dps: 10385.17645
+  tps: 5243.68298
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 7659.93801
-  tps: 3866.47082
+  dps: 7670.50219
+  tps: 3879.75688
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 10765.11773
-  tps: 5413.49941
+  dps: 10767.1575
+  tps: 5415.19959
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 10759.05146
-  tps: 5410.32883
+  dps: 10761.08977
+  tps: 5412.02794
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 10748.43549
-  tps: 5404.78031
+  dps: 10750.47125
+  tps: 5406.47755
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 9203.92773
-  tps: 4644.85713
+  dps: 9201.1027
+  tps: 4637.84821
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 8151.23824
-  tps: 4088.58957
+  dps: 8155.48727
+  tps: 4087.36894
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 8812.14209
-  tps: 4352.50279
+  dps: 8817.00188
+  tps: 4357.44445
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 10749.81852
-  tps: 5397.82508
+  dps: 10747.24471
+  tps: 5396.99979
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 10428.52045
-  tps: 5288.56818
+  dps: 10432.21661
+  tps: 5288.8117
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 10508.59227
-  tps: 5331.40314
+  dps: 10509.24458
+  tps: 5332.0367
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 10733.26981
-  tps: 5396.85385
+  dps: 10735.30194
+  tps: 5398.54843
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 10733.26981
-  tps: 5396.85385
+  dps: 10735.30194
+  tps: 5398.54843
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 10275.32458
-  tps: 5170.52766
+  dps: 10290.06081
+  tps: 5177.78344
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 10733.26981
-  tps: 5396.85385
+  dps: 10735.30194
+  tps: 5398.54843
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 10733.26981
-  tps: 5396.85385
+  dps: 10735.30194
+  tps: 5398.54843
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 7930.29354
-  tps: 3995.13956
+  dps: 8011.72077
+  tps: 4041.86851
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7734.38428
-  tps: 3735.89869
+  dps: 7733.29046
+  tps: 3735.24912
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10273.54054
-  tps: 5200.41503
+  dps: 10275.50367
+  tps: 5202.03045
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 10992.9446
-  tps: 5533.89196
+  dps: 10994.24789
+  tps: 5534.6938
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 32362.32946
-  tps: 16622.40187
+  dps: 32337.42861
+  tps: 16606.85492
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 10841.22885
-  tps: 5502.55532
+  dps: 10843.43286
+  tps: 5504.34371
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13857.25864
-  tps: 6295.7422
+  dps: 13856.55081
+  tps: 6295.85832
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 17435.69834
+  dps: 17435.72738
   tps: 8946.78245
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6215.88567
+  dps: 6215.91592
   tps: 3161.10732
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7320.77269
+  dps: 7320.92685
   tps: 3294.65954
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29291.75448
-  tps: 15917.56598
+  dps: 29303.20966
+  tps: 15924.39196
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10271.35316
-  tps: 5436.03545
+  dps: 10266.28342
+  tps: 5432.84043
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13933.2926
+  dps: 13932.77469
   tps: 6349.76629
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15778.49815
-  tps: 8589.95723
+  dps: 15777.75585
+  tps: 8589.48688
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5874.81045
-  tps: 3130.82318
+  dps: 5874.80592
+  tps: 3130.78772
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7411.19778
+  dps: 7411.34298
   tps: 3364.94429
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti_dd-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27092.01493
-  tps: 15401.58281
+  dps: 27094.7436
+  tps: 15403.73345
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti_dd-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10240.61961
-  tps: 5409.11645
+  dps: 10229.80201
+  tps: 5402.53664
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti_dd-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13788.6821
-  tps: 6220.07927
+  dps: 13787.70345
+  tps: 6219.95187
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti_dd-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14599.23302
-  tps: 8270.25477
+  dps: 14601.28772
+  tps: 8272.40309
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti_dd-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5870.99519
-  tps: 3115.83437
+  dps: 5871.01631
+  tps: 3115.82276
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti_dd-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7289.00682
+  dps: 7289.15179
   tps: 3277.10021
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 32779.33421
-  tps: 16699.48458
+  dps: 32753.86856
+  tps: 16683.84392
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 10963.90338
-  tps: 5521.25581
+  dps: 10966.07289
+  tps: 5523.0453
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14115.52217
-  tps: 6347.89933
+  dps: 14114.78329
+  tps: 6348.01554
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 17672.48999
+  dps: 17672.51904
   tps: 8991.52961
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6286.27457
+  dps: 6286.30489
   tps: 3172.37897
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7457.81485
+  dps: 7457.9695
   tps: 3322.89455
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29536.63816
-  tps: 15950.09279
+  dps: 29541.94035
+  tps: 15953.26938
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10372.15126
-  tps: 5456.69732
+  dps: 10357.65967
+  tps: 5447.81327
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14176.24909
+  dps: 14175.7201
   tps: 6395.88592
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15916.88055
-  tps: 8610.10421
+  dps: 15916.13836
+  tps: 8609.63354
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5933.00839
-  tps: 3144.35845
+  dps: 5933.00516
+  tps: 3144.323
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7539.16195
+  dps: 7539.30721
   tps: 3390.43801
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti_dd-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27241.62253
-  tps: 15442.65966
+  dps: 27245.06822
+  tps: 15445.16705
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti_dd-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10339.2293
-  tps: 5427.70172
+  dps: 10336.46597
+  tps: 5426.00783
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti_dd-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14033.96542
-  tps: 6264.51512
+  dps: 14032.96209
+  tps: 6264.38771
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti_dd-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14675.68601
-  tps: 8287.33792
+  dps: 14678.23434
+  tps: 8289.85047
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti_dd-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5914.45433
-  tps: 3119.37515
+  dps: 5914.47603
+  tps: 3119.36353
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti_dd-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7422.04604
+  dps: 7422.19098
   tps: 3304.53501
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 10508.24104
-  tps: 5310.21111
+  dps: 10461.92828
+  tps: 5280.69869
  }
 }

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -46,894 +46,894 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 11052.3778
-  tps: 6474.63061
+  dps: 11016.98326
+  tps: 6453.5499
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 11005.31323
-  tps: 6445.78193
+  dps: 10975.86284
+  tps: 6428.15015
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10824.28982
-  tps: 6337.77782
+  dps: 10781.73201
+  tps: 6312.39915
   hps: 64.65047
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10824.28982
-  tps: 6337.77782
+  dps: 10781.73201
+  tps: 6312.39915
   hps: 64.65047
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 11072.56067
-  tps: 6486.74034
+  dps: 11032.45251
+  tps: 6462.83144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 10655.71308
-  tps: 6246.4227
+  dps: 10641.78706
+  tps: 6240.43586
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 8735.76097
-  tps: 5117.30613
+  dps: 8731.35167
+  tps: 5114.25345
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 8691.41185
-  tps: 5095.47138
+  dps: 8610.82718
+  tps: 5046.41668
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8344.30928
-  tps: 4887.2165
+  dps: 8292.83706
+  tps: 4855.82562
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 11045.13179
-  tps: 6340.87735
+  dps: 11009.75067
+  tps: 6320.22614
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 11342.29714
-  tps: 6648.58222
+  dps: 11300.38647
+  tps: 6623.59182
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 11342.29714
-  tps: 6648.58222
+  dps: 11300.38647
+  tps: 6623.59182
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11349.33844
-  tps: 6652.80699
+  dps: 11306.65172
+  tps: 6627.35097
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 10966.10978
-  tps: 6422.8698
+  dps: 10927.31258
+  tps: 6399.74749
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 10969.99956
-  tps: 6426.36193
+  dps: 10965.28097
+  tps: 6421.77472
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 11062.03224
-  tps: 6470.50094
+  dps: 11019.3488
+  tps: 6444.52166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 9509.15797
-  tps: 5569.24691
+  dps: 9560.87455
+  tps: 5600.8349
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 8510.72501
-  tps: 4979.70944
+  dps: 8529.2079
+  tps: 4989.23183
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 10764.55506
-  tps: 6301.93697
+  dps: 10727.18367
+  tps: 6279.67014
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10941.7664
-  tps: 6408.26377
+  dps: 10900.56566
+  tps: 6383.69933
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 11404.38496
-  tps: 6680.38623
+  dps: 11433.74353
+  tps: 6696.03903
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11459.73447
-  tps: 6715.82401
+  dps: 11483.01608
+  tps: 6729.00687
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10844.45059
-  tps: 6349.87428
+  dps: 10801.88561
+  tps: 6324.49131
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 11075.05432
-  tps: 6488.23653
+  dps: 11036.61296
+  tps: 6465.32772
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 10977.01789
-  tps: 6422.76462
+  dps: 11046.82744
+  tps: 6465.78389
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 10962.62519
-  tps: 6413.11897
+  dps: 11005.10117
+  tps: 6439.18062
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 11045.13179
-  tps: 6470.28301
+  dps: 11009.75067
+  tps: 6449.21034
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 11045.13179
-  tps: 6470.28301
+  dps: 11009.75067
+  tps: 6449.21034
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 11072.56067
-  tps: 6486.74034
+  dps: 11032.45251
+  tps: 6462.83144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 11066.65571
-  tps: 6483.19736
+  dps: 11027.28221
+  tps: 6459.72927
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10907.96997
-  tps: 6376.02395
+  dps: 10908.43145
+  tps: 6377.72463
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 11045.13179
-  tps: 6470.28301
+  dps: 11009.75067
+  tps: 6449.21034
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 10956.37392
-  tps: 6416.18342
+  dps: 10953.16919
+  tps: 6415.65686
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 10954.59887
-  tps: 6415.96325
+  dps: 10916.93404
+  tps: 6393.52036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 10933.53477
-  tps: 6403.3248
+  dps: 10896.07232
+  tps: 6381.00333
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 11045.13179
-  tps: 6470.28301
+  dps: 11009.75067
+  tps: 6449.21034
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 11045.13179
-  tps: 6470.28301
+  dps: 11009.75067
+  tps: 6449.21034
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 10765.46748
-  tps: 6302.48442
+  dps: 10728.07402
+  tps: 6280.20435
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 11070.87222
-  tps: 6485.72726
+  dps: 11027.71575
+  tps: 6459.98939
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 10957.04388
-  tps: 6419.66694
+  dps: 10945.16038
+  tps: 6409.96041
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 10762.52248
-  tps: 6300.71742
+  dps: 10725.20172
+  tps: 6278.48097
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 11072.56067
-  tps: 6486.74034
+  dps: 11032.45251
+  tps: 6462.83144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 11066.65571
-  tps: 6483.19736
+  dps: 11027.28221
+  tps: 6459.72927
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 11064.57427
-  tps: 6481.94849
+  dps: 11020.75768
+  tps: 6455.81455
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 11045.13179
-  tps: 6470.28301
+  dps: 11009.75067
+  tps: 6449.21034
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 11078.58246
-  tps: 6490.3534
+  dps: 11043.1303
+  tps: 6469.23812
   hps: 16.93247
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50179"
  value: {
-  dps: 11342.29714
-  tps: 6648.58222
+  dps: 11300.38647
+  tps: 6623.59182
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50708"
  value: {
-  dps: 11342.29714
-  tps: 6648.58222
+  dps: 11300.38647
+  tps: 6623.59182
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 11027.82683
-  tps: 6453.95922
+  dps: 11035.42698
+  tps: 6463.24321
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 10983.42618
-  tps: 6433.25964
+  dps: 10944.78342
+  tps: 6410.22999
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10837.34831
-  tps: 6345.61292
+  dps: 10794.79949
+  tps: 6320.23964
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 11072.2109
-  tps: 6486.53047
+  dps: 11036.77228
+  tps: 6465.42331
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 11078.58246
-  tps: 6490.3534
+  dps: 11043.1303
+  tps: 6469.23812
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10878.3521
-  tps: 6370.21519
+  dps: 10835.71002
+  tps: 6344.78595
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10885.31233
-  tps: 6374.39133
+  dps: 10842.65442
+  tps: 6348.95259
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 11045.13179
-  tps: 6470.28301
+  dps: 11009.75067
+  tps: 6449.21034
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 11045.13179
-  tps: 6470.28301
+  dps: 11009.75067
+  tps: 6449.21034
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 10819.92757
-  tps: 6334.91314
+  dps: 10807.37558
+  tps: 6328.85288
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 10821.80891
-  tps: 6336.04194
+  dps: 10809.17724
+  tps: 6329.93388
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11342.29714
-  tps: 6648.58222
+  dps: 11300.38647
+  tps: 6623.59182
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 10766.53198
-  tps: 6303.12312
+  dps: 10729.11276
+  tps: 6280.8276
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 11045.13179
-  tps: 6470.28301
+  dps: 11009.75067
+  tps: 6449.21034
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 10762.23611
-  tps: 6300.5456
+  dps: 10724.92212
+  tps: 6278.31321
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 9352.00903
-  tps: 5479.95126
+  dps: 9340.24726
+  tps: 5474.05643
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 8440.01005
-  tps: 4937.0344
+  dps: 8442.32993
+  tps: 4938.08
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 11273.41052
-  tps: 6621.07727
+  dps: 11266.82095
+  tps: 6617.29304
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 9282.18463
-  tps: 5429.04867
+  dps: 9276.60837
+  tps: 5427.05922
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10838.00573
-  tps: 6346.00737
+  dps: 10795.31295
+  tps: 6320.54771
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shadowmourne-49623"
  value: {
-  dps: 11342.29714
-  tps: 6648.58222
+  dps: 11300.38647
+  tps: 6623.59182
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 10759.99292
-  tps: 6299.19969
+  dps: 10722.73191
+  tps: 6276.99909
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 10778.84686
-  tps: 6310.51205
+  dps: 10737.02839
+  tps: 6285.57697
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 10759.99292
-  tps: 6299.19969
+  dps: 10722.73191
+  tps: 6276.99909
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 11205.58333
-  tps: 6559.55176
+  dps: 11167.57117
+  tps: 6536.9376
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 10759.99292
-  tps: 6299.19969
+  dps: 10722.73191
+  tps: 6276.99909
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 11245.82103
-  tps: 6583.02918
+  dps: 11207.66992
+  tps: 6560.33517
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 10759.99292
-  tps: 6299.19969
+  dps: 10722.73191
+  tps: 6276.99909
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 10959.05371
-  tps: 6418.63616
+  dps: 10921.86584
+  tps: 6396.47944
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 10854.95549
-  tps: 6352.90597
+  dps: 10886.10264
+  tps: 6372.00208
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 10992.49885
-  tps: 6438.69048
+  dps: 10969.00572
+  tps: 6425.1426
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StormshroudArmor"
  value: {
-  dps: 8248.09815
-  tps: 4831.27018
+  dps: 8241.48353
+  tps: 4826.25416
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 11078.58246
-  tps: 6490.3534
+  dps: 11043.1303
+  tps: 6469.23812
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 11072.2109
-  tps: 6486.53047
+  dps: 11036.77228
+  tps: 6465.42331
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 11061.06068
-  tps: 6479.84034
+  dps: 11025.64574
+  tps: 6458.74738
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 9615.90352
-  tps: 5635.24039
+  dps: 9612.4248
+  tps: 5634.13747
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 8493.26892
-  tps: 4970.66691
+  dps: 8451.11075
+  tps: 4945.75551
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 9317.4716
-  tps: 5444.48389
+  dps: 9303.31624
+  tps: 5436.91311
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 11104.33116
-  tps: 6502.16275
+  dps: 11061.02818
+  tps: 6475.31768
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 11116.66451
-  tps: 6510.39348
+  dps: 11135.41637
+  tps: 6522.06285
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 11119.69947
-  tps: 6514.52307
+  dps: 11113.22857
+  tps: 6510.8454
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 11045.13179
-  tps: 6470.28301
+  dps: 11009.75067
+  tps: 6449.21034
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 11045.13179
-  tps: 6470.28301
+  dps: 11009.75067
+  tps: 6449.21034
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 10868.02634
-  tps: 6360.08991
+  dps: 10879.35083
+  tps: 6364.72638
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 11045.13179
-  tps: 6470.28301
+  dps: 11009.75067
+  tps: 6449.21034
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 11045.13179
-  tps: 6470.28301
+  dps: 11009.75067
+  tps: 6449.21034
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 8662.40241
-  tps: 5076.82487
+  dps: 8631.48295
+  tps: 5059.00188
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 10245.16743
-  tps: 5991.81622
+  dps: 10268.76316
+  tps: 6003.89562
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10824.32748
-  tps: 6337.80042
+  dps: 10781.80827
+  tps: 6312.4449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 10767.74855
-  tps: 6303.85306
+  dps: 10730.29989
+  tps: 6281.53988
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 11293.51868
-  tps: 6620.65019
+  dps: 11292.15434
+  tps: 6620.00293
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 37661.45742
-  tps: 22454.75127
+  dps: 37796.72143
+  tps: 22532.94179
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11260.53775
-  tps: 6605.97599
+  dps: 11264.80117
+  tps: 6610.47506
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13088.25043
-  tps: 7494.54173
+  dps: 13062.89094
+  tps: 7479.63227
  }
 }
 dps_results: {
@@ -960,106 +960,106 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_bl_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31846.9546
-  tps: 18850.77298
+  dps: 31926.62002
+  tps: 18898.27857
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_bl_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11409.95827
-  tps: 6587.43032
+  dps: 11459.2743
+  tps: 6616.49867
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_bl_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13600.92893
-  tps: 7265.34119
+  dps: 13779.4006
+  tps: 7373.67192
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_bl_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16419.58421
-  tps: 9676.7776
+  dps: 16456.5912
+  tps: 9699.48944
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_bl_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6867.5951
-  tps: 3945.30961
+  dps: 6863.86888
+  tps: 3943.5178
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_bl_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8074.94779
-  tps: 4249.0087
+  dps: 8091.55902
+  tps: 4258.35474
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_uh_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27002.78647
-  tps: 15961.58735
+  dps: 27000.11548
+  tps: 15960.18809
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_uh_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9614.77471
-  tps: 5528.80638
+  dps: 9655.67505
+  tps: 5553.6608
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_uh_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12922.26843
-  tps: 6893.91658
+  dps: 12924.90882
+  tps: 6898.67987
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_uh_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13657.90713
-  tps: 8026.05464
+  dps: 13704.0823
+  tps: 8053.09235
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_uh_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5832.34281
-  tps: 3330.53094
+  dps: 5818.76112
+  tps: 3322.05133
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_uh_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7485.6208
-  tps: 3902.06406
+  dps: 7464.53174
+  tps: 3889.48177
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync--FullBuffs-LongMultiTarget"
  value: {
-  dps: 36424.5656
-  tps: 21713.86237
+  dps: 36936.72925
+  tps: 22019.67298
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11313.61378
-  tps: 6645.9677
+  dps: 11323.55512
+  tps: 6651.86435
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12892.37402
-  tps: 7372.09373
+  dps: 12879.34389
+  tps: 7364.67968
  }
 }
 dps_results: {
@@ -1086,106 +1086,106 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_bl_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31846.9546
-  tps: 18850.77298
+  dps: 31926.62002
+  tps: 18898.27857
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_bl_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11409.95827
-  tps: 6587.43032
+  dps: 11459.2743
+  tps: 6616.49867
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_bl_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13600.92893
-  tps: 7265.34119
+  dps: 13779.4006
+  tps: 7373.67192
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_bl_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16419.58421
-  tps: 9676.7776
+  dps: 16456.5912
+  tps: 9699.48944
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_bl_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6867.5951
-  tps: 3945.30961
+  dps: 6863.86888
+  tps: 3943.5178
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_bl_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8074.94779
-  tps: 4249.0087
+  dps: 8091.55902
+  tps: 4258.35474
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_uh_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27002.78647
-  tps: 15961.58735
+  dps: 27000.11548
+  tps: 15960.18809
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_uh_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9614.77471
-  tps: 5528.80638
+  dps: 9655.67505
+  tps: 5553.6608
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_uh_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12922.26843
-  tps: 6893.91658
+  dps: 12924.90882
+  tps: 6898.67987
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_uh_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13657.90713
-  tps: 8026.05464
+  dps: 13704.0823
+  tps: 8053.09235
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_uh_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5832.34281
-  tps: 3330.53094
+  dps: 5818.76112
+  tps: 3322.05133
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_uh_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7485.6208
-  tps: 3902.06406
+  dps: 7464.53174
+  tps: 3889.48177
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 38102.848
-  tps: 22708.26671
+  dps: 38320.05463
+  tps: 22837.17434
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11342.29714
-  tps: 6648.58222
+  dps: 11300.38647
+  tps: 6623.59182
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13122.61304
-  tps: 7497.53796
+  dps: 13110.37237
+  tps: 7491.25711
  }
 }
 dps_results: {
@@ -1212,106 +1212,106 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_bl_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31950.23206
-  tps: 18902.59806
+  dps: 31968.67523
+  tps: 18915.87298
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_bl_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11413.06264
-  tps: 6582.58374
+  dps: 11447.8353
+  tps: 6603.26547
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_bl_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13707.6327
-  tps: 7311.89817
+  dps: 13906.40922
+  tps: 7431.67268
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_bl_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16533.30419
-  tps: 9740.8208
+  dps: 16565.35063
+  tps: 9760.39999
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_bl_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6891.50867
-  tps: 3956.28512
+  dps: 6908.69647
+  tps: 3965.81763
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_bl_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8136.44314
-  tps: 4276.99761
+  dps: 8159.42463
+  tps: 4288.9126
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_uh_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27032.27034
-  tps: 15972.17927
+  dps: 27055.92052
+  tps: 15986.71551
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_uh_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9646.02318
-  tps: 5540.68352
+  dps: 9669.72867
+  tps: 5555.27594
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_uh_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12975.56916
-  tps: 6910.03765
+  dps: 12973.89568
+  tps: 6912.05096
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_uh_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13671.16717
-  tps: 8029.59989
+  dps: 13725.52336
+  tps: 8061.58668
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_uh_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5822.64936
-  tps: 3320.54771
+  dps: 5812.22439
+  tps: 3313.5319
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_uh_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7552.52472
-  tps: 3933.41452
+  dps: 7526.12475
+  tps: 3917.9147
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync--FullBuffs-LongMultiTarget"
  value: {
-  dps: 36905.6359
-  tps: 21994.72852
+  dps: 37076.04632
+  tps: 22097.33932
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11330.85179
-  tps: 6649.61842
+  dps: 11350.09282
+  tps: 6661.06651
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12967.05495
-  tps: 7400.9381
+  dps: 13015.06066
+  tps: 7429.68454
  }
 }
 dps_results: {
@@ -1338,91 +1338,91 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_bl_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31950.23206
-  tps: 18902.59806
+  dps: 31968.67523
+  tps: 18915.87298
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_bl_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11413.06264
-  tps: 6582.58374
+  dps: 11447.8353
+  tps: 6603.26547
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_bl_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13707.6327
-  tps: 7311.89817
+  dps: 13906.40922
+  tps: 7431.67268
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_bl_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16533.30419
-  tps: 9740.8208
+  dps: 16565.35063
+  tps: 9760.39999
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_bl_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6891.50867
-  tps: 3956.28512
+  dps: 6908.69647
+  tps: 3965.81763
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_bl_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8136.44314
-  tps: 4276.99761
+  dps: 8159.42463
+  tps: 4288.9126
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_uh_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27032.27034
-  tps: 15972.17927
+  dps: 27055.92052
+  tps: 15986.71551
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_uh_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9646.02318
-  tps: 5540.68352
+  dps: 9669.72867
+  tps: 5555.27594
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_uh_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12975.56916
-  tps: 6910.03765
+  dps: 12973.89568
+  tps: 6912.05096
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_uh_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13671.16717
-  tps: 8029.59989
+  dps: 13725.52336
+  tps: 8061.58668
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_uh_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5822.64936
-  tps: 3320.54771
+  dps: 5812.22439
+  tps: 3313.5319
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_uh_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7552.52472
-  tps: 3933.41452
+  dps: 7526.12475
+  tps: 3917.9147
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 11057.6694
-  tps: 6487.88186
+  dps: 11054.98921
+  tps: 6487.80405
  }
 }

--- a/sim/deathknight/dps/TestFrostUH.results
+++ b/sim/deathknight/dps/TestFrostUH.results
@@ -46,894 +46,894 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 11189.6999
-  tps: 7975.67812
+  dps: 11247.49874
+  tps: 8019.28382
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 11168.90042
-  tps: 7960.13731
+  dps: 11169.73313
+  tps: 7961.85811
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10881.33081
-  tps: 7748.71848
+  dps: 10938.58269
+  tps: 7791.92161
   hps: 60.89457
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10881.33081
-  tps: 7748.71848
+  dps: 10938.58269
+  tps: 7791.92161
   hps: 60.89457
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 11219.85085
-  tps: 7997.86923
+  dps: 11277.82912
+  tps: 8041.60698
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 10653.60337
-  tps: 7600.29054
+  dps: 10615.90949
+  tps: 7576.59703
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 8677.05912
-  tps: 6184.26557
+  dps: 8673.27564
+  tps: 6181.64848
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 8616.57976
-  tps: 6150.17875
+  dps: 8662.04712
+  tps: 6181.86809
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8356.70279
-  tps: 5956.87816
+  dps: 8318.44148
+  tps: 5926.49832
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 11189.6999
-  tps: 7816.16456
+  dps: 11247.49874
+  tps: 7858.89814
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 11458.33313
-  tps: 8173.39219
+  dps: 11519.63672
+  tps: 8219.57737
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 11458.33313
-  tps: 8173.39219
+  dps: 11519.63672
+  tps: 8219.57737
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11467.07435
-  tps: 8179.82572
+  dps: 11527.69079
+  tps: 8225.50517
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 11050.44331
-  tps: 7873.18528
+  dps: 11113.53865
+  tps: 7920.68919
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 11146.07908
-  tps: 7943.58716
+  dps: 11168.56775
+  tps: 7961.22171
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 11147.70815
-  tps: 7924.57593
+  dps: 11205.4344
+  tps: 7968.22181
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 9679.05096
-  tps: 6897.21084
+  dps: 9767.72135
+  tps: 6966.88175
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkrunedPlate"
  value: {
-  dps: 8571.0368
-  tps: 6098.787
+  dps: 8562.86169
+  tps: 6093.30384
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 10861.97034
-  tps: 7734.46917
+  dps: 10920.55776
+  tps: 7778.65525
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 11012.75871
-  tps: 7845.44941
+  dps: 11083.93457
+  tps: 7898.90059
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 11566.24637
-  tps: 8239.54648
+  dps: 11652.41157
+  tps: 8302.8861
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11649.02353
-  tps: 8304.31022
+  dps: 11660.11751
+  tps: 8311.99519
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 11229.7356
-  tps: 8005.1444
+  dps: 11286.02543
+  tps: 8047.63947
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11171.7244
-  tps: 7948.59044
+  dps: 11165.40712
+  tps: 7943.38972
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11154.54789
-  tps: 7937.38301
+  dps: 11092.66007
+  tps: 7894.96863
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 11189.6999
-  tps: 7975.67812
+  dps: 11247.49874
+  tps: 8019.28382
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 11189.6999
-  tps: 7975.67812
+  dps: 11247.49874
+  tps: 8019.28382
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 11219.85085
-  tps: 7997.86923
+  dps: 11277.82912
+  tps: 8041.60698
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 11213.1822
-  tps: 7992.9611
+  dps: 11271.88066
+  tps: 8037.22891
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10972.37828
-  tps: 7803.03154
+  dps: 10958.957
+  tps: 7794.32762
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 11189.6999
-  tps: 7975.67812
+  dps: 11247.49874
+  tps: 8019.28382
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 11084.34971
-  tps: 7900.01009
+  dps: 11146.25578
+  tps: 7944.8406
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 11034.43031
-  tps: 7861.39971
+  dps: 11095.04691
+  tps: 7907.07927
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForgeEmber-37660"
  value: {
-  dps: 11000.43626
-  tps: 7836.38009
+  dps: 11062.85459
+  tps: 7883.38573
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 11189.6999
-  tps: 7975.67812
+  dps: 11247.49874
+  tps: 8019.28382
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 11189.6999
-  tps: 7975.67812
+  dps: 11247.49874
+  tps: 8019.28382
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 10863.23722
-  tps: 7735.4016
+  dps: 10921.83434
+  tps: 7779.59482
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 11135.46866
-  tps: 7935.76394
+  dps: 11194.67407
+  tps: 7980.40486
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 11067.35933
-  tps: 7886.40083
+  dps: 11021.25815
+  tps: 7852.33241
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 10859.25322
-  tps: 7732.46937
+  dps: 10917.80866
+  tps: 7776.63192
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 11219.85085
-  tps: 7997.86923
+  dps: 11277.82912
+  tps: 8041.60698
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 11213.1822
-  tps: 7992.9611
+  dps: 11271.88066
+  tps: 8037.22891
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-IncisorFragment-37723"
  value: {
-  dps: 11118.34796
-  tps: 7923.1631
+  dps: 11174.58559
+  tps: 7965.61974
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 11189.6999
-  tps: 7975.67812
+  dps: 11247.49874
+  tps: 8019.28382
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 11224.57607
-  tps: 8001.34698
+  dps: 11282.61045
+  tps: 8045.12604
   hps: 16.40824
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-LastWord-50179"
  value: {
-  dps: 11458.33313
-  tps: 8173.39219
+  dps: 11519.63672
+  tps: 8219.57737
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-LastWord-50708"
  value: {
-  dps: 11458.33313
-  tps: 8173.39219
+  dps: 11519.63672
+  tps: 8219.57737
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 11225.82354
-  tps: 7993.13313
+  dps: 11242.00257
+  tps: 8004.10423
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 11060.67573
-  tps: 7880.71634
+  dps: 11118.157
+  tps: 7924.0883
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 11217.93299
-  tps: 7996.45768
+  dps: 11275.92251
+  tps: 8040.20371
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 11224.57607
-  tps: 8001.34698
+  dps: 11282.61045
+  tps: 8045.12604
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 11189.6999
-  tps: 7975.67812
+  dps: 11247.49874
+  tps: 8019.28382
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 11189.6999
-  tps: 7975.67812
+  dps: 11247.49874
+  tps: 8019.28382
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 10927.73808
-  tps: 7782.84747
+  dps: 10979.91943
+  tps: 7822.18136
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 10929.63278
-  tps: 7784.24197
+  dps: 10982.05603
+  tps: 7823.7539
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11458.33313
-  tps: 8173.39219
+  dps: 11519.63672
+  tps: 8219.57737
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 10864.71525
-  tps: 7736.48942
+  dps: 10923.32369
+  tps: 7780.69098
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 11189.6999
-  tps: 7975.67812
+  dps: 11247.49874
+  tps: 8019.28382
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 10858.84372
-  tps: 7732.16798
+  dps: 10917.39728
+  tps: 7776.32914
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 9447.25744
-  tps: 6741.90602
+  dps: 9340.72994
+  tps: 6661.139
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ScourgebornePlate"
  value: {
-  dps: 8392.30372
-  tps: 5969.95527
+  dps: 8377.64172
+  tps: 5957.41459
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 11592.18123
-  tps: 8291.95314
+  dps: 11585.14753
+  tps: 8287.89043
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 9279.8396
-  tps: 6597.05336
+  dps: 9191.0617
+  tps: 6533.41566
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Shadowmourne-49623"
  value: {
-  dps: 11458.33313
-  tps: 8173.39219
+  dps: 11519.63672
+  tps: 8219.57737
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 10855.63596
-  tps: 7729.80706
+  dps: 10914.17482
+  tps: 7773.95741
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 10869.35268
-  tps: 7739.90257
+  dps: 10928.58255
+  tps: 7784.56151
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 10855.63596
-  tps: 7729.80706
+  dps: 10914.17482
+  tps: 7773.95741
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 11333.14299
-  tps: 8067.78806
+  dps: 11395.80072
+  tps: 8115.03231
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 10855.63596
-  tps: 7729.80706
+  dps: 10914.17482
+  tps: 7773.95741
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 11378.07159
-  tps: 8099.57642
+  dps: 11440.02091
+  tps: 8146.3052
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 10855.63596
-  tps: 7729.80706
+  dps: 10914.17482
+  tps: 7773.95741
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SouloftheDead-40382"
  value: {
-  dps: 11037.89813
-  tps: 7863.95203
+  dps: 11099.90188
+  tps: 7910.65253
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SparkofLife-37657"
  value: {
-  dps: 11084.75162
-  tps: 7895.17046
+  dps: 11076.29718
+  tps: 7889.78985
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 11152.00619
-  tps: 7949.6602
+  dps: 11151.13881
+  tps: 7948.29322
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-StormshroudArmor"
  value: {
-  dps: 8239.33326
-  tps: 5878.89853
+  dps: 8147.83159
+  tps: 5810.40887
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 11224.57607
-  tps: 8001.34698
+  dps: 11282.61045
+  tps: 8045.12604
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 11217.93299
-  tps: 7996.45768
+  dps: 11275.92251
+  tps: 8040.20371
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 11206.3076
-  tps: 7987.90139
+  dps: 11264.2186
+  tps: 8031.58964
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 9770.6805
-  tps: 6968.25184
+  dps: 9743.75589
+  tps: 6950.99455
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Thassarian'sPlate"
  value: {
-  dps: 8466.59094
-  tps: 6021.18128
+  dps: 8385.23221
+  tps: 5965.23827
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 9477.80086
-  tps: 6734.71112
+  dps: 9452.24581
+  tps: 6716.22344
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 11295.78734
-  tps: 8048.05423
+  dps: 11293.80812
+  tps: 8046.93177
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 11267.88656
-  tps: 8034.79618
+  dps: 11231.77289
+  tps: 8007.74422
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 11334.70406
-  tps: 8080.39896
+  dps: 11259.01461
+  tps: 8025.63283
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 11189.6999
-  tps: 7975.67812
+  dps: 11247.49874
+  tps: 8019.28382
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 11189.6999
-  tps: 7975.67812
+  dps: 11247.49874
+  tps: 8019.28382
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 10922.98957
-  tps: 7777.92791
+  dps: 10971.74539
+  tps: 7809.04654
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 11189.6999
-  tps: 7975.67812
+  dps: 11247.49874
+  tps: 8019.28382
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 11189.6999
-  tps: 7975.67812
+  dps: 11247.49874
+  tps: 8019.28382
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 8668.4258
-  tps: 6187.51542
+  dps: 8612.61477
+  tps: 6144.63951
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 10394.7522
-  tps: 7391.64627
+  dps: 10400.08089
+  tps: 7395.29221
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10881.34392
-  tps: 7748.72812
+  dps: 10938.71586
+  tps: 7792.01962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 10866.40442
-  tps: 7737.73265
+  dps: 10925.02581
+  tps: 7781.94374
  }
 }
 dps_results: {
  key: "TestFrostUH-Average-Default"
  value: {
-  dps: 11458.53354
-  tps: 8177.34509
+  dps: 11464.645
+  tps: 8182.14727
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 30160.17412
-  tps: 21961.79555
+  dps: 30138.29996
+  tps: 21944.86242
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11421.08243
-  tps: 8161.66901
+  dps: 11426.70789
+  tps: 8164.31812
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13468.39621
-  tps: 9296.29413
+  dps: 13452.53129
+  tps: 9285.62001
  }
 }
 dps_results: {
@@ -960,64 +960,64 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic-frost_uh_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 30910.85665
-  tps: 22379.40211
+  dps: 31044.06607
+  tps: 22477.0401
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic-frost_uh_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11707.2844
-  tps: 8237.65556
+  dps: 11729.59285
+  tps: 8252.47742
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic-frost_uh_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14200.14879
-  tps: 9247.20228
+  dps: 14266.36446
+  tps: 9291.15751
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic-frost_uh_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16012.14074
-  tps: 11533.01838
+  dps: 15963.16562
+  tps: 11496.36677
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic-frost_uh_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 7016.21354
-  tps: 4903.47357
+  dps: 7026.96421
+  tps: 4911.83762
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic-frost_uh_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8101.80118
-  tps: 5152.08569
+  dps: 8126.36961
+  tps: 5171.05644
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 29815.90395
-  tps: 21694.6821
+  dps: 29041.26465
+  tps: 21126.51505
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11458.33313
-  tps: 8173.39219
+  dps: 11519.63672
+  tps: 8219.57737
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13550.4812
-  tps: 9325.04073
+  dps: 13626.84862
+  tps: 9382.32285
  }
 }
 dps_results: {
@@ -1044,49 +1044,49 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic-frost_uh_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31096.5043
-  tps: 22504.46821
+  dps: 31064.46386
+  tps: 22483.39367
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic-frost_uh_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11777.62238
-  tps: 8278.03638
+  dps: 11704.63031
+  tps: 8223.8702
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic-frost_uh_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14298.15788
-  tps: 9292.51401
+  dps: 14304.26914
+  tps: 9294.78543
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic-frost_uh_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16173.03561
-  tps: 11643.68278
+  dps: 16024.18784
+  tps: 11534.39401
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic-frost_uh_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 7066.61422
-  tps: 4933.45219
+  dps: 7060.53767
+  tps: 4929.98291
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic-frost_uh_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8145.79662
-  tps: 5168.18787
+  dps: 8148.86618
+  tps: 5172.64526
  }
 }
 dps_results: {
  key: "TestFrostUH-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 10574.87055
-  tps: 7553.71227
+  dps: 10750.50604
+  tps: 7684.5917
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -46,1376 +46,1376 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 11442.41909
-  tps: 7563.21215
-  hps: 419.6587
+  dps: 11429.56687
+  tps: 7557.30128
+  hps: 423.60582
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 11442.41909
-  tps: 7563.21215
-  hps: 433.24059
+  dps: 11429.56687
+  tps: 7557.30128
+  hps: 437.3744
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 11995.29404
-  tps: 7825.74323
-  hps: 322.07496
+  dps: 11939.18811
+  tps: 7792.04153
+  hps: 325.06505
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 11669.1058
-  tps: 7761.69763
-  hps: 315.95226
+  dps: 11639.44688
+  tps: 7726.79708
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 11442.48443
-  tps: 7563.23111
-  hps: 409.19523
+  dps: 11429.59033
+  tps: 7557.2988
+  hps: 411.96954
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 11442.48443
-  tps: 7563.23111
-  hps: 409.19523
+  dps: 11429.59033
+  tps: 7557.2988
+  hps: 411.96954
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 12020.81285
-  tps: 7847.11966
-  hps: 317.63734
+  dps: 11965.50843
+  tps: 7816.11845
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 11341.4277
-  tps: 7318.5891
-  hps: 302.04873
+  dps: 11336.4291
+  tps: 7296.74245
+  hps: 305.28353
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 8922.1323
-  tps: 5752.64694
-  hps: 259.25488
+  dps: 8867.12945
+  tps: 5698.69889
+  hps: 260.63023
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 8736.48642
-  tps: 5670.92643
-  hps: 251.54395
+  dps: 8792.0105
+  tps: 5707.43021
+  hps: 242.31298
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8526.18419
-  tps: 5491.22442
-  hps: 244.15577
+  dps: 8544.55017
+  tps: 5514.49051
+  hps: 243.82849
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 11995.29404
-  tps: 7669.22837
-  hps: 317.63734
+  dps: 11939.18811
+  tps: 7636.2007
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 12143.33786
-  tps: 7961.19133
-  hps: 317.63734
+  dps: 12087.49125
+  tps: 7929.80145
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 12143.33786
-  tps: 7961.19133
-  hps: 317.63734
+  dps: 12087.49125
+  tps: 7929.80145
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 12155.38611
-  tps: 7973.22779
-  hps: 317.63734
+  dps: 12097.96346
+  tps: 7941.01147
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 11442.43199
-  tps: 7563.1899
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 11442.43199
-  tps: 7563.1899
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 11442.45455
-  tps: 7563.22418
-  hps: 411.86578
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 414.645
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 11601.26309
-  tps: 7710.92565
-  hps: 316.37353
+  dps: 11591.36027
+  tps: 7700.81903
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 11642.93708
-  tps: 7747.5762
-  hps: 316.37353
+  dps: 11614.13907
+  tps: 7721.13227
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 11807.4279
-  tps: 7758.91477
-  hps: 315.53099
+  dps: 11789.44989
+  tps: 7747.64192
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 9904.21837
-  tps: 6411.55392
-  hps: 291.03459
+  dps: 9913.0308
+  tps: 6427.23002
+  hps: 292.20184
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 8790.88526
-  tps: 5632.35909
-  hps: 308.21971
+  dps: 8819.57661
+  tps: 5666.39294
+  hps: 309.44931
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 12038.35464
-  tps: 8005.43878
-  hps: 354.70907
+  dps: 11997.94016
+  tps: 7965.47184
+  hps: 351.76018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 11564.86353
-  tps: 7678.84339
-  hps: 316.37353
+  dps: 11546.58654
+  tps: 7659.839
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 11901.64394
-  tps: 7976.41656
-  hps: 325.64146
+  dps: 11909.3992
+  tps: 7967.09032
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11958.87268
-  tps: 8062.80341
-  hps: 322.69257
+  dps: 11915.66613
+  tps: 8006.41255
+  hps: 322.27131
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 11442.41627
-  tps: 7563.16599
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 12024.42769
-  tps: 7849.82498
-  hps: 317.63734
+  dps: 11969.56919
+  tps: 7821.7232
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11851.05671
-  tps: 7778.40326
-  hps: 319.32242
+  dps: 11801.36758
+  tps: 7724.64572
+  hps: 319.74369
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11793.57996
-  tps: 7736.15343
-  hps: 316.37353
+  dps: 11805.85912
+  tps: 7738.22348
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 11995.29404
-  tps: 7825.74323
-  hps: 322.07496
+  dps: 11939.18811
+  tps: 7792.04153
+  hps: 325.06505
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 11995.29404
-  tps: 7825.74323
-  hps: 317.63734
+  dps: 11939.18811
+  tps: 7792.04153
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 12020.81285
-  tps: 7847.11966
-  hps: 317.63734
+  dps: 11965.50843
+  tps: 7816.11845
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 12014.95941
-  tps: 7842.07078
-  hps: 317.63734
+  dps: 11961.51073
+  tps: 7812.68241
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 11736.2643
-  tps: 7656.91957
-  hps: 318.90115
+  dps: 11732.08248
+  tps: 7643.75691
+  hps: 320.16496
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 11442.43199
-  tps: 7563.1899
-  hps: 331.70528
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 334.35539
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 11995.29404
-  tps: 7825.74323
-  hps: 317.63734
+  dps: 11939.18811
+  tps: 7792.04153
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 11688.05174
-  tps: 7785.22858
-  hps: 316.37353
+  dps: 11640.4596
+  tps: 7747.74398
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 11576.18447
-  tps: 7685.57153
-  hps: 316.37353
+  dps: 11566.10737
+  tps: 7677.2556
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 11442.43199
-  tps: 7563.1899
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 11442.43199
-  tps: 7563.1899
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 11553.14471
-  tps: 7664.10062
-  hps: 316.37353
+  dps: 11538.77224
+  tps: 7652.15601
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 11995.29404
-  tps: 7825.74323
-  hps: 317.63734
+  dps: 11939.18811
+  tps: 7792.04153
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 11995.29404
-  tps: 7825.74323
-  hps: 317.63734
+  dps: 11939.18811
+  tps: 7792.04153
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 12056.92618
-  tps: 8020.32654
-  hps: 354.70907
+  dps: 12016.68916
+  tps: 7980.2171
+  hps: 351.76018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 11713.63819
-  tps: 7786.49504
-  hps: 316.37353
+  dps: 11701.08147
+  tps: 7780.62375
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 11442.41627
-  tps: 7563.16599
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 11442.43882
-  tps: 7563.20027
-  hps: 316.37353
+  dps: 11429.55457
+  tps: 7557.23875
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 11442.43882
-  tps: 7563.20027
-  hps: 316.37353
+  dps: 11429.55457
+  tps: 7557.23875
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 11598.40679
-  tps: 7714.07957
-  hps: 315.95226
+  dps: 11564.26458
+  tps: 7675.942
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 11999.9702
-  tps: 7973.40926
-  hps: 354.70907
+  dps: 11958.09576
+  tps: 7933.09692
+  hps: 351.76018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 11442.43199
-  tps: 7563.1899
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 12020.81285
-  tps: 7847.11966
-  hps: 317.63734
+  dps: 11965.50843
+  tps: 7816.11845
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 12014.95941
-  tps: 7842.07078
-  hps: 317.63734
+  dps: 11961.51073
+  tps: 7812.68241
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 11639.28832
-  tps: 7726.98727
-  hps: 316.37353
+  dps: 11626.03245
+  tps: 7720.83207
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 11995.29404
-  tps: 7825.74323
-  hps: 317.63734
+  dps: 11939.18811
+  tps: 7792.04153
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 12032.82091
-  tps: 7855.75877
-  hps: 334.12103
+  dps: 11976.51812
+  tps: 7821.95634
+  hps: 337.06992
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50179"
  value: {
-  dps: 12143.33786
-  tps: 7961.19133
-  hps: 317.63734
+  dps: 12087.49125
+  tps: 7929.80145
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50708"
  value: {
-  dps: 12143.33786
-  tps: 7961.19133
-  hps: 317.63734
+  dps: 12087.49125
+  tps: 7929.80145
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 11442.41627
-  tps: 7563.16599
-  hps: 316.37353
+  dps: 11429.55457
+  tps: 7557.23875
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 11442.43199
-  tps: 7563.1899
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 11800.30391
-  tps: 7780.2961
-  hps: 319.74369
+  dps: 11786.07943
+  tps: 7752.94483
+  hps: 318.05861
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 11578.32896
-  tps: 7703.85835
-  hps: 316.37353
+  dps: 11572.83648
+  tps: 7695.30299
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 11442.41627
-  tps: 7563.16599
-  hps: 316.37353
+  dps: 11429.55457
+  tps: 7557.23875
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 12025.67294
-  tps: 7850.04153
-  hps: 317.63734
+  dps: 11969.40764
+  tps: 7816.25829
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 12032.82091
-  tps: 7855.75877
-  hps: 317.63734
+  dps: 11976.51812
+  tps: 7821.95634
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 11442.43199
-  tps: 7563.1899
-  hps: 316.37353
+  dps: 11429.55457
+  tps: 7557.23875
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 11442.43199
-  tps: 7563.1899
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 11442.43199
-  tps: 7563.1899
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 11995.29404
-  tps: 7825.74323
-  hps: 321.24291
+  dps: 11939.18811
+  tps: 7792.04153
+  hps: 324.22527
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 11995.29404
-  tps: 7825.74323
-  hps: 322.07496
+  dps: 11939.18811
+  tps: 7792.04153
+  hps: 325.06505
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 11442.43199
-  tps: 7563.1899
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 11533.50242
-  tps: 7649.24564
-  hps: 316.37353
+  dps: 11499.33359
+  tps: 7617.4335
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 11543.88748
-  tps: 7657.98019
-  hps: 316.37353
+  dps: 11509.71303
+  tps: 7626.1279
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 12143.33786
-  tps: 7961.19133
-  hps: 317.63734
+  dps: 12087.49125
+  tps: 7929.80145
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 12078.59297
-  tps: 8037.6956
-  hps: 354.70907
+  dps: 12038.56298
+  tps: 7997.41989
+  hps: 351.76018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 11995.29404
-  tps: 7825.74323
-  hps: 317.63734
+  dps: 11939.18811
+  tps: 7792.04153
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 11442.41627
-  tps: 7563.16599
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 11993.807
-  tps: 7968.61366
-  hps: 354.70907
+  dps: 11951.99605
+  tps: 7928.41904
+  hps: 351.76018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 9502.10597
-  tps: 6140.87498
+  dps: 9526.03801
+  tps: 6145.13792
   hps: 275.0639
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 8762.55823
-  tps: 5593.56442
-  hps: 284.94914
+  dps: 8740.06336
+  tps: 5597.40027
+  hps: 286.09046
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 11191.0836
-  tps: 7505.19865
-  hps: 335.91246
+  dps: 11184.40324
+  tps: 7497.93479
+  hps: 336.35856
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 9863.02095
-  tps: 6488.15096
-  hps: 360.50688
+  dps: 9867.68996
+  tps: 6483.14256
+  hps: 358.58418
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 11442.41627
-  tps: 7563.16599
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 12143.33786
-  tps: 7961.19133
-  hps: 317.63734
+  dps: 12087.49125
+  tps: 7929.80145
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 11442.43199
-  tps: 7563.1899
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 11945.51895
-  tps: 7931.03338
-  hps: 354.70907
+  dps: 11904.2182
+  tps: 7891.78054
+  hps: 351.76018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 11959.00337
-  tps: 7946.21448
-  hps: 354.70907
+  dps: 11920.54226
+  tps: 7911.15617
+  hps: 351.76018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 11945.51895
-  tps: 7931.03338
-  hps: 354.70907
+  dps: 11904.2182
+  tps: 7891.78054
+  hps: 351.76018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 11945.51895
-  tps: 7931.03338
-  hps: 354.70907
+  dps: 11904.2182
+  tps: 7891.78054
+  hps: 351.76018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 11945.51895
-  tps: 7931.03338
-  hps: 354.70907
+  dps: 11904.2182
+  tps: 7891.78054
+  hps: 351.76018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 11945.51895
-  tps: 7931.03338
-  hps: 354.70907
+  dps: 11904.2182
+  tps: 7891.78054
+  hps: 351.76018
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 11442.46218
-  tps: 7563.23578
-  hps: 347.86578
+  dps: 11429.55457
+  tps: 7557.23875
+  hps: 350.645
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 11442.43199
-  tps: 7563.1899
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 11442.43199
-  tps: 7563.1899
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SoulPreserver-37111"
  value: {
-  dps: 11442.43199
-  tps: 7563.1899
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SouloftheDead-40382"
  value: {
-  dps: 11586.66499
-  tps: 7695.64645
-  hps: 316.37353
+  dps: 11573.90195
+  tps: 7685.77118
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 11595.1139
-  tps: 7629.2241
-  hps: 314.26718
+  dps: 11596.80089
+  tps: 7622.08448
+  hps: 315.95226
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 11685.03946
-  tps: 7717.08909
-  hps: 321.42877
+  dps: 11675.30208
+  tps: 7701.83533
+  hps: 316.7948
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StormshroudArmor"
  value: {
-  dps: 8379.05707
-  tps: 5427.84565
-  hps: 232.82907
+  dps: 8435.84726
+  tps: 5485.85536
+  hps: 228.8254
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 12032.82091
-  tps: 7855.75877
-  hps: 317.63734
+  dps: 11976.51812
+  tps: 7821.95634
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 12025.67294
-  tps: 7850.04153
-  hps: 317.63734
+  dps: 11969.40764
+  tps: 7816.25829
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 12013.16398
-  tps: 7840.03635
-  hps: 317.63734
+  dps: 11956.96431
+  tps: 7806.28668
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 11442.41627
-  tps: 7563.16599
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 11442.43199
-  tps: 7563.1899
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 10116.61902
-  tps: 6593.8095
-  hps: 285.90184
+  dps: 10150.06044
+  tps: 6624.96049
+  hps: 291.31811
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 8864.97555
-  tps: 5657.81549
-  hps: 302.69926
+  dps: 8822.96657
+  tps: 5627.39565
+  hps: 297.86252
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 11442.43199
-  tps: 7563.1899
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 10576.01727
-  tps: 6849.83587
-  hps: 302.75443
+  dps: 10592.9207
+  tps: 6838.42363
+  hps: 305.19928
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 12065.38996
-  tps: 7856.36367
-  hps: 318.47988
+  dps: 12108.41716
+  tps: 7881.25419
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 11698.89272
-  tps: 7779.24923
-  hps: 317.63734
+  dps: 11724.17255
+  tps: 7784.76441
+  hps: 319.32242
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 11722.00792
-  tps: 7791.0803
-  hps: 318.47988
+  dps: 11717.15314
+  tps: 7801.85837
+  hps: 319.32242
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 11995.29404
-  tps: 7825.74323
-  hps: 317.63734
+  dps: 11939.18811
+  tps: 7792.04153
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 11995.29404
-  tps: 7825.74323
-  hps: 317.63734
+  dps: 11939.18811
+  tps: 7792.04153
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 11561.26816
-  tps: 7576.64413
-  hps: 316.37353
+  dps: 11556.05053
+  tps: 7561.08618
+  hps: 318.47988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 11995.29404
-  tps: 7825.74323
-  hps: 317.63734
+  dps: 11939.18811
+  tps: 7792.04153
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 11995.29404
-  tps: 7825.74323
-  hps: 317.63734
+  dps: 11939.18811
+  tps: 7792.04153
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 8761.3152
-  tps: 5680.39581
-  hps: 256.0063
+  dps: 8759.27531
+  tps: 5684.71821
+  hps: 246.57449
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 11389.53378
-  tps: 7400.88977
-  hps: 320.50999
+  dps: 11387.34353
+  tps: 7403.22618
+  hps: 322.38136
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 11442.41627
-  tps: 7563.16599
-  hps: 316.37353
+  dps: 11429.57423
+  tps: 7557.26863
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 12103.35501
-  tps: 8057.54595
-  hps: 354.70907
+  dps: 12063.56164
+  tps: 8017.08023
+  hps: 351.76018
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 12079.79755
-  tps: 7959.30754
-  hps: 319.10091
+  dps: 12081.31353
+  tps: 7959.90618
+  hps: 319.04123
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 58351.77018
-  tps: 61159.27043
-  hps: 320.86735
+  dps: 58282.55529
+  tps: 61021.43118
+  hps: 319.60409
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11918.70505
-  tps: 7937.3746
-  hps: 320.44626
+  dps: 11890.82484
+  tps: 7918.88737
+  hps: 317.49866
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16874.08083
-  tps: 8826.63203
+  dps: 16870.57312
+  tps: 8819.13821
   hps: 216.85917
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 35260.41818
-  tps: 37882.38085
-  hps: 207.00864
+  dps: 35223.33975
+  tps: 37943.43775
+  hps: 205.0688
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6075.05836
-  tps: 4427.18594
-  hps: 206.73152
+  dps: 6075.76095
+  tps: 4427.09091
+  hps: 207.00864
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7581.70978
-  tps: 4500.74982
-  hps: 159.344
+  dps: 7569.8533
+  tps: 4476.78422
+  hps: 155.1872
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_2h_ss-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14181.46465
-  tps: 9333.90514
+  dps: 14216.78262
+  tps: 9339.94594
   hps: 42.10858
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_2h_ss-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10215.06667
-  tps: 6007.27891
+  dps: 10208.04906
+  tps: 5990.17008
   hps: 42.10858
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_2h_ss-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 15206.83126
-  tps: 7210.30987
+  dps: 15238.79029
+  tps: 7216.39308
   hps: 210.54288
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_2h_ss-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6744.47555
-  tps: 4599.3294
+  dps: 6773.99776
+  tps: 4622.19929
   hps: 27.712
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_2h_ss-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5050.67637
-  tps: 3183.10003
+  dps: 5063.00354
+  tps: 3190.72573
   hps: 27.712
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_2h_ss-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6556.39489
-  tps: 3459.7399
+  dps: 6571.03152
+  tps: 3458.56929
   hps: 138.56
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_dnd_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 58949.69297
-  tps: 61031.00093
+  dps: 58922.51862
+  tps: 60981.15465
   hps: 235.80803
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_dnd_aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11190.75601
-  tps: 7472.67948
+  dps: 11175.15439
+  tps: 7462.22406
   hps: 235.80803
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_dnd_aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16181.30366
-  tps: 8714.78227
+  dps: 16092.14993
+  tps: 8635.16014
   hps: 336.86861
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_dnd_aoe-NoBuffs-LongMultiTarget"
  value: {
-  dps: 35019.29747
-  tps: 37382.94017
+  dps: 35189.10707
+  tps: 37608.07344
   hps: 155.46432
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_dnd_aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5685.89398
-  tps: 4167.70895
+  dps: 5706.96125
+  tps: 4183.46723
   hps: 155.1872
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_dnd_aoe-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7152.264
-  tps: 4454.44231
+  dps: 7141.96652
+  tps: 4424.38656
   hps: 221.696
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-unholy_dw_ss-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36088.5325
-  tps: 43100.6337
+  dps: 36056.0448
+  tps: 43073.41482
   hps: 235.80803
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-unholy_dw_ss-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11359.45498
-  tps: 7620.03291
+  dps: 11346.15549
+  tps: 7604.43722
   hps: 235.80803
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-unholy_dw_ss-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16218.3081
-  tps: 8814.19738
+  dps: 16175.66747
+  tps: 8768.1439
   hps: 336.86861
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-unholy_dw_ss-NoBuffs-LongMultiTarget"
  value: {
-  dps: 18603.20315
-  tps: 22811.81423
+  dps: 18621.73567
+  tps: 22843.42349
   hps: 155.74144
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-unholy_dw_ss-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5820.70447
-  tps: 4279.11813
+  dps: 5828.55942
+  tps: 4279.79299
   hps: 155.1872
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-unholy_dw_ss-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7197.72454
-  tps: 4484.46897
+  dps: 7223.1246
+  tps: 4489.74584
   hps: 221.696
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 58799.838
-  tps: 61392.71336
-  hps: 321.42877
+  dps: 58728.40965
+  tps: 61185.14463
+  hps: 317.63734
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 12143.33786
-  tps: 7961.19133
-  hps: 317.63734
+  dps: 12087.49125
+  tps: 7929.80145
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 17270.52921
-  tps: 8862.80773
+  dps: 17341.28362
+  tps: 8901.81176
   hps: 216.95389
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 35584.32461
-  tps: 38272.22912
-  hps: 206.0131
+  dps: 35557.93766
+  tps: 38289.66635
+  hps: 204.90401
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6177.29616
-  tps: 4440.03261
-  hps: 209.06309
+  dps: 6174.00076
+  tps: 4448.72091
+  hps: 209.61763
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7793.48879
-  tps: 4534.17858
-  hps: 159.4314
+  dps: 7772.61665
+  tps: 4506.71482
+  hps: 155.27232
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_2h_ss-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14369.52983
-  tps: 9375.57834
+  dps: 14382.89764
+  tps: 9372.69266
   hps: 42.12697
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_2h_ss-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10323.33954
-  tps: 5987.19739
+  dps: 10376.4762
+  tps: 6019.59773
   hps: 42.12697
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_2h_ss-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 15534.54782
-  tps: 7272.84066
+  dps: 15595.21358
+  tps: 7254.63739
   hps: 210.63484
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_2h_ss-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6762.99424
-  tps: 4572.1468
+  dps: 6763.86474
+  tps: 4580.11715
   hps: 27.7272
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_2h_ss-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5081.03941
-  tps: 3166.71627
+  dps: 5102.21619
+  tps: 3186.58926
   hps: 27.7272
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_2h_ss-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6680.20063
-  tps: 3473.00166
+  dps: 6717.41972
+  tps: 3491.87861
   hps: 138.636
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_dnd_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 59442.00202
-  tps: 61433.49956
-  hps: 235.91102
+  dps: 59451.32348
+  tps: 61481.79304
+  hps: 236.33229
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_dnd_aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11332.02593
-  tps: 7469.48119
+  dps: 11307.6135
+  tps: 7448.83622
   hps: 235.91102
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_dnd_aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16513.70887
-  tps: 8753.75467
+  dps: 16424.89984
+  tps: 8629.42998
   hps: 337.01574
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_dnd_aoe-NoBuffs-LongMultiTarget"
  value: {
-  dps: 35093.37165
-  tps: 37431.50102
-  hps: 155.27232
+  dps: 34874.97413
+  tps: 37203.02288
+  hps: 155.82686
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_dnd_aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5767.76688
-  tps: 4188.56855
+  dps: 5766.45343
+  tps: 4187.84515
   hps: 155.27232
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_dnd_aoe-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7269.64826
-  tps: 4462.08681
+  dps: 7271.28731
+  tps: 4451.02194
   hps: 221.8176
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-unholy_dw_ss-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36249.6482
-  tps: 43202.37394
+  dps: 36227.84248
+  tps: 43178.52758
   hps: 235.91102
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-unholy_dw_ss-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11462.59341
-  tps: 7597.7334
+  dps: 11460.66714
+  tps: 7599.56248
   hps: 235.91102
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-unholy_dw_ss-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16564.27241
-  tps: 8858.64817
-  hps: 337.01574
+  dps: 16534.75075
+  tps: 8797.37349
+  hps: 339.12209
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-unholy_dw_ss-NoBuffs-LongMultiTarget"
  value: {
-  dps: 18705.89107
-  tps: 22909.77328
+  dps: 18653.09152
+  tps: 22841.42993
   hps: 155.82686
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-unholy_dw_ss-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5880.45476
-  tps: 4286.01048
+  dps: 5861.10463
+  tps: 4261.92579
   hps: 155.27232
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-unholy_dw_ss-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7333.66985
-  tps: 4515.01867
+  dps: 7365.09858
+  tps: 4526.60615
   hps: 221.8176
  }
 }
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 11610.81447
-  tps: 7652.19762
-  hps: 313.00337
+  dps: 11599.92123
+  tps: 7657.61058
+  hps: 310.05448
  }
 }

--- a/sim/deathknight/talents_frost.go
+++ b/sim/deathknight/talents_frost.go
@@ -31,7 +31,7 @@ func (dk *Deathknight) ApplyFrostTalents() {
 	// Nerves Of Cold Steel
 	if dk.nervesOfColdSteelActive() {
 		dk.AddStat(stats.MeleeHit, core.MeleeHitRatingPerHitChance*float64(dk.Talents.NervesOfColdSteel))
-		dk.AutoAttacks.OHConfig.DamageMultiplier *= dk.nervesOfColdSteelBonus()
+		dk.AutoAttacks.OHConfig().DamageMultiplier *= dk.nervesOfColdSteelBonus()
 	}
 
 	// Icy Talons

--- a/sim/deathknight/talents_unholy.go
+++ b/sim/deathknight/talents_unholy.go
@@ -103,8 +103,8 @@ func (dk *Deathknight) applyNecrosis() {
 
 	// Replace normal melee swing applier with one that also applies necrosis damage.
 	// Doing it this way means you don't see necrosis dmg on the timeline but is faster.
-	dk.AutoAttacks.MHConfig.ApplyEffects = dk.necrosisMHAuto
-	dk.AutoAttacks.OHConfig.ApplyEffects = dk.necrosisOHAuto
+	dk.AutoAttacks.MHConfig().ApplyEffects = dk.necrosisMHAuto
+	dk.AutoAttacks.OHConfig().ApplyEffects = dk.necrosisOHAuto
 }
 
 func (dk *Deathknight) necrosisDamage(damage float64, sim *core.Simulation, target *core.Unit) {

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -46,965 +46,965 @@ character_stats_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2193.33073
-  tps: 6688.95963
+  dps: 2200.00646
+  tps: 6734.61761
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 2107.42882
-  tps: 6470.42731
-  hps: 82.39214
+  dps: 2103.91256
+  tps: 6418.2414
+  hps: 82.20134
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 2107.42882
-  tps: 6470.42731
-  hps: 82.39214
+  dps: 2103.91256
+  tps: 6418.2414
+  hps: 82.20134
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 2109.15845
-  tps: 6474.02353
+  dps: 2106.43805
+  tps: 6428.69318
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 2070.84544
-  tps: 6404.0485
+  dps: 2077.02002
+  tps: 6340.96246
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1963.73672
-  tps: 5937.61779
+  dps: 1959.48001
+  tps: 6041.46903
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1905.6931
-  tps: 5786.20977
+  dps: 1908.14418
+  tps: 5804.72047
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1799.39696
-  tps: 5488.58967
+  dps: 1794.30547
+  tps: 5443.21654
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2104.09782
-  tps: 6329.63648
+  dps: 2100.59107
+  tps: 6278.65062
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 2571.48897
-  tps: 7559.89926
+  dps: 2565.75895
+  tps: 7543.91456
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 2604.91681
-  tps: 7639.29145
+  dps: 2594.02176
+  tps: 7539.39986
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2125.72188
-  tps: 6528.67052
+  dps: 2122.82882
+  tps: 6482.82
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
   hps: 64
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2140.13972
-  tps: 6574.52914
+  dps: 2138.03181
+  tps: 6529.97377
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2173.15965
-  tps: 6652.44047
+  dps: 2180.61542
+  tps: 6644.50622
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 2176.73624
-  tps: 6676.72431
+  dps: 2172.22486
+  tps: 6623.88616
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 2400.20567
-  tps: 7359.73816
+  dps: 2403.11303
+  tps: 7339.53796
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedPlate"
  value: {
-  dps: 2101.02457
-  tps: 6501.29029
+  dps: 2117.81075
+  tps: 6539.73519
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Death'sChoice-47464"
  value: {
-  dps: 2295.09899
-  tps: 7079.61557
+  dps: 2291.53101
+  tps: 7019.4214
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 2123.80133
-  tps: 6521.66141
+  dps: 2121.09033
+  tps: 6475.70469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 2233.68131
-  tps: 6805.82183
+  dps: 2231.87336
+  tps: 6802.06368
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 2244.07297
-  tps: 6851.76615
+  dps: 2241.7631
+  tps: 6848.40245
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 2113.41433
-  tps: 6490.94469
+  dps: 2109.89394
+  tps: 6438.65983
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2111.02693
-  tps: 6477.89783
+  dps: 2108.29846
+  tps: 6432.55073
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 2181.22794
-  tps: 6594.51102
+  dps: 2171.34944
+  tps: 6597.28063
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 2171.47123
-  tps: 6584.77151
+  dps: 2166.23462
+  tps: 6581.70093
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 2104.09782
-  tps: 6458.81273
+  dps: 2100.59107
+  tps: 6406.78635
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2104.09782
-  tps: 6458.81273
+  dps: 2100.59107
+  tps: 6406.78635
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 2109.15845
-  tps: 6474.02353
+  dps: 2106.43805
+  tps: 6428.69318
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2107.9575
-  tps: 6468.99402
+  dps: 2104.42717
+  tps: 6421.98426
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 2154.97742
-  tps: 6650.54203
+  dps: 2149.78447
+  tps: 6584.05367
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 2104.09782
-  tps: 6458.81273
+  dps: 2100.59107
+  tps: 6406.78635
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2175.13572
-  tps: 6656.15384
+  dps: 2183.63957
+  tps: 6698.18045
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2133.90517
-  tps: 6559.0282
+  dps: 2132.17325
+  tps: 6512.67888
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2130.0322
-  tps: 6546.41085
+  dps: 2127.81118
+  tps: 6495.9339
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2104.09782
-  tps: 6458.81273
+  dps: 2100.59107
+  tps: 6406.78635
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2104.09782
-  tps: 6458.81273
+  dps: 2100.59107
+  tps: 6406.78635
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2182.45674
-  tps: 6738.0541
+  dps: 2178.87867
+  tps: 6683.91114
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 2159.81684
-  tps: 6605.261
+  dps: 2165.50796
+  tps: 6645.57199
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 2109.15845
-  tps: 6474.02353
+  dps: 2106.43805
+  tps: 6428.69318
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2107.9575
-  tps: 6468.99402
+  dps: 2104.42717
+  tps: 6421.98426
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2164.44263
-  tps: 6640.20594
+  dps: 2160.72521
+  tps: 6586.73191
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 2104.09782
-  tps: 6458.81273
+  dps: 2100.59107
+  tps: 6406.78635
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2114.76527
-  tps: 6495.60399
-  hps: 14.80983
+  dps: 2111.2429
+  tps: 6443.28165
+  hps: 15.08033
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-LastWord-50179"
  value: {
-  dps: 2366.59223
-  tps: 7045.24995
+  dps: 2352.63287
+  tps: 7051.5458
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-LastWord-50708"
  value: {
-  dps: 2389.28654
-  tps: 7104.00758
+  dps: 2375.2401
+  tps: 7110.29153
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2161.44738
-  tps: 6580.64445
+  dps: 2169.59633
+  tps: 6633.95697
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 2150.22107
-  tps: 6610.0618
+  dps: 2146.94485
+  tps: 6554.5494
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2111.29777
-  tps: 6483.64484
+  dps: 2107.78048
+  tps: 6431.4187
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 2112.73337
-  tps: 6488.59613
+  dps: 2109.21398
+  tps: 6436.33016
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2114.76527
-  tps: 6495.60399
+  dps: 2111.2429
+  tps: 6443.28165
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 2123.51737
-  tps: 6525.78932
+  dps: 2119.98219
+  tps: 6473.22417
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 2125.59159
-  tps: 6532.94318
+  dps: 2122.05338
+  tps: 6480.32047
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 2104.09782
-  tps: 6458.81273
+  dps: 2100.59107
+  tps: 6406.78635
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 2104.09782
-  tps: 6458.81273
+  dps: 2100.59107
+  tps: 6406.78635
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 2126.15079
-  tps: 6502.17703
+  dps: 2128.65443
+  tps: 6465.11949
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 2128.78156
-  tps: 6507.63194
+  dps: 2131.08833
+  tps: 6470.16618
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2123.74975
-  tps: 6520.03259
+  dps: 2119.82488
+  tps: 6466.66498
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2104.09782
-  tps: 6458.81273
+  dps: 2100.59107
+  tps: 6406.78635
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 2289.93682
-  tps: 7037.14269
+  dps: 2269.88898
+  tps: 6902.69839
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgebornePlate"
  value: {
-  dps: 2078.75497
-  tps: 6442.49642
+  dps: 2084.55306
+  tps: 6377.83127
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 2823.02717
-  tps: 8788.19934
+  dps: 2810.21628
+  tps: 8705.62116
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 2376.08429
-  tps: 7429.07132
+  dps: 2379.51913
+  tps: 7375.1097
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2112.50572
-  tps: 6487.98554
+  dps: 2108.96945
+  tps: 6435.59897
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Shadowmourne-49623"
  value: {
-  dps: 2866.55132
-  tps: 8415.13275
+  dps: 2858.12702
+  tps: 8404.56122
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SoulPreserver-37111"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SouloftheDead-40382"
  value: {
-  dps: 2135.28754
-  tps: 6561.89455
+  dps: 2133.70344
+  tps: 6515.85175
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 2130.98929
-  tps: 6532.50466
+  dps: 2129.91736
+  tps: 6417.25354
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 2172.77446
-  tps: 6593.86612
+  dps: 2180.92255
+  tps: 6617.24475
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-StormshroudArmor"
  value: {
-  dps: 1779.09181
-  tps: 5460.64335
+  dps: 1766.66478
+  tps: 5375.20723
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2114.76527
-  tps: 6495.60399
+  dps: 2111.2429
+  tps: 6443.28165
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 2112.73337
-  tps: 6488.59613
+  dps: 2109.21398
+  tps: 6436.33016
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2109.17756
-  tps: 6476.33238
+  dps: 2105.66337
+  tps: 6424.16506
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 2457.78064
-  tps: 7519.56164
+  dps: 2446.50843
+  tps: 7516.91381
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sPlate"
  value: {
-  dps: 2125.39911
-  tps: 6547.70906
+  dps: 2115.93996
+  tps: 6476.90708
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 2048.7281
-  tps: 6381.788
+  dps: 2058.7535
+  tps: 6403.36849
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 2122.21362
-  tps: 6472.66998
+  dps: 2123.12043
+  tps: 6509.28804
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2190.05855
-  tps: 6561.65242
+  dps: 2183.78645
+  tps: 6565.98238
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2192.16972
-  tps: 6635.70762
+  dps: 2187.20344
+  tps: 6629.1166
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2104.09782
-  tps: 6458.81273
+  dps: 2100.59107
+  tps: 6406.78635
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2104.09782
-  tps: 6458.81273
+  dps: 2100.59107
+  tps: 6406.78635
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 2127.48692
-  tps: 6430.19603
+  dps: 2131.0547
+  tps: 6456.39051
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2104.09782
-  tps: 6458.81273
+  dps: 2100.59107
+  tps: 6406.78635
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2104.09782
-  tps: 6458.81273
+  dps: 2100.59107
+  tps: 6406.78635
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1903.52092
-  tps: 5762.28659
+  dps: 1899.2843
+  tps: 5784.53205
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 1819.50355
-  tps: 5828.94661
+  dps: 1828.57504
+  tps: 5850.30926
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-WingedTalisman-37844"
  value: {
-  dps: 2107.41741
-  tps: 6470.26178
+  dps: 2103.9058
+  tps: 6418.1433
  }
 }
 dps_results: {
  key: "TestBloodTank-Average-Default"
  value: {
-  dps: 2481.24776
-  tps: 8338.99177
-  dtps: 293.22533
+  dps: 2481.51143
+  tps: 8341.35742
+  dtps: 293.07255
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_aggro-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2018.71168
-  tps: 4433.69545
+  dps: 2024.27697
+  tps: 4447.01955
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_aggro-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2018.71168
-  tps: 4433.69545
+  dps: 2024.27697
+  tps: 4447.01955
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_aggro-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2991.86855
-  tps: 4889.53279
+  dps: 3008.30647
+  tps: 4915.71297
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_aggro-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1218.91371
-  tps: 2633.77987
+  dps: 1219.52503
+  tps: 2632.48786
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_aggro-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1218.91371
-  tps: 2633.77987
+  dps: 1219.52503
+  tps: 2632.48786
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_aggro-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1809.11853
-  tps: 2735.38068
+  dps: 1795.35846
+  tps: 2713.33006
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_icy_touch-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7801.69886
-  tps: 18270.59611
+  dps: 7763.82525
+  tps: 18172.38992
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_icy_touch-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2168.70177
-  tps: 6559.46151
+  dps: 2173.98354
+  tps: 6620.33645
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_icy_touch-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3127.38525
-  tps: 7134.37536
+  dps: 3125.65712
+  tps: 7135.88091
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_icy_touch-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4209.99299
-  tps: 9953.29165
+  dps: 4223.94825
+  tps: 10000.00343
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_icy_touch-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1300.01717
-  tps: 3905.32194
+  dps: 1307.1606
+  tps: 3944.01973
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_icy_touch-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1853.58887
-  tps: 3984.84145
+  dps: 1867.30078
+  tps: 4019.61214
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_aggro-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2038.07006
-  tps: 4469.61846
+  dps: 2043.26328
+  tps: 4482.13424
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_aggro-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2038.07006
-  tps: 4469.61846
+  dps: 2043.26328
+  tps: 4482.13424
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_aggro-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3028.58962
-  tps: 4945.51101
+  dps: 3044.29456
+  tps: 4970.29957
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_aggro-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1232.7769
-  tps: 2659.66414
+  dps: 1233.34495
+  tps: 2658.30648
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_aggro-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1232.7769
-  tps: 2659.66414
+  dps: 1233.34495
+  tps: 2658.30648
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_aggro-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1837.43312
-  tps: 2783.33373
+  dps: 1823.20964
+  tps: 2760.55458
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_icy_touch-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7887.01691
-  tps: 18451.19107
+  dps: 7850.71701
+  tps: 18355.79133
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_icy_touch-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2188.61929
-  tps: 6603.53504
+  dps: 2193.61997
+  tps: 6664.69741
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_icy_touch-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3167.08597
-  tps: 7198.88275
+  dps: 3166.01836
+  tps: 7201.99872
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_icy_touch-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4265.77037
-  tps: 10072.98726
+  dps: 4278.12507
+  tps: 10117.10722
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_icy_touch-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1314.15377
-  tps: 3938.40789
+  dps: 1321.40495
+  tps: 3977.95295
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_icy_touch-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1880.22064
-  tps: 4031.34974
+  dps: 1894.07399
+  tps: 4066.16654
  }
 }
 dps_results: {
  key: "TestBloodTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2500.50023
-  tps: 8220.0542
-  dtps: 270.21877
+  dps: 2508.02105
+  tps: 8258.12733
+  dtps: 270.22081
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -46,936 +46,936 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7540.84638
-  tps: 5418.91575
+  dps: 7540.79956
+  tps: 5418.88251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7598.7356
-  tps: 5458.22222
+  dps: 7598.68797
+  tps: 5458.18841
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7442.40485
-  tps: 5346.77867
+  dps: 7442.35817
+  tps: 5346.74553
   hps: 89.11518
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7442.40485
-  tps: 5346.77867
+  dps: 7442.35817
+  tps: 5346.74553
   hps: 89.11518
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7572.47621
-  tps: 5441.37294
+  dps: 7572.42939
+  tps: 5441.33969
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6153.52349
-  tps: 4430.77546
+  dps: 6153.48436
+  tps: 4430.74768
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7540.84638
-  tps: 5310.53744
+  dps: 7540.79956
+  tps: 5310.50486
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 7580.73435
-  tps: 5447.23621
+  dps: 7580.68644
+  tps: 5447.2022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7721.53126
-  tps: 5547.20202
+  dps: 7721.48349
+  tps: 5547.1681
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7548.87005
-  tps: 5422.29418
+  dps: 7548.82337
+  tps: 5422.26103
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7579.68258
-  tps: 5444.32065
+  dps: 7579.6359
+  tps: 5444.2875
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 7580.73435
-  tps: 5447.23621
+  dps: 7580.68644
+  tps: 5447.2022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7879.94103
-  tps: 5657.35457
+  dps: 7879.89291
+  tps: 5657.32041
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7530.64014
-  tps: 5409.35094
+  dps: 7530.59346
+  tps: 5409.31779
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7848.35915
-  tps: 5635.08101
+  dps: 7848.31059
+  tps: 5635.04653
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7951.16914
-  tps: 5708.22567
+  dps: 7951.12043
+  tps: 5708.19109
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7574.90626
-  tps: 5443.09827
+  dps: 7574.85944
+  tps: 5443.06503
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7576.55555
-  tps: 5442.10046
+  dps: 7576.50887
+  tps: 5442.06731
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7586.15472
-  tps: 5448.84108
+  dps: 7586.10803
+  tps: 5448.80793
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 6986.25299
-  tps: 5022.31256
+  dps: 6986.21073
+  tps: 5022.28255
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreamwalkerGarb"
  value: {
-  dps: 5999.83064
-  tps: 4323.22406
+  dps: 5999.79447
+  tps: 4323.19838
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7540.84638
-  tps: 5418.91575
+  dps: 7540.79956
+  tps: 5418.88251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7540.84638
-  tps: 5418.91575
+  dps: 7540.79956
+  tps: 5418.88251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7572.47621
-  tps: 5441.37294
+  dps: 7572.42939
+  tps: 5441.33969
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7568.56196
-  tps: 5438.59382
+  dps: 7568.51515
+  tps: 5438.56058
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7582.50108
-  tps: 5446.24699
+  dps: 7582.45439
+  tps: 5446.21384
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7540.84638
-  tps: 5418.91575
+  dps: 7540.79956
+  tps: 5418.88251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7577.05762
-  tps: 5442.30735
+  dps: 7577.01094
+  tps: 5442.27421
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7534.99527
-  tps: 5412.3683
+  dps: 7534.94859
+  tps: 5412.33515
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7516.04487
-  tps: 5398.91351
+  dps: 7515.99818
+  tps: 5398.88036
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7540.84638
-  tps: 5418.91575
+  dps: 7540.79956
+  tps: 5418.88251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7540.84638
-  tps: 5418.91575
+  dps: 7540.79956
+  tps: 5418.88251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 7580.73435
-  tps: 5447.23621
+  dps: 7580.68644
+  tps: 5447.2022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7622.68852
-  tps: 5474.85487
+  dps: 7622.64184
+  tps: 5474.82172
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 7543.97464
-  tps: 5418.22014
+  dps: 7543.92611
+  tps: 5418.18569
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 6046.4755
-  tps: 4354.84618
+  dps: 6046.43779
+  tps: 4354.8194
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7556.47487
-  tps: 5427.84317
+  dps: 7556.42819
+  tps: 5427.81003
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 7580.73435
-  tps: 5447.23621
+  dps: 7580.68644
+  tps: 5447.2022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-49982"
  value: {
-  dps: 7819.61382
-  tps: 5616.69106
+  dps: 7819.56543
+  tps: 5616.65671
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 7928.1474
-  tps: 5693.60033
+  dps: 7928.09901
+  tps: 5693.56597
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdolofLunarFury-47670"
  value: {
-  dps: 7580.73435
-  tps: 5447.23621
+  dps: 7580.68644
+  tps: 5447.2022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 7859.85074
-  tps: 5645.33407
+  dps: 7859.80284
+  tps: 5645.30005
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 7580.73435
-  tps: 5447.23621
+  dps: 7580.68644
+  tps: 5447.2022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 7864.1836
-  tps: 5648.48518
+  dps: 7864.13569
+  tps: 5648.45117
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 7580.73435
-  tps: 5447.23621
+  dps: 7580.68644
+  tps: 5447.2022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 7629.74156
-  tps: 5482.03134
+  dps: 7629.69366
+  tps: 5481.99732
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 7580.73435
-  tps: 5447.23621
+  dps: 7580.68644
+  tps: 5447.2022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 7580.73435
-  tps: 5447.23621
+  dps: 7580.68644
+  tps: 5447.2022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7572.47621
-  tps: 5441.37294
+  dps: 7572.42939
+  tps: 5441.33969
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7568.56196
-  tps: 5438.59382
+  dps: 7568.51515
+  tps: 5438.56058
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7613.55508
-  tps: 5468.37012
+  dps: 7613.50765
+  tps: 5468.33645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7540.84638
-  tps: 5418.91575
+  dps: 7540.79956
+  tps: 5418.88251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7570.26636
-  tps: 5439.80394
+  dps: 7570.21933
+  tps: 5439.77055
   hps: 12.43348
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 9158.02539
-  tps: 6563.97181
+  dps: 9157.97168
+  tps: 6563.93368
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LasherweaveRegalia"
  value: {
-  dps: 6353.29055
-  tps: 4624.15413
+  dps: 6353.25438
+  tps: 4624.12845
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50179"
  value: {
-  dps: 7871.97977
-  tps: 5654.02046
+  dps: 7871.93187
+  tps: 5653.98645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 7893.3073
-  tps: 5669.16301
+  dps: 7893.2594
+  tps: 5669.129
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 7437.91196
-  tps: 5345.68274
+  dps: 7437.86949
+  tps: 5345.65259
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 5830.92069
-  tps: 4240.9148
+  dps: 5830.88451
+  tps: 4240.88911
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7591.1985
-  tps: 5452.72131
+  dps: 7591.15182
+  tps: 5452.68816
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7620.97659
-  tps: 5473.41504
+  dps: 7620.92991
+  tps: 5473.38189
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Nibelung-49992"
  value: {
-  dps: 7729.37576
-  tps: 5552.77162
+  dps: 7729.32786
+  tps: 5552.7376
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Nibelung-50648"
  value: {
-  dps: 7729.37576
-  tps: 5552.77162
+  dps: 7729.32786
+  tps: 5552.7376
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NightsongBattlegear"
  value: {
-  dps: 7356.88251
-  tps: 5285.90823
+  dps: 7356.83739
+  tps: 5285.8762
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NightsongGarb"
  value: {
-  dps: 5902.43989
-  tps: 4257.21767
+  dps: 5902.40371
+  tps: 4257.19198
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7560.81156
-  tps: 5433.09104
+  dps: 7560.76457
+  tps: 5433.05767
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7565.50925
-  tps: 5436.4264
+  dps: 7565.46222
+  tps: 5436.39301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7540.84638
-  tps: 5418.91575
+  dps: 7540.79956
+  tps: 5418.88251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7540.84638
-  tps: 5418.91575
+  dps: 7540.79956
+  tps: 5418.88251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7729.37576
-  tps: 5552.77162
+  dps: 7729.32786
+  tps: 5552.7376
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 7580.73435
-  tps: 5447.23621
+  dps: 7580.68644
+  tps: 5447.2022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7540.84638
-  tps: 5418.91575
+  dps: 7540.79956
+  tps: 5418.88251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 7580.73435
-  tps: 5447.23621
+  dps: 7580.68644
+  tps: 5447.2022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7536.88087
-  tps: 5413.70707
+  dps: 7536.83418
+  tps: 5413.67392
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 7476.41404
-  tps: 5370.92519
+  dps: 7476.36735
+  tps: 5370.89205
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7588.35722
-  tps: 5451.60144
+  dps: 7588.31054
+  tps: 5451.5683
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StormshroudArmor"
  value: {
-  dps: 6281.10861
-  tps: 4520.98696
+  dps: 6281.06941
+  tps: 4520.95913
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7565.50925
-  tps: 5436.4264
+  dps: 7565.46222
+  tps: 5436.39301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7560.81156
-  tps: 5433.09104
+  dps: 7560.76457
+  tps: 5433.05767
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7552.5906
-  tps: 5427.25416
+  dps: 7552.54368
+  tps: 5427.22084
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartHarness"
  value: {
-  dps: 6069.03347
-  tps: 4372.05892
+  dps: 6068.99471
+  tps: 4372.03141
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderheartRegalia"
  value: {
-  dps: 5245.75975
-  tps: 3788.13288
+  dps: 5245.72673
+  tps: 3788.10943
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7633.77237
-  tps: 5485.19236
+  dps: 7633.72556
+  tps: 5485.15912
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7595.76485
-  tps: 5458.20702
+  dps: 7595.71695
+  tps: 5458.17301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7630.35211
-  tps: 5482.39004
+  dps: 7630.3042
+  tps: 5482.35602
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7540.84638
-  tps: 5418.91575
+  dps: 7540.79956
+  tps: 5418.88251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7540.84638
-  tps: 5418.91575
+  dps: 7540.79956
+  tps: 5418.88251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7475.17641
-  tps: 5370.04647
+  dps: 7475.12972
+  tps: 5370.01333
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7540.84638
-  tps: 5418.91575
+  dps: 7540.79956
+  tps: 5418.88251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7540.84638
-  tps: 5418.91575
+  dps: 7540.79956
+  tps: 5418.88251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6431.99306
-  tps: 4628.78801
+  dps: 6431.95209
+  tps: 4628.75892
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6337.4012
-  tps: 4564.9184
+  dps: 6337.36366
+  tps: 4564.89175
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 7580.73435
-  tps: 5447.23621
+  dps: 7580.68644
+  tps: 5447.2022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7440.58168
-  tps: 5345.55901
+  dps: 7440.535
+  tps: 5345.52586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 7580.73435
-  tps: 5447.23621
+  dps: 7580.68644
+  tps: 5447.2022
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 7787.11658
-  tps: 5593.74224
+  dps: 7787.06524
+  tps: 5593.70579
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Default--FullBuffs-LongMultiTarget"
  value: {
-  dps: 7729.37576
-  tps: 5552.77162
+  dps: 7729.32786
+  tps: 5552.7376
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Default--FullBuffs-LongSingleTarget"
  value: {
-  dps: 7729.37576
-  tps: 5552.77162
+  dps: 7729.32786
+  tps: 5552.7376
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Default--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8471.98548
-  tps: 6072.69543
+  dps: 8471.74596
+  tps: 6072.52536
  }
 }
 dps_results: {
@@ -1002,22 +1002,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Default-NoBleed--FullBuffs-LongMultiTarget"
  value: {
-  dps: 7760.7578
-  tps: 5575.12765
+  dps: 7760.70989
+  tps: 5575.09364
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Default-NoBleed--FullBuffs-LongSingleTarget"
  value: {
-  dps: 7760.7578
-  tps: 5575.12765
+  dps: 7760.70989
+  tps: 5575.09364
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Default-NoBleed--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8611.25717
-  tps: 6170.83046
+  dps: 8611.01764
+  tps: 6170.66039
  }
 }
 dps_results: {
@@ -1044,22 +1044,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Flower-Aoe--FullBuffs-LongMultiTarget"
  value: {
-  dps: 22991.33879
-  tps: 16642.6613
+  dps: 22991.29088
+  tps: 16642.62728
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Flower-Aoe--FullBuffs-LongSingleTarget"
  value: {
-  dps: 4747.33047
-  tps: 3448.80558
+  dps: 4747.28257
+  tps: 3448.77157
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Flower-Aoe--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5662.93939
-  tps: 4084.57893
+  dps: 5662.69986
+  tps: 4084.40887
  }
 }
 dps_results: {
@@ -1086,7 +1086,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6283.36283
-  tps: 4524.68149
+  dps: 6283.32018
+  tps: 4524.65121
  }
 }

--- a/sim/druid/feral/TestFeralDoubleArmorPenTrinketsNoDesync.results
+++ b/sim/druid/feral/TestFeralDoubleArmorPenTrinketsNoDesync.results
@@ -46,936 +46,936 @@ character_stats_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 9670.43601
-  tps: 6932.12098
+  dps: 9670.37324
+  tps: 6932.07642
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 9845.43629
-  tps: 7053.82843
+  dps: 9845.37377
+  tps: 7053.78404
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
   hps: 90.47701
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
   hps: 90.47701
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 9709.87969
-  tps: 6960.05121
+  dps: 9709.81693
+  tps: 6960.00665
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 7553.51786
-  tps: 5428.28644
+  dps: 7553.47116
+  tps: 5428.25328
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 9670.43601
-  tps: 6793.47856
+  dps: 9670.37324
+  tps: 6793.43489
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 9620.89484
-  tps: 6896.87196
+  dps: 9620.83048
+  tps: 6896.82627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 9926.03455
-  tps: 7113.52115
+  dps: 9925.97034
+  tps: 7113.47557
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 9809.99757
-  tps: 7028.59215
+  dps: 9809.93618
+  tps: 7028.54857
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 9841.34878
-  tps: 7050.9263
+  dps: 9841.28739
+  tps: 7050.88272
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 9868.51379
-  tps: 7070.13867
+  dps: 9868.4524
+  tps: 7070.09508
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 9620.89484
-  tps: 6896.87196
+  dps: 9620.83048
+  tps: 6896.82627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Death'sChoice-47464"
  value: {
-  dps: 10246.59595
-  tps: 7338.65179
+  dps: 10246.53284
+  tps: 7338.60698
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 9764.16131
-  tps: 6996.04841
+  dps: 9764.09993
+  tps: 6996.00483
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10225.35998
-  tps: 7324.09776
+  dps: 10225.29582
+  tps: 7324.05221
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 10317.51216
-  tps: 7389.52581
+  dps: 10317.44778
+  tps: 7389.4801
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Defender'sCode-40257"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 9716.06716
-  tps: 6964.44431
+  dps: 9716.00439
+  tps: 6964.39975
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 9867.01454
-  tps: 7069.14899
+  dps: 9866.95315
+  tps: 7069.1054
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 9840.12642
-  tps: 7049.90885
+  dps: 9840.06503
+  tps: 7049.86527
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 8440.68689
-  tps: 6058.4756
+  dps: 8440.6336
+  tps: 6058.43776
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-DreamwalkerGarb"
  value: {
-  dps: 7224.34095
-  tps: 5196.4405
+  dps: 7224.29779
+  tps: 5196.40986
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 9670.43601
-  tps: 6932.12098
+  dps: 9670.37324
+  tps: 6932.07642
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 9670.43601
-  tps: 6932.12098
+  dps: 9670.37324
+  tps: 6932.07642
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 9709.87969
-  tps: 6960.05121
+  dps: 9709.81693
+  tps: 6960.00665
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 9703.66034
-  tps: 6955.63547
+  dps: 9703.59758
+  tps: 6955.59091
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 9776.59003
-  tps: 7005.32152
+  dps: 9776.52864
+  tps: 7005.27793
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 9670.43601
-  tps: 6932.12098
+  dps: 9670.37324
+  tps: 6932.07642
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 9841.60921
-  tps: 7050.73727
+  dps: 9841.54782
+  tps: 7050.69369
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 9795.79144
-  tps: 7018.5058
+  dps: 9795.73005
+  tps: 7018.46222
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 9660.13525
-  tps: 6922.41427
+  dps: 9660.07386
+  tps: 6922.37068
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ForgeEmber-37660"
  value: {
-  dps: 9782.32387
-  tps: 7008.94383
+  dps: 9782.26248
+  tps: 7008.90024
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 9670.43601
-  tps: 6932.12098
+  dps: 9670.37324
+  tps: 6932.07642
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 9670.43601
-  tps: 6932.12098
+  dps: 9670.37324
+  tps: 6932.07642
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 9620.89484
-  tps: 6896.87196
+  dps: 9620.83048
+  tps: 6896.82627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 9882.7937
-  tps: 7080.42698
+  dps: 9882.73231
+  tps: 7080.38339
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-FuturesightRune-38763"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 9071.29307
-  tps: 6505.68248
+  dps: 9071.23629
+  tps: 6505.64216
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 7340.44542
-  tps: 5276.85544
+  dps: 7340.40043
+  tps: 5276.82349
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 9819.03563
-  tps: 7034.78481
+  dps: 9818.97424
+  tps: 7034.74123
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 9620.89484
-  tps: 6896.87196
+  dps: 9620.83048
+  tps: 6896.82627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Heartpierce-49982"
  value: {
-  dps: 10065.53824
-  tps: 7212.4192
+  dps: 10065.4733
+  tps: 7212.3731
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Heartpierce-50641"
  value: {
-  dps: 10084.54788
-  tps: 7225.76648
+  dps: 10084.48293
+  tps: 7225.72036
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IdolofLunarFury-47670"
  value: {
-  dps: 9620.89484
-  tps: 6896.87196
+  dps: 9620.83048
+  tps: 6896.82627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 9971.75894
-  tps: 7146.13505
+  dps: 9971.69459
+  tps: 7146.08936
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 9620.89484
-  tps: 6896.87196
+  dps: 9620.83048
+  tps: 6896.82627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 9916.82489
-  tps: 7106.90751
+  dps: 9916.76053
+  tps: 7106.86182
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 9620.89484
-  tps: 6896.87196
+  dps: 9620.83048
+  tps: 6896.82627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 9683.60348
-  tps: 6941.46988
+  dps: 9683.53912
+  tps: 6941.42419
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 9620.89484
-  tps: 6896.87196
+  dps: 9620.83048
+  tps: 6896.82627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 9620.89484
-  tps: 6896.87196
+  dps: 9620.83048
+  tps: 6896.82627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 9709.87969
-  tps: 6960.05121
+  dps: 9709.81693
+  tps: 6960.00665
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 9703.66034
-  tps: 6955.63547
+  dps: 9703.59758
+  tps: 6955.59091
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-IncisorFragment-37723"
  value: {
-  dps: 9849.21212
-  tps: 7056.58406
+  dps: 9849.14985
+  tps: 7056.53985
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 9670.43601
-  tps: 6932.12098
+  dps: 9670.37324
+  tps: 6932.07642
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 9700.17486
-  tps: 6953.23556
+  dps: 9700.11184
+  tps: 6953.19082
   hps: 13.68562
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 10803.29164
-  tps: 7735.62582
+  dps: 10803.22402
+  tps: 7735.57781
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-LasherweaveRegalia"
  value: {
-  dps: 7737.24841
-  tps: 5561.42745
+  dps: 7737.20342
+  tps: 5561.39551
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-LastWord-50179"
  value: {
-  dps: 10102.18505
-  tps: 7238.58801
+  dps: 10102.12069
+  tps: 7238.54232
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-LastWord-50708"
  value: {
-  dps: 10127.93684
-  tps: 7256.87178
+  dps: 10127.87248
+  tps: 7256.82609
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 8810.67042
-  tps: 6323.40751
+  dps: 8810.61442
+  tps: 6323.36775
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 7159.55389
-  tps: 5151.11477
+  dps: 7159.51073
+  tps: 5151.08412
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 9918.30778
-  tps: 7105.41762
+  dps: 9918.2464
+  tps: 7105.37403
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 9879.92897
-  tps: 7077.94431
+  dps: 9879.86759
+  tps: 7077.90072
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Nibelung-49992"
  value: {
-  dps: 9929.99665
-  tps: 7116.33425
+  dps: 9929.93229
+  tps: 7116.28855
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Nibelung-50648"
  value: {
-  dps: 9929.99665
-  tps: 7116.33425
+  dps: 9929.93229
+  tps: 7116.28855
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-NightsongBattlegear"
  value: {
-  dps: 8797.29452
-  tps: 6312.63924
+  dps: 8797.23745
+  tps: 6312.59872
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-NightsongGarb"
  value: {
-  dps: 7074.86409
-  tps: 5091.28415
+  dps: 7074.82093
+  tps: 5091.25351
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 9694.51032
-  tps: 6949.21374
+  dps: 9694.44735
+  tps: 6949.16903
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 9700.17486
-  tps: 6953.23556
+  dps: 9700.11184
+  tps: 6953.19082
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 9670.43601
-  tps: 6932.12098
+  dps: 9670.37324
+  tps: 6932.07642
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 9670.43601
-  tps: 6932.12098
+  dps: 9670.37324
+  tps: 6932.07642
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 9929.99665
-  tps: 7116.33425
+  dps: 9929.93229
+  tps: 7116.28855
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 9620.89484
-  tps: 6896.87196
+  dps: 9620.83048
+  tps: 6896.82627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 9670.43601
-  tps: 6932.12098
+  dps: 9670.37324
+  tps: 6932.07642
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 9620.89484
-  tps: 6896.87196
+  dps: 9620.83048
+  tps: 6896.82627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SoulPreserver-37111"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SouloftheDead-40382"
  value: {
-  dps: 9800.49145
-  tps: 7021.84281
+  dps: 9800.43007
+  tps: 7021.79923
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SparkofLife-37657"
  value: {
-  dps: 9750.55618
-  tps: 6986.61313
+  dps: 9750.4948
+  tps: 6986.56955
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 9834.8873
-  tps: 7048.20832
+  dps: 9834.82295
+  tps: 7048.16263
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-StormshroudArmor"
  value: {
-  dps: 7731.20763
-  tps: 5553.92267
+  dps: 7731.16085
+  tps: 5553.88946
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 9700.17486
-  tps: 6953.23556
+  dps: 9700.11184
+  tps: 6953.19082
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 9694.51032
-  tps: 6949.21374
+  dps: 9694.44735
+  tps: 6949.16903
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 9684.59737
-  tps: 6942.17554
+  dps: 9684.53448
+  tps: 6942.1309
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ThunderheartHarness"
  value: {
-  dps: 7013.15164
-  tps: 5042.83154
+  dps: 7013.1072
+  tps: 5042.79999
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ThunderheartRegalia"
  value: {
-  dps: 6129.65333
-  tps: 4416.3704
+  dps: 6129.61494
+  tps: 4416.34314
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 9650.21298
-  tps: 6917.9122
+  dps: 9650.15022
+  tps: 6917.86764
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 9807.41351
-  tps: 7029.44979
+  dps: 9807.34915
+  tps: 7029.4041
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 9815.50612
-  tps: 7035.19555
+  dps: 9815.44177
+  tps: 7035.14985
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 9670.43601
-  tps: 6932.12098
+  dps: 9670.37324
+  tps: 6932.07642
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 9670.43601
-  tps: 6932.12098
+  dps: 9670.37324
+  tps: 6932.07642
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 9671.05904
-  tps: 6930.02059
+  dps: 9670.99765
+  tps: 6929.977
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 9670.43601
-  tps: 6932.12098
+  dps: 9670.37324
+  tps: 6932.07642
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 9670.43601
-  tps: 6932.12098
+  dps: 9670.37324
+  tps: 6932.07642
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 7853.53051
-  tps: 5641.37021
+  dps: 7853.48182
+  tps: 5641.33564
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7456.70928
-  tps: 5360.22543
+  dps: 7456.6638
+  tps: 5360.19314
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 9620.89484
-  tps: 6896.87196
+  dps: 9620.83048
+  tps: 6896.82627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-WingedTalisman-37844"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 9620.89484
-  tps: 6896.87196
+  dps: 9620.83048
+  tps: 6896.82627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-Average-Default"
  value: {
-  dps: 9936.5006
-  tps: 7121.02586
+  dps: 9936.43232
+  tps: 7120.97738
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-Settings-Tauren-P2DoubleArmorPenTrinkets-Default--FullBuffs-LongMultiTarget"
  value: {
-  dps: 9929.99665
-  tps: 7116.33425
+  dps: 9929.93229
+  tps: 7116.28855
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-Settings-Tauren-P2DoubleArmorPenTrinkets-Default--FullBuffs-LongSingleTarget"
  value: {
-  dps: 9929.99665
-  tps: 7116.33425
+  dps: 9929.93229
+  tps: 7116.28855
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-Settings-Tauren-P2DoubleArmorPenTrinkets-Default--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11218.51543
-  tps: 8021.60989
+  dps: 11218.19364
+  tps: 8021.38142
  }
 }
 dps_results: {
@@ -1002,7 +1002,7 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsNoDesync-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7549.62079
-  tps: 5424.69687
+  dps: 7549.56095
+  tps: 5424.65438
  }
 }

--- a/sim/druid/feral/TestFeralDoubleArmorPenTrinketsWithDesync.results
+++ b/sim/druid/feral/TestFeralDoubleArmorPenTrinketsWithDesync.results
@@ -46,936 +46,936 @@ character_stats_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 9697.57901
-  tps: 6951.31773
+  dps: 9697.51625
+  tps: 6951.27316
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 9842.05809
-  tps: 7051.65427
+  dps: 9841.99557
+  tps: 7051.60988
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
   hps: 90.47701
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
   hps: 90.47701
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 9743.45323
-  tps: 6983.88842
+  dps: 9743.39046
+  tps: 6983.84386
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 7591.29702
-  tps: 5454.73571
+  dps: 7591.25031
+  tps: 5454.70255
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 9697.57901
-  tps: 6812.29137
+  dps: 9697.51625
+  tps: 6812.2477
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 9689.21193
-  tps: 6945.3771
+  dps: 9689.14757
+  tps: 6945.3314
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 9960.5787
-  tps: 7138.0475
+  dps: 9960.51449
+  tps: 7138.00192
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 9800.74422
-  tps: 7022.02228
+  dps: 9800.68283
+  tps: 7021.97869
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 9841.31767
-  tps: 7050.60506
+  dps: 9841.25628
+  tps: 7050.56148
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 9852.82219
-  tps: 7058.84806
+  dps: 9852.7608
+  tps: 7058.80448
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 9689.21193
-  tps: 6945.3771
+  dps: 9689.14757
+  tps: 6945.3314
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Death'sChoice-47464"
  value: {
-  dps: 10216.58349
-  tps: 7317.49252
+  dps: 10216.52038
+  tps: 7317.44771
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 9764.16131
-  tps: 6996.04841
+  dps: 9764.09993
+  tps: 6996.00483
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10198.46607
-  tps: 7304.70393
+  dps: 10198.40191
+  tps: 7304.65838
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 10277.99962
-  tps: 7360.87361
+  dps: 10277.93524
+  tps: 7360.8279
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Defender'sCode-40257"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 9752.41831
-  tps: 6990.25363
+  dps: 9752.35555
+  tps: 6990.20907
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 9866.66647
-  tps: 7068.90186
+  dps: 9866.60508
+  tps: 7068.85827
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 9843.70145
-  tps: 7052.52191
+  dps: 9843.64006
+  tps: 7052.47832
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 8501.63788
-  tps: 6101.37687
+  dps: 8501.58459
+  tps: 6101.33903
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-DreamwalkerGarb"
  value: {
-  dps: 7218.82768
-  tps: 5192.67566
+  dps: 7218.78452
+  tps: 5192.64501
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 9697.57901
-  tps: 6951.31773
+  dps: 9697.51625
+  tps: 6951.27316
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 9697.57901
-  tps: 6951.31773
+  dps: 9697.51625
+  tps: 6951.27316
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 9743.45323
-  tps: 6983.88842
+  dps: 9743.39046
+  tps: 6983.84386
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 9728.48761
-  tps: 6973.26283
+  dps: 9728.42484
+  tps: 6973.21827
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 9776.59003
-  tps: 7005.32152
+  dps: 9776.52864
+  tps: 7005.27793
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 9697.57901
-  tps: 6951.31773
+  dps: 9697.51625
+  tps: 6951.27316
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 9841.45669
-  tps: 7050.62898
+  dps: 9841.3953
+  tps: 7050.5854
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 9795.79144
-  tps: 7018.5058
+  dps: 9795.73005
+  tps: 7018.46222
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 9660.13525
-  tps: 6922.41427
+  dps: 9660.07386
+  tps: 6922.37068
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ForgeEmber-37660"
  value: {
-  dps: 9782.32387
-  tps: 7008.94383
+  dps: 9782.26248
+  tps: 7008.90024
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 9697.57901
-  tps: 6951.31773
+  dps: 9697.51625
+  tps: 6951.27316
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 9697.57901
-  tps: 6951.31773
+  dps: 9697.51625
+  tps: 6951.27316
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 9689.21193
-  tps: 6945.3771
+  dps: 9689.14757
+  tps: 6945.3314
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 9870.7751
-  tps: 7071.89378
+  dps: 9870.71372
+  tps: 7071.85019
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-FuturesightRune-38763"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 9071.66504
-  tps: 6505.94658
+  dps: 9071.60826
+  tps: 6505.90626
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 7354.62884
-  tps: 5286.85088
+  dps: 7354.58385
+  tps: 5286.81893
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 9819.03563
-  tps: 7034.78481
+  dps: 9818.97424
+  tps: 7034.74123
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 9689.21193
-  tps: 6945.3771
+  dps: 9689.14757
+  tps: 6945.3314
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Heartpierce-49982"
  value: {
-  dps: 10184.97947
-  tps: 7297.14769
+  dps: 10184.91453
+  tps: 7297.10158
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Heartpierce-50641"
  value: {
-  dps: 10163.2358
-  tps: 7281.56011
+  dps: 10163.17085
+  tps: 7281.514
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IdolofLunarFury-47670"
  value: {
-  dps: 9689.21193
-  tps: 6945.3771
+  dps: 9689.14757
+  tps: 6945.3314
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 10062.64886
-  tps: 7210.51732
+  dps: 10062.5845
+  tps: 7210.47162
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 9689.21193
-  tps: 6945.3771
+  dps: 9689.14757
+  tps: 6945.3314
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 10030.99868
-  tps: 7187.9709
+  dps: 10030.93432
+  tps: 7187.92521
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 9689.21193
-  tps: 6945.3771
+  dps: 9689.14757
+  tps: 6945.3314
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 9753.53905
-  tps: 6990.97457
+  dps: 9753.47469
+  tps: 6990.92887
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 9689.21193
-  tps: 6945.3771
+  dps: 9689.14757
+  tps: 6945.3314
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 9689.21193
-  tps: 6945.3771
+  dps: 9689.14757
+  tps: 6945.3314
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 9743.45323
-  tps: 6983.88842
+  dps: 9743.39046
+  tps: 6983.84386
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 9728.48761
-  tps: 6973.26283
+  dps: 9728.42484
+  tps: 6973.21827
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-IncisorFragment-37723"
  value: {
-  dps: 9849.21212
-  tps: 7056.58406
+  dps: 9849.14985
+  tps: 7056.53985
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 9697.57901
-  tps: 6951.31773
+  dps: 9697.51625
+  tps: 6951.27316
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 9727.45176
-  tps: 6972.52738
+  dps: 9727.38874
+  tps: 6972.48263
   hps: 13.68562
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 10913.3349
-  tps: 7813.75654
+  dps: 10913.26729
+  tps: 7813.70853
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-LasherweaveRegalia"
  value: {
-  dps: 7735.80057
-  tps: 5560.24991
+  dps: 7735.75558
+  tps: 5560.21797
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-LastWord-50179"
  value: {
-  dps: 10124.64806
-  tps: 7254.53675
+  dps: 10124.58371
+  tps: 7254.49106
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-LastWord-50708"
  value: {
-  dps: 10150.49968
-  tps: 7272.8914
+  dps: 10150.43532
+  tps: 7272.8457
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 8834.97945
-  tps: 6340.66692
+  dps: 8834.92345
+  tps: 6340.62716
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 7150.77092
-  tps: 5145.47715
+  dps: 7150.72776
+  tps: 5145.44651
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 9879.71232
-  tps: 7078.31399
+  dps: 9879.65094
+  tps: 7078.2704
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 9879.92897
-  tps: 7077.94431
+  dps: 9879.86759
+  tps: 7077.90072
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Nibelung-49992"
  value: {
-  dps: 9951.78853
-  tps: 7131.80648
+  dps: 9951.72417
+  tps: 7131.76079
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Nibelung-50648"
  value: {
-  dps: 9951.78853
-  tps: 7131.80648
+  dps: 9951.72417
+  tps: 7131.76079
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-NightsongBattlegear"
  value: {
-  dps: 8849.46384
-  tps: 6349.52989
+  dps: 8849.40677
+  tps: 6349.48936
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-NightsongGarb"
  value: {
-  dps: 7104.30532
-  tps: 5112.11265
+  dps: 7104.26216
+  tps: 5112.082
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 9721.76171
-  tps: 6968.48744
+  dps: 9721.69874
+  tps: 6968.44273
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 9727.45176
-  tps: 6972.52738
+  dps: 9727.38874
+  tps: 6972.48263
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 9697.57901
-  tps: 6951.31773
+  dps: 9697.51625
+  tps: 6951.27316
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 9697.57901
-  tps: 6951.31773
+  dps: 9697.51625
+  tps: 6951.27316
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 9951.78853
-  tps: 7131.80648
+  dps: 9951.72417
+  tps: 7131.76079
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 9689.21193
-  tps: 6945.3771
+  dps: 9689.14757
+  tps: 6945.3314
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 9697.57901
-  tps: 6951.31773
+  dps: 9697.51625
+  tps: 6951.27316
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 9689.21193
-  tps: 6945.3771
+  dps: 9689.14757
+  tps: 6945.3314
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SoulPreserver-37111"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SouloftheDead-40382"
  value: {
-  dps: 9800.49145
-  tps: 7021.84281
+  dps: 9800.43007
+  tps: 7021.79923
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SparkofLife-37657"
  value: {
-  dps: 9750.55618
-  tps: 6986.61313
+  dps: 9750.4948
+  tps: 6986.56955
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 9834.8873
-  tps: 7048.20832
+  dps: 9834.82295
+  tps: 7048.16263
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-StormshroudArmor"
  value: {
-  dps: 7804.11298
-  tps: 5605.23675
+  dps: 7804.0662
+  tps: 5605.20353
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 9727.45176
-  tps: 6972.52738
+  dps: 9727.38874
+  tps: 6972.48263
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 9721.76171
-  tps: 6968.48744
+  dps: 9721.69874
+  tps: 6968.44273
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 9711.80413
-  tps: 6961.41756
+  dps: 9711.74125
+  tps: 6961.37291
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ThunderheartHarness"
  value: {
-  dps: 6985.40576
-  tps: 5023.28154
+  dps: 6985.36132
+  tps: 5023.24999
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ThunderheartRegalia"
  value: {
-  dps: 6104.89256
-  tps: 4399.01461
+  dps: 6104.85416
+  tps: 4398.98735
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 9725.61996
-  tps: 6971.45116
+  dps: 9725.5572
+  tps: 6971.4066
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 9828.3959
-  tps: 7044.42208
+  dps: 9828.33154
+  tps: 7044.37638
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 9838.73334
-  tps: 7051.83644
+  dps: 9838.66898
+  tps: 7051.79075
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 9697.57901
-  tps: 6951.31773
+  dps: 9697.51625
+  tps: 6951.27316
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 9697.57901
-  tps: 6951.31773
+  dps: 9697.51625
+  tps: 6951.27316
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 9671.05904
-  tps: 6930.02059
+  dps: 9670.99765
+  tps: 6929.977
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 9697.57901
-  tps: 6951.31773
+  dps: 9697.51625
+  tps: 6951.27316
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 9697.57901
-  tps: 6951.31773
+  dps: 9697.51625
+  tps: 6951.27316
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 7905.14589
-  tps: 5677.79277
+  dps: 7905.0972
+  tps: 5677.7582
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7509.10577
-  tps: 5397.87566
+  dps: 7509.0603
+  tps: 5397.84338
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 9689.21193
-  tps: 6945.3771
+  dps: 9689.14757
+  tps: 6945.3314
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-WingedTalisman-37844"
  value: {
-  dps: 9660.00901
-  tps: 6922.24985
+  dps: 9659.94762
+  tps: 6922.20627
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 9689.21193
-  tps: 6945.3771
+  dps: 9689.14757
+  tps: 6945.3314
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-Average-Default"
  value: {
-  dps: 10016.1636
-  tps: 7177.5622
+  dps: 10016.09531
+  tps: 7177.51372
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-Settings-Tauren-P2DoubleArmorPenTrinkets-Default--FullBuffs-LongMultiTarget"
  value: {
-  dps: 9951.78853
-  tps: 7131.80648
+  dps: 9951.72417
+  tps: 7131.76079
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-Settings-Tauren-P2DoubleArmorPenTrinkets-Default--FullBuffs-LongSingleTarget"
  value: {
-  dps: 9951.78853
-  tps: 7131.80648
+  dps: 9951.72417
+  tps: 7131.76079
  }
 }
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-Settings-Tauren-P2DoubleArmorPenTrinkets-Default--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11394.42151
-  tps: 8146.12927
+  dps: 11394.09972
+  tps: 8145.9008
  }
 }
 dps_results: {
@@ -1002,7 +1002,7 @@ dps_results: {
 dps_results: {
  key: "TestFeralDoubleArmorPenTrinketsWithDesync-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7617.88773
-  tps: 5473.01682
+  dps: 7617.82788
+  tps: 5472.97433
  }
 }

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -149,7 +149,7 @@ func (druid *Druid) registerCatFormSpell() {
 			}
 
 			if !druid.Env.MeasuringStats {
-				druid.AutoAttacks.ReplaceMHSwing = nil
+				druid.AutoAttacks.SetReplaceMHSwing(nil)
 				druid.AutoAttacks.EnableAutoSwing(sim)
 				druid.manageCooldownsEnabled()
 				druid.UpdateManaRegenRates()
@@ -181,7 +181,7 @@ func (druid *Druid) registerCatFormSpell() {
 			}
 
 			if !druid.Env.MeasuringStats {
-				druid.AutoAttacks.ReplaceMHSwing = nil
+				druid.AutoAttacks.SetReplaceMHSwing(nil)
 				druid.AutoAttacks.EnableAutoSwing(sim)
 				druid.manageCooldownsEnabled()
 				druid.UpdateManaRegenRates()
@@ -292,7 +292,7 @@ func (druid *Druid) registerBearFormSpell() {
 			druid.GainHealth(sim, healthFrac*druid.MaxHealth()-druid.CurrentHealth(), healthMetrics)
 
 			if !druid.Env.MeasuringStats {
-				druid.AutoAttacks.ReplaceMHSwing = druid.ReplaceBearMHFunc
+				druid.AutoAttacks.SetReplaceMHSwing(druid.ReplaceBearMHFunc)
 				druid.AutoAttacks.EnableAutoSwing(sim)
 
 				druid.manageCooldownsEnabled()
@@ -324,7 +324,7 @@ func (druid *Druid) registerBearFormSpell() {
 			druid.RemoveHealth(sim, druid.CurrentHealth()-healthFrac*druid.MaxHealth())
 
 			if !druid.Env.MeasuringStats {
-				druid.AutoAttacks.ReplaceMHSwing = nil
+				druid.AutoAttacks.SetReplaceMHSwing(nil)
 				druid.AutoAttacks.EnableAutoSwing(sim)
 
 				druid.manageCooldownsEnabled()

--- a/sim/druid/tank/TestFeralTank.results
+++ b/sim/druid/tank/TestFeralTank.results
@@ -46,48 +46,48 @@ character_stats_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 2603.32703
-  tps: 5488.86663
+  dps: 2603.26777
+  tps: 5488.74205
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 2515.99703
-  tps: 5303.28682
+  dps: 2517.39179
+  tps: 5305.82285
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2661.27369
-  tps: 5602.97836
+  dps: 2660.79781
+  tps: 5602.75103
   dtps: 6.74905
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 2523.18735
-  tps: 5330.32301
+  dps: 2527.14319
+  tps: 5333.92293
   dtps: 6.41606
   hps: 84.70415
  }
@@ -95,8 +95,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 2523.18735
-  tps: 5330.32301
+  dps: 2527.14319
+  tps: 5333.92293
   dtps: 6.41606
   hps: 84.70415
  }
@@ -104,64 +104,64 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 2557.64815
-  tps: 5386.46321
+  dps: 2560.12764
+  tps: 5392.59756
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 2103.31084
-  tps: 4447.25192
+  dps: 2103.25734
+  tps: 4447.13945
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2515.99703
-  tps: 5197.43859
+  dps: 2517.39179
+  tps: 5199.92414
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 2468.33744
-  tps: 5215.8269
+  dps: 2463.33463
+  tps: 5206.05682
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2607.4224
-  tps: 5502.74029
+  dps: 2606.20716
+  tps: 5497.12661
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
   hps: 64
  }
@@ -169,937 +169,937 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2586.61598
-  tps: 5471.74546
+  dps: 2586.63931
+  tps: 5471.4155
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2643.26298
-  tps: 5571.2906
+  dps: 2641.36995
+  tps: 5567.34697
   dtps: 6.74617
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 2540.01372
-  tps: 5363.05021
+  dps: 2533.25168
+  tps: 5349.35326
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 2525.66424
-  tps: 5319.56381
+  dps: 2520.49112
+  tps: 5308.08711
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Death'sChoice-47464"
  value: {
-  dps: 2715.32532
-  tps: 5709.5133
+  dps: 2718.67098
+  tps: 5720.97952
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 2575.20004
-  tps: 5439.58144
+  dps: 2580.11983
+  tps: 5450.3001
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 2765.00782
-  tps: 5818.99588
+  dps: 2754.20779
+  tps: 5801.5154
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 2786.13229
-  tps: 5860.17348
+  dps: 2781.47975
+  tps: 5852.83867
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2551.77928
-  tps: 5375.76584
+  dps: 2553.18747
+  tps: 5379.38265
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 2664.00889
-  tps: 5633.2763
+  dps: 2661.80931
+  tps: 5628.88818
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 2637.70508
-  tps: 5573.90475
+  dps: 2637.64581
+  tps: 5573.78018
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 2468.29996
-  tps: 5188.81017
+  dps: 2468.24079
+  tps: 5188.68578
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-DreamwalkerGarb"
  value: {
-  dps: 2118.23635
-  tps: 4516.51327
+  dps: 2117.86152
+  tps: 4515.9164
   dtps: 7.20775
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 2515.02528
-  tps: 5301.51976
+  dps: 2516.55692
+  tps: 5305.88181
   dtps: 6.53093
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2515.99703
-  tps: 5303.28682
+  dps: 2517.39179
+  tps: 5305.82285
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 2557.64815
-  tps: 5386.46321
+  dps: 2560.12764
+  tps: 5392.59756
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2538.24627
-  tps: 5344.86277
+  dps: 2540.72575
+  tps: 5350.99713
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 2606.95396
-  tps: 5523.66715
+  dps: 2612.35443
+  tps: 5534.23091
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 2515.99703
-  tps: 5303.28682
+  dps: 2517.39179
+  tps: 5305.82285
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2615.84752
-  tps: 5522.29385
+  dps: 2613.8529
+  tps: 5517.16181
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2581.56056
-  tps: 5460.42207
+  dps: 2581.58389
+  tps: 5460.09211
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 2527.5564
-  tps: 5334.36989
+  dps: 2522.38317
+  tps: 5324.24156
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2580.46558
-  tps: 5456.76848
+  dps: 2584.33836
+  tps: 5466.37777
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2515.99703
-  tps: 5303.28682
+  dps: 2517.39179
+  tps: 5305.82285
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2515.99703
-  tps: 5303.28682
+  dps: 2517.39179
+  tps: 5305.82285
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 2562.09922
-  tps: 5395.72838
+  dps: 2558.42796
+  tps: 5387.51482
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2647.85163
-  tps: 5570.78757
+  dps: 2653.19886
+  tps: 5581.52485
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 2657.35227
-  tps: 5547.77152
+  dps: 2654.66517
+  tps: 5541.91033
   dtps: 6.91076
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 2123.01154
-  tps: 4511.31227
+  dps: 2114.73054
+  tps: 4496.0502
   dtps: 7.20775
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 2622.51965
-  tps: 5518.95397
+  dps: 2622.46039
+  tps: 5518.82939
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 2538.33826
-  tps: 5353.02959
+  dps: 2543.33877
+  tps: 5362.89526
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Heartpierce-49982"
  value: {
-  dps: 2614.42314
-  tps: 5510.61483
+  dps: 2612.9177
+  tps: 5509.9865
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Heartpierce-50641"
  value: {
-  dps: 2622.91537
-  tps: 5534.77056
+  dps: 2615.93731
+  tps: 5524.78137
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdolofLunarFury-47670"
  value: {
-  dps: 2468.33744
-  tps: 5215.8269
+  dps: 2463.33463
+  tps: 5206.05682
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 2468.33744
-  tps: 5215.8269
+  dps: 2463.33463
+  tps: 5206.05682
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 2513.28123
-  tps: 5308.75487
+  dps: 2516.14229
+  tps: 5315.72271
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 2550.36279
-  tps: 5382.72027
+  dps: 2550.30353
+  tps: 5382.5957
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheLunarEclipse-50457"
  value: {
-  dps: 2489.27797
-  tps: 5263.9672
+  dps: 2491.833
+  tps: 5270.8334
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 2503.63847
-  tps: 5295.4137
+  dps: 2502.47778
+  tps: 5291.86771
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 2468.33744
-  tps: 5215.8269
+  dps: 2463.33463
+  tps: 5206.05682
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 2533.61439
-  tps: 5348.93421
+  dps: 2532.98326
+  tps: 5347.12903
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 2557.64815
-  tps: 5386.46321
+  dps: 2560.12764
+  tps: 5392.59756
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2538.24627
-  tps: 5344.86277
+  dps: 2540.72575
+  tps: 5350.99713
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2620.32536
-  tps: 5524.52196
+  dps: 2618.33389
+  tps: 5517.0498
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 2521.75853
-  tps: 5312.0236
+  dps: 2523.15328
+  tps: 5314.55963
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2519.56002
-  tps: 5319.96343
+  dps: 2513.31918
+  tps: 5307.68832
   dtps: 6.66421
-  hps: 21.74408
+  hps: 21.94609
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 3190.98726
-  tps: 6601.57456
+  dps: 3187.28105
+  tps: 6595.38613
   dtps: 5.8645
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LasherweaveRegalia"
  value: {
-  dps: 2436.97391
-  tps: 5228.10469
+  dps: 2439.73237
+  tps: 5231.20597
   dtps: 7.20775
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LastWord-50179"
  value: {
-  dps: 2610.90589
-  tps: 5498.75107
+  dps: 2617.32216
+  tps: 5508.83631
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-LastWord-50708"
  value: {
-  dps: 2622.12473
-  tps: 5533.46706
+  dps: 2629.08459
+  tps: 5542.63705
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 2631.29847
-  tps: 5550.89764
+  dps: 2627.35201
+  tps: 5540.79537
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 2145.4175
-  tps: 4575.05674
+  dps: 2145.36359
+  tps: 4576.45006
   dtps: 6.9612
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2664.32917
-  tps: 5621.63087
+  dps: 2664.26991
+  tps: 5621.5063
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 2676.45956
-  tps: 5586.14285
+  dps: 2676.39499
+  tps: 5586.00712
   dtps: 7.74456
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Nibelung-49992"
  value: {
-  dps: 2536.42398
-  tps: 5353.87925
+  dps: 2529.66193
+  tps: 5340.1823
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Nibelung-50648"
  value: {
-  dps: 2536.42398
-  tps: 5353.87925
+  dps: 2529.66193
+  tps: 5340.1823
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NightsongBattlegear"
  value: {
-  dps: 2602.1963
-  tps: 5500.41128
+  dps: 2606.57883
+  tps: 5507.97642
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-NightsongGarb"
  value: {
-  dps: 2119.12836
-  tps: 4530.66282
+  dps: 2116.79471
+  tps: 4529.67337
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 2530.43314
-  tps: 5347.64403
+  dps: 2530.02728
+  tps: 5346.93421
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 2518.83512
-  tps: 5317.62939
+  dps: 2516.41713
+  tps: 5312.10841
   dtps: 5.50054
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 2515.99703
-  tps: 5303.28682
+  dps: 2517.39179
+  tps: 5305.82285
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 2515.99703
-  tps: 5303.28682
+  dps: 2517.39179
+  tps: 5305.82285
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 2542.34917
-  tps: 5365.8385
+  dps: 2548.73661
+  tps: 5378.76934
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 2544.15333
-  tps: 5369.63102
+  dps: 2550.54077
+  tps: 5382.56187
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2602.62546
-  tps: 5498.18784
+  dps: 2604.6911
+  tps: 5499.95116
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 2579.23278
-  tps: 5435.52269
+  dps: 2580.33427
+  tps: 5438.71193
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2515.99703
-  tps: 5303.28682
+  dps: 2517.39179
+  tps: 5305.82285
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 2534.82378
-  tps: 5347.89018
+  dps: 2535.40748
+  tps: 5349.58677
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2526.89297
-  tps: 5334.16563
+  dps: 2522.00952
+  tps: 5324.6968
   dtps: 4.4102
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SoulPreserver-37111"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SouloftheDead-40382"
  value: {
-  dps: 2582.40075
-  tps: 5464.95356
+  dps: 2582.42407
+  tps: 5464.62359
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 2593.37838
-  tps: 5477.01508
+  dps: 2596.52527
+  tps: 5483.00415
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 2624.69684
-  tps: 5538.31218
+  dps: 2623.96055
+  tps: 5535.88447
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-StormshroudArmor"
  value: {
-  dps: 2059.56656
-  tps: 4340.57802
+  dps: 2059.51294
+  tps: 4340.4653
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 2530.43314
-  tps: 5347.64403
+  dps: 2530.02728
+  tps: 5346.93421
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2539.82917
-  tps: 5358.71023
+  dps: 2539.53773
+  tps: 5357.19531
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 2537.705
-  tps: 5356.98187
+  dps: 2530.94295
+  tps: 5343.28491
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartHarness"
  value: {
-  dps: 2095.39072
-  tps: 4551.0363
+  dps: 2095.33572
+  tps: 4550.92068
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderheartRegalia"
  value: {
-  dps: 1865.15631
-  tps: 3977.40746
+  dps: 1865.10833
+  tps: 3977.3066
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 2551.63706
-  tps: 5377.77853
+  dps: 2551.48878
+  tps: 5378.08595
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2675.86941
-  tps: 5658.28947
+  dps: 2677.7982
+  tps: 5662.75875
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2664.13122
-  tps: 5622.36246
+  dps: 2661.21566
+  tps: 5617.35603
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2515.99703
-  tps: 5303.28682
+  dps: 2517.39179
+  tps: 5305.82285
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2515.99703
-  tps: 5303.28682
+  dps: 2517.39179
+  tps: 5305.82285
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 2571.27933
-  tps: 5413.39212
+  dps: 2571.22007
+  tps: 5413.26755
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2515.99703
-  tps: 5303.28682
+  dps: 2517.39179
+  tps: 5305.82285
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2515.99703
-  tps: 5303.28682
+  dps: 2517.39179
+  tps: 5305.82285
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 2198.2081
-  tps: 4666.19158
+  dps: 2198.17368
+  tps: 4662.66132
   dtps: 6.36395
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 2036.79814
-  tps: 4347.11132
+  dps: 2036.75239
+  tps: 4347.01516
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 2468.33744
-  tps: 5215.8269
+  dps: 2463.33463
+  tps: 5206.05682
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WingedTalisman-37844"
  value: {
-  dps: 2523.2603
-  tps: 5331.28024
+  dps: 2518.08707
+  tps: 5321.15191
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 2558.92181
-  tps: 5391.4524
+  dps: 2563.48016
+  tps: 5400.01478
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-Average-Default"
  value: {
-  dps: 2664.65503
-  tps: 5648.53713
-  dtps: 59.70577
+  dps: 2671.62749
+  tps: 5666.45417
+  dtps: 58.28733
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-p1-Default-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4596.97168
-  tps: 10417.84607
+  dps: 4596.9065
+  tps: 10417.71071
   dtps: 6.22692
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-p1-Default-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2674.35053
-  tps: 5637.34408
+  dps: 2675.07347
+  tps: 5639.16861
   dtps: 6.66421
  }
 }
 dps_results: {
  key: "TestFeralTank-Settings-Tauren-p1-Default-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 2854.21381
-  tps: 6208.75396
+  dps: 2853.88789
+  tps: 6208.06885
   dtps: 33.32105
  }
 }
@@ -1127,8 +1127,8 @@ dps_results: {
 dps_results: {
  key: "TestFeralTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2783.18706
-  tps: 5902.60751
-  dtps: 52.92974
+  dps: 2765.82572
+  tps: 5861.75186
+  dtps: 54.87665
  }
 }

--- a/sim/encounters/ulduar/hodir_ai.go
+++ b/sim/encounters/ulduar/hodir_ai.go
@@ -337,12 +337,12 @@ func (ai *HodirAI) registerFrozenBlowSpell(target *core.Target) {
 	})
 
 	// Replace MH Hit when under Frozen Blows buff
-	ai.Target.Unit.AutoAttacks.ReplaceMHSwing = func(sim *core.Simulation, mhSwingSpell *core.Spell) *core.Spell {
+	ai.Target.Unit.AutoAttacks.SetReplaceMHSwing(func(sim *core.Simulation, mhSwingSpell *core.Spell) *core.Spell {
 		if ai.FrozenBlowsAura.IsActive() {
 			return ai.FrozenBlowsAuto
 		}
 		return mhSwingSpell
-	}
+	})
 
 	ai.FrozenBlowsAuto = target.GetOrRegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: core.TernaryInt32(ai.raidSize == 25, 63511, 62867)}.WithTag(1),

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -46,935 +46,935 @@ character_stats_results: {
 dps_results: {
  key: "TestBM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 7185.01083
-  tps: 5147.57896
+  dps: 7189.55017
+  tps: 5146.60022
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 6344.94423
-  tps: 4262.83997
+  dps: 6351.06055
+  tps: 4271.57821
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6363.97775
-  tps: 4266.81183
+  dps: 6369.03989
+  tps: 4276.4609
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6438.86987
-  tps: 4348.09246
+  dps: 6445.22599
+  tps: 4357.20203
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6280.57186
-  tps: 4214.55697
+  dps: 6286.66525
+  tps: 4223.34325
   hps: 92.16151
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6280.57186
-  tps: 4214.55697
+  dps: 6286.66525
+  tps: 4223.34325
   hps: 92.16151
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6391.69916
-  tps: 4291.85991
+  dps: 6396.77616
+  tps: 4303.04304
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6279.853
-  tps: 4230.75048
+  dps: 6259.74234
+  tps: 4211.60452
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 5958.76135
-  tps: 3891.83797
+  dps: 5956.25614
+  tps: 3885.95381
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBruise-50035"
  value: {
-  dps: 6130.74888
-  tps: 4101.88241
+  dps: 6139.561
+  tps: 4102.10945
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBruise-50692"
  value: {
-  dps: 6120.10921
-  tps: 4093.9824
+  dps: 6128.90856
+  tps: 4094.20794
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5339.35651
-  tps: 3591.32894
+  dps: 5347.40655
+  tps: 3606.1824
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5158.67765
-  tps: 3468.9396
+  dps: 5178.7472
+  tps: 3488.18028
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6363.97775
-  tps: 4182.81919
+  dps: 6369.03989
+  tps: 4192.28021
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6463.05956
-  tps: 4362.82632
+  dps: 6468.58218
+  tps: 4372.96544
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6463.05956
-  tps: 4362.82632
+  dps: 6468.58218
+  tps: 4372.96544
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6456.28595
-  tps: 4358.30894
+  dps: 6461.27995
+  tps: 4367.9129
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
   hps: 64
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 5907.97763
-  tps: 3953.51008
+  dps: 5907.22488
+  tps: 3950.85265
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6343.19382
-  tps: 4280.1374
+  dps: 6352.38917
+  tps: 4284.49958
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6402.25965
-  tps: 4340.53214
+  dps: 6411.33178
+  tps: 4342.9194
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6452.61758
-  tps: 4354.27115
+  dps: 6450.80058
+  tps: 4358.07873
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6594.65772
-  tps: 4462.77298
+  dps: 6596.07139
+  tps: 4468.58944
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6343.10641
-  tps: 4282.40355
+  dps: 6346.27903
+  tps: 4275.50887
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6610.70077
-  tps: 4506.0031
+  dps: 6606.84889
+  tps: 4507.70293
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6652.5393
-  tps: 4544.61609
+  dps: 6661.71513
+  tps: 4549.0504
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6381.3421
-  tps: 4284.5305
+  dps: 6385.8303
+  tps: 4293.61548
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6350.34074
-  tps: 4308.99139
+  dps: 6356.65227
+  tps: 4306.65823
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6351.2009
-  tps: 4288.66491
+  dps: 6358.24714
+  tps: 4292.60208
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6363.97775
-  tps: 4266.81183
+  dps: 6369.03989
+  tps: 4276.4609
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6376.2652
-  tps: 4275.82957
+  dps: 6382.70364
+  tps: 4287.21809
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6379.49325
-  tps: 4281.51625
+  dps: 6383.87779
+  tps: 4290.51073
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6378.68559
-  tps: 4280.70859
+  dps: 6383.56298
+  tps: 4290.19593
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6327.11607
-  tps: 4262.33845
+  dps: 6329.96912
+  tps: 4268.23351
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6363.97775
-  tps: 4266.81183
+  dps: 6369.03989
+  tps: 4276.4609
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6390.12666
-  tps: 4327.51865
+  dps: 6397.56348
+  tps: 4329.02283
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6340.89581
-  tps: 4278.36795
+  dps: 6348.62671
+  tps: 4280.09563
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6324.19094
-  tps: 4249.63722
+  dps: 6323.53397
+  tps: 4255.60672
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6326.84138
-  tps: 4262.33071
+  dps: 6333.73943
+  tps: 4265.7748
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6363.97775
-  tps: 4266.81183
+  dps: 6369.03989
+  tps: 4276.4609
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6363.97775
-  tps: 4266.81183
+  dps: 6369.03989
+  tps: 4276.4609
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6439.91884
-  tps: 4333.21152
+  dps: 6446.16425
+  tps: 4342.21263
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 6231.63162
-  tps: 4299.7928
+  dps: 6239.18169
+  tps: 4311.53445
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6376.54351
-  tps: 4314.93034
+  dps: 6385.42978
+  tps: 4317.11389
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5009.99192
-  tps: 3329.41133
+  dps: 5007.9512
+  tps: 3331.51676
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Heartpierce-49982"
  value: {
-  dps: 6511.411
-  tps: 4398.88865
+  dps: 6516.98905
+  tps: 4409.1096
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Heartpierce-50641"
  value: {
-  dps: 6512.45082
-  tps: 4399.66419
+  dps: 6518.03006
+  tps: 4409.8869
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6280.80891
-  tps: 4214.93559
+  dps: 6286.85592
+  tps: 4223.66401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6379.49325
-  tps: 4281.51625
+  dps: 6383.87779
+  tps: 4290.51073
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6378.68559
-  tps: 4280.70859
+  dps: 6383.56298
+  tps: 4290.19593
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6424.63507
-  tps: 4339.26456
+  dps: 6431.12177
+  tps: 4348.46023
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6428.94946
-  tps: 4325.72242
+  dps: 6428.01385
+  tps: 4331.57618
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6387.95371
-  tps: 4286.20256
+  dps: 6393.40482
+  tps: 4296.29357
   hps: 11.19844
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LastWord-50179"
  value: {
-  dps: 6463.05956
-  tps: 4362.82632
+  dps: 6468.58218
+  tps: 4372.96544
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LastWord-50708"
  value: {
-  dps: 6463.05956
-  tps: 4362.82632
+  dps: 6468.58218
+  tps: 4372.96544
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6375.75748
-  tps: 4303.55675
+  dps: 6365.09622
+  tps: 4295.9373
  }
 }
 dps_results: {
  key: "TestBM-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6405.21313
-  tps: 4324.15104
+  dps: 6400.4214
+  tps: 4324.6905
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Nibelung-49992"
  value: {
-  dps: 6580.64603
-  tps: 4457.82692
+  dps: 6580.08633
+  tps: 4464.05469
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Nibelung-50648"
  value: {
-  dps: 6585.05064
-  tps: 4460.98459
+  dps: 6584.83396
+  tps: 4467.73345
  }
 }
 dps_results: {
  key: "TestBM-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6381.40211
-  tps: 4279.74314
+  dps: 6386.48279
+  tps: 4289.4204
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6385.50195
-  tps: 4282.7858
+  dps: 6390.58701
+  tps: 4292.46969
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6363.97775
-  tps: 4266.81183
+  dps: 6369.03989
+  tps: 4276.4609
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6363.97775
-  tps: 4266.81183
+  dps: 6369.03989
+  tps: 4276.4609
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6289.17293
-  tps: 4223.18785
+  dps: 6295.36214
+  tps: 4232.06123
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6290.29025
-  tps: 4224.30517
+  dps: 6296.46735
+  tps: 4233.16644
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6463.05956
-  tps: 4362.82632
+  dps: 6468.58218
+  tps: 4372.96544
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6378.27016
-  tps: 4277.7978
+  dps: 6383.74732
+  tps: 4289.36031
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 6319.08004
-  tps: 4298.07513
+  dps: 6324.00193
+  tps: 4298.57797
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6655.25104
-  tps: 4551.05498
+  dps: 6659.49479
+  tps: 4556.82769
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6313.88547
-  tps: 4248.96918
+  dps: 6312.09667
+  tps: 4255.05637
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6322.73213
-  tps: 4257.78733
+  dps: 6323.05908
+  tps: 4265.06725
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6350.26035
-  tps: 4288.25795
+  dps: 6358.326
+  tps: 4289.36711
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SparkofLife-37657"
  value: {
-  dps: 6346.12896
-  tps: 4258.27572
+  dps: 6340.75387
+  tps: 4256.57801
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6418.80194
-  tps: 4298.98534
+  dps: 6418.43226
+  tps: 4299.14357
  }
 }
 dps_results: {
  key: "TestBM-AllItems-StormshroudArmor"
  value: {
-  dps: 5050.34605
-  tps: 3342.00715
+  dps: 5040.18249
+  tps: 3344.5557
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6385.50195
-  tps: 4282.7858
+  dps: 6390.58701
+  tps: 4292.46969
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6381.40211
-  tps: 4279.74314
+  dps: 6386.48279
+  tps: 4289.4204
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6374.22737
-  tps: 4274.41848
+  dps: 6379.30042
+  tps: 4284.08413
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6365.39433
-  tps: 4283.16626
+  dps: 6360.08744
+  tps: 4285.41065
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheFistsofFury"
  value: {
-  dps: 6161.87479
-  tps: 4128.70714
+  dps: 6169.33066
+  tps: 4128.89411
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6312.6576
-  tps: 4254.59259
+  dps: 6324.8676
+  tps: 4256.01175
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6387.33211
-  tps: 4285.98061
+  dps: 6385.39411
+  tps: 4294.18129
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6332.56556
-  tps: 4234.62823
+  dps: 6331.98589
+  tps: 4234.78646
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6332.56556
-  tps: 4234.62823
+  dps: 6331.98589
+  tps: 4234.78646
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6363.97775
-  tps: 4266.81183
+  dps: 6369.03989
+  tps: 4276.4609
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6363.97775
-  tps: 4266.81183
+  dps: 6369.03989
+  tps: 4276.4609
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6314.27327
-  tps: 4240.97705
+  dps: 6316.66525
+  tps: 4242.04095
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6363.97775
-  tps: 4266.81183
+  dps: 6369.03989
+  tps: 4276.4609
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6363.97775
-  tps: 4266.81183
+  dps: 6369.03989
+  tps: 4276.4609
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5253.80088
-  tps: 3532.67869
+  dps: 5271.36867
+  tps: 3547.09403
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6217.24678
-  tps: 4173.91339
+  dps: 6219.39293
+  tps: 4181.13578
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 6434.78941
-  tps: 4401.3569
+  dps: 6429.18968
+  tps: 4399.23869
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6280.83455
-  tps: 4214.96122
+  dps: 6286.88156
+  tps: 4223.68964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 6833.0189
-  tps: 4758.05895
+  dps: 6829.142
+  tps: 4753.53995
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 7038.23923
-  tps: 4966.89739
+  dps: 7040.87357
+  tps: 4966.4633
  }
 }
 dps_results: {
  key: "TestBM-Average-Default"
  value: {
-  dps: 6433.20261
-  tps: 4349.46133
+  dps: 6432.41489
+  tps: 4349.52094
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-p1_sv-Basic-bm-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14089.69804
-  tps: 13400.54792
+  dps: 14097.37708
+  tps: 13406.96699
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-p1_sv-Basic-bm-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6360.92184
-  tps: 4367.27242
+  dps: 6362.69653
+  tps: 4372.35982
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-p1_sv-Basic-bm-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7622.26077
-  tps: 5201.03751
+  dps: 7622.66902
+  tps: 5202.59373
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-p1_sv-Basic-bm-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7562.64991
-  tps: 8710.0143
+  dps: 7563.20544
+  tps: 8710.11183
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-p1_sv-Basic-bm-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3048.58679
-  tps: 2407.41844
+  dps: 3048.9954
+  tps: 2407.25718
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-p1_sv-Basic-bm-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3493.97125
-  tps: 2753.08417
+  dps: 3493.44407
+  tps: 2752.32679
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-p1_sv-Basic-bm-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14281.82423
-  tps: 13473.82205
+  dps: 14281.06531
+  tps: 13474.96368
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-p1_sv-Basic-bm-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6463.05956
-  tps: 4362.82632
+  dps: 6468.58218
+  tps: 4372.96544
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-p1_sv-Basic-bm-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7772.83752
-  tps: 5212.04328
+  dps: 7771.84444
+  tps: 5212.4213
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-p1_sv-Basic-bm-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7634.869
-  tps: 8751.05919
+  dps: 7635.84628
+  tps: 8750.03446
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-p1_sv-Basic-bm-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3078.71573
-  tps: 2403.14887
+  dps: 3077.81941
+  tps: 2403.24647
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-p1_sv-Basic-bm-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3553.79138
-  tps: 2766.14097
+  dps: 3552.2038
+  tps: 2765.22516
  }
 }
 dps_results: {
  key: "TestBM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6303.68473
-  tps: 4376.71809
+  dps: 6284.44596
+  tps: 4358.35418
  }
 }

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -46,1019 +46,1019 @@ character_stats_results: {
 dps_results: {
  key: "TestMM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 8466.66767
-  tps: 7546.367
+  dps: 8465.61535
+  tps: 7545.76939
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 7159.01669
-  tps: 6243.38723
+  dps: 7158.13438
+  tps: 6242.84146
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7175.18266
-  tps: 6249.51605
+  dps: 7174.28612
+  tps: 6248.97238
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7255.07928
-  tps: 6334.76723
+  dps: 7254.1853
+  tps: 6334.21428
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7089.64922
-  tps: 6180.27326
+  dps: 7088.76691
+  tps: 6179.72749
   hps: 91.71984
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7089.64922
-  tps: 6180.27326
+  dps: 7088.76691
+  tps: 6179.72749
   hps: 91.71984
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7198.56264
-  tps: 6273.85268
+  dps: 7197.6661
+  tps: 6273.30902
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7152.70991
-  tps: 6241.08314
+  dps: 7151.89178
+  tps: 6240.53161
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 6686.53191
-  tps: 5771.94829
+  dps: 6685.72102
+  tps: 5771.48879
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50035"
  value: {
-  dps: 6977.90995
-  tps: 6075.26474
+  dps: 6977.0213
+  tps: 6074.72142
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50692"
  value: {
-  dps: 6965.06881
-  tps: 6063.61868
+  dps: 6964.18144
+  tps: 6063.07616
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6119.44919
-  tps: 5335.53738
+  dps: 6127.59208
+  tps: 5344.57135
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5876.08601
-  tps: 5116.88398
+  dps: 5872.34043
+  tps: 5113.54385
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7175.18266
-  tps: 6125.83679
+  dps: 7174.28612
+  tps: 6125.304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7337.82851
-  tps: 6411.59336
+  dps: 7336.91871
+  tps: 6411.03702
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7337.82851
-  tps: 6411.59336
+  dps: 7336.91871
+  tps: 6411.03702
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7333.43388
-  tps: 6408.6069
+  dps: 7332.52556
+  tps: 6408.05146
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
   hps: 64
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 6612.58402
-  tps: 5734.56184
+  dps: 6611.54186
+  tps: 5734.0298
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7211.64242
-  tps: 6301.09302
+  dps: 7210.76011
+  tps: 6300.54725
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7244.96495
-  tps: 6332.76733
+  dps: 7244.08275
+  tps: 6332.22156
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7347.94901
-  tps: 6416.64989
+  dps: 7347.03922
+  tps: 6416.09355
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7531.7904
-  tps: 6591.75285
+  dps: 7530.84745
+  tps: 6591.18569
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7157.09435
-  tps: 6243.55105
+  dps: 7156.21204
+  tps: 6243.00528
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7479.69903
-  tps: 6553.34745
+  dps: 7478.73839
+  tps: 6552.7754
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7517.70046
-  tps: 6589.84779
+  dps: 7516.71526
+  tps: 6589.2685
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7195.52445
-  tps: 6270.71245
+  dps: 7194.6279
+  tps: 6270.16878
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7223.39472
-  tps: 6312.0282
+  dps: 7222.5124
+  tps: 6311.48243
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7207.05894
-  tps: 6297.49019
+  dps: 7206.17663
+  tps: 6296.94442
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7175.18266
-  tps: 6249.51605
+  dps: 7174.28612
+  tps: 6248.97238
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7187.71965
-  tps: 6261.19665
+  dps: 7186.82234
+  tps: 6260.65252
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7194.24689
-  tps: 6269.41991
+  dps: 7193.35034
+  tps: 6268.87625
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7191.78665
-  tps: 6266.95967
+  dps: 7190.8901
+  tps: 6266.41601
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7175.17663
-  tps: 6270.89288
+  dps: 7174.29431
+  tps: 6270.34711
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7175.18266
-  tps: 6249.51605
+  dps: 7174.28612
+  tps: 6248.97238
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7261.89103
-  tps: 6350.35867
+  dps: 7261.00872
+  tps: 6349.8129
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7194.45607
-  tps: 6282.49958
+  dps: 7193.57376
+  tps: 6281.9538
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7127.82834
-  tps: 6214.96196
+  dps: 7126.94307
+  tps: 6214.41438
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7171.80569
-  tps: 6260.04823
+  dps: 7170.92338
+  tps: 6259.50246
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7175.18266
-  tps: 6249.51605
+  dps: 7174.28612
+  tps: 6248.97238
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7175.18266
-  tps: 6249.51605
+  dps: 7174.28612
+  tps: 6248.97238
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7281.00317
-  tps: 6353.80326
+  dps: 7280.11479
+  tps: 6353.25624
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 7233.51338
-  tps: 6375.01298
+  dps: 7230.01254
+  tps: 6372.38081
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7223.03283
-  tps: 6310.91082
+  dps: 7222.15052
+  tps: 6310.36505
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5553.30092
-  tps: 4796.63036
+  dps: 5556.18604
+  tps: 4799.84754
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-49982"
  value: {
-  dps: 7395.77293
-  tps: 6464.22309
+  dps: 7394.85743
+  tps: 6463.66323
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-50641"
  value: {
-  dps: 7397.01905
-  tps: 6465.35492
+  dps: 7396.10343
+  tps: 6464.79498
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7089.76824
-  tps: 6180.25501
+  dps: 7088.88593
+  tps: 6179.70924
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7194.24689
-  tps: 6269.41991
+  dps: 7193.35034
+  tps: 6268.87625
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7191.78665
-  tps: 6266.95967
+  dps: 7190.8901
+  tps: 6266.41601
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7247.7188
-  tps: 6329.78741
+  dps: 7246.82741
+  tps: 6329.23605
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7248.04898
-  tps: 6321.77967
+  dps: 7247.15098
+  tps: 6321.23511
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7200.21957
-  tps: 6272.31359
+  dps: 7199.30937
+  tps: 6271.76728
   hps: 11.11942
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LastWord-50179"
  value: {
-  dps: 7337.82851
-  tps: 6411.59336
+  dps: 7336.91871
+  tps: 6411.03702
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LastWord-50708"
  value: {
-  dps: 7337.82851
-  tps: 6411.59336
+  dps: 7336.91871
+  tps: 6411.03702
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7089.78536
-  tps: 6180.27213
+  dps: 7088.90305
+  tps: 6179.72636
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7271.33757
-  tps: 6360.81514
+  dps: 7270.45526
+  tps: 6360.26937
  }
 }
 dps_results: {
  key: "TestMM-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7236.11754
-  tps: 6327.24994
+  dps: 7235.23523
+  tps: 6326.70417
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Nibelung-49992"
  value: {
-  dps: 7468.10832
-  tps: 6528.92669
+  dps: 7467.19102
+  tps: 6528.36572
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Nibelung-50648"
  value: {
-  dps: 7477.26065
-  tps: 6537.0346
+  dps: 7476.34279
+  tps: 6536.47328
  }
 }
 dps_results: {
  key: "TestMM-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7195.93657
-  tps: 6268.32534
+  dps: 7195.03796
+  tps: 6267.78041
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7200.81984
-  tps: 6272.75106
+  dps: 7199.92075
+  tps: 6272.20583
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7089.78536
-  tps: 6180.27213
+  dps: 7088.90305
+  tps: 6179.72636
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7175.18266
-  tps: 6249.51605
+  dps: 7174.28612
+  tps: 6248.97238
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7175.18266
-  tps: 6249.51605
+  dps: 7174.28612
+  tps: 6248.97238
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7098.88136
-  tps: 6189.34161
+  dps: 7097.99905
+  tps: 6188.79584
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7100.02447
-  tps: 6190.48472
+  dps: 7099.14216
+  tps: 6189.93895
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7337.82851
-  tps: 6411.59336
+  dps: 7336.91871
+  tps: 6411.03702
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7178.80539
-  tps: 6252.62975
+  dps: 7177.90884
+  tps: 6252.08608
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 7067.92036
-  tps: 6188.81051
+  dps: 7067.04257
+  tps: 6188.26738
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7610.72192
-  tps: 6683.14555
+  dps: 7609.79649
+  tps: 6682.57357
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7089.76417
-  tps: 6180.25094
+  dps: 7088.88186
+  tps: 6179.70517
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7142.42616
-  tps: 6231.9653
+  dps: 7141.54385
+  tps: 6231.41953
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7143.41456
-  tps: 6233.45273
+  dps: 7142.53225
+  tps: 6232.90696
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7213.50877
-  tps: 6302.46821
+  dps: 7212.62646
+  tps: 6301.92244
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SparkofLife-37657"
  value: {
-  dps: 7213.09095
-  tps: 6299.108
+  dps: 7212.20863
+  tps: 6298.56223
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7185.68482
-  tps: 6266.47215
+  dps: 7184.80251
+  tps: 6265.92638
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StormshroudArmor"
  value: {
-  dps: 5727.15237
-  tps: 4976.21324
+  dps: 5720.93674
+  tps: 4968.98786
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7200.81984
-  tps: 6272.75106
+  dps: 7199.92075
+  tps: 6272.20583
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7195.93657
-  tps: 6268.32534
+  dps: 7195.03796
+  tps: 6267.78041
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7187.39084
-  tps: 6260.58034
+  dps: 7186.49308
+  tps: 6260.03593
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7184.06464
-  tps: 6264.84586
+  dps: 7183.17643
+  tps: 6264.29646
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheFistsofFury"
  value: {
-  dps: 7010.19921
-  tps: 6107.47641
+  dps: 7009.30879
+  tps: 6106.93201
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7161.28693
-  tps: 6257.594
+  dps: 7160.38869
+  tps: 6257.04214
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7201.96374
-  tps: 6276.76109
+  dps: 7201.06719
+  tps: 6276.21743
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7090.03676
-  tps: 6180.52353
+  dps: 7089.15444
+  tps: 6179.97776
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7090.03676
-  tps: 6180.52353
+  dps: 7089.15444
+  tps: 6179.97776
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7175.18266
-  tps: 6249.51605
+  dps: 7174.28612
+  tps: 6248.97238
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7175.18266
-  tps: 6249.51605
+  dps: 7174.28612
+  tps: 6248.97238
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7151.22932
-  tps: 6238.0454
+  dps: 7150.347
+  tps: 6237.49963
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7175.18266
-  tps: 6249.51605
+  dps: 7174.28612
+  tps: 6248.97238
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7175.18266
-  tps: 6249.51605
+  dps: 7174.28612
+  tps: 6248.97238
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6022.46197
-  tps: 5252.73606
+  dps: 6033.80898
+  tps: 5263.97086
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7066.29458
-  tps: 6159.76523
+  dps: 7065.40714
+  tps: 6159.22265
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 7274.62567
-  tps: 6372.31057
+  dps: 7273.56326
+  tps: 6371.76516
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7089.78943
-  tps: 6180.2762
+  dps: 7088.90711
+  tps: 6179.73043
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7891.98915
-  tps: 6967.5668
+  dps: 7890.96887
+  tps: 6966.90655
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 8091.67717
-  tps: 7174.86466
+  dps: 8090.70871
+  tps: 7174.15331
  }
 }
 dps_results: {
  key: "TestMM-Average-Default"
  value: {
-  dps: 7344.09621
-  tps: 6425.47967
+  dps: 7343.60691
+  tps: 6425.09019
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14274.33158
-  tps: 14652.76432
+  dps: 14273.45625
+  tps: 14652.2258
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7329.96989
-  tps: 6454.80211
+  dps: 7329.07669
+  tps: 6454.24572
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8335.48272
-  tps: 7312.58988
+  dps: 8331.01675
+  tps: 7309.80794
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7421.76085
-  tps: 8909.65471
+  dps: 7421.54637
+  tps: 8909.49687
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3599.26399
-  tps: 3345.16253
+  dps: 3599.04952
+  tps: 3345.00469
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4184.34561
-  tps: 3850.53327
+  dps: 4183.27324
+  tps: 3849.74406
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14010.95681
-  tps: 14300.798
+  dps: 14010.41978
+  tps: 14300.56199
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7297.959
-  tps: 6420.58585
+  dps: 7297.42197
+  tps: 6420.34984
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8424.73711
-  tps: 7411.22505
+  dps: 8422.05193
+  tps: 7410.04502
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7270.62414
-  tps: 8731.36834
+  dps: 7270.38337
+  tps: 8731.29153
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3619.87157
-  tps: 3365.50453
+  dps: 3619.6308
+  tps: 3365.42772
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4418.24722
-  tps: 4077.83861
+  dps: 4417.04335
+  tps: 4077.45453
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14360.5723
-  tps: 14687.66625
+  dps: 14359.68038
+  tps: 14687.12778
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7337.82851
-  tps: 6411.59336
+  dps: 7336.91871
+  tps: 6411.03702
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8386.17169
-  tps: 7300.89917
+  dps: 8381.62272
+  tps: 7298.11744
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7452.13724
-  tps: 8914.11683
+  dps: 7451.91994
+  tps: 8913.95899
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3614.18547
-  tps: 3340.41291
+  dps: 3613.96817
+  tps: 3340.25507
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4308.46835
-  tps: 3947.14471
+  dps: 4307.38186
+  tps: 3946.3555
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14086.71608
-  tps: 14325.27418
+  dps: 14086.16418
+  tps: 14325.03819
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7332.70063
-  tps: 6407.32552
+  dps: 7332.14873
+  tps: 6407.08953
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8501.40254
-  tps: 7426.93741
+  dps: 8498.64305
+  tps: 7425.75746
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7324.11129
-  tps: 8769.08886
+  dps: 7323.86233
+  tps: 8769.01204
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3636.03963
-  tps: 3364.4352
+  dps: 3635.79068
+  tps: 3364.35839
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4461.16768
-  tps: 4099.72963
+  dps: 4459.92291
+  tps: 4099.34556
  }
 }
 dps_results: {
  key: "TestMM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7291.99841
-  tps: 6437.57063
+  dps: 7291.45852
+  tps: 6437.02329
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -46,1103 +46,1103 @@ character_stats_results: {
 dps_results: {
  key: "TestSV-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 8663.30881
-  tps: 7620.97145
+  dps: 8660.56242
+  tps: 7619.03465
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 7372.59115
-  tps: 6329.13825
+  dps: 7371.81455
+  tps: 6328.77879
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7473.88704
-  tps: 6417.7643
+  dps: 7472.93878
+  tps: 6417.40175
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7497.42174
-  tps: 6448.04664
+  dps: 7496.63554
+  tps: 6447.68204
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7322.83971
-  tps: 6283.62785
+  dps: 7322.06312
+  tps: 6283.26839
   hps: 91.06638
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7322.83971
-  tps: 6283.62785
+  dps: 7322.06312
+  tps: 6283.26839
   hps: 91.06638
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7482.46557
-  tps: 6428.84542
+  dps: 7481.51929
+  tps: 6428.48318
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7442.75729
-  tps: 6404.29294
+  dps: 7442.05071
+  tps: 6403.92794
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 7194.51316
-  tps: 6155.88035
+  dps: 7193.75512
+  tps: 6155.56198
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50035"
  value: {
-  dps: 7229.30616
-  tps: 6198.45737
+  dps: 7228.51609
+  tps: 6198.09795
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50692"
  value: {
-  dps: 7218.80084
-  tps: 6188.29213
+  dps: 7218.0114
+  tps: 6187.9332
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6190.49223
-  tps: 5332.41384
+  dps: 6189.60136
+  tps: 5332.67841
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5936.16572
-  tps: 5094.79861
+  dps: 5937.34261
+  tps: 5097.76301
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7464.29525
-  tps: 6284.15477
+  dps: 7463.34897
+  tps: 6283.79977
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7692.10291
-  tps: 6622.36014
+  dps: 7691.13771
+  tps: 6621.98868
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7695.75975
-  tps: 6624.91307
+  dps: 7694.79381
+  tps: 6624.54149
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7628.37414
-  tps: 6574.80439
+  dps: 7627.42104
+  tps: 6574.43533
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7390.39551
-  tps: 6330.26264
+  dps: 7389.60774
+  tps: 6329.90094
   hps: 64
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 6746.91557
-  tps: 5775.43303
+  dps: 6746.24854
+  tps: 5774.78079
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7425.03998
-  tps: 6385.18631
+  dps: 7424.26338
+  tps: 6384.82685
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7469.96694
-  tps: 6430.26506
+  dps: 7469.19039
+  tps: 6429.9056
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7560.21592
-  tps: 6506.3874
+  dps: 7559.40519
+  tps: 6506.01836
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7784.14332
-  tps: 6715.62137
+  dps: 7783.15705
+  tps: 6715.24428
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7396.1894
-  tps: 6357.1127
+  dps: 7395.4128
+  tps: 6356.75324
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7675.41593
-  tps: 6621.22809
+  dps: 7674.65063
+  tps: 6620.84821
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7722.51529
-  tps: 6667.09736
+  dps: 7721.72632
+  tps: 6666.71481
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7485.5394
-  tps: 6431.96666
+  dps: 7484.59312
+  tps: 6431.60442
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7385.72837
-  tps: 6359.46597
+  dps: 7384.95177
+  tps: 6359.10651
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7381.70957
-  tps: 6356.6045
+  dps: 7380.93298
+  tps: 6356.24504
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7473.88704
-  tps: 6417.7643
+  dps: 7472.93878
+  tps: 6417.40175
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7471.70355
-  tps: 6417.83248
+  dps: 7470.75659
+  tps: 6417.46993
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7482.46557
-  tps: 6428.89582
+  dps: 7481.51929
+  tps: 6428.53358
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7477.35752
-  tps: 6424.29803
+  dps: 7476.41124
+  tps: 6423.93579
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7351.00908
-  tps: 6320.59371
+  dps: 7350.23249
+  tps: 6320.23424
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7355.19705
-  tps: 6305.82612
+  dps: 7354.41501
+  tps: 6305.46557
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7464.29525
-  tps: 6411.11629
+  dps: 7463.34897
+  tps: 6410.75405
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7480.91424
-  tps: 6441.20569
+  dps: 7480.13764
+  tps: 6440.84623
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7416.29418
-  tps: 6376.3383
+  dps: 7415.51758
+  tps: 6375.97884
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7350.94098
-  tps: 6309.51718
+  dps: 7350.16204
+  tps: 6309.15646
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7392.80728
-  tps: 6353.47469
+  dps: 7392.03069
+  tps: 6353.11523
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7464.29525
-  tps: 6411.11629
+  dps: 7463.34897
+  tps: 6410.75405
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7464.29525
-  tps: 6411.11629
+  dps: 7463.34897
+  tps: 6410.75405
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7515.40688
-  tps: 6459.2706
+  dps: 7514.62771
+  tps: 6458.9109
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 7432.96221
-  tps: 6441.46457
+  dps: 7428.18945
+  tps: 6437.09741
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7445.3402
-  tps: 6405.78976
+  dps: 7444.56361
+  tps: 6405.4303
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5504.29608
-  tps: 4685.91838
+  dps: 5496.56429
+  tps: 4677.2931
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-49982"
  value: {
-  dps: 7723.74284
-  tps: 6657.29235
+  dps: 7722.77793
+  tps: 6656.91927
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-50641"
  value: {
-  dps: 7727.76883
-  tps: 6660.37919
+  dps: 7726.80323
+  tps: 6660.00597
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7321.77861
-  tps: 6282.61773
+  dps: 7321.00201
+  tps: 6282.25827
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7482.46557
-  tps: 6428.89582
+  dps: 7481.51929
+  tps: 6428.53358
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7477.35752
-  tps: 6424.29803
+  dps: 7476.41124
+  tps: 6423.93579
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7470.88171
-  tps: 6423.49251
+  dps: 7470.09763
+  tps: 6423.12905
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7478.80837
-  tps: 6430.91219
+  dps: 7477.86075
+  tps: 6430.54933
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7485.7863
-  tps: 6430.3534
+  dps: 7484.82138
+  tps: 6429.99004
   hps: 12.062
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LastWord-50179"
  value: {
-  dps: 7674.7329
-  tps: 6610.23374
+  dps: 7673.77123
+  tps: 6609.86283
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LastWord-50708"
  value: {
-  dps: 7671.68553
-  tps: 6608.1063
+  dps: 7670.72448
+  tps: 6607.73549
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7452.23838
-  tps: 6421.76847
+  dps: 7451.46179
+  tps: 6421.40901
  }
 }
 dps_results: {
  key: "TestSV-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7441.9175
-  tps: 6402.95717
+  dps: 7441.1409
+  tps: 6402.59771
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Nibelung-49992"
  value: {
-  dps: 7748.76422
-  tps: 6677.81375
+  dps: 7747.796
+  tps: 6677.43971
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Nibelung-50648"
  value: {
-  dps: 7755.6299
-  tps: 6683.79605
+  dps: 7754.66093
+  tps: 6683.42174
  }
 }
 dps_results: {
  key: "TestSV-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7321.78407
-  tps: 6282.62319
+  dps: 7321.00747
+  tps: 6282.26373
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7485.64446
-  tps: 6430.57499
+  dps: 7484.69621
+  tps: 6430.21185
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7490.6678
-  tps: 6435.15351
+  dps: 7489.7191
+  tps: 6434.79016
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7472.08858
-  tps: 6416.5178
+  dps: 7471.14069
+  tps: 6416.15531
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7473.88704
-  tps: 6417.7643
+  dps: 7472.93878
+  tps: 6417.40175
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7337.17817
-  tps: 6297.85769
+  dps: 7336.40157
+  tps: 6297.49822
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7338.98984
-  tps: 6299.66936
+  dps: 7338.21324
+  tps: 6299.30989
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7643.04025
-  tps: 6588.10837
+  dps: 7642.08503
+  tps: 6587.73848
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7464.29525
-  tps: 6410.88796
+  dps: 7463.34897
+  tps: 6410.52572
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 7332.76102
-  tps: 6334.02364
+  dps: 7331.98261
+  tps: 6333.65771
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7885.43188
-  tps: 6814.46421
+  dps: 7884.45383
+  tps: 6814.08182
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7390.39551
-  tps: 6330.26264
+  dps: 7389.60774
+  tps: 6329.90094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7321.79411
-  tps: 6288.09156
+  dps: 7321.01751
+  tps: 6287.7321
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7321.79411
-  tps: 6288.66006
+  dps: 7321.01751
+  tps: 6288.30059
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7418.27092
-  tps: 6380.05358
+  dps: 7417.49432
+  tps: 6379.69412
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SparkofLife-37657"
  value: {
-  dps: 7346.8252
-  tps: 6307.82351
+  dps: 7346.0486
+  tps: 6307.46405
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7421.44619
-  tps: 6373.03765
+  dps: 7420.66959
+  tps: 6372.67818
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StormshroudArmor"
  value: {
-  dps: 5749.1606
-  tps: 4917.55842
+  dps: 5755.9317
+  tps: 4923.74019
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7490.6678
-  tps: 6435.15351
+  dps: 7489.7191
+  tps: 6434.79016
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7485.64446
-  tps: 6430.57499
+  dps: 7484.69621
+  tps: 6430.21185
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7476.85361
-  tps: 6422.56259
+  dps: 7475.90617
+  tps: 6422.19982
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7380.14714
-  tps: 6335.57225
+  dps: 7379.36587
+  tps: 6335.21029
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheFistsofFury"
  value: {
-  dps: 7286.57619
-  tps: 6255.04233
+  dps: 7285.78285
+  tps: 6254.68193
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7427.15491
-  tps: 6394.71457
+  dps: 7426.35573
+  tps: 6394.34881
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7462.64808
-  tps: 6411.87264
+  dps: 7461.7018
+  tps: 6411.5104
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7321.93176
-  tps: 6282.77088
+  dps: 7321.15516
+  tps: 6282.41142
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7321.93176
-  tps: 6282.77088
+  dps: 7321.15516
+  tps: 6282.41142
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7464.29525
-  tps: 6411.11629
+  dps: 7463.34897
+  tps: 6410.75405
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7464.29525
-  tps: 6411.11629
+  dps: 7463.34897
+  tps: 6410.75405
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7356.12757
-  tps: 6324.34292
+  dps: 7355.35097
+  tps: 6323.98346
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7464.29525
-  tps: 6411.11629
+  dps: 7463.34897
+  tps: 6410.75405
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7464.29525
-  tps: 6411.11629
+  dps: 7463.34897
+  tps: 6410.75405
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6148.68625
-  tps: 5288.62121
+  dps: 6147.41096
+  tps: 5288.46843
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7303.37722
-  tps: 6272.43703
+  dps: 7302.58734
+  tps: 6272.07829
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 7459.59376
-  tps: 6437.66128
+  dps: 7458.35913
+  tps: 6437.29293
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7321.79411
-  tps: 6282.63324
+  dps: 7321.01751
+  tps: 6282.27377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7907.74607
-  tps: 6856.67961
+  dps: 7906.88253
+  tps: 6856.27975
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 8038.02702
-  tps: 6996.15646
+  dps: 8037.25365
+  tps: 6995.72467
  }
 }
 dps_results: {
  key: "TestSV-Average-Default"
  value: {
-  dps: 7613.42876
-  tps: 6565.95842
+  dps: 7612.98595
+  tps: 6565.6601
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31060.39892
-  tps: 31017.21368
+  dps: 31059.93091
+  tps: 31017.00964
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3625.22567
-  tps: 2637.0629
+  dps: 3624.75766
+  tps: 2636.85887
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4886.37703
-  tps: 3723.35344
+  dps: 4884.03696
+  tps: 3722.33325
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-aoe-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13107.72872
-  tps: 13990.7011
+  dps: 12752.98718
+  tps: 13543.01481
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1458.77488
-  tps: 1151.94682
+  dps: 1391.57167
+  tps: 1085.114
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-aoe-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2178.89371
-  tps: 1793.72999
+  dps: 2177.9672
+  tps: 1793.38241
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19928.37492
-  tps: 20119.7887
+  dps: 19927.45233
+  tps: 20119.42379
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7594.27275
-  tps: 6594.90692
+  dps: 7593.34516
+  tps: 6594.53701
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8457.90169
-  tps: 7323.8827
+  dps: 8453.26375
+  tps: 7322.03316
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10484.49844
-  tps: 11603.80206
+  dps: 10484.3478
+  tps: 11603.73254
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3827.28691
-  tps: 3506.67975
+  dps: 3827.13626
+  tps: 3506.61024
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4559.8542
-  tps: 4156.97684
+  dps: 4559.101
+  tps: 4156.62925
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20805.93715
-  tps: 21147.06699
+  dps: 20805.46913
+  tps: 21146.86295
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7674.20379
-  tps: 6678.50957
+  dps: 7673.73577
+  tps: 6678.30553
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9035.73531
-  tps: 7873.32996
+  dps: 9033.39524
+  tps: 7872.30977
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11127.64581
-  tps: 12245.05503
+  dps: 11127.46461
+  tps: 12244.98551
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3852.4054
-  tps: 3533.31513
+  dps: 3852.22419
+  tps: 3533.24561
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4784.2999
-  tps: 4385.60063
+  dps: 4783.39388
+  tps: 4385.25304
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31043.96692
-  tps: 30944.07909
+  dps: 31043.48583
+  tps: 30943.87507
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3673.6404
-  tps: 2631.11671
+  dps: 3673.14956
+  tps: 2630.90294
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4969.11967
-  tps: 3738.27222
+  dps: 4966.71421
+  tps: 3737.25209
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-aoe-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13147.00183
-  tps: 14003.87871
+  dps: 12686.99251
+  tps: 13452.10506
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1479.7841
-  tps: 1153.05843
+  dps: 1394.86382
+  tps: 1073.72853
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-aoe-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2205.12365
-  tps: 1798.74725
+  dps: 2204.16822
+  tps: 1798.39967
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20050.12155
-  tps: 20179.5756
+  dps: 20049.17133
+  tps: 20179.21071
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7643.04025
-  tps: 6588.10837
+  dps: 7642.08503
+  tps: 6587.73848
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8522.54204
-  tps: 7321.26785
+  dps: 8517.76595
+  tps: 7319.41841
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10506.04268
-  tps: 11620.03248
+  dps: 10505.88798
+  tps: 11619.96296
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3842.06655
-  tps: 3499.66519
+  dps: 3841.91185
+  tps: 3499.59567
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4598.46221
-  tps: 4171.50736
+  dps: 4597.68871
+  tps: 4171.15978
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20920.22975
-  tps: 21198.34186
+  dps: 20919.74866
+  tps: 21198.13783
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7718.0752
-  tps: 6665.5027
+  dps: 7717.59411
+  tps: 6665.29867
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9101.7618
-  tps: 7870.83539
+  dps: 9099.35634
+  tps: 7869.81526
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11197.83185
-  tps: 12302.31472
+  dps: 11197.64507
+  tps: 12302.2452
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3878.18028
-  tps: 3537.26158
+  dps: 3877.99349
+  tps: 3537.19207
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4822.03228
-  tps: 4399.80919
+  dps: 4821.09836
+  tps: 4399.4616
  }
 }
 dps_results: {
  key: "TestSV-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7549.76383
-  tps: 6580.77515
+  dps: 7549.34654
+  tps: 6580.41491
  }
 }

--- a/sim/hunter/hunter.go
+++ b/sim/hunter/hunter.go
@@ -117,9 +117,9 @@ func (hunter *Hunter) AddPartyBuffs(_ *proto.PartyBuffs) {
 
 func (hunter *Hunter) Initialize() {
 	// Update auto crit multipliers now that we have the targets.
-	hunter.AutoAttacks.MHConfig.CritMultiplier = hunter.critMultiplier(false, false, false)
-	hunter.AutoAttacks.OHConfig.CritMultiplier = hunter.critMultiplier(false, false, false)
-	hunter.AutoAttacks.RangedConfig.CritMultiplier = hunter.critMultiplier(false, false, false)
+	hunter.AutoAttacks.MHConfig().CritMultiplier = hunter.critMultiplier(false, false, false)
+	hunter.AutoAttacks.OHConfig().CritMultiplier = hunter.critMultiplier(false, false, false)
+	hunter.AutoAttacks.RangedConfig().CritMultiplier = hunter.critMultiplier(false, false, false)
 
 	hunter.registerAspectOfTheDragonhawkSpell()
 	hunter.registerAspectOfTheViperSpell()
@@ -222,7 +222,7 @@ func NewHunter(character *core.Character, options *proto.Player) *Hunter {
 		ReplaceMHSwing:  hunter.TryRaptorStrike,
 		AutoSwingRanged: true,
 	})
-	hunter.AutoAttacks.RangedConfig.ApplyEffects = func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+	hunter.AutoAttacks.RangedConfig().ApplyEffects = func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 		baseDamage := hunter.RangedWeaponDamage(sim, spell.RangedAttackPower(target)) +
 			hunter.AmmoDamageBonus +
 			spell.BonusWeaponDamage()

--- a/sim/hunter/talents.go
+++ b/sim/hunter/talents.go
@@ -34,7 +34,7 @@ func (hunter *Hunter) ApplyTalents() {
 	hunter.AddStat(stats.Dodge, 1*core.DodgeRatingPerDodgeChance*float64(hunter.Talents.CatlikeReflexes))
 	hunter.PseudoStats.RangedSpeedMultiplier *= 1 + 0.04*float64(hunter.Talents.SerpentsSwiftness)
 	hunter.PseudoStats.DamageTakenMultiplier *= 1 - 0.02*float64(hunter.Talents.SurvivalInstincts)
-	hunter.AutoAttacks.RangedConfig.DamageMultiplier *= hunter.markedForDeathMultiplier()
+	hunter.AutoAttacks.RangedConfig().DamageMultiplier *= hunter.markedForDeathMultiplier()
 
 	if hunter.Talents.LethalShots > 0 {
 		hunter.AddBonusRangedCritRating(1 * float64(hunter.Talents.LethalShots) * core.CritRatingPerCritChance)

--- a/sim/hunter/wotlk_items.go
+++ b/sim/hunter/wotlk_items.go
@@ -227,7 +227,7 @@ func init() {
 					Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | core.SpellFlagNoOnCastComplete,
 
 					DamageMultiplier: 0.5,
-					CritMultiplier:   hunter.AutoAttacks.RangedConfig.CritMultiplier,
+					CritMultiplier:   hunter.AutoAttacks.RangedConfig().CritMultiplier,
 					ThreatMultiplier: 1,
 
 					ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/paladin/paladin.go
+++ b/sim/paladin/paladin.go
@@ -125,7 +125,7 @@ func (paladin *Paladin) AddPartyBuffs(_ *proto.PartyBuffs) {
 
 func (paladin *Paladin) Initialize() {
 	// Update auto crit multipliers now that we have the targets.
-	paladin.AutoAttacks.MHConfig.CritMultiplier = paladin.MeleeCritMultiplier()
+	paladin.AutoAttacks.MHConfig().CritMultiplier = paladin.MeleeCritMultiplier()
 
 	paladin.registerSealOfVengeanceSpellAndAura()
 	paladin.registerSealOfRighteousnessSpellAndAura()

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -46,888 +46,888 @@ character_stats_results: {
 dps_results: {
  key: "TestProtection-AllItems-AegisBattlegear"
  value: {
-  dps: 3441.23371
-  tps: 8204.10335
+  dps: 3441.1714
+  tps: 8204.01424
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AegisPlate"
  value: {
-  dps: 3240.8299
-  tps: 7795.96771
+  dps: 3240.77653
+  tps: 7795.8914
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 3180.31697
-  tps: 7640.71653
+  dps: 3180.25975
+  tps: 7640.6347
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 3182.84456
-  tps: 7647.22253
+  dps: 3182.78733
+  tps: 7647.14069
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AshtongueTalismanofZeal-32489"
  value: {
-  dps: 3194.21122
-  tps: 7676.48032
+  dps: 3194.15399
+  tps: 7676.39848
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 3290.32664
-  tps: 7846.51553
+  dps: 3290.26768
+  tps: 7846.43123
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 3159.73757
-  tps: 7587.74514
+  dps: 3159.68034
+  tps: 7587.66331
   hps: 87.90158
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 3159.73757
-  tps: 7587.74514
+  dps: 3159.68034
+  tps: 7587.66331
   hps: 87.90158
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 3195.51909
-  tps: 7677.76231
+  dps: 3195.46187
+  tps: 7677.68048
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 3126.82073
-  tps: 7508.71588
+  dps: 3126.76435
+  tps: 7508.63526
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 2822.82134
-  tps: 6763.98569
+  dps: 2822.77404
+  tps: 6763.91805
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 2870.62159
-  tps: 6908.77259
+  dps: 2870.57567
+  tps: 6908.70692
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 2766.82369
-  tps: 6670.8268
+  dps: 2766.77934
+  tps: 6670.76337
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 3162.6239
-  tps: 7445.0554
+  dps: 3162.56667
+  tps: 7444.9752
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 3198.3293
-  tps: 7677.17336
+  dps: 3198.27117
+  tps: 7677.09023
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
   hps: 64
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 3200.76985
-  tps: 7680.07915
+  dps: 3200.71263
+  tps: 7679.99732
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 3261.92912
-  tps: 7768.51925
+  dps: 3261.87189
+  tps: 7768.43742
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 3392.41631
-  tps: 8170.33071
+  dps: 3392.35908
+  tps: 8170.24887
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DeadlyGladiator'sLibramofFortitude-42852"
  value: {
-  dps: 3090.8266
-  tps: 7410.3683
+  dps: 3090.76937
+  tps: 7410.28646
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Death'sChoice-47464"
  value: {
-  dps: 3475.92274
-  tps: 8327.36987
+  dps: 3475.86289
+  tps: 8327.2843
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 3191.14916
-  tps: 7660.87184
+  dps: 3191.09193
+  tps: 7660.79
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 3318.32789
-  tps: 7935.48405
+  dps: 3318.26847
+  tps: 7935.39908
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 3327.04692
-  tps: 7946.2969
+  dps: 3326.98732
+  tps: 7946.21167
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Defender'sCode-40257"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 3170.35539
-  tps: 7612.52787
+  dps: 3170.29816
+  tps: 7612.44603
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 3286.49864
-  tps: 7874.14491
+  dps: 3286.44141
+  tps: 7874.06307
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 3264.58805
-  tps: 7822.09747
+  dps: 3264.53082
+  tps: 7822.01563
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 3180.92821
-  tps: 7639.24343
+  dps: 3180.87098
+  tps: 7639.16159
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 3169.23498
-  tps: 7609.84734
+  dps: 3169.17775
+  tps: 7609.7655
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 3167.46989
-  tps: 7605.88572
+  dps: 3167.41267
+  tps: 7605.80388
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 3190.32097
-  tps: 7652.40884
+  dps: 3190.26374
+  tps: 7652.32701
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 3171.85713
-  tps: 7618.94088
+  dps: 3171.7999
+  tps: 7618.85905
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 3252.00486
-  tps: 7754.6226
+  dps: 3251.94763
+  tps: 7754.54076
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 3212.15465
-  tps: 7711.04977
+  dps: 3212.09742
+  tps: 7710.96793
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 3256.03023
-  tps: 7844.15884
+  dps: 3255.973
+  tps: 7844.07701
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 3172.50445
-  tps: 7620.60709
+  dps: 3172.44722
+  tps: 7620.52525
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ForgeEmber-37660"
  value: {
-  dps: 3191.29103
-  tps: 7660.07389
+  dps: 3191.2338
+  tps: 7659.99206
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 3162.6239
-  tps: 7595.17455
+  dps: 3162.56667
+  tps: 7595.09271
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 3162.04945
-  tps: 7593.69592
+  dps: 3161.99222
+  tps: 7593.61408
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FuriousGladiator'sLibramofFortitude-42853"
  value: {
-  dps: 3090.8266
-  tps: 7410.3683
+  dps: 3090.76937
+  tps: 7410.28646
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 3280.28558
-  tps: 7866.93557
+  dps: 3280.22835
+  tps: 7866.85373
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FuturesightRune-38763"
  value: {
-  dps: 3166.87483
-  tps: 7606.11646
+  dps: 3166.8176
+  tps: 7606.03462
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gladiator'sVindication"
  value: {
-  dps: 3572.39035
-  tps: 8516.38688
+  dps: 3572.32551
+  tps: 8516.29416
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 3181.58077
-  tps: 7643.96953
+  dps: 3181.52354
+  tps: 7643.88769
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 3184.45302
-  tps: 7651.36271
+  dps: 3184.39579
+  tps: 7651.28087
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 3239.40785
-  tps: 7739.0935
+  dps: 3239.35062
+  tps: 7739.01167
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HatefulGladiator'sLibramofFortitude-42851"
  value: {
-  dps: 3090.8266
-  tps: 7410.3683
+  dps: 3090.76937
+  tps: 7410.28646
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 3171.21818
-  tps: 7617.29623
+  dps: 3171.16095
+  tps: 7617.2144
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 3169.23498
-  tps: 7609.84734
+  dps: 3169.17775
+  tps: 7609.7655
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 3167.46989
-  tps: 7605.88572
+  dps: 3167.41267
+  tps: 7605.80388
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IncisorFragment-37723"
  value: {
-  dps: 3226.12267
-  tps: 7733.68005
+  dps: 3226.06409
+  tps: 7733.59629
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 3238.48084
-  tps: 7799.13275
+  dps: 3238.42362
+  tps: 7799.05091
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 3176.13
-  tps: 7625.67202
+  dps: 3176.07239
+  tps: 7625.58964
   hps: 15.99508
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LastWord-50179"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LastWord-50708"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 3181.69129
-  tps: 7644.25403
+  dps: 3181.63407
+  tps: 7644.17219
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofFuriousBlows-37574"
  value: {
-  dps: 3102.81178
-  tps: 7436.73608
+  dps: 3102.75456
+  tps: 7436.65425
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofReciprocation-40706"
  value: {
-  dps: 3090.8266
-  tps: 7410.3683
+  dps: 3090.76937
+  tps: 7410.28646
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofThreeTruths-50455"
  value: {
-  dps: 3090.8266
-  tps: 7410.3683
+  dps: 3090.76937
+  tps: 7410.28646
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofValiance-47661"
  value: {
-  dps: 3335.10473
-  tps: 7989.39295
+  dps: 3335.0475
+  tps: 7989.31111
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramoftheSacredShield-45145"
  value: {
-  dps: 3090.8266
-  tps: 7410.3683
+  dps: 3090.76937
+  tps: 7410.28646
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerBattlegear"
  value: {
-  dps: 2889.7945
-  tps: 6940.98305
+  dps: 2889.7452
+  tps: 6940.91255
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightswornBattlegear"
  value: {
-  dps: 4229.66023
-  tps: 10042.50987
+  dps: 4229.58395
+  tps: 10042.40079
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightswornPlate"
  value: {
-  dps: 3553.14883
-  tps: 8512.8919
+  dps: 3553.08441
+  tps: 8512.79978
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 3210.24871
-  tps: 7697.39102
+  dps: 3210.19148
+  tps: 7697.30919
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 3197.60907
-  tps: 7677.61758
+  dps: 3197.55184
+  tps: 7677.53575
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 3173.01031
-  tps: 7618.45475
+  dps: 3172.95278
+  tps: 7618.37248
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 3176.13
-  tps: 7625.67202
+  dps: 3176.07239
+  tps: 7625.58964
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RedemptionBattlegear"
  value: {
-  dps: 3213.28735
-  tps: 7646.86908
+  dps: 3213.23385
+  tps: 7646.79257
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RedemptionPlate"
  value: {
-  dps: 3100.31775
-  tps: 7455.60567
+  dps: 3100.26675
+  tps: 7455.53274
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 3301.46342
-  tps: 7812.84437
+  dps: 3301.40619
+  tps: 7812.76253
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 3318.77964
-  tps: 7839.97301
+  dps: 3318.72241
+  tps: 7839.89117
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 3197.34448
-  tps: 7674.83314
+  dps: 3197.28635
+  tps: 7674.75001
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RelentlessGladiator'sLibramofFortitude-42854"
  value: {
-  dps: 3090.8266
-  tps: 7410.3683
+  dps: 3090.76937
+  tps: 7410.28646
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 3180.08363
-  tps: 7638.60489
+  dps: 3180.0264
+  tps: 7638.52306
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SavageGladiator'sLibramofFortitude-42611"
  value: {
-  dps: 3090.8266
-  tps: 7410.3683
+  dps: 3090.76937
+  tps: 7410.28646
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 3210.72394
-  tps: 7721.60065
+  dps: 3210.66672
+  tps: 7721.51882
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 3241.98282
-  tps: 7804.79047
+  dps: 3241.92559
+  tps: 7804.70864
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SoulPreserver-37111"
  value: {
-  dps: 3168.3684
-  tps: 7609.96091
+  dps: 3168.31117
+  tps: 7609.87907
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SouloftheDead-40382"
  value: {
-  dps: 3198.30055
-  tps: 7675.02698
+  dps: 3198.24332
+  tps: 7674.94514
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SparkofLife-37657"
  value: {
-  dps: 3269.57426
-  tps: 7849.53695
+  dps: 3269.51703
+  tps: 7849.45512
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 3273.13227
-  tps: 7853.88364
+  dps: 3273.07781
+  tps: 7853.80577
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StormshroudArmor"
  value: {
-  dps: 2641.93469
-  tps: 6357.70955
+  dps: 2641.89022
+  tps: 6357.64596
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 3176.13
-  tps: 7625.67202
+  dps: 3176.07239
+  tps: 7625.58964
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 3173.01031
-  tps: 7618.45475
+  dps: 3172.95278
+  tps: 7618.37248
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 3167.55086
-  tps: 7605.82454
+  dps: 3167.49345
+  tps: 7605.74244
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 3268.52779
-  tps: 7876.96555
+  dps: 3268.47057
+  tps: 7876.88371
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 3159.75164
-  tps: 7587.78137
+  dps: 3159.69442
+  tps: 7587.69954
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 2988.44286
-  tps: 7190.09062
+  dps: 2988.39102
+  tps: 7190.01649
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 3188.01353
-  tps: 7659.25697
+  dps: 3187.95631
+  tps: 7659.17514
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 3453.2411
-  tps: 8223.88957
+  dps: 3453.18665
+  tps: 8223.8117
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 3512.75303
-  tps: 8348.74968
+  dps: 3512.69857
+  tps: 8348.6718
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 3162.6239
-  tps: 7595.17455
+  dps: 3162.56667
+  tps: 7595.09271
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 3162.04945
-  tps: 7593.69592
+  dps: 3161.99222
+  tps: 7593.61408
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 3193.26195
-  tps: 7668.68831
+  dps: 3193.20473
+  tps: 7668.60648
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TomeoftheLightbringer-32368"
  value: {
-  dps: 3136.69102
-  tps: 7528.42333
+  dps: 3136.63379
+  tps: 7528.3415
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 3162.04945
-  tps: 7593.69592
+  dps: 3161.99222
+  tps: 7593.61408
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 3162.6239
-  tps: 7595.17455
+  dps: 3162.56667
+  tps: 7595.09271
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Turalyon'sBattlegear"
  value: {
-  dps: 3450.62619
-  tps: 8224.86339
+  dps: 3450.56276
+  tps: 8224.77269
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Turalyon'sPlate"
  value: {
-  dps: 3298.48926
-  tps: 7919.96113
+  dps: 3298.43524
+  tps: 7919.88388
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 2811.81386
-  tps: 6736.0458
+  dps: 2811.76751
+  tps: 6735.97953
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 3126.28963
-  tps: 7559.27292
+  dps: 3126.25552
+  tps: 7559.22414
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WingedTalisman-37844"
  value: {
-  dps: 3168.64102
-  tps: 7610.66263
+  dps: 3168.58379
+  tps: 7610.58079
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathfulGladiator'sLibramofFortitude-51478"
  value: {
-  dps: 3090.8266
-  tps: 7410.3683
+  dps: 3090.76937
+  tps: 7410.28646
  }
 }
 dps_results: {
  key: "TestProtection-Average-Default"
  value: {
-  dps: 3642.06745
-  tps: 8730.61599
+  dps: 3642.01108
+  tps: 8730.53538
   dtps: 5.17687
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p1-Protection Paladin SOC-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10378.95047
-  tps: 27845.66742
+  dps: 10378.89859
+  tps: 27845.59323
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p1-Protection Paladin SOC-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2950.18961
-  tps: 7014.39486
+  dps: 2950.13773
+  tps: 7014.32066
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p1-Protection Paladin SOC-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3182.24142
-  tps: 7531.91915
+  dps: 3181.982
+  tps: 7531.54818
  }
 }
 dps_results: {
@@ -954,22 +954,22 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p1-Protection Paladin SOR-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9291.15098
-  tps: 25044.06601
+  dps: 9291.09909
+  tps: 25043.99181
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p1-Protection Paladin SOR-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2974.55602
-  tps: 7082.18487
+  dps: 2974.50413
+  tps: 7082.11067
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p1-Protection Paladin SOR-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3183.44612
-  tps: 7537.37244
+  dps: 3183.1867
+  tps: 7537.00147
  }
 }
 dps_results: {
@@ -996,22 +996,22 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p1-Protection Paladin SOV-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10235.54902
-  tps: 27467.94625
+  dps: 10235.49713
+  tps: 27467.87206
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p1-Protection Paladin SOV-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3280.1691
-  tps: 7865.90931
+  dps: 3280.11721
+  tps: 7865.83511
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p1-Protection Paladin SOV-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3411.95239
-  tps: 8139.0071
+  dps: 3411.69297
+  tps: 8138.63613
  }
 }
 dps_results: {
@@ -1038,22 +1038,22 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Settings-Human-p1-Protection Paladin SOC-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10076.87837
-  tps: 27030.45335
+  dps: 10076.82642
+  tps: 27030.37906
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p1-Protection Paladin SOC-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2929.04579
-  tps: 6956.31088
+  dps: 2928.99384
+  tps: 6956.2366
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p1-Protection Paladin SOC-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3185.58649
-  tps: 7539.48189
+  dps: 3185.32676
+  tps: 7539.11048
  }
 }
 dps_results: {
@@ -1080,22 +1080,22 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Settings-Human-p1-Protection Paladin SOR-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9067.54407
-  tps: 24426.26188
+  dps: 9067.49212
+  tps: 24426.1876
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p1-Protection Paladin SOR-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2947.87991
-  tps: 7013.43133
+  dps: 2947.82796
+  tps: 7013.35705
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p1-Protection Paladin SOR-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3187.09254
-  tps: 7545.58388
+  dps: 3186.83281
+  tps: 7545.21246
  }
 }
 dps_results: {
@@ -1122,22 +1122,22 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Settings-Human-p1-Protection Paladin SOV-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9955.63946
-  tps: 26697.83985
+  dps: 9955.58752
+  tps: 26697.76557
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p1-Protection Paladin SOV-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3269.17793
-  tps: 7833.41678
+  dps: 3269.12599
+  tps: 7833.34249
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p1-Protection Paladin SOV-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3415.81591
-  tps: 8147.8302
+  dps: 3415.55618
+  tps: 8147.45879
  }
 }
 dps_results: {
@@ -1164,8 +1164,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3776.71597
-  tps: 9054.09126
+  dps: 3776.66215
+  tps: 9054.01429
   dtps: 6.83554
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -46,64 +46,64 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AegisBattlegear"
  value: {
-  dps: 6267.63967
-  tps: 6353.09919
+  dps: 6267.52464
+  tps: 6352.98416
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AegisPlate"
  value: {
-  dps: 5624.28488
-  tps: 5704.54716
+  dps: 5624.17512
+  tps: 5704.4374
   dtps: 8.90286
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6465.838
-  tps: 6551.32242
+  dps: 6465.71452
+  tps: 6551.19894
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6471.39255
-  tps: 6556.87697
+  dps: 6471.26908
+  tps: 6556.75349
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AshtongueTalismanofZeal-32489"
  value: {
-  dps: 6469.56575
-  tps: 6555.04664
+  dps: 6469.44227
+  tps: 6554.92317
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6530.22786
-  tps: 6615.71228
+  dps: 6530.10682
+  tps: 6615.59123
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6628.68063
-  tps: 6714.02235
+  dps: 6628.55432
+  tps: 6713.89603
   dtps: 10.03858
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6420.38177
-  tps: 6505.86619
+  dps: 6420.2583
+  tps: 6505.74271
   dtps: 9.48456
   hps: 94.7032
  }
@@ -111,8 +111,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6420.38177
-  tps: 6505.86619
+  dps: 6420.2583
+  tps: 6505.74271
   dtps: 9.48456
   hps: 94.7032
  }
@@ -120,96 +120,96 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6545.17508
-  tps: 6630.59961
+  dps: 6545.05403
+  tps: 6630.47856
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6399.27432
-  tps: 6484.47157
+  dps: 6399.15708
+  tps: 6484.35433
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 5408.6806
-  tps: 5491.92688
+  dps: 5408.57284
+  tps: 5491.81912
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5352.74783
-  tps: 5436.05037
+  dps: 5352.64254
+  tps: 5435.94508
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5184.92032
-  tps: 5268.14279
+  dps: 5184.81786
+  tps: 5268.04033
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6536.42822
-  tps: 6491.18407
+  dps: 6536.30717
+  tps: 6491.06544
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6999.75956
-  tps: 7085.24398
+  dps: 6999.6297
+  tps: 7085.11412
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7031.57228
-  tps: 7117.0567
+  dps: 7031.44182
+  tps: 7116.92623
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6663.73767
-  tps: 6749.22209
+  dps: 6663.61419
+  tps: 6749.09861
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6420.64412
-  tps: 6506.12854
+  dps: 6420.52064
+  tps: 6506.00506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6420.64412
-  tps: 6506.12854
+  dps: 6420.52064
+  tps: 6506.00506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6420.64412
-  tps: 6506.12854
+  dps: 6420.52064
+  tps: 6506.00506
   dtps: 9.92959
   hps: 64
  }
@@ -217,304 +217,304 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6518.54487
-  tps: 6604.02929
+  dps: 6518.42139
+  tps: 6603.90581
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6568.6909
-  tps: 6654.04269
+  dps: 6568.56742
+  tps: 6653.91921
   dtps: 9.77043
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6420.64412
-  tps: 6505.60522
+  dps: 6420.52064
+  tps: 6505.48174
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7001.70251
-  tps: 7087.18693
+  dps: 7001.57473
+  tps: 7087.05915
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6484.37184
-  tps: 6569.85626
+  dps: 6484.24836
+  tps: 6569.73278
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6755.39831
-  tps: 6841.05039
+  dps: 6755.26996
+  tps: 6840.92204
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6800.16236
-  tps: 6885.78687
+  dps: 6800.03362
+  tps: 6885.65813
   dtps: 10.29273
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6420.64412
-  tps: 6506.12854
+  dps: 6420.52064
+  tps: 6506.00506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6548.10403
-  tps: 6633.58845
+  dps: 6547.98298
+  tps: 6633.4674
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6641.24137
-  tps: 6727.437
+  dps: 6641.1179
+  tps: 6727.31352
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6609.15362
-  tps: 6694.9679
+  dps: 6609.03015
+  tps: 6694.84443
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6530.22786
-  tps: 6615.71228
+  dps: 6530.10682
+  tps: 6615.59123
   dtps: 9.731
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6536.42822
-  tps: 6621.88313
+  dps: 6536.30717
+  tps: 6621.76208
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6545.17508
-  tps: 6630.65949
+  dps: 6545.05403
+  tps: 6630.53844
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6541.7627
-  tps: 6627.24712
+  dps: 6541.64166
+  tps: 6627.12607
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6540.28153
-  tps: 6626.29696
+  dps: 6540.15806
+  tps: 6626.17348
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6420.64412
-  tps: 6506.12854
+  dps: 6420.52064
+  tps: 6506.00506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6530.22786
-  tps: 6615.71228
+  dps: 6530.10682
+  tps: 6615.59123
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6577.74959
-  tps: 6663.25371
+  dps: 6577.62612
+  tps: 6663.13023
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6541.19513
-  tps: 6626.67955
+  dps: 6541.07166
+  tps: 6626.55608
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6420.64412
-  tps: 6505.99277
+  dps: 6420.52064
+  tps: 6505.86929
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6448.66937
-  tps: 6534.15379
+  dps: 6448.5459
+  tps: 6534.03031
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6500.48141
-  tps: 6585.96583
+  dps: 6500.35794
+  tps: 6585.84236
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6536.42822
-  tps: 6621.91263
+  dps: 6536.30717
+  tps: 6621.79159
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6535.18815
-  tps: 6620.67256
+  dps: 6535.0671
+  tps: 6620.55151
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuriousGladiator'sLibramofFortitude-42853"
  value: {
-  dps: 6682.47833
-  tps: 6767.96275
+  dps: 6682.35485
+  tps: 6767.83927
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6436.29786
-  tps: 6521.78228
+  dps: 6436.17439
+  tps: 6521.65881
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Gladiator'sVindication"
  value: {
-  dps: 6358.13746
-  tps: 6445.51667
+  dps: 6358.01378
+  tps: 6445.39299
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6468.61528
-  tps: 6554.09969
+  dps: 6468.4918
+  tps: 6553.97622
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6474.92727
-  tps: 6560.41169
+  dps: 6474.80379
+  tps: 6560.28821
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6541.49124
-  tps: 6626.80415
+  dps: 6541.36776
+  tps: 6626.68068
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HatefulGladiator'sLibramofFortitude-42851"
  value: {
-  dps: 6651.97402
-  tps: 6737.45844
+  dps: 6651.85055
+  tps: 6737.33497
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6431.53577
-  tps: 6517.02018
+  dps: 6431.41229
+  tps: 6516.89671
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6545.17508
-  tps: 6630.65949
+  dps: 6545.05403
+  tps: 6630.53844
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6541.7627
-  tps: 6627.24712
+  dps: 6541.64166
+  tps: 6627.12607
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6584.89722
-  tps: 6670.38164
+  dps: 6584.77153
+  tps: 6670.25595
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6530.22786
-  tps: 6617.31626
+  dps: 6530.10682
+  tps: 6617.19522
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6562.52264
-  tps: 6648.00706
+  dps: 6562.40098
+  tps: 6647.8854
   dtps: 9.92959
   hps: 12.10749
  }
@@ -522,560 +522,560 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-LastWord-50179"
  value: {
-  dps: 6862.21684
-  tps: 6947.70125
+  dps: 6862.09336
+  tps: 6947.57778
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LastWord-50708"
  value: {
-  dps: 6891.83304
-  tps: 6977.31746
+  dps: 6891.70956
+  tps: 6977.19398
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6420.64412
-  tps: 6506.12854
+  dps: 6420.52064
+  tps: 6506.00506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofFuriousBlows-37574"
  value: {
-  dps: 6594.38418
-  tps: 6679.8686
+  dps: 6594.26071
+  tps: 6679.74513
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofObstruction-40707"
  value: {
-  dps: 6570.03438
-  tps: 6655.5188
+  dps: 6569.9109
+  tps: 6655.39532
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofReciprocation-40706"
  value: {
-  dps: 6570.03438
-  tps: 6655.5188
+  dps: 6569.9109
+  tps: 6655.39532
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofThreeTruths-50455"
  value: {
-  dps: 6989.23336
-  tps: 7074.71778
+  dps: 6989.10988
+  tps: 7074.5943
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofValiance-47661"
  value: {
-  dps: 6956.44703
-  tps: 7041.93145
+  dps: 6956.32355
+  tps: 7041.80797
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramoftheSacredShield-45145"
  value: {
-  dps: 6570.03438
-  tps: 6655.5188
+  dps: 6569.9109
+  tps: 6655.39532
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerBattlegear"
  value: {
-  dps: 4826.60507
-  tps: 4907.79979
+  dps: 4826.50693
+  tps: 4907.70165
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornBattlegear"
  value: {
-  dps: 7652.50369
-  tps: 7740.0136
+  dps: 7652.37702
+  tps: 7739.88693
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightswornPlate"
  value: {
-  dps: 6084.50477
-  tps: 6166.71472
+  dps: 6084.39209
+  tps: 6166.60204
   dtps: 8.90286
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6420.64412
-  tps: 6506.12854
+  dps: 6420.52064
+  tps: 6506.00506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6554.17536
-  tps: 6640.04626
+  dps: 6554.05506
+  tps: 6639.92597
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6479.52108
-  tps: 6565.0055
+  dps: 6479.3976
+  tps: 6564.88202
   dtps: 10.29273
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6420.64412
-  tps: 6506.12854
+  dps: 6420.52064
+  tps: 6506.00506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6556.42894
-  tps: 6641.91336
+  dps: 6556.3074
+  tps: 6641.79181
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6562.5939
-  tps: 6648.07832
+  dps: 6562.47224
+  tps: 6647.95666
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6420.64412
-  tps: 6506.12854
+  dps: 6420.52064
+  tps: 6506.00506
   dtps: 8.19524
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6420.64412
-  tps: 6506.12854
+  dps: 6420.52064
+  tps: 6506.00506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6420.64412
-  tps: 6506.12854
+  dps: 6420.52064
+  tps: 6506.00506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6530.22786
-  tps: 6615.71228
+  dps: 6530.10682
+  tps: 6615.59123
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6530.22786
-  tps: 6615.71228
+  dps: 6530.10682
+  tps: 6615.59123
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6420.64412
-  tps: 6506.12854
+  dps: 6420.52064
+  tps: 6506.00506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionBattlegear"
  value: {
-  dps: 5848.02627
-  tps: 5937.34542
+  dps: 5847.91647
+  tps: 5937.23562
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RedemptionPlate"
  value: {
-  dps: 5361.48123
-  tps: 5443.07301
+  dps: 5361.37984
+  tps: 5442.97162
   dtps: 8.90286
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6682.44817
-  tps: 6767.96455
+  dps: 6682.32469
+  tps: 6767.84107
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6715.59195
-  tps: 6801.10833
+  dps: 6715.46847
+  tps: 6800.98485
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6663.73767
-  tps: 6749.22209
+  dps: 6663.61419
+  tps: 6749.09861
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelentlessGladiator'sLibramofFortitude-42854"
  value: {
-  dps: 6704.34243
-  tps: 6789.82685
+  dps: 6704.21895
+  tps: 6789.70337
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6530.22786
-  tps: 6615.1514
+  dps: 6530.10682
+  tps: 6615.03035
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6420.64412
-  tps: 6506.12854
+  dps: 6420.52064
+  tps: 6506.00506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SavageGladiator'sLibramofFortitude-42611"
  value: {
-  dps: 6642.69784
-  tps: 6728.18226
+  dps: 6642.57436
+  tps: 6728.05878
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6420.64412
-  tps: 6506.12854
+  dps: 6420.52064
+  tps: 6506.00506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7904.14539
-  tps: 7989.47082
+  dps: 7904.00969
+  tps: 7989.33513
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6420.64412
-  tps: 6506.12854
+  dps: 6420.52064
+  tps: 6506.00506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6420.64412
-  tps: 6506.12854
+  dps: 6420.52064
+  tps: 6506.00506
   dtps: 6.55074
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6460.53592
-  tps: 6546.58256
+  dps: 6460.41245
+  tps: 6546.45908
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6465.58552
-  tps: 6551.63215
+  dps: 6465.46204
+  tps: 6551.50868
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6439.5801
-  tps: 6525.06452
+  dps: 6439.45662
+  tps: 6524.94104
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6511.59115
-  tps: 6598.78712
+  dps: 6511.46767
+  tps: 6598.66364
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SparkofLife-37657"
  value: {
-  dps: 6505.88684
-  tps: 6588.05146
+  dps: 6505.76336
+  tps: 6587.92798
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6560.5516
-  tps: 6645.94398
+  dps: 6560.42813
+  tps: 6645.82051
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StormshroudArmor"
  value: {
-  dps: 5066.09756
-  tps: 5147.33665
+  dps: 5065.99489
+  tps: 5147.23399
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6562.5939
-  tps: 6648.07832
+  dps: 6562.47224
+  tps: 6647.95666
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6556.42894
-  tps: 6641.91336
+  dps: 6556.3074
+  tps: 6641.79181
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6545.64026
-  tps: 6631.12468
+  dps: 6545.51892
+  tps: 6631.00334
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6420.64412
-  tps: 6506.12854
+  dps: 6420.52064
+  tps: 6506.00506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6420.64412
-  tps: 6505.65975
+  dps: 6420.52064
+  tps: 6505.53628
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6420.64412
-  tps: 6506.12854
+  dps: 6420.52064
+  tps: 6506.00506
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5386.43187
-  tps: 5471.78324
+  dps: 5385.86671
+  tps: 5471.22541
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6579.44593
-  tps: 6665.08327
+  dps: 6578.78508
+  tps: 6664.4151
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7024.75055
-  tps: 7110.9882
+  dps: 7024.62707
+  tps: 7110.86472
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7123.46994
-  tps: 7209.75888
+  dps: 7123.34647
+  tps: 7209.63541
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6536.42822
-  tps: 6621.91263
+  dps: 6536.30717
+  tps: 6621.79159
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6535.18815
-  tps: 6620.67256
+  dps: 6535.0671
+  tps: 6620.55151
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6536.90876
-  tps: 6622.55771
+  dps: 6536.78528
+  tps: 6622.43424
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeoftheLightbringer-32368"
  value: {
-  dps: 6570.03438
-  tps: 6655.5188
+  dps: 6569.9109
+  tps: 6655.39532
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6535.18815
-  tps: 6620.67256
+  dps: 6535.0671
+  tps: 6620.55151
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6536.42822
-  tps: 6621.91263
+  dps: 6536.30717
+  tps: 6621.79159
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sBattlegear"
  value: {
-  dps: 6301.04402
-  tps: 6385.85246
+  dps: 6300.92689
+  tps: 6385.73533
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Turalyon'sPlate"
  value: {
-  dps: 5625.99866
-  tps: 5708.05762
+  dps: 5625.89234
+  tps: 5707.9513
   dtps: 8.90286
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5397.50839
-  tps: 5481.06036
+  dps: 5397.40235
+  tps: 5480.95432
   dtps: 9.23882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5145.68317
-  tps: 5230.54809
+  dps: 5145.63201
+  tps: 5230.49693
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6440.12991
-  tps: 6525.61433
+  dps: 6440.00643
+  tps: 6525.49085
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathfulGladiator'sLibramofFortitude-51478"
  value: {
-  dps: 6729.32997
-  tps: 6814.81439
+  dps: 6729.2065
+  tps: 6814.69091
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 6668.82111
-  tps: 6753.42361
+  dps: 6668.69511
+  tps: 6753.29762
   dtps: 13.59845
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Retribution Paladin SOC-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18965.87628
-  tps: 20677.97592
+  dps: 18965.75625
+  tps: 20677.85589
   dtps: 10.57482
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Retribution Paladin SOC-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5477.77449
-  tps: 5563.41103
+  dps: 5477.65446
+  tps: 5563.291
   dtps: 11.82069
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Retribution Paladin SOC-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6191.71827
-  tps: 6282.42821
+  dps: 6191.11812
+  tps: 6281.82806
   dtps: 59.10347
  }
 }
@@ -1103,24 +1103,24 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Retribution Paladin SOR-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16956.74719
-  tps: 18668.53276
+  dps: 16956.62716
+  tps: 18668.41273
   dtps: 10.33353
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Retribution Paladin SOR-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5849.36725
-  tps: 5934.9202
+  dps: 5849.24722
+  tps: 5934.80017
   dtps: 11.82069
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Retribution Paladin SOR-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6635.73718
-  tps: 6726.30523
+  dps: 6635.13703
+  tps: 6725.70508
   dtps: 59.10347
  }
 }
@@ -1148,24 +1148,24 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Retribution Paladin SOV 2 Target Swapping-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18992.40325
-  tps: 20700.56441
+  dps: 18992.27977
+  tps: 20700.44093
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Retribution Paladin SOV 2 Target Swapping-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6663.73767
-  tps: 6749.22209
+  dps: 6663.61419
+  tps: 6749.09861
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Retribution Paladin SOV 2 Target Swapping-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7382.6245
-  tps: 7473.39455
+  dps: 7382.00712
+  tps: 7472.77717
   dtps: 49.64794
  }
 }
@@ -1193,24 +1193,24 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Retribution Paladin SOV-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18992.40325
-  tps: 20700.56441
+  dps: 18992.27977
+  tps: 20700.44093
   dtps: 8.80605
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Retribution Paladin SOV-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6663.73767
-  tps: 6749.22209
+  dps: 6663.61419
+  tps: 6749.09861
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Retribution Paladin SOV-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7382.6245
-  tps: 7473.39455
+  dps: 7382.00712
+  tps: 7472.77717
   dtps: 49.64794
  }
 }
@@ -1238,24 +1238,24 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-p1-Retribution Paladin SOC-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19088.69151
-  tps: 20780.39477
+  dps: 19088.57134
+  tps: 20780.2746
   dtps: 10.14629
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-p1-Retribution Paladin SOC-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5488.47312
-  tps: 5573.1081
+  dps: 5488.35294
+  tps: 5572.98793
   dtps: 11.82069
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-p1-Retribution Paladin SOC-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6195.69496
-  tps: 6286.42559
+  dps: 6195.09407
+  tps: 6285.8247
   dtps: 59.10347
  }
 }
@@ -1283,24 +1283,24 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-p1-Retribution Paladin SOR-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17080.52512
-  tps: 18773.24803
+  dps: 17080.40494
+  tps: 18773.12786
   dtps: 9.95262
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-p1-Retribution Paladin SOR-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5863.49367
-  tps: 5948.03796
+  dps: 5863.37349
+  tps: 5947.91779
   dtps: 11.82069
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-p1-Retribution Paladin SOR-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6648.29988
-  tps: 6738.88871
+  dps: 6647.69899
+  tps: 6738.28782
   dtps: 59.10347
  }
 }
@@ -1328,24 +1328,24 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-p1-Retribution Paladin SOV 2 Target Swapping-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19118.88191
-  tps: 20804.26844
+  dps: 19118.75828
+  tps: 20804.14482
   dtps: 8.48862
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-p1-Retribution Paladin SOV 2 Target Swapping-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6676.98979
-  tps: 6761.42355
+  dps: 6676.86616
+  tps: 6761.29993
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-p1-Retribution Paladin SOV 2 Target Swapping-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7392.00961
-  tps: 7482.8009
+  dps: 7391.39147
+  tps: 7482.18276
   dtps: 49.64794
  }
 }
@@ -1373,24 +1373,24 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-p1-Retribution Paladin SOV-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19118.88191
-  tps: 20804.26844
+  dps: 19118.75828
+  tps: 20804.14482
   dtps: 8.48862
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-p1-Retribution Paladin SOV-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6676.98979
-  tps: 6761.42355
+  dps: 6676.86616
+  tps: 6761.29993
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-p1-Retribution Paladin SOV-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7392.00961
-  tps: 7482.8009
+  dps: 7391.39147
+  tps: 7482.18276
   dtps: 49.64794
  }
 }
@@ -1418,24 +1418,24 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-p1-Retribution Paladin SOC-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19001.03306
-  tps: 20693.62838
+  dps: 19000.91274
+  tps: 20693.50805
   dtps: 10.14629
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-p1-Retribution Paladin SOC-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5483.46432
-  tps: 5568.15784
+  dps: 5483.34399
+  tps: 5568.03751
   dtps: 11.82069
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-p1-Retribution Paladin SOC-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6191.83467
-  tps: 6282.57219
+  dps: 6191.23305
+  tps: 6281.97057
   dtps: 59.10347
  }
 }
@@ -1463,24 +1463,24 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-p1-Retribution Paladin SOR-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16989.27978
-  tps: 18681.27817
+  dps: 16989.15945
+  tps: 18681.15785
   dtps: 9.95262
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-p1-Retribution Paladin SOR-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5860.37621
-  tps: 5944.95499
+  dps: 5860.25589
+  tps: 5944.83467
   dtps: 11.82069
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-p1-Retribution Paladin SOR-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6644.38197
-  tps: 6734.97772
+  dps: 6643.78035
+  tps: 6734.3761
   dtps: 59.10347
  }
 }
@@ -1508,24 +1508,24 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-p1-Retribution Paladin SOV 2 Target Swapping-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19034.33903
-  tps: 20719.41176
+  dps: 19034.21526
+  tps: 20719.28799
   dtps: 8.48862
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-p1-Retribution Paladin SOV 2 Target Swapping-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6675.25118
-  tps: 6759.67856
+  dps: 6675.1274
+  tps: 6759.55479
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-p1-Retribution Paladin SOV 2 Target Swapping-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7390.5142
-  tps: 7481.31256
+  dps: 7389.89531
+  tps: 7480.69367
   dtps: 49.64794
  }
 }
@@ -1553,24 +1553,24 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-p1-Retribution Paladin SOV-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19034.33903
-  tps: 20719.41176
+  dps: 19034.21526
+  tps: 20719.28799
   dtps: 8.48862
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-p1-Retribution Paladin SOV-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6675.25118
-  tps: 6759.67856
+  dps: 6675.1274
+  tps: 6759.55479
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-p1-Retribution Paladin SOV-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7390.5142
-  tps: 7481.31256
+  dps: 7389.89531
+  tps: 7480.69367
   dtps: 49.64794
  }
 }
@@ -1598,24 +1598,24 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Retribution Paladin SOC-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18979.77143
-  tps: 20672.20702
+  dps: 18979.65129
+  tps: 20672.08688
   dtps: 10.14629
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Retribution Paladin SOC-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5480.01308
-  tps: 5564.69882
+  dps: 5479.89294
+  tps: 5564.57868
   dtps: 11.82069
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Retribution Paladin SOC-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6190.69614
-  tps: 6281.42677
+  dps: 6190.09544
+  tps: 6280.82607
   dtps: 59.10347
  }
 }
@@ -1643,24 +1643,24 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Retribution Paladin SOR-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16970.05523
-  tps: 18661.89934
+  dps: 16969.93508
+  tps: 18661.7792
   dtps: 9.95262
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Retribution Paladin SOR-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5853.62412
-  tps: 5938.19571
+  dps: 5853.50398
+  tps: 5938.07557
   dtps: 11.82069
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Retribution Paladin SOR-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6638.22114
-  tps: 6728.80997
+  dps: 6637.62044
+  tps: 6728.20926
   dtps: 59.10347
  }
 }
@@ -1688,24 +1688,24 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Retribution Paladin SOV 2 Target Swapping-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19007.86304
-  tps: 20692.81017
+  dps: 19007.73945
+  tps: 20692.68658
   dtps: 8.48862
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Retribution Paladin SOV 2 Target Swapping-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6666.98722
-  tps: 6751.40842
+  dps: 6666.86363
+  tps: 6751.28483
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Retribution Paladin SOV 2 Target Swapping-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7384.33262
-  tps: 7475.12391
+  dps: 7383.71468
+  tps: 7474.50596
   dtps: 49.64794
  }
 }
@@ -1733,24 +1733,24 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Retribution Paladin SOV-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19007.86304
-  tps: 20692.81017
+  dps: 19007.73945
+  tps: 20692.68658
   dtps: 8.48862
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Retribution Paladin SOV-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6666.98722
-  tps: 6751.40842
+  dps: 6666.86363
+  tps: 6751.28483
   dtps: 9.92959
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Retribution Paladin SOV-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7384.33262
-  tps: 7475.12391
+  dps: 7383.71468
+  tps: 7474.50596
   dtps: 49.64794
  }
 }
@@ -1778,8 +1778,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6317.37562
-  tps: 6402.75195
+  dps: 6317.26995
+  tps: 6402.64627
   dtps: 9.92959
  }
 }

--- a/sim/paladin/talents.go
+++ b/sim/paladin/talents.go
@@ -187,7 +187,7 @@ func (paladin *Paladin) applyReckoning() {
 		Duration:  time.Second * 8,
 		MaxStacks: 4,
 		OnInit: func(aura *core.Aura, sim *core.Simulation) {
-			config := paladin.AutoAttacks.MHConfig
+			config := *paladin.AutoAttacks.MHConfig()
 			config.ActionID = actionID
 			reckoningSpell = paladin.GetOrRegisterSpell(config)
 		},

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -266,8 +266,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7045.34981
-  tps: 6858.95973
+  dps: 7045.32619
+  tps: 6858.93611
  }
 }
 dps_results: {
@@ -756,8 +756,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7100.68007
-  tps: 6908.78989
+  dps: 7100.59501
+  tps: 6908.70483
  }
 }
 dps_results: {

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -46,768 +46,768 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 6558.21784
-  tps: 4656.33467
+  dps: 6558.02451
+  tps: 4656.1974
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6696.02812
-  tps: 4754.17996
+  dps: 6695.82572
+  tps: 4754.03626
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6708.91251
-  tps: 4763.32788
+  dps: 6708.71483
+  tps: 4763.18753
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6502.35885
-  tps: 4616.67478
+  dps: 6502.16552
+  tps: 4616.53752
   hps: 88.74318
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6502.35885
-  tps: 4616.67478
+  dps: 6502.16552
+  tps: 4616.53752
   hps: 88.74318
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6690.40018
-  tps: 4750.18412
+  dps: 6690.19778
+  tps: 4750.04043
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50035"
  value: {
-  dps: 6515.7935
-  tps: 4626.21338
+  dps: 6515.05695
+  tps: 4625.69043
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50692"
  value: {
-  dps: 6593.95132
-  tps: 4681.70544
+  dps: 6593.82035
+  tps: 4681.61245
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5011.83493
-  tps: 3558.4028
+  dps: 5011.67002
+  tps: 3558.28571
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6163.15862
-  tps: 4375.84262
+  dps: 6162.97096
+  tps: 4375.70938
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6696.02812
-  tps: 4659.09636
+  dps: 6695.82572
+  tps: 4658.95554
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6797.97485
-  tps: 4826.56215
+  dps: 6797.76751
+  tps: 4826.41493
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
   hps: 64
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6711.23015
-  tps: 4764.97341
+  dps: 6711.03682
+  tps: 4764.83614
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6668.60802
-  tps: 4734.71169
+  dps: 6668.40664
+  tps: 4734.56871
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6718.79386
-  tps: 4770.34364
+  dps: 6718.5952
+  tps: 4770.20259
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7014.87917
-  tps: 4980.56421
+  dps: 7014.66847
+  tps: 4980.41461
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6643.91222
-  tps: 4717.17767
+  dps: 6643.71889
+  tps: 4717.04041
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6916.6062
-  tps: 4910.7904
+  dps: 6916.40079
+  tps: 4910.64456
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7005.21488
-  tps: 4973.70257
+  dps: 7005.00977
+  tps: 4973.55694
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6700.82398
-  tps: 4757.58503
+  dps: 6700.62159
+  tps: 4757.44133
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6698.89069
-  tps: 4756.21239
+  dps: 6698.69736
+  tps: 4756.07513
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6666.60001
-  tps: 4733.28601
+  dps: 6666.40668
+  tps: 4733.14874
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6696.02812
-  tps: 4754.17996
+  dps: 6695.82572
+  tps: 4754.03626
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6696.02812
-  tps: 4754.17996
+  dps: 6695.82572
+  tps: 4754.03626
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6690.40018
-  tps: 4750.18412
+  dps: 6690.19778
+  tps: 4750.04043
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6678.29809
-  tps: 4741.59165
+  dps: 6678.0957
+  tps: 4741.44795
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6615.54819
-  tps: 4697.03922
+  dps: 6618.06804
+  tps: 4698.82831
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6696.02812
-  tps: 4754.17996
+  dps: 6695.82572
+  tps: 4754.03626
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6704.10429
-  tps: 4759.91404
+  dps: 6703.9029
+  tps: 4759.77106
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6636.10422
-  tps: 4711.634
+  dps: 6635.90283
+  tps: 4711.49101
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6491.80164
-  tps: 4609.17916
+  dps: 6491.60831
+  tps: 4609.0419
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6580.01548
-  tps: 4671.81099
+  dps: 6579.8141
+  tps: 4671.66801
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6696.02812
-  tps: 4754.17996
+  dps: 6695.82572
+  tps: 4754.03626
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6696.02812
-  tps: 4754.17996
+  dps: 6695.82572
+  tps: 4754.03626
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6746.8225
-  tps: 4790.24397
+  dps: 6746.62876
+  tps: 4790.10642
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 6583.82547
-  tps: 4674.51608
+  dps: 6583.59541
+  tps: 4674.35274
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6643.10118
-  tps: 4716.60184
+  dps: 6642.8998
+  tps: 4716.45885
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-49982"
  value: {
-  dps: 6806.60513
-  tps: 4832.68964
+  dps: 6806.39723
+  tps: 4832.54203
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-50641"
  value: {
-  dps: 6806.60513
-  tps: 4832.68964
+  dps: 6806.39723
+  tps: 4832.54203
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6690.40018
-  tps: 4750.18412
+  dps: 6690.19778
+  tps: 4750.04043
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6678.29809
-  tps: 4741.59165
+  dps: 6678.0957
+  tps: 4741.44795
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6669.13313
-  tps: 4735.08452
+  dps: 6668.92391
+  tps: 4734.93598
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6696.02812
-  tps: 4754.17996
+  dps: 6695.82572
+  tps: 4754.03626
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6730.07261
-  tps: 4778.35155
+  dps: 6729.86858
+  tps: 4778.20669
   hps: 11.11293
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6775.56892
-  tps: 4810.65394
+  dps: 6775.36754
+  tps: 4810.51095
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6581.05789
-  tps: 4672.5511
+  dps: 6581.51562
+  tps: 4672.87609
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6722.38592
-  tps: 4772.894
+  dps: 6722.18273
+  tps: 4772.74974
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6728.58776
-  tps: 4777.29731
+  dps: 6728.38438
+  tps: 4777.15291
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6696.02812
-  tps: 4754.17996
+  dps: 6695.82572
+  tps: 4754.03626
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6696.02812
-  tps: 4754.17996
+  dps: 6695.82572
+  tps: 4754.03626
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6677.91702
-  tps: 4741.32109
+  dps: 6677.72369
+  tps: 4741.18382
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6699.78555
-  tps: 4756.84774
+  dps: 6699.59222
+  tps: 4756.71047
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6806.60513
-  tps: 4832.68964
+  dps: 6806.39723
+  tps: 4832.54203
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6696.02812
-  tps: 4754.17996
+  dps: 6695.82572
+  tps: 4754.03626
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 8106.16435
-  tps: 5755.37669
+  dps: 8105.91547
+  tps: 5755.19999
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 4927.37403
-  tps: 3498.43556
+  dps: 4927.20421
+  tps: 3498.31499
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6660.49939
-  tps: 4728.95457
+  dps: 6660.29801
+  tps: 4728.81158
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 6619.82858
-  tps: 4700.07829
+  dps: 6619.63525
+  tps: 4699.94102
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6661.49499
-  tps: 4729.66144
+  dps: 6661.28933
+  tps: 4729.51543
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StormshroudArmor"
  value: {
-  dps: 5358.90696
-  tps: 3804.82394
+  dps: 5358.73892
+  tps: 3804.70463
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6728.58776
-  tps: 4777.29731
+  dps: 6728.38438
+  tps: 4777.15291
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6722.38592
-  tps: 4772.894
+  dps: 6722.18273
+  tps: 4772.74974
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6711.53271
-  tps: 4765.18822
+  dps: 6711.32984
+  tps: 4765.04419
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6585.85586
-  tps: 4675.95766
+  dps: 6585.65069
+  tps: 4675.81199
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheFistsofFury"
  value: {
-  dps: 5747.47568
-  tps: 4080.70774
+  dps: 5747.2447
+  tps: 4080.54374
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6752.47249
-  tps: 4794.25546
+  dps: 6752.24475
+  tps: 4794.09377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6887.06801
-  tps: 4889.81829
+  dps: 6886.87468
+  tps: 4889.68102
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6953.55382
-  tps: 4937.02321
+  dps: 6953.36049
+  tps: 4936.88595
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6696.02812
-  tps: 4754.17996
+  dps: 6695.82572
+  tps: 4754.03626
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6696.02812
-  tps: 4754.17996
+  dps: 6695.82572
+  tps: 4754.03626
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6561.63511
-  tps: 4658.76093
+  dps: 6561.44178
+  tps: 4658.62367
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6696.02812
-  tps: 4754.17996
+  dps: 6695.82572
+  tps: 4754.03626
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6696.02812
-  tps: 4754.17996
+  dps: 6695.82572
+  tps: 4754.03626
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5295.70241
-  tps: 3759.94871
+  dps: 5295.52517
+  tps: 3759.82287
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6373.32473
-  tps: 4525.06056
+  dps: 6373.10553
+  tps: 4524.90493
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6502.25767
-  tps: 4616.60295
+  dps: 6502.06434
+  tps: 4616.46568
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 6826.77905
-  tps: 4847.01313
+  dps: 6826.54255
+  tps: 4846.84521
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7558.5795
-  tps: 5366.59144
+  dps: 7558.3716
+  tps: 5366.44384
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7558.5795
-  tps: 5366.59144
+  dps: 7558.3716
+  tps: 5366.44384
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8811.65024
-  tps: 6256.27167
+  dps: 8810.61076
+  tps: 6255.53364
  }
 }
 dps_results: {
@@ -834,64 +834,64 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7169.13093
-  tps: 5090.08296
+  dps: 7168.92303
+  tps: 5089.93535
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7169.13093
-  tps: 5090.08296
+  dps: 7168.92303
+  tps: 5089.93535
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8361.42675
-  tps: 5936.61299
+  dps: 8360.38727
+  tps: 5935.87496
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate_expose-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3757.72287
-  tps: 2667.98324
+  dps: 3753.66924
+  tps: 2665.10516
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate_expose-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3757.72287
-  tps: 2667.98324
+  dps: 3753.66924
+  tps: 2665.10516
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate_expose-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3867.28542
-  tps: 2745.77265
+  dps: 3866.12528
+  tps: 2744.94895
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-rupture_mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7430.86182
-  tps: 5275.91189
+  dps: 7430.65392
+  tps: 5275.76428
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-rupture_mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7430.86182
-  tps: 5275.91189
+  dps: 7430.65392
+  tps: 5275.76428
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-rupture_mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8768.49754
-  tps: 6225.63325
+  dps: 8767.45805
+  tps: 6224.89522
  }
 }
 dps_results: {
@@ -918,22 +918,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-rupture_mutilate_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6806.60513
-  tps: 4832.68964
+  dps: 6806.39723
+  tps: 4832.54203
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-rupture_mutilate_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6806.60513
-  tps: 4832.68964
+  dps: 6806.39723
+  tps: 4832.54203
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-rupture_mutilate_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8163.57059
-  tps: 5796.13512
+  dps: 8162.53111
+  tps: 5795.39709
  }
 }
 dps_results: {
@@ -960,22 +960,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4946.79598
-  tps: 3512.22514
+  dps: 4946.57215
+  tps: 3512.06623
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4946.79598
-  tps: 3512.22514
+  dps: 4946.57215
+  tps: 3512.06623
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5794.21863
-  tps: 4113.89523
+  dps: 5793.09949
+  tps: 4113.10063
  }
 }
 dps_results: {
@@ -1002,64 +1002,64 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4671.42217
-  tps: 3316.70974
+  dps: 4671.19834
+  tps: 3316.55082
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4671.42217
-  tps: 3316.70974
+  dps: 4671.19834
+  tps: 3316.55082
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5447.70925
-  tps: 3867.87357
+  dps: 5446.59011
+  tps: 3867.07897
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate_expose-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2509.27638
-  tps: 1781.58623
+  dps: 2508.37466
+  tps: 1780.94601
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate_expose-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2509.27638
-  tps: 1781.58623
+  dps: 2508.37466
+  tps: 1780.94601
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate_expose-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2656.43309
-  tps: 1886.06749
+  dps: 2655.37206
+  tps: 1885.31417
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-rupture_mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5014.23705
-  tps: 3560.1083
+  dps: 5014.01322
+  tps: 3559.94938
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-rupture_mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5014.23705
-  tps: 3560.1083
+  dps: 5014.01322
+  tps: 3559.94938
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-rupture_mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5895.21587
-  tps: 4185.60327
+  dps: 5894.09672
+  tps: 4184.80867
  }
 }
 dps_results: {
@@ -1086,22 +1086,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-rupture_mutilate_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4588.31738
-  tps: 3257.70534
+  dps: 4588.09355
+  tps: 3257.54642
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-rupture_mutilate_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4588.31738
-  tps: 3257.70534
+  dps: 4588.09355
+  tps: 3257.54642
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-rupture_mutilate_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5488.77038
-  tps: 3897.02697
+  dps: 5487.65123
+  tps: 3896.23237
  }
 }
 dps_results: {
@@ -1128,22 +1128,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7144.18771
-  tps: 5072.37327
+  dps: 7143.96608
+  tps: 5072.21592
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7144.18771
-  tps: 5072.37327
+  dps: 7143.96608
+  tps: 5072.21592
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8286.51753
-  tps: 5883.42745
+  dps: 8285.4094
+  tps: 5882.64067
  }
 }
 dps_results: {
@@ -1170,64 +1170,64 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6757.6016
-  tps: 4797.89714
+  dps: 6757.37997
+  tps: 4797.73978
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6757.6016
-  tps: 4797.89714
+  dps: 6757.37997
+  tps: 4797.73978
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7834.50509
-  tps: 5562.49862
+  dps: 7833.39696
+  tps: 5561.71184
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate_expose-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3544.99809
-  tps: 2516.94864
+  dps: 3544.60936
+  tps: 2516.67265
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate_expose-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3544.99809
-  tps: 2516.94864
+  dps: 3544.60936
+  tps: 2516.67265
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate_expose-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3618.11683
-  tps: 2568.86295
+  dps: 3617.10772
+  tps: 2568.14648
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-rupture_mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7022.313
-  tps: 4985.84223
+  dps: 7022.09137
+  tps: 4985.68487
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-rupture_mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7022.313
-  tps: 4985.84223
+  dps: 7022.09137
+  tps: 4985.68487
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-rupture_mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8236.93185
-  tps: 5848.22162
+  dps: 8235.82372
+  tps: 5847.43484
  }
 }
 dps_results: {
@@ -1254,22 +1254,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-rupture_mutilate_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6444.42677
-  tps: 4575.54301
+  dps: 6444.20514
+  tps: 4575.38565
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-rupture_mutilate_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6444.42677
-  tps: 4575.54301
+  dps: 6444.20514
+  tps: 4575.38565
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-rupture_mutilate_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7701.31792
-  tps: 5467.93573
+  dps: 7700.20979
+  tps: 5467.14895
  }
 }
 dps_results: {
@@ -1296,22 +1296,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3562.43177
-  tps: 2529.32656
+  dps: 3562.22652
+  tps: 2529.18083
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3562.43177
-  tps: 2529.32656
+  dps: 3562.22652
+  tps: 2529.18083
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3605.90204
-  tps: 2560.19045
+  dps: 3604.8758
+  tps: 2559.46182
  }
 }
 dps_results: {
@@ -1338,64 +1338,64 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4014.18104
-  tps: 2850.06854
+  dps: 4013.97579
+  tps: 2849.92281
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4014.18104
-  tps: 2850.06854
+  dps: 4013.97579
+  tps: 2849.92281
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4690.64002
-  tps: 3330.35441
+  dps: 4689.61378
+  tps: 3329.62578
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate_expose-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2082.03574
-  tps: 1478.24537
+  dps: 2084.32021
+  tps: 1479.86735
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate_expose-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2082.03574
-  tps: 1478.24537
+  dps: 2084.32021
+  tps: 1479.86735
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate_expose-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2119.45894
-  tps: 1504.81585
+  dps: 2118.24649
+  tps: 1503.95501
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-rupture_mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4842.91247
-  tps: 3438.46785
+  dps: 4842.70722
+  tps: 3438.32212
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-rupture_mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4842.91247
-  tps: 3438.46785
+  dps: 4842.70722
+  tps: 3438.32212
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-rupture_mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5592.22269
-  tps: 3970.47811
+  dps: 5591.19645
+  tps: 3969.74948
  }
 }
 dps_results: {
@@ -1422,64 +1422,64 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-rupture_mutilate_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5050.98053
-  tps: 3586.19618
+  dps: 5050.77528
+  tps: 3586.05045
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-rupture_mutilate_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5050.98053
-  tps: 3586.19618
+  dps: 5050.77528
+  tps: 3586.05045
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-rupture_mutilate_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5797.66095
-  tps: 4116.33928
+  dps: 5796.63471
+  tps: 4115.61064
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-rupture_mutilate_expose-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2535.13794
-  tps: 1799.94794
+  dps: 2534.2129
+  tps: 1799.29116
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-rupture_mutilate_expose-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2535.13794
-  tps: 1799.94794
+  dps: 2534.2129
+  tps: 1799.29116
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-rupture_mutilate_expose-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2670.39361
-  tps: 1895.97946
+  dps: 2672.13051
+  tps: 1897.21266
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7611.00376
-  tps: 5403.81267
+  dps: 7610.78956
+  tps: 5403.66059
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7611.00376
-  tps: 5403.81267
+  dps: 7610.78956
+  tps: 5403.66059
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8899.76841
-  tps: 6318.83557
+  dps: 8898.6974
+  tps: 6318.07515
  }
 }
 dps_results: {
@@ -1506,64 +1506,64 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7200.40639
-  tps: 5112.28854
+  dps: 7200.19219
+  tps: 5112.13645
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7200.40639
-  tps: 5112.28854
+  dps: 7200.19219
+  tps: 5112.13645
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8437.14024
-  tps: 5990.36957
+  dps: 8436.06923
+  tps: 5989.60916
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate_expose-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3783.69685
-  tps: 2686.42476
+  dps: 3778.00163
+  tps: 2682.38116
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate_expose-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3783.69685
-  tps: 2686.42476
+  dps: 3778.00163
+  tps: 2682.38116
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate_expose-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3909.2756
-  tps: 2775.58567
+  dps: 3908.11546
+  tps: 2774.76198
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-rupture_mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7490.83125
-  tps: 5318.49018
+  dps: 7490.61704
+  tps: 5318.3381
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-rupture_mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7490.83125
-  tps: 5318.49018
+  dps: 7490.61704
+  tps: 5318.3381
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-rupture_mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8847.68823
-  tps: 6281.85864
+  dps: 8846.61722
+  tps: 6281.09823
  }
 }
 dps_results: {
@@ -1590,22 +1590,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-rupture_mutilate_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6848.43572
-  tps: 4862.38936
+  dps: 6848.22151
+  tps: 4862.23727
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-rupture_mutilate_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6848.43572
-  tps: 4862.38936
+  dps: 6848.22151
+  tps: 4862.23727
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-rupture_mutilate_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8251.32984
-  tps: 5858.44419
+  dps: 8250.25883
+  tps: 5857.68377
  }
 }
 dps_results: {
@@ -1632,22 +1632,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4982.10401
-  tps: 3537.29385
+  dps: 4981.87329
+  tps: 3537.13004
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4982.10401
-  tps: 3537.29385
+  dps: 4981.87329
+  tps: 3537.13004
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5856.3492
-  tps: 4158.00793
+  dps: 5855.19559
+  tps: 4157.18887
  }
 }
 dps_results: {
@@ -1674,64 +1674,64 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4690.69756
-  tps: 3330.39527
+  dps: 4690.46684
+  tps: 3330.23145
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4690.69756
-  tps: 3330.39527
+  dps: 4690.46684
+  tps: 3330.23145
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5502.03697
-  tps: 3906.44625
+  dps: 5500.88336
+  tps: 3905.62719
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate_expose-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2529.42103
-  tps: 1795.88893
+  dps: 2527.4676
+  tps: 1794.502
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate_expose-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2529.42103
-  tps: 1795.88893
+  dps: 2527.4676
+  tps: 1794.502
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate_expose-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2687.20733
-  tps: 1907.91721
+  dps: 2686.14631
+  tps: 1907.16388
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-rupture_mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5055.95045
-  tps: 3589.72482
+  dps: 5055.71972
+  tps: 3589.561
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-rupture_mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5055.95045
-  tps: 3589.72482
+  dps: 5055.71972
+  tps: 3589.561
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-rupture_mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5953.52252
-  tps: 4227.00099
+  dps: 5952.36891
+  tps: 4226.18193
  }
 }
 dps_results: {
@@ -1758,22 +1758,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-rupture_mutilate_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4616.59555
-  tps: 3277.78284
+  dps: 4616.36482
+  tps: 3277.61903
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-rupture_mutilate_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4616.59555
-  tps: 3277.78284
+  dps: 4616.36482
+  tps: 3277.61903
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-rupture_mutilate_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5550.57693
-  tps: 3940.90962
+  dps: 5549.42332
+  tps: 3940.09056
  }
 }
 dps_results: {
@@ -1800,22 +1800,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7191.91534
-  tps: 5106.25989
+  dps: 7191.6869
+  tps: 5106.0977
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7191.91534
-  tps: 5106.25989
+  dps: 7191.6869
+  tps: 5106.0977
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8372.61051
-  tps: 5944.55346
+  dps: 8371.46831
+  tps: 5943.7425
  }
 }
 dps_results: {
@@ -1842,64 +1842,64 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6786.26765
-  tps: 4818.25003
+  dps: 6786.0392
+  tps: 4818.08784
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6786.26765
-  tps: 4818.25003
+  dps: 6786.0392
+  tps: 4818.08784
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7904.96135
-  tps: 5612.52256
+  dps: 7903.81915
+  tps: 5611.7116
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate_expose-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3572.50465
-  tps: 2536.4783
+  dps: 3570.41235
+  tps: 2534.99277
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate_expose-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3572.50465
-  tps: 2536.4783
+  dps: 3570.41235
+  tps: 2534.99277
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate_expose-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3657.48257
-  tps: 2596.81263
+  dps: 3656.47347
+  tps: 2596.09616
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-rupture_mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7080.82485
-  tps: 5027.38564
+  dps: 7080.59641
+  tps: 5027.22345
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-rupture_mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7080.82485
-  tps: 5027.38564
+  dps: 7080.59641
+  tps: 5027.22345
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-rupture_mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8317.00993
-  tps: 5905.07705
+  dps: 8315.86772
+  tps: 5904.26608
  }
 }
 dps_results: {
@@ -1926,22 +1926,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-rupture_mutilate_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6487.07733
-  tps: 4605.8249
+  dps: 6486.84889
+  tps: 4605.66271
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-rupture_mutilate_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6487.07733
-  tps: 4605.8249
+  dps: 6486.84889
+  tps: 4605.66271
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-rupture_mutilate_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7784.05227
-  tps: 5526.67711
+  dps: 7782.91007
+  tps: 5525.86615
  }
 }
 dps_results: {
@@ -1968,22 +1968,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 3587.72635
-  tps: 2547.28571
+  dps: 3587.51489
+  tps: 2547.13557
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3587.72635
-  tps: 2547.28571
+  dps: 3587.51489
+  tps: 2547.13557
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3658.89749
-  tps: 2597.81722
+  dps: 3657.84021
+  tps: 2597.06655
  }
 }
 dps_results: {
@@ -2010,64 +2010,64 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4040.5501
-  tps: 2868.79057
+  dps: 4040.33864
+  tps: 2868.64044
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4040.5501
-  tps: 2868.79057
+  dps: 4040.33864
+  tps: 2868.64044
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4741.99709
-  tps: 3366.81793
+  dps: 4740.93981
+  tps: 3366.06726
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate_expose-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2097.37542
-  tps: 1489.13655
+  dps: 2099.67859
+  tps: 1490.7718
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate_expose-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2097.37542
-  tps: 1489.13655
+  dps: 2099.67859
+  tps: 1490.7718
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate_expose-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2147.24512
-  tps: 1524.54404
+  dps: 2146.03267
+  tps: 1523.6832
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-rupture_mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 4872.83467
-  tps: 3459.71262
+  dps: 4872.62322
+  tps: 3459.56248
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-rupture_mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4872.83467
-  tps: 3459.71262
+  dps: 4872.62322
+  tps: 3459.56248
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-rupture_mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5652.7425
-  tps: 4013.44717
+  dps: 5651.68522
+  tps: 4012.6965
  }
 }
 dps_results: {
@@ -2094,49 +2094,49 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-rupture_mutilate_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 5085.17907
-  tps: 3610.47714
+  dps: 5084.96762
+  tps: 3610.32701
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-rupture_mutilate_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5085.17907
-  tps: 3610.47714
+  dps: 5084.96762
+  tps: 3610.32701
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-rupture_mutilate_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5857.78646
-  tps: 4159.02838
+  dps: 5856.72918
+  tps: 4158.27772
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-rupture_mutilate_expose-NoBuffs-LongMultiTarget"
  value: {
-  dps: 2557.26199
-  tps: 1815.65601
+  dps: 2556.35942
+  tps: 1815.01519
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-rupture_mutilate_expose-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2557.26199
-  tps: 1815.65601
+  dps: 2556.35942
+  tps: 1815.01519
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-rupture_mutilate_expose-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2701.62673
-  tps: 1918.15498
+  dps: 2703.36364
+  tps: 1919.38818
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6384.49191
-  tps: 4532.98926
+  dps: 6384.2841
+  tps: 4532.84171
  }
 }

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -46,838 +46,838 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 6264.8177
-  tps: 4448.02056
+  dps: 6264.63724
+  tps: 4447.89244
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6372.20031
-  tps: 4524.26222
+  dps: 6372.02095
+  tps: 4524.13488
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6438.16294
-  tps: 4571.09569
+  dps: 6437.97827
+  tps: 4570.96457
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6244.9937
-  tps: 4433.94552
+  dps: 6244.81324
+  tps: 4433.8174
   hps: 88.93771
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6244.9937
-  tps: 4433.94552
+  dps: 6244.81324
+  tps: 4433.8174
   hps: 88.93771
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6392.3617
-  tps: 4538.57681
+  dps: 6392.18235
+  tps: 4538.44947
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50035"
  value: {
-  dps: 6641.82946
-  tps: 4715.69892
+  dps: 6641.63291
+  tps: 4715.55937
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50692"
  value: {
-  dps: 6755.49373
-  tps: 4796.40055
+  dps: 6755.2917
+  tps: 4796.25711
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4820.89766
-  tps: 3422.83734
+  dps: 4820.75148
+  tps: 3422.73355
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BonescytheBattlegear"
  value: {
-  dps: 5839.84198
-  tps: 4146.2878
+  dps: 5839.67563
+  tps: 4146.1697
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6372.20031
-  tps: 4433.77698
+  dps: 6372.02095
+  tps: 4433.65218
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6518.4425
-  tps: 4628.09417
+  dps: 6518.25861
+  tps: 4627.96361
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6518.4425
-  tps: 4628.09417
+  dps: 6518.25861
+  tps: 4627.96361
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6512.81223
-  tps: 4624.09668
+  dps: 6512.62886
+  tps: 4623.96649
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
   hps: 64
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6366.16949
-  tps: 4519.98034
+  dps: 6365.98903
+  tps: 4519.85221
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6398.49693
-  tps: 4542.93282
+  dps: 6398.31647
+  tps: 4542.8047
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6393.3212
-  tps: 4539.25805
+  dps: 6393.13951
+  tps: 4539.12905
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6718.34597
-  tps: 4770.02564
+  dps: 6718.15601
+  tps: 4769.89077
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6346.15715
-  tps: 4505.77158
+  dps: 6345.97669
+  tps: 4505.64345
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6682.56425
-  tps: 4744.62062
+  dps: 6682.375
+  tps: 4744.48625
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6751.23587
-  tps: 4793.37747
+  dps: 6751.04665
+  tps: 4793.24312
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6396.58868
-  tps: 4541.57796
+  dps: 6396.40932
+  tps: 4541.45062
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6429.84165
-  tps: 4565.18757
+  dps: 6429.66119
+  tps: 4565.05944
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6433.02212
-  tps: 4567.44571
+  dps: 6432.84166
+  tps: 4567.31758
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6372.20031
-  tps: 4524.26222
+  dps: 6372.02095
+  tps: 4524.13488
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6372.20031
-  tps: 4524.26222
+  dps: 6372.02095
+  tps: 4524.13488
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6392.3617
-  tps: 4538.57681
+  dps: 6392.18235
+  tps: 4538.44947
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6388.39967
-  tps: 4535.76377
+  dps: 6388.22031
+  tps: 4535.63642
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6348.55855
-  tps: 4507.47657
+  dps: 6347.35395
+  tps: 4506.62131
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6372.20031
-  tps: 4524.26222
+  dps: 6372.02095
+  tps: 4524.13488
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6392.49817
-  tps: 4538.6737
+  dps: 6392.31771
+  tps: 4538.54557
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6350.10585
-  tps: 4508.57515
+  dps: 6349.92539
+  tps: 4508.44703
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6329.1422
-  tps: 4493.69096
+  dps: 6328.96174
+  tps: 4493.56284
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6372.20031
-  tps: 4524.26222
+  dps: 6372.02095
+  tps: 4524.13488
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6372.20031
-  tps: 4524.26222
+  dps: 6372.02095
+  tps: 4524.13488
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6478.64514
-  tps: 4599.83805
+  dps: 6478.46446
+  tps: 4599.70977
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Gladiator'sVestments"
  value: {
-  dps: 6135.13069
-  tps: 4355.94279
+  dps: 6134.93082
+  tps: 4355.80088
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6376.57346
-  tps: 4527.36716
+  dps: 6376.393
+  tps: 4527.23903
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-49982"
  value: {
-  dps: 6518.4425
-  tps: 4628.09417
+  dps: 6518.25861
+  tps: 4627.96361
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-50641"
  value: {
-  dps: 6518.4425
-  tps: 4628.09417
+  dps: 6518.25861
+  tps: 4627.96361
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6392.3617
-  tps: 4538.57681
+  dps: 6392.18235
+  tps: 4538.44947
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6388.39967
-  tps: 4535.76377
+  dps: 6388.22031
+  tps: 4535.63642
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6428.21152
-  tps: 4564.03018
+  dps: 6428.0169
+  tps: 4563.892
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6372.20031
-  tps: 4524.26222
+  dps: 6372.02095
+  tps: 4524.13488
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6402.50323
-  tps: 4545.7773
+  dps: 6402.32253
+  tps: 4545.64899
   hps: 11.25035
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LastWord-50179"
  value: {
-  dps: 6518.4425
-  tps: 4628.09417
+  dps: 6518.25861
+  tps: 4627.96361
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LastWord-50708"
  value: {
-  dps: 6518.4425
-  tps: 4628.09417
+  dps: 6518.25861
+  tps: 4627.96361
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6416.96448
-  tps: 4556.04478
+  dps: 6416.78402
+  tps: 4555.91665
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6311.51686
-  tps: 4481.17697
+  dps: 6311.30028
+  tps: 4481.0232
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Nibelung-49992"
  value: {
-  dps: 6518.4425
-  tps: 4628.09417
+  dps: 6518.25861
+  tps: 4627.96361
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Nibelung-50648"
  value: {
-  dps: 6518.4425
-  tps: 4628.09417
+  dps: 6518.25861
+  tps: 4627.96361
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6397.27541
-  tps: 4542.06554
+  dps: 6397.09531
+  tps: 4541.93767
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6403.17543
-  tps: 4546.25456
+  dps: 6402.99516
+  tps: 4546.12657
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6372.20031
-  tps: 4524.26222
+  dps: 6372.02095
+  tps: 4524.13488
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6372.20031
-  tps: 4524.26222
+  dps: 6372.02095
+  tps: 4524.13488
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6364.42355
-  tps: 4518.74072
+  dps: 6364.24309
+  tps: 4518.61259
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6379.58578
-  tps: 4529.50591
+  dps: 6379.40533
+  tps: 4529.37778
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6518.4425
-  tps: 4628.09417
+  dps: 6518.25861
+  tps: 4627.96361
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6372.20031
-  tps: 4524.26222
+  dps: 6372.02095
+  tps: 4524.13488
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 7240.2157
-  tps: 5140.55314
+  dps: 7239.99449
+  tps: 5140.39609
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6518.4425
-  tps: 4628.09417
+  dps: 6518.25861
+  tps: 4627.96361
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Slayer'sArmor"
  value: {
-  dps: 4808.9943
-  tps: 3414.38595
+  dps: 4808.85451
+  tps: 3414.2867
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6353.01678
-  tps: 4510.64191
+  dps: 6352.83632
+  tps: 4510.51379
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SparkofLife-37657"
  value: {
-  dps: 6327.35994
-  tps: 4492.42556
+  dps: 6327.17948
+  tps: 4492.29743
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6416.30545
-  tps: 4555.57687
+  dps: 6415.97197
+  tps: 4555.3401
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StormshroudArmor"
  value: {
-  dps: 4971.45357
-  tps: 3529.73203
+  dps: 4971.3071
+  tps: 3529.62804
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6403.17543
-  tps: 4546.25456
+  dps: 6402.99516
+  tps: 4546.12657
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6397.27541
-  tps: 4542.06554
+  dps: 6397.09531
+  tps: 4541.93767
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6386.95037
-  tps: 4534.73476
+  dps: 6386.77058
+  tps: 4534.60711
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 6213.39609
-  tps: 4411.51122
+  dps: 6213.22164
+  tps: 4411.38736
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheFistsofFury"
  value: {
-  dps: 5566.12859
-  tps: 3951.9513
+  dps: 5565.96469
+  tps: 3951.83493
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5717.42798
-  tps: 4059.37386
+  dps: 5716.16491
+  tps: 4058.47709
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6447.04531
-  tps: 4577.40217
+  dps: 6445.79829
+  tps: 4576.51679
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6552.31616
-  tps: 4652.14447
+  dps: 6552.12895
+  tps: 4652.01156
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6577.50039
-  tps: 4670.02528
+  dps: 6577.31993
+  tps: 4669.89715
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6372.20031
-  tps: 4524.26222
+  dps: 6372.02095
+  tps: 4524.13488
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6372.20031
-  tps: 4524.26222
+  dps: 6372.02095
+  tps: 4524.13488
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6302.56072
-  tps: 4474.81811
+  dps: 6302.38026
+  tps: 4474.68999
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6372.20031
-  tps: 4524.26222
+  dps: 6372.02095
+  tps: 4524.13488
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6372.20031
-  tps: 4524.26222
+  dps: 6372.02095
+  tps: 4524.13488
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5127.09997
-  tps: 3640.24098
+  dps: 5126.93834
+  tps: 3640.12622
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6055.83848
-  tps: 4299.64532
+  dps: 6055.68499
+  tps: 4299.53634
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 6069.24861
-  tps: 4309.16651
+  dps: 6069.06835
+  tps: 4309.03853
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6244.37804
-  tps: 4433.50841
+  dps: 6244.19758
+  tps: 4433.38028
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 6518.52126
-  tps: 4628.1501
+  dps: 6518.32572
+  tps: 4628.01126
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Deadly-combat_cleave_snd-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20234.76193
-  tps: 14366.68097
+  dps: 20234.57804
+  tps: 14366.55041
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Deadly-combat_cleave_snd-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4350.67869
-  tps: 3088.98187
+  dps: 4350.79389
+  tps: 3089.06366
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Deadly-combat_cleave_snd-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5303.32537
-  tps: 3765.36101
+  dps: 5302.40594
+  tps: 3764.70822
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Deadly-combat_cleave_snd-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11972.19488
-  tps: 8500.25836
+  dps: 11970.59374
+  tps: 8499.12156
  }
 }
 dps_results: {
@@ -897,29 +897,29 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Deadly-combat_cleave_snd_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12490.75844
-  tps: 8868.4385
+  dps: 12490.57456
+  tps: 8868.30794
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Deadly-combat_cleave_snd_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4183.02677
-  tps: 2969.949
+  dps: 4182.84288
+  tps: 2969.81844
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Deadly-combat_cleave_snd_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5095.31414
-  tps: 3617.67304
+  dps: 5094.39471
+  tps: 3617.02025
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Deadly-combat_cleave_snd_expose-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6618.63876
-  tps: 4699.23352
+  dps: 6612.97249
+  tps: 4695.21047
  }
 }
 dps_results: {
@@ -939,22 +939,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Deadly-combat_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6037.86502
-  tps: 4286.88416
+  dps: 6037.68113
+  tps: 4286.7536
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Deadly-combat_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5200.29406
-  tps: 3692.20879
+  dps: 5200.11018
+  tps: 3692.07823
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Deadly-combat_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6173.4077
-  tps: 4383.11947
+  dps: 6172.48827
+  tps: 4382.46667
  }
 }
 dps_results: {
@@ -981,22 +981,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Deadly-fan_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21435.0837
-  tps: 15218.90942
+  dps: 21435.04268
+  tps: 15218.8803
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Deadly-fan_aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3539.18067
-  tps: 2512.81828
+  dps: 3539.13966
+  tps: 2512.78916
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Deadly-fan_aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4297.78322
-  tps: 3051.42609
+  dps: 4297.57812
+  tps: 3051.28047
  }
 }
 dps_results: {
@@ -1023,22 +1023,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Instant-combat_cleave_snd-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20796.13445
-  tps: 14765.25546
+  dps: 20795.95056
+  tps: 14765.1249
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Instant-combat_cleave_snd-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5704.77578
-  tps: 4050.3908
+  dps: 5704.94916
+  tps: 4050.5139
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Instant-combat_cleave_snd-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6879.98214
-  tps: 4884.78732
+  dps: 6879.06271
+  tps: 4884.13452
  }
 }
 dps_results: {
@@ -1065,29 +1065,29 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Instant-combat_cleave_snd_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12593.6931
-  tps: 8941.5221
+  dps: 12593.50921
+  tps: 8941.39154
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Instant-combat_cleave_snd_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5521.00073
-  tps: 3919.91052
+  dps: 5520.81684
+  tps: 3919.77996
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Instant-combat_cleave_snd_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6628.44461
-  tps: 4706.19568
+  dps: 6627.52518
+  tps: 4705.54288
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Instant-combat_cleave_snd_expose-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6512.574
-  tps: 4623.92754
+  dps: 6502.17508
+  tps: 4616.5443
  }
 }
 dps_results: {
@@ -1107,22 +1107,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Instant-combat_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7256.43998
-  tps: 5152.07239
+  dps: 7256.25609
+  tps: 5151.94183
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Instant-combat_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6518.4425
-  tps: 4628.09417
+  dps: 6518.25861
+  tps: 4627.96361
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Instant-combat_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7700.49323
-  tps: 5467.35019
+  dps: 7699.5738
+  tps: 5466.6974
  }
 }
 dps_results: {
@@ -1149,22 +1149,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Instant-fan_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23026.52179
-  tps: 16348.83047
+  dps: 23026.48078
+  tps: 16348.80135
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Instant-fan_aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4633.60152
-  tps: 3289.85708
+  dps: 4633.5605
+  tps: 3289.82796
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Deadly OH Instant-fan_aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5540.7941
-  tps: 3933.96381
+  dps: 5540.589
+  tps: 3933.81819
  }
 }
 dps_results: {
@@ -1191,29 +1191,29 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Deadly-combat_cleave_snd-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23060.58549
-  tps: 16373.0157
+  dps: 23060.4016
+  tps: 16372.88514
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Deadly-combat_cleave_snd-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6217.40679
-  tps: 4414.35882
+  dps: 6217.73432
+  tps: 4414.59137
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Deadly-combat_cleave_snd-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7506.79086
-  tps: 5329.82151
+  dps: 7505.87143
+  tps: 5329.16872
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Deadly-combat_cleave_snd-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12897.69181
-  tps: 9157.36119
+  dps: 12894.22483
+  tps: 9154.89963
  }
 }
 dps_results: {
@@ -1233,29 +1233,29 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Deadly-combat_cleave_snd_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13912.58983
-  tps: 9877.93878
+  dps: 13912.40594
+  tps: 9877.80822
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Deadly-combat_cleave_snd_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6006.29062
-  tps: 4264.46634
+  dps: 6006.10674
+  tps: 4264.33578
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Deadly-combat_cleave_snd_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7250.60441
-  tps: 5147.92913
+  dps: 7249.68498
+  tps: 5147.27634
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Deadly-combat_cleave_snd_expose-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7196.4786
-  tps: 5109.49981
+  dps: 7189.40934
+  tps: 5104.48063
  }
 }
 dps_results: {
@@ -1275,22 +1275,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Deadly-combat_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7722.34983
-  tps: 5482.86838
+  dps: 7722.16594
+  tps: 5482.73782
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Deadly-combat_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6973.08742
-  tps: 4950.89207
+  dps: 6972.90353
+  tps: 4950.76151
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Deadly-combat_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8270.93629
-  tps: 5872.36477
+  dps: 8270.01686
+  tps: 5871.71197
  }
 }
 dps_results: {
@@ -1317,22 +1317,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Deadly-fan_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25576.26808
-  tps: 18159.15034
+  dps: 25576.22706
+  tps: 18159.12122
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Deadly-fan_aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5051.40172
-  tps: 3586.49522
+  dps: 5051.3607
+  tps: 3586.46609
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Deadly-fan_aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6092.64625
-  tps: 4325.77884
+  dps: 6092.44116
+  tps: 4325.63322
  }
 }
 dps_results: {
@@ -1359,29 +1359,29 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Instant-combat_cleave_snd-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18028.7812
-  tps: 12800.43465
+  dps: 18028.59731
+  tps: 12800.30409
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Instant-combat_cleave_snd-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5302.45173
-  tps: 3764.74073
+  dps: 5301.56711
+  tps: 3764.11265
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Instant-combat_cleave_snd-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6600.91258
-  tps: 4686.64793
+  dps: 6599.99315
+  tps: 4685.99514
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Instant-combat_cleave_snd-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9924.55966
-  tps: 7046.43736
+  dps: 9924.43393
+  tps: 7046.34809
  }
 }
 dps_results: {
@@ -1401,29 +1401,29 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Instant-combat_cleave_snd_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11942.70779
-  tps: 8479.32253
+  dps: 11942.5239
+  tps: 8479.19197
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Instant-combat_cleave_snd_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5102.60898
-  tps: 3622.85238
+  dps: 5102.4251
+  tps: 3622.72182
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Instant-combat_cleave_snd_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6318.69001
-  tps: 4486.26991
+  dps: 6317.77058
+  tps: 4485.61711
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Instant-combat_cleave_snd_expose-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6033.76847
-  tps: 4283.97562
+  dps: 6036.05575
+  tps: 4285.59958
  }
 }
 dps_results: {
@@ -1443,22 +1443,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Instant-combat_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6852.48517
-  tps: 4865.26447
+  dps: 6852.30128
+  tps: 4865.13391
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Instant-combat_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6097.33089
-  tps: 4329.10493
+  dps: 6097.14701
+  tps: 4328.97437
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Instant-combat_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7397.60135
-  tps: 5252.29696
+  dps: 7396.68192
+  tps: 5251.64417
  }
 }
 dps_results: {
@@ -1485,22 +1485,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Instant-fan_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19109.15274
-  tps: 13567.49844
+  dps: 19109.11172
+  tps: 13567.46932
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Instant-fan_aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4217.62593
-  tps: 2994.51441
+  dps: 4217.58491
+  tps: 2994.48528
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat-MH Instant OH Instant-fan_aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5275.20299
-  tps: 3745.39412
+  dps: 5274.9979
+  tps: 3745.24851
  }
 }
 dps_results: {
@@ -1527,29 +1527,29 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Deadly-combat_cleave_snd-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20420.28057
-  tps: 14498.39921
+  dps: 20420.09133
+  tps: 14498.26484
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Deadly-combat_cleave_snd-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4389.29043
-  tps: 3116.39621
+  dps: 4389.79035
+  tps: 3116.75115
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Deadly-combat_cleave_snd-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5384.28224
-  tps: 3822.84039
+  dps: 5383.33602
+  tps: 3822.16857
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Deadly-combat_cleave_snd-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12058.2273
-  tps: 8561.34138
+  dps: 12056.42079
+  tps: 8560.05876
  }
 }
 dps_results: {
@@ -1569,29 +1569,29 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Deadly-combat_cleave_snd_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12600.27739
-  tps: 8946.19695
+  dps: 12600.08815
+  tps: 8946.06259
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Deadly-combat_cleave_snd_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4210.85136
-  tps: 2989.70446
+  dps: 4210.66211
+  tps: 2989.5701
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Deadly-combat_cleave_snd_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5183.44961
-  tps: 3680.24922
+  dps: 5182.50339
+  tps: 3679.57741
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Deadly-combat_cleave_snd_expose-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6695.48377
-  tps: 4753.79348
+  dps: 6701.23605
+  tps: 4757.87759
  }
 }
 dps_results: {
@@ -1611,22 +1611,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Deadly-combat_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6097.29038
-  tps: 4329.07617
+  dps: 6097.10114
+  tps: 4328.94181
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Deadly-combat_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5242.53134
-  tps: 3722.19725
+  dps: 5242.3421
+  tps: 3722.06289
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Deadly-combat_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6250.92622
-  tps: 4438.15761
+  dps: 6249.98
+  tps: 4437.4858
  }
 }
 dps_results: {
@@ -1653,22 +1653,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Deadly-fan_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21615.96589
-  tps: 15347.33578
+  dps: 21615.92487
+  tps: 15347.30666
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Deadly-fan_aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3565.33705
-  tps: 2531.3893
+  dps: 3565.29603
+  tps: 2531.36018
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Deadly-fan_aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4362.68672
-  tps: 3097.50757
+  dps: 4362.48163
+  tps: 3097.36196
  }
 }
 dps_results: {
@@ -1695,29 +1695,29 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Instant-combat_cleave_snd-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20922.56115
-  tps: 14855.01842
+  dps: 20922.37191
+  tps: 14854.88405
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Instant-combat_cleave_snd-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5752.9394
-  tps: 4084.58698
+  dps: 5753.08831
+  tps: 4084.6927
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Instant-combat_cleave_snd-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6978.62965
-  tps: 4954.82705
+  dps: 6977.68343
+  tps: 4954.15524
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Instant-combat_cleave_snd-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11751.19424
-  tps: 8343.34791
+  dps: 11751.20145
+  tps: 8343.35303
  }
 }
 dps_results: {
@@ -1737,29 +1737,29 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Instant-combat_cleave_snd_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12705.38445
-  tps: 9020.82296
+  dps: 12705.1952
+  tps: 9020.68859
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Instant-combat_cleave_snd_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5557.13921
-  tps: 3945.56884
+  dps: 5556.94997
+  tps: 3945.43448
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Instant-combat_cleave_snd_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6737.22596
-  tps: 4783.43043
+  dps: 6736.27974
+  tps: 4782.75862
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Instant-combat_cleave_snd_expose-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6570.21821
-  tps: 4664.85493
+  dps: 6562.81249
+  tps: 4659.59687
  }
 }
 dps_results: {
@@ -1779,22 +1779,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Instant-combat_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7331.13714
-  tps: 5205.10737
+  dps: 7330.9479
+  tps: 5204.97301
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Instant-combat_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6570.27818
-  tps: 4664.89751
+  dps: 6570.08894
+  tps: 4664.76314
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Instant-combat_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7796.6532
-  tps: 5535.62377
+  dps: 7795.70698
+  tps: 5534.95196
  }
 }
 dps_results: {
@@ -1821,22 +1821,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Instant-fan_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23204.40112
-  tps: 16475.1248
+  dps: 23204.3601
+  tps: 16475.09567
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Instant-fan_aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4667.48282
-  tps: 3313.9128
+  dps: 4667.4418
+  tps: 3313.88368
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Deadly OH Instant-fan_aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5623.03843
-  tps: 3992.35729
+  dps: 5622.83334
+  tps: 3992.21167
  }
 }
 dps_results: {
@@ -1863,29 +1863,29 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Deadly-combat_cleave_snd-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23245.43168
-  tps: 16504.25649
+  dps: 23245.24243
+  tps: 16504.12213
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Deadly-combat_cleave_snd-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6270.09515
-  tps: 4451.76755
+  dps: 6270.21461
+  tps: 4451.85237
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Deadly-combat_cleave_snd-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7613.41501
-  tps: 5405.52466
+  dps: 7612.46879
+  tps: 5404.85284
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Deadly-combat_cleave_snd-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13001.82841
-  tps: 9231.29817
+  dps: 12999.59044
+  tps: 9229.70921
  }
 }
 dps_results: {
@@ -1905,29 +1905,29 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Deadly-combat_cleave_snd_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14013.78934
-  tps: 9949.79043
+  dps: 14013.6001
+  tps: 9949.65607
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Deadly-combat_cleave_snd_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6049.43439
-  tps: 4295.09842
+  dps: 6049.24515
+  tps: 4294.96406
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Deadly-combat_cleave_snd_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7367.71885
-  tps: 5231.08038
+  dps: 7366.77263
+  tps: 5230.40857
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Deadly-combat_cleave_snd_expose-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7277.12394
-  tps: 5166.758
+  dps: 7276.14478
+  tps: 5166.06279
  }
 }
 dps_results: {
@@ -1947,22 +1947,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Deadly-combat_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7798.25178
-  tps: 5536.75876
+  dps: 7798.06254
+  tps: 5536.6244
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Deadly-combat_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7025.00934
-  tps: 4987.75663
+  dps: 7024.8201
+  tps: 4987.62227
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Deadly-combat_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8377.47887
-  tps: 5948.01
+  dps: 8376.53265
+  tps: 5947.33818
  }
 }
 dps_results: {
@@ -1989,22 +1989,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Deadly-fan_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25775.54774
-  tps: 18300.6389
+  dps: 25775.50672
+  tps: 18300.60977
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Deadly-fan_aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5087.74227
-  tps: 3612.29701
+  dps: 5087.70125
+  tps: 3612.26789
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Deadly-fan_aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6179.2453
-  tps: 4387.26416
+  dps: 6179.0402
+  tps: 4387.11854
  }
 }
 dps_results: {
@@ -2031,29 +2031,29 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Instant-combat_cleave_snd-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18199.4527
-  tps: 12921.61141
+  dps: 18199.26345
+  tps: 12921.47705
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Instant-combat_cleave_snd-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5354.37411
-  tps: 3801.60562
+  dps: 5352.99122
+  tps: 3800.62377
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Instant-combat_cleave_snd-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6694.79771
-  tps: 4753.30638
+  dps: 6693.8515
+  tps: 4752.63456
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Instant-combat_cleave_snd-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10001.36654
-  tps: 7100.97024
+  dps: 10001.21696
+  tps: 7100.86404
  }
 }
 dps_results: {
@@ -2073,29 +2073,29 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Instant-combat_cleave_snd_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 12039.79609
-  tps: 8548.25523
+  dps: 12039.60685
+  tps: 8548.12086
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Instant-combat_cleave_snd_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 5135.99472
-  tps: 3646.55625
+  dps: 5135.80547
+  tps: 3646.42189
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Instant-combat_cleave_snd_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 6427.32418
-  tps: 4563.40017
+  dps: 6426.37796
+  tps: 4562.72835
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Instant-combat_cleave_snd_expose-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6097.34925
-  tps: 4329.11797
+  dps: 6105.96527
+  tps: 4335.23534
  }
 }
 dps_results: {
@@ -2115,22 +2115,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Instant-combat_expose-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6927.17546
-  tps: 4918.29458
+  dps: 6926.98622
+  tps: 4918.16022
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Instant-combat_expose-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6146.41128
-  tps: 4363.95201
+  dps: 6146.22204
+  tps: 4363.81765
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Instant-combat_expose-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7491.68813
-  tps: 5319.09857
+  dps: 7490.74191
+  tps: 5318.42675
  }
 }
 dps_results: {
@@ -2157,22 +2157,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Instant-fan_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19281.77115
-  tps: 13690.05752
+  dps: 19281.73013
+  tps: 13690.02839
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Instant-fan_aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 4255.43319
-  tps: 3021.35757
+  dps: 4255.39217
+  tps: 3021.32844
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat-MH Instant OH Instant-fan_aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 5353.10704
-  tps: 3800.706
+  dps: 5352.90194
+  tps: 3800.56038
  }
 }
 dps_results: {
@@ -2199,7 +2199,7 @@ dps_results: {
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6153.89141
-  tps: 4369.2629
+  dps: 6153.71453
+  tps: 4369.13732
  }
 }

--- a/sim/rogue/TestSubtlety.results
+++ b/sim/rogue/TestSubtlety.results
@@ -46,837 +46,837 @@ character_stats_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 7870.75181
-  tps: 5586.63694
+  dps: 7878.76162
+  tps: 5592.3239
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 8107.55168
-  tps: 5752.07895
+  dps: 8091.90494
+  tps: 5740.96977
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 8101.05398
-  tps: 5750.98033
+  dps: 8088.69703
+  tps: 5742.97489
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7846.70617
-  tps: 5568.76463
-  hps: 88.34387
+  dps: 7852.55406
+  tps: 5572.10921
+  hps: 87.956
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7846.70617
-  tps: 5568.76463
-  hps: 88.34387
+  dps: 7852.55406
+  tps: 5572.10921
+  hps: 87.956
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 8137.71518
-  tps: 5774.37344
+  dps: 8136.09891
+  tps: 5773.22589
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlackBruise-50035"
  value: {
-  dps: 8116.06959
-  tps: 5759.69286
+  dps: 8102.69756
+  tps: 5750.01889
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlackBruise-50692"
  value: {
-  dps: 8210.95587
-  tps: 5827.06718
+  dps: 8197.68363
+  tps: 5817.46441
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5814.3254
-  tps: 4124.52663
+  dps: 5783.5765
+  tps: 4103.09378
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BonescytheBattlegear"
  value: {
-  dps: 6931.47826
-  tps: 4916.542
+  dps: 6944.18379
+  tps: 4925.98454
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 8107.55168
-  tps: 5637.03737
+  dps: 8091.90494
+  tps: 5626.15037
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8286.06039
-  tps: 5879.61104
+  dps: 8284.15256
+  tps: 5878.25648
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
   hps: 64
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 8025.85541
-  tps: 5696.35424
+  dps: 8021.47682
+  tps: 5693.24544
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 8061.76717
-  tps: 5722.24535
+  dps: 8057.04862
+  tps: 5718.95432
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 8060.16247
-  tps: 5719.8474
+  dps: 8046.72564
+  tps: 5710.34752
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Death'sChoice-47464"
  value: {
-  dps: 8427.24584
-  tps: 5979.1919
+  dps: 8422.7088
+  tps: 5975.55819
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 8006.82684
-  tps: 5681.29002
+  dps: 8015.17955
+  tps: 5687.99931
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 8295.24348
-  tps: 5886.72661
+  dps: 8297.62964
+  tps: 5888.82288
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 8396.04927
-  tps: 5958.22868
+  dps: 8395.43446
+  tps: 5956.56447
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 8147.10839
-  tps: 5780.55806
+  dps: 8134.97415
+  tps: 5772.04213
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 8083.64816
-  tps: 5735.86808
+  dps: 8092.31187
+  tps: 5741.62372
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 8065.77232
-  tps: 5724.73239
+  dps: 8061.86066
+  tps: 5721.1277
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 8107.55168
-  tps: 5752.07895
+  dps: 8091.90494
+  tps: 5740.96977
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 8107.55168
-  tps: 5752.07895
+  dps: 8091.90494
+  tps: 5740.96977
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 8137.71518
-  tps: 5774.37344
+  dps: 8136.09891
+  tps: 5773.22589
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 8143.38886
-  tps: 5779.37719
+  dps: 8135.25822
+  tps: 5773.60444
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7974.95333
-  tps: 5660.21374
+  dps: 7961.06654
+  tps: 5651.1946
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 8107.55168
-  tps: 5752.07895
+  dps: 8091.90494
+  tps: 5740.96977
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 8067.91576
-  tps: 5725.81572
+  dps: 8066.40849
+  tps: 5725.18209
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 8022.47109
-  tps: 5693.97007
+  dps: 8005.24255
+  tps: 5681.73781
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7982.51409
-  tps: 5664.82165
+  dps: 7965.80386
+  tps: 5654.1639
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 8107.55168
-  tps: 5752.07895
+  dps: 8091.90494
+  tps: 5740.96977
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 8107.55168
-  tps: 5752.07895
+  dps: 8091.90494
+  tps: 5740.96977
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 8100.93439
-  tps: 5749.20077
+  dps: 8106.97223
+  tps: 5752.65803
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Gladiator'sVestments"
  value: {
-  dps: 7288.31034
-  tps: 5172.32843
+  dps: 7290.25909
+  tps: 5173.71204
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 8019.98429
-  tps: 5691.00488
+  dps: 8013.15644
+  tps: 5687.30533
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Heartpierce-49982"
  value: {
-  dps: 8302.87853
-  tps: 5893.03954
+  dps: 8293.74535
+  tps: 5886.55499
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Heartpierce-50641"
  value: {
-  dps: 8302.87853
-  tps: 5893.03954
+  dps: 8293.74535
+  tps: 5886.55499
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 8137.71518
-  tps: 5774.37344
+  dps: 8136.09891
+  tps: 5773.22589
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 8143.38886
-  tps: 5779.37719
+  dps: 8135.25822
+  tps: 5773.60444
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-IncisorFragment-37723"
  value: {
-  dps: 8042.29617
-  tps: 5707.60306
+  dps: 8048.56647
+  tps: 5711.23728
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 8107.55168
-  tps: 5752.07895
+  dps: 8091.90494
+  tps: 5740.96977
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 8142.79817
-  tps: 5777.08854
+  dps: 8127.0879
+  tps: 5765.93424
   hps: 12.78749
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 8089.40129
-  tps: 5741.03465
+  dps: 8080.02577
+  tps: 5731.972
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7930.30075
-  tps: 5626.91318
+  dps: 7923.33057
+  tps: 5622.72376
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 8136.08455
-  tps: 5772.32481
+  dps: 8120.38638
+  tps: 5761.1791
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 8142.79817
-  tps: 5777.08854
+  dps: 8127.0879
+  tps: 5765.93424
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 8107.55168
-  tps: 5752.07895
+  dps: 8091.90494
+  tps: 5740.96977
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 8107.55168
-  tps: 5752.07895
+  dps: 8091.90494
+  tps: 5740.96977
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 8022.30122
-  tps: 5692.24203
+  dps: 8028.09857
+  tps: 5696.35815
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 8040.85868
-  tps: 5705.41783
+  dps: 8046.72174
+  tps: 5709.5806
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8302.87853
-  tps: 5893.03954
+  dps: 8293.74535
+  tps: 5886.55499
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 8107.55168
-  tps: 5752.07895
+  dps: 8091.90494
+  tps: 5740.96977
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 8457.71517
-  tps: 6001.34137
+  dps: 8456.59541
+  tps: 6000.54633
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Slayer'sArmor"
  value: {
-  dps: 5351.53092
-  tps: 3794.54267
+  dps: 5362.80006
+  tps: 3802.86766
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SouloftheDead-40382"
  value: {
-  dps: 8024.91215
-  tps: 5695.70322
+  dps: 8011.55548
+  tps: 5686.21999
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SparkofLife-37657"
  value: {
-  dps: 7963.37873
-  tps: 5651.60429
+  dps: 7963.72971
+  tps: 5651.46266
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 8070.50825
-  tps: 5726.81938
+  dps: 8046.03351
+  tps: 5710.27119
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-StormshroudArmor"
  value: {
-  dps: 6053.00399
-  tps: 4295.95996
+  dps: 6058.18796
+  tps: 4298.23587
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 8142.79817
-  tps: 5777.08854
+  dps: 8127.0879
+  tps: 5765.93424
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 8136.08455
-  tps: 5772.32481
+  dps: 8120.38638
+  tps: 5761.1791
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 8124.33572
-  tps: 5763.98828
+  dps: 8108.65873
+  tps: 5752.85761
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 7445.2008
-  tps: 5283.43392
+  dps: 7434.42061
+  tps: 5276.20716
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TheFistsofFury"
  value: {
-  dps: 6972.18242
-  tps: 4944.89577
+  dps: 6969.8589
+  tps: 4945.14714
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 8175.7533
-  tps: 5801.4877
+  dps: 8158.50934
+  tps: 5791.5549
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 8276.52256
-  tps: 5875.49069
+  dps: 8286.35396
+  tps: 5882.47098
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 8396.48964
-  tps: 5960.30902
+  dps: 8372.6304
+  tps: 5942.54215
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 8107.55168
-  tps: 5752.07895
+  dps: 8091.90494
+  tps: 5740.96977
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 8107.55168
-  tps: 5752.07895
+  dps: 8091.90494
+  tps: 5740.96977
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7963.97091
-  tps: 5651.24602
+  dps: 7973.19615
+  tps: 5658.98042
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 8107.55168
-  tps: 5752.07895
+  dps: 8091.90494
+  tps: 5740.96977
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 8107.55168
-  tps: 5752.07895
+  dps: 8091.90494
+  tps: 5740.96977
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6148.50878
-  tps: 4363.33848
+  dps: 6147.95301
+  tps: 4363.71655
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 7177.88832
-  tps: 5094.26897
+  dps: 7175.69723
+  tps: 5092.7133
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7846.33221
-  tps: 5568.49912
+  dps: 7852.05651
+  tps: 5571.75595
  }
 }
 dps_results: {
  key: "TestSubtlety-Average-Default"
  value: {
-  dps: 8311.52053
-  tps: 5898.38628
+  dps: 8311.04721
+  tps: 5898.06657
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-p2_hemosub-Subtlety--FullBuffs-LongMultiTarget"
  value: {
-  dps: 31063.54723
-  tps: 22055.11853
+  dps: 31003.75309
+  tps: 22012.6647
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-p2_hemosub-Subtlety--FullBuffs-LongSingleTarget"
  value: {
-  dps: 8302.87853
-  tps: 5893.03954
+  dps: 8293.74535
+  tps: 5886.55499
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-p2_hemosub-Subtlety--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9202.82134
-  tps: 6497.37367
+  dps: 9190.06172
+  tps: 6488.31434
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-p2_hemosub-Subtlety--NoBuffs-LongMultiTarget"
  value: {
-  dps: 19249.68587
-  tps: 13667.27697
+  dps: 19128.87522
+  tps: 13581.5014
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-p2_hemosub-Subtlety--NoBuffs-LongSingleTarget"
  value: {
-  dps: 4091.27574
-  tps: 2903.22932
+  dps: 4080.84021
+  tps: 2895.98982
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-BloodElf-p2_hemosub-Subtlety--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3990.28275
-  tps: 2821.77203
+  dps: 3951.18614
+  tps: 2797.29313
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p2_hemosub-Subtlety--FullBuffs-LongMultiTarget"
  value: {
-  dps: 30736.39303
-  tps: 21822.83905
+  dps: 30778.33038
+  tps: 21852.61457
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p2_hemosub-Subtlety--FullBuffs-LongSingleTarget"
  value: {
-  dps: 8260.81378
-  tps: 5863.79055
+  dps: 8262.17181
+  tps: 5865.74484
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p2_hemosub-Subtlety--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9119.98395
-  tps: 6461.14512
+  dps: 9103.16406
+  tps: 6449.203
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p2_hemosub-Subtlety--NoBuffs-LongMultiTarget"
  value: {
-  dps: 19003.33314
-  tps: 13492.36653
+  dps: 19040.08521
+  tps: 13518.4605
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p2_hemosub-Subtlety--NoBuffs-LongSingleTarget"
  value: {
-  dps: 4064.43692
-  tps: 2883.14709
+  dps: 4073.19017
+  tps: 2889.89032
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p2_hemosub-Subtlety--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3954.08906
-  tps: 2798.18684
+  dps: 3963.10672
+  tps: 2804.58938
  }
 }
 dps_results: {
  key: "TestSubtlety-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7555.35686
-  tps: 5363.04174
+  dps: 7588.61002
+  tps: 5384.20883
  }
 }

--- a/sim/rogue/hack_and_slash.go
+++ b/sim/rogue/hack_and_slash.go
@@ -19,7 +19,7 @@ func (rogue *Rogue) registerHackAndSlash(mask core.ProcMask) {
 		Label:    "Hack and Slash",
 		Duration: core.NeverExpires,
 		OnInit: func(aura *core.Aura, sim *core.Simulation) {
-			config := rogue.AutoAttacks.MHConfig
+			config := *rogue.AutoAttacks.MHConfig()
 			config.ActionID = core.ActionID{SpellID: 13964}
 			hackAndSlashSpell = rogue.GetOrRegisterSpell(config)
 		},

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -152,8 +152,8 @@ func (rogue *Rogue) HasMinorGlyph(glyph proto.RogueMinorGlyph) bool {
 
 func (rogue *Rogue) Initialize() {
 	// Update auto crit multipliers now that we have the targets.
-	rogue.AutoAttacks.MHConfig.CritMultiplier = rogue.MeleeCritMultiplier(false)
-	rogue.AutoAttacks.OHConfig.CritMultiplier = rogue.MeleeCritMultiplier(false)
+	rogue.AutoAttacks.MHConfig().CritMultiplier = rogue.MeleeCritMultiplier(false)
+	rogue.AutoAttacks.OHConfig().CritMultiplier = rogue.MeleeCritMultiplier(false)
 
 	if rogue.Talents.QuickRecovery > 0 {
 		rogue.QuickRecoveryMetrics = rogue.NewEnergyMetrics(core.ActionID{SpellID: 31245})

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -26,7 +26,7 @@ func (rogue *Rogue) ApplyTalents() {
 	rogue.AddStat(stats.SpellHit, core.SpellHitRatingPerHitChance*1*float64(rogue.Talents.Precision))
 	rogue.AddStat(stats.Expertise, core.ExpertisePerQuarterPercentReduction*5*float64(rogue.Talents.WeaponExpertise))
 	rogue.AddStat(stats.ArmorPenetration, core.ArmorPenPerPercentArmor*3*float64(rogue.Talents.SerratedBlades))
-	rogue.AutoAttacks.OHConfig.DamageMultiplier *= rogue.dwsMultiplier()
+	rogue.AutoAttacks.OHConfig().DamageMultiplier *= rogue.dwsMultiplier()
 
 	if rogue.Talents.Deadliness > 0 {
 		rogue.MultiplyStat(stats.AttackPower, 1.0+0.02*float64(rogue.Talents.Deadliness))

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -46,978 +46,978 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7555.70751
-  tps: 4146.16802
+  dps: 7555.38801
+  tps: 4145.99422
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7575.8299
-  tps: 4157.77017
+  dps: 7575.51041
+  tps: 4157.59638
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7436.37753
-  tps: 4078.62981
+  dps: 7436.24227
+  tps: 4078.54216
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7560.11433
-  tps: 4150.56538
+  dps: 7560.09746
+  tps: 4150.52766
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7392.11958
-  tps: 4051.84525
+  dps: 7391.80006
+  tps: 4051.67144
   hps: 95.40076
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7392.11958
-  tps: 4051.84525
+  dps: 7391.80006
+  tps: 4051.67144
   hps: 95.40076
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7433.40234
-  tps: 4075.52289
+  dps: 7433.26708
+  tps: 4075.43524
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7218.22597
-  tps: 3942.27936
+  dps: 7218.09374
+  tps: 3942.19381
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 7859.6865
-  tps: 4335.4831
+  dps: 7859.54875
+  tps: 4335.39386
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50035"
  value: {
-  dps: 7431.50003
-  tps: 4067.04249
+  dps: 7437.85979
+  tps: 4070.24045
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50692"
  value: {
-  dps: 7494.96132
-  tps: 4103.32651
+  dps: 7497.40332
+  tps: 4104.5592
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6106.90704
-  tps: 3320.54843
+  dps: 6104.30473
+  tps: 3319.88219
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6049.06391
-  tps: 3290.0928
+  dps: 6047.03111
+  tps: 3290.49684
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7459.39216
-  tps: 3978.87546
+  dps: 7459.2569
+  tps: 3978.79032
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7603.56008
-  tps: 4179.49066
+  dps: 7603.4221
+  tps: 4179.40126
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7603.56008
-  tps: 4179.49066
+  dps: 7603.4221
+  tps: 4179.40126
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7604.04958
-  tps: 4178.30315
+  dps: 7603.9121
+  tps: 4178.21406
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7391.9844
-  tps: 4051.76865
+  dps: 7391.66488
+  tps: 4051.59484
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7391.9844
-  tps: 4051.76865
+  dps: 7391.66488
+  tps: 4051.59484
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7391.986
-  tps: 4051.76865
+  dps: 7391.66649
+  tps: 4051.59484
   hps: 64
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7520.86281
-  tps: 4129.12148
+  dps: 7520.72483
+  tps: 4129.03208
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7504.49452
-  tps: 4130.77984
+  dps: 7504.35654
+  tps: 4130.69043
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7586.40907
-  tps: 4156.22784
+  dps: 7586.30423
+  tps: 4156.15619
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 7641.78544
-  tps: 4200.42202
+  dps: 7643.76181
+  tps: 4203.01798
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7750.86068
-  tps: 4239.4359
+  dps: 7754.50291
+  tps: 4241.37277
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7480.70981
-  tps: 4109.37987
+  dps: 7481.35418
+  tps: 4108.69773
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7720.31157
-  tps: 4218.45001
+  dps: 7715.25263
+  tps: 4214.51392
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7766.48472
-  tps: 4237.77282
+  dps: 7763.2699
+  tps: 4234.05411
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7391.986
-  tps: 4051.76865
+  dps: 7391.66649
+  tps: 4051.59484
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7452.51508
-  tps: 4086.11108
+  dps: 7452.37982
+  tps: 4086.02344
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7840.90705
-  tps: 4317.8889
+  dps: 7840.77156
+  tps: 4317.80124
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7738.38526
-  tps: 4251.9222
+  dps: 7738.24976
+  tps: 4251.83454
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 6835.46917
-  tps: 3726.82073
+  dps: 6840.36128
+  tps: 3727.55867
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterGarb"
  value: {
-  dps: 6477.98746
-  tps: 3534.19339
+  dps: 6477.88381
+  tps: 3534.12652
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7436.37753
-  tps: 4078.62981
+  dps: 7436.24227
+  tps: 4078.54216
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7485.77138
-  tps: 4110.50662
+  dps: 7485.63635
+  tps: 4110.41916
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7449.80319
-  tps: 4084.78926
+  dps: 7449.66793
+  tps: 4084.70162
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7445.58412
-  tps: 4082.40718
+  dps: 7445.44886
+  tps: 4082.31954
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7504.68631
-  tps: 4115.8593
+  dps: 7502.36413
+  tps: 4114.93945
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7391.9844
-  tps: 4051.76865
+  dps: 7391.66488
+  tps: 4051.59484
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7436.37753
-  tps: 4078.62981
+  dps: 7436.24227
+  tps: 4078.54216
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7518.70869
-  tps: 4134.27919
+  dps: 7518.57071
+  tps: 4134.18979
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7632.19555
-  tps: 4194.4935
+  dps: 7633.42746
+  tps: 4195.50309
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7409.06231
-  tps: 4059.52698
+  dps: 7408.92576
+  tps: 4059.43863
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7493.51102
-  tps: 4110.3068
+  dps: 7493.19152
+  tps: 4110.133
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7571.96249
-  tps: 4142.49483
+  dps: 7571.82451
+  tps: 4142.40543
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7459.39216
-  tps: 4091.90496
+  dps: 7459.2569
+  tps: 4091.81732
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7454.78923
-  tps: 4089.24993
+  dps: 7454.65397
+  tps: 4089.16229
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 8351.8297
-  tps: 4544.38994
+  dps: 8351.67259
+  tps: 4544.28828
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 7887.78356
-  tps: 4357.45264
+  dps: 7886.76999
+  tps: 4357.13911
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 7654.72729
-  tps: 4207.88908
+  dps: 7656.70543
+  tps: 4210.48826
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7598.0001
-  tps: 4162.10627
+  dps: 7597.86431
+  tps: 4162.01841
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7448.69591
-  tps: 4084.46563
+  dps: 7448.3764
+  tps: 4084.29183
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 7115.92868
-  tps: 3848.56103
+  dps: 7087.14735
+  tps: 3829.83659
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sWartide"
  value: {
-  dps: 6263.93197
-  tps: 3387.21387
+  dps: 6256.8866
+  tps: 3384.95856
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7565.77165
-  tps: 4151.9691
+  dps: 7565.45216
+  tps: 4151.7953
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7588.63801
-  tps: 4165.15337
+  dps: 7588.31851
+  tps: 4164.97957
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7531.9473
-  tps: 4140.18252
+  dps: 7531.80932
+  tps: 4140.09312
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 7617.08802
-  tps: 4185.39433
+  dps: 7619.08171
+  tps: 4187.99004
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-49982"
  value: {
-  dps: 7603.56008
-  tps: 4179.49066
+  dps: 7603.4221
+  tps: 4179.40126
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-50641"
  value: {
-  dps: 7603.56008
-  tps: 4179.49066
+  dps: 7603.4221
+  tps: 4179.40126
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7562.37217
-  tps: 4153.02847
+  dps: 7562.05268
+  tps: 4152.85467
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7449.80319
-  tps: 4084.78926
+  dps: 7449.66793
+  tps: 4084.70162
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7445.58412
-  tps: 4082.40718
+  dps: 7445.44886
+  tps: 4082.31954
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7524.90818
-  tps: 4124.81286
+  dps: 7524.58145
+  tps: 4124.63502
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7447.04072
-  tps: 4082.12983
+  dps: 7446.90494
+  tps: 4082.04185
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7472.96508
-  tps: 4099.12253
+  dps: 7472.82893
+  tps: 4099.03431
   hps: 11.01615
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50179"
  value: {
-  dps: 7603.56008
-  tps: 4179.49066
+  dps: 7603.4221
+  tps: 4179.40126
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50708"
  value: {
-  dps: 7603.56008
-  tps: 4179.49066
+  dps: 7603.4221
+  tps: 4179.40126
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7391.986
-  tps: 4051.76865
+  dps: 7391.66649
+  tps: 4051.59484
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7391.9844
-  tps: 4051.76865
+  dps: 7391.66488
+  tps: 4051.59484
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7513.99213
-  tps: 4123.86566
+  dps: 7513.85664
+  tps: 4123.778
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Nibelung-49992"
  value: {
-  dps: 7603.56008
-  tps: 4179.49066
+  dps: 7603.4221
+  tps: 4179.40126
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Nibelung-50648"
  value: {
-  dps: 7603.56008
-  tps: 4179.49066
+  dps: 7603.4221
+  tps: 4179.40126
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7391.98761
-  tps: 4051.76865
+  dps: 7391.66809
+  tps: 4051.59484
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7467.26231
-  tps: 4095.9796
+  dps: 7467.12634
+  tps: 4095.89149
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7472.96508
-  tps: 4099.12253
+  dps: 7472.82893
+  tps: 4099.03431
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7391.97864
-  tps: 4051.76865
+  dps: 7391.65913
+  tps: 4051.59484
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7391.9844
-  tps: 4051.76865
+  dps: 7391.66488
+  tps: 4051.59484
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7391.9844
-  tps: 4051.76865
+  dps: 7391.66488
+  tps: 4051.59484
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7436.37753
-  tps: 4078.62981
+  dps: 7436.24227
+  tps: 4078.54216
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7436.37753
-  tps: 4078.62981
+  dps: 7436.24227
+  tps: 4078.54216
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7391.9844
-  tps: 4051.76865
+  dps: 7391.66488
+  tps: 4051.59484
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7809.92124
-  tps: 4331.89167
+  dps: 7809.78574
+  tps: 4331.80401
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7860.45066
-  tps: 4365.24143
+  dps: 7860.31516
+  tps: 4365.15377
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7603.56008
-  tps: 4179.49066
+  dps: 7603.4221
+  tps: 4179.40126
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 7670.4424
-  tps: 4216.95622
+  dps: 7672.42268
+  tps: 4219.55931
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7447.74989
-  tps: 4087.76957
+  dps: 7447.61463
+  tps: 4087.68193
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7391.986
-  tps: 4051.76865
+  dps: 7391.66649
+  tps: 4051.59484
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 7610.6345
-  tps: 4181.79633
+  dps: 7612.62397
+  tps: 4184.38949
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7391.986
-  tps: 4051.76865
+  dps: 7391.66649
+  tps: 4051.59484
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7603.56008
-  tps: 4179.49066
+  dps: 7603.4221
+  tps: 4179.40126
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7391.9844
-  tps: 4051.76865
+  dps: 7391.66488
+  tps: 4051.59484
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7391.9844
-  tps: 4051.76865
+  dps: 7391.66488
+  tps: 4051.59484
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkycallTotem-33506"
  value: {
-  dps: 7594.46912
-  tps: 4172.52428
+  dps: 7594.86045
+  tps: 4173.75299
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterHarness"
  value: {
-  dps: 5436.57722
-  tps: 2938.57431
+  dps: 5436.47878
+  tps: 2938.51089
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterRegalia"
  value: {
-  dps: 5376.73633
-  tps: 2922.99663
+  dps: 5377.8102
+  tps: 2923.77735
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7516.75358
-  tps: 4128.52082
+  dps: 7516.61809
+  tps: 4128.43315
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7528.43586
-  tps: 4132.94452
+  dps: 7525.17234
+  tps: 4131.05833
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7460.58347
-  tps: 4091.32145
+  dps: 7460.26396
+  tps: 4091.14765
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7499.0876
-  tps: 4115.0569
+  dps: 7498.54668
+  tps: 4114.73053
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SparkofLife-37657"
  value: {
-  dps: 7483.46741
-  tps: 4111.45443
+  dps: 7483.33191
+  tps: 4111.36677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7535.6572
-  tps: 4116.94595
+  dps: 7535.5081
+  tps: 4118.75467
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 7611.43712
-  tps: 4179.45417
+  dps: 7613.44673
+  tps: 4182.0575
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StormshroudArmor"
  value: {
-  dps: 5704.04582
-  tps: 3092.85063
+  dps: 5699.96748
+  tps: 3089.25307
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7472.96508
-  tps: 4099.12253
+  dps: 7472.82893
+  tps: 4099.03431
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7467.26231
-  tps: 4095.9796
+  dps: 7467.12634
+  tps: 4095.89149
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7451.37583
-  tps: 4087.08781
+  dps: 7451.24015
+  tps: 4086.99989
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7391.98734
-  tps: 4051.76865
+  dps: 7391.66783
+  tps: 4051.59484
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7447.76283
-  tps: 4082.01612
+  dps: 7447.62524
+  tps: 4081.9271
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheFistsofFury"
  value: {
-  dps: 6562.61385
-  tps: 3561.08212
+  dps: 6566.6149
+  tps: 3562.77847
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7391.9844
-  tps: 4051.76865
+  dps: 7391.66488
+  tps: 4051.59484
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 7338.47659
-  tps: 4035.29101
+  dps: 7338.49388
+  tps: 4035.19032
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sRegalia"
  value: {
-  dps: 6990.31757
-  tps: 3851.66718
+  dps: 6986.19191
+  tps: 3849.32295
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7507.02633
-  tps: 4125.15935
+  dps: 7508.98057
+  tps: 4126.89033
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TidefuryRaiment"
  value: {
-  dps: 5399.74949
-  tps: 2916.38183
+  dps: 5399.65184
+  tps: 2916.3189
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7581.29971
-  tps: 4163.13061
+  dps: 7581.15939
+  tps: 4163.04058
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7603.47318
-  tps: 4178.03518
+  dps: 7606.10592
+  tps: 4180.1133
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7459.39216
-  tps: 4091.90496
+  dps: 7459.2569
+  tps: 4091.81732
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7454.78923
-  tps: 4089.24993
+  dps: 7454.65397
+  tps: 4089.16229
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7531.4511
-  tps: 4131.4265
+  dps: 7531.3156
+  tps: 4131.33883
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 7830.20801
-  tps: 4316.73836
+  dps: 7825.30428
+  tps: 4313.61703
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofQuakingEarth-47667"
  value: {
-  dps: 7722.86207
-  tps: 4238.33882
+  dps: 7725.68111
+  tps: 4241.60004
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 7859.54114
-  tps: 4308.93499
+  dps: 7861.50642
+  tps: 4311.55975
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheElementalPlane-40708"
  value: {
-  dps: 7594.41896
-  tps: 4178.33417
+  dps: 7594.32474
+  tps: 4178.2754
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7454.78923
-  tps: 4089.24993
+  dps: 7454.65397
+  tps: 4089.16229
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7459.39216
-  tps: 4091.90496
+  dps: 7459.2569
+  tps: 4091.81732
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6052.75801
-  tps: 3289.23846
+  dps: 6047.53886
+  tps: 3285.16169
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7798.82481
-  tps: 4282.85217
+  dps: 7799.23226
+  tps: 4283.14429
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7491.54376
-  tps: 4091.85804
+  dps: 7491.22424
+  tps: 4091.68423
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 7298.01268
-  tps: 4007.48138
+  dps: 7302.40708
+  tps: 4011.40106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerGarb"
  value: {
-  dps: 7005.31071
-  tps: 3863.97312
+  dps: 7005.20352
+  tps: 3863.90387
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 7687.08193
-  tps: 4226.55672
+  dps: 7689.06448
+  tps: 4229.16396
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 7623.51762
-  tps: 4189.17589
+  dps: 7624.36137
+  tps: 4189.58851
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_ft-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26288.76937
-  tps: 15742.3351
+  dps: 26288.81397
+  tps: 15742.56368
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_ft-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7706.46401
-  tps: 4192.55465
+  dps: 7703.39171
+  tps: 4191.54959
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_ft-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9615.77337
-  tps: 4589.52519
+  dps: 9615.0837
+  tps: 4589.07833
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_ft-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13767.69616
-  tps: 8868.01007
+  dps: 13784.84683
+  tps: 8878.03048
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_ft-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4020.55422
-  tps: 2137.38683
+  dps: 4020.59858
+  tps: 2137.41962
  }
 }
 dps_results: {
@@ -1030,78 +1030,78 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_wf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25796.29271
-  tps: 15495.29935
+  dps: 25761.17061
+  tps: 15476.15133
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_wf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7773.50119
-  tps: 4243.77471
+  dps: 7770.60723
+  tps: 4240.93173
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_wf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9645.83537
-  tps: 4617.67778
+  dps: 9645.1457
+  tps: 4617.23092
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_wf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13223.09985
-  tps: 8443.4259
+  dps: 13201.57219
+  tps: 8428.77325
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_wf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4066.30461
-  tps: 2165.56054
+  dps: 4062.75145
+  tps: 2165.3211
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_wf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5338.3402
-  tps: 2514.32912
+  dps: 5340.22394
+  tps: 2516.33238
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-phase_3-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26130.60055
-  tps: 15713.73209
+  dps: 26130.72756
+  tps: 15708.87515
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-phase_3-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7669.16104
-  tps: 4174.80073
+  dps: 7670.45465
+  tps: 4175.88237
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-phase_3-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9576.38176
-  tps: 4561.8082
+  dps: 9576.19352
+  tps: 4561.71596
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-phase_3-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13601.80543
-  tps: 8701.71153
+  dps: 13587.74105
+  tps: 8686.55786
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-phase_3-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3998.98371
-  tps: 2119.14893
+  dps: 3995.95405
+  tps: 2117.37687
  }
 }
 dps_results: {
@@ -1114,36 +1114,36 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_ft-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21795.44709
-  tps: 13271.32898
+  dps: 21768.03231
+  tps: 13251.18925
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_ft-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6556.30191
-  tps: 3510.95709
+  dps: 6549.52793
+  tps: 3502.42615
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_ft-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8494.81669
-  tps: 3914.41667
+  dps: 8493.19042
+  tps: 3913.3226
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_ft-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10692.09644
-  tps: 7426.25233
+  dps: 10679.7829
+  tps: 7426.73635
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_ft-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2993.48268
-  tps: 1630.55304
+  dps: 2993.07639
+  tps: 1630.34376
  }
 }
 dps_results: {
@@ -1156,288 +1156,288 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_wf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20979.4015
-  tps: 12736.70809
+  dps: 20979.12553
+  tps: 12736.51577
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_wf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6636.41267
-  tps: 3567.04956
+  dps: 6639.63523
+  tps: 3568.23371
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_wf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8621.09489
-  tps: 4005.03127
+  dps: 8619.46862
+  tps: 4003.93719
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_wf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9958.99597
-  tps: 6917.89332
+  dps: 9927.93938
+  tps: 6911.53506
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_wf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3049.77412
-  tps: 1667.28149
+  dps: 3042.35975
+  tps: 1663.03992
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_wf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4085.11766
-  tps: 1936.40106
+  dps: 4086.67052
+  tps: 1937.48807
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-phase_3-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21333.69354
-  tps: 12920.62246
+  dps: 21334.49142
+  tps: 12921.37943
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-phase_3-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6521.18018
-  tps: 3489.70213
+  dps: 6516.21269
+  tps: 3486.84939
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-phase_3-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8435.62198
-  tps: 3890.32689
+  dps: 8435.06146
+  tps: 3889.97406
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-phase_3-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10405.28766
-  tps: 7217.42592
+  dps: 10411.97261
+  tps: 7210.32116
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-phase_3-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2980.10175
-  tps: 1616.57632
+  dps: 2984.25684
+  tps: 1620.45335
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-phase_3-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4068.58061
-  tps: 1931.99696
+  dps: 4062.06457
+  tps: 1927.93793
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_ft-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26040.45754
-  tps: 15819.87469
+  dps: 26036.65881
+  tps: 15825.85704
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_ft-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7603.56008
-  tps: 4179.49066
+  dps: 7603.4221
+  tps: 4179.40126
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_ft-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9601.81872
-  tps: 4685.67433
+  dps: 9616.37206
+  tps: 4696.34995
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_ft-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13373.19797
-  tps: 8678.62029
+  dps: 13352.43637
+  tps: 8665.19533
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_ft-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3987.69956
-  tps: 2145.80698
+  dps: 3981.3504
+  tps: 2141.40901
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_ft-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5177.46948
-  tps: 2506.18553
+  dps: 5177.86816
+  tps: 2505.77375
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_wf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25371.04022
-  tps: 15301.47023
+  dps: 25388.0402
+  tps: 15322.82423
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_wf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7680.72356
-  tps: 4234.29114
+  dps: 7679.09477
+  tps: 4232.62599
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_wf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9636.78628
-  tps: 4721.10288
+  dps: 9634.44391
+  tps: 4718.42972
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_wf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12987.24686
-  tps: 8421.70789
+  dps: 12992.30982
+  tps: 8435.1971
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_wf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4050.35752
-  tps: 2189.65744
+  dps: 4041.35222
+  tps: 2184.45165
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_wf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5258.27118
-  tps: 2550.55493
+  dps: 5252.70402
+  tps: 2547.45399
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-phase_3-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25754.65936
-  tps: 15554.99758
+  dps: 25725.34525
+  tps: 15536.37253
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-phase_3-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7629.30233
-  tps: 4199.3597
+  dps: 7635.27448
+  tps: 4205.88127
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-phase_3-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9530.30573
-  tps: 4663.09834
+  dps: 9522.56879
+  tps: 4655.77643
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-phase_3-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13317.72649
-  tps: 8614.09622
+  dps: 13390.16902
+  tps: 8674.49828
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-phase_3-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3939.93628
-  tps: 2118.06546
+  dps: 3940.3364
+  tps: 2118.11034
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-phase_3-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5152.86995
-  tps: 2480.43284
+  dps: 5159.24251
+  tps: 2485.04316
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_ft-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21508.80933
-  tps: 13149.16065
+  dps: 21508.47681
+  tps: 13148.64825
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_ft-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6494.6328
-  tps: 3493.04504
+  dps: 6494.30745
+  tps: 3492.82616
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_ft-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8397.42616
-  tps: 3916.3862
+  dps: 8395.79942
+  tps: 3915.29181
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_ft-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10520.26167
-  tps: 7341.26268
+  dps: 10516.84746
+  tps: 7347.45431
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_ft-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2969.44345
-  tps: 1628.12274
+  dps: 2969.44202
+  tps: 1628.10401
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_ft-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3969.23916
-  tps: 1897.49183
+  dps: 3968.80449
+  tps: 1897.27885
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_wf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21036.32904
-  tps: 12869.59758
+  dps: 21058.37728
+  tps: 12907.98965
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_wf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6563.83628
-  tps: 3548.71796
+  dps: 6562.69585
+  tps: 3550.39829
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_wf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8477.46107
-  tps: 3979.84841
+  dps: 8475.83432
+  tps: 3978.75402
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_wf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9874.13786
-  tps: 6962.9888
+  dps: 9894.60901
+  tps: 6972.19506
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_wf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3024.02085
-  tps: 1666.89355
+  dps: 3031.30887
+  tps: 1671.98393
  }
 }
 dps_results: {
@@ -1450,22 +1450,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-phase_3-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21378.83741
-  tps: 13090.23159
+  dps: 21387.2867
+  tps: 13085.27147
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-phase_3-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6495.39721
-  tps: 3495.84742
+  dps: 6495.16588
+  tps: 3495.71092
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-phase_3-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8430.01037
-  tps: 3953.85926
+  dps: 8429.4497
+  tps: 3953.50633
  }
 }
 dps_results: {
@@ -1478,21 +1478,21 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-phase_3-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2930.60404
-  tps: 1599.9115
+  dps: 2936.54919
+  tps: 1604.65442
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-phase_3-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4030.72513
-  tps: 1945.96685
+  dps: 4030.64483
+  tps: 1946.11958
  }
 }
 dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7267.4586
-  tps: 3972.77173
+  dps: 7266.06941
+  tps: 3971.59846
  }
 }

--- a/sim/shaman/enhancement/enhancement.go
+++ b/sim/shaman/enhancement/enhancement.go
@@ -160,25 +160,25 @@ func (enh *EnhancementShaman) ApplySyncType(syncType proto.ShamanSyncType) {
 
 	switch syncType {
 	case proto.ShamanSyncType_SyncMainhandOffhandSwings:
-		enh.AutoAttacks.ReplaceMHSwing = func(sim *core.Simulation, mhSwingSpell *core.Spell) *core.Spell {
+		enh.AutoAttacks.SetReplaceMHSwing(func(sim *core.Simulation, mhSwingSpell *core.Spell) *core.Spell {
 			if aa := &enh.AutoAttacks; aa.OffhandSwingAt()-sim.CurrentTime > FlurryICD {
 				if nextMHSwingAt := sim.CurrentTime + aa.MainhandSwingSpeed(); nextMHSwingAt > aa.OffhandSwingAt() {
 					aa.SetOffhandSwingAt(nextMHSwingAt)
 				}
 			}
 			return mhSwingSpell
-		}
+		})
 	case proto.ShamanSyncType_DelayOffhandSwings:
-		enh.AutoAttacks.ReplaceMHSwing = func(sim *core.Simulation, mhSwingSpell *core.Spell) *core.Spell {
+		enh.AutoAttacks.SetReplaceMHSwing(func(sim *core.Simulation, mhSwingSpell *core.Spell) *core.Spell {
 			if aa := &enh.AutoAttacks; aa.OffhandSwingAt()-sim.CurrentTime > FlurryICD {
 				if nextMHSwingAt := sim.CurrentTime + aa.MainhandSwingSpeed() + 100*time.Millisecond; nextMHSwingAt > aa.OffhandSwingAt() {
 					aa.SetOffhandSwingAt(nextMHSwingAt)
 				}
 			}
 			return mhSwingSpell
-		}
+		})
 	default:
-		enh.AutoAttacks.ReplaceMHSwing = nil
+		enh.AutoAttacks.SetReplaceMHSwing(nil)
 	}
 }
 

--- a/sim/shaman/enhancement/priority_rotation.go
+++ b/sim/shaman/enhancement/priority_rotation.go
@@ -202,7 +202,7 @@ func (rotation *PriorityRotation) buildPriorityRotation(enh *EnhancementShaman) 
 	lavaLash := Spell{
 		condition: func(sim *core.Simulation, target *core.Unit) bool {
 			//Checking if we learned the spell, ie untalented
-			return enh.LavaLash != nil && enh.AutoAttacks.IsDualWielding()
+			return enh.LavaLash != nil && enh.AutoAttacks.IsDualWielding
 		},
 		cast: func(sim *core.Simulation, target *core.Unit) bool {
 			//TODO add in LL delay so we don't lose flametongues, if Last attack = current time

--- a/sim/shaman/stormstrike.go
+++ b/sim/shaman/stormstrike.go
@@ -134,7 +134,7 @@ func (shaman *Shaman) registerStormstrikeSpell() {
 
 				mhHit(sim, target, spell)
 
-				if shaman.AutoAttacks.IsDualWielding() {
+				if shaman.AutoAttacks.IsDualWielding {
 					ohHit(sim, target, spell)
 				}
 

--- a/sim/shaman/talents.go
+++ b/sim/shaman/talents.go
@@ -47,8 +47,8 @@ func (shaman *Shaman) ApplyTalents() {
 
 	if shaman.Talents.SpiritWeapons {
 		shaman.PseudoStats.CanParry = true
-		shaman.AutoAttacks.MHConfig.ThreatMultiplier *= 0.7 // TODO this looks fishy
-		shaman.AutoAttacks.OHConfig.ThreatMultiplier *= 0.7
+		shaman.AutoAttacks.MHConfig().ThreatMultiplier *= 0.7 // TODO this looks fishy
+		shaman.AutoAttacks.OHConfig().ThreatMultiplier *= 0.7
 	}
 
 	shaman.applyElementalFocus()

--- a/sim/warlock/TestAffliction.results
+++ b/sim/warlock/TestAffliction.results
@@ -46,42 +46,42 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 11589.70341
+  dps: 11589.67197
   tps: 10452.41374
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 11638.96447
+  dps: 11638.93297
   tps: 10499.40259
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 11413.90321
+  dps: 11413.87238
   tps: 10287.8283
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 11442.21264
+  dps: 11442.18137
   tps: 10308.57993
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 11219.3566
+  dps: 11219.32577
   tps: 10104.34087
   hps: 95.37766
  }
@@ -89,7 +89,7 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 11219.3566
+  dps: 11219.32577
   tps: 10104.34087
   hps: 95.37766
  }
@@ -97,49 +97,49 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 11491.63633
+  dps: 11491.60505
   tps: 10354.42035
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8955.39497
+  dps: 8955.3686
   tps: 8057.14462
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 11496.24105
+  dps: 11496.2097
   tps: 10154.62872
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11676.35017
+  dps: 11676.3189
   tps: 10542.71746
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
   hps: 64
  }
@@ -147,616 +147,616 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 11571.89745
+  dps: 11571.86984
   tps: 10515.76953
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 11299.19985
+  dps: 11299.16902
   tps: 10176.26635
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 11350.027
+  dps: 11349.99617
   tps: 10230.42741
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 11336.61438
+  dps: 11336.58355
   tps: 10220.84977
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Death'sChoice-47464"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 11258.51335
+  dps: 11258.48252
   tps: 10143.37591
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DeathbringerGarb"
  value: {
-  dps: 9925.28495
+  dps: 9925.25797
   tps: 8937.44783
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Defender'sCode-40257"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 11468.64221
+  dps: 11468.61093
   tps: 10335.0095
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11993.51457
+  dps: 11993.48358
   tps: 10846.68163
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11904.82651
+  dps: 11904.79561
   tps: 10766.46936
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 11442.21264
+  dps: 11442.18137
   tps: 10308.57993
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 11550.43891
+  dps: 11550.40755
   tps: 10409.37533
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 11466.29094
+  dps: 11466.25966
   tps: 10332.65823
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 11462.67734
+  dps: 11462.64607
   tps: 10329.04463
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 11415.61284
+  dps: 11415.58201
   tps: 10301.0259
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 11442.21264
+  dps: 11442.18137
   tps: 10308.57993
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 11392.41888
+  dps: 11392.38805
   tps: 10279.20572
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 11613.66401
+  dps: 11613.63318
   tps: 10483.35914
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 11249.84836
+  dps: 11249.81753
   tps: 10132.57025
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 11454.84677
+  dps: 11454.81557
   tps: 10326.95014
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForgeEmber-37660"
  value: {
-  dps: 11451.53994
+  dps: 11451.50911
   tps: 10328.09448
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 11496.24105
+  dps: 11496.2097
   tps: 10359.9915
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 11483.13215
+  dps: 11483.10081
   tps: 10346.93252
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FuturesightRune-38763"
  value: {
-  dps: 11396.70013
+  dps: 11396.66909
   tps: 10272.15143
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 9767.03013
+  dps: 9767.00232
   tps: 8803.57053
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 11606.44686
+  dps: 11606.41539
   tps: 10468.57327
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 11672.86848
+  dps: 11672.83693
   tps: 10531.51463
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 11328.93517
+  dps: 11328.90434
   tps: 10205.04178
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 10182.44957
+  dps: 10182.41944
   tps: 9094.66969
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 11619.71969
+  dps: 11619.6888
   tps: 10481.11354
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 11466.29094
+  dps: 11466.25966
   tps: 10332.65823
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 11462.67734
+  dps: 11462.64607
   tps: 10329.04463
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IncisorFragment-37723"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 11459.57037
+  dps: 11459.5391
   tps: 10323.93
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 11442.21264
+  dps: 11442.18137
   tps: 10308.57993
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 11421.26296
+  dps: 11421.23209
   tps: 10295.25432
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MaleficRaiment"
  value: {
-  dps: 7590.00232
+  dps: 7589.97796
   tps: 6721.58269
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 11315.56453
+  dps: 11315.5337
   tps: 10200.4271
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 11949.70402
+  dps: 11949.67282
   tps: 10816.94364
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 11442.21264
+  dps: 11442.18137
   tps: 10308.57993
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 11442.21264
+  dps: 11442.18137
   tps: 10308.57993
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PlagueheartGarb"
  value: {
-  dps: 9359.46773
+  dps: 9359.44073
   tps: 8392.88387
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 11442.21264
+  dps: 11442.18137
   tps: 10308.57993
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 11442.21264
+  dps: 11442.18137
   tps: 10308.57993
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 11613.09502
+  dps: 11613.06369
   tps: 10482.68486
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 11679.35305
+  dps: 11679.32166
   tps: 10546.02539
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11650.10483
+  dps: 11650.07356
   tps: 10516.47212
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 11448.68581
+  dps: 11448.65453
   tps: 10313.21361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 11570.03638
+  dps: 11570.00502
   tps: 10439.46262
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 11589.75558
+  dps: 11589.72415
   tps: 10453.99405
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulPreserver-37111"
  value: {
-  dps: 11373.8891
+  dps: 11373.85802
   tps: 10249.78418
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SouloftheDead-40382"
  value: {
-  dps: 11360.2256
+  dps: 11360.19477
   tps: 10246.13078
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SparkofLife-37657"
  value: {
-  dps: 11381.60186
+  dps: 11381.57103
   tps: 10259.64889
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 11198.52319
+  dps: 11198.49236
   tps: 10072.41303
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 11442.21264
+  dps: 11442.18137
   tps: 10308.57993
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 11442.21264
+  dps: 11442.18137
   tps: 10308.57993
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 11442.21264
+  dps: 11442.18137
   tps: 10308.57993
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 11304.64392
+  dps: 11304.61296
   tps: 10184.06172
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 11227.72664
+  dps: 11227.69581
   tps: 10109.72371
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 11219.88278
+  dps: 11219.85195
   tps: 10104.74534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 11442.21264
+  dps: 11442.18137
   tps: 10308.57993
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 11200.20378
+  dps: 11200.17331
   tps: 10072.41303
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 11200.20378
+  dps: 11200.17331
   tps: 10072.41303
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 11496.24105
+  dps: 11496.2097
   tps: 10359.9915
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 11483.13215
+  dps: 11483.10081
   tps: 10346.93252
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 11486.31437
+  dps: 11486.28331
   tps: 10362.89506
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 11483.13215
+  dps: 11483.10081
   tps: 10346.93252
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 11496.24105
+  dps: 11496.2097
   tps: 10359.9915
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WingedTalisman-37844"
  value: {
-  dps: 11364.28627
+  dps: 11364.25543
   tps: 10240.43639
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 11806.07212
+  dps: 11806.03711
   tps: 10670.62344
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p3_affliction_alliance-AffItemSwap--FullBuffs-LongMultiTarget"
  value: {
-  dps: 30582.98136
+  dps: 30582.95058
   tps: 35643.74638
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p3_affliction_alliance-AffItemSwap--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11724.38345
+  dps: 11724.35268
   tps: 10597.71332
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p3_affliction_alliance-AffItemSwap--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12726.4766
+  dps: 12726.32274
   tps: 11558.42963
  }
 }
@@ -784,21 +784,21 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Settings-Orc-p3_affliction_alliance-Affliction Warlock--FullBuffs-LongMultiTarget"
  value: {
-  dps: 33161.3041
+  dps: 33161.27282
   tps: 38262.64229
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p3_affliction_alliance-Affliction Warlock--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11676.35017
+  dps: 11676.3189
   tps: 10542.71746
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p3_affliction_alliance-Affliction Warlock--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12803.3077
+  dps: 12803.15133
   tps: 11637.50671
  }
 }
@@ -826,7 +826,7 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 11634.98248
+  dps: 11634.95167
   tps: 10542.71746
  }
 }

--- a/sim/warlock/TestDemonology.results
+++ b/sim/warlock/TestDemonology.results
@@ -46,42 +46,42 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 10604.36898
+  dps: 10604.30798
   tps: 8885.1363
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 10640.20902
+  dps: 10640.14789
   tps: 8916.36317
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 10471.77686
+  dps: 10471.71694
   tps: 8770.33561
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 10662.35912
+  dps: 10662.2963
   tps: 8920.39325
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10295.98408
+  dps: 10295.92428
   tps: 8616.2298
   hps: 98.20466
  }
@@ -89,7 +89,7 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10295.98408
+  dps: 10295.92428
   tps: 8616.2298
   hps: 98.20466
  }
@@ -97,49 +97,49 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 10668.02323
+  dps: 10667.96044
   tps: 8924.92243
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8341.78209
+  dps: 8341.7356
   tps: 6969.29925
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 10688.20693
+  dps: 10688.14397
   tps: 8765.37118
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 10879.42382
+  dps: 10879.36103
   tps: 9138.29292
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10352.67332
+  dps: 10352.6133
   tps: 8665.46136
   hps: 64
  }
@@ -147,616 +147,616 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 10968.31656
+  dps: 10968.26577
   tps: 9379.56995
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 10428.25453
+  dps: 10428.19472
   tps: 8748.06518
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 10464.82704
+  dps: 10464.76723
   tps: 8785.35934
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 10421.72496
+  dps: 10421.66512
   tps: 8734.68072
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Death'sChoice-47464"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10334.89623
+  dps: 10334.83643
   tps: 8654.70689
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DeathbringerGarb"
  value: {
-  dps: 9323.60353
+  dps: 9323.55579
   tps: 7853.2179
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 10677.46841
+  dps: 10677.40562
   tps: 8936.33751
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11091.71394
+  dps: 11091.65342
   tps: 9354.00944
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11016.25861
+  dps: 11016.19821
   tps: 9287.5221
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 10662.35912
+  dps: 10662.2963
   tps: 8920.39325
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 10693.91646
+  dps: 10693.85349
   tps: 8945.53008
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 10675.15882
+  dps: 10675.09603
   tps: 8934.02792
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 10671.16977
+  dps: 10671.10698
   tps: 8930.03887
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10508.48794
+  dps: 10508.42814
   tps: 8829.57244
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10332.49936
+  dps: 10332.43945
   tps: 8648.95559
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 10654.63883
+  dps: 10654.57604
   tps: 8913.50793
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 10447.11188
+  dps: 10447.05207
   tps: 8769.17559
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 10642.52833
+  dps: 10642.46846
   tps: 8935.15369
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10346.88763
+  dps: 10346.82782
   tps: 8661.34453
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10493.09432
+  dps: 10493.03378
   tps: 8789.11652
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForgeEmber-37660"
  value: {
-  dps: 10614.95234
+  dps: 10614.89225
   tps: 8909.05579
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 10688.20693
+  dps: 10688.14397
   tps: 8942.10206
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 10685.42688
+  dps: 10685.36395
   tps: 8940.21624
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10462.57071
+  dps: 10462.51043
   tps: 8762.40805
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 9175.07087
+  dps: 9175.02132
   tps: 7691.21526
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 10622.45931
+  dps: 10622.39824
   tps: 8900.97561
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 10668.03458
+  dps: 10667.97335
   tps: 8940.56507
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 10453.86273
+  dps: 10453.80293
   tps: 8775.51739
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 9615.25472
+  dps: 9615.19692
   tps: 7984.96246
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 10627.07595
+  dps: 10627.01591
   tps: 8903.85379
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 10675.15882
+  dps: 10675.09603
   tps: 8934.02792
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 10671.16977
+  dps: 10671.10698
   tps: 8930.03887
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IncisorFragment-37723"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 10668.89129
+  dps: 10668.8285
   tps: 8927.3497
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 10654.63883
+  dps: 10654.57604
   tps: 8913.50793
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10499.17866
+  dps: 10499.11872
   tps: 8794.14199
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MaleficRaiment"
  value: {
-  dps: 7250.6781
+  dps: 7250.63571
   tps: 5975.51356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 10394.69359
+  dps: 10394.63379
   tps: 8714.50425
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 10576.01732
+  dps: 10575.95678
   tps: 8872.03951
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 10654.63883
+  dps: 10654.57604
   tps: 8913.50793
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 10654.63883
+  dps: 10654.57604
   tps: 8913.50793
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PlagueheartGarb"
  value: {
-  dps: 8883.47395
+  dps: 8883.42606
   tps: 7445.29568
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 10661.12639
+  dps: 10661.06357
   tps: 8919.31291
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 10662.35912
+  dps: 10662.2963
   tps: 8920.39325
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 10753.53251
+  dps: 10753.47171
   tps: 9040.65571
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 10793.95595
+  dps: 10793.89503
   tps: 9076.93663
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 10857.05704
+  dps: 10856.99425
   tps: 9115.92614
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 10661.78434
+  dps: 10661.72155
   tps: 8918.29649
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10352.67332
+  dps: 10352.6133
   tps: 8665.46136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 10590.27084
+  dps: 10590.20999
   tps: 8876.56401
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 10619.35779
+  dps: 10619.29681
   tps: 8901.39628
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10419.53583
+  dps: 10419.47552
   tps: 8723.56962
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SouloftheDead-40382"
  value: {
-  dps: 10434.67425
+  dps: 10434.61444
   tps: 8754.95535
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SparkofLife-37657"
  value: {
-  dps: 10500.23482
+  dps: 10500.17502
   tps: 8812.6417
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 10487.61162
+  dps: 10487.55182
   tps: 8795.65399
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 10654.63883
+  dps: 10654.57604
   tps: 8913.50793
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 10654.63883
+  dps: 10654.57604
   tps: 8913.50793
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 10654.63883
+  dps: 10654.57604
   tps: 8913.50793
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10374.27507
+  dps: 10374.21495
   tps: 8683.67864
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10359.11739
+  dps: 10359.05756
   tps: 8670.92251
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10293.92291
+  dps: 10293.86311
   tps: 8613.73356
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 10654.63883
+  dps: 10654.57604
   tps: 8913.50793
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 10591.22432
+  dps: 10591.1627
   tps: 8889.47961
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 10591.22432
+  dps: 10591.1627
   tps: 8889.47961
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 10688.20693
+  dps: 10688.14397
   tps: 8942.10206
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 10685.42688
+  dps: 10685.36395
   tps: 8940.21624
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 10558.39672
+  dps: 10558.33646
   tps: 8867.6235
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 10685.42688
+  dps: 10685.36395
   tps: 8940.21624
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 10688.20693
+  dps: 10688.14397
   tps: 8942.10206
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10481.35226
+  dps: 10481.29225
   tps: 8780.40047
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 10984.9289
+  dps: 10984.86614
   tps: 9234.4239
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3_demo_alliance-Demonology Warlock--FullBuffs-LongMultiTarget"
  value: {
-  dps: 35688.50982
+  dps: 35688.44714
   tps: 39967.79205
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3_demo_alliance-Demonology Warlock--FullBuffs-LongSingleTarget"
  value: {
-  dps: 10879.42382
+  dps: 10879.36103
   tps: 9138.29292
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3_demo_alliance-Demonology Warlock--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12309.70211
+  dps: 12309.38867
   tps: 10349.46003
  }
 }
@@ -784,21 +784,21 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3_demo_alliance-Demonology Warlock-demo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 13982.39609
+  dps: 13982.33268
   tps: 13817.09351
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3_demo_alliance-Demonology Warlock-demo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10847.41562
+  dps: 10847.35212
   tps: 9104.96012
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3_demo_alliance-Demonology Warlock-demo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12337.7829
+  dps: 12337.46591
   tps: 10378.28722
  }
 }
@@ -826,7 +826,7 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 10730.83996
+  dps: 10730.78451
   tps: 9136.29049
  }
 }

--- a/sim/warlock/inferno.go
+++ b/sim/warlock/inferno.go
@@ -129,7 +129,7 @@ func (warlock *Warlock) NewInfernal() *InfernalPet {
 		},
 		AutoSwingMelee: true,
 	})
-	infernal.AutoAttacks.MHConfig.DamageMultiplier *= 3.2
+	infernal.AutoAttacks.MHConfig().DamageMultiplier *= 3.2
 
 	core.ApplyPetConsumeEffects(&infernal.Character, warlock.Consumes)
 

--- a/sim/warrior/deep_wounds.go
+++ b/sim/warrior/deep_wounds.go
@@ -50,27 +50,27 @@ func (warrior *Warrior) applyDeepWounds() {
 				return
 			}
 			if result.Outcome.Matches(core.OutcomeCrit) {
-				warrior.procDeepWounds(sim, result.Target, spell.IsMH())
+				warrior.procDeepWounds(sim, result.Target, spell.IsOH())
 			}
 		},
 	})
 }
 
-func (warrior *Warrior) procDeepWounds(sim *core.Simulation, target *core.Unit, isMh bool) {
+func (warrior *Warrior) procDeepWounds(sim *core.Simulation, target *core.Unit, isOh bool) {
 	dot := warrior.DeepWounds.Dot(target)
 
 	outstandingDamage := core.TernaryFloat64(dot.IsActive(), dot.SnapshotBaseDamage*float64(dot.NumberOfTicks-dot.TickCount), 0)
 
 	attackTable := warrior.AttackTables[target.UnitIndex]
 	var awd float64
-	if isMh {
-		adm := warrior.AutoAttacks.MHAuto().AttackerDamageMultiplier(attackTable)
-		tdm := warrior.AutoAttacks.MHAuto().TargetDamageMultiplier(attackTable, false)
-		awd = (warrior.AutoAttacks.MH().CalculateAverageWeaponDamage(dot.Spell.MeleeAttackPower()) + dot.Spell.BonusWeaponDamage()) * adm * tdm
-	} else {
+	if isOh {
 		adm := warrior.AutoAttacks.OHAuto().AttackerDamageMultiplier(attackTable)
 		tdm := warrior.AutoAttacks.OHAuto().TargetDamageMultiplier(attackTable, false)
 		awd = ((warrior.AutoAttacks.OH().CalculateAverageWeaponDamage(dot.Spell.MeleeAttackPower()) * 0.5) + dot.Spell.BonusWeaponDamage()) * adm * tdm
+	} else { // MH, Ranged (e.g. Thunder Clap)
+		adm := warrior.AutoAttacks.MHAuto().AttackerDamageMultiplier(attackTable)
+		tdm := warrior.AutoAttacks.MHAuto().TargetDamageMultiplier(attackTable, false)
+		awd = (warrior.AutoAttacks.MH().CalculateAverageWeaponDamage(dot.Spell.MeleeAttackPower()) + dot.Spell.BonusWeaponDamage()) * adm * tdm
 	}
 	newDamage := awd * 0.16 * float64(warrior.Talents.DeepWounds)
 

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -46,481 +46,481 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6554.01044
-  tps: 5327.96685
+  dps: 6555.06587
+  tps: 5328.88954
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6532.91222
-  tps: 5302.89603
+  dps: 6515.88266
+  tps: 5288.62453
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
   hps: 89.11518
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
   hps: 89.11518
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6593.26666
-  tps: 5362.02081
+  dps: 6594.42923
+  tps: 5362.44182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6322.58753
-  tps: 5139.4522
+  dps: 6332.75057
+  tps: 5147.91442
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlackBruise-50035"
  value: {
-  dps: 4785.38058
-  tps: 3943.40268
+  dps: 4791.87965
+  tps: 3948.57624
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlackBruise-50692"
  value: {
-  dps: 4968.74326
-  tps: 4083.59476
+  dps: 4972.61797
+  tps: 4086.97011
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 5310.19846
-  tps: 4307.96195
+  dps: 5310.07908
+  tps: 4308.64507
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5197.19888
-  tps: 4220.7348
+  dps: 5195.68077
+  tps: 4219.32105
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 4981.10601
-  tps: 4046.1315
+  dps: 4980.0795
+  tps: 4045.30453
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6553.31336
-  tps: 5222.66225
+  dps: 6554.36526
+  tps: 5223.56314
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 8582.8993
-  tps: 7057.14544
+  dps: 8579.03685
+  tps: 7049.65034
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 8690.57752
-  tps: 7136.47654
+  dps: 8693.52555
+  tps: 7142.41545
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6719.5785
-  tps: 5466.3935
+  dps: 6715.28662
+  tps: 5461.97931
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
   hps: 64
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6422.72988
-  tps: 5219.10186
+  dps: 6421.10346
+  tps: 5218.95302
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6468.77284
-  tps: 5255.48151
+  dps: 6466.30654
+  tps: 5253.98643
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6818.23992
-  tps: 5536.07608
+  dps: 6802.30138
+  tps: 5523.31377
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6401.28296
-  tps: 5202.02863
+  dps: 6400.45289
+  tps: 5202.02585
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6820.94495
-  tps: 5538.37067
+  dps: 6823.84805
+  tps: 5542.13928
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6857.77532
-  tps: 5570.03148
+  dps: 6841.64147
+  tps: 5556.56365
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6335.35622
-  tps: 5138.82155
+  dps: 6334.16085
+  tps: 5138.79901
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6599.38877
-  tps: 5367.11188
+  dps: 6600.55133
+  tps: 5367.53289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6473.3587
-  tps: 5259.14963
+  dps: 6473.35866
+  tps: 5259.14959
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6446.60316
-  tps: 5236.13759
+  dps: 6443.52855
+  tps: 5233.34139
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 5931.7964
-  tps: 4835.58873
+  dps: 5922.46418
+  tps: 4828.29025
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DreadnaughtPlate"
  value: {
-  dps: 5178.6228
-  tps: 4210.33209
+  dps: 5187.35796
+  tps: 4216.80864
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6553.31336
-  tps: 5329.16344
+  dps: 6554.36526
+  tps: 5330.08274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6553.31336
-  tps: 5329.16344
+  dps: 6554.36526
+  tps: 5330.08274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6593.26666
-  tps: 5362.02081
+  dps: 6594.42923
+  tps: 5362.44182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6584.29944
-  tps: 5355.67783
+  dps: 6586.30678
+  tps: 5356.66146
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6422.83932
-  tps: 5218.90171
+  dps: 6427.48545
+  tps: 5222.88264
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6553.31336
-  tps: 5329.16344
+  dps: 6554.36526
+  tps: 5330.08274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6467.56561
-  tps: 5255.92616
+  dps: 6465.09931
+  tps: 5254.43108
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6416.08534
-  tps: 5214.74195
+  dps: 6413.61904
+  tps: 5213.24686
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6391.33673
-  tps: 5190.54764
+  dps: 6388.97906
+  tps: 5189.15642
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6553.31336
-  tps: 5329.16344
+  dps: 6554.36526
+  tps: 5330.08274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6553.31336
-  tps: 5329.16344
+  dps: 6554.36526
+  tps: 5330.08274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6568.62475
-  tps: 5333.09369
+  dps: 6557.63269
+  tps: 5322.42529
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 6248.10809
-  tps: 5059.68036
+  dps: 6255.71973
+  tps: 5065.96057
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6447.68085
-  tps: 5238.49475
+  dps: 6445.21455
+  tps: 5236.99966
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Heartpierce-49982"
  value: {
-  dps: 7881.36826
-  tps: 6480.38239
+  dps: 7917.234
+  tps: 6515.24764
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Heartpierce-50641"
  value: {
-  dps: 7929.51889
-  tps: 6521.25681
+  dps: 7972.31605
+  tps: 6560.05499
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6593.26666
-  tps: 5362.02081
+  dps: 6594.42923
+  tps: 5362.44182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6584.29944
-  tps: 5355.67783
+  dps: 6586.30678
+  tps: 5356.66146
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6540.88012
-  tps: 5309.21789
+  dps: 6542.1431
+  tps: 5309.6584
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6553.31336
-  tps: 5329.16344
+  dps: 6554.36526
+  tps: 5330.08274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6606.12248
-  tps: 5373.4336
+  dps: 6599.08038
+  tps: 5368.40496
   hps: 13.00101
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LastWord-50179"
  value: {
-  dps: 8025.05822
-  tps: 6598.23618
+  dps: 7999.73493
+  tps: 6575.5332
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LastWord-50708"
  value: {
-  dps: 8092.35516
-  tps: 6657.0612
+  dps: 8133.10298
+  tps: 6684.46747
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6483.81767
-  tps: 5266.8289
+  dps: 6490.20348
+  tps: 5271.33405
  }
 }
 dps_results: {
  key: "TestArms-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6478.40447
-  tps: 5266.50251
+  dps: 6466.51383
+  tps: 5255.09606
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6330.64595
-  tps: 5136.25934
+  dps: 6326.92682
+  tps: 5133.68202
  }
 }
 dps_results: {
@@ -540,120 +540,120 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6611.64015
-  tps: 5377.28095
+  dps: 6607.21891
+  tps: 5374.01569
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6615.41947
-  tps: 5380.55541
+  dps: 6611.00018
+  tps: 5377.29357
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6344.32821
-  tps: 5149.10754
+  dps: 6345.72275
+  tps: 5150.16666
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6379.5471
-  tps: 5180.74751
+  dps: 6380.93867
+  tps: 5181.80335
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6553.31336
-  tps: 5329.16344
+  dps: 6554.36526
+  tps: 5330.08274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6553.31336
-  tps: 5329.16344
+  dps: 6554.36526
+  tps: 5330.08274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6702.38969
-  tps: 5450.34489
+  dps: 6697.70276
+  tps: 5445.61423
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6553.31336
-  tps: 5329.16344
+  dps: 6554.36526
+  tps: 5330.08274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6324.72833
-  tps: 5132.59382
+  dps: 6319.35459
+  tps: 5129.38144
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Shadowmourne-49623"
  value: {
-  dps: 9638.96768
-  tps: 7919.09819
+  dps: 9733.61034
+  tps: 7990.74133
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 6089.44091
-  tps: 4958.22969
+  dps: 6090.24912
+  tps: 4959.13694
  }
 }
 dps_results: {
@@ -666,50 +666,50 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6419.91099
-  tps: 5217.80246
+  dps: 6417.44469
+  tps: 5216.30738
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SparkofLife-37657"
  value: {
-  dps: 6370.99434
-  tps: 5172.41909
+  dps: 6369.46778
+  tps: 5172.08621
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6519.22478
-  tps: 5293.70239
+  dps: 6508.30623
+  tps: 5285.92586
  }
 }
 dps_results: {
@@ -722,197 +722,197 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6615.41947
-  tps: 5380.55541
+  dps: 6611.00018
+  tps: 5377.29357
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6611.64015
-  tps: 5377.28095
+  dps: 6607.21891
+  tps: 5374.01569
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6590.03256
-  tps: 5358.08113
+  dps: 6592.94458
+  tps: 5360.32057
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheFistsofFury"
  value: {
-  dps: 4825.93687
-  tps: 4059.10222
+  dps: 4858.04456
+  tps: 4087.96789
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5148.84633
-  tps: 4316.27234
+  dps: 5164.84455
+  tps: 4335.23535
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6589.95036
-  tps: 5359.30894
+  dps: 6594.91174
+  tps: 5365.19558
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6650.43757
-  tps: 5410.6944
+  dps: 6656.60405
+  tps: 5415.60021
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6720.00718
-  tps: 5463.07082
+  dps: 6721.92597
+  tps: 5465.46952
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6553.31336
-  tps: 5329.16344
+  dps: 6554.36526
+  tps: 5330.08274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6553.31336
-  tps: 5329.16344
+  dps: 6554.36526
+  tps: 5330.08274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6427.72253
-  tps: 5221.02934
+  dps: 6416.12386
+  tps: 5212.1961
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6553.31336
-  tps: 5329.16344
+  dps: 6554.36526
+  tps: 5330.08274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6553.31336
-  tps: 5329.16344
+  dps: 6554.36526
+  tps: 5330.08274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5206.71603
-  tps: 4223.57879
+  dps: 5209.24066
+  tps: 4225.31486
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 3795.48012
-  tps: 3172.7421
+  dps: 3792.65739
+  tps: 3170.39325
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6319.93525
-  tps: 5128.65033
+  dps: 6317.51799
+  tps: 5127.18067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 6790.93368
-  tps: 5523.19213
+  dps: 6789.32081
+  tps: 5521.32769
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Wrynn'sPlate"
  value: {
-  dps: 5603.78756
-  tps: 4550.36006
+  dps: 5604.21451
+  tps: 4550.78456
  }
 }
 dps_results: {
  key: "TestArms-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 7365.39588
-  tps: 6002.69385
+  dps: 7364.49013
+  tps: 6001.95732
  }
 }
 dps_results: {
  key: "TestArms-AllItems-YmirjarLord'sPlate"
  value: {
-  dps: 5843.0184
-  tps: 4746.85842
+  dps: 5840.48195
+  tps: 4745.70983
  }
 }
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 6716.71894
-  tps: 5461.99499
+  dps: 6717.71871
+  tps: 5462.78306
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-p1_arms-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 8474.07602
-  tps: 7157.81365
+  dps: 8485.21888
+  tps: 7167.57915
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-p1_arms-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 6600.37942
-  tps: 5352.84031
+  dps: 6590.11604
+  tps: 5345.11857
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-p1_arms-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7012.48508
-  tps: 5763.01888
+  dps: 6997.00417
+  tps: 5749.05654
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-p1_arms-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 4910.08041
-  tps: 4204.05779
+  dps: 4910.04724
+  tps: 4204.03126
  }
 }
 dps_results: {
@@ -932,36 +932,36 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Human-p1_arms-Basic-arms-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11906.57829
-  tps: 11011.09514
+  dps: 11924.62575
+  tps: 11028.5597
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-p1_arms-Basic-arms-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6733.8157
-  tps: 5425.80149
+  dps: 6744.86884
+  tps: 5435.64421
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-p1_arms-Basic-arms-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7279.26113
-  tps: 5922.37023
+  dps: 7303.9868
+  tps: 5943.01221
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-p1_arms-Basic-arms-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6198.0661
-  tps: 5883.49454
+  dps: 6201.566
+  tps: 5886.67849
  }
 }
 dps_results: {
  key: "TestArms-Settings-Human-p1_arms-Basic-arms-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3508.72973
-  tps: 2830.91293
+  dps: 3507.48553
+  tps: 2829.64022
  }
 }
 dps_results: {
@@ -974,29 +974,29 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 8650.48828
-  tps: 7305.00095
+  dps: 8654.58634
+  tps: 7308.95778
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 6702.38969
-  tps: 5450.34489
+  dps: 6697.70276
+  tps: 5445.61423
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7229.80125
-  tps: 5953.10426
+  dps: 7232.4472
+  tps: 5955.18662
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 5010.15338
-  tps: 4299.51905
+  dps: 5004.19706
+  tps: 4293.86774
  }
 }
 dps_results: {
@@ -1016,36 +1016,36 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms-Basic-arms-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11940.61768
-  tps: 11049.68237
+  dps: 11974.1173
+  tps: 11074.57371
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms-Basic-arms-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6785.38856
-  tps: 5487.0128
+  dps: 6750.31463
+  tps: 5459.33646
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms-Basic-arms-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7379.87823
-  tps: 6038.23714
+  dps: 7373.00838
+  tps: 6033.37017
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms-Basic-arms-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6345.88031
-  tps: 6022.3867
+  dps: 6352.90441
+  tps: 6027.91913
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms-Basic-arms-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3535.77971
-  tps: 2856.56853
+  dps: 3536.91307
+  tps: 2857.80735
  }
 }
 dps_results: {
@@ -1058,7 +1058,7 @@ dps_results: {
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6209.03844
-  tps: 5029.74756
+  dps: 6215.16686
+  tps: 5035.82366
  }
 }

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -932,8 +932,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Human-p1_arms-Basic-arms-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10652.07342
-  tps: 10007.49125
+  dps: 11906.57829
+  tps: 11011.09514
  }
 }
 dps_results: {
@@ -953,8 +953,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Human-p1_arms-Basic-arms-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5528.79397
-  tps: 5348.07684
+  dps: 6198.0661
+  tps: 5883.49454
  }
 }
 dps_results: {
@@ -1016,8 +1016,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms-Basic-arms-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10689.87998
-  tps: 10049.09221
+  dps: 11940.61768
+  tps: 11049.68237
  }
 }
 dps_results: {
@@ -1037,8 +1037,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms-Basic-arms-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5670.62396
-  tps: 5482.18162
+  dps: 6345.88031
+  tps: 6022.3867
  }
 }
 dps_results: {

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -46,866 +46,866 @@ character_stats_results: {
 dps_results: {
  key: "TestFury-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6760.22199
-  tps: 4997.99884
+  dps: 6769.35575
+  tps: 5007.97002
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6728.46254
-  tps: 4972.31199
+  dps: 6719.55703
+  tps: 4964.97991
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
   hps: 90.47701
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
   hps: 90.47701
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6808.16147
-  tps: 5032.76469
+  dps: 6788.83496
+  tps: 5020.01835
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6579.79642
-  tps: 4868.59552
+  dps: 6600.83662
+  tps: 4887.12964
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlackBruise-50035"
  value: {
-  dps: 5833.67568
-  tps: 4328.73701
+  dps: 5828.42091
+  tps: 4327.00901
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlackBruise-50692"
  value: {
-  dps: 5917.54802
-  tps: 4388.85577
+  dps: 5904.89724
+  tps: 4380.84678
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 5401.13735
-  tps: 4000.79692
+  dps: 5408.52246
+  tps: 4004.7527
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5357.05216
-  tps: 3970.11423
+  dps: 5331.70678
+  tps: 3950.82776
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5069.8974
-  tps: 3759.46145
+  dps: 5081.33052
+  tps: 3765.63585
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6761.23902
-  tps: 4899.36847
+  dps: 6763.44707
+  tps: 4903.78012
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6946.09586
-  tps: 5135.85557
+  dps: 6940.6091
+  tps: 5133.85523
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6946.09586
-  tps: 5135.85557
+  dps: 6940.6091
+  tps: 5133.85523
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6946.09586
-  tps: 5135.85557
+  dps: 6940.6091
+  tps: 5133.85523
  }
 }
 dps_results: {
  key: "TestFury-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
   hps: 64
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6673.47414
-  tps: 4934.58163
+  dps: 6688.51548
+  tps: 4944.54856
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6703.46837
-  tps: 4955.11318
+  dps: 6720.85386
+  tps: 4966.4248
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7068.30576
-  tps: 5221.00252
+  dps: 7095.64087
+  tps: 5240.27457
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6681.60381
-  tps: 4942.67892
+  dps: 6674.7509
+  tps: 4935.28117
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7066.31517
-  tps: 5226.2442
+  dps: 7061.55294
+  tps: 5220.86364
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7136.12242
-  tps: 5274.08043
+  dps: 7106.22263
+  tps: 5255.35876
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6591.94224
-  tps: 4872.17204
+  dps: 6574.42563
+  tps: 4861.57392
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6808.2813
-  tps: 5032.53957
+  dps: 6788.82053
+  tps: 5019.65148
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6746.16514
-  tps: 4992.69788
+  dps: 6747.8234
+  tps: 4991.06997
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6701.93267
-  tps: 4959.28134
+  dps: 6689.56363
+  tps: 4950.32588
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 6139.74969
-  tps: 4547.70706
+  dps: 6090.50089
+  tps: 4510.32353
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DreadnaughtPlate"
  value: {
-  dps: 5263.97341
-  tps: 3901.33005
+  dps: 5261.46396
+  tps: 3897.66066
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6761.23902
-  tps: 4999.0578
+  dps: 6763.44707
+  tps: 5003.55829
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6761.23902
-  tps: 4999.0578
+  dps: 6763.44707
+  tps: 5003.55829
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6808.16147
-  tps: 5032.76469
+  dps: 6788.83496
+  tps: 5020.01835
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6803.16289
-  tps: 5029.03472
+  dps: 6772.62733
+  tps: 5008.95015
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6685.3369
-  tps: 4943.17423
+  dps: 6723.37452
+  tps: 4972.05668
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6761.23902
-  tps: 4999.0578
+  dps: 6763.44707
+  tps: 5003.55829
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6704.21821
-  tps: 4955.92471
+  dps: 6717.76076
+  tps: 4965.71051
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6658.22068
-  tps: 4923.19472
+  dps: 6672.34012
+  tps: 4933.36427
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6639.9512
-  tps: 4910.245
+  dps: 6659.14983
+  tps: 4922.26692
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6761.23902
-  tps: 4999.0578
+  dps: 6763.44707
+  tps: 5003.55829
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6761.23902
-  tps: 4999.0578
+  dps: 6763.44707
+  tps: 5003.55829
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6785.80898
-  tps: 5015.31849
+  dps: 6730.52271
+  tps: 4973.37435
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 6518.9521
-  tps: 4816.24271
+  dps: 6519.10307
+  tps: 4817.20488
  }
 }
 dps_results: {
  key: "TestFury-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6680.09296
-  tps: 4938.37639
+  dps: 6702.27274
+  tps: 4952.38693
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Heartpierce-49982"
  value: {
-  dps: 6946.09586
-  tps: 5135.85557
+  dps: 6940.6091
+  tps: 5133.85523
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Heartpierce-50641"
  value: {
-  dps: 6946.09586
-  tps: 5135.85557
+  dps: 6940.6091
+  tps: 5133.85523
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6808.16147
-  tps: 5032.76469
+  dps: 6788.83496
+  tps: 5020.01835
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6803.16289
-  tps: 5029.03472
+  dps: 6772.62733
+  tps: 5008.95015
  }
 }
 dps_results: {
  key: "TestFury-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6783.28024
-  tps: 5017.73647
+  dps: 6805.75862
+  tps: 5032.8745
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6761.23902
-  tps: 4999.0578
+  dps: 6763.44707
+  tps: 5003.55829
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6790.96071
-  tps: 5023.01403
+  dps: 6796.91327
+  tps: 5026.8624
   hps: 13.7626
  }
 }
 dps_results: {
  key: "TestFury-AllItems-LastWord-50179"
  value: {
-  dps: 6946.09586
-  tps: 5135.85557
+  dps: 6940.6091
+  tps: 5133.85523
  }
 }
 dps_results: {
  key: "TestFury-AllItems-LastWord-50708"
  value: {
-  dps: 6946.09586
-  tps: 5135.85557
+  dps: 6940.6091
+  tps: 5133.85523
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6786.33276
-  tps: 5018.95331
+  dps: 6818.02251
+  tps: 5042.73941
  }
 }
 dps_results: {
  key: "TestFury-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6712.39141
-  tps: 4964.33435
+  dps: 6693.68029
+  tps: 4948.25579
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6569.82289
-  tps: 4855.42967
+  dps: 6569.42796
+  tps: 4858.72077
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtArmor"
  value: {
-  dps: 4152.20873
-  tps: 3083.84871
+  dps: 4143.20409
+  tps: 3074.91206
  }
 }
 dps_results: {
  key: "TestFury-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 4929.54075
-  tps: 3655.61347
+  dps: 4951.35038
+  tps: 3671.2703
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6788.97465
-  tps: 5020.40917
+  dps: 6794.91191
+  tps: 5025.57132
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6799.45971
-  tps: 5029.35058
+  dps: 6801.78841
+  tps: 5030.70738
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6610.12493
-  tps: 4887.02193
+  dps: 6588.54402
+  tps: 4870.42905
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6607.04243
-  tps: 4884.31848
+  dps: 6594.76359
+  tps: 4874.12005
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6761.23902
-  tps: 4999.0578
+  dps: 6763.44707
+  tps: 5003.55829
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6761.23902
-  tps: 4999.0578
+  dps: 6763.44707
+  tps: 5003.55829
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6935.63334
-  tps: 5128.40525
+  dps: 6922.43718
+  tps: 5119.88806
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6761.23902
-  tps: 4999.0578
+  dps: 6763.44707
+  tps: 5003.55829
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6589.4031
-  tps: 4869.90907
+  dps: 6601.59595
+  tps: 4880.50511
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6946.09586
-  tps: 5135.85557
+  dps: 6940.6091
+  tps: 5133.85523
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 6442.43134
-  tps: 4762.29066
+  dps: 6472.40951
+  tps: 4784.58478
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SiegebreakerPlate"
  value: {
-  dps: 5493.99623
-  tps: 4064.7353
+  dps: 5511.33387
+  tps: 4080.6015
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6660.3848
-  tps: 4924.72858
+  dps: 6674.16527
+  tps: 4934.75193
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SparkofLife-37657"
  value: {
-  dps: 6640.41094
-  tps: 4911.02542
+  dps: 6651.57478
+  tps: 4918.27794
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6775.60344
-  tps: 5009.44299
+  dps: 6801.84763
+  tps: 5026.92841
  }
 }
 dps_results: {
  key: "TestFury-AllItems-StormshroudArmor"
  value: {
-  dps: 5027.03662
-  tps: 3728.72524
+  dps: 5032.87583
+  tps: 3731.72923
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6799.45971
-  tps: 5029.35058
+  dps: 6801.78841
+  tps: 5030.70738
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6788.97465
-  tps: 5020.40917
+  dps: 6794.91191
+  tps: 5025.57132
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6780.49822
-  tps: 5014.50988
+  dps: 6794.71122
+  tps: 5026.05471
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheFistsofFury"
  value: {
-  dps: 5006.80751
-  tps: 3709.33453
+  dps: 4992.66993
+  tps: 3698.69071
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 5359.59122
-  tps: 3970.14881
+  dps: 5369.04135
+  tps: 3980.15803
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6788.71029
-  tps: 5017.0106
+  dps: 6834.36558
+  tps: 5052.09811
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6885.91531
-  tps: 5090.2862
+  dps: 6907.1146
+  tps: 5106.5422
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6907.77145
-  tps: 5103.9007
+  dps: 6898.09243
+  tps: 5093.68528
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6761.23902
-  tps: 4999.0578
+  dps: 6763.44707
+  tps: 5003.55829
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6761.23902
-  tps: 4999.0578
+  dps: 6763.44707
+  tps: 5003.55829
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6642.62559
-  tps: 4912.93482
+  dps: 6641.65886
+  tps: 4910.8004
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6761.23902
-  tps: 4999.0578
+  dps: 6763.44707
+  tps: 5003.55829
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6761.23902
-  tps: 4999.0578
+  dps: 6763.44707
+  tps: 5003.55829
  }
 }
 dps_results: {
  key: "TestFury-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5334.75237
-  tps: 3953.60694
+  dps: 5362.20081
+  tps: 3972.53856
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 5117.19129
-  tps: 3835.56173
+  dps: 5143.22874
+  tps: 3856.01871
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6551.36198
-  tps: 4841.44738
+  dps: 6571.52621
+  tps: 4859.63778
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 7134.548
-  tps: 5271.49328
+  dps: 7157.15344
+  tps: 5289.59288
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Wrynn'sPlate"
  value: {
-  dps: 5753.31767
-  tps: 4255.69164
+  dps: 5779.20071
+  tps: 4275.58158
  }
 }
 dps_results: {
  key: "TestFury-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 7963.26815
-  tps: 5876.58334
+  dps: 7912.58981
+  tps: 5841.06932
  }
 }
 dps_results: {
  key: "TestFury-AllItems-YmirjarLord'sPlate"
  value: {
-  dps: 6129.71288
-  tps: 4535.41033
+  dps: 6122.77848
+  tps: 4529.55758
  }
 }
 dps_results: {
  key: "TestFury-Average-Default"
  value: {
-  dps: 6939.17959
-  tps: 5131.13751
+  dps: 6939.12125
+  tps: 5130.87554
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-p1_fury-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 9194.69651
-  tps: 7340.72966
+  dps: 9230.5901
+  tps: 7367.28027
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-p1_fury-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 6873.32982
-  tps: 5081.14527
+  dps: 6900.84691
+  tps: 5101.72765
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-p1_fury-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7897.40963
-  tps: 5832.12271
+  dps: 7876.26356
+  tps: 5813.13344
  }
 }
 dps_results: {
@@ -919,7 +919,7 @@ dps_results: {
  key: "TestFury-Settings-Human-p1_fury-Basic--NoBuffs-LongSingleTarget"
  value: {
   dps: 3130.15371
-  tps: 2329.05542
+  tps: 2329.05403
  }
 }
 dps_results: {
@@ -932,22 +932,22 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Human-p1_fury-Basic-fury-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10335.53844
-  tps: 8055.47326
+  dps: 10279.11986
+  tps: 8011.90491
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-p1_fury-Basic-fury-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6956.89606
-  tps: 5172.37235
+  dps: 6975.30394
+  tps: 5188.47019
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-p1_fury-Basic-fury-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8334.00253
-  tps: 6194.42682
+  dps: 8351.86484
+  tps: 6205.71951
  }
 }
 dps_results: {
@@ -974,22 +974,22 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Orc-p1_fury-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 9277.3113
-  tps: 7397.17369
+  dps: 9293.72981
+  tps: 7412.8061
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-p1_fury-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 6946.09586
-  tps: 5135.85557
+  dps: 6940.6091
+  tps: 5133.85523
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-p1_fury-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7962.43878
-  tps: 5883.1142
+  dps: 7959.25586
+  tps: 5876.33887
  }
 }
 dps_results: {
@@ -1016,29 +1016,29 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Orc-p1_fury-Basic-fury-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10420.27644
-  tps: 8119.1797
+  dps: 10441.07954
+  tps: 8135.12736
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-p1_fury-Basic-fury-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6948.04992
-  tps: 5165.92716
+  dps: 6957.8002
+  tps: 5172.53591
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-p1_fury-Basic-fury-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8418.04587
-  tps: 6247.66223
+  dps: 8433.41303
+  tps: 6256.22466
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-p1_fury-Basic-fury-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4441.18536
-  tps: 3610.77623
+  dps: 4440.7641
+  tps: 3610.83804
  }
 }
 dps_results: {
@@ -1058,7 +1058,7 @@ dps_results: {
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6427.97419
-  tps: 4752.89604
+  dps: 6383.16995
+  tps: 4718.99262
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -950,22 +950,22 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_balanced-Basic-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1050.46307
-  tps: 3335.71088
+  dps: 1084.94322
+  tps: 3407.20547
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_balanced-Basic-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 865.20912
-  tps: 2483.44764
+  dps: 866.97075
+  tps: 2487.10038
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_balanced-Basic-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 831.10607
-  tps: 2403.87441
+  dps: 833.49622
+  tps: 2408.83039
  }
 }
 dps_results: {
@@ -992,22 +992,22 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_balanced-Basic-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1063.03306
-  tps: 3372.37903
+  dps: 1097.36592
+  tps: 3443.56821
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_balanced-Basic-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 880.11232
-  tps: 2527.63516
+  dps: 881.93425
+  tps: 2531.41294
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_balanced-Basic-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 853.54235
-  tps: 2468.41035
+  dps: 854.88707
+  tps: 2471.19863
  }
 }
 dps_results: {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -46,7 +46,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtectionWarrior-StatWeights-Default"
  value: {
-  weights: 0.84402
+  weights: 0.76367
   weights: 0
   weights: 0
   weights: 0
@@ -57,7 +57,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.26128
+  weights: 0.2638
   weights: 0
   weights: 0
   weights: 0
@@ -66,12 +66,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.01763
+  weights: -3e-05
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.4296
-  weights: 0.02365
+  weights: 0.43043
+  weights: 0.09932
   weights: 0
   weights: 0
   weights: 0
@@ -91,860 +91,860 @@ stat_weights_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 1492.16288
-  tps: 3847.92366
+  dps: 1497.4236
+  tps: 3865.5531
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 1435.93252
-  tps: 3735.51904
+  dps: 1443.61597
+  tps: 3757.74334
   hps: 82.16554
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 1435.93252
-  tps: 3735.51904
+  dps: 1443.61597
+  tps: 3757.74334
   hps: 82.16554
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 1432.45726
-  tps: 3726.53558
+  dps: 1436.29269
+  tps: 3738.87948
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 1393.99519
-  tps: 3624.03087
+  dps: 1403.06881
+  tps: 3652.51629
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackBruise-50035"
  value: {
-  dps: 1494.89492
-  tps: 3818.41811
+  dps: 1502.62813
+  tps: 3840.29252
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackBruise-50692"
  value: {
-  dps: 1530.89424
-  tps: 3899.59064
+  dps: 1532.82854
+  tps: 3902.58233
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1237.10945
-  tps: 3228.6515
+  dps: 1236.90562
+  tps: 3226.4392
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1219.43838
-  tps: 3178.43388
+  dps: 1213.25286
+  tps: 3161.94609
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1147.52043
-  tps: 3013.48094
+  dps: 1149.45808
+  tps: 3021.01244
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 1427.79042
-  tps: 3644.04989
+  dps: 1429.13677
+  tps: 3649.22353
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 1469.09582
-  tps: 3821.18171
+  dps: 1464.89347
+  tps: 3806.56276
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
   hps: 64
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 1484.02375
-  tps: 3850.02245
+  dps: 1482.8109
+  tps: 3850.33623
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 1516.38327
-  tps: 3908.87551
+  dps: 1514.2653
+  tps: 3906.78831
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 1473.69837
-  tps: 3821.43497
+  dps: 1475.90374
+  tps: 3829.1951
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Death'sChoice-47464"
  value: {
-  dps: 1512.51148
-  tps: 3898.9294
+  dps: 1516.88738
+  tps: 3908.179
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 1457.44228
-  tps: 3780.76742
+  dps: 1458.84083
+  tps: 3789.00873
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 1541.20394
-  tps: 3979.54268
+  dps: 1550.72349
+  tps: 4003.56481
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 1560.16977
-  tps: 4023.55742
+  dps: 1559.26933
+  tps: 4021.26044
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 1434.21983
-  tps: 3731.95805
+  dps: 1438.34767
+  tps: 3744.86385
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 1474.34129
-  tps: 3818.97285
+  dps: 1471.50005
+  tps: 3813.02114
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 1466.38796
-  tps: 3802.49281
+  dps: 1470.21311
+  tps: 3812.0458
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DreadnaughtBattlegear"
  value: {
-  dps: 1476.6297
-  tps: 3801.55673
+  dps: 1474.02677
+  tps: 3793.84899
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DreadnaughtPlate"
  value: {
-  dps: 1348.649
-  tps: 3510.16656
+  dps: 1354.59803
+  tps: 3527.38642
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 1427.79042
-  tps: 3718.36519
+  dps: 1429.13677
+  tps: 3723.6434
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 1427.79042
-  tps: 3718.36519
+  dps: 1429.13677
+  tps: 3723.6434
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 1432.45726
-  tps: 3726.53558
+  dps: 1436.29269
+  tps: 3738.87948
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 1431.56771
-  tps: 3723.93198
+  dps: 1436.28313
+  tps: 3739.17223
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 1455.48429
-  tps: 3784.00787
+  dps: 1452.25212
+  tps: 3775.3647
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 1441.30568
-  tps: 3754.79625
+  dps: 1442.7152
+  tps: 3760.24472
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 1504.15954
-  tps: 3880.23246
+  dps: 1503.39455
+  tps: 3880.58924
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 1466.84916
-  tps: 3801.86451
+  dps: 1466.27182
+  tps: 3802.47188
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForgeEmber-37660"
  value: {
-  dps: 1465.5706
-  tps: 3804.64259
+  dps: 1464.82611
+  tps: 3806.06243
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 1427.79042
-  tps: 3718.36519
+  dps: 1429.13677
+  tps: 3723.6434
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 1427.79042
-  tps: 3718.36519
+  dps: 1429.13677
+  tps: 3723.6434
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 1474.54979
-  tps: 3821.40065
+  dps: 1473.63265
+  tps: 3820.71002
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuturesightRune-38763"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 1541.11596
-  tps: 3897.66875
+  dps: 1546.55353
+  tps: 3917.21448
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 1501.88277
-  tps: 3879.82914
+  dps: 1499.30293
+  tps: 3876.2045
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Heartpierce-49982"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Heartpierce-50641"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 1432.45726
-  tps: 3726.53558
+  dps: 1436.29269
+  tps: 3738.87948
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 1431.56771
-  tps: 3723.93198
+  dps: 1436.28313
+  tps: 3739.17223
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IncisorFragment-37723"
  value: {
-  dps: 1475.72791
-  tps: 3826.28175
+  dps: 1477.31363
+  tps: 3830.89904
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 1427.79042
-  tps: 3718.36519
+  dps: 1429.13677
+  tps: 3723.6434
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 1432.90177
-  tps: 3729.80403
-  hps: 16.4224
+  dps: 1439.81394
+  tps: 3750.17262
+  hps: 16.38289
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LastWord-50179"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LastWord-50708"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 1448.87336
-  tps: 3770.40171
+  dps: 1456.808
+  tps: 3793.30312
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 1483.64985
-  tps: 3848.22004
+  dps: 1487.95987
+  tps: 3858.19024
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 1493.19343
-  tps: 3873.80495
+  dps: 1488.45581
+  tps: 3857.26512
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 1438.33173
-  tps: 3743.71632
+  dps: 1439.06283
+  tps: 3744.35518
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 1144.34986
-  tps: 3010.71218
+  dps: 1143.96277
+  tps: 3010.38028
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 1211.96118
-  tps: 3128.88988
+  dps: 1212.73705
+  tps: 3132.14296
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 1436.62272
-  tps: 3740.53374
+  dps: 1441.44826
+  tps: 3755.28496
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 1432.90177
-  tps: 3729.80403
+  dps: 1439.81394
+  tps: 3750.17262
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 1435.43874
-  tps: 3732.82554
+  dps: 1438.52633
+  tps: 3741.00002
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 1432.12149
-  tps: 3720.88451
+  dps: 1437.28281
+  tps: 3735.73938
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 1427.79042
-  tps: 3718.36519
+  dps: 1429.13677
+  tps: 3723.6434
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 1427.79042
-  tps: 3718.36519
+  dps: 1429.13677
+  tps: 3723.6434
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 1460.66484
-  tps: 3796.0981
+  dps: 1464.99517
+  tps: 3809.20556
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 1427.79042
-  tps: 3718.36519
+  dps: 1429.13677
+  tps: 3723.6434
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 1436.96018
-  tps: 3743.46836
+  dps: 1432.85618
+  tps: 3727.67586
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Shadowmourne-49623"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SiegebreakerBattlegear"
  value: {
-  dps: 1530.29988
-  tps: 3926.91282
+  dps: 1528.60272
+  tps: 3922.80255
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SiegebreakerPlate"
  value: {
-  dps: 1369.58017
-  tps: 3556.65058
+  dps: 1362.18488
+  tps: 3534.24554
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SoulPreserver-37111"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SouloftheDead-40382"
  value: {
-  dps: 1469.3097
-  tps: 3807.98458
+  dps: 1468.61799
+  tps: 3808.46535
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SparkofLife-37657"
  value: {
-  dps: 1441.39532
-  tps: 3744.89113
+  dps: 1440.66133
+  tps: 3742.16595
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 1469.99871
-  tps: 3820.43531
+  dps: 1478.71065
+  tps: 3846.54338
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StormshroudArmor"
  value: {
-  dps: 1133.36044
-  tps: 2981.13488
+  dps: 1131.41118
+  tps: 2973.77697
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 1432.90177
-  tps: 3729.80403
+  dps: 1439.81394
+  tps: 3750.17262
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 1436.62272
-  tps: 3740.53374
+  dps: 1441.44826
+  tps: 3755.28496
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1437.42908
-  tps: 3742.51097
+  dps: 1434.21835
+  tps: 3734.84239
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheFistsofFury"
  value: {
-  dps: 1003.46725
-  tps: 2272.57733
+  dps: 1002.18698
+  tps: 2269.92269
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1067.68517
-  tps: 2409.37142
+  dps: 1067.10265
+  tps: 2408.07406
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 1436.70606
-  tps: 3736.99994
+  dps: 1433.77973
+  tps: 3730.22067
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 1471.54162
-  tps: 3816.61233
+  dps: 1478.24422
+  tps: 3833.2328
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 1470.97732
-  tps: 3813.54077
+  dps: 1467.27925
+  tps: 3802.76201
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 1427.79042
-  tps: 3718.36519
+  dps: 1429.13677
+  tps: 3723.6434
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 1427.79042
-  tps: 3718.36519
+  dps: 1429.13677
+  tps: 3723.6434
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 1434.64805
-  tps: 3723.40579
+  dps: 1436.78984
+  tps: 3728.88041
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 1427.79042
-  tps: 3718.36519
+  dps: 1429.13677
+  tps: 3723.6434
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 1427.79042
-  tps: 3718.36519
+  dps: 1429.13677
+  tps: 3723.6434
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1214.15323
-  tps: 3165.81322
+  dps: 1207.40792
+  tps: 3148.8019
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 1327.31904
-  tps: 3471.45462
+  dps: 1320.86781
+  tps: 3455.68965
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WingedTalisman-37844"
  value: {
-  dps: 1435.89794
-  tps: 3735.42581
+  dps: 1443.50947
+  tps: 3757.45627
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Wrynn'sBattlegear"
  value: {
-  dps: 1716.63565
-  tps: 4348.40103
+  dps: 1715.22713
+  tps: 4343.02026
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Wrynn'sPlate"
  value: {
-  dps: 1443.65237
-  tps: 3732.51284
+  dps: 1438.9139
+  tps: 3715.52095
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-YmirjarLord'sBattlegear"
  value: {
-  dps: 1925.28523
-  tps: 4840.26501
+  dps: 1915.35055
+  tps: 4811.31977
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-YmirjarLord'sPlate"
  value: {
-  dps: 1566.47867
-  tps: 4036.75514
+  dps: 1565.56182
+  tps: 4034.16559
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 2771.43209
-  tps: 6732.50018
-  dtps: 127.46896
+  dps: 2771.65176
+  tps: 6733.04173
+  dtps: 127.4897
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_balanced-Basic-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1479.581
-  tps: 3902.21774
+  dps: 1476.36368
+  tps: 3891.49394
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_balanced-Basic-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1479.581
-  tps: 3851.86774
+  dps: 1476.36368
+  tps: 3840.82728
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_balanced-Basic-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1643.01563
-  tps: 4246.04821
+  dps: 1639.76544
+  tps: 4236.26058
  }
 }
 dps_results: {
@@ -971,22 +971,22 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_balanced-Basic-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1490.53905
-  tps: 3923.57859
+  dps: 1493.10216
+  tps: 3930.30504
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_balanced-Basic-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 1490.53905
-  tps: 3873.54526
+  dps: 1493.10216
+  tps: 3879.63837
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_balanced-Basic-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1682.8701
-  tps: 4348.51957
+  dps: 1681.29892
+  tps: 4344.50046
  }
 }
 dps_results: {
@@ -1013,8 +1013,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2874.62831
-  tps: 6986.65854
-  dtps: 121.25386
+  dps: 2890.35455
+  tps: 7022.68811
+  dtps: 120.81343
  }
 }

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -19,7 +19,7 @@ func (warrior *Warrior) ApplyTalents() {
 	warrior.PseudoStats.BaseDodge += 0.01 * float64(warrior.Talents.Anticipation)
 	warrior.PseudoStats.BaseParry += 0.01 * float64(warrior.Talents.Deflection)
 	warrior.PseudoStats.DodgeReduction += 0.01 * float64(warrior.Talents.WeaponMastery)
-	warrior.AutoAttacks.OHConfig.DamageMultiplier *= 1 + 0.05*float64(warrior.Talents.DualWieldSpecialization)
+	warrior.AutoAttacks.OHConfig().DamageMultiplier *= 1 + 0.05*float64(warrior.Talents.DualWieldSpecialization)
 
 	if warrior.Talents.ArmoredToTheTeeth > 0 {
 		coeff := float64(warrior.Talents.ArmoredToTheTeeth)
@@ -353,7 +353,7 @@ func (warrior *Warrior) applyTitansGrip() {
 	if !warrior.Talents.TitansGrip {
 		return
 	}
-	if !warrior.AutoAttacks.IsDualWielding() {
+	if !warrior.AutoAttacks.IsDualWielding {
 		return
 	}
 	if warrior.MainHand().HandType != proto.HandType_HandTypeTwoHand && warrior.OffHand().HandType != proto.HandType_HandTypeTwoHand {
@@ -432,7 +432,7 @@ func (warrior *Warrior) registerSwordSpecialization(procMask core.ProcMask) {
 		Label:    "Sword Specialization",
 		Duration: core.NeverExpires,
 		OnInit: func(aura *core.Aura, sim *core.Simulation) {
-			config := warrior.AutoAttacks.MHConfig
+			config := *warrior.AutoAttacks.MHConfig()
 			config.ActionID = core.ActionID{SpellID: 12281}
 			swordSpecializationSpell = warrior.GetOrRegisterSpell(config)
 		},
@@ -788,7 +788,7 @@ func (warrior *Warrior) RegisterBladestormCD() {
 	numHits := min(4, warrior.Env.GetNumTargets())
 	results := make([]*core.SpellResult, numHits)
 
-	if warrior.AutoAttacks.IsDualWielding() {
+	if warrior.AutoAttacks.IsDualWielding {
 		warrior.BladestormOH = warrior.RegisterSpell(core.SpellConfig{
 			ActionID:    actionID,
 			SpellSchool: core.SpellSchoolPhysical,

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -114,8 +114,8 @@ func (warrior *Warrior) AddPartyBuffs(_ *proto.PartyBuffs) {
 }
 
 func (warrior *Warrior) Initialize() {
-	warrior.AutoAttacks.MHConfig.CritMultiplier = warrior.autoCritMultiplier(mh)
-	warrior.AutoAttacks.OHConfig.CritMultiplier = warrior.autoCritMultiplier(oh)
+	warrior.AutoAttacks.MHConfig().CritMultiplier = warrior.autoCritMultiplier(mh)
+	warrior.AutoAttacks.OHConfig().CritMultiplier = warrior.autoCritMultiplier(oh)
 
 	warrior.Shout = warrior.makeShoutSpell()
 

--- a/sim/warrior/whirlwind.go
+++ b/sim/warrior/whirlwind.go
@@ -12,7 +12,7 @@ func (warrior *Warrior) registerWhirlwindSpell() {
 	numHits := min(4, warrior.Env.GetNumTargets())
 	results := make([]*core.SpellResult, numHits)
 
-	if warrior.AutoAttacks.IsDualWielding() && warrior.GetOHWeapon().WeaponType != proto.WeaponType_WeaponTypeStaff &&
+	if warrior.AutoAttacks.IsDualWielding && warrior.GetOHWeapon().WeaponType != proto.WeaponType_WeaponTypeStaff &&
 		warrior.GetOHWeapon().WeaponType != proto.WeaponType_WeaponTypePolearm {
 		warrior.WhirlwindOH = warrior.RegisterSpell(core.SpellConfig{
 			ActionID:    actionID.WithTag(1),


### PR DESCRIPTION
[core] introduce WeaponAttack, a per weapon (MH, OH, Ranged) AutoAttack

[warrior] ranged attacks (namely Thunder Clap) now properly trigger MH Deep Wounds

No test changes but for Arms-Warrior.


[core] handle WeaponAttacks via a "task"-like system

[core] slightly speedup advance() by using an inlineable tryAdvance() stub

Affected "Average" tests are mostly unchanged. For e.g. DKs and Enhancement Shamans, this is almost a ~10% perf gain (non-APL). 