### PR TITLE
dk-rune-costs

### DIFF
--- a/sim/core/runic_power_helper.go
+++ b/sim/core/runic_power_helper.go
@@ -5,11 +5,15 @@ import (
 	"time"
 )
 
-// RuneCost's bit layout is: <rrrr_rrrr_dduu_ffbb>. Each part is just a count now (0..3 for runes).
-type RuneCost uint16
+// RuneCost's bit layout is: <16r.4d.4u.4f.4b>. Each part is just a count now (0..15 for runes).
+type RuneCost int32
 
-func NewRuneCost(rp, blood, frost, unholy, death int8) RuneCost {
-	return RuneCost(rp)<<8 | RuneCost((death&0b11)<<6|(unholy&0b11)<<4|(frost&0b11)<<2|blood&0b11)
+func NewRuneCost(rp int16, blood, frost, unholy, death int8) RuneCost {
+	return RuneCost(rp)<<16 |
+		RuneCost(death&0xf)<<12 |
+		RuneCost(unholy&0xf)<<8 |
+		RuneCost(frost&0xf)<<4 |
+		RuneCost(blood&0xf)
 }
 
 func (rc RuneCost) String() string {
@@ -18,27 +22,27 @@ func (rc RuneCost) String() string {
 
 // HasRune returns if this cost includes a rune portion.
 func (rc RuneCost) HasRune() bool {
-	return rc&0b1111_1111 > 0
+	return rc&0xffff > 0
 }
 
-func (rc RuneCost) RunicPower() int8 {
-	return int8(rc >> 8)
+func (rc RuneCost) RunicPower() int16 {
+	return int16(rc >> 16)
 }
 
 func (rc RuneCost) Blood() int8 {
-	return int8(rc & 0b11)
+	return int8(rc & 0xf)
 }
 
 func (rc RuneCost) Frost() int8 {
-	return int8((rc >> 2) & 0b11)
+	return int8((rc >> 4) & 0xf)
 }
 
 func (rc RuneCost) Unholy() int8 {
-	return int8((rc >> 4) & 0b11)
+	return int8((rc >> 8) & 0xf)
 }
 
 func (rc RuneCost) Death() int8 {
-	return int8((rc >> 6) & 0b11)
+	return int8((rc >> 12) & 0xf)
 }
 
 type Predictor struct {

--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -46,1040 +46,1040 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 10741.61533
-  tps: 5401.84848
+  dps: 10677.20213
+  tps: 5364.85589
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10454.16679
-  tps: 5290.93479
+  dps: 10412.14153
+  tps: 5280.10343
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10275.51572
-  tps: 5202.03768
+  dps: 10196.88184
+  tps: 5162.48222
   hps: 94.38579
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10275.51572
-  tps: 5202.03768
+  dps: 10196.88184
+  tps: 5162.48222
   hps: 94.38579
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 10769.56377
-  tps: 5416.79288
+  dps: 10699.42508
+  tps: 5376.43212
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 10261.35442
-  tps: 5162.91183
+  dps: 10184.61264
+  tps: 5120.31809
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 8073.28492
-  tps: 4073.72772
+  dps: 8056.94799
+  tps: 4059.34545
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 8011.22871
-  tps: 4042.43378
+  dps: 8031.07925
+  tps: 4048.49411
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 7747.14648
-  tps: 3912.20006
+  dps: 7688.35705
+  tps: 3868.26738
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 10735.30194
-  tps: 5290.57746
+  dps: 10670.92357
+  tps: 5254.34368
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 12569.16603
-  tps: 6421.19142
+  dps: 12547.83462
+  tps: 6412.47935
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 12629.44234
-  tps: 6455.39297
+  dps: 12672.49654
+  tps: 6485.89847
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 10966.07289
-  tps: 5523.0453
+  dps: 10892.42012
+  tps: 5480.7557
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
   hps: 64
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 10419.13257
-  tps: 5277.14824
+  dps: 10359.03902
+  tps: 5247.20415
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 10460.89475
-  tps: 5298.39348
+  dps: 10416.63644
+  tps: 5283.83939
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 10553.15508
-  tps: 5320.94849
+  dps: 10477.29457
+  tps: 5280.8955
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 8976.86927
-  tps: 4531.5221
+  dps: 9004.45904
+  tps: 4547.23708
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 7941.6571
-  tps: 3995.09352
+  dps: 7924.72528
+  tps: 3992.97909
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10372.0626
-  tps: 5253.14357
+  dps: 10303.1279
+  tps: 5217.34852
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10941.6685
-  tps: 5573.73978
+  dps: 10887.5384
+  tps: 5555.79003
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 10999.90578
-  tps: 5607.57155
+  dps: 10929.18228
+  tps: 5572.0838
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10293.79312
-  tps: 5211.59817
+  dps: 10215.0467
+  tps: 5171.9802
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 10773.6796
-  tps: 5419.26237
+  dps: 10704.31664
+  tps: 5379.36706
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 10527.68231
-  tps: 5323.37289
+  dps: 10569.11157
+  tps: 5363.48859
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 10486.13733
-  tps: 5317.61759
+  dps: 10477.31836
+  tps: 5317.45449
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 10735.30194
-  tps: 5398.54843
+  dps: 10670.92357
+  tps: 5361.57518
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 10735.30194
-  tps: 5398.54843
+  dps: 10670.92357
+  tps: 5361.57518
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 10769.56377
-  tps: 5416.79288
+  dps: 10699.42508
+  tps: 5376.43212
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 10763.74537
-  tps: 5414.06921
+  dps: 10694.24589
+  tps: 5373.65091
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10382.19848
-  tps: 5228.98597
+  dps: 10359.32756
+  tps: 5231.60564
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 10735.30194
-  tps: 5398.54843
+  dps: 10670.92357
+  tps: 5361.57518
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 10447.75279
-  tps: 5290.86367
+  dps: 10408.20577
+  tps: 5277.25111
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 10409.38561
-  tps: 5272.77767
+  dps: 10349.60742
+  tps: 5243.31458
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForgeEmber-37660"
  value: {
-  dps: 10377.33012
-  tps: 5255.52076
+  dps: 10314.64331
+  tps: 5224.52425
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 10735.30194
-  tps: 5398.54843
+  dps: 10670.92357
+  tps: 5361.57518
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 10735.30194
-  tps: 5398.54843
+  dps: 10670.92357
+  tps: 5361.57518
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 10507.89513
-  tps: 5326.00884
+  dps: 10427.73647
+  tps: 5285.60611
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 10422.5075
-  tps: 5275.85001
+  dps: 10393.73074
+  tps: 5270.38121
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 10769.56377
-  tps: 5416.79288
+  dps: 10699.42508
+  tps: 5376.43212
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 10763.74537
-  tps: 5414.06921
+  dps: 10694.24589
+  tps: 5373.65091
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IncisorFragment-37723"
  value: {
-  dps: 10512.13718
-  tps: 5335.19778
+  dps: 10432.26857
+  tps: 5294.93286
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 10735.30194
-  tps: 5398.54843
+  dps: 10670.92357
+  tps: 5361.57518
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 10767.1575
-  tps: 5415.19959
-  hps: 16.44049
+  dps: 10702.60343
+  tps: 5378.12872
+  hps: 16.54901
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50179"
  value: {
-  dps: 12253.59563
-  tps: 6236.81887
+  dps: 12256.01633
+  tps: 6240.00452
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50708"
  value: {
-  dps: 12323.98075
-  tps: 6276.00856
+  dps: 12326.22266
+  tps: 6279.10307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 10505.72187
-  tps: 5320.37895
+  dps: 10505.87147
+  tps: 5322.2231
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 10623.58924
-  tps: 5362.95992
+  dps: 10539.11778
+  tps: 5321.08899
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10287.33802
-  tps: 5208.22133
+  dps: 10208.63132
+  tps: 5168.62542
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 10761.08977
-  tps: 5412.02794
+  dps: 10696.56917
+  tps: 5374.97566
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 10767.1575
-  tps: 5415.19959
+  dps: 10702.60343
+  tps: 5378.12872
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10324.60544
-  tps: 5227.71697
+  dps: 10245.66944
+  tps: 5187.99368
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10330.93144
-  tps: 5231.02628
+  dps: 10251.95651
+  tps: 5191.28136
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 10735.30194
-  tps: 5398.54843
+  dps: 10670.92357
+  tps: 5361.57518
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 10735.30194
-  tps: 5398.54843
+  dps: 10670.92357
+  tps: 5361.57518
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 10333.40258
-  tps: 5238.19335
+  dps: 10275.16889
+  tps: 5210.2437
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 10341.91264
-  tps: 5243.29939
+  dps: 10283.42781
+  tps: 5215.19905
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 10956.1733
-  tps: 5517.8968
+  dps: 10883.07991
+  tps: 5475.48064
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 10735.30194
-  tps: 5398.54843
+  dps: 10670.92357
+  tps: 5361.57518
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 8575.39408
-  tps: 4306.42421
+  dps: 8558.22114
+  tps: 4295.89574
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 7896.08653
-  tps: 3961.6275
+  dps: 7892.2371
+  tps: 3961.61447
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 10615.69833
-  tps: 5434.24155
+  dps: 10548.76028
+  tps: 5399.47252
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 8636.84154
-  tps: 4339.33195
+  dps: 8658.45895
+  tps: 4358.14018
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10293.03966
-  tps: 5210.91316
+  dps: 10214.37715
+  tps: 5171.34109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 13816.21798
-  tps: 7097.45263
+  dps: 13761.54085
+  tps: 7071.03671
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SouloftheDead-40382"
  value: {
-  dps: 10412.8016
-  tps: 5274.1722
+  dps: 10353.2974
+  tps: 5245.24628
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofLife-37657"
  value: {
-  dps: 10339.53189
-  tps: 5231.67721
+  dps: 10298.96183
+  tps: 5216.46316
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 10385.17645
-  tps: 5243.68298
+  dps: 10311.18438
+  tps: 5212.33296
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 7670.50219
-  tps: 3879.75688
+  dps: 7624.88629
+  tps: 3844.48464
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 10767.1575
-  tps: 5415.19959
+  dps: 10702.60343
+  tps: 5378.12872
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 10761.08977
-  tps: 5412.02794
+  dps: 10696.56917
+  tps: 5374.97566
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 10750.47125
-  tps: 5406.47755
+  dps: 10686.00922
+  tps: 5369.45782
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 9201.1027
-  tps: 4637.84821
+  dps: 9114.01328
+  tps: 4586.44334
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 8155.48727
-  tps: 4087.36894
+  dps: 8104.33637
+  tps: 4069.5673
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 8817.00188
-  tps: 4357.44445
+  dps: 8815.93629
+  tps: 4355.22822
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 10747.24471
-  tps: 5396.99979
+  dps: 10751.69659
+  tps: 5394.91031
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 10432.21661
-  tps: 5288.8117
+  dps: 10430.79789
+  tps: 5303.37051
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 10509.24458
-  tps: 5332.0367
+  dps: 10503.18755
+  tps: 5338.80597
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 10735.30194
-  tps: 5398.54843
+  dps: 10670.92357
+  tps: 5361.57518
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 10735.30194
-  tps: 5398.54843
+  dps: 10670.92357
+  tps: 5361.57518
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 10290.06081
-  tps: 5177.78344
+  dps: 10227.49322
+  tps: 5160.56887
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 10735.30194
-  tps: 5398.54843
+  dps: 10670.92357
+  tps: 5361.57518
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 10735.30194
-  tps: 5398.54843
+  dps: 10670.92357
+  tps: 5361.57518
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 8011.72077
-  tps: 4041.86851
+  dps: 7991.80399
+  tps: 4030.18482
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7733.29046
-  tps: 3735.24912
+  dps: 7756.78696
+  tps: 3749.47786
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10275.50367
-  tps: 5202.03045
+  dps: 10196.86979
+  tps: 5162.47499
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 10994.24789
-  tps: 5534.6938
+  dps: 10969.31046
+  tps: 5526.63009
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 32337.42861
-  tps: 16606.85492
+  dps: 32239.31723
+  tps: 16557.73023
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 10843.43286
-  tps: 5504.34371
+  dps: 10770.97441
+  tps: 5462.5519
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13856.55081
-  tps: 6295.85832
+  dps: 13845.82552
+  tps: 6288.7892
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 17435.72738
-  tps: 8946.78245
+  dps: 17359.01949
+  tps: 8920.8456
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6215.91592
-  tps: 3161.10732
+  dps: 6230.87833
+  tps: 3170.4907
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7320.92685
-  tps: 3294.65954
+  dps: 7271.43018
+  tps: 3261.52028
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29303.20966
-  tps: 15924.39196
+  dps: 28951.18292
+  tps: 15720.99978
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10266.28342
-  tps: 5432.84043
+  dps: 10331.16727
+  tps: 5474.36126
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13932.77469
-  tps: 6349.76629
+  dps: 14103.30036
+  tps: 6473.24717
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15777.75585
-  tps: 8589.48688
+  dps: 15854.16826
+  tps: 8640.46288
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5874.80592
-  tps: 3130.78772
+  dps: 5928.15696
+  tps: 3157.98341
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7411.34298
-  tps: 3364.94429
+  dps: 7455.47863
+  tps: 3383.84205
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti_dd-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27094.7436
-  tps: 15403.73345
+  dps: 27355.96888
+  tps: 15582.79538
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti_dd-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10229.80201
-  tps: 5402.53664
+  dps: 10250.01878
+  tps: 5416.21838
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti_dd-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13787.70345
-  tps: 6219.95187
+  dps: 13772.45173
+  tps: 6214.02319
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti_dd-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14601.28772
-  tps: 8272.40309
+  dps: 14565.12591
+  tps: 8249.45013
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti_dd-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5871.01631
-  tps: 3115.82276
+  dps: 5797.85968
+  tps: 3081.19385
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_pesti_dd-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7289.15179
-  tps: 3277.10021
+  dps: 7230.17097
+  tps: 3241.53317
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 32753.86856
-  tps: 16683.84392
+  dps: 32658.0051
+  tps: 16635.95539
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 10966.07289
-  tps: 5523.0453
+  dps: 10892.42012
+  tps: 5480.7557
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14114.78329
-  tps: 6348.01554
+  dps: 14104.09677
+  tps: 6340.94105
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 17672.51904
-  tps: 8991.52961
+  dps: 17598.75643
+  tps: 8968.30415
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6286.30489
-  tps: 3172.37897
+  dps: 6302.04226
+  tps: 3181.89866
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7457.9695
-  tps: 3322.89455
+  dps: 7408.82968
+  tps: 3289.72785
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29541.94035
-  tps: 15953.26938
+  dps: 29214.1003
+  tps: 15764.84094
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10357.65967
-  tps: 5447.81327
+  dps: 10451.38922
+  tps: 5506.62831
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14175.7201
-  tps: 6395.88592
+  dps: 14343.80138
+  tps: 6519.4248
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15916.13836
-  tps: 8609.63354
+  dps: 16026.11956
+  tps: 8681.04755
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5933.00516
-  tps: 3144.323
+  dps: 5992.87941
+  tps: 3175.15581
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7539.30721
-  tps: 3390.43801
+  dps: 7584.50062
+  tps: 3409.42861
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti_dd-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27245.06822
-  tps: 15445.16705
+  dps: 27435.83336
+  tps: 15583.92529
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti_dd-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10336.46597
-  tps: 5426.00783
+  dps: 10344.8979
+  tps: 5433.10233
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti_dd-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14032.96209
-  tps: 6264.38771
+  dps: 14017.38132
+  tps: 6258.46268
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti_dd-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14678.23434
-  tps: 8289.85047
+  dps: 14581.7378
+  tps: 8230.81728
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti_dd-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5914.47603
-  tps: 3119.36353
+  dps: 5851.11811
+  tps: 3091.2155
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_pesti_dd-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7422.19098
-  tps: 3304.53501
+  dps: 7363.20325
+  tps: 3268.95549
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 10461.92828
-  tps: 5280.69869
+  dps: 10511.98796
+  tps: 5314.70021
  }
 }

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -46,804 +46,804 @@ character_stats_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2200.00646
-  tps: 6734.61761
+  dps: 2194.33941
+  tps: 6697.38448
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 2103.91256
-  tps: 6418.2414
-  hps: 82.20134
+  dps: 2112.41683
+  tps: 6527.80845
+  hps: 82.49012
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 2103.91256
-  tps: 6418.2414
-  hps: 82.20134
+  dps: 2112.41683
+  tps: 6527.80845
+  hps: 82.49012
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 2106.43805
-  tps: 6428.69318
+  dps: 2114.30558
+  tps: 6532.46699
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 2077.02002
-  tps: 6340.96246
+  dps: 2086.40099
+  tps: 6384.43233
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1959.48001
-  tps: 6041.46903
+  dps: 1958.60616
+  tps: 6002.1816
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1908.14418
-  tps: 5804.72047
+  dps: 1912.28698
+  tps: 5822.35801
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1794.30547
-  tps: 5443.21654
+  dps: 1797.20938
+  tps: 5433.27165
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2100.59107
-  tps: 6278.65062
+  dps: 2109.10067
+  tps: 6386.19631
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 2565.75895
-  tps: 7543.91456
+  dps: 2577.47138
+  tps: 7598.66498
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 2594.02176
-  tps: 7539.39986
+  dps: 2616.56261
+  tps: 7656.30924
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2122.82882
-  tps: 6482.82
+  dps: 2130.66524
+  tps: 6587.64073
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
   hps: 64
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2138.03181
-  tps: 6529.97377
+  dps: 2143.15785
+  tps: 6628.47604
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2180.61542
-  tps: 6644.50622
+  dps: 2187.2656
+  tps: 6647.36737
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 2172.22486
-  tps: 6623.88616
+  dps: 2181.40736
+  tps: 6740.61927
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 2403.11303
-  tps: 7339.53796
+  dps: 2400.30889
+  tps: 7268.86155
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedPlate"
  value: {
-  dps: 2117.81075
-  tps: 6539.73519
+  dps: 2109.23582
+  tps: 6507.60126
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Death'sChoice-47464"
  value: {
-  dps: 2291.53101
-  tps: 7019.4214
+  dps: 2301.59673
+  tps: 7143.09576
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 2121.09033
-  tps: 6475.70469
+  dps: 2127.94429
+  tps: 6577.3218
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 2231.87336
-  tps: 6802.06368
+  dps: 2232.37668
+  tps: 6804.98168
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 2241.7631
-  tps: 6848.40245
+  dps: 2248.15636
+  tps: 6881.27486
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 2109.89394
-  tps: 6438.65983
+  dps: 2118.46229
+  tps: 6548.98361
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2108.29846
-  tps: 6432.55073
+  dps: 2115.88902
+  tps: 6535.75026
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 2171.34944
-  tps: 6597.28063
+  dps: 2165.69335
+  tps: 6571.60861
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 2166.23462
-  tps: 6581.70093
+  dps: 2170.49482
+  tps: 6542.49772
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 2100.59107
-  tps: 6406.78635
+  dps: 2109.10067
+  tps: 6516.52685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2100.59107
-  tps: 6406.78635
+  dps: 2109.10067
+  tps: 6516.52685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 2106.43805
-  tps: 6428.69318
+  dps: 2114.30558
+  tps: 6532.46699
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2104.42717
-  tps: 6421.98426
+  dps: 2113.07411
+  tps: 6529.91353
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 2149.78447
-  tps: 6584.05367
+  dps: 2155.12033
+  tps: 6591.91133
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 2100.59107
-  tps: 6406.78635
+  dps: 2109.10067
+  tps: 6516.52685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2183.63957
-  tps: 6698.18045
+  dps: 2175.01138
+  tps: 6647.95168
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2132.17325
-  tps: 6512.67888
+  dps: 2138.55838
+  tps: 6606.80207
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2127.81118
-  tps: 6495.9339
+  dps: 2134.58782
+  tps: 6590.90621
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2100.59107
-  tps: 6406.78635
+  dps: 2109.10067
+  tps: 6516.52685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2100.59107
-  tps: 6406.78635
+  dps: 2109.10067
+  tps: 6516.52685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2178.87867
-  tps: 6683.91114
+  dps: 2187.92218
+  tps: 6798.94789
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 2165.50796
-  tps: 6645.57199
+  dps: 2164.09139
+  tps: 6626.19025
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 2106.43805
-  tps: 6428.69318
+  dps: 2114.30558
+  tps: 6532.46699
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2104.42717
-  tps: 6421.98426
+  dps: 2113.07411
+  tps: 6529.91353
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2160.72521
-  tps: 6586.73191
+  dps: 2169.25735
+  tps: 6698.54552
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 2100.59107
-  tps: 6406.78635
+  dps: 2109.10067
+  tps: 6516.52685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2111.2429
-  tps: 6443.28165
+  dps: 2119.81977
+  tps: 6553.69
   hps: 15.08033
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-LastWord-50179"
  value: {
-  dps: 2352.63287
-  tps: 7051.5458
+  dps: 2362.81459
+  tps: 7125.9177
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-LastWord-50708"
  value: {
-  dps: 2375.2401
-  tps: 7110.29153
+  dps: 2385.3674
+  tps: 7184.60741
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2169.59633
-  tps: 6633.95697
+  dps: 2168.79862
+  tps: 6652.52501
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 2146.94485
-  tps: 6554.5494
+  dps: 2156.49448
+  tps: 6668.6766
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2107.78048
-  tps: 6431.4187
+  dps: 2116.33548
+  tps: 6541.60997
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 2109.21398
-  tps: 6436.33016
+  dps: 2117.77803
+  tps: 6546.61131
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2111.2429
-  tps: 6443.28165
+  dps: 2119.81977
+  tps: 6553.69
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 2119.98219
-  tps: 6473.22417
+  dps: 2128.61423
+  tps: 6584.18046
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 2122.05338
-  tps: 6480.32047
+  dps: 2130.6985
+  tps: 6591.40663
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 2100.59107
-  tps: 6406.78635
+  dps: 2109.10067
+  tps: 6516.52685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 2100.59107
-  tps: 6406.78635
+  dps: 2109.10067
+  tps: 6516.52685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 2128.65443
-  tps: 6465.11949
+  dps: 2125.79192
+  tps: 6526.43905
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 2131.08833
-  tps: 6470.16618
+  dps: 2128.63514
+  tps: 6532.33446
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2119.82488
-  tps: 6466.66498
+  dps: 2128.66694
+  tps: 6578.50078
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2100.59107
-  tps: 6406.78635
+  dps: 2109.10067
+  tps: 6516.52685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 2269.88898
-  tps: 6902.69839
+  dps: 2284.10733
+  tps: 6988.61219
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgebornePlate"
  value: {
-  dps: 2084.55306
-  tps: 6377.83127
+  dps: 2094.00628
+  tps: 6421.70877
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 2810.21628
-  tps: 8705.62116
+  dps: 2819.55049
+  tps: 8769.16553
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 2379.51913
-  tps: 7375.1097
+  dps: 2378.234
+  tps: 7409.94516
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2108.96945
-  tps: 6435.59897
+  dps: 2117.54089
+  tps: 6545.77247
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Shadowmourne-49623"
  value: {
-  dps: 2858.12702
-  tps: 8404.56122
+  dps: 2850.88574
+  tps: 8394.63681
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SoulPreserver-37111"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SouloftheDead-40382"
  value: {
-  dps: 2133.70344
-  tps: 6515.85175
+  dps: 2139.78481
+  tps: 6611.64397
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 2129.91736
-  tps: 6417.25354
+  dps: 2138.23014
+  tps: 6473.98925
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 2180.92255
-  tps: 6617.24475
+  dps: 2179.28371
+  tps: 6608.97476
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-StormshroudArmor"
  value: {
-  dps: 1766.66478
-  tps: 5375.20723
+  dps: 1774.17815
+  tps: 5402.52686
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2111.2429
-  tps: 6443.28165
+  dps: 2119.81977
+  tps: 6553.69
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 2109.21398
-  tps: 6436.33016
+  dps: 2117.77803
+  tps: 6546.61131
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2105.66337
-  tps: 6424.16506
+  dps: 2114.205
+  tps: 6534.22359
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 2446.50843
-  tps: 7516.91381
+  dps: 2454.59064
+  tps: 7540.40482
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sPlate"
  value: {
-  dps: 2115.93996
-  tps: 6476.90708
+  dps: 2123.15655
+  tps: 6540.56758
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 2058.7535
-  tps: 6403.36849
+  dps: 2053.59603
+  tps: 6353.77311
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 2123.12043
-  tps: 6509.28804
+  dps: 2121.22381
+  tps: 6526.40659
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2183.78645
-  tps: 6565.98238
+  dps: 2193.0009
+  tps: 6652.95022
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2187.20344
-  tps: 6629.1166
+  dps: 2188.29779
+  tps: 6672.43844
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2100.59107
-  tps: 6406.78635
+  dps: 2109.10067
+  tps: 6516.52685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2100.59107
-  tps: 6406.78635
+  dps: 2109.10067
+  tps: 6516.52685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 2131.0547
-  tps: 6456.39051
+  dps: 2133.42002
+  tps: 6486.13984
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2100.59107
-  tps: 6406.78635
+  dps: 2109.10067
+  tps: 6516.52685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2100.59107
-  tps: 6406.78635
+  dps: 2109.10067
+  tps: 6516.52685
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1899.2843
-  tps: 5784.53205
+  dps: 1899.49584
+  tps: 5796.53094
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 1828.57504
-  tps: 5850.30926
+  dps: 1825.712
+  tps: 5811.22242
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-WingedTalisman-37844"
  value: {
-  dps: 2103.9058
-  tps: 6418.1433
+  dps: 2112.43634
+  tps: 6528.09163
  }
 }
 dps_results: {
  key: "TestBloodTank-Average-Default"
  value: {
-  dps: 2481.51143
-  tps: 8341.35742
-  dtps: 293.07255
+  dps: 2481.58973
+  tps: 8346.17239
+  dtps: 293.23961
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_aggro-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2024.27697
-  tps: 4447.01955
+  dps: 2030.03462
+  tps: 4459.13487
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_aggro-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2024.27697
-  tps: 4447.01955
+  dps: 2030.03462
+  tps: 4459.13487
  }
 }
 dps_results: {
@@ -856,78 +856,78 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_aggro-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1219.52503
-  tps: 2632.48786
+  dps: 1222.61533
+  tps: 2644.05091
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_aggro-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1219.52503
-  tps: 2632.48786
+  dps: 1222.61533
+  tps: 2644.05091
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_aggro-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1795.35846
-  tps: 2713.33006
+  dps: 1796.2285
+  tps: 2715.34894
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_icy_touch-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7763.82525
-  tps: 18172.38992
+  dps: 7762.99393
+  tps: 18193.6846
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_icy_touch-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2173.98354
-  tps: 6620.33645
+  dps: 2161.759
+  tps: 6593.5782
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_icy_touch-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3125.65712
-  tps: 7135.88091
+  dps: 3129.86007
+  tps: 7107.78937
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_icy_touch-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4223.94825
-  tps: 10000.00343
+  dps: 4205.46741
+  tps: 9932.95112
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_icy_touch-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1307.1606
-  tps: 3944.01973
+  dps: 1299.64111
+  tps: 3875.31972
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_icy_touch-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1867.30078
-  tps: 4019.61214
+  dps: 1863.46961
+  tps: 4010.5147
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_aggro-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2043.26328
-  tps: 4482.13424
+  dps: 2049.29904
+  tps: 4494.87167
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_aggro-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2043.26328
-  tps: 4482.13424
+  dps: 2049.29904
+  tps: 4494.87167
  }
 }
 dps_results: {
@@ -940,71 +940,71 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_aggro-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1233.34495
-  tps: 2658.30648
+  dps: 1236.73155
+  tps: 2670.48989
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_aggro-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1233.34495
-  tps: 2658.30648
+  dps: 1236.73155
+  tps: 2670.48989
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_aggro-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1823.20964
-  tps: 2760.55458
+  dps: 1824.07218
+  tps: 2762.57632
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_icy_touch-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7850.71701
-  tps: 18355.79133
+  dps: 7849.6422
+  tps: 18376.37516
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_icy_touch-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2193.61997
-  tps: 6664.69741
+  dps: 2181.78571
+  tps: 6639.52598
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_icy_touch-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3166.01836
-  tps: 7201.99872
+  dps: 3170.19748
+  tps: 7173.87669
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_icy_touch-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4278.12507
-  tps: 10117.10722
+  dps: 4261.16655
+  tps: 10052.21822
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_icy_touch-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1321.40495
-  tps: 3977.95295
+  dps: 1313.76492
+  tps: 3907.90198
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_icy_touch-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1894.07399
-  tps: 4066.16654
+  dps: 1890.20107
+  tps: 4057.06063
  }
 }
 dps_results: {
  key: "TestBloodTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2508.02105
-  tps: 8258.12733
-  dtps: 270.22081
+  dps: 2518.72417
+  tps: 8346.67457
+  dtps: 270.18813
  }
 }


### PR DESCRIPTION
[dk] "doubled" RuneCost sizes so runes don't overflow in tests (e.g. a UUFFBB spell could be optimized to more than 3 death runes instead)

[dk] death runes are now spent preferring their original rune type, before falling back to the "generic" unholy -> frost -> blood order

The original rune types are determined by subtracting the optimized rune cost from the spell's default rune cost. For DKs, the latter is never changed, so this is fine. Alternatively, the optimized rune cost could additionally store those "blood-death", "frost-death", and "unholy-death" rune counts.

The used scheme has been tested to yield the same results as looking for "blood-death" runes within blood slots only, then "frost-death" runes within frost slots only, then "unholy-death" runes within unholy slots only, and finally looking for any remaining death runes in the "generic" order. The used scheme is very slightly faster, and requires less code changes.
 

