### PR TITLE
warlock: fix DP bug

### DIFF
--- a/sim/warlock/TestDemonology.results
+++ b/sim/warlock/TestDemonology.results
@@ -46,780 +46,780 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 13624.11997
-  tps: 11854.08317
+  dps: 13112.64872
+  tps: 11396.44971
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 13664.4972
-  tps: 11890.23544
+  dps: 13153.3238
+  tps: 11432.91789
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 13495.49957
-  tps: 11740.5329
+  dps: 12944.76727
+  tps: 11243.0318
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 13817.62655
-  tps: 12029.82944
+  dps: 13159.13847
+  tps: 11436.0341
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 13266.49242
-  tps: 11532.9444
-  hps: 102.24381
+  dps: 12771.31638
+  tps: 11087.15351
+  hps: 101.98077
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 13266.49242
-  tps: 11532.9444
-  hps: 102.24381
+  dps: 12771.31638
+  tps: 11087.15351
+  hps: 101.98077
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 13822.49123
-  tps: 12035.64378
+  dps: 13194.00134
+  tps: 11470.73053
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 10078.59391
-  tps: 8607.99461
+  dps: 9687.10981
+  tps: 8263.04401
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 13838.4474
-  tps: 11808.17737
+  dps: 13207.62167
+  tps: 11254.00898
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 14192.11049
-  tps: 12405.09214
+  dps: 13515.30034
+  tps: 11793.31776
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 13329.62624
-  tps: 11589.48893
+  dps: 12827.54953
+  tps: 11137.72878
   hps: 64
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 12940.86626
-  tps: 11232.9057
+  dps: 12385.81509
+  tps: 10735.22646
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 13425.32394
-  tps: 11691.57919
+  dps: 12919.79946
+  tps: 11235.38619
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 13452.65876
-  tps: 11718.97961
+  dps: 12931.95871
+  tps: 11247.57588
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 13403.67171
-  tps: 11664.03512
+  dps: 12896.22251
+  tps: 11208.09888
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Death'sChoice-47464"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 13309.98903
-  tps: 11576.24428
+  dps: 12814.77333
+  tps: 11130.36006
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DeathbringerGarb"
  value: {
-  dps: 11002.49343
-  tps: 9418.62314
+  dps: 10529.50331
+  tps: 9000.04047
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Defender'sCode-40257"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 13851.58794
-  tps: 12064.56959
+  dps: 13192.21271
+  tps: 11470.23013
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 14114.36706
-  tps: 12331.23433
+  dps: 13461.57482
+  tps: 11739.75465
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 13817.62655
-  tps: 12029.82944
+  dps: 13159.13847
+  tps: 11436.0341
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 13853.24196
-  tps: 12061.6652
+  dps: 13217.16104
+  tps: 11488.90995
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 13844.70562
-  tps: 12057.68727
+  dps: 13186.10848
+  tps: 11464.1259
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 13836.96673
-  tps: 12049.94838
+  dps: 13177.97301
+  tps: 11455.99043
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 13456.88075
-  tps: 11724.77127
+  dps: 12958.07612
+  tps: 11273.49044
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 13300.5819
-  tps: 11563.48707
+  dps: 12802.49111
+  tps: 11115.62688
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 13810.57805
-  tps: 12023.5597
+  dps: 13151.21952
+  tps: 11429.23694
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 13443.62748
-  tps: 11709.80348
+  dps: 12974.67215
+  tps: 11290.25471
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 13693.22505
-  tps: 11932.73771
+  dps: 13122.89913
+  tps: 11414.97117
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 13298.99725
-  tps: 11560.50993
+  dps: 12797.63615
+  tps: 11111.12819
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 13501.03875
-  tps: 11744.54941
+  dps: 12961.54888
+  tps: 11256.74191
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForgeEmber-37660"
  value: {
-  dps: 13640.03525
-  tps: 11880.68989
+  dps: 13030.95733
+  tps: 11330.87109
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 13838.4474
-  tps: 12046.8906
+  dps: 13207.62167
+  tps: 11481.41775
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 13840.82475
-  tps: 12050.30291
+  dps: 13196.84586
+  tps: 11471.55124
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FuturesightRune-38763"
  value: {
-  dps: 13473.3569
-  tps: 11719.65512
+  dps: 12926.10946
+  tps: 11225.9707
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 10796.59802
-  tps: 9208.58986
+  dps: 10349.03345
+  tps: 8813.92387
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 13642.61537
-  tps: 11870.74004
+  dps: 13133.53359
+  tps: 11415.45075
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 13689.80325
-  tps: 11913.10056
+  dps: 13171.33429
+  tps: 11447.75197
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 13403.1943
-  tps: 11669.62528
+  dps: 12918.16526
+  tps: 11234.00829
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 11347.09919
-  tps: 9591.22904
+  dps: 10834.8235
+  tps: 9140.56279
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 13653.07416
-  tps: 11879.60228
+  dps: 13142.0921
+  tps: 11422.45656
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 13844.70562
-  tps: 12057.68727
+  dps: 13186.10848
+  tps: 11464.1259
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 13836.96673
-  tps: 12049.94838
+  dps: 13177.97301
+  tps: 11455.99043
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IncisorFragment-37723"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 13831.21852
-  tps: 12044.44003
+  dps: 13215.6572
+  tps: 11493.18381
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 13810.57805
-  tps: 12023.5597
+  dps: 13151.21952
+  tps: 11429.23694
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 13512.84433
-  tps: 11754.56046
+  dps: 12972.91529
+  tps: 11267.32474
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MaleficRaiment"
  value: {
-  dps: 8643.10423
-  tps: 7271.39932
+  dps: 8371.5001
+  tps: 7030.20939
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 13376.74475
-  tps: 11643
+  dps: 12873.1854
+  tps: 11188.77214
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 13572.85414
-  tps: 11816.36481
+  dps: 13029.05318
+  tps: 11324.24622
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 13810.57805
-  tps: 12023.5597
+  dps: 13151.21952
+  tps: 11429.23694
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 13810.57805
-  tps: 12023.5597
+  dps: 13151.21952
+  tps: 11429.23694
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PlagueheartGarb"
  value: {
-  dps: 10458.22674
-  tps: 8913.12001
+  dps: 10072.76242
+  tps: 8573.70098
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 13816.15504
-  tps: 12028.50394
+  dps: 13157.67036
+  tps: 11434.71179
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 13817.62655
-  tps: 12029.82944
+  dps: 13159.13847
+  tps: 11436.0341
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 13800.67135
-  tps: 12036.30976
+  dps: 13274.88975
+  tps: 11563.06221
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 13882.1557
-  tps: 12114.57723
+  dps: 13345.32746
+  tps: 11630.70747
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 14154.91144
-  tps: 12367.89309
+  dps: 13477.27137
+  tps: 11755.28879
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 13798.58573
-  tps: 12011.29003
+  dps: 13173.06407
+  tps: 11449.73832
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 13329.62624
-  tps: 11589.48893
+  dps: 12827.54953
+  tps: 11137.72878
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 13597.89716
-  tps: 11834.87613
+  dps: 13078.56149
+  tps: 11365.1688
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 13640.89789
-  tps: 11873.87326
+  dps: 13112.49863
+  tps: 11395.06245
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SoulPreserver-37111"
  value: {
-  dps: 13429.10951
-  tps: 11680.52207
+  dps: 12899.49995
+  tps: 11201.55942
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SouloftheDead-40382"
  value: {
-  dps: 13429.158
-  tps: 11697.77606
+  dps: 12941.74387
+  tps: 11259.26006
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SparkofLife-37657"
  value: {
-  dps: 13432.13554
-  tps: 11690.7918
+  dps: 12913.29298
+  tps: 11225.06753
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 13284.81019
-  tps: 11536.61825
+  dps: 12783.72229
+  tps: 11085.46327
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 13810.57805
-  tps: 12023.5597
+  dps: 13151.21952
+  tps: 11429.23694
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 13810.57805
-  tps: 12023.5597
+  dps: 13151.21952
+  tps: 11429.23694
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 13810.57805
-  tps: 12023.5597
+  dps: 13151.21952
+  tps: 11429.23694
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 13371.74327
-  tps: 11628.34175
+  dps: 12856.17124
+  tps: 11163.14199
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 13311.29255
-  tps: 11573.40573
+  dps: 12826.24332
+  tps: 11136.17769
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 13266.70698
-  tps: 11532.96223
+  dps: 12770.9633
+  tps: 11086.55004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 13810.57805
-  tps: 12023.5597
+  dps: 13151.21952
+  tps: 11429.23694
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 13294.28728
-  tps: 11539.5823
+  dps: 12790.02221
+  tps: 11085.59401
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 13294.28728
-  tps: 11539.5823
+  dps: 12790.02221
+  tps: 11085.59401
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 13838.4474
-  tps: 12046.8906
+  dps: 13207.62167
+  tps: 11481.41775
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 13840.82475
-  tps: 12050.30291
+  dps: 13196.84586
+  tps: 11471.55124
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 13519.92246
-  tps: 11775.61056
+  dps: 13014.68519
+  tps: 11320.36003
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 13840.82475
-  tps: 12050.30291
+  dps: 13196.84586
+  tps: 11471.55124
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 13838.4474
-  tps: 12046.8906
+  dps: 13207.62167
+  tps: 11481.41775
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WingedTalisman-37844"
  value: {
-  dps: 13480.94211
-  tps: 11727.11324
+  dps: 12913.64441
+  tps: 11215.75235
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 14341.97534
-  tps: 12535.50277
+  dps: 13615.99165
+  tps: 11881.82616
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock--FullBuffs-LongMultiTarget"
  value: {
-  dps: 42911.40339
-  tps: 47974.52647
+  dps: 41995.52439
+  tps: 47043.88787
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock--FullBuffs-LongSingleTarget"
  value: {
-  dps: 14192.11049
-  tps: 12405.09214
+  dps: 13515.30034
+  tps: 11793.31776
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16119.13056
-  tps: 14092.12454
+  dps: 15431.28705
+  tps: 13474.68546
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock--NoBuffs-LongMultiTarget"
  value: {
-  dps: 26229.94279
-  tps: 32236.1327
+  dps: 25823.49893
+  tps: 31860.5489
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock--NoBuffs-LongSingleTarget"
  value: {
-  dps: 8221.88899
-  tps: 7606.40382
+  dps: 7992.29317
+  tps: 7392.09229
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8658.03734
-  tps: 7899.67015
+  dps: 8542.39463
+  tps: 7794.17422
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock-demo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17602.95013
-  tps: 17496.51052
+  dps: 16782.29271
+  tps: 16727.40668
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock-demo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 14139.87328
-  tps: 12351.16446
+  dps: 13503.94658
+  tps: 11780.87988
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock-demo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16034.4906
-  tps: 14007.68732
+  dps: 15354.47106
+  tps: 13397.6874
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock-demo-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10755.74703
-  tps: 12488.22985
+  dps: 10535.75007
+  tps: 12279.91047
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock-demo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 8178.07001
-  tps: 7558.9712
+  dps: 8001.09744
+  tps: 7397.93263
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock-demo-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8613.0367
-  tps: 7852.44505
+  dps: 8505.38119
+  tps: 7754.71103
  }
 }
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 14062.6613
-  tps: 12420.35873
+  dps: 13375.60269
+  tps: 11795.40042
  }
 }

--- a/sim/warlock/talents.go
+++ b/sim/warlock/talents.go
@@ -584,7 +584,7 @@ func (warlock *Warlock) setupDemonicPact() {
 			if warlock.DemonicPactAura.IsActive() {
 				lastBonus = warlock.DemonicPactAura.ExclusiveEffects[0].Priority
 			}
-			newSPBonus := math.Round(dpMult * warlock.GetStat(stats.SpellPower))
+			newSPBonus := math.Round(dpMult*warlock.GetStat(stats.SpellPower)) - lastBonus
 
 			if warlock.DemonicPactAura.RemainingDuration(sim) < 10*time.Second || newSPBonus >= lastBonus {
 				warlock.updateDPASP(sim)


### PR DESCRIPTION
In 064908b, while removing the old DP code, we accidentally removed the part where the new DP is reduced by the SP of the old one, thus DPASP went way up.