### PR TITLE
add additional SM proc chances

### DIFF
--- a/sim/deathknight/diseases.go
+++ b/sim/deathknight/diseases.go
@@ -125,6 +125,17 @@ func (dk *Deathknight) registerBloodPlague() {
 	// Tier9 4Piece
 	canCrit := dk.HasSetBonus(ItemSetThassariansBattlegear, 4)
 
+	// SM can proc off blood plague application
+	bloodPlagueApplicationSpell := dk.RegisterSpell(core.SpellConfig{
+		ActionID:    core.ActionID{SpellID: 55078}.WithTag(1),
+		SpellSchool: core.SpellSchoolShadow,
+		ProcMask:    core.ProcMaskProc,
+		Flags:       core.SpellFlagNoLogs | core.SpellFlagNoMetrics,
+		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+			dk.BloodPlagueSpell.Dot(target).Apply(sim)
+		},
+	})
+
 	dk.BloodPlagueSpell = dk.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 55078},
 		SpellSchool: core.SpellSchoolShadow,
@@ -170,8 +181,7 @@ func (dk *Deathknight) registerBloodPlague() {
 		},
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			dot := spell.Dot(target)
-			dot.Apply(sim)
+			bloodPlagueApplicationSpell.Cast(sim, target)
 		},
 	})
 	dk.BloodPlagueExtended = make([]int, dk.Env.GetNumTargets())

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -252,15 +252,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11054.42214
-  tps: 6470.50132
+  dps: 11054.58588
+  tps: 6470.59956
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11002.10987
-  tps: 6438.46412
+  dps: 11001.03092
+  tps: 6437.82133
  }
 }
 dps_results: {

--- a/sim/deathknight/dps/TestFrostUH.results
+++ b/sim/deathknight/dps/TestFrostUH.results
@@ -252,15 +252,15 @@ dps_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11161.39555
-  tps: 7940.5934
+  dps: 11179.30689
+  tps: 7954.12011
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11092.40836
-  tps: 7894.83816
+  dps: 11092.15512
+  tps: 7894.5297
  }
 }
 dps_results: {

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -278,16 +278,16 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11799.1826
-  tps: 7724.64572
+  dps: 11798.98234
+  tps: 7724.62368
   hps: 319.74369
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11803.67413
-  tps: 7738.22348
+  dps: 11803.88112
+  tps: 7738.28514
   hps: 318.90115
  }
 }

--- a/sim/deathknight/scourge_strike.go
+++ b/sim/deathknight/scourge_strike.go
@@ -21,7 +21,7 @@ func (dk *Deathknight) registerScourgeStrikeShadowDamageSpell() *core.Spell {
 	return dk.Unit.RegisterSpell(core.SpellConfig{
 		ActionID:    ScourgeStrikeActionID.WithTag(2),
 		SpellSchool: core.SpellSchoolShadow,
-		ProcMask:    core.ProcMaskSpellDamage,
+		ProcMask:    core.ProcMaskSpellDamage | core.ProcMaskProc,
 		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIgnoreAttackerModifiers,
 
 		DamageMultiplier: 1,

--- a/sim/deathknight/talents_unholy.go
+++ b/sim/deathknight/talents_unholy.go
@@ -158,12 +158,10 @@ func (dk *Deathknight) applyBloodCakedBlade() {
 }
 
 func (dk *Deathknight) bloodCakedBladeHit(isMh bool) *core.Spell {
-	procMask := core.ProcMaskProc
-
 	return dk.Unit.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 50463}.WithTag(core.TernaryInt32(isMh, 1, 2)),
 		SpellSchool: core.SpellSchoolPhysical,
-		ProcMask:    procMask,
+		ProcMask:    core.ProcMaskProc,
 		Flags:       core.SpellFlagNoOnCastComplete | core.SpellFlagMeleeMetrics,
 
 		DamageMultiplier: 1 *

--- a/sim/rogue/TestAssassination.results
+++ b/sim/rogue/TestAssassination.results
@@ -13,7 +13,7 @@ character_stats_results: {
   final_stats: 221
   final_stats: 0
   final_stats: 5504.84
-  final_stats: 469.94994
+  final_stats: 469.94995
   final_stats: 2072.9756
   final_stats: 221
   final_stats: 94

--- a/sim/rogue/TestCombat.results
+++ b/sim/rogue/TestCombat.results
@@ -13,7 +13,7 @@ character_stats_results: {
   final_stats: 264
   final_stats: 0
   final_stats: 5996.3904
-  final_stats: 418.94994
+  final_stats: 418.94995
   final_stats: 2218.9399
   final_stats: 264
   final_stats: 94


### PR DESCRIPTION
From: https://classic.warcraftlogs.com/reports/Ppmvr72z1HWA6Fcn#fight=31&type=summary&source=3&view=events
and https://classic.warcraftlogs.com/reports/XJHvwBQTMR4ZjAxy#fight=6&type=summary&translate=true&source=14&pins=2%24Off%24%23244F4B%24any%7Cdamage%7Ccasts%7Cauras%24-1%246818027.0.0.DeathKnight%246818027.0.0.DeathKnight%24false%240.0.0.Any%24true%2464859%7C50842%7C49941%7C55078%7C45524%7C49924%7C45470%7C55095%7C55262%7C1%7C49921%7C56815%7C71905&view=events&eventstart=4078241

Can proc off BCB (already in sim), blood plague application, and scourge strike shadow portion