### PR TITLE
Implement item swapping in APL

### DIFF
--- a/proto/api.proto
+++ b/proto/api.proto
@@ -27,6 +27,9 @@ message Player {
 	Consumes consumes = 4;
 	UnitStats bonus_stats = 36;
 
+	bool enable_item_swap = 46;
+	ItemSwap item_swap = 45;
+
 	IndividualBuffs buffs = 15;
 
 	oneof spec {

--- a/proto/apl.proto
+++ b/proto/apl.proto
@@ -46,7 +46,7 @@ message APLListItem {
     APLAction action = 3; // The action to be performed.
 }
 
-// NextIndex: 17
+// NextIndex: 18
 message APLAction {
     APLValue condition = 1; // If set, action will only execute if value is true or != 0.
 
@@ -73,6 +73,7 @@ message APLAction {
         APLActionActivateAura activate_aura = 13;
         APLActionCancelAura cancel_aura = 10;
         APLActionTriggerICD trigger_icd = 11;
+        APLActionItemSwap item_swap = 17;
     }
 }
 
@@ -247,6 +248,17 @@ message APLActionActivateAura {
 
 message APLActionTriggerICD {
     ActionID aura_id = 1;
+}
+
+message APLActionItemSwap {
+    enum SwapSet {
+        Unknown = 0;
+        Main = 1;
+        Swap1 = 2;
+    }
+
+    // The set to swap to.
+    SwapSet swap_set = 1;
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/proto/ui.proto
+++ b/proto/ui.proto
@@ -293,6 +293,8 @@ message SavedSettings {
 	Cooldowns cooldowns = 6;
 	string rotation_json = 8;
 	repeated Profession professions = 9;
+	bool enable_item_swap = 18;
+	ItemSwap item_swap = 17;
 
 	int32 reaction_time_ms = 10;
 	int32 channel_clip_delay_ms = 14;

--- a/sim/core/apl_action.go
+++ b/sim/core/apl_action.go
@@ -175,6 +175,8 @@ func (rot *APLRotation) newAPLActionImpl(config *proto.APLAction) APLActionImpl 
 		return rot.newActionCancelAura(config.GetCancelAura())
 	case *proto.APLAction_TriggerIcd:
 		return rot.newActionTriggerICD(config.GetTriggerIcd())
+	case *proto.APLAction_ItemSwap:
+		return rot.newActionItemSwap(config.GetItemSwap())
 	default:
 		return nil
 	}

--- a/sim/core/apl_actions_misc.go
+++ b/sim/core/apl_actions_misc.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+
 	"github.com/wowsims/wotlk/sim/core/proto"
 )
 
@@ -116,4 +117,47 @@ func (action *APLActionTriggerICD) Execute(sim *Simulation) {
 }
 func (action *APLActionTriggerICD) String() string {
 	return fmt.Sprintf("Trigger ICD(%s)", action.aura.ActionID)
+}
+
+type APLActionItemSwap struct {
+	defaultAPLActionImpl
+	character *Character
+	swapSet   proto.APLActionItemSwap_SwapSet
+}
+
+func (rot *APLRotation) newActionItemSwap(config *proto.APLActionItemSwap) APLActionImpl {
+	if config.SwapSet == proto.APLActionItemSwap_Unknown {
+		rot.ValidationWarning("Unknown item swap set")
+		return nil
+	}
+
+	character := rot.unit.Env.Raid.GetPlayerFromUnit(rot.unit).GetCharacter()
+	if !character.ItemSwap.IsEnabled() {
+		if config.SwapSet != proto.APLActionItemSwap_Main {
+			rot.ValidationWarning("No swap set configured in Settings.")
+		}
+		return nil
+	}
+
+	return &APLActionItemSwap{
+		character: character,
+		swapSet:   config.SwapSet,
+	}
+}
+func (action *APLActionItemSwap) IsReady(sim *Simulation) bool {
+	return (action.swapSet == proto.APLActionItemSwap_Main) == action.character.ItemSwap.IsSwapped()
+}
+func (action *APLActionItemSwap) Execute(sim *Simulation) {
+	if sim.Log != nil {
+		action.character.Log(sim, "Item Swap to set %s", action.swapSet)
+	}
+
+	if action.swapSet == proto.APLActionItemSwap_Main {
+		action.character.ItemSwap.reset(sim)
+	} else {
+		action.character.ItemSwap.SwapItems(sim, action.character.ItemSwap.slots, true)
+	}
+}
+func (action *APLActionItemSwap) String() string {
+	return fmt.Sprintf("Item Swap(%s)", action.swapSet)
 }

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -181,6 +181,10 @@ func NewCharacter(party *Party, partyIndex int, player *proto.Player) Character 
 	}
 	character.PseudoStats.InFrontOfTarget = player.InFrontOfTarget
 
+	if player.EnableItemSwap && player.ItemSwap != nil {
+		character.enableItemSwap(player.ItemSwap, character.DefaultMeleeCritMultiplier(), character.DefaultMeleeCritMultiplier(), 0)
+	}
+
 	return character
 }
 

--- a/sim/core/item_swaps.go
+++ b/sim/core/item_swaps.go
@@ -19,6 +19,9 @@ type ItemSwap struct {
 	ohCritMultiplier     float64
 	rangedCritMultiplier float64
 
+	// Which slots to actually swap.
+	slots []proto.ItemSlot
+
 	// Used for resetting
 	initialEquippedItems   [3]Item
 	initialUnequippedItems [3]Item
@@ -33,15 +36,49 @@ TODO All the extra parameters here and the code in multiple places for handling 
 
 	we'll need to figure out something cleaner as this will be quite error-prone
 */
-func (character *Character) EnableItemSwap(itemSwap *proto.ItemSwap, mhCritMultiplier float64, ohCritMultiplier float64, rangedCritMultiplier float64) {
-	items := getItems(itemSwap)
+func (character *Character) enableItemSwap(itemSwap *proto.ItemSwap, mhCritMultiplier float64, ohCritMultiplier float64, rangedCritMultiplier float64) {
+	var slots []proto.ItemSlot
+	hasMhSwap := itemSwap.MhItem != nil && itemSwap.MhItem.Id != 0
+	hasOhSwap := itemSwap.OhItem != nil && itemSwap.OhItem.Id != 0
+	hasRangedSwap := itemSwap.RangedItem != nil && itemSwap.RangedItem.Id != 0
+
+	mainItems := [3]Item{
+		character.Equipment[proto.ItemSlot_ItemSlotMainHand],
+		character.Equipment[proto.ItemSlot_ItemSlotOffHand],
+		character.Equipment[proto.ItemSlot_ItemSlotRanged],
+	}
+	swapItems := [3]Item{
+		toItem(itemSwap.MhItem),
+		toItem(itemSwap.OhItem),
+		toItem(itemSwap.RangedItem),
+	}
+
+	// Handle MH and OH together, because present MH + empty OH --> swap MH and unequip OH
+	if hasMhSwap || hasOhSwap {
+		if swapItems[0].ID != mainItems[0].ID {
+			slots = append(slots, proto.ItemSlot_ItemSlotMainHand)
+		}
+		if swapItems[1].ID != mainItems[1].ID {
+			slots = append(slots, proto.ItemSlot_ItemSlotOffHand)
+		}
+	}
+	if hasRangedSwap {
+		if swapItems[2].ID != mainItems[2].ID {
+			slots = append(slots, proto.ItemSlot_ItemSlotRanged)
+		}
+	}
+
+	if len(slots) == 0 {
+		return
+	}
 
 	character.ItemSwap = ItemSwap{
 		character:            character,
 		mhCritMultiplier:     mhCritMultiplier,
 		ohCritMultiplier:     ohCritMultiplier,
 		rangedCritMultiplier: rangedCritMultiplier,
-		unEquippedItems:      items,
+		slots:                slots,
+		unEquippedItems:      swapItems,
 		swapped:              false,
 	}
 }
@@ -161,7 +198,10 @@ func (swap *ItemSwap) SwapItems(sim *Simulation, slots []proto.ItemSlot, useGCD 
 	}
 
 	if useGCD {
-		character.SetGCDTimer(sim, 1500*time.Millisecond+sim.CurrentTime)
+		newGCD := sim.CurrentTime + 1500*time.Millisecond
+		if newGCD > character.GCD.ReadyAt() {
+			character.SetGCDTimer(sim, newGCD)
+		}
 	}
 	swap.swapped = !swap.swapped
 }
@@ -256,18 +296,6 @@ func getInitialEquippedItems(character *Character) [3]Item {
 
 	for i := range items {
 		items[i] = character.Equipment[i+int(offset)]
-	}
-
-	return items
-}
-
-func getItems(itemSwap *proto.ItemSwap) [3]Item {
-	var items [3]Item
-
-	if itemSwap != nil {
-		items[0] = toItem(itemSwap.MhItem)
-		items[1] = toItem(itemSwap.OhItem)
-		items[2] = toItem(itemSwap.RangedItem)
 	}
 
 	return items

--- a/sim/deathknight/dps/dps_deathknight.go
+++ b/sim/deathknight/dps/dps_deathknight.go
@@ -75,10 +75,6 @@ func NewDpsDeathknight(character *core.Character, player *proto.Player) *DpsDeat
 		AutoSwingMelee: true,
 	})
 
-	if dpsDk.Talents.SummonGargoyle && dpsDk.Rotation.UseGargoyle && dpsDk.Rotation.EnableWeaponSwap {
-		dpsDk.EnableItemSwap(dpsDk.Rotation.WeaponSwap, dpsDk.DefaultMeleeCritMultiplier(), dpsDk.DefaultMeleeCritMultiplier(), 0)
-	}
-
 	dpsDk.br.dk = dpsDk
 	dpsDk.sr.dk = dpsDk
 	dpsDk.ur.dk = dpsDk

--- a/sim/shaman/enhancement/enhancement.go
+++ b/sim/shaman/enhancement/enhancement.go
@@ -62,10 +62,6 @@ func NewEnhancementShaman(character *core.Character, options *proto.Player) *Enh
 
 	enh.ApplySyncType(enhOptions.Options.SyncType)
 
-	if enh.Totems.UseFireElemental && enhOptions.Rotation.EnableItemSwap {
-		enh.EnableItemSwap(enhOptions.Rotation.ItemSwap, enh.DefaultMeleeCritMultiplier(), enh.DefaultMeleeCritMultiplier(), 0)
-	}
-
 	if enhOptions.Rotation.LightningboltWeave {
 		enh.maelstromWeaponMinStack = enhOptions.Rotation.MaelstromweaponMinStack
 	} else {
@@ -136,9 +132,12 @@ func (enh *EnhancementShaman) Initialize() {
 		})
 	}
 	enh.DelayDPSCooldowns(3 * time.Second)
-	enh.RegisterPrepullAction(-time.Second, func(sim *core.Simulation) {
-		enh.ItemSwap.SwapItems(sim, []proto.ItemSlot{proto.ItemSlot_ItemSlotMainHand, proto.ItemSlot_ItemSlotOffHand}, false)
-	})
+
+	if !enh.IsUsingAPL {
+		enh.RegisterPrepullAction(-time.Second, func(sim *core.Simulation) {
+			enh.ItemSwap.SwapItems(sim, []proto.ItemSlot{proto.ItemSlot_ItemSlotMainHand, proto.ItemSlot_ItemSlotOffHand}, false)
+		})
+	}
 }
 
 func (enh *EnhancementShaman) Reset(sim *core.Simulation) {

--- a/sim/shaman/fire_elemental_totem.go
+++ b/sim/shaman/fire_elemental_totem.go
@@ -56,7 +56,7 @@ func (shaman *Shaman) registerFireElementalTotem() {
 			shaman.FireElemental.EnableWithTimeout(sim, shaman.FireElemental, fireTotemDuration)
 
 			//TODO handle more then one swap if the fight is greater then 5 mins, for now will just do the one.
-			if shaman.FireElementalTotem.SpellMetrics[target.Index].Casts == 1 {
+			if !shaman.IsUsingAPL && shaman.FireElementalTotem.SpellMetrics[target.Index].Casts == 1 {
 				shaman.ItemSwap.SwapItems(sim, []proto.ItemSlot{proto.ItemSlot_ItemSlotMainHand, proto.ItemSlot_ItemSlotOffHand}, true)
 			}
 

--- a/sim/warlock/warlock.go
+++ b/sim/warlock/warlock.go
@@ -203,8 +203,10 @@ func (warlock *Warlock) Reset(sim *core.Simulation) {
 		warlock.petStmBonusSP = 0
 	}
 
-	warlock.ItemSwap.SwapItems(sim, []proto.ItemSlot{proto.ItemSlot_ItemSlotMainHand,
-		proto.ItemSlot_ItemSlotOffHand, proto.ItemSlot_ItemSlotRanged}, false)
+	if !warlock.IsUsingAPL {
+		warlock.ItemSwap.SwapItems(sim, []proto.ItemSlot{proto.ItemSlot_ItemSlotMainHand,
+			proto.ItemSlot_ItemSlotOffHand, proto.ItemSlot_ItemSlotRanged}, false)
+	}
 	warlock.corrRefreshList = make([]time.Duration, len(warlock.Env.Encounter.TargetUnits))
 	warlock.setupCooldowns(sim)
 }
@@ -235,10 +237,6 @@ func NewWarlock(character *core.Character, options *proto.Player) *Warlock {
 	}
 
 	warlock.Infernal = warlock.NewInfernal()
-
-	if warlock.Rotation.Type == proto.Warlock_Rotation_Affliction && warlock.Rotation.EnableWeaponSwap {
-		warlock.EnableItemSwap(warlock.Rotation.WeaponSwap, 1, 1, 1)
-	}
 
 	warlock.applyWeaponImbue()
 	wotlk.ConstructValkyrPets(&warlock.Character)

--- a/sim/warlock/warlock_test.go
+++ b/sim/warlock/warlock_test.go
@@ -22,9 +22,6 @@ func TestAffliction(t *testing.T) {
 		Glyphs:      AfflictionGlyphs,
 		Consumes:    FullConsumes,
 		SpecOptions: core.SpecOptionsCombo{Label: "Affliction Warlock", SpecOptions: DefaultAfflictionWarlock},
-		OtherSpecOptions: []core.SpecOptionsCombo{
-			{Label: "AffItemSwap", SpecOptions: afflictionItemSwap},
-		},
 
 		ItemFilter: ItemFilter,
 	}))
@@ -126,13 +123,6 @@ var DefaultAfflictionWarlock = &proto.Player_Warlock{
 	Warlock: &proto.Warlock{
 		Options:  defaultAfflictionOptions,
 		Rotation: defaultAfflictionRotation,
-	},
-}
-
-var afflictionItemSwap = &proto.Player_Warlock{
-	Warlock: &proto.Warlock{
-		Options:  defaultAfflictionOptions,
-		Rotation: afflictionItemSwapRotation,
 	},
 }
 

--- a/ui/core/components/individual_sim_ui/apl_actions.ts
+++ b/ui/core/components/individual_sim_ui/apl_actions.ts
@@ -19,12 +19,15 @@ import {
 	APLActionActivateAura,
 	APLActionCancelAura,
 	APLActionTriggerICD,
+	APLActionItemSwap,
+	APLActionItemSwap_SwapSet as ItemSwapSet,
 
 	APLValue,
 } from '../../proto/apl.js';
 
 import { isHealingSpec } from '../../proto_utils/utils.js';
 import { EventID } from '../../typed_event.js';
+import { itemSwapEnabledSpecs } from '../../individual_sim_ui.js';
 import { Input, InputConfig } from '../input.js';
 import { Player } from '../../player.js';
 import { TextDropdownPicker } from '../dropdown_picker.js';
@@ -238,6 +241,22 @@ type ActionKindConfig<T> = {
 	newValue: () => T,
 	factory: (parent: HTMLElement, player: Player<any>, config: InputConfig<Player<any>, T>) => Input<Player<any>, T>,
 };
+
+function itemSwapSetFieldConfig(field: string): AplHelpers.APLPickerBuilderFieldConfig<any, any> {
+	return {
+		field: field,
+		newValue: () => ItemSwapSet.Swap1,
+		factory: (parent, player, config) => new TextDropdownPicker(parent, player, {
+			...config,
+			defaultLabel: 'None',
+			equals: (a, b) => a == b,
+			values: [
+				{ value: ItemSwapSet.Main, label: 'Main' },
+				{ value: ItemSwapSet.Swap1, label: 'Swapped' },
+			],
+		}),
+	};
+}
 
 function actionFieldConfig(field: string): AplHelpers.APLPickerBuilderFieldConfig<any, any> {
 	return {
@@ -530,6 +549,16 @@ const actionKindFactories: {[f in NonNullable<APLActionKind>]: ActionKindConfig<
 		newValue: () => APLActionTriggerICD.create(),
 		fields: [
 			AplHelpers.actionIdFieldConfig('auraId', 'icd_auras'),
+		],
+	}),
+	['itemSwap']: inputBuilder({
+		label: 'Item Swap',
+		submenu: ['Misc'],
+		shortDescription: 'Swaps items, using the swap set specified in Settings.',
+		includeIf: (player: Player<any>, isPrepull: boolean) => itemSwapEnabledSpecs.includes(player.spec),
+		newValue: () => APLActionItemSwap.create(),
+		fields: [
+			itemSwapSetFieldConfig('swapSet'),
 		],
 	}),
 };

--- a/ui/core/components/individual_sim_ui/rotation_tab.ts
+++ b/ui/core/components/individual_sim_ui/rotation_tab.ts
@@ -6,7 +6,6 @@ import {
 import {
 	APLRotation,
 	APLRotation_Type as APLRotationType,
-	SimpleRotation,
 } from "../../proto/apl";
 import {
 	SavedRotation,
@@ -21,7 +20,6 @@ import { NumberPicker } from "../number_picker";
 import { BooleanPicker } from "../boolean_picker";
 import { EnumPicker } from "../enum_picker";
 import { Input } from "../input";
-import { ItemSwapPicker } from "../item_swap_picker";
 import { CooldownsPicker } from "./cooldowns_picker";
 import { CustomRotationPicker } from "./custom_rotation_picker";
 import { SavedDataManager } from "../saved_data_manager";
@@ -181,8 +179,6 @@ export class RotationTab extends SimTab {
 				new EnumPicker(sectionElem, this.simUI.player, inputConfig);
 			} else if (inputConfig.type == 'customRotation') {
 				new CustomRotationPicker(sectionElem, this.simUI, this.simUI.player, inputConfig);
-			} else if (inputConfig.type == 'itemSwap') {
-				new ItemSwapPicker(sectionElem, this.simUI, this.simUI.player, inputConfig)
 			}
 		});
 	}

--- a/ui/core/components/individual_sim_ui/settings_tab.ts
+++ b/ui/core/components/individual_sim_ui/settings_tab.ts
@@ -5,6 +5,7 @@ import {
 	Debuffs,
 	HealingModel,
 	IndividualBuffs,
+	ItemSwap,
 	PartyBuffs,
 	Profession,
 	RaidBuffs,
@@ -233,16 +234,24 @@ export class SettingsTab extends SimTab {
 			!inputs.extraCssClasses?.includes('within-raid-sim-hide') || true
 		)
 
-		if (settings.length > 0) {
+		const swapSlots = this.simUI.individualConfig.itemSwapSlots || [];
+		if (settings.length > 0 || swapSlots.length > 0) {
 			const contentBlock = new ContentBlock(this.column2, 'other-settings', {
 				header: { title: 'Other' }
 			});
 
-			this.configureInputSection(contentBlock.bodyElement, this.simUI.individualConfig.otherInputs);
+			if (settings.length > 0) {
+				this.configureInputSection(contentBlock.bodyElement, this.simUI.individualConfig.otherInputs);
+				contentBlock.bodyElement.querySelectorAll('.input-root').forEach(elem => {
+					elem.classList.add('input-inline');
+				})
+			}
 
-			contentBlock.bodyElement.querySelectorAll('.input-root').forEach(elem => {
-				elem.classList.add('input-inline');
-			})
+			if (swapSlots.length > 0) {
+				const _itemSwapPicker = new ItemSwapPicker(contentBlock.bodyElement, this.simUI, this.simUI.player, {
+					itemSlots: swapSlots,
+				});
+			}
 		}
 	}
 
@@ -395,6 +404,8 @@ export class SettingsTab extends SimTab {
 					consumes: player.getConsumes(),
 					race: player.getRace(),
 					professions: player.getProfessions(),
+					enableItemSwap: player.getEnableItemSwap(),
+					itemSwap: player.getItemSwapGear().toProto(),
 					reactionTimeMs: player.getReactionTime(),
 					channelClipDelayMs: player.getChannelClipDelay(),
 					inFrontOfTarget: player.getInFrontOfTarget(),
@@ -417,6 +428,8 @@ export class SettingsTab extends SimTab {
 					simUI.player.setConsumes(eventID, newSettings.consumes || Consumes.create());
 					simUI.player.setRace(eventID, newSettings.race);
 					simUI.player.setProfessions(eventID, newSettings.professions);
+					simUI.player.setEnableItemSwap(eventID, newSettings.enableItemSwap);
+					simUI.player.setItemSwapGear(eventID, simUI.sim.db.lookupItemSwap(newSettings.itemSwap || ItemSwap.create()));
 					simUI.player.setReactionTime(eventID, newSettings.reactionTimeMs);
 					simUI.player.setChannelClipDelay(eventID, newSettings.channelClipDelayMs);
 					simUI.player.setInFrontOfTarget(eventID, newSettings.inFrontOfTarget);
@@ -439,6 +452,7 @@ export class SettingsTab extends SimTab {
 				this.simUI.player.consumesChangeEmitter,
 				this.simUI.player.raceChangeEmitter,
 				this.simUI.player.professionChangeEmitter,
+				this.simUI.player.itemSwapChangeEmitter,
 				this.simUI.player.miscOptionsChangeEmitter,
 				this.simUI.player.inFrontOfTargetChangeEmitter,
 				this.simUI.player.distanceFromTargetChangeEmitter,
@@ -468,8 +482,6 @@ export class SettingsTab extends SimTab {
 				new EnumPicker(sectionElem, this.simUI.player, inputConfig);
 			} else if (inputConfig.type == 'customRotation') {
 				new CustomRotationPicker(sectionElem, this.simUI, this.simUI.player, inputConfig);
-			} else if (inputConfig.type == 'itemSwap') {
-				new ItemSwapPicker(sectionElem, this.simUI, this.simUI.player, inputConfig)
 			}
 		});
 	};

--- a/ui/core/components/input_helpers.ts
+++ b/ui/core/components/input_helpers.ts
@@ -1,13 +1,12 @@
 import { ActionId } from '../proto_utils/action_id.js';
-import { CustomRotation, ItemSwap, ItemSlot } from '../proto/common.js';
+import { CustomRotation } from '../proto/common.js';
 import { Spec } from '../proto/common.js';
 import { Player } from '../player.js';
 import { EventID, TypedEvent } from '../typed_event.js';
 import { SpecOptions, SpecRotation } from '../proto_utils/utils.js';
-import { ItemSwapPickerConfig } from './item_swap_picker.js'
 import { CustomRotationPickerConfig } from './individual_sim_ui/custom_rotation_picker.js';
 import { IconPickerConfig } from './icon_picker.js';
-import { IconEnumPicker, IconEnumPickerConfig, IconEnumValueConfig } from './icon_enum_picker.js';
+import { IconEnumPickerConfig, IconEnumValueConfig } from './icon_enum_picker.js';
 import { EnumPickerConfig, EnumValueConfig } from './enum_picker.js';
 import { BooleanPickerConfig } from './boolean_picker.js';
 import { NumberPickerConfig } from './number_picker.js';
@@ -476,35 +475,5 @@ export function makeCustomRotationInput<SpecType extends Spec, T>(config: Wrappe
 		numColumns: config.numColumns,
 		showCastsPerMinute: config.showCastsPerMinute || false,
 		values: config.values,
-	}
-}
-
-
-export interface TypedItemSwapPickerConfig<SpecType extends Spec, T> extends ItemSwapPickerConfig<SpecType, T> {
-	type: 'itemSwap',
-}
-
-interface WrappedItemSwapInputConfig<SpecType extends Spec> {
-	fieldName: keyof SpecRotation<SpecType>,
-	values: Array<ItemSlot>,
-	labelTooltip?: string,
-	getValue?: (player: Player<SpecType>) => ItemSwap,
-	setValue?: (eventID: EventID, player: Player<SpecType>, newValue: ItemSwap) => void,
-	showWhen?: (player: Player<SpecType>) => boolean
-}
-
-export function MakeItemSwapInput<SpecType extends Spec>(config: WrappedItemSwapInputConfig<SpecType>): TypedItemSwapPickerConfig<SpecType, ItemSwap> {
-	return {
-		type: 'itemSwap',
-		getValue: config.getValue || ((player: Player<SpecType>) => (player.getRotation()[config.fieldName] as unknown as ItemSwap) || ItemSwap.create()),
-		setValue: config.setValue || ((eventID: EventID, player: Player<SpecType>, newValue: ItemSwap) => {
-			const options = player.getRotation();
-			(options[config.fieldName] as unknown as ItemSwap) = newValue;
-			player.setRotation(eventID, options);
-		}),
-		itemSlots: config.values,
-		changedEvent: (player: Player<SpecType>) => player.rotationChangeEmitter,
-		labelTooltip: config.labelTooltip,
-		showWhen: config.showWhen,
 	}
 }

--- a/ui/core/components/item_swap_picker.ts
+++ b/ui/core/components/item_swap_picker.ts
@@ -1,38 +1,55 @@
-import { Spec, ItemSlot, ItemSwap } from '../proto/common.js';
+import { Spec, ItemSlot, ItemSpec } from '../proto/common.js';
 import { Player } from '../player.js';
 import { Component } from './component.js';
 import { IconItemSwapPicker } from './gear_picker.js'
-import { Input, InputConfig } from './input.js'
+import { Input } from './input.js'
 import { SimUI } from '../sim_ui.js';
-import { TypedEvent } from '../typed_event.js';
-import tippy from 'tippy.js';
+import { EventID, TypedEvent } from '../typed_event.js';
+import { BooleanPicker } from './boolean_picker.js';
 
-export interface ItemSwapPickerConfig<SpecType extends Spec, T> extends InputConfig<Player<SpecType>, T> {
+export interface ItemSwapPickerConfig {
 	itemSlots: Array<ItemSlot>;
 }
 
-export class ItemSwapPicker<SpecType extends Spec, T> extends Component {
+export class ItemSwapPicker<SpecType extends Spec> extends Component {
+	private readonly itemSlots: Array<ItemSlot>;
+	private readonly enableItemSwapPicker: BooleanPicker<Player<SpecType>>;
 
-	constructor(parentElem: HTMLElement, simUI: SimUI, player: Player<SpecType>, config: ItemSwapPickerConfig<SpecType, T>) {
+	constructor(parentElem: HTMLElement, simUI: SimUI, player: Player<SpecType>, config: ItemSwapPickerConfig) {
 		super(parentElem, 'item-swap-picker-root');
+		this.itemSlots = config.itemSlots;
 
-		this.rootElem.classList.add('input-root', 'input-inline')
+		this.enableItemSwapPicker = new BooleanPicker(this.rootElem, player, {
+			label: 'Enable Item Swapping',
+			labelTooltip: 'Allows configuring an Item Swap Set which is used with the <b>Item Swap</b> APL action.',
+			extraCssClasses: ['input-inline'],
+			getValue: (player: Player<SpecType>) => player.getEnableItemSwap(),
+			setValue(eventID: EventID, player: Player<SpecType>, newValue: boolean) {
+				player.setEnableItemSwap(eventID, newValue);
+			},
+			changedEvent: (player: Player<SpecType>) => player.itemSwapChangeEmitter,
+		});
 
-		const label = document.createElement("label")
-		label.classList.add('form-label')
-		label.textContent = "Item Swap"
-		this.rootElem.appendChild(label);
+		const swapPickerContainer = document.createElement('div');
+		this.rootElem.appendChild(swapPickerContainer);
+		const toggleEnabled = () => {
+			if (!player.getEnableItemSwap()) {
+				swapPickerContainer.classList.add('hide');
+			} else {
+				swapPickerContainer.classList.remove('hide');
+			}
+		};
+		player.itemSwapChangeEmitter.on(toggleEnabled);
+		toggleEnabled();
 
-		if (config.labelTooltip) {
-			tippy(label, {
-				'content': config.labelTooltip,
-				ignoreAttributes: true,
-			});
-		}
+		const label = document.createElement("label");
+		label.classList.add('form-label');
+		label.textContent = "Item Swap";
+		swapPickerContainer.appendChild(label);
 
 		let itemSwapContainer = Input.newGroupContainer();
-		itemSwapContainer.classList.add('icon-group')
-		this.rootElem.appendChild(itemSwapContainer);
+		itemSwapContainer.classList.add('icon-group');
+		swapPickerContainer.appendChild(itemSwapContainer);
 
 		let swapButtonFragment = document.createElement('fragment');
 		swapButtonFragment.innerHTML = `
@@ -45,57 +62,41 @@ export class ItemSwapPicker<SpecType extends Spec, T> extends Component {
 			>
 				<i class="fas fa-arrows-rotate me-1"></i>
 			</a>
-		`
+		`;
 
 		const swapButton = swapButtonFragment.children[0] as HTMLElement;
-		itemSwapContainer.appendChild(swapButton)
+		itemSwapContainer.appendChild(swapButton);
 
-		swapButton.addEventListener('click', event => { this.swapWithGear(player, config) });
+		swapButton.addEventListener('click', _event => { this.swapWithGear(TypedEvent.nextEventID(), player) });
 
-		config.changedEvent(player).on(eventID => {
-			const show = !config.showWhen || config.showWhen(player);
-			if (show) {
-				this.rootElem.classList.remove('hide');
-			} else {
-				this.rootElem.classList.add('hide');
-			}
-		});
-
-		config.itemSlots.forEach(itemSlot => {
-			new IconItemSwapPicker(itemSwapContainer, simUI, player, itemSlot, config);
+		this.itemSlots.forEach(itemSlot => {
+			new IconItemSwapPicker(itemSwapContainer, simUI, player, itemSlot, {
+				getValue: (player: Player<any>) => player.getItemSwapGear().getEquippedItem(itemSlot)?.asSpec() || ItemSpec.create(),
+				setValue: (eventID: EventID, player: Player<any>, newValue: ItemSpec) => {
+					let curIsg = player.getItemSwapGear();
+					curIsg = curIsg.withEquippedItem(itemSlot, player.sim.db.lookupItemSpec(newValue), player.canDualWield2H())
+					player.setItemSwapGear(eventID, curIsg);
+				},
+				changedEvent: (player: Player<any>) => player.itemSwapChangeEmitter,
+			});
 		});
 	}
 
-	swapWithGear(player: Player<SpecType>, config: ItemSwapPickerConfig<SpecType, T>) {
-		let gear = player.getGear()
+	swapWithGear(eventID: EventID, player: Player<SpecType>) {
+		let newGear = player.getGear();
+		let newIsg = player.getItemSwapGear();
 
-		const gearMap = new Map();
-		const itemSwapMap = new Map();
+		this.itemSlots.forEach(slot => {
+			const gearItem = player.getGear().getEquippedItem(slot);
+			const swapItem = player.getItemSwapGear().getEquippedItem(slot);
 
-		config.itemSlots.forEach(slot => {
-			const gearItem = player.getGear().getEquippedItem(slot)
-			const swapItem = player.getItemSwapGear().getEquippedItem(slot)
+			newGear = newGear.withEquippedItem(slot, swapItem, player.canDualWield2H())
+			newIsg = newIsg.withEquippedItem(slot, gearItem, player.canDualWield2H())
+		});
 
-			gearMap.set(slot, gearItem)
-			itemSwapMap.set(slot, swapItem)
-		})
-
-		itemSwapMap.forEach((item, slot) => {
-			gear = gear.withEquippedItem(slot, item, player.canDualWield2H())
-		})
-
-		gearMap.forEach((item, slot) => {
-			player.getItemSwapGear().equipItem(slot, item, player.canDualWield2H())
-		})
-
-		let eventID = TypedEvent.nextEventID()
-		player.setGear(eventID, gear)
-
-		const itemSwap = player.getItemSwapGear().toProto() as unknown as T
-		config.setValue(eventID, player, itemSwap)
+		TypedEvent.freezeAllAndDo(() => {
+			player.setGear(eventID, newGear);
+			player.setItemSwapGear(eventID, newIsg);
+		});
 	}
-
 }
-
-
-

--- a/ui/core/components/stat_weights_action.ts
+++ b/ui/core/components/stat_weights_action.ts
@@ -679,7 +679,7 @@ class EpWeightsMenu extends BaseModal {
 			if (equippedItem == null) {
 				return;
 			}
-			const item = equippedItem.item;
+			//const item = equippedItem.item;
 			const socketColors = equippedItem.curSocketColors(isBlacksmithing);
 
 			// Compare whether its better to match sockets + get socket bonus, or just use best gems.

--- a/ui/core/individual_sim_ui.ts
+++ b/ui/core/individual_sim_ui.ts
@@ -72,8 +72,7 @@ export type InputConfig<ModObject> = (
 	InputHelpers.TypedBooleanPickerConfig<ModObject> |
 	InputHelpers.TypedNumberPickerConfig<ModObject> |
 	InputHelpers.TypedEnumPickerConfig<ModObject> |
-	InputHelpers.TypedCustomRotationPickerConfig<any, any> |
-	InputHelpers.TypedItemSwapPickerConfig<any, any>
+	InputHelpers.TypedCustomRotationPickerConfig<any, any>
 );
 
 export interface InputSection {
@@ -144,6 +143,9 @@ export interface IndividualSimUIConfig<SpecType extends Spec> extends PlayerConf
 	includeBuffDebuffInputs: Array<any>,
 	excludeBuffDebuffInputs: Array<any>,
 	otherInputs: InputSection;
+	// Currently, many classes don't support item swapping, and only in certain slots.
+	// So enable it only where it is supported.
+	itemSwapSlots?: Array<ItemSlot>,
 
 	// For when extra sections are needed (e.g. Shaman totems)
 	customSections?: Array<(parentElem: HTMLElement, simUI: IndividualSimUI<SpecType>) => ContentBlock>,
@@ -163,6 +165,8 @@ export function registerSpecConfig<SpecType extends Spec>(spec: SpecType, config
 	registerPlayerConfig(spec, config);
 	return config;
 }
+
+export let itemSwapEnabledSpecs: Array<Spec> = [];
 
 export interface Settings {
 	raidBuffs: RaidBuffs,
@@ -203,6 +207,10 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 		this.raidSimResultsManager = null;
 		this.prevEpIterations = 0;
 		this.prevEpSimResult = null;
+
+		if ((config.itemSwapSlots || []).length > 0 && !itemSwapEnabledSpecs.includes(player.spec)) {
+			itemSwapEnabledSpecs.push(player.spec);
+		}
 
 		this.addWarning({
 			updateOn: this.player.gearChangeEmitter,

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -90,6 +90,7 @@ import { Raid } from './raid.js';
 import { Sim } from './sim.js';
 import { stringComparator, sum } from './utils.js';
 import { ElementalShaman_Options, ElementalShaman_Options_ThunderstormRange, ElementalShaman_Rotation, ElementalShaman_Rotation_BloodlustUse, EnhancementShaman_Rotation, EnhancementShaman_Rotation_BloodlustUse, RestorationShaman_Rotation, RestorationShaman_Rotation_BloodlustUse } from './proto/shaman.js';
+import { Database } from './proto_utils/database.js';
 
 export interface AuraStats {
 	data: AuraStatsProto,
@@ -241,7 +242,8 @@ export class Player<SpecType extends Spec> {
 	private bonusStats: Stats = new Stats();
 	private gear: Gear = new Gear({});
 	//private bulkEquipmentSpec: BulkEquipmentSpec = BulkEquipmentSpec.create();
-	private itemSwapGear: ItemSwapGear = new ItemSwapGear();
+	private enableItemSwap: boolean = false;
+	private itemSwapGear: ItemSwapGear = new ItemSwapGear({});
 	private race: Race;
 	private profession1: Profession = 0;
 	private profession2: Profession = 0;
@@ -282,6 +284,7 @@ export class Player<SpecType extends Spec> {
 	readonly consumesChangeEmitter = new TypedEvent<void>('PlayerConsumes');
 	readonly bonusStatsChangeEmitter = new TypedEvent<void>('PlayerBonusStats');
 	readonly gearChangeEmitter = new TypedEvent<void>('PlayerGear');
+	readonly itemSwapChangeEmitter = new TypedEvent<void>('PlayerItemSwap');
 	readonly professionChangeEmitter = new TypedEvent<void>('PlayerProfession');
 	readonly raceChangeEmitter = new TypedEvent<void>('PlayerRace');
 	readonly rotationChangeEmitter = new TypedEvent<void>('PlayerRotation');
@@ -334,6 +337,7 @@ export class Player<SpecType extends Spec> {
 			this.consumesChangeEmitter,
 			this.bonusStatsChangeEmitter,
 			this.gearChangeEmitter,
+			this.itemSwapChangeEmitter,
 			this.professionChangeEmitter,
 			this.raceChangeEmitter,
 			this.rotationChangeEmitter,
@@ -637,45 +641,36 @@ export class Player<SpecType extends Spec> {
 		return this.gear;
 	}
 
-	getItemSwapGear(): ItemSwapGear {
-		return this.itemSwapGear;
-	}
-
 	setGear(eventID: EventID, newGear: Gear) {
 		if (newGear.equals(this.gear))
 			return;
 
-		// Commented for now because the UI for this is weird.
-		//// If trinkets have changed and there were cooldowns assigned for those trinkets,
-		//// try to match them up and switch to the new trinkets.
-		//const newCooldowns = this.getCooldowns();
-		//const oldTrinketIds = this.gear.getTrinkets().map(trinket => trinket?.asActionIdProto() || ActionIdProto.create());
-		//const newTrinketIds = newGear.getTrinkets().map(trinket => trinket?.asActionIdProto() || ActionIdProto.create());
+		this.gear = newGear;
+		this.gearChangeEmitter.emit(eventID);
+	}
 
-		//for (let i = 0; i < 2; i++) {
-		//	const oldTrinketId = oldTrinketIds[i];
-		//	const newTrinketId = newTrinketIds[i];
-		//	if (ActionIdProto.equals(oldTrinketId, ActionIdProto.create())) {
-		//		continue;
-		//	}
-		//	if (ActionIdProto.equals(newTrinketId, ActionIdProto.create())) {
-		//		continue;
-		//	}
-		//	if (ActionIdProto.equals(oldTrinketId, newTrinketId)) {
-		//		continue;
-		//	}
-		//	newCooldowns.cooldowns.forEach(cd => {
-		//		if (ActionIdProto.equals(cd.id, oldTrinketId)) {
-		//			cd.id = newTrinketId;
-		//		}
-		//	});
-		//}
+	getEnableItemSwap(): boolean {
+		return this.enableItemSwap;
+	}
 
-		TypedEvent.freezeAllAndDo(() => {
-			this.gear = newGear;
-			this.gearChangeEmitter.emit(eventID);
-			//this.setCooldowns(eventID, newCooldowns);
-		});
+	setEnableItemSwap(eventID: EventID, newEnableItemSwap: boolean) {
+		if (newEnableItemSwap == this.enableItemSwap)
+			return;
+
+		this.enableItemSwap = newEnableItemSwap;
+		this.itemSwapChangeEmitter.emit(eventID);
+	}
+
+	getItemSwapGear(): ItemSwapGear {
+		return this.itemSwapGear;
+	}
+
+	setItemSwapGear(eventID: EventID, newItemSwapGear: ItemSwapGear) {
+		if (newItemSwapGear.equals(this.itemSwapGear))
+			return;
+
+		this.itemSwapGear = newItemSwapGear;
+		this.itemSwapChangeEmitter.emit(eventID);
 	}
 
 	/*
@@ -1333,23 +1328,7 @@ export class Player<SpecType extends Spec> {
 	private toDatabase(): SimDatabase {
 		const dbGear = this.getGear().toDatabase()
 		const dbItemSwapGear = this.getItemSwapGear().toDatabase();
-		return SimDatabase.create({
-			items: dbGear.items.concat(dbItemSwapGear.items).filter(function(elem, index, self) {
-				return index === self.findIndex((t) => (
-					t.id === elem.id
-				));
-			}),
-			enchants: dbGear.enchants.concat(dbItemSwapGear.enchants).filter(function(elem, index, self) {
-				return index === self.findIndex((t) => (
-					t.effectId === elem.effectId
-				));
-			}),
-			gems: dbGear.gems.concat(dbItemSwapGear.gems).filter(function(elem, index, self) {
-				return index === self.findIndex((t) => (
-					t.id === elem.id
-				));
-			}),
-		})
+		return Database.mergeSimDatabases(dbGear, dbItemSwapGear);
 	}
 
 	toProto(forExport?: boolean, forSimming?: boolean): PlayerProto {
@@ -1365,6 +1344,8 @@ export class Player<SpecType extends Spec> {
 				equipment: gear.asSpec(),
 				consumes: this.getConsumes(),
 				bonusStats: this.getBonusStats().toProto(),
+				enableItemSwap: this.getEnableItemSwap(),
+				itemSwap: this.getItemSwapGear().toProto(),
 				buffs: this.getBuffs(),
 				cooldowns: (aplIsLaunched || (forSimming && aplRotation.type == APLRotationType.TypeAPL))
 					? Cooldowns.create({ hpPercentForDefensives: this.getCooldowns().hpPercentForDefensives })
@@ -1430,6 +1411,8 @@ export class Player<SpecType extends Spec> {
 			this.setName(eventID, proto.name);
 			this.setRace(eventID, proto.race);
 			this.setGear(eventID, proto.equipment ? this.sim.db.lookupEquipmentSpec(proto.equipment) : new Gear({}));
+			this.setEnableItemSwap(eventID, proto.enableItemSwap);
+			this.setItemSwapGear(eventID, proto.itemSwap ? this.sim.db.lookupItemSwap(proto.itemSwap) : new ItemSwapGear({}));
 			//this.setBulkEquipmentSpec(eventID, BulkEquipmentSpec.create()); // Do not persist the bulk equipment settings.
 			this.setConsumes(eventID, proto.consumes || Consumes.create());
 			this.setBonusStats(eventID, Stats.fromProto(proto.bonusStats || UnitStats.create()));
@@ -1555,6 +1538,33 @@ export class Player<SpecType extends Spec> {
 					}
 				}
 			}
+
+			if (this.spec == Spec.SpecWarlock || this.spec == Spec.SpecDeathknight) {
+				const rot = this.getRotation() as SpecRotation<Spec.SpecWarlock | Spec.SpecDeathknight>;
+				if (rot.enableWeaponSwap) {
+					this.setEnableItemSwap(eventID, rot.enableWeaponSwap);
+					rot.enableWeaponSwap = false;
+					this.setRotation(eventID, rot as SpecRotation<SpecType>)
+				}
+				if (rot.weaponSwap) {
+					this.setItemSwapGear(eventID, this.sim.db.lookupItemSwap(rot.weaponSwap));
+					rot.weaponSwap = undefined;
+					this.setRotation(eventID, rot as SpecRotation<SpecType>)
+				}
+			}
+			if (this.spec == Spec.SpecEnhancementShaman) {
+				const rot = this.getRotation() as SpecRotation<Spec.SpecEnhancementShaman>;
+				if (rot.enableItemSwap) {
+					this.setEnableItemSwap(eventID, rot.enableItemSwap);
+					rot.enableItemSwap = false;
+					this.setRotation(eventID, rot as SpecRotation<SpecType>)
+				}
+				if (rot.itemSwap) {
+					this.setItemSwapGear(eventID, this.sim.db.lookupItemSwap(rot.itemSwap));
+					rot.itemSwap = undefined;
+					this.setRotation(eventID, rot as SpecRotation<SpecType>)
+				}
+			}
 		});
 	}
 
@@ -1566,6 +1576,8 @@ export class Player<SpecType extends Spec> {
 
 	applySharedDefaults(eventID: EventID) {
 		TypedEvent.freezeAllAndDo(() => {
+			this.setEnableItemSwap(eventID, false);
+			this.setItemSwapGear(eventID, new ItemSwapGear({}));
 			this.setReactionTime(eventID, 200);
 			this.setInFrontOfTarget(eventID, isTankSpec(this.spec));
 			this.setHealingModel(eventID, HealingModel.create({

--- a/ui/core/proto_utils/database.ts
+++ b/ui/core/proto_utils/database.ts
@@ -3,8 +3,10 @@ import {
 	GemColor,
 	ItemSlot,
 	ItemSpec,
+	ItemSwap,
 	PresetEncounter,
 	PresetTarget,
+	SimDatabase,
 } from '../proto/common.js';
 import {
 	GlyphID,
@@ -23,8 +25,9 @@ import {
 } from './utils.js';
 import { gemEligibleForSocket, gemMatchesSocket } from './gems.js';
 import { EquippedItem } from './equipped_item.js';
-import { Gear } from './gear.js';
+import { Gear, ItemSwapGear } from './gear.js';
 import { CHARACTER_LEVEL } from '../constants/mechanics.js';
+import { distinct } from '../utils.js';
 
 const dbUrlJson = '/wotlk/assets/database/db.json';
 const dbUrlBin = '/wotlk/assets/database/db.bin';
@@ -216,6 +219,14 @@ export class Database {
 		return new Gear(gearMap);
 	}
 
+	lookupItemSwap(itemSwap: ItemSwap): ItemSwapGear {
+		return new ItemSwapGear({
+			[ItemSlot.ItemSlotMainHand]: itemSwap.mhItem ? this.lookupItemSpec(itemSwap.mhItem): null,
+			[ItemSlot.ItemSlotOffHand]: itemSwap.ohItem ? this.lookupItemSpec(itemSwap.ohItem): null,
+			[ItemSlot.ItemSlotRanged]: itemSwap.rangedItem ? this.lookupItemSpec(itemSwap.rangedItem): null,
+		});
+	}
+
 	enchantSpellIdToEffectId(enchantSpellId: number): number {
 		const enchant = Object.values(this.enchantsBySlot).flat().find(enchant => enchant.spellId == enchantSpellId);
 		return enchant ? enchant.effectId : 0;
@@ -277,5 +288,13 @@ export class Database {
 			console.error('Error while fetching url: ' + url + '\n\n' + e);
 			return IconData.create();
 		}
+	}
+
+	public static mergeSimDatabases(db1: SimDatabase, db2: SimDatabase): SimDatabase {
+		return SimDatabase.create({
+			items: distinct(db1.items.concat(db2.items), (a, b) => a.id == b.id),
+			enchants: distinct(db1.enchants.concat(db2.enchants), (a, b) => a.effectId == b.effectId),
+			gems: distinct(db1.gems.concat(db2.gems), (a, b) => a.id == b.id),
+		})
 	}
 }

--- a/ui/core/proto_utils/equipped_item.ts
+++ b/ui/core/proto_utils/equipped_item.ts
@@ -1,9 +1,7 @@
 import { GemColor } from '../proto/common.js';
-import { ItemSlot } from '../proto/common.js';
 import { ItemSpec } from '../proto/common.js';
 import { ItemType } from '../proto/common.js';
 import { Profession } from '../proto/common.js';
-import { Stat } from '../proto/common.js';
 import {
 	UIEnchant as Enchant,
 	UIGem as Gem,

--- a/ui/core/utils.ts
+++ b/ui/core/utils.ts
@@ -68,6 +68,7 @@ export function intersection<T>(a: Array<T>, b: Array<T>): Array<T> {
 }
 
 // Returns a new array containing only distinct elements of arr.
+// comparator should return true if the two elements are considered equal, and false otherwise.
 export function distinct<T>(arr: Array<T>, comparator?: (a: T, b: T) => boolean): Array<T> {
 	comparator = comparator || ((a: T, b: T) => a == b);
 	const distinctArr: Array<T> = [];

--- a/ui/deathknight/inputs.ts
+++ b/ui/deathknight/inputs.ts
@@ -370,23 +370,6 @@ export const FrostCustomRotation = InputHelpers.makeCustomRotationInput<Spec.Spe
 	showWhen: (player: Player<Spec.SpecDeathknight>) => player.getRotation().frostRotationType == FrostRotationType.Custom,
 });
 
-export const EnableWeaponSwap = InputHelpers.makeRotationBooleanInput<Spec.SpecDeathknight>({
-	fieldName: 'enableWeaponSwap',
-	label: 'Enable Weapon Swapping',
-	showWhen: (player: Player<Spec.SpecDeathknight>) => !player.getRotation().autoRotation && player.getTalents().summonGargoyle && player.getRotation().useGargoyle,
-})
-
-export const WeaponSwapInputs = InputHelpers.MakeItemSwapInput<Spec.SpecDeathknight>({
-	fieldName: 'weaponSwap',
-	values: [
-		ItemSlot.ItemSlotMainHand,
-		ItemSlot.ItemSlotOffHand,
-		//ItemSlot.ItemSlotRanged, Not support yet
-	],
-	labelTooltip: '<b>Berserking</b> will be equipped when FC has procced and Berserking is not active.<br><br><b>Black Magic</b> will be prioed to swap during gargoyle or if gargoyle will be on CD for full BM Icd.',
-	showWhen: (player: Player<Spec.SpecDeathknight>) => !player.getRotation().autoRotation && player.getTalents().summonGargoyle && player.getRotation().useGargoyle && player.getRotation().enableWeaponSwap,
-})
-
 export const NewDrwInput = InputHelpers.makeSpecOptionsBooleanInput<Spec.SpecDeathknight>({
 	fieldName: 'newDrw',
 	label: 'PTR DRW Scaling',
@@ -426,8 +409,6 @@ export const DeathKnightRotationConfig = {
 		UseAutoRotation,
 		BloodTapGhoulFrenzy,
 		UseGargoyle,
-		EnableWeaponSwap,
-		WeaponSwapInputs,
 		UseEmpowerRuneWeapon,
 		UseDancingRuneWeapon,
 		//NewDrwInput,

--- a/ui/deathknight/sim.ts
+++ b/ui/deathknight/sim.ts
@@ -199,6 +199,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDeathknight, {
 			OtherInputs.InFrontOfTarget,
 		],
 	},
+	itemSwapSlots: [ItemSlot.ItemSlotMainHand, ItemSlot.ItemSlotOffHand],
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.
 		showExecuteProportion: false,

--- a/ui/enhancement_shaman/inputs.ts
+++ b/ui/enhancement_shaman/inputs.ts
@@ -1,7 +1,3 @@
-import { BooleanPicker } from '../core/components/boolean_picker.js';
-import { EnumPicker } from '../core/components/enum_picker.js';
-import { IconEnumPicker, IconEnumPickerConfig } from '../core/components/icon_enum_picker.js';
-import { IconPickerConfig } from '../core/components/icon_picker.js';
 import {
 	AirTotem,
 	EarthTotem,
@@ -18,7 +14,7 @@ import {
 	EnhancementShaman_Rotation,
 	EnhancementShaman_Rotation_BloodlustUse
 } from '../core/proto/shaman.js';
-import { CustomSpell, Spec, ItemSwap, ItemSlot } from '../core/proto/common.js';
+import { Spec } from '../core/proto/common.js';
 import { ActionId } from '../core/proto_utils/action_id.js';
 import { Player } from '../core/player.js';
 
@@ -78,27 +74,9 @@ export const SyncTypeInput = InputHelpers.makeSpecOptionsEnumInput<Spec.SpecEnha
 	],
 });
 
-export const EnhancmentItemSwapInputs = InputHelpers.MakeItemSwapInput<Spec.SpecEnhancementShaman>({
-	fieldName: 'itemSwap',
-	values: [
-		ItemSlot.ItemSlotMainHand,
-		ItemSlot.ItemSlotOffHand,
-		//ItemSlot.ItemSlotRanged, Not support yet
-	],
-	labelTooltip: 'Start with the swapped items until Fire Elemntal has been summoned, swap back to normal gear set. Weapons come pre enchanted with FT9 and FT10. If a slot is empty it will not be used in the swap',
-	showWhen: (player: Player<Spec.SpecEnhancementShaman>) => (player.getSpecOptions().totems?.useFireElemental && player.getRotation().enableItemSwap) || false
-})
-
 export const EnhancementShamanRotationConfig = {
 	inputs:
 		[
-			InputHelpers.makeRotationBooleanInput<Spec.SpecEnhancementShaman>({
-				fieldName: 'enableItemSwap',
-				label: 'Enable Item Swapping',
-				labelTooltip: 'Toggle on/off item swapping',
-				showWhen: (player: Player<Spec.SpecEnhancementShaman>) => player.getSpecOptions().totems?.useFireElemental || false
-			}),
-			EnhancmentItemSwapInputs,
 			InputHelpers.makeRotationEnumInput<Spec.SpecEnhancementShaman, RotationType>({
 				fieldName: 'rotationType',
 				label: 'Type',

--- a/ui/enhancement_shaman/sim.ts
+++ b/ui/enhancement_shaman/sim.ts
@@ -2,6 +2,7 @@ import {
 	Class,
 	Faction,
 	IndividualBuffs,
+	ItemSlot,
 	PartyBuffs,
 	PseudoStat,
 	Race,
@@ -142,6 +143,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecEnhancementShaman, {
 			OtherInputs.InFrontOfTarget,
 		],
 	},
+	itemSwapSlots: [ItemSlot.ItemSlotMainHand, ItemSlot.ItemSlotOffHand],
 	customSections: [
 		TotemsSection,
 		FireElementalSection

--- a/ui/warlock/inputs.ts
+++ b/ui/warlock/inputs.ts
@@ -11,7 +11,7 @@ import {
 	Warlock_Options_Summon as Summon,
 } from '../core/proto/warlock.js';
 
-import { Spec, Glyphs, ItemSlot } from '../core/proto/common.js';
+import { Spec, Glyphs } from '../core/proto/common.js';
 import { ActionId } from '../core/proto_utils/action_id.js';
 import { Player } from '../core/player.js';
 import { EventID, TypedEvent } from '../core/typed_event.js';
@@ -258,22 +258,6 @@ export const WarlockRotationConfig = {
 			label: 'Detonate Seed on Cast',
 			labelTooltip: 'Simulates raid doing damage to targets such that seed detonates immediately on cast.',
 			showWhen: (player: Player<Spec.SpecWarlock>) => player.getRotation().primarySpell == PrimarySpell.Seed,
-		}),
-		InputHelpers.makeRotationBooleanInput<Spec.SpecWarlock>({
-			fieldName: 'enableWeaponSwap',
-			label: 'Enable Weapon Swapping',
-			labelTooltip: 'Toggle on/off item swapping',
-			showWhen: (player: Player<Spec.SpecWarlock>) => player.getRotation().type == RotationType.Affliction
-		}),
-		InputHelpers.MakeItemSwapInput<Spec.SpecWarlock>({
-			fieldName: 'weaponSwap',
-			values: [
-				ItemSlot.ItemSlotMainHand,
-				ItemSlot.ItemSlotOffHand,
-				ItemSlot.ItemSlotRanged,
-			],
-			labelTooltip: 'Start with the swapped items until Corruption has been cast, then swap back to normal gear set. If a slot is empty it will not be used in the swap',
-			showWhen: (player: Player<Spec.SpecWarlock>) => (player.getRotation().type == RotationType.Affliction && player.getRotation().enableWeaponSwap) || false
 		}),
 	],
 };

--- a/ui/warlock/sim.ts
+++ b/ui/warlock/sim.ts
@@ -1,6 +1,7 @@
 import {
 	Class,
 	Faction,
+	ItemSlot,
 	PartyBuffs,
 	Race,
 	Spec,
@@ -131,6 +132,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarlock, {
 			OtherInputs.nibelungAverageCasts,
 		],
 	},
+	itemSwapSlots: [ItemSlot.ItemSlotMainHand, ItemSlot.ItemSlotOffHand, ItemSlot.ItemSlotRanged],
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.
 		showExecuteProportion: false,


### PR DESCRIPTION
Implements #4082.

A few notes on this PR:
- All existing ItemSwap options (DK DPS, Enhance, and Warlock) are deprecated and replaced with new fields on the Player proto.
- UI changes include conversion logic for backwards compatibility.
- Legacy rotation logic should be preserved.
- `sim.ts` files in the UI have a new option to specify which item swap slots are supported. This means that even though APL is generically supporting item swaps now, they are still not enabled for any new classes/specs.
- Refactor the UI ItemSwapGear class to correctly be immutable.