### PR TITLE
Add blood tap as a major defensive CD option when 4pc T10 is present

### DIFF
--- a/sim/deathknight/blood_tap.go
+++ b/sim/deathknight/blood_tap.go
@@ -43,4 +43,11 @@ func (dk *Deathknight) registerBloodTapSpell() {
 			dk.BloodTapAura.Activate(sim)
 		},
 	})
+
+	if !dk.Inputs.IsDps && dk.HasSetBonus(ItemSetScourgelordsPlate, 4) {
+		dk.AddMajorCooldown(core.MajorCooldown{
+			Spell: dk.BloodTap,
+			Type:  core.CooldownTypeSurvival,
+		})
+	}
 }

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -603,8 +603,8 @@ dps_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 2378.234
-  tps: 7409.94516
+  dps: 2369.21163
+  tps: 7920.62357
  }
 }
 dps_results: {

--- a/ui/tank_deathknight/inputs.ts
+++ b/ui/tank_deathknight/inputs.ts
@@ -83,10 +83,10 @@ export const TankDeathKnightRotationConfig = {
 			fieldName: 'bloodTapPrio',
 			label: 'Blood Tap',
 			labelTooltip: 'Chose how to use Blood Tap:<br>\
-				<b>Defensive</b>: Save Blood Tap for activating defensive cds.<br>\
+				<b>Use as Defensive Cooldown</b>: Use as defined in Cooldowns (Requires T9 4pc).<br>\
 				<b>Offensive</b>: Use Blood Tap for extra Icy Touches.',
 			values: [
-				{ name: 'Defensive', value: BloodTapPrio.Defensive },
+				{ name: 'Use as Defensive Cooldown', value: BloodTapPrio.Defensive },
 				{ name: 'Offensive', value: BloodTapPrio.Offensive },
 			],
 			changeEmitter: (player: Player<Spec.SpecTankDeathknight>) => TypedEvent.onAny([player.rotationChangeEmitter, player.talentsChangeEmitter]),

--- a/ui/tank_deathknight/inputs.ts
+++ b/ui/tank_deathknight/inputs.ts
@@ -83,7 +83,7 @@ export const TankDeathKnightRotationConfig = {
 			fieldName: 'bloodTapPrio',
 			label: 'Blood Tap',
 			labelTooltip: 'Chose how to use Blood Tap:<br>\
-				<b>Use as Defensive Cooldown</b>: Use as defined in Cooldowns (Requires T9 4pc).<br>\
+				<b>Use as Defensive Cooldown</b>: Use as defined in Cooldowns (Requires T10 4pc).<br>\
 				<b>Offensive</b>: Use Blood Tap for extra Icy Touches.',
 			values: [
 				{ name: 'Use as Defensive Cooldown', value: BloodTapPrio.Defensive },


### PR DESCRIPTION
t10 4pc buff support exists but the sim in legacy mode doesn't support blood tap as a Cooldown to schedule. This change allows for that and repurposes the old "Defensive" option to do something.