### PR TITLE
vigo/minorChanges

### DIFF
--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -467,6 +467,14 @@ func (character *Character) Finalize() {
 
 	character.Unit.finalize()
 
+	// For now, restrict this optimization to rogues only. Ferals will require
+	// some extra logic to handle their ExcessEnergy() calc.
+	if character.Class == proto.Class_ClassRogue {
+		character.Env.RegisterPostFinalizeEffect(func() {
+			character.energyBar.setupEnergyThresholds()
+		})
+	}
+
 	character.majorCooldownManager.finalize()
 	character.ItemSwap.finalize()
 }

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -443,15 +443,6 @@ func (unit *Unit) finalize() {
 	for _, spell := range unit.Spellbook {
 		spell.finalize()
 	}
-
-	// For now, restrict this optimization to rogues only. Ferals will require
-	// some extra logic to handle their ExcessEnergy() calc.
-	agent := unit.Env.Raid.GetPlayerFromUnit(unit)
-	if agent != nil && agent.GetCharacter().Class == proto.Class_ClassRogue {
-		unit.Env.RegisterPostFinalizeEffect(func() {
-			unit.energyBar.setupEnergyThresholds()
-		})
-	}
 }
 
 func (unit *Unit) reset(sim *Simulation, _ Agent) {
@@ -563,7 +554,7 @@ func (unit *Unit) GetMetadata() *proto.UnitMetadata {
 	return metadata
 }
 
-func (unit *Unit) StartAPLLoop(sim *Simulation) {
+func (unit *Unit) StartAPLLoop(_ *Simulation) {
 	if unit.HasManaBar() {
 		unit.ManaRequired = 0
 	}

--- a/sim/druid/feral/TestFeralApl.results
+++ b/sim/druid/feral/TestFeralApl.results
@@ -1,0 +1,1001 @@
+character_stats_results: {
+ key: "TestFeralApl-CharacterStats-Default"
+ value: {
+  final_stats: 491.18916
+  final_stats: 2188.3488
+  final_stats: 2143.7493
+  final_stats: 385.33968
+  final_stats: 394.85424
+  final_stats: 500
+  final_stats: 125
+  final_stats: 230
+  final_stats: 1315.66126
+  final_stats: 469
+  final_stats: 0
+  final_stats: 12469.20382
+  final_stats: 230
+  final_stats: 3152.25975
+  final_stats: 469
+  final_stats: 605
+  final_stats: 220.97496
+  final_stats: 8996.0952
+  final_stats: 0
+  final_stats: 0
+  final_stats: 11142.1976
+  final_stats: 3330.8
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 2069.58472
+  final_stats: 0
+  final_stats: 0
+  final_stats: 29045.343
+  final_stats: 75
+  final_stats: 75
+  final_stats: 75
+  final_stats: 75
+  final_stats: 130
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Althor'sAbacus-50359"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Althor'sAbacus-50366"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-AshtongueTalismanofEquilibrium-32486"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-AustereEarthsiegeDiamond"
+ value: {
+  dps: 11242.52294
+  tps: 8050.09758
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Bandit'sInsignia-40371"
+ value: {
+  dps: 11198.69811
+  tps: 8019.20631
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-BaubleofTrueBlood-50354"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+  hps: 91.80479
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-BaubleofTrueBlood-50726"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+  hps: 91.80479
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-BeamingEarthsiegeDiamond"
+ value: {
+  dps: 11285.83135
+  tps: 8080.84655
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-BlessedRegaliaofUndeadCleansing"
+ value: {
+  dps: 8472.69712
+  tps: 6081.27765
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-BracingEarthsiegeDiamond"
+ value: {
+  dps: 11242.52294
+  tps: 7889.09563
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-BrutalGladiator'sIdolofResolve-35019"
+ value: {
+  dps: 11212.30021
+  tps: 8028.78901
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-ChaoticSkyflareDiamond"
+ value: {
+  dps: 11563.15321
+  tps: 8277.74508
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-CorpseTongueCoin-50349"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-CorpseTongueCoin-50352"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-CorrodedSkeletonKey-50356"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+  hps: 64
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-DarkmoonCard:Berserker!-42989"
+ value: {
+  dps: 11165.28932
+  tps: 7995.48607
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-DarkmoonCard:Death-42990"
+ value: {
+  dps: 11191.18222
+  tps: 8013.79524
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-DarkmoonCard:Greatness-44255"
+ value: {
+  dps: 11210.02165
+  tps: 8027.02167
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-DeadlyGladiator'sIdolofResolve-42588"
+ value: {
+  dps: 11212.30021
+  tps: 8028.78901
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Death'sChoice-47464"
+ value: {
+  dps: 11565.82955
+  tps: 8279.72006
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-DeathKnight'sAnguish-38212"
+ value: {
+  dps: 11121.74121
+  tps: 7964.41734
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Deathbringer'sWill-50362"
+ value: {
+  dps: 11583.01548
+  tps: 8291.92207
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Deathbringer'sWill-50363"
+ value: {
+  dps: 11704.68121
+  tps: 8378.45431
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Defender'sCode-40257"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-DestructiveSkyflareDiamond"
+ value: {
+  dps: 11295.16784
+  tps: 8087.47546
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-DislodgedForeignObject-50348"
+ value: {
+  dps: 11214.81916
+  tps: 8030.80183
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-DislodgedForeignObject-50353"
+ value: {
+  dps: 11162.84122
+  tps: 7993.44877
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-DreamwalkerBattlegear"
+ value: {
+  dps: 9219.6516
+  tps: 6611.16661
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-DreamwalkerGarb"
+ value: {
+  dps: 7980.90872
+  tps: 5734.35148
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-EffulgentSkyflareDiamond"
+ value: {
+  dps: 11242.52294
+  tps: 8050.09758
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-EmberSkyflareDiamond"
+ value: {
+  dps: 11242.52294
+  tps: 8050.09758
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-EnigmaticSkyflareDiamond"
+ value: {
+  dps: 11285.83135
+  tps: 8080.84655
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-EnigmaticStarflareDiamond"
+ value: {
+  dps: 11282.33097
+  tps: 8078.36128
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-EphemeralSnowflake-50260"
+ value: {
+  dps: 11049.58589
+  tps: 7913.26185
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-EssenceofGossamer-37220"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-EternalEarthsiegeDiamond"
+ value: {
+  dps: 11242.52294
+  tps: 8050.09758
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-ExtractofNecromanticPower-40373"
+ value: {
+  dps: 11197.2449
+  tps: 8018.17453
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-EyeoftheBroodmother-45308"
+ value: {
+  dps: 11140.29938
+  tps: 7977.74322
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Figurine-SapphireOwl-42413"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-ForethoughtTalisman-40258"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-ForgeEmber-37660"
+ value: {
+  dps: 11100.1077
+  tps: 7949.13234
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-ForlornSkyflareDiamond"
+ value: {
+  dps: 11242.52294
+  tps: 8050.09758
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-ForlornStarflareDiamond"
+ value: {
+  dps: 11242.52294
+  tps: 8050.09758
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-FuriousGladiator'sIdolofResolve-42589"
+ value: {
+  dps: 11212.30021
+  tps: 8028.78901
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-FuryoftheFiveFlights-40431"
+ value: {
+  dps: 11237.73842
+  tps: 8046.77536
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-FuturesightRune-38763"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Gladiator'sSanctuary"
+ value: {
+  dps: 9710.12641
+  tps: 6959.85245
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Gladiator'sWildhide"
+ value: {
+  dps: 8070.99864
+  tps: 5795.99694
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-GlowingTwilightScale-54573"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-GlowingTwilightScale-54589"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-GnomishLightningGenerator-41121"
+ value: {
+  dps: 11167.85616
+  tps: 7997.4581
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-HatefulGladiator'sIdolofResolve-42587"
+ value: {
+  dps: 11212.30021
+  tps: 8028.78901
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Heartpierce-49982"
+ value: {
+  dps: 11751.08687
+  tps: 8411.32754
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Heartpierce-50641"
+ value: {
+  dps: 11798.3545
+  tps: 8444.43884
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-IdolofLunarFury-47670"
+ value: {
+  dps: 11212.30021
+  tps: 8028.78901
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-IdoloftheCorruptor-45509"
+ value: {
+  dps: 11212.30021
+  tps: 8028.78901
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-IdoloftheCryingMoon-50456"
+ value: {
+  dps: 11603.48638
+  tps: 8306.30684
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-IdoloftheLunarEclipse-50457"
+ value: {
+  dps: 11212.30021
+  tps: 8028.78901
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-IdoloftheRavenGoddess-32387"
+ value: {
+  dps: 11267.51824
+  tps: 8067.99381
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-IdoloftheUnseenMoon-33510"
+ value: {
+  dps: 11212.30021
+  tps: 8028.78901
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-IdoloftheWhiteStag-32257"
+ value: {
+  dps: 11212.30021
+  tps: 8028.78901
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-IllustrationoftheDragonSoul-40432"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-ImpassiveSkyflareDiamond"
+ value: {
+  dps: 11285.83135
+  tps: 8080.84655
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-ImpassiveStarflareDiamond"
+ value: {
+  dps: 11282.33097
+  tps: 8078.36128
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-IncisorFragment-37723"
+ value: {
+  dps: 11220.0487
+  tps: 8034.21565
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-InsightfulEarthsiegeDiamond"
+ value: {
+  dps: 11242.52294
+  tps: 8050.09758
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-InvigoratingEarthsiegeDiamond"
+ value: {
+  dps: 11275.21708
+  tps: 8073.31042
+  hps: 15.15199
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-LasherweaveBattlegear"
+ value: {
+  dps: 11876.22946
+  tps: 8498.08476
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-LasherweaveRegalia"
+ value: {
+  dps: 8630.99226
+  tps: 6199.12663
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-LastWord-50179"
+ value: {
+  dps: 11760.52477
+  tps: 8417.87888
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-LastWord-50708"
+ value: {
+  dps: 11788.84408
+  tps: 8437.98559
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Lavanthor'sTalisman-37872"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-MajesticDragonFigurine-40430"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Malfurion'sBattlegear"
+ value: {
+  dps: 9845.70373
+  tps: 7059.62731
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Malfurion'sRegalia"
+ value: {
+  dps: 7987.52535
+  tps: 5741.29289
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-MeteoriteWhetstone-37390"
+ value: {
+  dps: 11215.13324
+  tps: 8031.02483
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-NevermeltingIceCrystal-50259"
+ value: {
+  dps: 11097.70589
+  tps: 7947.27747
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Nibelung-49992"
+ value: {
+  dps: 11570.86052
+  tps: 8283.21726
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Nibelung-50648"
+ value: {
+  dps: 11570.86052
+  tps: 8283.21726
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-NightsongBattlegear"
+ value: {
+  dps: 9769.94881
+  tps: 7002.84985
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-NightsongGarb"
+ value: {
+  dps: 7873.26884
+  tps: 5661.29257
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-OfferingofSacrifice-37638"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-PersistentEarthshatterDiamond"
+ value: {
+  dps: 11268.98962
+  tps: 8068.88892
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-PersistentEarthsiegeDiamond"
+ value: {
+  dps: 11275.21708
+  tps: 8073.31042
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-PetrifiedScarab-21685"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-PetrifiedTwilightScale-54571"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-PetrifiedTwilightScale-54591"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-PowerfulEarthshatterDiamond"
+ value: {
+  dps: 11242.52294
+  tps: 8050.09758
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-PowerfulEarthsiegeDiamond"
+ value: {
+  dps: 11242.52294
+  tps: 8050.09758
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-PurifiedShardoftheGods"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-ReignoftheDead-47316"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-ReignoftheDead-47477"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-RelentlessEarthsiegeDiamond"
+ value: {
+  dps: 11570.86052
+  tps: 8283.21726
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-RelentlessGladiator'sIdolofResolve-42591"
+ value: {
+  dps: 11212.30021
+  tps: 8028.78901
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-RevitalizingSkyflareDiamond"
+ value: {
+  dps: 11242.52294
+  tps: 8050.09758
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-RuneofRepulsion-40372"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-SavageGladiator'sIdolofResolve-42574"
+ value: {
+  dps: 11212.30021
+  tps: 8028.78901
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-SealofthePantheon-36993"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-ShinyShardoftheGods"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Sindragosa'sFlawlessFang-50361"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-SliverofPureIce-50339"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-SliverofPureIce-50346"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-SoulPreserver-37111"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-SouloftheDead-40382"
+ value: {
+  dps: 11152.69224
+  tps: 7986.54214
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-SparkofLife-37657"
+ value: {
+  dps: 11070.78441
+  tps: 7928.16322
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-SphereofRedDragon'sBlood-37166"
+ value: {
+  dps: 11158.05651
+  tps: 7992.14565
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-StormshroudArmor"
+ value: {
+  dps: 8622.35283
+  tps: 6187.90714
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-SwiftSkyflareDiamond"
+ value: {
+  dps: 11275.21708
+  tps: 8073.31042
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-SwiftStarflareDiamond"
+ value: {
+  dps: 11268.98962
+  tps: 8068.88892
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-SwiftWindfireDiamond"
+ value: {
+  dps: 11258.09158
+  tps: 8061.15131
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-TalismanofTrollDivinity-37734"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-TearsoftheVanquished-47215"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-TheGeneral'sHeart-45507"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-ThunderheartHarness"
+ value: {
+  dps: 7437.25927
+  tps: 5343.12531
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-ThunderheartRegalia"
+ value: {
+  dps: 6567.30708
+  tps: 4726.50627
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-ThunderingSkyflareDiamond"
+ value: {
+  dps: 11268.14575
+  tps: 8068.66371
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-TinyAbominationinaJar-50351"
+ value: {
+  dps: 11127.62626
+  tps: 7971.66198
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-TinyAbominationinaJar-50706"
+ value: {
+  dps: 11202.17897
+  tps: 8024.44483
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-TirelessSkyflareDiamond"
+ value: {
+  dps: 11242.52294
+  tps: 8050.09758
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-TirelessStarflareDiamond"
+ value: {
+  dps: 11242.52294
+  tps: 8050.09758
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-TomeofArcanePhenomena-36972"
+ value: {
+  dps: 11049.54187
+  tps: 7913.45496
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-TrenchantEarthshatterDiamond"
+ value: {
+  dps: 11242.52294
+  tps: 8050.09758
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-TrenchantEarthsiegeDiamond"
+ value: {
+  dps: 11242.52294
+  tps: 8050.09758
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-UndeadSlayer'sBlessedArmor"
+ value: {
+  dps: 8810.19617
+  tps: 6321.20112
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-Val'anyr,HammerofAncientKings-46017"
+ value: {
+  dps: 8675.06384
+  tps: 6227.65034
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-VengefulGladiator'sIdolofResolve-33947"
+ value: {
+  dps: 11212.30021
+  tps: 8028.78901
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-WingedTalisman-37844"
+ value: {
+  dps: 10989.03386
+  tps: 7870.19512
+ }
+}
+dps_results: {
+ key: "TestFeralApl-AllItems-WrathfulGladiator'sIdolofResolve-51429"
+ value: {
+  dps: 11212.30021
+  tps: 8028.78901
+ }
+}
+dps_results: {
+ key: "TestFeralApl-Average-Default"
+ value: {
+  dps: 11510.71683
+  tps: 8240.99029
+ }
+}
+dps_results: {
+ key: "TestFeralApl-Settings-Tauren-p3-Default-default-FullBuffs-LongMultiTarget"
+ value: {
+  dps: 11570.86052
+  tps: 8283.21726
+ }
+}
+dps_results: {
+ key: "TestFeralApl-Settings-Tauren-p3-Default-default-FullBuffs-LongSingleTarget"
+ value: {
+  dps: 11570.86052
+  tps: 8283.21726
+ }
+}
+dps_results: {
+ key: "TestFeralApl-Settings-Tauren-p3-Default-default-FullBuffs-ShortSingleTarget"
+ value: {
+  dps: 13254.05193
+  tps: 9479.92847
+ }
+}
+dps_results: {
+ key: "TestFeralApl-Settings-Tauren-p3-Default-default-NoBuffs-LongMultiTarget"
+ value: {
+  dps: 7190.91844
+  tps: 5172.48616
+ }
+}
+dps_results: {
+ key: "TestFeralApl-Settings-Tauren-p3-Default-default-NoBuffs-LongSingleTarget"
+ value: {
+  dps: 7190.91844
+  tps: 5172.48616
+ }
+}
+dps_results: {
+ key: "TestFeralApl-Settings-Tauren-p3-Default-default-NoBuffs-ShortSingleTarget"
+ value: {
+  dps: 7724.94375
+  tps: 5553.88773
+ }
+}
+dps_results: {
+ key: "TestFeralApl-SwitchInFrontOfTarget-Default"
+ value: {
+  dps: 4134.32776
+  tps: 2945.31934
+ }
+}

--- a/sim/druid/feral/apl_values.go
+++ b/sim/druid/feral/apl_values.go
@@ -23,7 +23,7 @@ type APLValueCatExcessEnergy struct {
 	cat *FeralDruid
 }
 
-func (cat *FeralDruid) newValueCatExcessEnergy(rot *core.APLRotation, config *proto.APLValueCatExcessEnergy) core.APLValue {
+func (cat *FeralDruid) newValueCatExcessEnergy(_ *core.APLRotation, _ *proto.APLValueCatExcessEnergy) core.APLValue {
 	return &APLValueCatExcessEnergy{
 		cat: cat,
 	}
@@ -36,23 +36,17 @@ func (value *APLValueCatExcessEnergy) GetFloat(sim *core.Simulation) float64 {
 	pendingPool := PoolingActions{}
 	pendingPool.create(4)
 
-	curCp := cat.ComboPoints()
 	simTimeRemain := sim.GetRemainingDuration()
-	rakeDot := cat.Rake.CurDot()
-	ripDot := cat.Rip.CurDot()
-	mangleRefreshPending := cat.bleedAura.IsActive() && cat.bleedAura.RemainingDuration(sim) < (simTimeRemain-time.Second)
-	endThresh := time.Second * 10
-
-	if ripDot.IsActive() && (ripDot.RemainingDuration(sim) < simTimeRemain-endThresh) && curCp == 5 {
+	if ripDot := cat.Rip.CurDot(); ripDot.IsActive() && ripDot.RemainingDuration(sim) < simTimeRemain-time.Second*10 && cat.ComboPoints() == 5 {
 		ripCost := core.Ternary(cat.berserkExpectedAt(sim, ripDot.ExpiresAt()), cat.Rip.DefaultCast.Cost*0.5, cat.Rip.DefaultCast.Cost)
 		pendingPool.addAction(ripDot.ExpiresAt(), ripCost)
 		cat.ripRefreshPending = true
 	}
-	if rakeDot.IsActive() && (rakeDot.RemainingDuration(sim) < simTimeRemain-rakeDot.Duration) {
+	if rakeDot := cat.Rake.CurDot(); rakeDot.IsActive() && rakeDot.RemainingDuration(sim) < simTimeRemain-rakeDot.Duration {
 		rakeCost := core.Ternary(cat.berserkExpectedAt(sim, rakeDot.ExpiresAt()), cat.Rake.DefaultCast.Cost*0.5, cat.Rake.DefaultCast.Cost)
 		pendingPool.addAction(rakeDot.ExpiresAt(), rakeCost)
 	}
-	if mangleRefreshPending {
+	if cat.bleedAura.IsActive() && cat.bleedAura.RemainingDuration(sim) < simTimeRemain-time.Second {
 		mangleCost := core.Ternary(cat.berserkExpectedAt(sim, cat.bleedAura.ExpiresAt()), cat.MangleCat.DefaultCast.Cost*0.5, cat.MangleCat.DefaultCast.Cost)
 		pendingPool.addAction(cat.bleedAura.ExpiresAt(), mangleCost)
 	}
@@ -75,7 +69,7 @@ type APLValueCatNewSavageRoarDuration struct {
 	cat *FeralDruid
 }
 
-func (cat *FeralDruid) newValueCatNewSavageRoarDuration(rot *core.APLRotation, config *proto.APLValueCatNewSavageRoarDuration) core.APLValue {
+func (cat *FeralDruid) newValueCatNewSavageRoarDuration(_ *core.APLRotation, _ *proto.APLValueCatNewSavageRoarDuration) core.APLValue {
 	return &APLValueCatNewSavageRoarDuration{
 		cat: cat,
 	}
@@ -83,7 +77,7 @@ func (cat *FeralDruid) newValueCatNewSavageRoarDuration(rot *core.APLRotation, c
 func (value *APLValueCatNewSavageRoarDuration) Type() proto.APLValueType {
 	return proto.APLValueType_ValueTypeDuration
 }
-func (value *APLValueCatNewSavageRoarDuration) GetDuration(sim *core.Simulation) time.Duration {
+func (value *APLValueCatNewSavageRoarDuration) GetDuration(_ *core.Simulation) time.Duration {
 	cat := value.cat
 	return cat.SavageRoarDurationTable[cat.ComboPoints()]
 }

--- a/sim/druid/feral/feral_test.go
+++ b/sim/druid/feral/feral_test.go
@@ -44,6 +44,21 @@ func TestFeral(t *testing.T) {
 	}))
 }
 
+func TestFeralApl(t *testing.T) {
+	core.RunTestSuite(t, t.Name(), core.FullCharacterTestSuiteGenerator(core.CharacterSuiteConfig{
+		Class: proto.Class_ClassDruid,
+		Race:  proto.Race_RaceTauren,
+
+		GearSet:     core.GetGearSet("../../../ui/feral_druid/gear_sets", "p3"),
+		Talents:     StandardTalents,
+		Glyphs:      StandardGlyphs,
+		Consumes:    FullConsumes,
+		SpecOptions: core.SpecOptionsCombo{Label: "Default", SpecOptions: PlayerOptionsMonoCat},
+		Rotation:    core.GetAplRotation("../../../ui/feral_druid/apls", "default"),
+		ItemFilter:  FeralItemFilter,
+	}))
+}
+
 func TestFeralDoubleArmorPenTrinketsNoDesync(t *testing.T) {
 	core.RunTestSuite(t, t.Name(), core.FullCharacterTestSuiteGenerator(core.CharacterSuiteConfig{
 		Class:       proto.Class_ClassDruid,

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -6,13 +6,13 @@ character_stats_results: {
   final_stats: 1355.75
   final_stats: 833.976
   final_stats: 320.1
-  final_stats: 3148.17956
+  final_stats: 3148.20708
   final_stats: 109
   final_stats: 374
   final_stats: 1632.42984
   final_stats: 360
   final_stats: 0
-  final_stats: 5425.63186
+  final_stats: 5425.7236
   final_stats: 570.73993
   final_stats: 1851.49064
   final_stats: 360
@@ -46,1453 +46,1453 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7551.16901
-  tps: 4145.99422
+  dps: 7551.22288
+  tps: 4506.40045
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7571.27822
-  tps: 4157.59638
+  dps: 7571.33209
+  tps: 4518.00261
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7432.23831
-  tps: 4078.54216
+  dps: 7432.29269
+  tps: 4444.65886
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7555.94818
-  tps: 4150.52766
+  dps: 7556.00198
+  tps: 4520.15467
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7387.68838
-  tps: 4051.67144
+  dps: 7387.74225
+  tps: 4412.07767
   hps: 95.40076
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7387.68838
-  tps: 4051.67144
+  dps: 7387.74225
+  tps: 4412.07767
   hps: 95.40076
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7429.26312
-  tps: 4075.43524
+  dps: 7429.31748
+  tps: 4440.68518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7214.01285
-  tps: 3942.19381
+  dps: 7214.06309
+  tps: 4286.53216
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 7855.43706
-  tps: 4335.39386
+  dps: 7855.49458
+  tps: 4732.00351
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50035"
  value: {
-  dps: 7434.01596
-  tps: 4070.24045
+  dps: 7434.06846
+  tps: 4494.04002
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50692"
  value: {
-  dps: 7493.56364
-  tps: 4104.5592
+  dps: 7493.61626
+  tps: 4538.18907
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6100.63866
-  tps: 3319.88219
+  dps: 6100.6793
+  tps: 3598.15706
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6043.32824
-  tps: 3290.49684
+  dps: 6043.36963
+  tps: 3550.84828
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7455.23833
-  tps: 3978.79032
+  dps: 7455.2927
+  tps: 4371.49279
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7599.31041
-  tps: 4179.40126
+  dps: 7599.36593
+  tps: 4554.96973
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7599.31041
-  tps: 4179.40126
+  dps: 7599.36593
+  tps: 4554.96973
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7599.80498
-  tps: 4178.21406
+  dps: 7599.8606
+  tps: 4553.33149
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7387.5532
-  tps: 4051.59484
+  dps: 7387.60707
+  tps: 4412.00106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7387.5532
-  tps: 4051.59484
+  dps: 7387.60707
+  tps: 4412.00106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7387.5548
-  tps: 4051.59484
+  dps: 7387.60867
+  tps: 4412.00106
   hps: 64
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7516.61315
-  tps: 4129.03208
+  dps: 7516.66801
+  tps: 4496.98339
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7498.29351
-  tps: 4129.32449
+  dps: 7498.34779
+  tps: 4493.1962
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7582.17139
-  tps: 4156.15619
+  dps: 7582.2326
+  tps: 4532.36101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 7639.65012
-  tps: 4203.01798
+  dps: 7639.70535
+  tps: 4574.28307
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7750.33425
-  tps: 4241.37277
+  dps: 7750.38852
+  tps: 4633.04638
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7477.2425
-  tps: 4108.69773
+  dps: 7477.29706
+  tps: 4473.82938
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7711.14094
-  tps: 4214.51392
+  dps: 7711.19648
+  tps: 4608.47643
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7759.15821
-  tps: 4234.05411
+  dps: 7759.21397
+  tps: 4633.58657
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7387.5548
-  tps: 4051.59484
+  dps: 7387.60867
+  tps: 4412.00106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7448.37586
-  tps: 4086.02344
+  dps: 7448.43038
+  tps: 4453.5828
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7836.65987
-  tps: 4317.80124
+  dps: 7836.71565
+  tps: 4697.61157
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7734.13808
-  tps: 4251.83454
+  dps: 7734.19336
+  tps: 4627.63907
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 6836.4093
-  tps: 3727.55867
+  dps: 6836.45896
+  tps: 4053.45224
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterGarb"
  value: {
-  dps: 6473.86219
-  tps: 3534.12652
+  dps: 6473.91636
+  tps: 3791.67426
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7432.23831
-  tps: 4078.54216
+  dps: 7432.29269
+  tps: 4444.65886
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7481.61457
-  tps: 4110.41916
+  dps: 7481.6702
+  tps: 4478.88948
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7445.66397
-  tps: 4084.70162
+  dps: 7445.71848
+  tps: 4451.98829
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7441.4449
-  tps: 4082.31954
+  dps: 7441.49939
+  tps: 4449.81179
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7498.25245
-  tps: 4114.93945
+  dps: 7498.30721
+  tps: 4485.1773
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7387.5532
-  tps: 4051.59484
+  dps: 7387.60707
+  tps: 4412.00106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7432.23831
-  tps: 4078.54216
+  dps: 7432.29269
+  tps: 4444.65886
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7514.45903
-  tps: 4134.18979
+  dps: 7514.51365
+  tps: 4499.46303
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7629.31578
-  tps: 4195.50309
+  dps: 7629.37055
+  tps: 4562.45131
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7404.80421
-  tps: 4059.43863
+  dps: 7404.86112
+  tps: 4420.8207
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7489.01329
-  tps: 4110.133
+  dps: 7489.06715
+  tps: 4470.53923
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7567.71283
-  tps: 4142.40543
+  dps: 7567.76737
+  tps: 4507.73844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7455.23833
-  tps: 4091.81732
+  dps: 7455.2927
+  tps: 4457.93402
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7450.63833
-  tps: 4089.16229
+  dps: 7450.6927
+  tps: 4455.27899
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 8347.24991
-  tps: 4544.28828
+  dps: 8347.3227
+  tps: 4991.94144
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 7882.13696
-  tps: 4357.13911
+  dps: 7882.22063
+  tps: 4675.1757
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 7652.59374
-  tps: 4210.48826
+  dps: 7652.64897
+  tps: 4581.75335
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7593.75263
-  tps: 4162.01841
+  dps: 7593.80657
+  tps: 4540.18261
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7444.22754
-  tps: 4084.29183
+  dps: 7444.28141
+  tps: 4444.69806
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 7083.21273
-  tps: 3829.83659
+  dps: 7083.27204
+  tps: 4181.34774
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sWartide"
  value: {
-  dps: 6252.86217
-  tps: 3384.95856
+  dps: 6252.12636
+  tps: 3615.20928
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7561.22656
-  tps: 4151.7953
+  dps: 7561.28043
+  tps: 4512.20153
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7584.07793
-  tps: 4164.97957
+  dps: 7584.1318
+  tps: 4525.3858
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7527.69764
-  tps: 4140.09312
+  dps: 7527.75223
+  tps: 4504.38512
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 7614.97003
-  tps: 4187.99004
+  dps: 7615.02525
+  tps: 4559.25513
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-49982"
  value: {
-  dps: 7599.31041
-  tps: 4179.40126
+  dps: 7599.36593
+  tps: 4554.96973
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-50641"
  value: {
-  dps: 7599.31041
-  tps: 4179.40126
+  dps: 7599.36593
+  tps: 4554.96973
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7557.94099
-  tps: 4152.85467
+  dps: 7557.99486
+  tps: 4513.2609
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7445.66397
-  tps: 4084.70162
+  dps: 7445.71848
+  tps: 4451.98829
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7441.4449
-  tps: 4082.31954
+  dps: 7441.49939
+  tps: 4449.81179
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7520.44049
-  tps: 4124.63502
+  dps: 7520.4948
+  tps: 4499.46817
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7442.89617
-  tps: 4082.04185
+  dps: 7442.95212
+  tps: 4448.58814
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7468.81688
-  tps: 4099.03431
+  dps: 7468.87131
+  tps: 4467.55597
   hps: 11.01615
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50179"
  value: {
-  dps: 7599.31041
-  tps: 4179.40126
+  dps: 7599.36593
+  tps: 4554.96973
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50708"
  value: {
-  dps: 7599.31041
-  tps: 4179.40126
+  dps: 7599.36593
+  tps: 4554.96973
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7387.5548
-  tps: 4051.59484
+  dps: 7387.60867
+  tps: 4412.00106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7387.5532
-  tps: 4051.59484
+  dps: 7387.60707
+  tps: 4412.00106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7509.67841
-  tps: 4123.778
+  dps: 7509.7324
+  tps: 4485.03396
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Nibelung-49992"
  value: {
-  dps: 7599.31041
-  tps: 4179.40126
+  dps: 7599.36593
+  tps: 4554.96973
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Nibelung-50648"
  value: {
-  dps: 7599.31041
-  tps: 4179.40126
+  dps: 7599.36593
+  tps: 4554.96973
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7387.55641
-  tps: 4051.59484
+  dps: 7387.61028
+  tps: 4412.00106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7463.11582
-  tps: 4095.89149
+  dps: 7463.17025
+  tps: 4464.03199
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7468.81688
-  tps: 4099.03431
+  dps: 7468.87131
+  tps: 4467.55597
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7387.54744
-  tps: 4051.59484
+  dps: 7387.60131
+  tps: 4412.00106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7387.5532
-  tps: 4051.59484
+  dps: 7387.60707
+  tps: 4412.00106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7387.5532
-  tps: 4051.59484
+  dps: 7387.60707
+  tps: 4412.00106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7432.23831
-  tps: 4078.54216
+  dps: 7432.29269
+  tps: 4444.65886
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7432.23831
-  tps: 4078.54216
+  dps: 7432.29269
+  tps: 4444.65886
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7387.5532
-  tps: 4051.59484
+  dps: 7387.60707
+  tps: 4412.00106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7805.58413
-  tps: 4331.80401
+  dps: 7805.63806
+  tps: 4692.81942
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7856.10276
-  tps: 4365.15377
+  dps: 7856.15669
+  tps: 4726.16917
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7599.31041
-  tps: 4179.40126
+  dps: 7599.36593
+  tps: 4554.96973
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 7668.311
-  tps: 4219.55931
+  dps: 7668.36622
+  tps: 4590.8244
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7443.61067
-  tps: 4087.68193
+  dps: 7443.66514
+  tps: 4454.84215
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7387.5548
-  tps: 4051.59484
+  dps: 7387.60867
+  tps: 4412.00106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 7608.51228
-  tps: 4184.38949
+  dps: 7608.56751
+  tps: 4555.65457
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7387.5548
-  tps: 4051.59484
+  dps: 7387.60867
+  tps: 4412.00106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7599.31041
-  tps: 4179.40126
+  dps: 7599.36593
+  tps: 4554.96973
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7387.5532
-  tps: 4051.59484
+  dps: 7387.60707
+  tps: 4412.00106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7387.5532
-  tps: 4051.59484
+  dps: 7387.60707
+  tps: 4412.00106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkycallTotem-33506"
  value: {
-  dps: 7590.74877
-  tps: 4173.75299
+  dps: 7590.80412
+  tps: 4545.36982
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterHarness"
  value: {
-  dps: 5432.76204
-  tps: 2938.51089
+  dps: 5432.79459
+  tps: 3161.54669
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterRegalia"
  value: {
-  dps: 5374.20033
-  tps: 2923.77735
+  dps: 5377.09601
+  tps: 3118.69452
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7512.41168
-  tps: 4128.43315
+  dps: 7512.4654
+  tps: 4488.57543
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7520.95394
-  tps: 4131.05833
+  dps: 7521.00756
+  tps: 4489.39857
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7456.10731
-  tps: 4091.14765
+  dps: 7456.16118
+  tps: 4451.55388
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7494.43499
-  tps: 4114.73053
+  dps: 7494.4897
+  tps: 4481.48869
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SparkofLife-37657"
  value: {
-  dps: 7479.22023
-  tps: 4111.36677
+  dps: 7479.2748
+  tps: 4477.40587
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7531.39642
-  tps: 4118.75467
+  dps: 7531.45062
+  tps: 4490.66454
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 7609.33504
-  tps: 4182.0575
+  dps: 7609.39027
+  tps: 4556.01682
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StormshroudArmor"
  value: {
-  dps: 5696.10627
-  tps: 3089.25307
+  dps: 5696.13947
+  tps: 3335.04843
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7468.81688
-  tps: 4099.03431
+  dps: 7468.87131
+  tps: 4467.55597
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7463.11582
-  tps: 4095.89149
+  dps: 7463.17025
+  tps: 4464.03199
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7447.23233
-  tps: 4086.99989
+  dps: 7447.28673
+  tps: 4454.4222
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7387.55614
-  tps: 4051.59484
+  dps: 7387.61001
+  tps: 4412.00106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7443.49382
-  tps: 4081.9271
+  dps: 7443.55399
+  tps: 4446.18613
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheFistsofFury"
  value: {
-  dps: 6562.78556
-  tps: 3562.77847
+  dps: 6562.83479
+  tps: 3898.66725
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7387.5532
-  tps: 4051.59484
+  dps: 7387.60707
+  tps: 4412.00106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 7334.50007
-  tps: 4035.19032
+  dps: 7334.55667
+  tps: 4373.00373
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sRegalia"
  value: {
-  dps: 6982.0956
-  tps: 3849.32295
+  dps: 6982.15847
+  tps: 4129.68966
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7504.97661
-  tps: 4126.89033
+  dps: 7505.03167
+  tps: 4502.91649
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TidefuryRaiment"
  value: {
-  dps: 5396.11419
-  tps: 2916.3189
+  dps: 5394.0838
+  tps: 3130.8434
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7577.0477
-  tps: 4163.04058
+  dps: 7577.10317
+  tps: 4544.7385
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7601.99423
-  tps: 4180.1133
+  dps: 7602.04996
+  tps: 4563.33704
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7455.23833
-  tps: 4091.81732
+  dps: 7455.2927
+  tps: 4457.93402
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7450.63833
-  tps: 4089.16229
+  dps: 7450.6927
+  tps: 4455.27899
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7527.16315
-  tps: 4131.33883
+  dps: 7527.21765
+  tps: 4498.50208
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 7821.19259
-  tps: 4313.61703
+  dps: 7821.24986
+  tps: 4705.96131
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofQuakingEarth-47667"
  value: {
-  dps: 7721.56943
-  tps: 4241.60004
+  dps: 7721.62464
+  tps: 4625.52252
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 7857.39474
-  tps: 4311.55975
+  dps: 7857.44993
+  tps: 4706.15674
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheElementalPlane-40708"
  value: {
-  dps: 7590.21305
-  tps: 4178.2754
+  dps: 7590.26847
+  tps: 4551.83695
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7450.63833
-  tps: 4089.16229
+  dps: 7450.6927
+  tps: 4455.27899
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7455.23833
-  tps: 4091.81732
+  dps: 7455.2927
+  tps: 4457.93402
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6043.88295
-  tps: 3285.16169
+  dps: 6043.91705
+  tps: 3559.43808
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7794.97152
-  tps: 4283.14429
+  dps: 7795.02818
+  tps: 4669.09218
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7487.11256
-  tps: 4091.68423
+  dps: 7487.16643
+  tps: 4452.09045
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 7298.40397
-  tps: 4011.40106
+  dps: 7298.45886
+  tps: 4357.65686
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerGarb"
  value: {
-  dps: 7001.1038
-  tps: 3863.90387
+  dps: 7001.16635
+  tps: 4140.84415
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 7684.9528
-  tps: 4229.16396
+  dps: 7685.00802
+  tps: 4600.42904
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 7620.23338
-  tps: 4189.58851
+  dps: 7620.26411
+  tps: 4565.62899
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_ft-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26249.60367
-  tps: 15742.56368
+  dps: 26249.72731
+  tps: 16118.60862
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_ft-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7699.28044
-  tps: 4191.54959
+  dps: 7699.33608
+  tps: 4565.63209
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_ft-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9594.52738
-  tps: 4589.07833
+  dps: 9594.59562
+  tps: 5020.09434
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_ft-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13757.65417
-  tps: 8878.03048
+  dps: 13763.46534
+  tps: 9089.71623
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_ft-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4017.85506
-  tps: 2137.41962
+  dps: 4015.91067
+  tps: 2346.86625
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_ft-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5212.25755
-  tps: 2446.17435
+  dps: 5212.29144
+  tps: 2660.48211
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_wf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25721.96031
-  tps: 15476.15133
+  dps: 25722.08226
+  tps: 15850.30265
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_wf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7766.49597
-  tps: 4240.93173
+  dps: 7766.55218
+  tps: 4614.97344
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_wf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9624.58938
-  tps: 4617.23092
+  dps: 9624.65799
+  tps: 5045.77593
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_wf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13174.37953
-  tps: 8428.77325
+  dps: 13163.13171
+  tps: 8633.56542
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_wf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4060.00792
-  tps: 2165.3211
+  dps: 4059.72286
+  tps: 2376.09695
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_wf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5326.50631
-  tps: 2516.33238
+  dps: 5326.54097
+  tps: 2735.10182
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-phase_3-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26091.51726
-  tps: 15708.87515
+  dps: 26091.64018
+  tps: 16081.41792
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-phase_3-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7666.34338
-  tps: 4175.88237
+  dps: 7666.39868
+  tps: 4546.66377
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-phase_3-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9555.6372
-  tps: 4561.71596
+  dps: 9555.70497
+  tps: 4989.89658
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-phase_3-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13560.54839
-  tps: 8686.55786
+  dps: 13559.77145
+  tps: 8900.36759
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-phase_3-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3993.21052
-  tps: 2117.37687
+  dps: 3992.93883
+  tps: 2325.64352
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-phase_3-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5223.4731
-  tps: 2458.82795
+  dps: 5223.50686
+  tps: 2672.65427
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_ft-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21768.03231
-  tps: 13251.18925
+  dps: 21768.14853
+  tps: 13630.82366
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_ft-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6549.52793
-  tps: 3502.42615
+  dps: 6549.58353
+  tps: 3880.18754
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_ft-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8493.19042
-  tps: 3913.3226
+  dps: 8493.26029
+  tps: 4354.11574
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_ft-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10679.7829
-  tps: 7426.73635
+  dps: 10679.68338
+  tps: 7595.27798
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_ft-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2993.07639
-  tps: 1630.34376
+  dps: 2996.21675
+  tps: 1794.37111
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_ft-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4015.50326
-  tps: 1886.07417
+  dps: 4015.53509
+  tps: 2052.20641
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_wf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20979.12553
-  tps: 12736.51577
+  dps: 20979.23936
+  tps: 13117.35913
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_wf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6639.63523
-  tps: 3568.23371
+  dps: 6639.69163
+  tps: 3946.78008
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_wf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8619.46862
-  tps: 4003.93719
+  dps: 8619.5394
+  tps: 4445.01481
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_wf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9927.93938
-  tps: 6911.53506
+  dps: 9926.88955
+  tps: 7086.87277
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_wf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3042.35975
-  tps: 1663.03992
+  dps: 3044.1999
+  tps: 1828.15167
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_wf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4086.67052
-  tps: 1937.48807
+  dps: 4086.70298
+  tps: 2104.42225
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-phase_3-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21334.49142
-  tps: 12921.37943
+  dps: 21334.60591
+  tps: 13299.13823
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-phase_3-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6516.21269
-  tps: 3486.84939
+  dps: 6516.26788
+  tps: 3860.91745
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-phase_3-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8435.06146
-  tps: 3889.97406
+  dps: 8435.13083
+  tps: 4325.33426
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-phase_3-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10411.97261
-  tps: 7210.32116
+  dps: 10414.33237
+  tps: 7380.13889
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-phase_3-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2984.25684
-  tps: 1620.45335
+  dps: 2986.01548
+  tps: 1784.0936
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-phase_3-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4062.06457
-  tps: 1927.93793
+  dps: 4062.09662
+  tps: 2094.26622
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_ft-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25997.44452
-  tps: 15825.85704
+  dps: 25997.56786
+  tps: 16202.46462
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_ft-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7599.31041
-  tps: 4179.40126
+  dps: 7599.36593
+  tps: 4554.96973
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_ft-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9595.81365
-  tps: 4696.34995
+  dps: 9595.8833
+  tps: 5146.67199
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_ft-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13325.24085
-  tps: 8665.19533
+  dps: 13310.12383
+  tps: 8871.98313
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_ft-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3978.60659
-  tps: 2141.40901
+  dps: 3974.18198
+  tps: 2352.45029
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_ft-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5164.14909
-  tps: 2505.77375
+  dps: 5164.18366
+  tps: 2730.35194
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_wf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25348.82592
-  tps: 15322.82423
+  dps: 25348.94745
+  tps: 15701.96251
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_wf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7674.98308
-  tps: 4232.62599
+  dps: 7675.03918
+  tps: 4607.29109
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_wf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9613.88549
-  tps: 4718.42972
+  dps: 9613.95526
+  tps: 5168.68323
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_wf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12965.11429
-  tps: 8435.1971
+  dps: 12953.03505
+  tps: 8646.67606
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_wf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4038.6084
-  tps: 2184.45165
+  dps: 4038.64877
+  tps: 2397.35028
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_wf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5238.98494
-  tps: 2547.45399
+  dps: 5239.02002
+  tps: 2774.64476
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-phase_3-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25686.13096
-  tps: 15536.37253
+  dps: 25686.2533
+  tps: 15914.46641
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-phase_3-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7631.1628
-  tps: 4205.88127
+  dps: 7631.21841
+  tps: 4582.12617
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-phase_3-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9502.01038
-  tps: 4655.77643
+  dps: 9502.07918
+  tps: 5098.96327
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-phase_3-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13362.97349
-  tps: 8674.49828
+  dps: 13363.28434
+  tps: 8894.11584
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-phase_3-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3937.59259
-  tps: 2118.11034
+  dps: 3940.4125
+  tps: 2331.10205
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-phase_3-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5145.52344
-  tps: 2485.04316
+  dps: 5145.55745
+  tps: 2701.72676
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_ft-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21508.47681
-  tps: 13148.64825
+  dps: 21508.59245
+  tps: 13528.58401
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_ft-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6494.30745
-  tps: 3492.82616
+  dps: 6494.3631
+  tps: 3872.94901
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_ft-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8395.79942
-  tps: 3915.29181
+  dps: 8395.86974
+  tps: 4368.40094
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_ft-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10516.84746
-  tps: 7347.45431
+  dps: 10519.26364
+  tps: 7518.86815
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_ft-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2969.44202
-  tps: 1628.10401
+  dps: 2969.46751
+  tps: 1791.78993
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_ft-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3968.80449
-  tps: 1897.27885
+  dps: 3968.83643
+  tps: 2068.36286
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_wf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21058.37728
-  tps: 12907.98965
+  dps: 21058.4915
+  tps: 13292.74186
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_wf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6562.69585
-  tps: 3550.39829
+  dps: 6562.75204
+  tps: 3928.68293
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_wf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8475.83432
-  tps: 3978.75402
+  dps: 8475.90527
+  tps: 4431.08666
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_wf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9894.60901
-  tps: 6972.19506
+  dps: 9901.12513
+  tps: 7151.10988
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_wf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3031.30887
-  tps: 1671.98393
+  dps: 3030.88243
+  tps: 1836.21597
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_wf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4042.5674
-  tps: 1947.16305
+  dps: 4042.59997
+  tps: 2118.5086
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-phase_3-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21387.2867
-  tps: 13085.27147
+  dps: 21387.40171
+  tps: 13467.73833
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-phase_3-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6495.16588
-  tps: 3495.71092
+  dps: 6495.22137
+  tps: 3875.74041
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-phase_3-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8429.4497
-  tps: 3953.50633
+  dps: 8429.51999
+  tps: 4410.77629
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-phase_3-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10330.30617
-  tps: 7176.61741
+  dps: 10322.63124
+  tps: 7347.65055
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-phase_3-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2936.54919
-  tps: 1604.65442
+  dps: 2936.57426
+  tps: 1768.19472
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-phase_3-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4030.64483
-  tps: 1946.11958
+  dps: 4030.67707
+  tps: 2119.91451
  }
 }
 dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7261.95773
-  tps: 3971.59846
+  dps: 7262.01053
+  tps: 4325.07316
  }
 }

--- a/sim/shaman/shaman.go
+++ b/sim/shaman/shaman.go
@@ -262,10 +262,6 @@ func (shaman *Shaman) Initialize() {
 		shaman.setupProcTrackers()
 	}
 
-	if shaman.Talents.SpiritWeapons {
-		shaman.PseudoStats.ThreatMultiplier -= 0.3
-	}
-
 	// Healing stream totem applies a HoT (aura) and so needs to be handled as a pre-pull action
 	// instead of during init/reset.
 	if shaman.Totems.Water == proto.WaterTotem_HealingStreamTotem {

--- a/sim/shaman/talents.go
+++ b/sim/shaman/talents.go
@@ -39,16 +39,15 @@ func (shaman *Shaman) ApplyTalents() {
 		shaman.AddStatDependency(stats.AttackPower, stats.SpellPower, 0.1*float64(shaman.Talents.MentalQuickness))
 	}
 	if shaman.Talents.MentalDexterity > 0 {
-		shaman.AddStatDependency(stats.Intellect, stats.AttackPower, 0.3333*float64(shaman.Talents.MentalDexterity))
+		shaman.AddStatDependency(stats.Intellect, stats.AttackPower, []float64{0, 0.33, 0.66, 1}[shaman.Talents.MentalDexterity])
 	}
 	if shaman.Talents.NaturesBlessing > 0 {
 		shaman.AddStatDependency(stats.Intellect, stats.SpellPower, 0.1*float64(shaman.Talents.NaturesBlessing))
 	}
 
 	if shaman.Talents.SpiritWeapons {
+		shaman.PseudoStats.ThreatMultiplier *= 0.7
 		shaman.PseudoStats.CanParry = true
-		shaman.AutoAttacks.MHConfig().ThreatMultiplier *= 0.7 // TODO this looks fishy
-		shaman.AutoAttacks.OHConfig().ThreatMultiplier *= 0.7
 	}
 
 	shaman.applyElementalFocus()

--- a/ui/feral_druid/apls/default.apl.json
+++ b/ui/feral_druid/apls/default.apl.json
@@ -1,0 +1,20 @@
+{
+  "type": "TypeAPL",
+  "prepullActions": [
+    {"action":{"activateAura":{"auraId":{"spellId":16870}}},"doAtValue":{"const":{"val":"-1s"}}}
+  ],
+  "priorityList": [
+    {"action":{"autocastOtherCooldowns":{}}},
+    {"action":{"condition":{"and":{"vals":[{"not":{"val":{"auraIsActive":{"auraId":{"spellId":16870}}}}},{"cmp":{"op":"OpLe","lhs":{"currentEnergy":{}},"rhs":{"const":{"val":"80"}}}}]}},"castSpell":{"spellId":{"spellId":16857}}}},
+    {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"currentEnergy":{}},"rhs":{"const":{"val":"30"}}}},"castSpell":{"spellId":{"spellId":50213}}}},
+    {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"auraRemainingTime":{"auraId":{"spellId":52610}}},"rhs":{"const":{"val":"1s"}}}},"castSpell":{"spellId":{"spellId":52610}}}},
+    {"action":{"condition":{"auraShouldRefresh":{"auraId":{"spellId":48566},"maxOverlap":{"const":{"val":"0ms"}}}},"castSpell":{"spellId":{"spellId":48566}}}},
+    {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":16870}}},"castSpell":{"spellId":{"spellId":48572}}}},
+    {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpGe","lhs":{"currentComboPoints":{}},"rhs":{"const":{"val":"5"}}}},{"not":{"val":{"auraIsActive":{"sourceUnit":{"type":"CurrentTarget"},"auraId":{"spellId":49800}}}}},{"cmp":{"op":"OpGe","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"4"}}}}]}},"castSpell":{"spellId":{"spellId":49800}}}},
+    {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpGe","lhs":{"currentComboPoints":{}},"rhs":{"const":{"val":"5"}}}},{"cmp":{"op":"OpGe","lhs":{"auraRemainingTime":{"sourceUnit":{"type":"CurrentTarget"},"auraId":{"spellId":49800}}},"rhs":{"const":{"val":"4s"}}}},{"or":{"vals":[{"not":{"val":{"auraIsActive":{"auraId":{"spellId":50334}}}}},{"cmp":{"op":"OpLe","lhs":{"currentEnergy":{}},"rhs":{"const":{"val":"30"}}}}]}},{"cmp":{"op":"OpGe","lhs":{"auraRemainingTime":{"auraId":{"spellId":52610}}},"rhs":{"const":{"val":"4s"}}}}]}},"castSpell":{"spellId":{"spellId":48577}}}},
+    {"action":{"condition":{"and":{"vals":[{"not":{"val":{"auraIsActive":{"sourceUnit":{"type":"CurrentTarget"},"auraId":{"spellId":48574}}}}},{"cmp":{"op":"OpGe","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"9"}}}}]}},"castSpell":{"spellId":{"spellId":48574}}}},
+    {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpGe","lhs":{"currentEnergy":{}},"rhs":{"const":{"val":"50"}}}},{"cmp":{"op":"OpLe","lhs":{"currentEnergy":{}},"rhs":{"const":{"val":"85"}}}},{"cmp":{"op":"OpGt","lhs":{"spellTimeToReady":{"spellId":{"spellId":50213}}},"rhs":{"const":{"val":"15s"}}}}]}},"castSpell":{"spellId":{"spellId":50334}}}},
+    {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"currentComboPoints":{}},"rhs":{"const":{"val":"4"}}}},"castSpell":{"spellId":{"spellId":48572}}}},
+    {"action":{"condition":{"or":{"vals":[{"cmp":{"op":"OpGe","lhs":{"currentEnergy":{}},"rhs":{"const":{"val":"85"}}}},{"auraIsActive":{"auraId":{"spellId":50334}}}]}},"castSpell":{"spellId":{"spellId":48572}}}}
+  ]
+}


### PR DESCRIPTION
[core] move energy threshold setup from unit to character

[druid/feral] add a default APL, and related test, slightly refactor APLValueCatExcessEnergy 

[shaman] Spirit Weapons' threat reduction now works like "every other threat reduction", and doesn't apply to AutoAttacks twice 
[shaman] while at it, fix Mental Dexterity to use the correct Intellect -> AP stat multipliers (tested in-game)