### PR TITLE
Make sidebar stats align to bottom when they don't use the entire view height

### DIFF
--- a/ui/scss/core/sim_ui/_sidebar.scss
+++ b/ui/scss/core/sim_ui/_sidebar.scss
@@ -3,8 +3,6 @@
 @import "../components/sim_title_dropdown";
 
 .sim-sidebar {
-  min-height: 100vh;
-  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -19,7 +17,6 @@
     padding-bottom: map.get($spacers, 3);
     display: flex;
     flex-direction: column;
-    flex-grow: 1;
 
     &> *:not(:last-child) {
       margin-bottom: map.get($spacers, 4);
@@ -55,12 +52,6 @@
       justify-content: center;
       align-items: center;
     }
-
-    .sim-sidebar-footer {
-      flex: 1;
-      display: flex;
-      align-items: flex-end;
-    }
   }
 }
 
@@ -73,6 +64,21 @@
       .sim-sidebar-actions {
         padding: 0;
         margin: 0;
+      }
+    }
+  }
+}
+
+@include media-breakpoint-up(md) {
+  .sim-sidebar {
+    // Allow the stats to align to the bottom of the viewport if the section is small enough to avoid scrolling
+    .sim-sidebar-content {
+      min-height: calc(100vh - $sim-header-height);
+
+      .sim-sidebar-footer {
+        flex: 1;
+        display: flex;
+        align-items: flex-end;
       }
     }
   }

--- a/ui/scss/core/sim_ui/_sidebar.scss
+++ b/ui/scss/core/sim_ui/_sidebar.scss
@@ -3,6 +3,7 @@
 @import "../components/sim_title_dropdown";
 
 .sim-sidebar {
+  min-height: 100vh;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -53,6 +54,12 @@
       display: flex;
       justify-content: center;
       align-items: center;
+    }
+
+    .sim-sidebar-footer {
+      flex: 1;
+      display: flex;
+      align-items: flex-end;
     }
   }
 }


### PR DESCRIPTION

Before
<img width="100%" alt="image" src="https://github.com/wowsims/wotlk/assets/12898988/02a02f6f-ef7a-4e21-9efe-5bc0b60be015">

After
<img width="100%" alt="image" src="https://github.com/wowsims/wotlk/assets/12898988/95627503-92c2-41be-b7cc-d5100c89f4d9">
