### PR TITLE
Remove legacy trinket desync options

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -851,8 +851,9 @@ message Cooldowns {
 
 	// % HP threshold, below which defensive cooldowns can be used.
 	double hp_percent_for_defensives = 2;
-	int32 desync_proc_trinket1_seconds = 3;
-	int32 desync_proc_trinket2_seconds = 4;
+
+	int32 desync_proc_trinket1_seconds = 3 [deprecated = true];
+	int32 desync_proc_trinket2_seconds = 4 [deprecated = true];
 }
 
 message HealingModel {

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -413,9 +413,6 @@ func (character *Character) AddPartyBuffs(partyBuffs *proto.PartyBuffs) {
 
 func (character *Character) initialize(agent Agent) {
 	character.majorCooldownManager.initialize(character)
-	if !character.IsUsingAPL {
-		character.DesyncTrinketProcs()
-	}
 
 	character.gcdAction = &PendingAction{
 		Priority: ActionPriorityGCD,

--- a/sim/core/major_cooldown.go
+++ b/sim/core/major_cooldown.go
@@ -162,10 +162,8 @@ func (mcd *MajorCooldown) tryActivateHelper(sim *Simulation, character *Characte
 }
 
 type cooldownConfigs struct {
-	Cooldowns                 []*proto.Cooldown
-	HpPercentForDefensives    float64
-	DesyncProcTrinket1Seconds int32
-	DesyncProcTrinket2Seconds int32
+	Cooldowns              []*proto.Cooldown
+	HpPercentForDefensives float64
 }
 
 type majorCooldownManager struct {
@@ -191,9 +189,7 @@ func newMajorCooldownManager(cooldowns *proto.Cooldowns) majorCooldownManager {
 	}
 
 	cooldownConfigs := cooldownConfigs{
-		HpPercentForDefensives:    cooldowns.HpPercentForDefensives,
-		DesyncProcTrinket1Seconds: cooldowns.DesyncProcTrinket1Seconds,
-		DesyncProcTrinket2Seconds: cooldowns.DesyncProcTrinket2Seconds,
+		HpPercentForDefensives: cooldowns.HpPercentForDefensives,
 	}
 	for _, cooldownConfig := range cooldowns.Cooldowns {
 		if cooldownConfig.Id != nil {
@@ -273,90 +269,6 @@ func (mcdm *majorCooldownManager) DelayDPSCooldowns(delay time.Duration) {
 			}
 		}
 	})
-}
-
-func desyncTrinketProcAura(aura *Aura, delay time.Duration) {
-	if cb := aura.OnSpellHitDealt; cb != nil {
-		aura.OnSpellHitDealt = func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
-			if sim.CurrentTime >= delay {
-				cb(aura, sim, spell, result)
-			}
-		}
-	}
-
-	if cb := aura.OnSpellHitTaken; cb != nil {
-		aura.OnSpellHitTaken = func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
-			if sim.CurrentTime >= delay {
-				cb(aura, sim, spell, result)
-			}
-		}
-	}
-
-	if cb := aura.OnPeriodicDamageDealt; cb != nil {
-		aura.OnPeriodicDamageDealt = func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
-			if sim.CurrentTime >= delay {
-				cb(aura, sim, spell, result)
-			}
-		}
-	}
-
-	if cb := aura.OnHealDealt; cb != nil {
-		aura.OnHealDealt = func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
-			if sim.CurrentTime >= delay {
-				cb(aura, sim, spell, result)
-			}
-		}
-	}
-
-	if cb := aura.OnPeriodicHealDealt; cb != nil {
-		aura.OnPeriodicHealDealt = func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
-			if sim.CurrentTime >= delay {
-				cb(aura, sim, spell, result)
-			}
-		}
-	}
-
-	if cb := aura.OnCastComplete; cb != nil {
-		aura.OnCastComplete = func(aura *Aura, sim *Simulation, spell *Spell) {
-			if sim.CurrentTime >= delay {
-				cb(aura, sim, spell)
-			}
-		}
-	}
-}
-
-func findTrinketAura(character *Character, trinketID int32) *Aura {
-	for _, aura := range character.auras {
-		if aura.ActionIDForProc.ItemID == trinketID {
-			return aura
-		}
-	}
-	return nil
-}
-
-// Desyncs trinket procs per configured user settings.
-// Hold the first proc back until some time into the simulation (i.e. because the player
-// un-equipped and re-equipped the trinket before pull).
-func (mcdm *majorCooldownManager) DesyncTrinketProcs() {
-	if delay := time.Duration(mcdm.cooldownConfigs.DesyncProcTrinket1Seconds) * time.Second; delay > 0 {
-		if trinket1 := mcdm.character.Trinket1(); trinket1.ID > 0 && HasItemEffect(trinket1.ID) {
-			mcdm.character.Env.RegisterPostFinalizeEffect(func() {
-				if aura := findTrinketAura(mcdm.character, trinket1.ID); aura != nil {
-					desyncTrinketProcAura(aura, delay)
-				}
-			})
-		}
-	}
-
-	if delay := time.Duration(mcdm.cooldownConfigs.DesyncProcTrinket2Seconds) * time.Second; delay > 0 {
-		if trinket2 := mcdm.character.Trinket2(); trinket2.ID > 0 && HasItemEffect(trinket2.ID) {
-			mcdm.character.Env.RegisterPostFinalizeEffect(func() {
-				if aura := findTrinketAura(mcdm.character, trinket2.ID); aura != nil {
-					desyncTrinketProcAura(aura, delay)
-				}
-			})
-		}
-	}
 }
 
 func (mcdm *majorCooldownManager) reset(_ *Simulation) {

--- a/sim/druid/feral/feral_test.go
+++ b/sim/druid/feral/feral_test.go
@@ -59,43 +59,6 @@ func TestFeralApl(t *testing.T) {
 	}))
 }
 
-func TestFeralDoubleArmorPenTrinketsNoDesync(t *testing.T) {
-	core.RunTestSuite(t, t.Name(), core.FullCharacterTestSuiteGenerator(core.CharacterSuiteConfig{
-		Class:       proto.Class_ClassDruid,
-		Race:        proto.Race_RaceTauren,
-		GearSet:     core.GearSetCombo{Label: "P2DoubleArmorPenTrinkets", GearSet: P2GearDoubleArmorPenTrinkets},
-		Talents:     StandardTalents,
-		Glyphs:      StandardGlyphs,
-		Consumes:    FullConsumes,
-		SpecOptions: core.SpecOptionsCombo{Label: "Default", SpecOptions: PlayerOptionsMonoCat},
-		ItemFilter:  FeralItemFilter,
-
-		Cooldowns: &proto.Cooldowns{
-			DesyncProcTrinket1Seconds: 0,
-			DesyncProcTrinket2Seconds: 0,
-		},
-	}))
-}
-
-func TestFeralDoubleArmorPenTrinketsWithDesync(t *testing.T) {
-	core.RunTestSuite(t, t.Name(), core.FullCharacterTestSuiteGenerator(core.CharacterSuiteConfig{
-		Class:       proto.Class_ClassDruid,
-		Race:        proto.Race_RaceTauren,
-		GearSet:     core.GearSetCombo{Label: "P2DoubleArmorPenTrinkets", GearSet: P2GearDoubleArmorPenTrinkets},
-		Talents:     StandardTalents,
-		Glyphs:      StandardGlyphs,
-		Consumes:    FullConsumes,
-		SpecOptions: core.SpecOptionsCombo{Label: "Default", SpecOptions: PlayerOptionsMonoCat},
-
-		ItemFilter: FeralItemFilter,
-
-		Cooldowns: &proto.Cooldowns{
-			DesyncProcTrinket1Seconds: 0,
-			DesyncProcTrinket2Seconds: 10,
-		},
-	}))
-}
-
 func BenchmarkSimulate(b *testing.B) {
 	rsr := &proto.RaidSimRequest{
 		Raid: core.SinglePlayerRaidProto(

--- a/ui/core/components/individual_sim_ui/cooldowns_picker.ts
+++ b/ui/core/components/individual_sim_ui/cooldowns_picker.ts
@@ -3,12 +3,10 @@ import { IconEnumPicker, IconEnumValueConfig } from '../icon_enum_picker.js';
 import { NumberListPicker } from '../number_list_picker.js';
 import { Player } from '../../player.js';
 import { EventID, TypedEvent } from '../../typed_event.js';
-import { ActionID as ActionIdProto, ItemSlot } from '../../proto/common.js';
+import { ActionID as ActionIdProto } from '../../proto/common.js';
 import { Cooldown } from '../../proto/common.js';
 import { ActionId } from '../../proto_utils/action_id.js';
 import { Tooltip } from 'bootstrap';
-import { NumberPicker } from '../number_picker.js';
-import { Sim } from 'ui/core/sim.js';
 
 export class CooldownsPicker extends Component {
 	readonly player: Player<any>;
@@ -74,54 +72,6 @@ export class CooldownsPicker extends Component {
 
 			this.cooldownPickers.push(row);
 		}
-
-		this.addTrinketDesyncPicker(ItemSlot.ItemSlotTrinket1);
-		this.addTrinketDesyncPicker(ItemSlot.ItemSlotTrinket2);
-	}
-
-	private addTrinketDesyncPicker(slot: ItemSlot) {
-		const index = slot - ItemSlot.ItemSlotTrinket1 + 1;
-		const picker = new NumberPicker(this.rootElem, this.player.sim, {
-			label: `Desync Proc Trinket ${index}`,
-			labelTooltip: ' Put the trinket on a cooldown before pull by re-equipping it. Must be between 0 and 30 seconds.',
-			extraCssClasses: [
-				'within-raid-sim-hide',
-			],
-			inline: true,
-			changedEvent: (_: Sim) => this.player.cooldownsChangeEmitter,
-			getValue: (_: Sim) => {
-				const cooldowns = this.player.getCooldowns();
-				return (slot == ItemSlot.ItemSlotTrinket1) ? cooldowns.desyncProcTrinket1Seconds : cooldowns.desyncProcTrinket2Seconds;
-			},
-			setValue: (eventID: EventID, _: Sim, newValue: number) => {
-				if (newValue >= 0) {
-					const newCooldowns = this.player.getCooldowns();
-					if (slot == ItemSlot.ItemSlotTrinket1) {
-						newCooldowns.desyncProcTrinket1Seconds = newValue;
-					} else {
-						newCooldowns.desyncProcTrinket2Seconds = newValue
-					}
-					this.player.setCooldowns(eventID, newCooldowns);
-				}
-			},
-			enableWhen: (sim: Sim) => {
-				// TODO(Riotdog-GehennasEU): Only show if the slot is non-empty and the
-				// trinket has a proc effect?
-				return true;
-			},
-		});
-
-		const pickerInput = picker.rootElem.querySelector('.number-picker-input') as HTMLInputElement;
-		pickerInput.type = 'number';
-		pickerInput.min = "0";
-
-		const validator = () => {
-			if (!pickerInput.checkValidity()) {
-				pickerInput.reportValidity();
-			}
-		};
-		pickerInput.addEventListener('change', validator);
-		pickerInput.addEventListener('focusout', validator);
 	}
 
 	private makeActionPicker(parentElem: HTMLElement, cooldownIndex: number): IconEnumPicker<Player<any>, ActionIdProto> {


### PR DESCRIPTION
Trinket desyncing remains available via the `TriggerICD` APL prepull action.