### PR TITLE
Handle recursive controlling actions in APL

### DIFF
--- a/sim/core/apl_actions_sequences.go
+++ b/sim/core/apl_actions_sequences.go
@@ -136,7 +136,7 @@ func (action *APLActionStrictSequence) IsReady(sim *Simulation) bool {
 	return true
 }
 func (action *APLActionStrictSequence) Execute(sim *Simulation) {
-	action.unit.Rotation.controllingAction = action
+	action.unit.Rotation.pushControllingAction(action)
 }
 func (action *APLActionStrictSequence) GetNextAction(sim *Simulation) *APLAction {
 	if action.subactions[action.curIdx].IsReady(sim) {
@@ -145,7 +145,7 @@ func (action *APLActionStrictSequence) GetNextAction(sim *Simulation) *APLAction
 		action.curIdx++
 		if action.curIdx == len(action.subactions) {
 			action.curIdx = 0
-			action.unit.Rotation.controllingAction = nil
+			action.unit.Rotation.popControllingAction(action)
 		}
 
 		return nextAction
@@ -153,7 +153,7 @@ func (action *APLActionStrictSequence) GetNextAction(sim *Simulation) *APLAction
 		// If the GCD is ready when the next subaction isn't, it means the sequence is bad
 		// so reset and exit the sequence.
 		action.curIdx = 0
-		action.unit.Rotation.controllingAction = nil
+		action.unit.Rotation.popControllingAction(action)
 		return action.unit.Rotation.getNextAction(sim)
 	} else {
 		// Return nil to wait for the GCD to become ready.

--- a/sim/core/apl_actions_timing.go
+++ b/sim/core/apl_actions_timing.go
@@ -36,7 +36,7 @@ func (action *APLActionWait) IsReady(sim *Simulation) bool {
 }
 
 func (action *APLActionWait) Execute(sim *Simulation) {
-	action.unit.Rotation.controllingAction = action
+	action.unit.Rotation.pushControllingAction(action)
 	action.curWaitTime = sim.CurrentTime + action.duration.GetDuration(sim)
 
 	pa := &PendingAction{
@@ -49,7 +49,7 @@ func (action *APLActionWait) Execute(sim *Simulation) {
 
 func (action *APLActionWait) GetNextAction(sim *Simulation) *APLAction {
 	if sim.CurrentTime >= action.curWaitTime {
-		action.unit.Rotation.controllingAction = nil
+		action.unit.Rotation.popControllingAction(action)
 		return action.unit.Rotation.getNextAction(sim)
 	} else {
 		return nil
@@ -86,12 +86,12 @@ func (action *APLActionWaitUntil) IsReady(sim *Simulation) bool {
 }
 
 func (action *APLActionWaitUntil) Execute(sim *Simulation) {
-	action.unit.Rotation.controllingAction = action
+	action.unit.Rotation.pushControllingAction(action)
 }
 
 func (action *APLActionWaitUntil) GetNextAction(sim *Simulation) *APLAction {
 	if action.condition.GetBool(sim) {
-		action.unit.Rotation.controllingAction = nil
+		action.unit.Rotation.popControllingAction(action)
 		return action.unit.Rotation.getNextAction(sim)
 	} else {
 		return nil


### PR DESCRIPTION
Allows options which take control of the APL behavior (currently Strict Sequences and Waits) to work properly when nested.